### PR TITLE
docs(utils): refine Bootstrap wording and add test module comment

### DIFF
--- a/src/utils/Bootstrap.test.ts
+++ b/src/utils/Bootstrap.test.ts
@@ -1,5 +1,20 @@
 // @vitest-environment happy-dom
 
+/**
+ * Unit tests for {@link bootstrap}.
+ *
+ * Covers the DOM-facing startup flow:
+ * - optional waiting for `DOMContentLoaded`
+ * - WebGPU support validation and canvas lookup failures
+ * - success and failure paths around `BTAPI.initialize()`
+ * - default and custom canvas/container identifiers
+ * - propagation of success and error callbacks
+ *
+ * The suite uses a minimal happy-dom document plus a mocked `BTAPI`
+ * initialization path so bootstrap behavior can be validated without running
+ * the full engine.
+ */
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { BTAPI } from '../core/BTAPI';
@@ -20,6 +35,7 @@ class MockDemo implements IBlitTechDemo {
     }
 
     update() {}
+
     render() {}
 }
 
@@ -29,11 +45,15 @@ class MockDemo implements IBlitTechDemo {
 
 function setupDOM(): { canvas: HTMLCanvasElement; container: HTMLDivElement } {
     const container = document.createElement('div');
+
     container.id = DEFAULT_CONTAINER_ID;
+
     document.body.appendChild(container);
 
     const canvas = document.createElement('canvas');
+
     canvas.id = DEFAULT_CANVAS_ID;
+
     document.body.appendChild(canvas);
 
     return { canvas, container };
@@ -47,11 +67,13 @@ function teardownDOM(): void {
 
 function stubWebGPU(): void {
     const nav = navigator as unknown as Record<string, unknown>;
+
     nav.gpu = {};
 }
 
 function unstubWebGPU(): void {
     const nav = navigator as unknown as Record<string, unknown>;
+
     delete nav.gpu;
 }
 
@@ -65,7 +87,9 @@ describe('bootstrap', () => {
 
     afterEach(() => {
         vi.restoreAllMocks();
+
         unstubWebGPU();
+
         teardownDOM();
     });
 
@@ -74,29 +98,39 @@ describe('bootstrap', () => {
     describe('waitForDOMReady', () => {
         it('should skip DOM waiting when waitForDOMReady is false', async () => {
             setupDOM();
+
             stubWebGPU();
+
             const result = await bootstrap(MockDemo, { waitForDOMReady: false });
+
             expect(result).toBe(true);
         });
 
         it('should resolve after DOMContentLoaded when readyState is loading', async () => {
             Object.defineProperty(document, 'readyState', { value: 'loading', writable: true, configurable: true });
+
             setupDOM();
+
             stubWebGPU();
 
             const bootstrapPromise = bootstrap(MockDemo, { waitForDOMReady: true });
 
             Object.defineProperty(document, 'readyState', { value: 'complete', writable: true, configurable: true });
+
             document.dispatchEvent(new Event('DOMContentLoaded'));
 
             const result = await bootstrapPromise;
+
             expect(result).toBe(true);
         });
 
-        it('should proceed immediately when readyState is complete', async () => {
+        it('should proceed immediately when the readyState is complete', async () => {
             setupDOM();
+
             stubWebGPU();
+
             const result = await bootstrap(MockDemo, { waitForDOMReady: true });
+
             expect(result).toBe(true);
         });
     });
@@ -108,9 +142,11 @@ describe('bootstrap', () => {
     describe('WebGPU validation', () => {
         it('should return false and call onError when WebGPU is not supported', async () => {
             setupDOM();
+
             // No navigator.gpu installed.
             const onError = vi.fn();
             const result = await bootstrap(MockDemo, { waitForDOMReady: false, onError });
+
             expect(result).toBe(false);
             expect(onError).toHaveBeenCalledOnce();
         });
@@ -123,17 +159,22 @@ describe('bootstrap', () => {
     describe('canvas validation', () => {
         it('should return false and call onError when canvas is not found', async () => {
             stubWebGPU();
+
             // No canvas in DOM — only the container.
             const container = document.createElement('div');
+
             container.id = DEFAULT_CONTAINER_ID;
+
             document.body.appendChild(container);
 
             const onError = vi.fn();
+
             const result = await bootstrap(MockDemo, {
                 waitForDOMReady: false,
                 canvasId: 'nonexistent-canvas',
                 onError,
             });
+
             expect(result).toBe(false);
             expect(onError).toHaveBeenCalledOnce();
         });
@@ -146,32 +187,40 @@ describe('bootstrap', () => {
     describe('engine initialization', () => {
         it('should return false and call onError when BTAPI.initialize returns false', async () => {
             setupDOM();
+
             stubWebGPU();
+
             vi.spyOn(BTAPI.instance, 'initialize').mockResolvedValue(false);
 
             const onError = vi.fn();
             const result = await bootstrap(MockDemo, { waitForDOMReady: false, onError });
+
             expect(result).toBe(false);
             expect(onError).toHaveBeenCalledOnce();
         });
 
         it('should return false and call onError when BTAPI.initialize throws', async () => {
             setupDOM();
+
             stubWebGPU();
+
             vi.spyOn(BTAPI.instance, 'initialize').mockRejectedValue(new Error('Init exploded'));
 
             const onError = vi.fn();
             const result = await bootstrap(MockDemo, { waitForDOMReady: false, onError });
+
             expect(result).toBe(false);
             expect(onError).toHaveBeenCalledOnce();
         });
 
         it('should return true and call onSuccess on successful initialization', async () => {
             setupDOM();
+
             stubWebGPU();
 
             const onSuccess = vi.fn();
             const result = await bootstrap(MockDemo, { waitForDOMReady: false, onSuccess });
+
             expect(result).toBe(true);
             expect(onSuccess).toHaveBeenCalledOnce();
         });
@@ -179,25 +228,33 @@ describe('bootstrap', () => {
         it('should use default canvas and container IDs when not specified', async () => {
             setupDOM();
             stubWebGPU();
+
             const result = await bootstrap(MockDemo, { waitForDOMReady: false });
+
             expect(result).toBe(true);
         });
 
         it('should use custom canvas and container IDs when specified', async () => {
             const container = document.createElement('div');
+
             container.id = 'custom-container';
+
             document.body.appendChild(container);
 
             const canvas = document.createElement('canvas');
+
             canvas.id = 'custom-canvas';
+
             document.body.appendChild(canvas);
 
             stubWebGPU();
+
             const result = await bootstrap(MockDemo, {
                 waitForDOMReady: false,
                 canvasId: 'custom-canvas',
                 containerId: 'custom-container',
             });
+
             expect(result).toBe(true);
         });
     });
@@ -209,14 +266,16 @@ describe('bootstrap', () => {
     describe('unexpected errors', () => {
         it('should return false when BTAPI.initialize throws synchronously', async () => {
             setupDOM();
+
             stubWebGPU();
 
             vi.spyOn(BTAPI.instance, 'initialize').mockImplementation(() => {
-                throw new Error('Synchronous throw from initialize');
+                throw new Error('The synchronous throw from initialize');
             });
 
             const onError = vi.fn();
             const result = await bootstrap(MockDemo, { waitForDOMReady: false, onError });
+
             expect(result).toBe(false);
             expect(onError).toHaveBeenCalledOnce();
         });

--- a/src/utils/Bootstrap.ts
+++ b/src/utils/Bootstrap.ts
@@ -66,12 +66,12 @@ interface BootstrapResult {
 
 /** Error message for WebGPU not supported. */
 const WEBGPU_NOT_SUPPORTED_MESSAGE =
-    'Your browser does not support WebGPU.\n\n' +
+    'The browser does not support WebGPU.\n\n' +
     'Supported browsers:\n' +
     'Chrome/Edge 113+\n' +
     'Firefox Nightly (with the flag enabled)\n' +
     'Safari 18+\n\n' +
-    'Please update your browser or try a different one.';
+    'Please update the browser or try a different one.';
 
 /** Error message for initialization failure. */
 const INIT_FAILED_MESSAGE = 'The engine failed to initialize. Check the console for details.';
@@ -162,7 +162,7 @@ function validateCanvas(
         result = handleBootstrapError(
             'Canvas Error',
             `Failed to find the canvas element with the id '${canvasId}'.\n\n` +
-                'Make sure your HTML includes a canvas element with the correct ID.',
+                'Make sure the HTML includes a canvas element with the correct ID.',
             new Error(`Canvas element '${canvasId}' not found`),
             containerId,
             onError,
@@ -204,8 +204,10 @@ async function initializeDemo(
     let result: BootstrapResult;
 
     if (initialized) {
-        console.log('[BT] Demo started successfully!');
+        console.log('[BT] Demo started successfully');
+
         onSuccess?.();
+
         result = { success: true };
     } else {
         const displayMessage: ErrorContent = initError
@@ -237,7 +239,7 @@ async function initializeDemo(
  *
  * @param DemoClass - Demo class constructor implementing IBlitTechDemo.
  * @param options - Optional configuration for IDs and callbacks.
- * @returns Promise resolving to true if initialization succeeded, false otherwise.
+ * @returns `true` when the demo boots successfully; otherwise `false`.
  *
  * @example
  * // Simplest usage - uses default IDs.
@@ -278,21 +280,25 @@ export async function bootstrap(DemoClass: DemoConstructor, options: BootstrapOp
     try {
         // Validate WebGPU support.
         const webGPUResult = validateWebGPU(containerId, onError);
+
         success = webGPUResult.success;
 
         // Validate canvas element.
         if (success) {
             const { canvas, result: canvasResult } = validateCanvas(canvasId, containerId, onError);
+
             success = canvasResult.success;
 
             // Initialize the demo.
             if (success && canvas) {
                 const initResult = await initializeDemo(DemoClass, canvas, containerId, onSuccess, onError);
+
                 success = initResult.success;
             }
         }
     } catch (err) {
         const error = err instanceof Error ? err : new Error(String(err));
+
         console.error('[BT] Bootstrap error:', error);
 
         handleBootstrapError(


### PR DESCRIPTION
- Replace second-person voice in error messages with neutral third-person ("Your browser" -> "The browser", "your HTML" -> "the HTML")
- Remove trailing exclamation mark from success log message
- Improve @returns JSDoc on bootstrap() for precision
- Add module-level JSDoc block to Bootstrap.test.ts describing covered startup scenarios
- Add blank lines throughout Bootstrap.ts and test for readability


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Bootstrap Documentation and Formatting Refinements

This PR refines user-facing messaging and documentation in the Bootstrap utility module while improving code readability.

### Documentation Improvements

- Added a module-level JSDoc block to `Bootstrap.test.ts` describing the covered startup scenarios
- Enhanced the `@returns` JSDoc on `bootstrap()` to explicitly clarify the meaning of the boolean success value

### User-Facing Text Updates

**Bootstrap.ts:**
- Replaced second-person voice with neutral third-person in error messages:
  - WebGPU unsupported message: "Your browser" → "The browser", "update your browser" → "update the browser"
  - Canvas missing help text: "your HTML" → "the HTML"
- Removed trailing exclamation mark from the success log message in `initializeDemo`

**Bootstrap.test.ts:**
- Updated synchronous-throw error message string in the `BTAPI.instance.initialize` mock from "Synchronous throw from initialize" to "The synchronous throw from initialize"
- Modified test name from "should proceed immediately when readyState is complete" to "should proceed immediately when the readyState is complete"

### Code Formatting

- Inserted blank lines throughout both `Bootstrap.ts` and `Bootstrap.test.ts` for improved readability
- Added strategic formatting newline/statement separators around `onSuccess?.()` and result assignment

No functional changes to control flow, validation logic, or error handling. No exported/public entity signature changes.

Changes: +72 lines / -7 lines

<!-- end of auto-generated comment: release notes by coderabbit.ai -->