### PR TITLE
chore: remove changeset references and configuration

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,7 +7,6 @@ src/
 .vscode/
 .zed/
 .idea/
-.changeset/
 
 # AI assistant configs (development only)
 ai-rules/

--- a/.prettierignore
+++ b/.prettierignore
@@ -25,10 +25,3 @@ vite.config.*.timestamp-*
 
 # JSON is handled by Biome
 *.json
-
-# Generated files
-CHANGELOG.md
-
-# Changesets (auto-generated)
-.changeset/*.md
-!.changeset/README.md

--- a/README.md
+++ b/README.md
@@ -313,7 +313,6 @@ The engine displays an error message if the browser doesn’t support WebGPU.
 - **Vite** — Fast build tool with HMR
 - **WGSL** — WebGPU Shading Language
 - **Biome** — Fast formatter and linter
-- **Changesets** — Version management and changelog generation
 
 ## Assets & Fonts
 

--- a/docs/developer-experience-guide.md
+++ b/docs/developer-experience-guide.md
@@ -197,7 +197,15 @@ test(vector): add tests for magnitude calculation
 
 1. Ensure all tests pass
 2. Update documentation if needed
-3. Rebase on latest main:
+3. Run preflight checks:
+
+   ```bash
+   pnpm preflight
+   ```
+
+   This runs format check, lint, typecheck, spellcheck, and knip.
+
+4. Rebase on latest main:
 
    ```bash
    git fetch upstream

--- a/docs/developer-experience-guide.md
+++ b/docs/developer-experience-guide.md
@@ -197,13 +197,7 @@ test(vector): add tests for magnitude calculation
 
 1. Ensure all tests pass
 2. Update documentation if needed
-3. Add changeset if making library changes:
-
-   ```bash
-   pnpm changeset
-   ```
-
-4. Rebase on latest main:
+3. Rebase on latest main:
 
    ```bash
    git fetch upstream
@@ -365,15 +359,6 @@ Update README.md if you:
 - Change public API
 - Add new examples
 - Update prerequisites
-
-### Changelog
-
-Changesets automatically generate CHANGELOG.md:
-
-```bash
-pnpm changeset
-# Follow prompts to describe changes
-```
 
 ## Getting Help
 
@@ -721,16 +706,8 @@ Closes #
 ## Documentation
 
 - [ ] Updated README.md if needed
-- [ ] Updated CHANGELOG.md (via changeset)
 - [ ] Added code comments for complex logic
 - [ ] Updated TypeScript types/interfaces
-
-## Changeset
-
-<!-- Required for library changes -->
-
-- [ ] Created changeset (`pnpm changeset`)
-- [ ] Or this change doesn't affect the published library
 
 ## Screenshots/Videos
 
@@ -1078,11 +1055,6 @@ playwright-report/
 test-results/
 coverage/
 
-# Changesets (keep config, ignore temp files)
-.changeset/*.md
-!.changeset/README.md
-!.changeset/config.json
-
 # Docs build (when added)
 docs/.astro/
 docs/dist/
@@ -1109,7 +1081,6 @@ docs/dist/
 ### Before Releases
 
 - [ ] Run a full test suite
-- [ ] Update CHANGELOG.md (via changesets)
 - [ ] Bump version
 - [ ] Test library build
 - [ ] Test examples deployment


### PR DESCRIPTION
Remove all references to Changesets version management tool from project documentation and ignore files. This cleanup removes:
- .changeset/ from .npmignore
- Changeset-related patterns from .prettierignore
- Changeset from README tech stack
- Changeset workflow steps from developer guide
- Changeset sections from PR template

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR removes all references to the Changesets version-management workflow from project configuration and documentation and adds an explicit preflight step to contributor guidance.

## Changes

- Package configuration
  - Removed `.changeset/` from `.npmignore` exclusion patterns.

- Formatting configuration
  - Removed `CHANGELOG.md` and `.changeset/*.md` patterns from `.prettierignore` (keeps `!.changeset/README.md` negation if present).

- Documentation
  - Removed Changesets from the Technologies section in README.md.
  - Updated docs/developer-experience-guide.md and contributing guidance to:
    - Remove instructions to run `pnpm changeset` and the "Changelog" section describing automatic `CHANGELOG.md` generation via Changesets.
    - Remove PR checklist and release checklist items related to creating changesets or updating `CHANGELOG.md`.
    - Remove suggested `.changeset/*.md` ignore rules from example `.gitignore` content.
    - Insert an explicit preflight instruction: contributors should run `pnpm preflight` (format, lint, typecheck, spellcheck, knip) before rebasing on main / before submitting PRs.

- PR template
  - Updated test/checklist items to require `pnpm preflight` instead of Changesets-related checks.

This cleanup completes the migration away from a Changesets-based workflow and standardizes preflight checks as the contributor pre-submission step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->