### PR TITLE
fix: harden engine initialization and public API surface

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,10 +16,8 @@
   "keywords": [
     "webgpu",
     "typescript",
-    "game-engine",
     "retro",
     "pixel-art",
-    "2d-game",
     "2d-demo",
     "sprite",
     "canvas",

--- a/src/BlitTech.ts
+++ b/src/BlitTech.ts
@@ -11,6 +11,7 @@ import { BitmapFont } from './assets/BitmapFont';
 import { SpriteSheet } from './assets/SpriteSheet';
 import { BTAPI } from './core/BTAPI';
 import type { HardwareSettings, IBlitTechDemo } from './core/IBlitTechDemo';
+import { defaultHardwareSettings } from './core/IBlitTechDemo';
 import type { BootstrapOptions } from './utils/Bootstrap';
 import { bootstrap, checkWebGPUSupport, displayError, getCanvas } from './utils/Bootstrap';
 import { Color32 } from './utils/Color32';
@@ -473,6 +474,7 @@ export {
     bootstrap,
     checkWebGPUSupport,
     Color32,
+    defaultHardwareSettings,
     displayError,
     getCanvas,
     Rect2i,

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -146,7 +146,14 @@ export class BTAPI {
         console.log('[BlitTech] Querying hardware settings...');
 
         this.hwSettings = demo.queryHardware();
-        this.updateInterval = 1000 / this.hwSettings.targetFPS;
+
+        const { targetFPS } = this.hwSettings;
+
+        if (!Number.isFinite(targetFPS) || targetFPS <= 0) {
+            throw new Error(`[BlitTech] Invalid targetFPS: ${targetFPS}. Must be a finite number > 0.`);
+        }
+
+        this.updateInterval = 1000 / targetFPS;
 
         console.log('[BlitTech] Hardware settings:', {
             displaySize: `${this.hwSettings.displaySize.x}x${this.hwSettings.displaySize.y}`,

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -330,15 +330,26 @@ export class BTAPI {
             // Accumulator for fixed timestep.
             this.accumulator += deltaTime;
 
-            // Fixed update loop (run at target FPS).
-            while (this.accumulator >= this.updateInterval) {
+            // Clamp accumulator to prevent spiral-of-death after long pauses.
+            const MAX_STEPS = 8;
+            const maxAccumulator = this.updateInterval * MAX_STEPS;
+
+            if (this.accumulator > maxAccumulator) {
+                this.accumulator = maxAccumulator;
+            }
+
+            // Fixed update loop (run at target FPS, capped at MAX_STEPS per frame).
+            const steps = Math.min(Math.floor(this.accumulator / this.updateInterval), MAX_STEPS);
+
+            for (let i = 0; i < steps; i++) {
                 if (this.demo) {
                     this.demo.update();
                 }
 
                 this.ticks++;
-                this.accumulator -= this.updateInterval;
             }
+
+            this.accumulator -= steps * this.updateInterval;
 
             // Variable render loop.
             if (this.demo && this.renderer) {

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -150,7 +150,9 @@ export class BTAPI {
         const { targetFPS } = this.hwSettings;
 
         if (!Number.isFinite(targetFPS) || targetFPS <= 0) {
-            throw new Error(`[BlitTech] Invalid targetFPS: ${targetFPS}. Must be a finite number > 0.`);
+            console.error(`[BlitTech] Invalid targetFPS: ${targetFPS}. Must be a finite number > 0.`);
+
+            return false;
         }
 
         this.updateInterval = 1000 / targetFPS;

--- a/src/utils/Bootstrap.ts
+++ b/src/utils/Bootstrap.ts
@@ -79,10 +79,7 @@ const WEBGPU_NOT_SUPPORTED_MESSAGE =
     'Please update your browser or try a different one.';
 
 /** Error message for initialization failure. */
-const INIT_FAILED_MESSAGE =
-    'The engine failed to initialize.\n\n' +
-    'This usually means WebGPU could not access your GPU.\n' +
-    'Check the console for detailed error messages.';
+const INIT_FAILED_MESSAGE = 'The engine failed to initialize. Check the console for details.';
 
 // #endregion
 
@@ -342,7 +339,16 @@ async function initializeDemo(
     onError?: (error: Error) => void,
 ): Promise<BootstrapResult> {
     const demo = new DemoClass();
-    const initialized = await BTAPI.instance.initialize(demo, canvas);
+    let initialized: boolean;
+    let initError: Error | undefined;
+
+    try {
+        initialized = await BTAPI.instance.initialize(demo, canvas);
+    } catch (err) {
+        initialized = false;
+        initError = err instanceof Error ? err : new Error(String(err));
+    }
+
     let result: BootstrapResult;
 
     if (initialized) {
@@ -350,10 +356,14 @@ async function initializeDemo(
         onSuccess?.();
         result = { success: true };
     } else {
+        const displayMessage: ErrorContent = initError
+            ? { text: INIT_FAILED_MESSAGE, code: initError.message }
+            : INIT_FAILED_MESSAGE;
+
         result = handleBootstrapError(
             'Initialization Failed',
-            INIT_FAILED_MESSAGE,
-            new Error('Engine initialization failed'),
+            displayMessage,
+            initError ?? new Error('Engine initialization failed'),
             containerId,
             onError,
         );

--- a/src/utils/Bootstrap.ts
+++ b/src/utils/Bootstrap.ts
@@ -345,8 +345,9 @@ async function initializeDemo(
     try {
         initialized = await BTAPI.instance.initialize(demo, canvas);
     } catch (err) {
-        initialized = false;
         initError = err instanceof Error ? err : new Error(String(err));
+        console.error('[Blit-Tech] Engine initialization threw an unexpected error:', initError);
+        initialized = false;
     }
 
     let result: BootstrapResult;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Hardened engine initialization and improved error surfacing; tightened public API exports.

## BTAPI initialization and main loop
- validate targetFPS in initialize(): extracts targetFPS and returns false (with error log) if not a finite number > 0 instead of computing an invalid update interval.
- compute updateInterval from validated targetFPS.
- Prevent spiral-of-death: accumulator is clamped and update steps capped (MAX_STEPS = 8). The update loop now computes steps = min(floor(accumulator / updateInterval), MAX_STEPS), runs a fixed for-loop for that many updates, and subtracts steps * updateInterval from the accumulator.

## Improved error handling in bootstrap
- INIT_FAILED_MESSAGE shortened to a single-line user-friendly message.
- initializeDemo now wraps engine initialization in try/catch (caught non-Error values are normalized to Error). On failure the handler receives a structured ErrorContent ({ text: INIT_FAILED_MESSAGE, code: initError.message }) when an init error exists, and the actual captured error object is forwarded to callbacks instead of always creating a generic Error. This surfaces concrete initialization errors to the UI and callbacks.

## Public API additions
- Exported defaultHardwareSettings from the main module (src/BlitTech.ts) to make demo hardware defaults available to consumers.

## Package metadata updates
- Removed two keywords from package.json: "game-engine" and "2d-game".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->