### PR TITLE
fix(ci): skip merge commits in DCO validation

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -47,6 +47,14 @@ jobs:
           echo "Checking commits:"
           for commit in $COMMITS; do
             SUBJECT=$(git log --format=%s -n 1 "$commit")
+
+            # Skip merge commits (they have 2+ parents and are created by GitHub)
+            PARENT_COUNT=$(git log --format=%P -n 1 "$commit" | wc -w)
+            if [ "$PARENT_COUNT" -gt 1 ]; then
+              echo "[SKIP] $commit: $SUBJECT (merge commit)"
+              continue
+            fi
+
             if git log --format=%B -n 1 "$commit" | grep -q "^Signed-off-by: "; then
               echo "[PASS] $commit: $SUBJECT"
             else
@@ -110,6 +118,14 @@ jobs:
           echo "Checking commits:"
           for commit in $COMMITS; do
             SUBJECT=$(git log --format=%s -n 1 "$commit")
+
+            # Skip merge commits (they have 2+ parents and are created by GitHub)
+            PARENT_COUNT=$(git log --format=%P -n 1 "$commit" | wc -w)
+            if [ "$PARENT_COUNT" -gt 1 ]; then
+              echo "[SKIP] $commit: $SUBJECT (merge commit)"
+              continue
+            fi
+
             if git log --format=%B -n 1 "$commit" | grep -q "^Signed-off-by: "; then
               echo "[PASS] $commit: $SUBJECT"
             else


### PR DESCRIPTION
GitHub-created merge commits don't include DCO sign-off lines, causing the DCO check to fail when PRs are merged. This change updates the workflow to skip merge commits (commits with 2+ parents) since they only combine already-validated commits.

Merge commits are created by GitHub's system and represent commits that were already checked during the pull request phase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updates the DCO validation workflow to skip merge commits during sign-off checks. The workflow now detects commits with multiple parents (merge commits created by GitHub) and excludes them from DCO validation, since merge commits are system-generated and simply combine already-validated commits.

The change adds a parent count check in both the "Check DCO for Pull Request" and "Check DCO for Push" job steps. For each commit being validated, the workflow counts the number of parents using `git log --format=%P`, and if a commit has more than one parent, it skips the Signed-off-by verification and logs a "[SKIP]" message. Non-merge commits continue to be validated as before, requiring a Signed-off-by line in their commit message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->