### PR TITLE
test: fill unit test coverage gaps in rendering and asset modules

### DIFF
--- a/src/assets/AssetLoader.test.ts
+++ b/src/assets/AssetLoader.test.ts
@@ -117,4 +117,59 @@ describe('AssetLoader', () => {
     });
 
     // #endregion
+
+    // #region Error Handling
+
+    describe('error handling', () => {
+        beforeEach(() => {
+            vi.stubGlobal(
+                'Image',
+                class {
+                    onload: (() => void) | null = null;
+                    onerror: (() => void) | null = null;
+                    private _src = '';
+
+                    get src(): string {
+                        return this._src;
+                    }
+
+                    set src(value: string) {
+                        this._src = value;
+                        // Simulate error for URLs containing 'fail'
+                        if (value.includes('fail')) {
+                            this.onerror?.();
+                        } else {
+                            this.onload?.();
+                        }
+                    }
+                },
+            );
+        });
+
+        afterEach(() => {
+            vi.unstubAllGlobals();
+        });
+
+        it('should reject when image fails to load', async () => {
+            await expect(AssetLoader.loadImage('fail.png')).rejects.toThrow('Failed to load image: fail.png');
+        });
+
+        it('should not cache images that failed to load', async () => {
+            try {
+                await AssetLoader.loadImage('fail.png');
+            } catch {
+                // Expected
+            }
+            expect(AssetLoader.isLoaded('fail.png')).toBe(false);
+            expect(AssetLoader.getImage('fail.png')).toBeNull();
+        });
+
+        it('should reject loadImages when any image fails', async () => {
+            await expect(AssetLoader.loadImages(['ok.png', 'fail.png'])).rejects.toThrow(
+                'Failed to load image: fail.png',
+            );
+        });
+    });
+
+    // #endregion
 });

--- a/src/assets/BitmapFont.test.ts
+++ b/src/assets/BitmapFont.test.ts
@@ -270,6 +270,75 @@ describe('BitmapFont', () => {
     });
 
     // #endregion
+
+    // #region Default metadata fallbacks
+
+    describe('default metadata fallbacks', () => {
+        it('should use defaults when name, size, lineHeight, baseline are missing', async () => {
+            vi.stubGlobal(
+                'fetch',
+                vi.fn().mockResolvedValue({
+                    ok: true,
+                    json: vi.fn().mockResolvedValue({
+                        texture: 'data:image/png;base64,aGVsbG8=',
+                        glyphs: { A: { x: 0, y: 0, w: 8, h: 12, ox: 0, oy: 0, adv: 9 } },
+                    }),
+                }),
+            );
+            const f = await BitmapFont.load('minimal.btfont');
+            expect(f.name).toBe('Unknown');
+            expect(f.size).toBe(12);
+            expect(f.lineHeight).toBe(12);
+            expect(f.baseline).toBe(12);
+        });
+
+        it('should use size as fallback for lineHeight and baseline', async () => {
+            vi.stubGlobal(
+                'fetch',
+                vi.fn().mockResolvedValue({
+                    ok: true,
+                    json: vi.fn().mockResolvedValue({
+                        name: 'CustomFont',
+                        size: 16,
+                        texture: 'data:image/png;base64,aGVsbG8=',
+                        glyphs: { A: { x: 0, y: 0, w: 8, h: 16, ox: 0, oy: 0, adv: 9 } },
+                    }),
+                }),
+            );
+            const f = await BitmapFont.load('partial.btfont');
+            expect(f.name).toBe('CustomFont');
+            expect(f.size).toBe(16);
+            expect(f.lineHeight).toBe(16); // Falls back to size
+            expect(f.baseline).toBe(16); // Falls back to size
+        });
+    });
+
+    // #endregion
+
+    // #region Edge cases
+
+    describe('edge cases', () => {
+        it('should return 0 for measureText with empty string', () => {
+            expect(font.measureText('')).toBe(0);
+        });
+
+        it('should measure mixed ASCII and Unicode text', () => {
+            // A(9) + e-acute(7) + B(8) = 24
+            const width = font.measureText('A\u00e9B');
+            expect(width).toBe(24);
+        });
+
+        it('should return reusable object from measureTextSize', () => {
+            const size1 = font.measureTextSize('A');
+            const size2 = font.measureTextSize('AB');
+            // Same reference (reused object)
+            expect(size1).toBe(size2);
+            // But values reflect the latest measurement
+            expect(size2.width).toBe(17);
+        });
+    });
+
+    // #endregion
 });
 
 // #endregion

