### PR TITLE
refactor(utils): simplify Color32 docs and remove redundant bitwise truncation

### DIFF
--- a/src/utils/Color32.test.ts
+++ b/src/utils/Color32.test.ts
@@ -226,7 +226,7 @@ describe('fromUint32', () => {
     it('unpacks ABGR correctly', () => {
         // ABGR: A=255, B=0, G=0, R=255 -> opaque red
         const packed = (255 << 24) | 255;
-        const c = Color32.fromUint32(packed);
+        const c = Color32.fromUint32(packed >>> 0);
 
         expect(c.r).toBe(255);
         expect(c.g).toBe(0);

--- a/src/utils/Color32.test.ts
+++ b/src/utils/Color32.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Unit tests for {@link Color32} and its small helper exports.
+ *
+ * Covers byte clamping, constructor normalization, shared color singletons,
+ * factory methods, packing and unpacking, hex parsing, arithmetic helpers,
+ * interpolation, cloning, equality, and normalized float conversion behavior.
+ */
+
 import { describe, expect, it } from 'vitest';
 
 import { clampByte, Color32, INV_255 } from './Color32';
@@ -35,14 +43,16 @@ describe('clampByte', () => {
 describe('Color32 constructor', () => {
     it('defaults to white (255, 255, 255, 255)', () => {
         const c = new Color32();
+
         expect(c.r).toBe(255);
         expect(c.g).toBe(255);
         expect(c.b).toBe(255);
         expect(c.a).toBe(255);
     });
 
-    it('clamps values outside 0-255 range', () => {
+    it('clamps values outside the 0-255 range', () => {
         const c = new Color32(-10, 300, 128, 500);
+
         expect(c.r).toBe(0);
         expect(c.g).toBe(255);
         expect(c.b).toBe(128);
@@ -51,6 +61,7 @@ describe('Color32 constructor', () => {
 
     it('truncates float values to integers', () => {
         const c = new Color32(100.9, 200.1, 50.5, 128.7);
+
         expect(c.r).toBe(100);
         expect(c.g).toBe(200);
         expect(c.b).toBe(50);
@@ -65,6 +76,7 @@ describe('Color32 constructor', () => {
 describe('static color getters', () => {
     it('white() returns (255, 255, 255, 255)', () => {
         const w = Color32.white();
+
         expect(w.r).toBe(255);
         expect(w.g).toBe(255);
         expect(w.b).toBe(255);
@@ -73,6 +85,7 @@ describe('static color getters', () => {
 
     it('black() returns (0, 0, 0, 255)', () => {
         const b = Color32.black();
+
         expect(b.r).toBe(0);
         expect(b.g).toBe(0);
         expect(b.b).toBe(0);
@@ -81,6 +94,7 @@ describe('static color getters', () => {
 
     it('transparent() returns (0, 0, 0, 0)', () => {
         const t = Color32.transparent();
+
         expect(t.r).toBe(0);
         expect(t.g).toBe(0);
         expect(t.b).toBe(0);
@@ -89,6 +103,7 @@ describe('static color getters', () => {
 
     it('red() returns (255, 0, 0, 255)', () => {
         const c = Color32.red();
+
         expect(c.r).toBe(255);
         expect(c.g).toBe(0);
         expect(c.b).toBe(0);
@@ -97,6 +112,7 @@ describe('static color getters', () => {
 
     it('green() returns (0, 255, 0, 255)', () => {
         const c = Color32.green();
+
         expect(c.r).toBe(0);
         expect(c.g).toBe(255);
         expect(c.b).toBe(0);
@@ -105,6 +121,7 @@ describe('static color getters', () => {
 
     it('blue() returns (0, 0, 255, 255)', () => {
         const c = Color32.blue();
+
         expect(c.r).toBe(0);
         expect(c.g).toBe(0);
         expect(c.b).toBe(255);
@@ -113,6 +130,7 @@ describe('static color getters', () => {
 
     it('yellow() returns (255, 255, 0, 255)', () => {
         const c = Color32.yellow();
+
         expect(c.r).toBe(255);
         expect(c.g).toBe(255);
         expect(c.b).toBe(0);
@@ -121,6 +139,7 @@ describe('static color getters', () => {
 
     it('cyan() returns (0, 255, 255, 255)', () => {
         const c = Color32.cyan();
+
         expect(c.r).toBe(0);
         expect(c.g).toBe(255);
         expect(c.b).toBe(255);
@@ -129,6 +148,7 @@ describe('static color getters', () => {
 
     it('magenta() returns (255, 0, 255, 255)', () => {
         const c = Color32.magenta();
+
         expect(c.r).toBe(255);
         expect(c.g).toBe(0);
         expect(c.b).toBe(255);
@@ -161,6 +181,7 @@ describe('static color getters', () => {
 
     it('gray(128) returns (128, 128, 128, 255)', () => {
         const g = Color32.gray(128);
+
         expect(g.r).toBe(128);
         expect(g.g).toBe(128);
         expect(g.b).toBe(128);
@@ -169,6 +190,7 @@ describe('static color getters', () => {
 
     it('gray(0) returns black-like gray', () => {
         const g = Color32.gray(0);
+
         expect(g.r).toBe(0);
         expect(g.g).toBe(0);
         expect(g.b).toBe(0);
@@ -183,6 +205,7 @@ describe('static color getters', () => {
 describe('fromRGBAUnchecked', () => {
     it('creates color without clamping', () => {
         const c = Color32.fromRGBAUnchecked(100, 150, 200, 250);
+
         expect(c.r).toBe(100);
         expect(c.g).toBe(150);
         expect(c.b).toBe(200);
@@ -191,6 +214,7 @@ describe('fromRGBAUnchecked', () => {
 
     it('does not clamp out-of-range values', () => {
         const c = Color32.fromRGBAUnchecked(300, -10, 999, 0);
+
         expect(c.r).toBe(300);
         expect(c.g).toBe(-10);
         expect(c.b).toBe(999);
@@ -201,8 +225,9 @@ describe('fromRGBAUnchecked', () => {
 describe('fromUint32', () => {
     it('unpacks ABGR correctly', () => {
         // ABGR: A=255, B=0, G=0, R=255 -> opaque red
-        const packed = (255 << 24) | (0 << 16) | (0 << 8) | 255;
-        const c = Color32.fromUint32(packed >>> 0);
+        const packed = (255 << 24) | 255;
+        const c = Color32.fromUint32(packed);
+
         expect(c.r).toBe(255);
         expect(c.g).toBe(0);
         expect(c.b).toBe(0);
@@ -213,6 +238,7 @@ describe('fromUint32', () => {
         const original = new Color32(64, 128, 192, 240);
         const packed = original.toUint32();
         const unpacked = Color32.fromUint32(packed);
+
         expect(unpacked.r).toBe(64);
         expect(unpacked.g).toBe(128);
         expect(unpacked.b).toBe(192);
@@ -231,6 +257,7 @@ describe('fromHex', () => {
 
     it('parses #RGBA shorthand', () => {
         const c = Color32.fromHex('#F008');
+
         expect(c.r).toBe(255);
         expect(c.g).toBe(0);
         expect(c.b).toBe(0);
@@ -239,6 +266,7 @@ describe('fromHex', () => {
 
     it('parses #RRGGBB format', () => {
         const c = Color32.fromHex('#1A2B3C');
+
         expect(c.r).toBe(0x1a);
         expect(c.g).toBe(0x2b);
         expect(c.b).toBe(0x3c);
@@ -247,6 +275,7 @@ describe('fromHex', () => {
 
     it('parses #RRGGBBAA format', () => {
         const c = Color32.fromHex('#1A2B3C80');
+
         expect(c.r).toBe(0x1a);
         expect(c.g).toBe(0x2b);
         expect(c.b).toBe(0x3c);
@@ -255,6 +284,7 @@ describe('fromHex', () => {
 
     it('parses without leading #', () => {
         const c = Color32.fromHex('FF8000');
+
         expect(c.r).toBe(255);
         expect(c.g).toBe(128);
         expect(c.b).toBe(0);
@@ -271,6 +301,7 @@ describe('fromHex', () => {
 describe('fromFloat', () => {
     it('converts normalized floats to byte values', () => {
         const c = Color32.fromFloat(1.0, 0.5, 0.0);
+
         expect(c.r).toBe(255);
         expect(c.g).toBe(127);
         expect(c.b).toBe(0);
@@ -279,12 +310,14 @@ describe('fromFloat', () => {
 
     it('supports explicit alpha', () => {
         const c = Color32.fromFloat(0.0, 0.0, 0.0, 0.5);
+
         expect(c.r).toBe(0);
         expect(c.a).toBe(127);
     });
 
     it('clamps values outside 0.0-1.0 via constructor', () => {
         const c = Color32.fromFloat(2.0, -1.0, 0.5);
+
         expect(c.r).toBe(255);
         expect(c.g).toBe(0);
         expect(c.b).toBe(127);
@@ -294,6 +327,7 @@ describe('fromFloat', () => {
 describe('fromHSL', () => {
     it('converts red (0, 100, 50) to (255, 0, 0, 255)', () => {
         const c = Color32.fromHSL(0, 100, 50);
+
         expect(c.r).toBe(255);
         expect(c.g).toBe(0);
         expect(c.b).toBe(0);
@@ -302,6 +336,7 @@ describe('fromHSL', () => {
 
     it('converts green (120, 100, 50) to (0, 255, 0, 255)', () => {
         const c = Color32.fromHSL(120, 100, 50);
+
         expect(c.r).toBe(0);
         expect(c.g).toBe(255);
         expect(c.b).toBe(0);
@@ -310,6 +345,7 @@ describe('fromHSL', () => {
 
     it('converts gray (0, 0, 50) to ~(127, 127, 127, 255)', () => {
         const c = Color32.fromHSL(0, 0, 50);
+
         expect(c.r).toBe(127);
         expect(c.g).toBe(127);
         expect(c.b).toBe(127);
@@ -318,6 +354,7 @@ describe('fromHSL', () => {
 
     it('supports custom alpha', () => {
         const c = Color32.fromHSL(0, 100, 50, 128);
+
         expect(c.r).toBe(255);
         expect(c.a).toBe(128);
     });
@@ -331,6 +368,7 @@ describe('toFloat32Array', () => {
     it('returns 4-element Float32Array with values in [0, 1]', () => {
         const c = new Color32(255, 0, 128, 255);
         const arr = c.toFloat32Array();
+
         expect(arr).toBeInstanceOf(Float32Array);
         expect(arr.length).toBe(4);
         expect(arr[0]).toBeCloseTo(1.0, 3);
@@ -342,6 +380,7 @@ describe('toFloat32Array', () => {
     it('returns all zeros for transparent black', () => {
         const c = new Color32(0, 0, 0, 0);
         const arr = c.toFloat32Array();
+
         expect(arr[0]).toBeCloseTo(0.0, 5);
         expect(arr[1]).toBeCloseTo(0.0, 5);
         expect(arr[2]).toBeCloseTo(0.0, 5);
@@ -353,17 +392,21 @@ describe('writeToFloat32Array', () => {
     it('writes normalized values at default offset 0', () => {
         const c = new Color32(255, 128, 0, 255);
         const buf = new Float32Array(4);
+
         c.writeToFloat32Array(buf);
+
         expect(buf[0]).toBeCloseTo(1.0, 3);
         expect(buf[1]).toBeCloseTo(128 / 255, 3);
         expect(buf[2]).toBeCloseTo(0.0, 3);
         expect(buf[3]).toBeCloseTo(1.0, 3);
     });
 
-    it('writes at specified offset', () => {
+    it('writes at the specified offset', () => {
         const buf = new Float32Array(8);
         const c = new Color32(64, 128, 192, 255);
+
         c.writeToFloat32Array(buf, 4);
+
         expect(buf[0]).toBe(0);
         expect(buf[4]).toBeCloseTo(64 / 255, 3);
         expect(buf[5]).toBeCloseTo(128 / 255, 3);
@@ -373,9 +416,10 @@ describe('writeToFloat32Array', () => {
 });
 
 describe('toFloatRGBA', () => {
-    it('returns object with normalized r, g, b, a', () => {
+    it('returns the object with normalized r, g, b, a', () => {
         const c = new Color32(255, 0, 128, 64);
         const f = c.toFloatRGBA();
+
         expect(f.r).toBeCloseTo(1.0, 3);
         expect(f.g).toBeCloseTo(0.0, 3);
         expect(f.b).toBeCloseTo(128 / 255, 3);
@@ -384,6 +428,7 @@ describe('toFloatRGBA', () => {
 
     it('returns all ones for white', () => {
         const f = new Color32(255, 255, 255, 255).toFloatRGBA();
+
         expect(f.r).toBeCloseTo(1.0, 5);
         expect(f.g).toBeCloseTo(1.0, 5);
         expect(f.b).toBeCloseTo(1.0, 5);
@@ -395,6 +440,7 @@ describe('toUint32', () => {
     it('packs in ABGR format', () => {
         const c = new Color32(255, 0, 0, 255);
         const packed = c.toUint32();
+
         expect(packed & 0xff).toBe(255); // R
         expect((packed >>> 8) & 0xff).toBe(0); // G
         expect((packed >>> 16) & 0xff).toBe(0); // B
@@ -404,6 +450,7 @@ describe('toUint32', () => {
     it('roundtrips with fromUint32', () => {
         const c = new Color32(12, 34, 56, 78);
         const roundtripped = Color32.fromUint32(c.toUint32());
+
         expect(roundtripped.r).toBe(12);
         expect(roundtripped.g).toBe(34);
         expect(roundtripped.b).toBe(56);
@@ -414,16 +461,19 @@ describe('toUint32', () => {
 describe('toHex', () => {
     it('returns #rrggbbaa format', () => {
         const c = new Color32(255, 128, 0, 255);
+
         expect(c.toHex()).toBe('#ff8000ff');
     });
 
     it('pads single-digit hex values with zero', () => {
         const c = new Color32(0, 0, 0, 0);
+
         expect(c.toHex()).toBe('#00000000');
     });
 
     it('handles white correctly', () => {
         const c = new Color32(255, 255, 255, 255);
+
         expect(c.toHex()).toBe('#ffffffff');
     });
 });
@@ -431,17 +481,20 @@ describe('toHex', () => {
 describe('toCSS', () => {
     it('returns rgba() string with alpha as 0.0-1.0', () => {
         const c = new Color32(255, 128, 0, 255);
+
         expect(c.toCSS()).toBe('rgba(255, 128, 0, 1.000)');
     });
 
     it('formats zero alpha correctly', () => {
         const c = new Color32(0, 0, 0, 0);
+
         expect(c.toCSS()).toBe('rgba(0, 0, 0, 0.000)');
     });
 
     it('formats half alpha correctly', () => {
         const c = new Color32(100, 200, 50, 128);
         const css = c.toCSS();
+
         expect(css).toMatch(/^rgba\(100, 200, 50, 0\.50[0-9]\)$/);
     });
 });
@@ -449,6 +502,7 @@ describe('toCSS', () => {
 describe('toString', () => {
     it('returns Color32(r, g, b, a) format', () => {
         const c = new Color32(10, 20, 30, 40);
+
         expect(c.toString()).toBe('Color32(10, 20, 30, 40)');
     });
 
@@ -465,17 +519,20 @@ describe('equals', () => {
     it('returns true for identical colors', () => {
         const a = new Color32(10, 20, 30, 40);
         const b = new Color32(10, 20, 30, 40);
+
         expect(a.equals(b)).toBe(true);
     });
 
     it('returns false for different colors', () => {
         const a = new Color32(10, 20, 30, 40);
         const b = new Color32(10, 20, 30, 41);
+
         expect(a.equals(b)).toBe(false);
     });
 
     it('returns false for null or undefined', () => {
         const a = new Color32(10, 20, 30, 40);
+
         expect(a.equals(null as unknown as Color32)).toBe(false);
         expect(a.equals(undefined as unknown as Color32)).toBe(false);
     });
@@ -489,16 +546,19 @@ describe('clone', () => {
     it('creates an independent copy', () => {
         const original = new Color32(10, 20, 30, 40);
         const copy = original.clone();
+
         expect(copy.r).toBe(10);
         expect(copy.g).toBe(20);
         expect(copy.b).toBe(30);
         expect(copy.a).toBe(40);
     });
 
-    it('modifying clone does not affect original', () => {
+    it("modifying clone doesn't affect the original", () => {
         const original = new Color32(10, 20, 30, 40);
         const copy = original.clone();
+
         copy.r = 255;
+
         expect(original.r).toBe(10);
     });
 });
@@ -507,6 +567,7 @@ describe('withAlpha', () => {
     it('changes alpha only, preserving RGB', () => {
         const c = new Color32(10, 20, 30, 255);
         const result = c.withAlpha(128);
+
         expect(result.r).toBe(10);
         expect(result.g).toBe(20);
         expect(result.b).toBe(30);
@@ -515,12 +576,14 @@ describe('withAlpha', () => {
 
     it('clamps alpha value', () => {
         const c = new Color32(10, 20, 30, 255);
+
         expect(c.withAlpha(-10).a).toBe(0);
         expect(c.withAlpha(300).a).toBe(255);
     });
 
-    it('does not modify original', () => {
+    it('does not modify the original', () => {
         const c = new Color32(10, 20, 30, 255);
+
         c.withAlpha(0);
         expect(c.a).toBe(255);
     });
@@ -530,6 +593,7 @@ describe('withRGB', () => {
     it('changes RGB and keeps alpha', () => {
         const c = new Color32(10, 20, 30, 128);
         const result = c.withRGB(100, 200, 50);
+
         expect(result.r).toBe(100);
         expect(result.g).toBe(200);
         expect(result.b).toBe(50);
@@ -539,6 +603,7 @@ describe('withRGB', () => {
     it('clamps RGB values via constructor', () => {
         const c = new Color32(10, 20, 30, 128);
         const result = c.withRGB(-5, 300, 100);
+
         expect(result.r).toBe(0);
         expect(result.g).toBe(255);
         expect(result.b).toBe(100);
@@ -549,6 +614,7 @@ describe('invert', () => {
     it('inverts RGB channels (255 - value), keeps alpha', () => {
         const c = new Color32(0, 100, 255, 128);
         const inv = c.invert();
+
         expect(inv.r).toBe(255);
         expect(inv.g).toBe(155);
         expect(inv.b).toBe(0);
@@ -558,6 +624,7 @@ describe('invert', () => {
     it('double invert returns original values', () => {
         const c = new Color32(42, 99, 200, 180);
         const doubleInv = c.invert().invert();
+
         expect(doubleInv.r).toBe(42);
         expect(doubleInv.g).toBe(99);
         expect(doubleInv.b).toBe(200);
@@ -573,7 +640,9 @@ describe('lerp', () => {
     it('returns this color at t=0', () => {
         const a = new Color32(0, 0, 0, 255);
         const b = new Color32(255, 255, 255, 255);
+
         const result = a.lerp(b, 0);
+
         expect(result.r).toBe(0);
         expect(result.g).toBe(0);
         expect(result.b).toBe(0);
@@ -583,6 +652,7 @@ describe('lerp', () => {
         const a = new Color32(0, 0, 0, 255);
         const b = new Color32(255, 255, 255, 255);
         const result = a.lerp(b, 1);
+
         expect(result.r).toBe(255);
         expect(result.g).toBe(255);
         expect(result.b).toBe(255);
@@ -592,6 +662,7 @@ describe('lerp', () => {
         const a = new Color32(0, 0, 0, 0);
         const b = new Color32(200, 100, 50, 254);
         const result = a.lerp(b, 0.5);
+
         expect(result.r).toBe(100);
         expect(result.g).toBe(50);
         expect(result.b).toBe(25);
@@ -601,6 +672,7 @@ describe('lerp', () => {
     it('clamps t outside [0, 1]', () => {
         const a = new Color32(100, 100, 100, 255);
         const b = new Color32(200, 200, 200, 255);
+
         expect(a.lerp(b, -5).r).toBe(100);
         expect(a.lerp(b, 10).r).toBe(200);
     });
@@ -611,6 +683,7 @@ describe('lerpInPlace', () => {
         const a = new Color32(0, 0, 0, 0);
         const b = new Color32(200, 100, 50, 254);
         const returned = a.lerpInPlace(b, 0.5);
+
         expect(returned).toBe(a);
         expect(a.r).toBe(100);
         expect(a.g).toBe(50);
@@ -621,6 +694,7 @@ describe('lerpInPlace', () => {
     it('at t=0 keeps original values', () => {
         const a = new Color32(42, 84, 126, 200);
         a.lerpInPlace(new Color32(255, 255, 255, 255), 0);
+
         expect(a.r).toBe(42);
         expect(a.g).toBe(84);
         expect(a.b).toBe(126);
@@ -633,15 +707,17 @@ describe('multiply', () => {
         const a = new Color32(255, 128, 0, 255);
         const b = new Color32(128, 255, 255, 255);
         const result = a.multiply(b);
+
         // 255 * 128 / 255 = 128, 128 * 255 / 255 = 128, 0 * 255 / 255 = 0
         expect(result.r).toBe(128);
         expect(result.g).toBe(128);
         expect(result.b).toBe(0);
     });
 
-    it('multiplying by white returns same color', () => {
+    it('multiplying by white returns the same color', () => {
         const c = new Color32(100, 150, 200, 255);
         const result = c.multiply(new Color32(255, 255, 255, 255));
+
         expect(result.r).toBe(100);
         expect(result.g).toBe(150);
         expect(result.b).toBe(200);
@@ -650,6 +726,7 @@ describe('multiply', () => {
     it('multiplying by black returns black', () => {
         const c = new Color32(100, 150, 200, 255);
         const result = c.multiply(new Color32(0, 0, 0, 255));
+
         expect(result.r).toBe(0);
         expect(result.g).toBe(0);
         expect(result.b).toBe(0);
@@ -661,6 +738,7 @@ describe('multiplyInPlace', () => {
         const a = new Color32(255, 128, 64, 255);
         const b = new Color32(128, 128, 128, 255);
         const returned = a.multiplyInPlace(b);
+
         expect(returned).toBe(a);
         expect(a.r).toBe(128);
         expect(a.g).toBe(64);
@@ -673,15 +751,17 @@ describe('add', () => {
         const a = new Color32(200, 100, 50, 200);
         const b = new Color32(100, 200, 50, 100);
         const result = a.add(b);
+
         expect(result.r).toBe(255); // 200 + 100 = 300, clamped
         expect(result.g).toBe(255); // 100 + 200 = 300, clamped
         expect(result.b).toBe(100); // 50 + 50
         expect(result.a).toBe(255); // 200 + 100 = 300, clamped
     });
 
-    it('adding black returns same color', () => {
+    it('adding black returns the same color', () => {
         const c = new Color32(42, 84, 126, 200);
         const result = c.add(new Color32(0, 0, 0, 0));
+
         expect(result.r).toBe(42);
         expect(result.g).toBe(84);
         expect(result.b).toBe(126);
@@ -694,6 +774,7 @@ describe('addInPlace', () => {
         const a = new Color32(200, 100, 50, 128);
         const b = new Color32(100, 50, 25, 64);
         const returned = a.addInPlace(b);
+
         expect(returned).toBe(a);
         expect(a.r).toBe(255); // clamped
         expect(a.g).toBe(150);
@@ -706,6 +787,7 @@ describe('premultiplyAlpha', () => {
     it('multiplies RGB by alpha/255', () => {
         const c = new Color32(200, 100, 50, 128);
         const pm = c.premultiplyAlpha();
+
         // 200 * (128/255) ~= 100, 100 * (128/255) ~= 50, 50 * (128/255) ~= 25
         expect(pm.r).toBe(100);
         expect(pm.g).toBe(50);
@@ -716,6 +798,7 @@ describe('premultiplyAlpha', () => {
     it('fully opaque color is unchanged', () => {
         const c = new Color32(100, 150, 200, 255);
         const pm = c.premultiplyAlpha();
+
         expect(pm.r).toBe(100);
         expect(pm.g).toBe(150);
         expect(pm.b).toBe(200);
@@ -724,6 +807,7 @@ describe('premultiplyAlpha', () => {
     it('fully transparent color zeroes RGB', () => {
         const c = new Color32(200, 150, 100, 0);
         const pm = c.premultiplyAlpha();
+
         expect(pm.r).toBe(0);
         expect(pm.g).toBe(0);
         expect(pm.b).toBe(0);
@@ -739,6 +823,7 @@ describe('setRGBA', () => {
     it('sets all channels with clamping and returns this', () => {
         const c = new Color32(0, 0, 0, 0);
         const returned = c.setRGBA(300, -10, 128, 200);
+
         expect(returned).toBe(c);
         expect(c.r).toBe(255);
         expect(c.g).toBe(0);
@@ -748,7 +833,9 @@ describe('setRGBA', () => {
 
     it('truncates floats', () => {
         const c = new Color32();
+
         c.setRGBA(100.9, 50.1, 200.7, 128.3);
+
         expect(c.r).toBe(100);
         expect(c.g).toBe(50);
         expect(c.b).toBe(200);
@@ -760,6 +847,7 @@ describe('setRGBAUnchecked', () => {
     it('sets all channels without clamping and returns this', () => {
         const c = new Color32();
         const returned = c.setRGBAUnchecked(10, 20, 30, 40);
+
         expect(returned).toBe(c);
         expect(c.r).toBe(10);
         expect(c.g).toBe(20);
@@ -769,7 +857,9 @@ describe('setRGBAUnchecked', () => {
 
     it('does not clamp invalid values', () => {
         const c = new Color32();
+
         c.setRGBAUnchecked(300, -5, 1000, 0);
+
         expect(c.r).toBe(300);
         expect(c.g).toBe(-5);
     });
@@ -780,6 +870,7 @@ describe('copyFrom', () => {
         const source = new Color32(11, 22, 33, 44);
         const target = new Color32();
         const returned = target.copyFrom(source);
+
         expect(returned).toBe(target);
         expect(target.r).toBe(11);
         expect(target.g).toBe(22);
@@ -787,11 +878,14 @@ describe('copyFrom', () => {
         expect(target.a).toBe(44);
     });
 
-    it('is independent after copy (changing source does not affect target)', () => {
+    it("is independent after the copy (changing source doesn't affect target)", () => {
         const source = new Color32(11, 22, 33, 44);
         const target = new Color32();
+
         target.copyFrom(source);
+
         source.r = 255;
+
         expect(target.r).toBe(11);
     });
 });
@@ -803,11 +897,13 @@ describe('copyFrom', () => {
 describe('luminance', () => {
     it('returns approximately 1.0 for white', () => {
         const c = new Color32(255, 255, 255, 255);
+
         expect(c.luminance()).toBeCloseTo(1.0, 3);
     });
 
     it('returns approximately 0.0 for black', () => {
         const c = new Color32(0, 0, 0, 255);
+
         expect(c.luminance()).toBeCloseTo(0.0, 5);
     });
 
@@ -815,6 +911,7 @@ describe('luminance', () => {
         const r = new Color32(255, 0, 0, 255).luminance();
         const g = new Color32(0, 255, 0, 255).luminance();
         const b = new Color32(0, 0, 255, 255).luminance();
+
         // Green should have the highest luminance contribution
         expect(g).toBeGreaterThan(r);
         expect(g).toBeGreaterThan(b);

--- a/src/utils/Color32.ts
+++ b/src/utils/Color32.ts
@@ -401,7 +401,7 @@ export class Color32 {
     writeToFloat32Array(target: Float32Array, offset: number = 0): void {
         // Using direct index assignment for the best performance.
         // This is safe: offset is truncated to integer, the target is a typed Float32Array.
-        const i = offset;
+        const i = offset | 0;
 
         // eslint-disable-next-line security/detect-object-injection
         target[i] = this.r * INV_255;
@@ -555,10 +555,10 @@ export class Color32 {
         const oneMinusT = 1 - tc;
 
         return Color32.fromRGBAUnchecked(
-            this.r * oneMinusT + other.r * tc,
-            this.g * oneMinusT + other.g * tc,
-            this.b * oneMinusT + other.b * tc,
-            this.a * oneMinusT + other.a * tc,
+            (this.r * oneMinusT + other.r * tc) | 0,
+            (this.g * oneMinusT + other.g * tc) | 0,
+            (this.b * oneMinusT + other.b * tc) | 0,
+            (this.a * oneMinusT + other.a * tc) | 0,
         );
     }
 
@@ -575,10 +575,10 @@ export class Color32 {
 
         const oneMinusT = 1 - tc;
 
-        this.r = this.r * oneMinusT + other.r * tc;
-        this.g = this.g * oneMinusT + other.g * tc;
-        this.b = this.b * oneMinusT + other.b * tc;
-        this.a = this.a * oneMinusT + other.a * tc;
+        this.r = (this.r * oneMinusT + other.r * tc) | 0;
+        this.g = (this.g * oneMinusT + other.g * tc) | 0;
+        this.b = (this.b * oneMinusT + other.b * tc) | 0;
+        this.a = (this.a * oneMinusT + other.a * tc) | 0;
 
         return this;
     }
@@ -592,10 +592,10 @@ export class Color32 {
      */
     multiply(other: Color32): Color32 {
         return Color32.fromRGBAUnchecked(
-            this.r * other.r * INV_255,
-            this.g * other.g * INV_255,
-            this.b * other.b * INV_255,
-            this.a * other.a * INV_255,
+            (this.r * other.r * INV_255) | 0,
+            (this.g * other.g * INV_255) | 0,
+            (this.b * other.b * INV_255) | 0,
+            (this.a * other.a * INV_255) | 0,
         );
     }
 
@@ -607,10 +607,10 @@ export class Color32 {
      * @returns This color instance for chaining.
      */
     multiplyInPlace(other: Color32): this {
-        this.r = this.r * other.r * INV_255;
-        this.g = this.g * other.g * INV_255;
-        this.b = this.b * other.b * INV_255;
-        this.a = this.a * other.a * INV_255;
+        this.r = (this.r * other.r * INV_255) | 0;
+        this.g = (this.g * other.g * INV_255) | 0;
+        this.b = (this.b * other.b * INV_255) | 0;
+        this.a = (this.a * other.a * INV_255) | 0;
 
         return this;
     }
@@ -651,7 +651,12 @@ export class Color32 {
     premultiplyAlpha(): Color32 {
         const alphaMul = this.a * INV_255;
 
-        return Color32.fromRGBAUnchecked(this.r * alphaMul, this.g * alphaMul, this.b * alphaMul, this.a);
+        return Color32.fromRGBAUnchecked(
+            (this.r * alphaMul) | 0,
+            (this.g * alphaMul) | 0,
+            (this.b * alphaMul) | 0,
+            this.a,
+        );
     }
 
     // #endregion
@@ -747,7 +752,7 @@ export class Color32 {
 export function clampByte(n: number): number {
     // Bitwise operations: if n < 0, use 0; if n > 255, use 255; else truncate n.
     // This is faster than Math.max(0, Math.min(255, n)) | 0.
-    return n < 0 ? 0 : n > 255 ? 255 : n;
+    return n < 0 ? 0 : n > 255 ? 255 : n | 0;
 }
 
 // #endregion

--- a/src/utils/Color32.ts
+++ b/src/utils/Color32.ts
@@ -1,27 +1,18 @@
 /**
- * 32-bit RGBA color with 8-bit channels (0-255).
- * Inspired by RetroBlit's Color32.
+ * 32-bit RGBA color with 8-bit channels.
  *
- * Performance notes:
- * - Use static color constants like white or black—they return cached singletons.
- * - Use fromRGBAUnchecked() for trusted values in hot paths to skip validation.
- * - Use writeToFloat32Array() to write to pre-allocated buffers instead of allocating.
+ * The type provides cached singleton colors, packing and conversion helpers,
+ * and a mix of allocation-free and convenience APIs for renderer code.
  */
 
 // #region Constants
 
-/**
- * Reciprocal of 255 for fast normalization (1/255).
- * Multiplication is faster than division in most JavaScript engines.
- * Exported for use in other color-related utilities.
- */
+/** Reciprocal of 255 used for fast byte-to-float normalization. */
 export const INV_255 = 1 / 255;
 
-/**
- * Pre-computed hex lookup table for fast byte-to-hex conversion.
- * Trades ~2 KB memory for faster hex string generation.
- */
+/** Precomputed lookup table for byte-to-hex conversion. */
 const HEX_TABLE: string[] = new Array(256);
+
 for (let i = 0; i < 256; i++) {
     // eslint-disable-next-line security/detect-object-injection
     HEX_TABLE[i] = i.toString(16).padStart(2, '0');
@@ -31,10 +22,7 @@ for (let i = 0; i < 256; i++) {
 
 // #region Color32 Class
 
-/**
- * 32-bit RGBA color with 8-bit channels (0-255).
- * Provides comprehensive color manipulation and conversion utilities.
- */
+/** Mutable 32-bit RGBA color value with 8-bit channels. */
 export class Color32 {
     // #region Static Color Constants
 
@@ -86,8 +74,7 @@ export class Color32 {
     // #region Constructor
 
     /**
-     * Creates a new 32-bit RGBA color.
-     * All values are clamped to 0-255 range and truncated to integers.
+     * Creates a clamped 8-bit RGBA color.
      *
      * @param r - Red channel (0-255, defaults to 255).
      * @param g - Green channel (0-255, defaults to 255).
@@ -211,11 +198,10 @@ export class Color32 {
     // #region Static Factory Methods
 
     /**
-     * Creates a Color32 from RGBA values without validation or clamping.
-     * Use this in hot paths when values are guaranteed to be valid integers 0-255.
+     * Creates a color without clamping or validation.
      *
-     * WARNING: Passing invalid values will result in undefined behavior.
-     * Only use when certain the values are valid.
+     * Intended for trusted hot paths where channel values are already known to
+     * be valid byte-range numbers.
      *
      * @param r - Red channel (must be integer 0-255).
      * @param g - Green channel (must be integer 0-255).
@@ -225,6 +211,7 @@ export class Color32 {
      */
     static fromRGBAUnchecked(r: number, g: number, b: number, a: number): Color32 {
         const color = Object.create(Color32.prototype) as Color32;
+
         color.r = r;
         color.g = g;
         color.b = b;
@@ -250,8 +237,8 @@ export class Color32 {
     }
 
     /**
-     * Parses a CSS hex color string into a Color32.
-     * Supports formats: #RGB, #RGBA, #RRGGBB, #RRGGBBAA.
+     * Parses a CSS-style hex color string.
+     * Supports `#RGB`, `#RGBA`, `#RRGGBB`, and `#RRGGBBAA`.
      *
      * @param hex - Hex color string with or without leading #.
      * @returns Parsed color.
@@ -317,8 +304,7 @@ export class Color32 {
     }
 
     /**
-     * Creates a color from normalized float values (0.0-1.0 range).
-     * Useful when working with shader outputs or HDR values.
+     * Creates a color from normalized float components in the `0.0-1.0` range.
      *
      * @param r - Red channel (0.0-1.0).
      * @param g - Green channel (0.0-1.0).
@@ -331,8 +317,7 @@ export class Color32 {
     }
 
     /**
-     * Creates a color from HSL (Hue, Saturation, Lightness) values.
-     * Useful for generating colors based on color-wheel positions.
+     * Creates a color from HSL values.
      *
      * @param h - Hue in degrees (0-360).
      * @param s - Saturation as percentage (0-100).
@@ -416,7 +401,7 @@ export class Color32 {
     writeToFloat32Array(target: Float32Array, offset: number = 0): void {
         // Using direct index assignment for the best performance.
         // This is safe: offset is truncated to integer, the target is a typed Float32Array.
-        const i = offset | 0;
+        const i = offset;
 
         // eslint-disable-next-line security/detect-object-injection
         target[i] = this.r * INV_255;
@@ -570,10 +555,10 @@ export class Color32 {
         const oneMinusT = 1 - tc;
 
         return Color32.fromRGBAUnchecked(
-            (this.r * oneMinusT + other.r * tc) | 0,
-            (this.g * oneMinusT + other.g * tc) | 0,
-            (this.b * oneMinusT + other.b * tc) | 0,
-            (this.a * oneMinusT + other.a * tc) | 0,
+            this.r * oneMinusT + other.r * tc,
+            this.g * oneMinusT + other.g * tc,
+            this.b * oneMinusT + other.b * tc,
+            this.a * oneMinusT + other.a * tc,
         );
     }
 
@@ -590,10 +575,10 @@ export class Color32 {
 
         const oneMinusT = 1 - tc;
 
-        this.r = (this.r * oneMinusT + other.r * tc) | 0;
-        this.g = (this.g * oneMinusT + other.g * tc) | 0;
-        this.b = (this.b * oneMinusT + other.b * tc) | 0;
-        this.a = (this.a * oneMinusT + other.a * tc) | 0;
+        this.r = this.r * oneMinusT + other.r * tc;
+        this.g = this.g * oneMinusT + other.g * tc;
+        this.b = this.b * oneMinusT + other.b * tc;
+        this.a = this.a * oneMinusT + other.a * tc;
 
         return this;
     }
@@ -607,10 +592,10 @@ export class Color32 {
      */
     multiply(other: Color32): Color32 {
         return Color32.fromRGBAUnchecked(
-            (this.r * other.r * INV_255) | 0,
-            (this.g * other.g * INV_255) | 0,
-            (this.b * other.b * INV_255) | 0,
-            (this.a * other.a * INV_255) | 0,
+            this.r * other.r * INV_255,
+            this.g * other.g * INV_255,
+            this.b * other.b * INV_255,
+            this.a * other.a * INV_255,
         );
     }
 
@@ -622,10 +607,10 @@ export class Color32 {
      * @returns This color instance for chaining.
      */
     multiplyInPlace(other: Color32): this {
-        this.r = (this.r * other.r * INV_255) | 0;
-        this.g = (this.g * other.g * INV_255) | 0;
-        this.b = (this.b * other.b * INV_255) | 0;
-        this.a = (this.a * other.a * INV_255) | 0;
+        this.r = this.r * other.r * INV_255;
+        this.g = this.g * other.g * INV_255;
+        this.b = this.b * other.b * INV_255;
+        this.a = this.a * other.a * INV_255;
 
         return this;
     }
@@ -666,12 +651,7 @@ export class Color32 {
     premultiplyAlpha(): Color32 {
         const alphaMul = this.a * INV_255;
 
-        return Color32.fromRGBAUnchecked(
-            (this.r * alphaMul) | 0,
-            (this.g * alphaMul) | 0,
-            (this.b * alphaMul) | 0,
-            this.a,
-        );
+        return Color32.fromRGBAUnchecked(this.r * alphaMul, this.g * alphaMul, this.b * alphaMul, this.a);
     }
 
     // #endregion
@@ -767,7 +747,7 @@ export class Color32 {
 export function clampByte(n: number): number {
     // Bitwise operations: if n < 0, use 0; if n > 255, use 255; else truncate n.
     // This is faster than Math.max(0, Math.min(255, n)) | 0.
-    return n < 0 ? 0 : n > 255 ? 255 : n | 0;
+    return n < 0 ? 0 : n > 255 ? 255 : n;
 }
 
 // #endregion


### PR DESCRIPTION
Trim JSDoc to concise summaries — remove verbose @example blocks, inline performance annotations, and redundant class descriptions. Remove `| 0` integer truncation from lerp, lerpInPlace, multiply, multiplyInPlace, and premultiplyAlpha since channel values are already integers or the callers rely on clamping at constructor time. Drop the `>>> 0` unsigned-right-shift workaround in fromUint32 test. Add file-level JSDoc and blank-line spacing between arrange/act/assert steps throughout the test file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Simplify Color32 documentation and adjust bitwise truncation changes

This PR streamlines JSDoc for Color32 and modifies where bitwise integer truncation is applied, with accompanying test cleanup.

### Documentation
- Trimmed and clarified file- and member-level JSDoc in src/utils/Color32.ts: removed verbose examples and attribution, inlined performance notes, and tightened descriptions of cached colors, packing/conversion helpers, and allocation-free vs convenience APIs.

### Bitwise truncation changes
- Original commits removed redundant `| 0` truncation from several methods that compute channel values (lerp, lerpInPlace, multiply, multiplyInPlace, premultiplyAlpha) and from a few helper sites (e.g., writeToFloat32Array offset usage, clampByte).
- Rationale recorded: channel values are expected to be integers or are clamped at construction time, so explicit bitwise truncation was considered redundant.
- A later commit undoes that removal: "fix(utils): restore bitwise integer truncation in Color32 operations" reintroduces the bitwise truncation.

### Tests
- Added a file-level JSDoc to src/utils/Color32.test.ts and made numerous test-description wording edits.
- Simplified the packed value expression in the fromUint32 test to `const packed = (255 << 24) | 255`; the test’s assertions and roundtrip checks remain unchanged.
- Blank lines were inserted between arrange/act/assert steps across many tests to improve readability.
- Note: test string and formatting edits are non-functional; no public API signatures were changed.

### Impact
- No exported/public API signatures were changed.
- Documentation clarity improved; bitwise-truncation behavior was toggled during the branch’s history (removed, then restored).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->