### PR TITLE
chore(changeset): add condition to skip changeset verification for dependabot

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -8,6 +8,7 @@ jobs:
   changeset:
     name: Verify Changeset
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Fixes #3 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Skips running the changeset verification workflow on Dependabot PRs.
> 
> - Adds job-level `if: github.actor != 'dependabot[bot]'` in `changeset-check.yml` to bypass the check for Dependabot
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14a93f760938c7d51432fce14f6f15adbe323994. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->