--- a/src/assets/BitmapFont.ts
+++ b/src/assets/BitmapFont.ts
@@ -113,7 +113,7 @@ const ASCII_CACHE_SIZE = 128;
  * - Optimized loops using charCodeAt for ASCII text
  *
  * @example
- * ```typescript
+ * ```ts
  * const font = await BitmapFont.load('fonts/MyFont.btfont');
  * BT.printFont(font, new Vector2i(10, 10), 'Hello World!', Color32.white());
  * ```

--- a/src/render/PrimitivePipeline.test.ts
+++ b/src/render/PrimitivePipeline.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import {
     createMockGPUDevice,
@@ -223,6 +223,178 @@ describe('with initialized pipeline', () => {
             pipeline.encodePass(createMockRenderPassEncoder());
         }).not.toThrow();
         pipeline.setCameraOffset(Vector2i.zero());
+    });
+});
+
+// #endregion
+
+// #region Vertex Count Verification
+
+describe('vertex count verification', () => {
+    const device = createMockGPUDevice();
+    const pipeline = new PrimitivePipeline();
+
+    beforeAll(async () => {
+        installMockNavigatorGPU();
+        await pipeline.initialize(device, new Vector2i(320, 240));
+    });
+
+    afterAll(() => {
+        uninstallMockNavigatorGPU();
+    });
+
+    it('drawRectFill produces 6 vertices (two triangles)', () => {
+        pipeline.reset();
+        pipeline.drawRectFill(new Rect2i(0, 0, 10, 10), Color32.red());
+
+        let totalVertices = 0;
+        const renderPass = {
+            ...createMockRenderPassEncoder(),
+            draw: (vertexCount: number) => {
+                totalVertices += vertexCount;
+            },
+        } as unknown as GPURenderPassEncoder;
+
+        pipeline.encodePass(renderPass);
+        expect(totalVertices).toBe(6);
+    });
+
+    it('drawPixel produces 6 vertices (1x1 filled rect)', () => {
+        pipeline.reset();
+        pipeline.drawPixel(new Vector2i(5, 5), Color32.green());
+
+        let totalVertices = 0;
+        const renderPass = {
+            ...createMockRenderPassEncoder(),
+            draw: (vertexCount: number) => {
+                totalVertices += vertexCount;
+            },
+        } as unknown as GPURenderPassEncoder;
+
+        pipeline.encodePass(renderPass);
+        expect(totalVertices).toBe(6);
+    });
+
+    it('horizontal line uses a single quad (6 vertices)', () => {
+        pipeline.reset();
+        pipeline.drawLine(new Vector2i(0, 10), new Vector2i(100, 10), Color32.white());
+
+        let totalVertices = 0;
+        const renderPass = {
+            ...createMockRenderPassEncoder(),
+            draw: (vertexCount: number) => {
+                totalVertices += vertexCount;
+            },
+        } as unknown as GPURenderPassEncoder;
+
+        pipeline.encodePass(renderPass);
+        expect(totalVertices).toBe(6);
+    });
+
+    it('vertical line uses a single quad (6 vertices)', () => {
+        pipeline.reset();
+        pipeline.drawLine(new Vector2i(10, 0), new Vector2i(10, 50), Color32.white());
+
+        let totalVertices = 0;
+        const renderPass = {
+            ...createMockRenderPassEncoder(),
+            draw: (vertexCount: number) => {
+                totalVertices += vertexCount;
+            },
+        } as unknown as GPURenderPassEncoder;
+
+        pipeline.encodePass(renderPass);
+        expect(totalVertices).toBe(6);
+    });
+
+    it('diagonal line uses 6 vertices per pixel (Bresenham)', () => {
+        pipeline.reset();
+        // A 45-degree diagonal from (0,0) to (4,4) = 5 pixels
+        pipeline.drawLine(new Vector2i(0, 0), new Vector2i(4, 4), Color32.white());
+
+        let totalVertices = 0;
+        const renderPass = {
+            ...createMockRenderPassEncoder(),
+            draw: (vertexCount: number) => {
+                totalVertices += vertexCount;
+            },
+        } as unknown as GPURenderPassEncoder;
+
+        pipeline.encodePass(renderPass);
+        expect(totalVertices).toBe(5 * 6); // 5 pixels * 6 vertices each
+    });
+
+    it('drawRect with height <= 2 skips vertical side lines', () => {
+        pipeline.reset();
+        // height=2 means y1-y0 = 1, which is NOT > 1, so no vertical sides
+        pipeline.drawRect(new Rect2i(0, 0, 10, 2), Color32.red());
+
+        let totalVertices = 0;
+        const renderPass = {
+            ...createMockRenderPassEncoder(),
+            draw: (vertexCount: number) => {
+                totalVertices += vertexCount;
+            },
+        } as unknown as GPURenderPassEncoder;
+
+        pipeline.encodePass(renderPass);
+        // Only top + bottom lines = 2 quads = 12 vertices (no left/right)
+        expect(totalVertices).toBe(12);
+    });
+
+    it('drawRect with height > 2 includes all four sides', () => {
+        pipeline.reset();
+        pipeline.drawRect(new Rect2i(0, 0, 10, 10), Color32.red());
+
+        let totalVertices = 0;
+        const renderPass = {
+            ...createMockRenderPassEncoder(),
+            draw: (vertexCount: number) => {
+                totalVertices += vertexCount;
+            },
+        } as unknown as GPURenderPassEncoder;
+
+        pipeline.encodePass(renderPass);
+        // 4 sides = 4 quads = 24 vertices
+        expect(totalVertices).toBe(24);
+    });
+
+    it('drawText produces 6 vertices per character', () => {
+        pipeline.reset();
+        pipeline.drawText(new Vector2i(0, 0), Color32.white(), 'Hi');
+
+        let totalVertices = 0;
+        const renderPass = {
+            ...createMockRenderPassEncoder(),
+            draw: (vertexCount: number) => {
+                totalVertices += vertexCount;
+            },
+        } as unknown as GPURenderPassEncoder;
+
+        pipeline.encodePass(renderPass);
+        expect(totalVertices).toBe(2 * 6); // 2 characters * 6 vertices each
+    });
+
+    it('buffer overflow triggers console.warn and does not crash', () => {
+        pipeline.reset();
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        // Fill buffer: 50000 max vertices, each drawRectFill uses 6 vertices
+        // ~8333 rects fill the buffer; drawing more should trigger warn
+        for (let i = 0; i < 8400; i++) {
+            pipeline.drawRectFill(new Rect2i(0, 0, 1, 1), Color32.white());
+        }
+
+        expect(warnSpy).toHaveBeenCalled();
+        const msg = warnSpy.mock.calls.find((c) => String(c[0]).includes('capacity exceeded'));
+        expect(msg).toBeDefined();
+
+        // encodePass should still work without crashing
+        expect(() => {
+            pipeline.encodePass(createMockRenderPassEncoder());
+        }).not.toThrow();
+
+        warnSpy.mockRestore();
     });
 });
 

--- a/src/render/PrimitivePipeline.test.ts
+++ b/src/render/PrimitivePipeline.test.ts
@@ -379,22 +379,24 @@ describe('vertex count verification', () => {
         pipeline.reset();
         const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-        // Fill buffer: 50000 max vertices, each drawRectFill uses 6 vertices
-        // ~8333 rects fill the buffer; drawing more should trigger warn
-        for (let i = 0; i < 8400; i++) {
-            pipeline.drawRectFill(new Rect2i(0, 0, 1, 1), Color32.white());
+        try {
+            // Fill buffer: 50000 max vertices, each drawRectFill uses 6 vertices
+            // ~8333 rects fill the buffer; drawing more should trigger warn
+            for (let i = 0; i < 8400; i++) {
+                pipeline.drawRectFill(new Rect2i(0, 0, 1, 1), Color32.white());
+            }
+
+            expect(warnSpy).toHaveBeenCalled();
+            const msg = warnSpy.mock.calls.find((c) => String(c[0]).includes('capacity exceeded'));
+            expect(msg).toBeDefined();
+
+            // encodePass should still work without crashing
+            expect(() => {
+                pipeline.encodePass(createMockRenderPassEncoder());
+            }).not.toThrow();
+        } finally {
+            warnSpy.mockRestore();
         }
-
-        expect(warnSpy).toHaveBeenCalled();
-        const msg = warnSpy.mock.calls.find((c) => String(c[0]).includes('capacity exceeded'));
-        expect(msg).toBeDefined();
-
-        // encodePass should still work without crashing
-        expect(() => {
-            pipeline.encodePass(createMockRenderPassEncoder());
-        }).not.toThrow();
-
-        warnSpy.mockRestore();
     });
 });
 

--- a/src/render/Renderer.test.ts
+++ b/src/render/Renderer.test.ts
@@ -252,24 +252,26 @@ describe('endFrame error paths', () => {
 
         const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-        renderer.beginFrame();
-        renderer.drawRectFill(new Rect2i(0, 0, 10, 10), Color32.red());
-        expect(() => {
-            renderer.endFrame();
-        }).not.toThrow();
-
-        expect(errorSpy).toHaveBeenCalledWith(
-            expect.stringContaining('Failed to get current texture'),
-            expect.any(Error),
-        );
-
-        // Should be able to start a new frame after error
-        expect(() => {
+        try {
             renderer.beginFrame();
-        }).not.toThrow();
+            renderer.drawRectFill(new Rect2i(0, 0, 10, 10), Color32.red());
+            expect(() => {
+                renderer.endFrame();
+            }).not.toThrow();
 
-        errorSpy.mockRestore();
-        uninstallMockNavigatorGPU();
+            expect(errorSpy).toHaveBeenCalledWith(
+                expect.stringContaining('Failed to get current texture'),
+                expect.any(Error),
+            );
+
+            // Should be able to start a new frame after error
+            expect(() => {
+                renderer.beginFrame();
+            }).not.toThrow();
+        } finally {
+            errorSpy.mockRestore();
+            uninstallMockNavigatorGPU();
+        }
     });
 
     it('skips frame when texture has zero dimensions', async () => {
@@ -289,15 +291,17 @@ describe('endFrame error paths', () => {
 
         const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-        renderer.beginFrame();
-        expect(() => {
-            renderer.endFrame();
-        }).not.toThrow();
+        try {
+            renderer.beginFrame();
+            expect(() => {
+                renderer.endFrame();
+            }).not.toThrow();
 
-        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('zero dimensions'));
-
-        warnSpy.mockRestore();
-        uninstallMockNavigatorGPU();
+            expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('zero dimensions'));
+        } finally {
+            warnSpy.mockRestore();
+            uninstallMockNavigatorGPU();
+        }
     });
 });
 
@@ -314,12 +318,15 @@ describe('initialize error paths', () => {
         installMockNavigatorGPU();
 
         const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-        const result = await renderer.initialize();
-        expect(result).toBe(false);
-        expect(errorSpy).toHaveBeenCalled();
 
-        errorSpy.mockRestore();
-        uninstallMockNavigatorGPU();
+        try {
+            const result = await renderer.initialize();
+            expect(result).toBe(false);
+            expect(errorSpy).toHaveBeenCalled();
+        } finally {
+            errorSpy.mockRestore();
+            uninstallMockNavigatorGPU();
+        }
     });
 });
 

--- a/src/render/Renderer.test.ts
+++ b/src/render/Renderer.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import {
     createMockGPUCanvasContext,
@@ -229,6 +229,97 @@ describe('with initialized renderer', () => {
         expect(() => {
             renderer.endFrame();
         }).not.toThrow();
+    });
+});
+
+// #endregion
+
+// #region Error Paths
+
+describe('endFrame error paths', () => {
+    it('recovers gracefully when getCurrentTexture throws', async () => {
+        const device = createMockGPUDevice();
+        const throwingContext = {
+            ...createMockGPUCanvasContext(),
+            getCurrentTexture: () => {
+                throw new Error('Context lost');
+            },
+        } as unknown as GPUCanvasContext;
+
+        const renderer = new Renderer(device, throwingContext, new Vector2i(320, 240));
+        installMockNavigatorGPU();
+        await renderer.initialize();
+
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        renderer.beginFrame();
+        renderer.drawRectFill(new Rect2i(0, 0, 10, 10), Color32.red());
+        expect(() => {
+            renderer.endFrame();
+        }).not.toThrow();
+
+        expect(errorSpy).toHaveBeenCalledWith(
+            expect.stringContaining('Failed to get current texture'),
+            expect.any(Error),
+        );
+
+        // Should be able to start a new frame after error
+        expect(() => {
+            renderer.beginFrame();
+        }).not.toThrow();
+
+        errorSpy.mockRestore();
+        uninstallMockNavigatorGPU();
+    });
+
+    it('skips frame when texture has zero dimensions', async () => {
+        const device = createMockGPUDevice();
+        const zeroTextureContext = {
+            ...createMockGPUCanvasContext(),
+            getCurrentTexture: () => ({
+                width: 0,
+                height: 0,
+                createView: () => ({ label: 'MockView' }),
+            }),
+        } as unknown as GPUCanvasContext;
+
+        const renderer = new Renderer(device, zeroTextureContext, new Vector2i(320, 240));
+        installMockNavigatorGPU();
+        await renderer.initialize();
+
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        renderer.beginFrame();
+        expect(() => {
+            renderer.endFrame();
+        }).not.toThrow();
+
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('zero dimensions'));
+
+        warnSpy.mockRestore();
+        uninstallMockNavigatorGPU();
+    });
+});
+
+describe('initialize error paths', () => {
+    it('returns false when pipeline creation throws', async () => {
+        const throwingDevice = {
+            ...createMockGPUDevice(),
+            createShaderModule: () => {
+                throw new Error('Shader compilation failed');
+            },
+        } as unknown as GPUDevice;
+
+        const renderer = new Renderer(throwingDevice, createMockGPUCanvasContext(), new Vector2i(320, 240));
+        installMockNavigatorGPU();
+
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        const result = await renderer.initialize();
+        expect(result).toBe(false);
+        expect(errorSpy).toHaveBeenCalled();
+
+        errorSpy.mockRestore();
+        uninstallMockNavigatorGPU();
     });
 });
 

--- a/src/render/SpritePipeline.test.ts
+++ b/src/render/SpritePipeline.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import {
     createMockGPUDevice,
@@ -6,6 +6,7 @@ import {
     installMockNavigatorGPU,
     uninstallMockNavigatorGPU,
 } from '../__test__/webgpu-mock';
+import type { BitmapFont, Glyph } from '../assets/BitmapFont';
 import { SpriteSheet } from '../assets/SpriteSheet';
 import { Color32 } from '../utils/Color32';
 import { Rect2i } from '../utils/Rect2i';
@@ -274,6 +275,153 @@ describe('drawSprite', () => {
                 pipeline.drawSprite(sheet, new Rect2i(0, 0, 16, 16), new Vector2i(i * 16, 0));
                 pipeline.encodePass(createMockRenderPassEncoder());
             }
+        }).not.toThrow();
+    });
+
+    it('buffer overflow triggers console.warn and does not crash', () => {
+        pipeline.reset();
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const sheet = new SpriteSheet(mockImage);
+
+        // MAX_SPRITE_VERTICES = 50000, each sprite = 6 vertices * 8 floats
+        // 50000 / 6 = ~8333 sprites max; draw more to trigger overflow
+        for (let i = 0; i < 8400; i++) {
+            pipeline.drawSprite(sheet, new Rect2i(0, 0, 8, 8), new Vector2i(0, 0));
+        }
+
+        expect(warnSpy).toHaveBeenCalled();
+        const msg = warnSpy.mock.calls.find((c) => String(c[0]).includes('capacity exceeded'));
+        expect(msg).toBeDefined();
+
+        expect(() => {
+            pipeline.encodePass(createMockRenderPassEncoder());
+        }).not.toThrow();
+
+        warnSpy.mockRestore();
+    });
+});
+
+// #endregion
+
+// #region drawBitmapText
+
+describe('drawBitmapText', () => {
+    const device = createMockGPUDevice();
+    const pipeline = new SpritePipeline();
+    const mockImage = { width: 64, height: 16 } as HTMLImageElement;
+
+    /** Creates a mock glyph. */
+    function makeGlyph(x: number, w: number, offsetX: number, offsetY: number, advance: number): Glyph {
+        return {
+            rect: new Rect2i(x, 0, w, 12),
+            offsetX,
+            offsetY,
+            advance,
+        };
+    }
+
+    /** Creates a mock BitmapFont. */
+    function makeMockFont(glyphMap: Record<string, Glyph>, sheet: SpriteSheet): BitmapFont {
+        return {
+            getSpriteSheet: () => sheet,
+            getGlyphByCode: (code: number) => glyphMap[String.fromCharCode(code)] ?? null,
+        } as unknown as BitmapFont;
+    }
+
+    beforeAll(async () => {
+        installMockNavigatorGPU();
+        await pipeline.initialize(device, new Vector2i(320, 240));
+    });
+
+    afterAll(() => {
+        uninstallMockNavigatorGPU();
+    });
+
+    it('renders characters that have glyphs', () => {
+        pipeline.reset();
+        const sheet = new SpriteSheet(mockImage);
+        const font = makeMockFont(
+            {
+                A: makeGlyph(0, 8, 0, 0, 9),
+                B: makeGlyph(8, 7, 0, 0, 8),
+            },
+            sheet,
+        );
+
+        pipeline.drawBitmapText(font, new Vector2i(10, 20), 'AB');
+
+        let drawCallCount = 0;
+        let totalVertices = 0;
+        const renderPass = {
+            ...createMockRenderPassEncoder(),
+            draw: (vertexCount: number) => {
+                drawCallCount++;
+                totalVertices += vertexCount;
+            },
+        } as unknown as GPURenderPassEncoder;
+
+        pipeline.encodePass(renderPass);
+        expect(drawCallCount).toBe(1); // Same texture = 1 batch
+        expect(totalVertices).toBe(12); // 2 characters * 6 vertices
+    });
+
+    it('silently skips characters without glyphs', () => {
+        pipeline.reset();
+        const sheet = new SpriteSheet(mockImage);
+        const font = makeMockFont(
+            {
+                A: makeGlyph(0, 8, 0, 0, 9),
+            },
+            sheet,
+        );
+
+        // 'Z' has no glyph - should be silently skipped
+        pipeline.drawBitmapText(font, new Vector2i(0, 0), 'AZA');
+
+        let totalVertices = 0;
+        const renderPass = {
+            ...createMockRenderPassEncoder(),
+            draw: (vertexCount: number) => {
+                totalVertices += vertexCount;
+            },
+        } as unknown as GPURenderPassEncoder;
+
+        pipeline.encodePass(renderPass);
+        expect(totalVertices).toBe(12); // Only 2 'A' glyphs rendered
+    });
+
+    it('empty string produces no draw calls', () => {
+        pipeline.reset();
+        const sheet = new SpriteSheet(mockImage);
+        const font = makeMockFont({}, sheet);
+
+        pipeline.drawBitmapText(font, new Vector2i(0, 0), '');
+
+        let drawCallCount = 0;
+        const renderPass = {
+            ...createMockRenderPassEncoder(),
+            draw: () => {
+                drawCallCount++;
+            },
+        } as unknown as GPURenderPassEncoder;
+
+        pipeline.encodePass(renderPass);
+        expect(drawCallCount).toBe(0);
+    });
+
+    it('applies custom tint color without error', () => {
+        pipeline.reset();
+        const sheet = new SpriteSheet(mockImage);
+        const font = makeMockFont(
+            {
+                X: makeGlyph(0, 8, 0, 0, 9),
+            },
+            sheet,
+        );
+
+        expect(() => {
+            pipeline.drawBitmapText(font, new Vector2i(0, 0), 'X', Color32.red());
+            pipeline.encodePass(createMockRenderPassEncoder());
         }).not.toThrow();
     });
 });

--- a/src/render/SpritePipeline.test.ts
+++ b/src/render/SpritePipeline.test.ts
@@ -283,21 +283,23 @@ describe('drawSprite', () => {
         const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
         const sheet = new SpriteSheet(mockImage);
 
-        // MAX_SPRITE_VERTICES = 50000, each sprite = 6 vertices * 8 floats
-        // 50000 / 6 = ~8333 sprites max; draw more to trigger overflow
-        for (let i = 0; i < 8400; i++) {
-            pipeline.drawSprite(sheet, new Rect2i(0, 0, 8, 8), new Vector2i(0, 0));
+        try {
+            // MAX_SPRITE_VERTICES = 50000, each sprite = 6 vertices * 8 floats
+            // 50000 / 6 = ~8333 sprites max; draw more to trigger overflow
+            for (let i = 0; i < 8400; i++) {
+                pipeline.drawSprite(sheet, new Rect2i(0, 0, 8, 8), new Vector2i(0, 0));
+            }
+
+            expect(warnSpy).toHaveBeenCalled();
+            const msg = warnSpy.mock.calls.find((c) => String(c[0]).includes('capacity exceeded'));
+            expect(msg).toBeDefined();
+
+            expect(() => {
+                pipeline.encodePass(createMockRenderPassEncoder());
+            }).not.toThrow();
+        } finally {
+            warnSpy.mockRestore();
         }
-
-        expect(warnSpy).toHaveBeenCalled();
-        const msg = warnSpy.mock.calls.find((c) => String(c[0]).includes('capacity exceeded'));
-        expect(msg).toBeDefined();
-
-        expect(() => {
-            pipeline.encodePass(createMockRenderPassEncoder());
-        }).not.toThrow();
-
-        warnSpy.mockRestore();
     });
 });
 


### PR DESCRIPTION
Add vertex count verification, buffer overflow, and error path tests for PrimitivePipeline, SpritePipeline, Renderer, AssetLoader, and BitmapFont. Covers drawBitmapText, endFrame error recovery, image load failures, and metadata defaults. Raises statement coverage from 94.9% to 97.6%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR adds comprehensive unit tests across rendering and asset modules to fill coverage gaps, focusing on error paths, vertex-count verification, buffer overflow handling, and test hygiene improvements. Statement coverage increases from 94.9% to 97.6%.

## Changes by Module

### Asset Loading (AssetLoader)
- Added an error-handling test suite that stubs global Image to simulate load failures when the URL contains "fail".
- Verifies `loadImage('fail.png')` rejects with `Failed to load image: fail.png`.
- Confirms failed image loads are not cached (`isLoaded` remains false and `getImage` returns null).
- Ensures `loadImages(['ok.png','fail.png'])` rejects when any image fails.

### Font Rendering (BitmapFont)
- Added tests for metadata default fallbacks: `name` defaults to `"Unknown"`, and numeric fields (`size`, `lineHeight`, `baseline`) default to `12` when missing.
- Added tests where `size` is present and `lineHeight`/`baseline` are derived from `size`.
- Edge-case tests: `measureText('')` returns 0, correct widths for mixed ASCII/Unicode, and `measureTextSize` reuses the same object reference while updating values.
- Minor JSDoc update: code block language annotation changed from `typescript` to `ts`.

### Primitive Rendering (PrimitivePipeline)
- Added vertex-count verification tests that spy on the mocked GPURenderPassEncoder.draw calls from `pipeline.encodePass()` to assert expected vertex counts per primitive:
  - `drawRectFill`, `drawPixel`, `drawLine` (hor/vert): 6 vertices
  - Diagonal `drawLine` (Bresenham): `pixels * 6` vertices
  - `drawRect`: 12 vertices for small heights (<=2), 24 when taller (>2)
  - `drawText`: `characters * 6` vertices
- Added a buffer-overflow test that spams draw calls to exceed capacity, asserts `console.warn` is called with a "capacity exceeded" message, and confirms `encodePass()` continues without throwing.

### Sprite Rendering (SpritePipeline)
- Added tests for sprite buffer overflow: spamming `drawSprite` beyond capacity triggers `console.warn("capacity exceeded")` while `encodePass()` still succeeds.
- Added `drawBitmapText` tests verifying:
  - Strings composed of glyph-backed characters produce a single draw batch with expected vertex totals.
  - Characters without glyphs are skipped without errors.
  - Empty strings produce no draw calls.
  - Supplying a custom tint does not throw and encodes successfully.

### Top-Level Renderer
- Added error-recovery tests:
  - `endFrame()` handles `GPUCanvasContext.getCurrentTexture()` throwing: does not throw, logs an error with "Failed to get current texture", and allows subsequent `beginFrame()` to run.
  - `endFrame()` handles zero-dimension textures without throwing and logs a "zero dimensions" warning.
  - `initialize()` returns `false` when shader/module creation fails and logs an error.

## Test Hygiene / Commit-level Notes
- Tests wrap spy assertions in try/finally blocks so `mockRestore()` and `uninstallMockNavigatorGPU()` always run even if expectations throw, preventing spy leakage between tests.

## Impact
- Only test files and a minor JSDoc annotation were changed; no public API or runtime code behavior was modified.
- Increases unit-test statement coverage from 94.9% to 97.6%.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->