### PR TITLE
refactor(test): clean up webgpu mock definitions

### DIFF
--- a/src/__test__/webgpu-mock.ts
+++ b/src/__test__/webgpu-mock.ts
@@ -80,8 +80,8 @@ export function createMockGPUDevice(): GPUDevice {
         createBindGroup: () => ({ label: 'MockBindGroup' }) as unknown as GPUBindGroup,
         createSampler: () => ({ label: 'MockSampler' }) as unknown as GPUSampler,
         createTexture: (desc: GPUTextureDescriptor) => {
-            let width = 256;
-            let height = 256;
+            let width: number;
+            let height: number;
 
             if (typeof desc.size === 'number') {
                 width = desc.size;
@@ -128,7 +128,6 @@ export function createMockGPUDevice(): GPUDevice {
 export function createMockGPUCanvasContext(): GPUCanvasContext {
     return {
         configure: () => {},
-        unconfigure: () => {},
         getCurrentTexture: () => createMockGPUTexture(),
         canvas: {} as HTMLCanvasElement,
     } as unknown as GPUCanvasContext;
@@ -154,7 +153,7 @@ export function installMockNavigatorGPU(): void {
     };
 
     // Use Object.defineProperty to override navigator (may be a getter in Node.js).
-    const existingNav = typeof navigator !== 'undefined' ? navigator : {};
+    const existingNav = typeof navigator === 'undefined' ? {} : navigator;
     Object.defineProperty(globalThis, 'navigator', {
         value: { ...existingNav, gpu: mockGPU },
         writable: true,


### PR DESCRIPTION
- Add explicit type annotations to width/height variables
- Remove invalid unconfigure method from mock canvas context
- Simplify ternary condition in navigator check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Changes

This PR cleans up the WebGPU mock definitions in `src/__test__/webgpu-mock.ts` with three targeted improvements:

**1. Type annotations for texture dimensions**
- Added explicit `number` type annotations to `width` and `height` variables in `createMockGPUDevice().createTexture()`
- Variables are now properly typed before being populated from the descriptor's size property

**2. Removed invalid canvas context method**
- Eliminated the `unconfigure` method from the mock object returned by `createMockGPUCanvasContext()`
- This method was not part of the valid GPUCanvasContext API

**3. Simplified navigator configuration logic**
- Refactored `installMockNavigatorGPU()` to simplify the ternary condition
- Changed to use an empty object `{}` as the fallback when `navigator` is undefined, providing a cleaner spread source for defining `globalThis.navigator`

### Impact

Lines changed: +3/-4

These are internal test mock refinements with no impact on production code. The changes improve type safety and remove API compliance issues from the test infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->