### PR TITLE
refactor(utils): simplify Rect2i docs, reorganize statics, and add test spacing

### DIFF
--- a/src/utils/Rect2i.test.ts
+++ b/src/utils/Rect2i.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Unit tests for {@link Rect2i}.
+ *
+ * Exercises integer construction, derived edge and center properties,
+ * allocation-free output helpers, geometric queries, mutation helpers, and the
+ * rectangle arithmetic used across rendering and collision code.
+ */
+
 import { describe, expect, it } from 'vitest';
 
 import { Rect2i } from './Rect2i';
@@ -9,6 +17,7 @@ describe('Rect2i', () => {
     describe('constructor', () => {
         it('should default to (0, 0, 0, 0)', () => {
             const r = new Rect2i();
+
             expect(r.x).toBe(0);
             expect(r.y).toBe(0);
             expect(r.width).toBe(0);
@@ -17,6 +26,7 @@ describe('Rect2i', () => {
 
         it('should pass through integer values unchanged', () => {
             const r = new Rect2i(10, 20, 100, 200);
+
             expect(r.x).toBe(10);
             expect(r.y).toBe(20);
             expect(r.width).toBe(100);
@@ -25,6 +35,7 @@ describe('Rect2i', () => {
 
         it('should truncate positive floats toward zero', () => {
             const r = new Rect2i(1.9, 2.7, 3.1, 4.99);
+
             expect(r.x).toBe(1);
             expect(r.y).toBe(2);
             expect(r.width).toBe(3);
@@ -33,6 +44,7 @@ describe('Rect2i', () => {
 
         it('should truncate negative floats toward zero', () => {
             const r = new Rect2i(-1.7, -2.9, -3.1, -4.5);
+
             expect(r.x).toBe(-1);
             expect(r.y).toBe(-2);
             expect(r.width).toBe(-3);
@@ -47,11 +59,13 @@ describe('Rect2i', () => {
     describe('right', () => {
         it('should return x + width', () => {
             const r = new Rect2i(10, 20, 100, 50);
+
             expect(r.right).toBe(110);
         });
 
         it('should handle negative x', () => {
             const r = new Rect2i(-5, 0, 20, 10);
+
             expect(r.right).toBe(15);
         });
     });
@@ -59,11 +73,13 @@ describe('Rect2i', () => {
     describe('bottom', () => {
         it('should return y + height', () => {
             const r = new Rect2i(10, 20, 100, 50);
+
             expect(r.bottom).toBe(70);
         });
 
         it('should handle negative y', () => {
             const r = new Rect2i(0, -10, 20, 30);
+
             expect(r.bottom).toBe(20);
         });
     });
@@ -71,16 +87,19 @@ describe('Rect2i', () => {
     describe('centerX', () => {
         it('should return truncated center for even width', () => {
             const r = new Rect2i(0, 0, 100, 50);
+
             expect(r.centerX).toBe(50);
         });
 
         it('should truncate toward zero for odd width', () => {
             const r = new Rect2i(0, 0, 11, 10);
+
             expect(r.centerX).toBe(5);
         });
 
         it('should handle offset position', () => {
             const r = new Rect2i(10, 0, 20, 10);
+
             expect(r.centerX).toBe(20);
         });
     });
@@ -88,16 +107,19 @@ describe('Rect2i', () => {
     describe('centerY', () => {
         it('should return truncated center for even height', () => {
             const r = new Rect2i(0, 0, 50, 100);
+
             expect(r.centerY).toBe(50);
         });
 
         it('should truncate toward zero for odd height', () => {
             const r = new Rect2i(0, 0, 10, 11);
+
             expect(r.centerY).toBe(5);
         });
 
         it('should handle offset position', () => {
             const r = new Rect2i(0, 10, 10, 20);
+
             expect(r.centerY).toBe(20);
         });
     });
@@ -110,14 +132,17 @@ describe('Rect2i', () => {
         it('should return Vector2i(x, y)', () => {
             const r = new Rect2i(5, 10, 100, 200);
             const m = r.min;
+
             expect(m.x).toBe(5);
             expect(m.y).toBe(10);
         });
 
         it('should return a new Vector2i instance each time', () => {
             const r = new Rect2i(5, 10, 100, 200);
+
             const m1 = r.min;
             const m2 = r.min;
+
             expect(m1).not.toBe(m2);
             expect(m1.x).toBe(m2.x);
             expect(m1.y).toBe(m2.y);
@@ -128,6 +153,7 @@ describe('Rect2i', () => {
         it('should return Vector2i(x + width, y + height)', () => {
             const r = new Rect2i(5, 10, 100, 200);
             const m = r.max;
+
             expect(m.x).toBe(105);
             expect(m.y).toBe(210);
         });
@@ -135,6 +161,7 @@ describe('Rect2i', () => {
         it('should handle zero-size rect', () => {
             const r = new Rect2i(5, 10, 0, 0);
             const m = r.max;
+
             expect(m.x).toBe(5);
             expect(m.y).toBe(10);
         });
@@ -144,6 +171,7 @@ describe('Rect2i', () => {
         it('should return Vector2i at the center', () => {
             const r = new Rect2i(0, 0, 100, 200);
             const c = r.center;
+
             expect(c.x).toBe(50);
             expect(c.y).toBe(100);
         });
@@ -151,6 +179,7 @@ describe('Rect2i', () => {
         it('should truncate toward zero for odd dimensions', () => {
             const r = new Rect2i(0, 0, 11, 13);
             const c = r.center;
+
             expect(c.x).toBe(5);
             expect(c.y).toBe(6);
         });
@@ -158,6 +187,7 @@ describe('Rect2i', () => {
         it('should account for position offset', () => {
             const r = new Rect2i(10, 20, 100, 200);
             const c = r.center;
+
             expect(c.x).toBe(60);
             expect(c.y).toBe(120);
         });
@@ -167,12 +197,14 @@ describe('Rect2i', () => {
         it('should return Vector2i(x, y)', () => {
             const r = new Rect2i(15, 25, 100, 200);
             const p = r.position;
+
             expect(p.x).toBe(15);
             expect(p.y).toBe(25);
         });
 
         it('should create a new Vector2i each time', () => {
             const r = new Rect2i(15, 25, 100, 200);
+
             expect(r.position).not.toBe(r.position);
         });
     });
@@ -180,7 +212,9 @@ describe('Rect2i', () => {
     describe('position setter', () => {
         it('should set x and y from a vector', () => {
             const r = new Rect2i(0, 0, 100, 200);
+
             r.position = new Vector2i(10, 20);
+
             expect(r.x).toBe(10);
             expect(r.y).toBe(20);
             expect(r.width).toBe(100);
@@ -189,7 +223,9 @@ describe('Rect2i', () => {
 
         it('should truncate to integer', () => {
             const r = new Rect2i(0, 0, 100, 200);
+
             r.position = Vector2i.fromXYUnchecked(1.9, 2.7);
+
             expect(r.x).toBe(1);
             expect(r.y).toBe(2);
         });
@@ -199,12 +235,14 @@ describe('Rect2i', () => {
         it('should return Vector2i(width, height)', () => {
             const r = new Rect2i(15, 25, 100, 200);
             const s = r.size;
+
             expect(s.x).toBe(100);
             expect(s.y).toBe(200);
         });
 
         it('should create a new Vector2i each time', () => {
             const r = new Rect2i(15, 25, 100, 200);
+
             expect(r.size).not.toBe(r.size);
         });
     });
@@ -213,6 +251,7 @@ describe('Rect2i', () => {
         it('should set width and height from a vector', () => {
             const r = new Rect2i(10, 20, 0, 0);
             r.size = new Vector2i(50, 60);
+
             expect(r.x).toBe(10);
             expect(r.y).toBe(20);
             expect(r.width).toBe(50);
@@ -221,7 +260,9 @@ describe('Rect2i', () => {
 
         it('should truncate to integer', () => {
             const r = new Rect2i(0, 0, 0, 0);
+
             r.size = Vector2i.fromXYUnchecked(7.8, 9.3);
+
             expect(r.width).toBe(7);
             expect(r.height).toBe(9);
         });
@@ -235,7 +276,9 @@ describe('Rect2i', () => {
         it('should write min to the output vector', () => {
             const r = new Rect2i(5, 10, 100, 200);
             const out = new Vector2i();
+
             r.minTo(out);
+
             expect(out.x).toBe(5);
             expect(out.y).toBe(10);
         });
@@ -244,6 +287,7 @@ describe('Rect2i', () => {
             const r = new Rect2i(5, 10, 100, 200);
             const out = new Vector2i();
             const result = r.minTo(out);
+
             expect(result).toBe(out);
         });
     });
@@ -252,7 +296,9 @@ describe('Rect2i', () => {
         it('should write max to the output vector', () => {
             const r = new Rect2i(5, 10, 100, 200);
             const out = new Vector2i();
+
             r.maxTo(out);
+
             expect(out.x).toBe(105);
             expect(out.y).toBe(210);
         });
@@ -260,6 +306,7 @@ describe('Rect2i', () => {
         it('should return the output vector for chaining', () => {
             const r = new Rect2i(5, 10, 100, 200);
             const out = new Vector2i();
+
             expect(r.maxTo(out)).toBe(out);
         });
     });
@@ -268,7 +315,9 @@ describe('Rect2i', () => {
         it('should write center to the output vector', () => {
             const r = new Rect2i(0, 0, 100, 200);
             const out = new Vector2i();
+
             r.centerTo(out);
+
             expect(out.x).toBe(50);
             expect(out.y).toBe(100);
         });
@@ -276,7 +325,9 @@ describe('Rect2i', () => {
         it('should truncate toward zero for odd dimensions', () => {
             const r = new Rect2i(0, 0, 11, 13);
             const out = new Vector2i();
+
             r.centerTo(out);
+
             expect(out.x).toBe(5);
             expect(out.y).toBe(6);
         });
@@ -284,6 +335,7 @@ describe('Rect2i', () => {
         it('should return the output vector for chaining', () => {
             const r = new Rect2i(0, 0, 100, 200);
             const out = new Vector2i();
+
             expect(r.centerTo(out)).toBe(out);
         });
     });
@@ -292,7 +344,9 @@ describe('Rect2i', () => {
         it('should write position to the output vector', () => {
             const r = new Rect2i(15, 25, 100, 200);
             const out = new Vector2i();
+
             r.positionTo(out);
+
             expect(out.x).toBe(15);
             expect(out.y).toBe(25);
         });
@@ -300,6 +354,7 @@ describe('Rect2i', () => {
         it('should return the output vector for chaining', () => {
             const r = new Rect2i(15, 25, 100, 200);
             const out = new Vector2i();
+
             expect(r.positionTo(out)).toBe(out);
         });
     });
@@ -308,7 +363,9 @@ describe('Rect2i', () => {
         it('should write size to the output vector', () => {
             const r = new Rect2i(15, 25, 100, 200);
             const out = new Vector2i();
+
             r.sizeTo(out);
+
             expect(out.x).toBe(100);
             expect(out.y).toBe(200);
         });
@@ -316,6 +373,7 @@ describe('Rect2i', () => {
         it('should return the output vector for chaining', () => {
             const r = new Rect2i(15, 25, 100, 200);
             const out = new Vector2i();
+
             expect(r.sizeTo(out)).toBe(out);
         });
     });
@@ -327,16 +385,19 @@ describe('Rect2i', () => {
     describe('contains', () => {
         it('should return true for a point inside', () => {
             const r = new Rect2i(0, 0, 100, 100);
+
             expect(r.contains(new Vector2i(50, 50))).toBe(true);
         });
 
         it('should return true for a point on the min edge (inclusive)', () => {
             const r = new Rect2i(10, 20, 100, 100);
+
             expect(r.contains(new Vector2i(10, 20))).toBe(true);
         });
 
         it('should return false for a point on the max edge (exclusive)', () => {
             const r = new Rect2i(10, 20, 100, 100);
+
             expect(r.contains(new Vector2i(110, 120))).toBe(false);
             expect(r.contains(new Vector2i(110, 50))).toBe(false);
             expect(r.contains(new Vector2i(50, 120))).toBe(false);
@@ -344,6 +405,7 @@ describe('Rect2i', () => {
 
         it('should return false for a point outside', () => {
             const r = new Rect2i(10, 20, 100, 100);
+
             expect(r.contains(new Vector2i(0, 0))).toBe(false);
             expect(r.contains(new Vector2i(200, 200))).toBe(false);
         });
@@ -352,21 +414,25 @@ describe('Rect2i', () => {
     describe('containsXY', () => {
         it('should return true for a point inside', () => {
             const r = new Rect2i(0, 0, 100, 100);
+
             expect(r.containsXY(50, 50)).toBe(true);
         });
 
         it('should return true for min edge (inclusive)', () => {
             const r = new Rect2i(10, 20, 100, 100);
+
             expect(r.containsXY(10, 20)).toBe(true);
         });
 
         it('should return false for max edge (exclusive)', () => {
             const r = new Rect2i(10, 20, 100, 100);
+
             expect(r.containsXY(110, 120)).toBe(false);
         });
 
         it('should return false for a point outside', () => {
             const r = new Rect2i(10, 20, 100, 100);
+
             expect(r.containsXY(0, 0)).toBe(false);
         });
     });
@@ -375,6 +441,7 @@ describe('Rect2i', () => {
         it('should return true for overlapping rects', () => {
             const a = new Rect2i(0, 0, 100, 100);
             const b = new Rect2i(50, 50, 100, 100);
+
             expect(a.intersects(b)).toBe(true);
             expect(b.intersects(a)).toBe(true);
         });
@@ -382,12 +449,14 @@ describe('Rect2i', () => {
         it('should return false for adjacent rects (no overlap)', () => {
             const a = new Rect2i(0, 0, 100, 100);
             const b = new Rect2i(100, 0, 100, 100);
+
             expect(a.intersects(b)).toBe(false);
         });
 
         it('should return true when one rect is fully inside another', () => {
             const outer = new Rect2i(0, 0, 100, 100);
             const inner = new Rect2i(20, 20, 10, 10);
+
             expect(outer.intersects(inner)).toBe(true);
             expect(inner.intersects(outer)).toBe(true);
         });
@@ -395,6 +464,7 @@ describe('Rect2i', () => {
         it('should return false for non-overlapping rects', () => {
             const a = new Rect2i(0, 0, 10, 10);
             const b = new Rect2i(50, 50, 10, 10);
+
             expect(a.intersects(b)).toBe(false);
         });
     });
@@ -404,6 +474,7 @@ describe('Rect2i', () => {
             const a = new Rect2i(0, 0, 100, 100);
             const b = new Rect2i(50, 50, 100, 100);
             const result = a.intersection(b);
+
             expect(result).not.toBeNull();
             expect(result!.x).toBe(50);
             expect(result!.y).toBe(50);
@@ -421,6 +492,7 @@ describe('Rect2i', () => {
             const outer = new Rect2i(0, 0, 100, 100);
             const inner = new Rect2i(20, 30, 10, 15);
             const result = outer.intersection(inner);
+
             expect(result).not.toBeNull();
             expect(result!.x).toBe(20);
             expect(result!.y).toBe(30);
@@ -435,6 +507,7 @@ describe('Rect2i', () => {
             const b = new Rect2i(50, 50, 100, 100);
             const out = new Rect2i();
             const result = a.intersectionTo(b, out);
+
             expect(result).toBe(true);
             expect(out.x).toBe(50);
             expect(out.y).toBe(50);
@@ -447,6 +520,7 @@ describe('Rect2i', () => {
             const b = new Rect2i(20, 20, 10, 10);
             const out = new Rect2i(99, 99, 99, 99);
             const result = a.intersectionTo(b, out);
+
             expect(result).toBe(false);
             expect(out.x).toBe(99);
             expect(out.y).toBe(99);
@@ -460,6 +534,7 @@ describe('Rect2i', () => {
             const a = new Rect2i(0, 0, 100, 100);
             const b = new Rect2i(80, 70, 100, 100);
             const depth = a.intersectionDepth(b);
+
             expect(depth.x).toBe(20);
             expect(depth.y).toBe(30);
         });
@@ -468,6 +543,7 @@ describe('Rect2i', () => {
             const a = new Rect2i(80, 70, 100, 100);
             const b = new Rect2i(0, 0, 100, 100);
             const depth = a.intersectionDepth(b);
+
             expect(depth.x).toBe(20);
             expect(depth.y).toBe(30);
         });
@@ -478,7 +554,9 @@ describe('Rect2i', () => {
             const a = new Rect2i(0, 0, 100, 100);
             const b = new Rect2i(80, 70, 100, 100);
             const out = new Vector2i();
+
             a.intersectionDepthTo(b, out);
+
             expect(out.x).toBe(20);
             expect(out.y).toBe(30);
         });
@@ -487,6 +565,7 @@ describe('Rect2i', () => {
             const a = new Rect2i(0, 0, 100, 100);
             const b = new Rect2i(80, 70, 100, 100);
             const out = new Vector2i();
+
             expect(a.intersectionDepthTo(b, out)).toBe(out);
         });
     });
@@ -499,11 +578,13 @@ describe('Rect2i', () => {
         it('should return true for identical rects', () => {
             const a = new Rect2i(10, 20, 30, 40);
             const b = new Rect2i(10, 20, 30, 40);
+
             expect(a.equals(b)).toBe(true);
         });
 
         it('should return false when any component differs', () => {
             const base = new Rect2i(10, 20, 30, 40);
+
             expect(base.equals(new Rect2i(99, 20, 30, 40))).toBe(false);
             expect(base.equals(new Rect2i(10, 99, 30, 40))).toBe(false);
             expect(base.equals(new Rect2i(10, 20, 99, 40))).toBe(false);
@@ -515,6 +596,7 @@ describe('Rect2i', () => {
         it('should create an independent copy', () => {
             const original = new Rect2i(10, 20, 30, 40);
             const copy = original.clone();
+
             expect(copy.x).toBe(10);
             expect(copy.y).toBe(20);
             expect(copy.width).toBe(30);
@@ -525,7 +607,9 @@ describe('Rect2i', () => {
         it('should not be affected by changes to the original', () => {
             const original = new Rect2i(10, 20, 30, 40);
             const copy = original.clone();
+
             original.x = 999;
+
             expect(copy.x).toBe(10);
         });
     });
@@ -544,6 +628,7 @@ describe('Rect2i', () => {
         it('should return the output rect for chaining', () => {
             const source = new Rect2i(10, 20, 30, 40);
             const out = new Rect2i();
+
             expect(source.cloneTo(out)).toBe(out);
         });
     });
@@ -551,16 +636,19 @@ describe('Rect2i', () => {
     describe('toString', () => {
         it('should format as Rect2i(x, y, width, height)', () => {
             const r = new Rect2i(10, 20, 30, 40);
+
             expect(r.toString()).toBe('Rect2i(10, 20, 30, 40)');
         });
 
         it('should handle negative values', () => {
             const r = new Rect2i(-5, -10, 20, 30);
+
             expect(r.toString()).toBe('Rect2i(-5, -10, 20, 30)');
         });
 
         it('should handle zero rect', () => {
             const r = new Rect2i();
+
             expect(r.toString()).toBe('Rect2i(0, 0, 0, 0)');
         });
     });
@@ -572,7 +660,9 @@ describe('Rect2i', () => {
     describe('set', () => {
         it('should set all components', () => {
             const r = new Rect2i();
+
             r.set(10, 20, 30, 40);
+
             expect(r.x).toBe(10);
             expect(r.y).toBe(20);
             expect(r.width).toBe(30);
@@ -581,7 +671,9 @@ describe('Rect2i', () => {
 
         it('should truncate floats toward zero', () => {
             const r = new Rect2i();
+
             r.set(1.9, -2.7, 3.1, 4.99);
+
             expect(r.x).toBe(1);
             expect(r.y).toBe(-2);
             expect(r.width).toBe(3);
@@ -591,6 +683,7 @@ describe('Rect2i', () => {
         it('should return this for chaining', () => {
             const r = new Rect2i();
             const result = r.set(10, 20, 30, 40);
+
             expect(result).toBe(r);
         });
     });
@@ -598,7 +691,9 @@ describe('Rect2i', () => {
     describe('setPosition', () => {
         it('should set x and y only', () => {
             const r = new Rect2i(0, 0, 100, 200);
+
             r.setPosition(10, 20);
+
             expect(r.x).toBe(10);
             expect(r.y).toBe(20);
             expect(r.width).toBe(100);
@@ -607,13 +702,16 @@ describe('Rect2i', () => {
 
         it('should truncate floats', () => {
             const r = new Rect2i();
+
             r.setPosition(1.7, -2.3);
+
             expect(r.x).toBe(1);
             expect(r.y).toBe(-2);
         });
 
         it('should return this for chaining', () => {
             const r = new Rect2i();
+
             expect(r.setPosition(10, 20)).toBe(r);
         });
     });
@@ -621,7 +719,9 @@ describe('Rect2i', () => {
     describe('setSize', () => {
         it('should set width and height only', () => {
             const r = new Rect2i(10, 20, 0, 0);
+
             r.setSize(100, 200);
+
             expect(r.x).toBe(10);
             expect(r.y).toBe(20);
             expect(r.width).toBe(100);
@@ -630,13 +730,16 @@ describe('Rect2i', () => {
 
         it('should truncate floats', () => {
             const r = new Rect2i();
+
             r.setSize(5.9, 6.1);
+
             expect(r.width).toBe(5);
             expect(r.height).toBe(6);
         });
 
         it('should return this for chaining', () => {
             const r = new Rect2i();
+
             expect(r.setSize(100, 200)).toBe(r);
         });
     });
@@ -645,7 +748,9 @@ describe('Rect2i', () => {
         it('should copy all values from another rect', () => {
             const source = new Rect2i(10, 20, 30, 40);
             const target = new Rect2i();
+
             target.copyFrom(source);
+
             expect(target.x).toBe(10);
             expect(target.y).toBe(20);
             expect(target.width).toBe(30);
@@ -654,13 +759,16 @@ describe('Rect2i', () => {
 
         it('should return this for chaining', () => {
             const r = new Rect2i();
+
             expect(r.copyFrom(new Rect2i(1, 2, 3, 4))).toBe(r);
         });
 
         it('should not link the two rects', () => {
             const source = new Rect2i(10, 20, 30, 40);
             const target = new Rect2i();
+
             target.copyFrom(source);
+
             source.x = 999;
             expect(target.x).toBe(10);
         });
@@ -669,7 +777,9 @@ describe('Rect2i', () => {
     describe('translate', () => {
         it('should move the rect by the given offset', () => {
             const r = new Rect2i(10, 20, 30, 40);
+
             r.translate(5, -3);
+
             expect(r.x).toBe(15);
             expect(r.y).toBe(17);
             expect(r.width).toBe(30);
@@ -678,13 +788,16 @@ describe('Rect2i', () => {
 
         it('should truncate float offsets', () => {
             const r = new Rect2i(10, 20, 30, 40);
+
             r.translate(1.9, -2.7);
+
             expect(r.x).toBe(11);
             expect(r.y).toBe(18);
         });
 
         it('should return this for chaining', () => {
             const r = new Rect2i();
+
             expect(r.translate(5, 5)).toBe(r);
         });
     });
@@ -692,7 +805,9 @@ describe('Rect2i', () => {
     describe('expand', () => {
         it('should expand on all sides by the given amount', () => {
             const r = new Rect2i(10, 20, 30, 40);
+
             r.expand(5);
+
             expect(r.x).toBe(5);
             expect(r.y).toBe(15);
             expect(r.width).toBe(40);
@@ -701,7 +816,9 @@ describe('Rect2i', () => {
 
         it('should shrink with negative amount', () => {
             const r = new Rect2i(10, 20, 30, 40);
+
             r.expand(-2);
+
             expect(r.x).toBe(12);
             expect(r.y).toBe(22);
             expect(r.width).toBe(26);
@@ -710,6 +827,7 @@ describe('Rect2i', () => {
 
         it('should return this for chaining', () => {
             const r = new Rect2i(10, 20, 30, 40);
+
             expect(r.expand(5)).toBe(r);
         });
     });
@@ -717,7 +835,9 @@ describe('Rect2i', () => {
     describe('expandXY', () => {
         it('should expand with different horizontal and vertical amounts', () => {
             const r = new Rect2i(10, 20, 30, 40);
+
             r.expandXY(5, 3);
+
             expect(r.x).toBe(5);
             expect(r.y).toBe(17);
             expect(r.width).toBe(40);
@@ -726,7 +846,9 @@ describe('Rect2i', () => {
 
         it('should handle mixed positive and negative values', () => {
             const r = new Rect2i(10, 20, 30, 40);
+
             r.expandXY(2, -3);
+
             expect(r.x).toBe(8);
             expect(r.y).toBe(23);
             expect(r.width).toBe(34);
@@ -735,6 +857,7 @@ describe('Rect2i', () => {
 
         it('should return this for chaining', () => {
             const r = new Rect2i(10, 20, 30, 40);
+
             expect(r.expandXY(5, 3)).toBe(r);
         });
     });
@@ -742,6 +865,7 @@ describe('Rect2i', () => {
     describe('chaining mutations', () => {
         it('should support chaining multiple mutation methods', () => {
             const r = new Rect2i().set(0, 0, 100, 100).translate(10, 20).expand(5);
+
             expect(r.x).toBe(5);
             expect(r.y).toBe(15);
             expect(r.width).toBe(110);
@@ -756,6 +880,7 @@ describe('Rect2i', () => {
     describe('zero', () => {
         it('should return a rect at (0, 0, 0, 0)', () => {
             const r = Rect2i.zero();
+
             expect(r.x).toBe(0);
             expect(r.y).toBe(0);
             expect(r.width).toBe(0);
@@ -765,11 +890,13 @@ describe('Rect2i', () => {
         it('should return the same frozen singleton', () => {
             const a = Rect2i.zero();
             const b = Rect2i.zero();
+
             expect(a).toBe(b);
         });
 
         it('should be frozen (immutable)', () => {
             const r = Rect2i.zero();
+
             expect(Object.isFrozen(r)).toBe(true);
         });
     });
@@ -779,6 +906,7 @@ describe('Rect2i', () => {
             const min = new Vector2i(10, 20);
             const max = new Vector2i(50, 80);
             const r = Rect2i.fromMinMax(min, max);
+
             expect(r.x).toBe(10);
             expect(r.y).toBe(20);
             expect(r.width).toBe(40);
@@ -788,6 +916,7 @@ describe('Rect2i', () => {
         it('should handle zero-size rect (min equals max)', () => {
             const p = new Vector2i(10, 20);
             const r = Rect2i.fromMinMax(p, p);
+
             expect(r.x).toBe(10);
             expect(r.y).toBe(20);
             expect(r.width).toBe(0);
@@ -798,6 +927,7 @@ describe('Rect2i', () => {
     describe('fromMinMaxXY', () => {
         it('should create a rect from raw coordinates', () => {
             const r = Rect2i.fromMinMaxXY(10, 20, 50, 80);
+
             expect(r.x).toBe(10);
             expect(r.y).toBe(20);
             expect(r.width).toBe(40);
@@ -806,6 +936,7 @@ describe('Rect2i', () => {
 
         it('should truncate float coordinates', () => {
             const r = Rect2i.fromMinMaxXY(1.9, 2.7, 10.1, 20.5);
+
             expect(r.x).toBe(1);
             expect(r.y).toBe(2);
             expect(r.width).toBe(9);
@@ -814,6 +945,7 @@ describe('Rect2i', () => {
 
         it('should handle negative coordinates', () => {
             const r = Rect2i.fromMinMaxXY(-10, -20, 10, 20);
+
             expect(r.x).toBe(-10);
             expect(r.y).toBe(-20);
             expect(r.width).toBe(20);
@@ -826,6 +958,7 @@ describe('Rect2i', () => {
             const center = new Vector2i(50, 50);
             const size = new Vector2i(20, 30);
             const r = Rect2i.fromCenterSize(center, size);
+
             expect(r.x).toBe(40);
             expect(r.y).toBe(35);
             expect(r.width).toBe(20);
@@ -836,6 +969,7 @@ describe('Rect2i', () => {
             const center = new Vector2i(50, 50);
             const size = new Vector2i(11, 13);
             const r = Rect2i.fromCenterSize(center, size);
+
             expect(r.x).toBe(45);
             expect(r.y).toBe(44);
             expect(r.width).toBe(11);
@@ -846,6 +980,7 @@ describe('Rect2i', () => {
     describe('fromCenterSizeXY', () => {
         it('should create a centered rect from raw coordinates', () => {
             const r = Rect2i.fromCenterSizeXY(50, 50, 20, 30);
+
             expect(r.x).toBe(40);
             expect(r.y).toBe(35);
             expect(r.width).toBe(20);
@@ -854,14 +989,16 @@ describe('Rect2i', () => {
 
         it('should truncate float inputs', () => {
             const r = Rect2i.fromCenterSizeXY(50.9, 50.1, 20.7, 30.3);
+
             expect(r.x).toBe(40);
             expect(r.y).toBe(35);
             expect(r.width).toBe(20);
             expect(r.height).toBe(30);
         });
 
-        it('should handle origin center', () => {
+        it('should handle the origin center', () => {
             const r = Rect2i.fromCenterSizeXY(0, 0, 10, 10);
+
             expect(r.x).toBe(-5);
             expect(r.y).toBe(-5);
             expect(r.width).toBe(10);
@@ -872,6 +1009,7 @@ describe('Rect2i', () => {
     describe('fromValuesUnchecked', () => {
         it('should create a rect without truncation', () => {
             const r = Rect2i.fromValuesUnchecked(10, 20, 30, 40);
+
             expect(r.x).toBe(10);
             expect(r.y).toBe(20);
             expect(r.width).toBe(30);
@@ -880,6 +1018,7 @@ describe('Rect2i', () => {
 
         it('should preserve integer values without extra truncation', () => {
             const r = Rect2i.fromValuesUnchecked(1, 2, 3, 4);
+
             expect(r.x).toBe(1);
             expect(r.y).toBe(2);
             expect(r.width).toBe(3);

--- a/src/utils/Rect2i.ts
+++ b/src/utils/Rect2i.ts
@@ -148,7 +148,7 @@ export class Rect2i {
 
     // #endregion
 
-    // #region Zero-Allocation Output Methods
+    // #region Static Factory Methods
 
     /**
      * Returns a zero-sized rectangle at origin.
@@ -231,10 +231,6 @@ export class Rect2i {
         return Rect2i.fromValuesUnchecked((centerX | 0) - halfWidth, (centerY | 0) - halfHeight, w, h);
     }
 
-    // #endregion
-
-    // #region Intersection Tests
-
     /**
      * Creates a Rect2i from integer values without truncation.
      * Use this in hot paths when values are guaranteed to be integers.
@@ -258,6 +254,10 @@ export class Rect2i {
 
         return r;
     }
+
+    // #endregion
+
+    // #region Zero-Allocation Output Methods
 
     /**
      * Writes the top-left corner (min) to an existing vector.
@@ -344,7 +344,7 @@ export class Rect2i {
 
     // #endregion
 
-    // #region Utility
+    // #region Intersection Tests
 
     /**
      * Tests raw coordinates against this rectangle without allocating a vector.
@@ -415,10 +415,6 @@ export class Rect2i {
         return true;
     }
 
-    // #endregion
-
-    // #region In-Place Mutation Methods
-
     /**
      * Calculates intersection depth for collision resolution.
      * Returns how much the rectangles overlap in each axis.
@@ -472,6 +468,10 @@ export class Rect2i {
         return out;
     }
 
+    // #endregion
+
+    // #region Utility Methods
+
     /**
      * Checks if this rectangle equals another (all components match).
      *
@@ -517,6 +517,10 @@ export class Rect2i {
         return `Rect2i(${this.x}, ${this.y}, ${this.width}, ${this.height})`;
     }
 
+    // #endregion
+
+    // #region In-Place Mutation Methods
+
     /**
      * Sets all components of this rectangle.
      * Modifies this rectangle directly for maximum performance.
@@ -537,10 +541,6 @@ export class Rect2i {
 
         return this;
     }
-
-    // #endregion
-
-    // #region Static Constructors
 
     /**
      * Sets only the position of this rectangle, keeping the size unchanged.
@@ -630,10 +630,6 @@ export class Rect2i {
 
         return this;
     }
-
-    // #endregion
-
-    // #region Static Factories
 
     /**
      * Expands this rectangle by different amounts horizontally and vertically.

--- a/src/utils/Rect2i.ts
+++ b/src/utils/Rect2i.ts
@@ -329,6 +329,10 @@ export class Rect2i {
         return out;
     }
 
+    // #endregion
+
+    // #region Intersection Tests
+
     /**
      * Tests if a point lies within this rectangle.
      * Uses half-open interval: includes min, excludes max.
@@ -341,10 +345,6 @@ export class Rect2i {
             point.x >= this.x && point.x < this.x + this.width && point.y >= this.y && point.y < this.y + this.height
         );
     }
-
-    // #endregion
-
-    // #region Intersection Tests
 
     /**
      * Tests raw coordinates against this rectangle without allocating a vector.

--- a/src/utils/Rect2i.ts
+++ b/src/utils/Rect2i.ts
@@ -2,13 +2,11 @@ import { Vector2i } from './Vector2i';
 
 /**
  * Integer rectangle for pixel-perfect bounds and regions.
- * Inspired by RetroBlit's Rect2i.
  *
- * Performance notes:
- * - Use fromValuesUnchecked() for trusted integer values in hot paths
- * - Use raw value getters (centerX, centerY, right, bottom) to avoid allocations
- * - Use “To” methods (centerTo, minTo, maxTo, etc.) for zero-allocation output
- * - Bitwise |0 is used for integer truncation (truncates toward zero, not floor)
+ * Used throughout the engine for sprite regions, display-space bounds, and
+ * zero-allocation geometry helpers. Both convenience getters and allocation-free
+ * `*To()` helpers are provided so callers can choose between readability and
+ * hot-path efficiency.
  */
 export class Rect2i {
     // #region Cached Static Rectangles
@@ -21,11 +19,7 @@ export class Rect2i {
     // #region Constructor
 
     /**
-     * Creates a new integer rectangle.
-     * All values are truncated to integers using |0.
-     *
-     * Note: For negative non-integers, |0 truncates toward zero (e.g., –1.7 becomes –1).
-     * If you need floor behavior for negative values, use Math.floor before passing.
+     * Creates an integer rectangle, truncating all inputs toward zero.
      *
      * @param x - Left-edge X coordinate (defaults to 0).
      * @param y - Top-edge Y coordinate (defaults to 0).
@@ -57,40 +51,32 @@ export class Rect2i {
     // #region Raw Value Getters (Zero Allocation)
 
     /**
-     * Gets the right edge X coordinate (x + width).
-     * Use this instead of max.x in hot paths to avoid allocation.
-     *
-     * @returns Right edge coordinate.
+     * Gets the exclusive right edge (`x + width`).
+     * @returns Right edge X coordinate.
      */
     get right(): number {
         return this.x + this.width;
     }
 
     /**
-     * Gets the bottom edge Y coordinate (y + height).
-     * Use this instead of max.y in hot paths to avoid allocation.
-     *
-     * @returns Bottom edge coordinate.
+     * Gets the exclusive bottom edge (`y + height`).
+     * @returns Bottom edge Y coordinate.
      */
     get bottom(): number {
         return this.y + this.height;
     }
 
     /**
-     * Gets the center X coordinate.
-     * Use this instead of center.x in hot paths to avoid allocation.
-     *
-     * @returns Center X coordinate (truncated toward zero).
+     * Gets the truncated horizontal center coordinate.
+     * @returns Center X coordinate.
      */
     get centerX(): number {
         return (this.x + this.width / 2) | 0;
     }
 
     /**
-     * Gets the center Y coordinate.
-     * Use this instead of center.y in hot paths to avoid allocation.
-     *
-     * @returns Center Y coordinate (truncated toward zero).
+     * Gets the truncated vertical center coordinate.
+     * @returns Center Y coordinate.
      */
     get centerY(): number {
         return (this.y + this.height / 2) | 0;
@@ -101,44 +87,32 @@ export class Rect2i {
     // #region Computed Properties
 
     /**
-     * Gets the top-left corner of the rectangle.
-     *
-     * Note: Creates a new Vector2i. Use minTo() in hot paths.
-     *
-     * @returns Vector2i representing (x, y).
+     * Gets the top-left corner as a new vector.
+     * @returns Vector2i at (x, y).
      */
     get min(): Vector2i {
         return Vector2i.fromXYUnchecked(this.x, this.y);
     }
 
     /**
-     * Gets the bottom-right corner of the rectangle (exclusive).
-     *
-     * Note: Creates a new Vector2i. Use maxTo() in hot paths.
-     *
-     * @returns Vector2i representing (x + width, y + height).
+     * Gets the exclusive bottom-right corner as a new vector.
+     * @returns Vector2i at (x + width, y + height).
      */
     get max(): Vector2i {
         return Vector2i.fromXYUnchecked(this.x + this.width, this.y + this.height);
     }
 
     /**
-     * Gets the center point of the rectangle.
-     *
-     * Note: Creates a new Vector2i. Use centerTo() or centerX/centerY in hot paths.
-     *
-     * @returns Vector2i at the rectangle's center (truncated toward zero).
+     * Gets the truncated center point as a new vector.
+     * @returns Vector2i at the rectangle center.
      */
     get center(): Vector2i {
         return Vector2i.fromXYUnchecked((this.x + this.width / 2) | 0, (this.y + this.height / 2) | 0);
     }
 
     /**
-     * Gets the position (top-left corner) as a vector.
-     *
-     * Note: Creates a new Vector2i. Use x/y directly or positionTo() in hot paths.
-     *
-     * @returns Vector2i representing (x, y).
+     * Gets the top-left position as a new vector.
+     * @returns Vector2i at (x, y).
      */
     get position(): Vector2i {
         return Vector2i.fromXYUnchecked(this.x, this.y);
@@ -155,11 +129,8 @@ export class Rect2i {
     }
 
     /**
-     * Gets the size (width, height) as a vector.
-     *
-     * Note: Creates a new Vector2i. Use width/height directly or sizeTo() in hot paths.
-     *
-     * @returns Vector2i representing (width, height).
+     * Gets the size as a new vector.
+     * @returns Vector2i at (width, height).
      */
     get size(): Vector2i {
         return Vector2i.fromXYUnchecked(this.width, this.height);
@@ -178,6 +149,115 @@ export class Rect2i {
     // #endregion
 
     // #region Zero-Allocation Output Methods
+
+    /**
+     * Returns a zero-sized rectangle at origin.
+     * Returns a cached frozen singleton - do not modify.
+     *
+     * @returns Rectangle at (0, 0) with size (0, 0) (cached).
+     */
+    static zero(): Rect2i {
+        return Rect2i._zero;
+    }
+
+    /**
+     * Creates a rectangle from two corner points.
+     *
+     * Note: min must be less than or equal to max component-wise.
+     * If min > max on any axis, the resulting width/height will be negative,
+     * which may cause unexpected behavior in intersection/containment tests.
+     *
+     * @param min - Top-left corner.
+     * @param max - Bottom-right corner.
+     * @returns New rectangle spanning from min to max.
+     */
+    static fromMinMax(min: Vector2i, max: Vector2i): Rect2i {
+        // Vector2i values are already integers, use unchecked.
+        return Rect2i.fromValuesUnchecked(min.x, min.y, max.x - min.x, max.y - min.y);
+    }
+
+    /**
+     * Creates a rectangle from two corner points specified as raw coordinates.
+     * Zero allocation alternative to fromMinMax() when you have raw coordinates.
+     *
+     * Note: min coordinates must be less than or equal to max coordinates.
+     * If min > max on any axis, the resulting width/height will be negative.
+     *
+     * @param minX - Left-edge X coordinate.
+     * @param minY - Top-edge Y coordinate.
+     * @param maxX - Right-edge X coordinate.
+     * @param maxY - Bottom-edge Y coordinate.
+     * @returns New rectangle spanning from (minX, minY) to (maxX, maxY).
+     */
+    static fromMinMaxXY(minX: number, minY: number, maxX: number, maxY: number): Rect2i {
+        const x = minX | 0;
+        const y = minY | 0;
+
+        return Rect2i.fromValuesUnchecked(x, y, (maxX | 0) - x, (maxY | 0) - y);
+    }
+
+    /**
+     * Creates a rectangle centered on a point with a given size.
+     *
+     * @param center - Center point of the rectangle.
+     * @param size - Width and height as a vector.
+     * @returns New rectangle centered on the given point.
+     */
+    static fromCenterSize(center: Vector2i, size: Vector2i): Rect2i {
+        // Use |0 to truncate division results.
+        const halfWidth = (size.x / 2) | 0;
+        const halfHeight = (size.y / 2) | 0;
+
+        // All arithmetic on integers, use unchecked.
+        return Rect2i.fromValuesUnchecked(center.x - halfWidth, center.y - halfHeight, size.x, size.y);
+    }
+
+    /**
+     * Creates a rectangle centered on raw coordinates with a given size.
+     * Zero allocation alternative to fromCenterSize() when you have raw coordinates.
+     *
+     * @param centerX - Center X coordinate.
+     * @param centerY - Center Y coordinate.
+     * @param width - Width of the rectangle.
+     * @param height - Height of the rectangle.
+     * @returns New rectangle centered on the given point.
+     */
+    static fromCenterSizeXY(centerX: number, centerY: number, width: number, height: number): Rect2i {
+        const w = width | 0;
+        const h = height | 0;
+        const halfWidth = (w / 2) | 0;
+        const halfHeight = (h / 2) | 0;
+
+        return Rect2i.fromValuesUnchecked((centerX | 0) - halfWidth, (centerY | 0) - halfHeight, w, h);
+    }
+
+    // #endregion
+
+    // #region Intersection Tests
+
+    /**
+     * Creates a Rect2i from integer values without truncation.
+     * Use this in hot paths when values are guaranteed to be integers.
+     *
+     * WARNING: Passing non-integer values will result in non-integer rect components.
+     * Only use when you’re certain the values are already integers.
+     *
+     * @param x - Left-edge X coordinate (must be integer).
+     * @param y - Top-edge Y coordinate (must be integer).
+     * @param width - Width in pixels (must be integer).
+     * @param height - Height in pixels (must be integer).
+     * @returns New Rect2i with the specified values.
+     */
+    static fromValuesUnchecked(x: number, y: number, width: number, height: number): Rect2i {
+        const r = Object.create(Rect2i.prototype) as Rect2i;
+
+        r.x = x;
+        r.y = y;
+        r.width = width;
+        r.height = height;
+
+        return r;
+    }
 
     /**
      * Writes the top-left corner (min) to an existing vector.
@@ -249,10 +329,6 @@ export class Rect2i {
         return out;
     }
 
-    // #endregion
-
-    // #region Intersection Tests
-
     /**
      * Tests if a point lies within this rectangle.
      * Uses half-open interval: includes min, excludes max.
@@ -266,10 +342,12 @@ export class Rect2i {
         );
     }
 
+    // #endregion
+
+    // #region Utility
+
     /**
-     * Tests if raw x, y coordinates lie within this rectangle.
-     * Uses half-open interval: includes min, excludes max.
-     * Zero allocation alternative to contains() when you have raw coordinates.
+     * Tests raw coordinates against this rectangle without allocating a vector.
      *
      * @param px - X coordinate to test.
      * @param py - Y coordinate to test.
@@ -297,8 +375,6 @@ export class Rect2i {
     /**
      * Calculates the overlapping region of two rectangles.
      *
-     * Note: Creates a new Rect2i. Use intersectionTo() in hot paths.
-     *
      * @param other - Rectangle to intersect with.
      * @returns New rectangle representing the overlap, or null if no overlap.
      */
@@ -317,8 +393,7 @@ export class Rect2i {
     }
 
     /**
-     * Calculates the overlapping region and writes to an existing rectangle.
-     * Zero allocation alternative to intersection().
+     * Calculates the overlapping region and writes it into an existing rectangle.
      *
      * @param other - Rectangle to intersect with.
      * @param out - Rectangle to write the result to.
@@ -339,6 +414,10 @@ export class Rect2i {
 
         return true;
     }
+
+    // #endregion
+
+    // #region In-Place Mutation Methods
 
     /**
      * Calculates intersection depth for collision resolution.
@@ -393,10 +472,6 @@ export class Rect2i {
         return out;
     }
 
-    // #endregion
-
-    // #region Utility
-
     /**
      * Checks if this rectangle equals another (all components match).
      *
@@ -442,10 +517,6 @@ export class Rect2i {
         return `Rect2i(${this.x}, ${this.y}, ${this.width}, ${this.height})`;
     }
 
-    // #endregion
-
-    // #region In-Place Mutation Methods
-
     /**
      * Sets all components of this rectangle.
      * Modifies this rectangle directly for maximum performance.
@@ -466,6 +537,10 @@ export class Rect2i {
 
         return this;
     }
+
+    // #endregion
+
+    // #region Static Constructors
 
     /**
      * Sets only the position of this rectangle, keeping the size unchanged.
@@ -556,6 +631,10 @@ export class Rect2i {
         return this;
     }
 
+    // #endregion
+
+    // #region Static Factories
+
     /**
      * Expands this rectangle by different amounts horizontally and vertically.
      * Modifies this rectangle directly for maximum performance.
@@ -576,119 +655,6 @@ export class Rect2i {
         this.height += v * 2;
 
         return this;
-    }
-
-    // #endregion
-
-    // #region Static Constructors
-
-    /**
-     * Returns a zero-sized rectangle at origin.
-     * Returns a cached frozen singleton - do not modify.
-     *
-     * @returns Rectangle at (0, 0) with size (0, 0) (cached).
-     */
-    static zero(): Rect2i {
-        return Rect2i._zero;
-    }
-
-    /**
-     * Creates a rectangle from two corner points.
-     *
-     * Note: min must be less than or equal to max component-wise.
-     * If min > max on any axis, the resulting width/height will be negative,
-     * which may cause unexpected behavior in intersection/containment tests.
-     *
-     * @param min - Top-left corner.
-     * @param max - Bottom-right corner.
-     * @returns New rectangle spanning from min to max.
-     */
-    static fromMinMax(min: Vector2i, max: Vector2i): Rect2i {
-        // Vector2i values are already integers, use unchecked.
-        return Rect2i.fromValuesUnchecked(min.x, min.y, max.x - min.x, max.y - min.y);
-    }
-
-    /**
-     * Creates a rectangle from two corner points specified as raw coordinates.
-     * Zero allocation alternative to fromMinMax() when you have raw coordinates.
-     *
-     * Note: min coordinates must be less than or equal to max coordinates.
-     * If min > max on any axis, the resulting width/height will be negative.
-     *
-     * @param minX - Left-edge X coordinate.
-     * @param minY - Top-edge Y coordinate.
-     * @param maxX - Right-edge X coordinate.
-     * @param maxY - Bottom-edge Y coordinate.
-     * @returns New rectangle spanning from (minX, minY) to (maxX, maxY).
-     */
-    static fromMinMaxXY(minX: number, minY: number, maxX: number, maxY: number): Rect2i {
-        const x = minX | 0;
-        const y = minY | 0;
-
-        return Rect2i.fromValuesUnchecked(x, y, (maxX | 0) - x, (maxY | 0) - y);
-    }
-
-    /**
-     * Creates a rectangle centered on a point with a given size.
-     *
-     * @param center - Center point of the rectangle.
-     * @param size - Width and height as a vector.
-     * @returns New rectangle centered on the given point.
-     */
-    static fromCenterSize(center: Vector2i, size: Vector2i): Rect2i {
-        // Use |0 to truncate division results.
-        const halfWidth = (size.x / 2) | 0;
-        const halfHeight = (size.y / 2) | 0;
-
-        // All arithmetic on integers, use unchecked.
-        return Rect2i.fromValuesUnchecked(center.x - halfWidth, center.y - halfHeight, size.x, size.y);
-    }
-
-    /**
-     * Creates a rectangle centered on raw coordinates with a given size.
-     * Zero allocation alternative to fromCenterSize() when you have raw coordinates.
-     *
-     * @param centerX - Center X coordinate.
-     * @param centerY - Center Y coordinate.
-     * @param width - Width of the rectangle.
-     * @param height - Height of the rectangle.
-     * @returns New rectangle centered on the given point.
-     */
-    static fromCenterSizeXY(centerX: number, centerY: number, width: number, height: number): Rect2i {
-        const w = width | 0;
-        const h = height | 0;
-        const halfWidth = (w / 2) | 0;
-        const halfHeight = (h / 2) | 0;
-
-        return Rect2i.fromValuesUnchecked((centerX | 0) - halfWidth, (centerY | 0) - halfHeight, w, h);
-    }
-
-    // #endregion
-
-    // #region Static Factories
-
-    /**
-     * Creates a Rect2i from integer values without truncation.
-     * Use this in hot paths when values are guaranteed to be integers.
-     *
-     * WARNING: Passing non-integer values will result in non-integer rect components.
-     * Only use when you’re certain the values are already integers.
-     *
-     * @param x - Left-edge X coordinate (must be integer).
-     * @param y - Top-edge Y coordinate (must be integer).
-     * @param width - Width in pixels (must be integer).
-     * @param height - Height in pixels (must be integer).
-     * @returns New Rect2i with the specified values.
-     */
-    static fromValuesUnchecked(x: number, y: number, width: number, height: number): Rect2i {
-        const r = Object.create(Rect2i.prototype) as Rect2i;
-
-        r.x = x;
-        r.y = y;
-        r.width = width;
-        r.height = height;
-
-        return r;
     }
 
     // #endregion


### PR DESCRIPTION
Trim JSDoc throughout Rect2i to single-line summaries — drop hot-path notes, allocation warnings, and per-getter @returns lines. Rewrite the class-level doc to describe use cases rather than implementation details. Move static factory methods (zero, fromMinMax, fromMinMaxXY, fromCenter, fromValuesUnchecked) into the zero-allocation section to co-locate with the *To() helpers. Add file-level JSDoc and blank-line spacing between arrange/act/assert steps across the full test file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Title: refactor(utils): simplify Rect2i docs, reorganize statics, and add test spacing
Number: 59 — open — source branch: rect2i → target: main
User: vancura
URL: https://github.com/vancura/blit-tech/pull/59
Created at: 2026-03-27T16:50:36Z

## Documentation and organization improvements for Rect2i utility

This PR refactors the `Rect2i` class documentation, reorganizes static factory placement, adjusts region markers to match method semantics, and improves test file formatting for readability.

### Key changes

**src/utils/Rect2i.ts**
- Simplified class- and member-level JSDoc to shorter summaries and reframed class-level usage guidance (emphasizing both convenience getters and allocation-free `*To()` helpers).
- Converted many multi-line JSDoc blocks into single-line summaries and removed per-getter `@returns` detail in several places.
- Reorganized region markers and method section ordering to better align sections with method semantics (including moving static factory methods earlier into a "Static Factory Methods" / zero-allocation area so they sit alongside `*To()` helpers).
- Kept the integer-truncation behavior in the constructor and retained an unchecked factory (`fromValuesUnchecked`) for allocation-free construction (with an explanatory note).
- Minor comment wording changes to use clearer "writes into" phrasing for zero-allocation output methods.

**src/utils/Rect2i.test.ts**
- Added a file-level JSDoc describing the test suite purpose and scope.
- Inserted blank-line spacing between arrange/act/assert steps inside test cases to improve readability.
- Adjusted one test title for grammatical consistency (`'should handle origin center'` → `'should handle the origin center'`).
- No test logic, assertions, or control flow were changed.

**Other**
- Commit includes a targeted refactor moving `contains()` into the Intersection Tests region to align region grouping with method semantics.

### Impact

No functional changes to behavior or public API signatures. Changes are limited to documentation, test formatting, and internal organization/region markers; existing public methods and types remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->