### PR TITLE
feat(renderer): add frame capture to PNG via GPU readback

### DIFF
--- a/src/BlitTech.ts
+++ b/src/BlitTech.ts
@@ -430,6 +430,49 @@ export const BT = {
 
     // #endregion
 
+    // #region Frame Capture
+
+    /**
+     * Captures the next rendered frame as a PNG blob.
+     * The capture happens on the next render cycle after this call.
+     *
+     * @returns Promise resolving to a PNG Blob of the rendered frame.
+     *
+     * @example
+     * const blob = await BT.captureFrame();
+     * const url = URL.createObjectURL(blob);
+     * console.log('Captured frame:', url);
+     */
+    captureFrame: async (): Promise<Blob> => {
+        return await BTAPI.instance.captureFrame();
+    },
+
+    /**
+     * Captures the next rendered frame and triggers a browser file download.
+     * Convenience wrapper around captureFrame() that handles the download flow.
+     *
+     * @param filename - Download filename (defaults to "blit-tech-capture.png").
+     *
+     * @example
+     * // Download with default filename
+     * await BT.downloadFrame();
+     *
+     * // Download with custom filename
+     * await BT.downloadFrame('screenshot-001.png');
+     */
+    downloadFrame: async (filename: string = 'blit-tech-capture.png'): Promise<void> => {
+        const blob = await BTAPI.instance.captureFrame();
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+
+        link.href = url;
+        link.download = filename;
+        link.click();
+        URL.revokeObjectURL(url);
+    },
+
+    // #endregion
+
     // #region Sprite Rendering
 
     /**

--- a/src/__test__/setup.ts
+++ b/src/__test__/setup.ts
@@ -17,6 +17,13 @@ if (typeof GPUBufferUsage === 'undefined') {
     };
 }
 
+if (typeof GPUMapMode === 'undefined') {
+    (globalThis as unknown as Record<string, unknown>).GPUMapMode = {
+        READ: 0x0001,
+        WRITE: 0x0002,
+    };
+}
+
 if (typeof GPUTextureUsage === 'undefined') {
     (globalThis as unknown as Record<string, unknown>).GPUTextureUsage = {
         COPY_SRC: 0x01,

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -399,6 +399,25 @@ export class BTAPI {
 
     // #endregion
 
+    // #region Frame Capture API
+
+    /**
+     * Captures the next rendered frame as a PNG blob.
+     * The capture occurs on the next render cycle.
+     *
+     * @returns Promise resolving to a PNG Blob.
+     * @throws Error if the renderer is not initialized.
+     */
+    public captureFrame(): Promise<Blob> {
+        if (!this.renderer) {
+            return Promise.reject(new Error('[BT] Cannot capture frame: renderer not initialized'));
+        }
+
+        return this.renderer.captureFrame();
+    }
+
+    // #endregion
+
     // #region Camera API
 
     /**

--- a/src/render/Renderer.test.ts
+++ b/src/render/Renderer.test.ts
@@ -234,6 +234,110 @@ describe('with initialized renderer', () => {
 
 // #endregion
 
+// #region Frame Capture
+
+describe('frame capture', () => {
+    it('captureFrame returns a promise', async () => {
+        const device = createMockGPUDevice();
+        const context = createMockGPUCanvasContext();
+        const renderer = new Renderer(device, context, new Vector2i(320, 240));
+
+        installMockNavigatorGPU();
+        await renderer.initialize();
+
+        const promise = renderer.captureFrame();
+        expect(promise).toBeInstanceOf(Promise);
+
+        uninstallMockNavigatorGPU();
+    });
+
+    it('endFrame triggers capture when pending', async () => {
+        const copyTextureToBufferFn = vi.fn();
+        const device = createMockGPUDevice();
+
+        // Override createCommandEncoder to include copyTextureToBuffer.
+        const originalCreate = device.createCommandEncoder.bind(device);
+        vi.spyOn(device, 'createCommandEncoder').mockImplementation(() => {
+            const encoder = originalCreate();
+            (encoder as unknown as Record<string, unknown>).copyTextureToBuffer = copyTextureToBufferFn;
+
+            return encoder;
+        });
+
+        const context = createMockGPUCanvasContext();
+        const renderer = new Renderer(device, context, new Vector2i(4, 4));
+
+        installMockNavigatorGPU();
+        await renderer.initialize();
+
+        // Stub browser APIs for PNG conversion.
+        vi.stubGlobal(
+            'ImageData',
+            class MockImageData {
+                constructor(
+                    public data: Uint8ClampedArray,
+                    public width: number,
+                    public height: number,
+                ) {}
+            },
+        );
+
+        vi.stubGlobal(
+            'OffscreenCanvas',
+            class MockOffscreenCanvas {
+                getContext(): { putImageData: ReturnType<typeof vi.fn> } {
+                    return { putImageData: vi.fn() };
+                }
+                async convertToBlob(): Promise<Blob> {
+                    return new Blob(['test'], { type: 'image/png' });
+                }
+            },
+        );
+
+        const capturePromise = renderer.captureFrame();
+
+        renderer.beginFrame();
+        renderer.endFrame();
+
+        const blob = await capturePromise;
+
+        expect(copyTextureToBufferFn).toHaveBeenCalledOnce();
+        expect(blob).toBeInstanceOf(Blob);
+        expect(blob.type).toBe('image/png');
+
+        vi.unstubAllGlobals();
+        uninstallMockNavigatorGPU();
+    });
+
+    it('endFrame does not call copyTextureToBuffer without pending capture', async () => {
+        const copyTextureToBufferFn = vi.fn();
+        const device = createMockGPUDevice();
+
+        const originalCreate = device.createCommandEncoder.bind(device);
+        vi.spyOn(device, 'createCommandEncoder').mockImplementation(() => {
+            const encoder = originalCreate();
+            (encoder as unknown as Record<string, unknown>).copyTextureToBuffer = copyTextureToBufferFn;
+
+            return encoder;
+        });
+
+        const context = createMockGPUCanvasContext();
+        const renderer = new Renderer(device, context, new Vector2i(320, 240));
+
+        installMockNavigatorGPU();
+        await renderer.initialize();
+
+        renderer.beginFrame();
+        renderer.endFrame();
+
+        expect(copyTextureToBufferFn).not.toHaveBeenCalled();
+
+        uninstallMockNavigatorGPU();
+    });
+});
+
+// #endregion
+
 // #region Error Paths
 
 describe('endFrame error paths', () => {

--- a/src/render/Renderer.test.ts
+++ b/src/render/Renderer.test.ts
@@ -239,15 +239,53 @@ describe('with initialized renderer', () => {
 describe('frame capture', () => {
     it('captureFrame returns a promise', async () => {
         const device = createMockGPUDevice();
+
+        // Add copyTextureToBuffer to mock command encoder.
+        const originalCreate = device.createCommandEncoder.bind(device);
+        vi.spyOn(device, 'createCommandEncoder').mockImplementation(() => {
+            const encoder = originalCreate();
+            (encoder as unknown as Record<string, unknown>).copyTextureToBuffer = vi.fn();
+
+            return encoder;
+        });
+
         const context = createMockGPUCanvasContext();
-        const renderer = new Renderer(device, context, new Vector2i(320, 240));
+        const renderer = new Renderer(device, context, new Vector2i(4, 4));
 
         installMockNavigatorGPU();
+
+        vi.stubGlobal(
+            'ImageData',
+            class MockImageData {
+                constructor(
+                    public data: Uint8ClampedArray,
+                    public width: number,
+                    public height: number,
+                ) {}
+            },
+        );
+
+        vi.stubGlobal(
+            'OffscreenCanvas',
+            class MockOffscreenCanvas {
+                getContext(): { putImageData: ReturnType<typeof vi.fn> } {
+                    return { putImageData: vi.fn() };
+                }
+                async convertToBlob(): Promise<Blob> {
+                    return new Blob(['test'], { type: 'image/png' });
+                }
+            },
+        );
+
         await renderer.initialize();
 
         const promise = renderer.captureFrame();
         expect(promise).toBeInstanceOf(Promise);
 
+        renderer.endFrame();
+        await promise;
+
+        vi.unstubAllGlobals();
         uninstallMockNavigatorGPU();
     });
 

--- a/src/render/Renderer.ts
+++ b/src/render/Renderer.ts
@@ -1,6 +1,7 @@
 import type { BitmapFont } from '../assets/BitmapFont';
 import type { SpriteSheet } from '../assets/SpriteSheet';
 import { Color32 } from '../utils/Color32';
+import { FrameCapture } from '../utils/FrameCapture';
 import type { Rect2i } from '../utils/Rect2i';
 import { Vector2i } from '../utils/Vector2i';
 import { PrimitivePipeline } from './PrimitivePipeline';
@@ -28,6 +29,9 @@ export class Renderer {
 
     /** Camera offset for scrolling effects. */
     private cameraOffset: Vector2i = Vector2i.zero();
+
+    /** Frame capture manager for PNG export. */
+    private readonly frameCapture = new FrameCapture();
 
     // #endregion
 
@@ -158,7 +162,20 @@ export class Renderer {
         this.sprites.encodePass(renderPass);
 
         renderPass.end();
+
+        // If a frame capture is pending, add the texture-to-buffer copy before submit.
+        const capturing = this.frameCapture.hasPendingCapture();
+
+        if (capturing) {
+            this.frameCapture.executeCaptureInEncoder(this.device, texture, commandEncoder);
+        }
+
         this.device.queue.submit([commandEncoder.finish()]);
+
+        // Resolve the capture asynchronously (does not block the game loop).
+        if (capturing) {
+            void this.frameCapture.resolveCapture(this.device);
+        }
 
         // Defensive reset so pipeline state is clean even if beginFrame() is not called next.
         // beginFrame() also resets; this prevents stale data from persisting across frames.
@@ -275,6 +292,21 @@ export class Renderer {
      */
     drawBitmapText(font: BitmapFont, pos: Vector2i, text: string, color: Color32 = Color32.white()): void {
         this.sprites.drawBitmapText(font, pos, text, color);
+    }
+
+    // #endregion
+
+    // #region Frame Capture
+
+    /**
+     * Captures the next rendered frame as a PNG blob.
+     * The capture happens on the next `endFrame()` call.
+     * If a capture is already pending, the previous one is rejected.
+     *
+     * @returns Promise resolving to a PNG Blob of the rendered frame.
+     */
+    captureFrame(): Promise<Blob> {
+        return this.frameCapture.requestCapture();
     }
 
     // #endregion

--- a/src/utils/FrameCapture.test.ts
+++ b/src/utils/FrameCapture.test.ts
@@ -224,13 +224,38 @@ describe('FrameCapture', () => {
         expect(result.type).toBe('image/png');
     });
 
-    it('should detect BGRA format from texture', () => {
+    it('should swizzle BGRA pixels to RGBA during resolve', async () => {
         const capture = new FrameCapture();
-
-        void capture.requestCapture();
+        const capturePromise = capture.requestCapture();
 
         const device = createMockGPUDevice();
         const bgraTexture = { ...createMockGPUTexture(4, 4), format: 'bgra8unorm' } as unknown as GPUTexture;
+
+        // Prepare a buffer with known BGRA pixel data.
+        const paddedBytesPerRow = alignedBytesPerRow(4);
+        const bufferSize = paddedBytesPerRow * 4;
+        const pixelBuffer = new ArrayBuffer(bufferSize);
+        const view = new Uint8Array(pixelBuffer);
+
+        // Fill first pixel of each row with BGRA = [10, 20, 30, 255].
+        for (let y = 0; y < 4; y++) {
+            const offset = y * paddedBytesPerRow;
+            // eslint-disable-next-line security/detect-object-injection -- typed array indexed by loop counter
+            view[offset] = 10; // B
+            view[offset + 1] = 20; // G
+            view[offset + 2] = 30; // R
+            view[offset + 3] = 255; // A
+        }
+
+        // Override createBuffer to return a buffer with our pixel data.
+        const originalCreateBuffer = device.createBuffer.bind(device);
+        vi.spyOn(device, 'createBuffer').mockImplementation((desc: GPUBufferDescriptor) => {
+            const buf = originalCreateBuffer(desc);
+            (buf as unknown as Record<string, unknown>).getMappedRange = () => pixelBuffer;
+
+            return buf;
+        });
+
         const encoder = {
             ...device.createCommandEncoder(),
             copyTextureToBuffer: vi.fn(),
@@ -238,9 +263,53 @@ describe('FrameCapture', () => {
 
         capture.executeCaptureInEncoder(device, bgraTexture, encoder);
 
-        // The BGRA flag is stored internally -- we verify it indirectly
-        // through the resolveCapture flow. For now, just verify no error.
-        expect(capture.hasPendingCapture()).toBe(true);
+        // Capture the pixel data passed to ImageData to verify swizzle.
+        let capturedPixels: Uint8ClampedArray | null = null;
+
+        vi.stubGlobal(
+            'ImageData',
+            class MockImageData {
+                constructor(
+                    public data: Uint8ClampedArray,
+                    public width: number,
+                    public height: number,
+                ) {
+                    capturedPixels = data;
+                }
+            },
+        );
+
+        vi.stubGlobal(
+            'OffscreenCanvas',
+            class MockOffscreenCanvas {
+                getContext(): { putImageData: ReturnType<typeof vi.fn> } {
+                    return { putImageData: vi.fn() };
+                }
+                async convertToBlob(): Promise<Blob> {
+                    return new Blob(['png'], { type: 'image/png' });
+                }
+            },
+        );
+
+        await capture.resolveCapture(device);
+        await capturePromise;
+
+        expect(capture.hasPendingCapture()).toBe(false);
+        expect(capturedPixels).not.toBeNull();
+
+        // After swizzle, first pixel of each row should be RGBA = [30, 20, 10, 255].
+        const pixels = capturedPixels!;
+
+        for (let y = 0; y < 4; y++) {
+            const offset = y * 4 * 4; // 4 pixels per row, 4 bytes per pixel (no padding in output)
+            // eslint-disable-next-line security/detect-object-injection -- typed array indexed by loop counter
+            expect(pixels[offset]).toBe(30); // R (was B=10, swapped with R=30)
+            expect(pixels[offset + 1]).toBe(20); // G (unchanged)
+            expect(pixels[offset + 2]).toBe(10); // B (was R=30, swapped with B=10)
+            expect(pixels[offset + 3]).toBe(255); // A (unchanged)
+        }
+
+        vi.unstubAllGlobals();
     });
 
     it('should not throw when resolveCapture is called without pending capture', async () => {

--- a/src/utils/FrameCapture.test.ts
+++ b/src/utils/FrameCapture.test.ts
@@ -1,0 +1,254 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createMockGPUDevice, createMockGPUTexture } from '../__test__/webgpu-mock';
+import { alignedBytesPerRow, FrameCapture, swizzleBGRAtoRGBA } from './FrameCapture';
+
+// #region Browser API Mocks
+
+/**
+ * Installs browser-only globals (ImageData, OffscreenCanvas) that don't exist in Node.js.
+ * Call in beforeEach for tests that exercise the full capture-to-PNG flow.
+ */
+function installBrowserMocks(): void {
+    const mockBlob = new Blob(['png-data'], { type: 'image/png' });
+
+    // Use classes so they work with `new`.
+    vi.stubGlobal(
+        'ImageData',
+        class MockImageData {
+            data: Uint8ClampedArray;
+            width: number;
+            height: number;
+            constructor(data: Uint8ClampedArray, width: number, height: number) {
+                this.data = data;
+                this.width = width;
+                this.height = height;
+            }
+        },
+    );
+
+    vi.stubGlobal(
+        'OffscreenCanvas',
+        class MockOffscreenCanvas {
+            getContext(): { putImageData: ReturnType<typeof vi.fn> } {
+                return { putImageData: vi.fn() };
+            }
+            async convertToBlob(): Promise<Blob> {
+                return mockBlob;
+            }
+        },
+    );
+}
+
+// #endregion
+
+// #region alignedBytesPerRow
+
+describe('alignedBytesPerRow', () => {
+    it('should return 256 for widths up to 64 pixels', () => {
+        // 64 * 4 = 256, which is already aligned.
+        expect(alignedBytesPerRow(1)).toBe(256);
+        expect(alignedBytesPerRow(32)).toBe(256);
+        expect(alignedBytesPerRow(64)).toBe(256);
+    });
+
+    it('should round up to next 256 boundary', () => {
+        // 65 * 4 = 260 -> next 256 multiple = 512
+        expect(alignedBytesPerRow(65)).toBe(512);
+        // 128 * 4 = 512 -> already aligned
+        expect(alignedBytesPerRow(128)).toBe(512);
+        // 320 * 4 = 1280 -> next 256 multiple = 1280 (already aligned)
+        expect(alignedBytesPerRow(320)).toBe(1280);
+    });
+
+    it('should handle typical retro resolutions', () => {
+        // 160 * 4 = 640 -> next 256 = 768
+        expect(alignedBytesPerRow(160)).toBe(768);
+        // 240 * 4 = 960 -> next 256 = 1024
+        expect(alignedBytesPerRow(240)).toBe(1024);
+        // 256 * 4 = 1024 -> already aligned
+        expect(alignedBytesPerRow(256)).toBe(1024);
+    });
+});
+
+// #endregion
+
+// #region swizzleBGRAtoRGBA
+
+describe('swizzleBGRAtoRGBA', () => {
+    it('should swap B and R channels', () => {
+        // BGRA: B=10, G=20, R=30, A=40
+        const data = new Uint8ClampedArray([10, 20, 30, 40]);
+
+        swizzleBGRAtoRGBA(data);
+
+        // RGBA: R=30, G=20, B=10, A=40
+        expect(data[0]).toBe(30);
+        expect(data[1]).toBe(20);
+        expect(data[2]).toBe(10);
+        expect(data[3]).toBe(40);
+    });
+
+    it('should handle multiple pixels', () => {
+        const data = new Uint8ClampedArray([
+            255,
+            0,
+            0,
+            255, // Pixel 1: BGRA (blue)
+            0,
+            255,
+            0,
+            255, // Pixel 2: BGRA (green)
+        ]);
+
+        swizzleBGRAtoRGBA(data);
+
+        // Pixel 1: RGBA (blue channel stays, red channel swapped)
+        expect(data[0]).toBe(0); // R (was B=255, now R from position 2)
+        expect(data[2]).toBe(255); // B (was R=0, now B from position 0)
+        // Pixel 2: green channel unchanged
+        expect(data[4]).toBe(0);
+        expect(data[5]).toBe(255);
+        expect(data[6]).toBe(0);
+    });
+
+    it('should handle empty array', () => {
+        const data = new Uint8ClampedArray([]);
+
+        swizzleBGRAtoRGBA(data);
+
+        expect(data.length).toBe(0);
+    });
+});
+
+// #endregion
+
+// #region FrameCapture
+
+describe('FrameCapture', () => {
+    beforeEach(() => {
+        installBrowserMocks();
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('should start with no pending capture', () => {
+        const capture = new FrameCapture();
+
+        expect(capture.hasPendingCapture()).toBe(false);
+    });
+
+    it('should set pending flag after requestCapture', () => {
+        const capture = new FrameCapture();
+
+        // Don't await -- just queue the request.
+        void capture.requestCapture();
+
+        expect(capture.hasPendingCapture()).toBe(true);
+    });
+
+    it('should reject previous capture when a new one is requested', async () => {
+        const capture = new FrameCapture();
+
+        const firstCapture = capture.requestCapture();
+
+        void capture.requestCapture();
+
+        await expect(firstCapture).rejects.toThrow('superseded');
+    });
+
+    it('should clear pending flag after resolveCapture', async () => {
+        const capture = new FrameCapture();
+
+        void capture.requestCapture();
+
+        expect(capture.hasPendingCapture()).toBe(true);
+
+        const device = createMockGPUDevice();
+        const texture = createMockGPUTexture(4, 4);
+        const encoder = device.createCommandEncoder();
+
+        // Add copyTextureToBuffer to mock encoder.
+        (encoder as unknown as Record<string, unknown>).copyTextureToBuffer = vi.fn();
+
+        capture.executeCaptureInEncoder(device, texture, encoder as unknown as GPUCommandEncoder);
+
+        await capture.resolveCapture(device);
+
+        expect(capture.hasPendingCapture()).toBe(false);
+    });
+
+    it('should call copyTextureToBuffer in executeCaptureInEncoder', () => {
+        const capture = new FrameCapture();
+
+        void capture.requestCapture();
+
+        const device = createMockGPUDevice();
+        const texture = createMockGPUTexture(320, 240);
+        const copyFn = vi.fn();
+        const encoder = {
+            ...device.createCommandEncoder(),
+            copyTextureToBuffer: copyFn,
+        } as unknown as GPUCommandEncoder;
+
+        capture.executeCaptureInEncoder(device, texture, encoder);
+
+        expect(copyFn).toHaveBeenCalledOnce();
+
+        // Verify the buffer destination has aligned bytesPerRow.
+        const destArg = copyFn.mock.calls[0]?.[1] as { bytesPerRow: number };
+
+        expect(destArg.bytesPerRow).toBe(alignedBytesPerRow(320));
+    });
+
+    it('should resolve with a Blob on successful capture', async () => {
+        const capture = new FrameCapture();
+        const capturePromise = capture.requestCapture();
+
+        const device = createMockGPUDevice();
+        const texture = createMockGPUTexture(4, 4);
+        const encoder = {
+            ...device.createCommandEncoder(),
+            copyTextureToBuffer: vi.fn(),
+        } as unknown as GPUCommandEncoder;
+
+        capture.executeCaptureInEncoder(device, texture, encoder);
+
+        await capture.resolveCapture(device);
+
+        const result = await capturePromise;
+
+        expect(result).toBeInstanceOf(Blob);
+        expect(result.type).toBe('image/png');
+    });
+
+    it('should detect BGRA format from texture', () => {
+        const capture = new FrameCapture();
+
+        void capture.requestCapture();
+
+        const device = createMockGPUDevice();
+        const bgraTexture = { ...createMockGPUTexture(4, 4), format: 'bgra8unorm' } as unknown as GPUTexture;
+        const encoder = {
+            ...device.createCommandEncoder(),
+            copyTextureToBuffer: vi.fn(),
+        } as unknown as GPUCommandEncoder;
+
+        capture.executeCaptureInEncoder(device, bgraTexture, encoder);
+
+        // The BGRA flag is stored internally -- we verify it indirectly
+        // through the resolveCapture flow. For now, just verify no error.
+        expect(capture.hasPendingCapture()).toBe(true);
+    });
+
+    it('should not throw when resolveCapture is called without pending capture', async () => {
+        const capture = new FrameCapture();
+        const device = createMockGPUDevice();
+
+        await expect(capture.resolveCapture(device)).resolves.toBeUndefined();
+    });
+});
+
+// #endregion

--- a/src/utils/FrameCapture.ts
+++ b/src/utils/FrameCapture.ts
@@ -1,0 +1,248 @@
+/**
+ * GPU frame capture utility for Blit-Tech.
+ * Captures the rendered frame from a WebGPU texture to a PNG blob
+ * using GPU readback (copyTextureToBuffer + mapAsync).
+ */
+
+// #region Constants
+
+/** WebGPU requires buffer row byte alignment to be a multiple of this value. */
+const BYTES_PER_ROW_ALIGNMENT = 256;
+
+/** Bytes per pixel for RGBA/BGRA 8-bit formats. */
+const BYTES_PER_PIXEL = 4;
+
+// #endregion
+
+// #region Pending Capture State
+
+/** Resolve function for the pending capture promise. */
+type CaptureResolve = (blob: Blob) => void;
+
+/** Reject function for the pending capture promise. */
+type CaptureReject = (reason: Error) => void;
+
+// #endregion
+
+// #region Helper Functions
+
+/**
+ * Calculates the aligned bytes-per-row for a given pixel width.
+ * WebGPU requires `bytesPerRow` in copyTextureToBuffer to be a multiple of 256.
+ *
+ * @param width - Width in pixels.
+ * @returns Aligned bytes per row.
+ */
+export function alignedBytesPerRow(width: number): number {
+    const unaligned = width * BYTES_PER_PIXEL;
+
+    return Math.ceil(unaligned / BYTES_PER_ROW_ALIGNMENT) * BYTES_PER_ROW_ALIGNMENT;
+}
+
+/**
+ * Swizzles BGRA pixel data to RGBA in place.
+ * Many platforms use `bgra8unorm` as the preferred canvas format.
+ *
+ * @param data - Pixel data buffer (modified in place).
+ */
+export function swizzleBGRAtoRGBA(data: Uint8ClampedArray): void {
+    for (let i = 0; i < data.length; i += BYTES_PER_PIXEL) {
+        // eslint-disable-next-line security/detect-object-injection -- typed array indexed by loop counter
+        const b = data[i] ?? 0;
+        const r = data[i + 2] ?? 0;
+
+        // eslint-disable-next-line security/detect-object-injection -- typed array indexed by loop counter
+        data[i] = r;
+        data[i + 2] = b;
+    }
+}
+
+/**
+ * Converts raw pixel data from a GPU readback buffer into a PNG Blob.
+ * Handles row padding removal and BGRA-to-RGBA swizzle.
+ *
+ * @param buffer - Mapped GPU buffer containing pixel data.
+ * @param width - Image width in pixels.
+ * @param height - Image height in pixels.
+ * @param paddedBytesPerRow - Aligned bytes per row (may include padding).
+ * @param isBGRA - Whether the source format is BGRA (needs swizzle).
+ * @returns Promise resolving to a PNG Blob.
+ */
+export async function pixelBufferToPNG(
+    buffer: ArrayBuffer,
+    width: number,
+    height: number,
+    paddedBytesPerRow: number,
+    isBGRA: boolean,
+): Promise<Blob> {
+    const actualBytesPerRow = width * BYTES_PER_PIXEL;
+    const pixels = new Uint8ClampedArray(width * height * BYTES_PER_PIXEL);
+    const source = new Uint8Array(buffer);
+
+    // Copy rows, stripping any padding bytes.
+    for (let y = 0; y < height; y++) {
+        const srcOffset = y * paddedBytesPerRow;
+        const dstOffset = y * actualBytesPerRow;
+
+        pixels.set(source.subarray(srcOffset, srcOffset + actualBytesPerRow), dstOffset);
+    }
+
+    if (isBGRA) {
+        swizzleBGRAtoRGBA(pixels);
+    }
+
+    const imageData = new ImageData(pixels, width, height);
+    const offscreen = new OffscreenCanvas(width, height);
+    const ctx = offscreen.getContext('2d');
+
+    if (!ctx) {
+        throw new Error('[FrameCapture] Failed to create 2D context on OffscreenCanvas');
+    }
+
+    ctx.putImageData(imageData, 0, 0);
+
+    return await offscreen.convertToBlob({ type: 'image/png' });
+}
+
+// #endregion
+
+// #region FrameCapture Class
+
+/**
+ * Manages deferred frame capture from a WebGPU render target.
+ * Call `requestCapture()` to queue a capture, then integrate with the
+ * renderer's `endFrame()` to execute the GPU readback.
+ */
+export class FrameCapture {
+    /** Resolve callback for the pending capture. */
+    private pendingResolve: CaptureResolve | null = null;
+
+    /** Reject callback for the pending capture. */
+    private pendingReject: CaptureReject | null = null;
+
+    /** Staging buffer for GPU-to-CPU readback. */
+    private stagingBuffer: GPUBuffer | null = null;
+
+    /** Width of the captured frame. */
+    private captureWidth = 0;
+
+    /** Height of the captured frame. */
+    private captureHeight = 0;
+
+    /** Padded bytes per row used in the staging buffer. */
+    private paddedBytesPerRow = 0;
+
+    /** Whether the source format is BGRA. */
+    private isBGRA = false;
+
+    /**
+     * Returns true if a capture is queued and waiting for the next frame.
+     *
+     * @returns True if a capture request is pending.
+     */
+    hasPendingCapture(): boolean {
+        return this.pendingResolve !== null;
+    }
+
+    /**
+     * Queues a capture for the next rendered frame.
+     * If a capture is already pending, the previous one is rejected.
+     *
+     * @returns Promise resolving to the captured PNG Blob.
+     */
+    requestCapture(): Promise<Blob> {
+        if (this.pendingResolve) {
+            this.pendingReject?.(new Error('[FrameCapture] Capture superseded by a new request'));
+            this.cleanup();
+        }
+
+        return new Promise<Blob>((resolve, reject) => {
+            this.pendingResolve = resolve;
+            this.pendingReject = reject;
+        });
+    }
+
+    /**
+     * Adds a texture-to-buffer copy command to the given command encoder.
+     * Must be called after the render pass ends but before `device.queue.submit()`.
+     *
+     * @param device - WebGPU device for buffer creation.
+     * @param texture - The rendered canvas texture to capture.
+     * @param commandEncoder - Active command encoder to add the copy command to.
+     */
+    executeCaptureInEncoder(device: GPUDevice, texture: GPUTexture, commandEncoder: GPUCommandEncoder): void {
+        this.captureWidth = texture.width;
+        this.captureHeight = texture.height;
+        this.paddedBytesPerRow = alignedBytesPerRow(this.captureWidth);
+        this.isBGRA = texture.format === 'bgra8unorm';
+
+        const bufferSize = this.paddedBytesPerRow * this.captureHeight;
+
+        this.stagingBuffer = device.createBuffer({
+            label: 'Frame Capture Staging',
+            size: bufferSize,
+            usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+        });
+
+        commandEncoder.copyTextureToBuffer(
+            { texture },
+            { buffer: this.stagingBuffer, bytesPerRow: this.paddedBytesPerRow, rowsPerImage: this.captureHeight },
+            { width: this.captureWidth, height: this.captureHeight },
+        );
+    }
+
+    /**
+     * Maps the staging buffer, converts pixels to PNG, and resolves the pending promise.
+     * Call this after `device.queue.submit()`. This is async but does not block the game loop.
+     *
+     * @param device - WebGPU device (used for onSubmittedWorkDone).
+     */
+    async resolveCapture(device: GPUDevice): Promise<void> {
+        const resolve = this.pendingResolve;
+        const reject = this.pendingReject;
+        const buffer = this.stagingBuffer;
+
+        // Clear pending state immediately so the next frame is not affected.
+        this.pendingResolve = null;
+        this.pendingReject = null;
+        this.stagingBuffer = null;
+
+        if (!resolve || !reject || !buffer) {
+            return;
+        }
+
+        try {
+            await device.queue.onSubmittedWorkDone();
+            await buffer.mapAsync(GPUMapMode.READ);
+
+            const data = buffer.getMappedRange();
+            const blob = await pixelBufferToPNG(
+                data,
+                this.captureWidth,
+                this.captureHeight,
+                this.paddedBytesPerRow,
+                this.isBGRA,
+            );
+
+            buffer.unmap();
+            buffer.destroy();
+            resolve(blob);
+        } catch (error) {
+            buffer.destroy();
+            reject(error instanceof Error ? error : new Error(String(error)));
+        }
+    }
+
+    /** Cleans up pending state without resolving or rejecting. */
+    private cleanup(): void {
+        this.pendingResolve = null;
+        this.pendingReject = null;
+
+        if (this.stagingBuffer) {
+            this.stagingBuffer.destroy();
+            this.stagingBuffer = null;
+        }
+    }
+}
+
+// #endregion


### PR DESCRIPTION
Add BT.captureFrame() and BT.downloadFrame() public API methods for
capturing the rendered frame as a PNG blob. Uses WebGPU
copyTextureToBuffer with a staging buffer for reliable pixel readback,
handling BGRA-to-RGBA swizzle and 256-byte row alignment.

- New FrameCapture utility class with deferred capture pattern
- Integrates into Renderer.endFrame() without blocking the game loop
- Wired through BTAPI to BT namespace with JSDoc and examples
- 14 unit tests covering alignment math, swizzle, and capture lifecycle
- Added GPUMapMode constants to test setup


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR adds GPU-backed frame capture to export rendered frames as PNGs. It exposes two public methods on the BT namespace—captureFrame() to obtain a Blob and downloadFrame() to trigger a browser download—and implements reliable WebGPU readback, BGRA→RGBA swizzle, and 256-byte row alignment via a new FrameCapture utility integrated into the renderer.

## Key Changes

### Public API
- BT.captureFrame(): Promise<Blob> — returns the next rendered frame as a PNG Blob.
- BT.downloadFrame(filename?): Promise<void> — captures the next frame and initiates a browser download (default filename "blit-tech-capture.png").

### Core Implementation
- New src/utils/FrameCapture.ts:
  - alignedBytesPerRow(width): computes WebGPU-compliant 256-byte aligned bytesPerRow.
  - swizzleBGRAtoRGBA(data): in-place BGRA→RGBA channel swap.
  - pixelBufferToPNG(...): strips per-row padding, creates an OffscreenCanvas/ImageData, and converts to PNG Blob.
  - FrameCapture class: manages deferred capture lifecycle with requestCapture(), executeCaptureInEncoder(), resolveCapture(), hasPendingCapture(), and supersession/cleanup behavior.
- Renderer integration:
  - Renderer holds a FrameCapture instance.
  - Renderer.captureFrame(): delegates to FrameCapture.requestCapture().
  - endFrame(): when a capture is pending, records a copyTextureToBuffer into the command encoder using a MAP_READ staging buffer and then asynchronously calls FrameCapture.resolveCapture() after submission so the capture resolution does not block the main loop.
- BTAPI.captureFrame(): forwards to renderer.captureFrame() and returns appropriate rejection when renderer is absent.
- BlitTech namespace (src/BlitTech.ts) gains BT.downloadFrame() and BT.captureFrame() wrappers with JSDoc and examples.

### GPU Pixel Handling Details
- Uses GPU copyTextureToBuffer into a staging MAP_READ GPUBuffer.
- Accounts for WebGPU-required row padding (256-byte alignment) when reading back pixels.
- Supports swizzling BGRA readback from formats like bgra8unorm into RGBA for image encoding.
- Converts mapped buffer to PNG via OffscreenCanvas.convertToBlob / ImageData.

### Tests and Test Infrastructure
- Adds comprehensive tests covering alignment math, BGRA→RGBA swizzle, FrameCapture lifecycle, encoder integration, and resolution flow:
  - src/utils/FrameCapture.test.ts (323 lines): tests alignedBytesPerRow, swizzleBGRAtoRGBA, FrameCapture request/resolve/supersede flows, executeCaptureInEncoder behavior, and BGRA→RGBA path with deterministic mock data.
  - src/render/Renderer.test.ts (475 lines): integration tests that assert captureFrame() returns a Promise, that a pending capture causes a single copyTextureToBuffer during endFrame(), and that a non-pending endFrame() does not invoke copyTextureToBuffer; mocks ImageData and OffscreenCanvas.convertToBlob for PNG path.
- Test setup shim:
  - src/__test__/setup.ts (35 lines): installs a GPUMapMode shim (READ/WRITE bitmask) for Node test environment compatibility.

## Files Modified / Added
- src/BlitTech.ts (530 lines)
- src/core/BTAPI.ts (450 lines)
- src/render/Renderer.ts (347 lines)
- src/render/Renderer.test.ts (475 lines)
- src/utils/FrameCapture.ts (248 lines) — new
- src/utils/FrameCapture.test.ts (323 lines) — new
- src/__test__/setup.ts (35 lines)

## Notes for Reviewers
- Pay attention to resource cleanup: MAP_READ buffer destruction and promise rejection on errors/supersession are implemented; verify there are no dangling buffers in error paths.
- The capture is intentionally deferred and resolved asynchronously after submit to avoid blocking the game loop—ensure this timing aligns with user expectations and existing render lifecycle.
- Tests include browser API mocks (ImageData, OffscreenCanvas.convertToBlob) and deterministic BGRA readback injection; validate mocks reflect intended runtime behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->