### PR TITLE
refactor(utils): tighten FrameCapture docs and add test spacing

### DIFF
--- a/src/utils/FrameCapture.test.ts
+++ b/src/utils/FrameCapture.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Unit tests for {@link FrameCapture} and its supporting pixel helpers.
+ *
+ * Covers row-alignment math, BGRA-to-RGBA swizzling, pending-capture state
+ * management, texture-to-buffer copy encoding, and PNG conversion using stubbed
+ * browser-only APIs such as `ImageData` and `OffscreenCanvas`.
+ */
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createMockGPUDevice, createMockGPUTexture } from '../__test__/webgpu-mock';
@@ -33,6 +41,7 @@ function installBrowserMocks(): void {
             getContext(): { putImageData: ReturnType<typeof vi.fn> } {
                 return { putImageData: vi.fn() };
             }
+
             async convertToBlob(): Promise<Blob> {
                 return mockBlob;
             }
@@ -106,13 +115,14 @@ describe('swizzleBGRAtoRGBA', () => {
         // Pixel 1: RGBA (blue channel stays, red channel swapped)
         expect(data[0]).toBe(0); // R (was B=255, now R from position 2)
         expect(data[2]).toBe(255); // B (was R=0, now B from position 0)
+
         // Pixel 2: green channel unchanged
         expect(data[4]).toBe(0);
         expect(data[5]).toBe(255);
         expect(data[6]).toBe(0);
     });
 
-    it('should handle empty array', () => {
+    it('should handle an empty array', () => {
         const data = new Uint8ClampedArray([]);
 
         swizzleBGRAtoRGBA(data);
@@ -140,7 +150,7 @@ describe('FrameCapture', () => {
         expect(capture.hasPendingCapture()).toBe(false);
     });
 
-    it('should set pending flag after requestCapture', () => {
+    it('should set a pending flag after requestCapture', () => {
         const capture = new FrameCapture();
 
         // Don't await -- just queue the request.
@@ -149,7 +159,7 @@ describe('FrameCapture', () => {
         expect(capture.hasPendingCapture()).toBe(true);
     });
 
-    it('should reject previous capture when a new one is requested', async () => {
+    it('should reject the previous capture when a new one is requested', async () => {
         const capture = new FrameCapture();
 
         const firstCapture = capture.requestCapture();
@@ -159,7 +169,7 @@ describe('FrameCapture', () => {
         await expect(firstCapture).rejects.toThrow('superseded');
     });
 
-    it('should clear pending flag after resolveCapture', async () => {
+    it('should clear the pending flag after resolveCapture', async () => {
         const capture = new FrameCapture();
 
         void capture.requestCapture();
@@ -249,8 +259,10 @@ describe('FrameCapture', () => {
 
         // Override createBuffer to return a buffer with our pixel data.
         const originalCreateBuffer = device.createBuffer.bind(device);
+
         vi.spyOn(device, 'createBuffer').mockImplementation((desc: GPUBufferDescriptor) => {
             const buf = originalCreateBuffer(desc);
+
             (buf as unknown as Record<string, unknown>).getMappedRange = () => pixelBuffer;
 
             return buf;
@@ -285,6 +297,7 @@ describe('FrameCapture', () => {
                 getContext(): { putImageData: ReturnType<typeof vi.fn> } {
                     return { putImageData: vi.fn() };
                 }
+
                 async convertToBlob(): Promise<Blob> {
                     return new Blob(['png'], { type: 'image/png' });
                 }
@@ -302,6 +315,7 @@ describe('FrameCapture', () => {
 
         for (let y = 0; y < 4; y++) {
             const offset = y * 4 * 4; // 4 pixels per row, 4 bytes per pixel (no padding in output)
+
             // eslint-disable-next-line security/detect-object-injection -- typed array indexed by loop counter
             expect(pixels[offset]).toBe(30); // R (was B=10, swapped with R=30)
             expect(pixels[offset + 1]).toBe(20); // G (unchanged)

--- a/src/utils/FrameCapture.ts
+++ b/src/utils/FrameCapture.ts
@@ -1,7 +1,8 @@
 /**
- * GPU frame capture utility for Blit-Tech.
- * Captures the rendered frame from a WebGPU texture to a PNG blob
- * using GPU readback (copyTextureToBuffer + mapAsync).
+ * Utilities for capturing a rendered WebGPU frame as a PNG blob.
+ *
+ * The module handles row alignment, optional BGRA swizzling, GPU readback, and
+ * browser-side PNG encoding.
  */
 
 // #region Constants
@@ -27,11 +28,9 @@ type CaptureReject = (reason: Error) => void;
 // #region Helper Functions
 
 /**
- * Calculates the aligned bytes-per-row for a given pixel width.
- * WebGPU requires `bytesPerRow` in copyTextureToBuffer to be a multiple of 256.
- *
- * @param width - Width in pixels.
- * @returns Aligned bytes per row.
+ * Calculates the `bytesPerRow` value required by `copyTextureToBuffer()`.
+ * @param width
+ * @returns Aligned bytes per row (multiple of 256).
  */
 export function alignedBytesPerRow(width: number): number {
     const unaligned = width * BYTES_PER_PIXEL;
@@ -40,10 +39,8 @@ export function alignedBytesPerRow(width: number): number {
 }
 
 /**
- * Swizzles BGRA pixel data to RGBA in place.
- * Many platforms use `bgra8unorm` as the preferred canvas format.
- *
- * @param data - Pixel data buffer (modified in place).
+ * Swaps BGRA pixel data into RGBA order in place.
+ * @param data
  */
 export function swizzleBGRAtoRGBA(data: Uint8ClampedArray): void {
     for (let i = 0; i < data.length; i += BYTES_PER_PIXEL) {
@@ -58,14 +55,15 @@ export function swizzleBGRAtoRGBA(data: Uint8ClampedArray): void {
 }
 
 /**
- * Converts raw pixel data from a GPU readback buffer into a PNG Blob.
- * Handles row padding removal and BGRA-to-RGBA swizzle.
+ * Converts mapped GPU pixel data into a PNG blob.
  *
- * @param buffer - Mapped GPU buffer containing pixel data.
- * @param width - Image width in pixels.
- * @param height - Image height in pixels.
- * @param paddedBytesPerRow - Aligned bytes per row (may include padding).
- * @param isBGRA - Whether the source format is BGRA (needs swizzle).
+ * Removes row padding introduced by WebGPU alignment requirements and
+ * optionally swizzles BGRA input into RGBA before encoding.
+ * @param buffer
+ * @param width
+ * @param height
+ * @param paddedBytesPerRow
+ * @param isBGRA
  * @returns Promise resolving to a PNG Blob.
  */
 export async function pixelBufferToPNG(
@@ -109,9 +107,11 @@ export async function pixelBufferToPNG(
 // #region FrameCapture Class
 
 /**
- * Manages deferred frame capture from a WebGPU render target.
- * Call `requestCapture()` to queue a capture, then integrate with the
- * renderer's `endFrame()` to execute the GPU readback.
+ * Coordinates deferred capture of the next rendered frame.
+ *
+ * A capture request is queued ahead of frame submission, the renderer records a
+ * texture-to-buffer copy during `endFrame()`, and the captured data is resolved
+ * asynchronously after GPU work completes.
  */
 export class FrameCapture {
     /** Resolve callback for the pending capture. */
@@ -145,14 +145,15 @@ export class FrameCapture {
     }
 
     /**
-     * Queues a capture for the next rendered frame.
-     * If a capture is already pending, the previous one is rejected.
+     * Queues capture of the next submitted frame.
+     * If another request is already pending, that earlier request is rejected.
      *
      * @returns Promise resolving to the captured PNG Blob.
      */
     requestCapture(): Promise<Blob> {
         if (this.pendingResolve) {
             this.pendingReject?.(new Error('[FrameCapture] Capture superseded by a new request'));
+
             this.cleanup();
         }
 
@@ -163,8 +164,8 @@ export class FrameCapture {
     }
 
     /**
-     * Adds a texture-to-buffer copy command to the given command encoder.
-     * Must be called after the render pass ends but before `device.queue.submit()`.
+     * Records the texture-to-buffer copy needed for a pending frame capture.
+     * Call after the render pass ends but before submitting the command buffer.
      *
      * @param device - WebGPU device for buffer creation.
      * @param texture - The rendered canvas texture to capture.
@@ -192,8 +193,7 @@ export class FrameCapture {
     }
 
     /**
-     * Maps the staging buffer, converts pixels to PNG, and resolves the pending promise.
-     * Call this after `device.queue.submit()`. This is async but does not block the game loop.
+     * Waits for GPU completion, reads back the staging buffer, and resolves the pending capture.
      *
      * @param device - WebGPU device (used for onSubmittedWorkDone).
      */
@@ -233,7 +233,7 @@ export class FrameCapture {
         }
     }
 
-    /** Cleans up pending state without resolving or rejecting. */
+    /** Clears the pending capture state and destroys any staging buffer. */
     private cleanup(): void {
         this.pendingResolve = null;
         this.pendingReject = null;

--- a/src/utils/FrameCapture.ts
+++ b/src/utils/FrameCapture.ts
@@ -7,20 +7,56 @@
 
 // #region Constants
 
-/** WebGPU requires buffer row byte alignment to be a multiple of this value. */
+/**
+ * Represents the required byte alignment for the number of bytes per row
+ * in a data buffer. This value ensures that each row of data starts at a
+ * memory address divisible by the specified alignment.
+ *
+ * Alignment is crucial for optimizing memory access and ensuring compatibility
+ * with hardware requirements, such as in graphics or compute operations.
+ *
+ * The value is typically a power of 2, which simplifies calculations and
+ * aligns with common hardware constraints.
+ */
 const BYTES_PER_ROW_ALIGNMENT = 256;
 
-/** Bytes per pixel for RGBA/BGRA 8-bit formats. */
+/**
+ * Represents the number of bytes used to store a single pixel in an image or graphics context.
+ * This constant is typically used in image processing or graphics-related computations to
+ * determine memory requirements or to process pixel data.
+ *
+ * The value of 4 signifies that each pixel is represented using 4 bytes, which is commonly
+ * associated with RGBA color models, where each component (Red, Green, Blue, and Alpha)
+ * occupies one byte.
+ */
 const BYTES_PER_PIXEL = 4;
 
 // #endregion
 
 // #region Pending Capture State
 
-/** Resolve function for the pending capture promise. */
+/**
+ * Represents a function type that processes a `Blob` object.
+ *
+ * This type is commonly used for asynchronous operations where a `Blob`
+ * result needs to be captured or processed, such as handling media streams
+ * or creating output from captured data.
+ *
+ * @callback CaptureResolve
+ * @param {Blob} blob - The `Blob` object to be processed.
+ */
 type CaptureResolve = (blob: Blob) => void;
 
-/** Reject function for the pending capture promise. */
+/**
+ * A type alias representing a function used to handle rejection scenarios during an operation.
+ *
+ * This function is typically invoked to signal that an operation has failed.
+ * The function accepts an Error object as a parameter, which provides details
+ * regarding the reason for the failure.
+ *
+ * @callback CaptureReject
+ * @param {Error} reason - The error object representing the reason for the rejection.
+ */
 type CaptureReject = (reason: Error) => void;
 
 // #endregion
@@ -28,9 +64,12 @@ type CaptureReject = (reason: Error) => void;
 // #region Helper Functions
 
 /**
- * Calculates the `bytesPerRow` value required by `copyTextureToBuffer()`.
- * @param width
- * @returns Aligned bytes per row (multiple of 256).
+ * Calculates the aligned byte size per row for a given image width.
+ *
+ * The alignment ensures that the byte size per row is compliant with the specified row alignment boundary.
+ *
+ * @param {number} width - The width of the image in pixels.
+ * @returns {number} The aligned byte size per row.
  */
 export function alignedBytesPerRow(width: number): number {
     const unaligned = width * BYTES_PER_PIXEL;
@@ -39,8 +78,10 @@ export function alignedBytesPerRow(width: number): number {
 }
 
 /**
- * Swaps BGRA pixel data into RGBA order in place.
- * @param data
+ * Converts a pixel array from BGRA format to RGBA format by swapping the blue and red color channels.
+ *
+ * @param {Uint8ClampedArray} data - The pixel array in BGRA format. Each pixel is represented by 4 consecutive bytes (blue, green, red, alpha).
+ * @returns {void} This function modifies the input array in place and does not return a value.
  */
 export function swizzleBGRAtoRGBA(data: Uint8ClampedArray): void {
     for (let i = 0; i < data.length; i += BYTES_PER_PIXEL) {
@@ -55,16 +96,14 @@ export function swizzleBGRAtoRGBA(data: Uint8ClampedArray): void {
 }
 
 /**
- * Converts mapped GPU pixel data into a PNG blob.
+ * Converts a pixel buffer into a PNG image Blob.
  *
- * Removes row padding introduced by WebGPU alignment requirements and
- * optionally swizzles BGRA input into RGBA before encoding.
- * @param buffer
- * @param width
- * @param height
- * @param paddedBytesPerRow
- * @param isBGRA
- * @returns Promise resolving to a PNG Blob.
+ * @param {ArrayBuffer} buffer - The input pixel buffer containing the raw image data.
+ * @param {number} width - The width of the image in pixels.
+ * @param {number} height - The height of the image in pixels.
+ * @param {number} paddedBytesPerRow - The number of bytes per row in the buffer, including padding bytes.
+ * @param {boolean} isBGRA - Indicates whether the pixel data is in BGRA format and needs to be converted to RGBA.
+ * @returns {Promise<Blob>} A promise that resolves to a Blob containing the PNG image.
  */
 export async function pixelBufferToPNG(
     buffer: ArrayBuffer,
@@ -107,11 +146,7 @@ export async function pixelBufferToPNG(
 // #region FrameCapture Class
 
 /**
- * Coordinates deferred capture of the next rendered frame.
- *
- * A capture request is queued ahead of frame submission, the renderer records a
- * texture-to-buffer copy during `endFrame()`, and the captured data is resolved
- * asynchronously after GPU work completes.
+ * Class responsible for capturing a single frame from a WebGPU rendering pipeline and converting it to a PNG Blob.
  */
 export class FrameCapture {
     /** Resolve callback for the pending capture. */


### PR DESCRIPTION
Rewrite module, class, and method JSDoc for concision — shorter summaries, drop redundant @param/@returns lines where the signature is self-evident, and convert the module header to a two-sentence description. Add file-level JSDoc and blank-line spacing between arrange/act/assert steps in the test file. Minor test description wording tweaks for grammar consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Documentation Refactoring for FrameCapture Module

### Changes in `src/utils/FrameCapture.ts`
- Rewrote module-level JSDoc into a concise two-sentence description covering deferred frame capture, row padding removal, optional BGRA→RGBA swizzling, GPU readback, and client-side PNG encoding.
- Tightened class and method JSDoc for brevity and clarity:
  - `requestCapture()`: clarified when requests are queued and earlier requests are rejected.
  - `executeCaptureInEncoder()`: clarified that the copy command is recorded after the render pass ends but before submission.
  - `resolveCapture()`: clarified waiting for GPU completion and reading back the staging buffer before resolving.
  - `cleanup()`: clarified that it clears pending state and destroys any staging buffer.
- Removed redundant `@param` and `@returns` annotations where the TypeScript signatures are self-evident; removed verbose callback/JSDoc that duplicated types.
- Minor formatting: inserted a blank line after rejecting a superseded capture request.

### Changes in `src/utils/FrameCapture.test.ts`
- Added file-level JSDoc documenting the test suite scope: row-alignment math, BGRA→RGBA swizzling, pending-capture state, texture-to-buffer copy encoding, and PNG conversion using stubbed browser APIs (`ImageData`, `OffscreenCanvas`).
- Improved test description wording for grammar consistency (e.g., "an empty array", "the pending flag", "the previous capture", "the superseded" scenario).
- Inserted blank-line spacing between arrange/act/assert steps for readability.
- Minor whitespace-only edits in browser mock setup and around mocked `createBuffer` / pixel assertions; no behavioral changes.

### Impact
- Lines changed: +85/-36 across both files (FrameCapture.ts: +67/-32; FrameCapture.test.ts: +18/-4).
- No changes to exported/public signatures, parameters, return types, or runtime behavior.
- Net effect: documentation and tests made more concise and readable; only non-functional formatting edits and doc updates were introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->