### PR TITLE
docs(core): improve WebGPUContext documentation and error messages

### DIFF
--- a/src/core/WebGPUContext.test.ts
+++ b/src/core/WebGPUContext.test.ts
@@ -1,3 +1,16 @@
+/**
+ * Unit tests for {@link initializeWebGPU}.
+ *
+ * Covers the WebGPU bootstrap path used during engine initialization:
+ * - graceful failure when WebGPU support, adapters, devices, or canvas context
+ *   creation are unavailable
+ * - successful device/context initialization with mocked GPU objects
+ * - canvas pixel sizing and optional CSS display sizing
+ *
+ * Browser GPU capabilities are simulated with the local WebGPU mock helpers so
+ * the suite can validate setup logic deterministically.
+ */
+
 import { afterEach, describe, expect, it } from 'vitest';
 
 import {
@@ -37,7 +50,9 @@ describe('initializeWebGPU', () => {
 
         try {
             delete nav.gpu;
+
             const result = await initializeWebGPU(canvas, displaySize);
+
             expect(result).toBeNull();
         } finally {
             if (originalGpu !== undefined) {
@@ -65,6 +80,7 @@ describe('initializeWebGPU', () => {
 
         const canvas = createMockCanvas();
         const result = await initializeWebGPU(canvas, displaySize);
+
         expect(result).toBeNull();
     });
 
@@ -87,6 +103,7 @@ describe('initializeWebGPU', () => {
 
         const canvas = createMockCanvas();
         const result = await initializeWebGPU(canvas, displaySize);
+
         expect(result).toBeNull();
     });
 
@@ -96,8 +113,10 @@ describe('initializeWebGPU', () => {
 
     it('should return null when canvas.getContext returns null', async () => {
         installMockNavigatorGPU();
+
         const canvas = createMockCanvas(null);
         const result = await initializeWebGPU(canvas, displaySize);
+
         expect(result).toBeNull();
     });
 
@@ -107,8 +126,11 @@ describe('initializeWebGPU', () => {
 
     it('should return device and context on success', async () => {
         installMockNavigatorGPU();
+
         const canvas = createMockCanvas();
+
         const result = await initializeWebGPU(canvas, displaySize);
+
         expect(result).not.toBeNull();
         expect(result?.device).toBeDefined();
         expect(result?.context).toBeDefined();
@@ -116,25 +138,34 @@ describe('initializeWebGPU', () => {
 
     it('should set canvas resolution from displaySize', async () => {
         installMockNavigatorGPU();
+
         const canvas = createMockCanvas();
+
         await initializeWebGPU(canvas, displaySize);
+
         expect(canvas.width).toBe(320);
         expect(canvas.height).toBe(240);
     });
 
     it('should set CSS size when canvasDisplaySize is provided', async () => {
         installMockNavigatorGPU();
+
         const canvas = createMockCanvas();
         const canvasDisplaySize = new Vector2i(640, 480);
+
         await initializeWebGPU(canvas, displaySize, canvasDisplaySize);
+
         expect(canvas.style.width).toBe('640px');
         expect(canvas.style.height).toBe('480px');
     });
 
     it('should not set CSS size when canvasDisplaySize is not provided', async () => {
         installMockNavigatorGPU();
+
         const canvas = createMockCanvas();
+
         await initializeWebGPU(canvas, displaySize);
+
         expect(canvas.style.width).toBe('');
         expect(canvas.style.height).toBe('');
     });

--- a/src/core/WebGPUContext.ts
+++ b/src/core/WebGPUContext.ts
@@ -3,7 +3,7 @@ import type { Vector2i } from '../utils/Vector2i';
 // #region Types
 
 /**
- * Result of a successful WebGPU context initialization.
+ * Result returned when WebGPU canvas initialization succeeds.
  */
 export interface WebGPUContextResult {
     /** Initialized WebGPU device. */
@@ -18,8 +18,11 @@ export interface WebGPUContextResult {
 // #region WebGPU Initialization
 
 /**
- * Initializes the WebGPU adapter, device, and canvas context.
- * Configures the canvas resolution and optional CSS display size for upscaling.
+ * Initializes the WebGPU adapter, device, and canvas context for a canvas.
+ *
+ * The function configures the canvas pixel resolution first, optionally applies
+ * a separate CSS display size, then configures the WebGPU context using the
+ * browser's preferred canvas format.
  *
  * @param canvas - HTML canvas element to configure for WebGPU rendering.
  * @param displaySize - Internal rendering resolution in pixels.
@@ -32,7 +35,7 @@ export async function initializeWebGPU(
     canvasDisplaySize?: Vector2i,
 ): Promise<WebGPUContextResult | null> {
     if (!navigator.gpu) {
-        console.error('[BT] WebGPU is not supported in this browser.');
+        console.error("[BT] WebGPU isn't supported in this browser.");
         console.error('[BT] Please use Chrome/Edge 113+ or Firefox Nightly with WebGPU enabled.');
         console.error('[BT] See: https://caniuse.com/webgpu');
 
@@ -45,9 +48,9 @@ export async function initializeWebGPU(
     if (!adapter) {
         console.error('[BT] Failed to get WebGPU adapter.');
         console.error('[BT] This could mean:');
-        console.error('[BT]   1. Your GPU/drivers are too old');
+        console.error('[BT]   1. The GPU/drivers are too old');
         console.error('[BT]   2. WebGPU is disabled in browser settings');
-        console.error('[BT]   3. Running in incompatible environment (VM, remote desktop, etc.)');
+        console.error('[BT]   3. Running in an incompatible environment (VM, remote desktop, etc.)');
         console.error('[BT] Browser:', navigator.userAgent);
 
         return null;


### PR DESCRIPTION
- Add comprehensive module documentation to test suite
- Expand JSDoc for initializeWebGPU function and result type
- Clarify canvas configuration and context initialization steps
- Add blank lines throughout tests for improved readability
- Refine error messages for consistency and clarity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Documentation and Error Message Improvements

### src/core/WebGPUContext.ts
Enhanced JSDoc documentation for better clarity and consistency:
- Updated `WebGPUContextResult` interface documentation to be more concise ("Result returned when WebGPU canvas initialization succeeds")
- Expanded `initializeWebGPU` function documentation with explicit details about the canvas configuration sequence: pixel resolution first, optional CSS display sizing next, then WebGPU context configuration using the browser's preferred format

Refined error messages for improved clarity:
- Changed "WebGPU is not supported" to "WebGPU isn't supported"
- Updated adapter failure hints: "Your GPU/drivers are too old" → "The GPU/drivers are too old" and "Running in incompatible environment" → "Running in an incompatible environment (VM, remote desktop, etc.)"

### src/core/WebGPUContext.test.ts
Added comprehensive module-level documentation describing the test suite's scope: coverage of the WebGPU bootstrap path, graceful failure scenarios, successful initialization, and canvas sizing configuration. Documentation also notes that browser GPU capabilities are simulated via local WebGPU mock helpers for deterministic validation.

Improved test readability by inserting blank lines between logical test operations throughout the suite. No changes to test logic, assertions, control flow, or mocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->