### PR TITLE
refactor(api): simplify BlitTech.ts docs and add test spacing

### DIFF
--- a/src/BlitTech.test.ts
+++ b/src/BlitTech.test.ts
@@ -1,7 +1,11 @@
+// noinspection DuplicatedCode
+
 /**
- * Tests for the BT public API facade in BlitTech.ts.
- * Verifies that each BT.* method delegates correctly to BTAPI.instance,
- * and that the warnOnce helper suppresses duplicate warnings.
+ * Unit tests for the public `BT` facade exported from `BlitTech.ts`.
+ *
+ * Covers delegation from top-level `BT.*` calls into `BTAPI.instance`,
+ * default return behavior for hardware-dependent queries, and the warning
+ * suppression behavior used by facade helpers.
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -393,7 +397,7 @@ describe('BT.printMeasure', () => {
         BT.printMeasure('again');
         BT.printMeasure('again');
 
-        // warnOnce suppresses duplicates; total warn calls across both invocations is 0 or 1.
+        // warnOnce suppresses duplicates; total warn calls across both invocations are 0 or 1.
         expect(warnSpy.mock.calls.length).toBeLessThanOrEqual(1);
     });
 });
@@ -447,6 +451,7 @@ describe('BT.drawSprite', () => {
         expect(spy).toHaveBeenCalledWith(sheet, srcRect, destPos, undefined);
     });
 
+    //
     it('forwards the tint argument', () => {
         const spy = vi.spyOn(BTAPI.instance, 'drawSprite').mockReturnValue(undefined);
         const sheet = new SpriteSheet(mockImage);
@@ -468,6 +473,7 @@ describe('BT.drawSprite', () => {
 
     it('does not throw when called multiple times', () => {
         vi.spyOn(BTAPI.instance, 'drawSprite').mockReturnValue(undefined);
+
         const sheet = new SpriteSheet(mockImage);
 
         expect(() => {

--- a/src/BlitTech.test.ts
+++ b/src/BlitTech.test.ts
@@ -451,7 +451,6 @@ describe('BT.drawSprite', () => {
         expect(spy).toHaveBeenCalledWith(sheet, srcRect, destPos, undefined);
     });
 
-    //
     it('forwards the tint argument', () => {
         const spy = vi.spyOn(BTAPI.instance, 'drawSprite').mockReturnValue(undefined);
         const sheet = new SpriteSheet(mockImage);

--- a/src/BlitTech.ts
+++ b/src/BlitTech.ts
@@ -1,8 +1,8 @@
 /**
- * Blit-Tech - WebGPU Retro Engine
+ * Public Blit-Tech entrypoint.
  *
- * Main static API inspired by RetroBlit's RB namespace.
- * All demo code interacts with the engine through this interface.
+ * This module re-exports the main runtime types and exposes the `BT` facade
+ * used by demos for rendering, timing, bootstrap, and future input helpers.
  */
 
 import { AssetLoader } from './assets/AssetLoader';
@@ -21,10 +21,7 @@ import { Vector2i } from './utils/Vector2i';
 
 // #region Module State
 
-/**
- * Tracks which warning messages have been displayed to avoid console spam.
- * Each function name is stored after its first warning is shown.
- */
+/** Tracks one-time facade warnings to avoid repeated console noise. */
 const _warnedFunctions = new Set<string>();
 
 // #endregion
@@ -32,8 +29,7 @@ const _warnedFunctions = new Set<string>();
 // #region Helper Functions
 
 /**
- * Displays a warning message once per function to avoid console spam.
- * Further calls with the same function name will be silently ignored.
+ * Emits a warning message only once for a named facade function.
  *
  * @param funcName - Unique identifier for the function (used for deduplication).
  * @param message - Warning message to display in the console.
@@ -41,6 +37,7 @@ const _warnedFunctions = new Set<string>();
 function warnOnce(funcName: string, message: string): void {
     if (!_warnedFunctions.has(funcName)) {
         console.warn(message);
+
         _warnedFunctions.add(funcName);
     }
 }
@@ -49,10 +46,7 @@ function warnOnce(funcName: string, message: string): void {
 
 // #region Public API
 
-/**
- * Main Blit-Tech API module.
- * All engine features are accessed through BT.* methods.
- */
+/** Main Blit-Tech API namespace used by runtime demos. */
 export const BT = {
     // #region Constants - Sprite Transform Flags
 
@@ -125,31 +119,11 @@ export const BT = {
     // #region Initialization
 
     /**
-     * Initializes the engine with a demo instance and canvas element.
-     * This is the entry point for all Blit-Tech demos.
+     * Initializes the engine against a demo instance and target canvas.
      *
-     * Setup sequence:
-     * 1. Calls demo.queryHardware() to get display settings
-     * 2. Initializes WebGPU device and context
-     * 3. Creates a renderer with a configured display size
-     * 4. Calls demo.initialize() to load assets
-     * 5. Starts the loop (fixed update, variable render)
-     *
-     * IMPORTANT: Canvas must be attached to DOM before calling this.
-     * In Electron, wait for DOM ready before initializing.
-     *
-     * @param demo - Demo implementing IBlitTechDemo interface.
-     * @param canvas - HTML canvas element to render to.
-     * @returns Promise that resolves to true if successful, false on error.
-     *
-     * @example
-     * const canvas = document.getElementById('blit-tech-canvas') as HTMLCanvasElement;
-     * const demo = new MyDemo();
-     * const success = await BT.initialize(demo, canvas);
-     *
-     * if (!success) {
-     *   console.error('Failed to initialize Blit-Tech');
-     * }
+     * @param demo - Demo implementation that provides lifecycle hooks.
+     * @param canvas - Canvas used as the engine render target.
+     * @returns `true` when initialization succeeds; otherwise `false`.
      */
     initialize: async (demo: IBlitTechDemo, canvas: HTMLCanvasElement): Promise<boolean> => {
         return await BTAPI.instance.initialize(demo, canvas);
@@ -160,10 +134,12 @@ export const BT = {
     // #region Hardware Information
 
     /**
-     * Gets the current display size in pixels.
-     * Returns the internal rendering resolution configured by the demo.
+     * Returns the active internal display resolution in pixels.
      *
-     * @returns Display size as Vector2i, or zero vector if not initialized.
+     * This is the logical render size configured by the demo, not the canvas
+     * element's CSS size.
+     *
+     * @returns Configured display size, or `Vector2i.zero()` before initialization.
      */
     displaySize: (): Vector2i => {
         const settings = BTAPI.instance.getHardwareSettings();
@@ -172,10 +148,12 @@ export const BT = {
     },
 
     /**
-     * Gets the target frames per second for update() calls.
-     * Update() runs at this fixed rate, while render() runs at a variable rate.
+     * Returns the fixed update rate.
      *
-     * @returns Target frames per second, or 60 if not initialized.
+     * `update()` runs at this target frequency, while rendering may occur at a
+     * different cadence.
+     *
+     * @returns Target updates per second, or `60` before initialization.
      */
     fps: (): number => {
         const settings = BTAPI.instance.getHardwareSettings();
@@ -184,18 +162,19 @@ export const BT = {
     },
 
     /**
-     * Gets the current tick count (increments each update).
-     * Ticks increment once per fixed update call (e.g., 60 times/second at 60 FPS).
+     * Returns the current fixed-update tick counter.
      *
-     * @returns Current tick count since initialization or last reset.
+     * The counter increments once per engine update and is typically used for
+     * frame-based timing.
+     *
+     * @returns Tick count since initialization or the last {@link BT.ticksReset}.
      */
     ticks: (): number => {
         return BTAPI.instance.getTicks();
     },
 
     /**
-     * Resets the tick counter to zero.
-     * Useful for timing-based demo events and animations.
+     * Resets the fixed-update tick counter back to zero.
      */
     ticksReset: (): void => {
         BTAPI.instance.resetTicks();
@@ -206,21 +185,22 @@ export const BT = {
     // #region Rendering - Clear Operations
 
     /**
-     * Clears the screen with a solid color.
-     * Called at the start of each frame to set the background color.
+     * Sets the frame clear color.
      *
-     * @param color - Fill color for the entire screen.
+     * The renderer uses this color when clearing the full display at the start
+     * of the next frame.
+     *
+     * @param color - Color used for the full-screen clear pass.
      */
     clear: (color: Color32): void => {
         BTAPI.instance.setClearColor(color);
     },
 
     /**
-     * Clears a rectangular region with a solid color.
-     * Useful for erasing specific areas of the screen.
+     * Fills a rectangular display region with a solid color.
      *
-     * @param color - Fill color for the region.
-     * @param rect - Region to clear in pixel coordinates.
+     * @param color - Fill color applied to the region.
+     * @param rect - Rectangle in display pixel coordinates.
      */
     clearRect: (color: Color32, rect: Rect2i): void => {
         BTAPI.instance.clearRect(color, rect);
@@ -231,9 +211,9 @@ export const BT = {
     // #region Rendering - Primitives
 
     /**
-     * Draws a single pixel at the specified position.
+     * Draws a single pixel.
      *
-     * @param pos - Pixel coordinates.
+     * @param pos - Target pixel in display coordinates.
      * @param color - Pixel color.
      */
     drawPixel: (pos: Vector2i, color: Color32): void => {
@@ -241,11 +221,12 @@ export const BT = {
     },
 
     /**
-     * Draws a line between two points using Bresenham's algorithm.
-     * Produces pixel-perfect lines without the antialiasing.
+     * Draws a pixel-perfect line between two points.
      *
-     * @param p0 - Start point.
-     * @param p1 - End point.
+     * Uses rasterized line drawing without antialiasing.
+     *
+     * @param p0 - Start position in display coordinates.
+     * @param p1 - End position in display coordinates.
      * @param color - Line color.
      */
     drawLine: (p0: Vector2i, p1: Vector2i, color: Color32): void => {
@@ -253,9 +234,9 @@ export const BT = {
     },
 
     /**
-     * Draws a rectangle outline (unfilled).
+     * Draws an unfilled rectangle outline.
      *
-     * @param rect - Rectangle bounds in pixel coordinates.
+     * @param rect - Rectangle bounds in display coordinates.
      * @param color - Outline color.
      */
     drawRect: (rect: Rect2i, color: Color32): void => {
@@ -265,7 +246,7 @@ export const BT = {
     /**
      * Draws a filled rectangle.
      *
-     * @param rect - Rectangle bounds in pixel coordinates.
+     * @param rect - Rectangle bounds in display coordinates.
      * @param color - Fill color.
      */
     drawRectFill: (rect: Rect2i, color: Color32): void => {
@@ -277,26 +258,25 @@ export const BT = {
     // #region Camera
 
     /**
-     * Sets the camera offset for scrolling effects.
-     * This amount offsets all drawing operations.
+     * Sets the global camera offset applied to subsequent draw calls.
      *
-     * @param offset - Camera position offset in pixels.
+     * @param offset - Camera translation in display pixels.
      */
     cameraSet: (offset: Vector2i): void => {
         BTAPI.instance.setCameraOffset(offset);
     },
 
     /**
-     * Gets the current camera offset.
+     * Returns the current global camera offset.
      *
-     * @returns Current camera position offset.
+     * @returns Camera translation in display pixels.
      */
     cameraGet: (): Vector2i => {
         return BTAPI.instance.getCameraOffset();
     },
 
     /**
-     * Resets the camera offset to (0, 0).
+     * Resets the global camera offset to `(0, 0)`.
      */
     cameraReset: (): void => {
         BTAPI.instance.resetCamera();
@@ -307,12 +287,13 @@ export const BT = {
     // #region Input - Gamepad Buttons
 
     /**
-     * Checks if a gamepad button is currently held down.
-     * Returns true for every frame the button remains pressed.
+     * Checks whether a gamepad button is currently held.
      *
-     * @param _button - Button constant (BTN_*).
-     * @param _player - Player index (0-3).
-     * @returns True if button is held down, false otherwise.
+     * This API is currently a stub and always returns `false`.
+     *
+     * @param _button - Button constant from the `BTN_*` set.
+     * @param _player - Zero-based player index.
+     * @returns `true` while the button remains pressed. Returns `false` until the input system is implemented.
      */
     buttonDown: (_button: number, _player: number = 0): boolean => {
         // TODO: Implement input system.
@@ -320,12 +301,13 @@ export const BT = {
     },
 
     /**
-     * Checks if a gamepad button was just pressed this frame.
-     * Returns true only on the first frame the button is pressed.
+     * Checks whether a gamepad button was pressed on the current frame.
      *
-     * @param _button - Button constant (BTN_*).
-     * @param _player - Player index (0-3).
-     * @returns True if button was just pressed, false otherwise.
+     * This API is currently a stub and always returns `false`.
+     *
+     * @param _button - Button constant from the `BTN_*` set.
+     * @param _player - Zero-based player index.
+     * @returns `true` on the transition frame. Returns `false` until the input system is implemented.
      */
     buttonPressed: (_button: number, _player: number = 0): boolean => {
         // TODO: Implement input system.
@@ -333,12 +315,13 @@ export const BT = {
     },
 
     /**
-     * Checks if a gamepad button was just released this frame.
-     * Returns true only on the first frame the button is released.
+     * Checks whether a gamepad button was released on the current frame.
      *
-     * @param _button - Button constant (BTN_*).
-     * @param _player - Player index (0-3).
-     * @returns True if button was just released, false otherwise.
+     * This API is currently a stub and always returns `false`.
+     *
+     * @param _button - Button constant from the `BTN_*` set.
+     * @param _player - Zero-based player index.
+     * @returns `true` on the release frame. Returns `false` until the input system is implemented.
      */
     buttonReleased: (_button: number, _player: number = 0): boolean => {
         // TODO: Implement input system.
@@ -350,11 +333,12 @@ export const BT = {
     // #region Input - Keyboard
 
     /**
-     * Checks if a keyboard key is currently held down.
-     * Returns true for every frame the key remains pressed.
+     * Checks whether a keyboard key is currently held.
      *
-     * @param _key - Key code (e.g., "KeyW", "Space", "ArrowUp").
-     * @returns True if key is held down, false otherwise.
+     * This API is currently a stub and always returns `false`.
+     *
+     * @param _key - DOM keyboard code such as `"KeyW"` or `"Space"`.
+     * @returns `true` while the key remains pressed. Returns `false` until the input system is implemented.
      */
     keyDown: (_key: string): boolean => {
         // TODO: Implement input system.
@@ -362,11 +346,12 @@ export const BT = {
     },
 
     /**
-     * Checks if a keyboard key was just pressed this frame.
-     * Returns true only on the first frame the key is pressed.
+     * Checks whether a keyboard key was pressed on the current frame.
      *
-     * @param _key - Key code (e.g., "KeyW", "Space", "ArrowUp").
-     * @returns True if key was just pressed, false otherwise.
+     * This API is currently a stub and always returns `false`.
+     *
+     * @param _key - DOM keyboard code such as `"KeyW"` or `"Space"`.
+     * @returns `true` on the transition frame. Returns `false` until the input system is implemented.
      */
     keyPressed: (_key: string): boolean => {
         // TODO: Implement input system.
@@ -374,11 +359,12 @@ export const BT = {
     },
 
     /**
-     * Checks if a keyboard key was just released this frame.
-     * Returns true only on the first frame the key is released.
+     * Checks whether a keyboard key was released on the current frame.
      *
-     * @param _key - Key code (e.g., "KeyW", "Space", "ArrowUp").
-     * @returns True if key was just released, false otherwise.
+     * This API is currently a stub and always returns `false`.
+     *
+     * @param _key - DOM keyboard code such as `"KeyW"` or `"Space"`.
+     * @returns `true` on the release frame. Returns `false` until the input system is implemented.
      */
     keyReleased: (_key: string): boolean => {
         // TODO: Implement input system.
@@ -390,24 +376,26 @@ export const BT = {
     // #region Text Rendering
 
     /**
-     * Prints placeholder text at the specified position.
-     * Each character is rendered as a simple colored block.
-     * For proper text rendering, use printFont() instead.
+     * Draws basic placeholder text.
      *
-     * @param pos - Text position (top-left corner).
+     * This uses the engine's fallback text rendering. For authored bitmap fonts,
+     * prefer {@link BT.printFont}.
+     *
+     * @param pos - Text origin in display coordinates.
      * @param color - Text color.
-     * @param text - String to display.
+     * @param text - String to render.
      */
     print: (pos: Vector2i, color: Color32, text: string): void => {
         BTAPI.instance.drawText(pos, color, text);
     },
 
     /**
-     * Measures the pixel dimensions of text.
-     * Currently, returns zero vector - implementation pending.
+     * Measures fallback text dimensions.
+     *
+     * This API is not implemented yet and currently returns `Vector2i.zero()`.
      *
      * @param _text - Text string to measure.
-     * @returns Size of text in pixels (currently always zero).
+     * @returns Text size in pixels. Returns `Vector2i.zero()` until measurement support is implemented.
      */
     printMeasure: (_text: string): Vector2i => {
         warnOnce('printMeasure', '[BT.printMeasure] Not yet implemented');
@@ -416,13 +404,15 @@ export const BT = {
     },
 
     /**
-     * Draws text using a bitmap font with variable-width glyphs.
-     * Supports Unicode characters and per-glyph rendering offsets.
+     * Draws text with a bitmap font.
      *
-     * @param font - Bitmap font to use for rendering.
-     * @param pos - Text position (top-left corner).
+     * Supports proportional glyph widths and glyph-level offsets defined by the
+     * supplied {@link BitmapFont}.
+     *
+     * @param font - Font asset used for rendering.
+     * @param pos - Text origin in display coordinates.
      * @param text - String to render.
-     * @param color - Optional text color (defaults to white).
+     * @param color - Optional tint color. Defaults to white when omitted.
      */
     printFont: (font: BitmapFont, pos: Vector2i, text: string, color?: Color32): void => {
         BTAPI.instance.drawBitmapText(font, pos, text, color);
@@ -434,9 +424,10 @@ export const BT = {
 
     /**
      * Captures the next rendered frame as a PNG blob.
-     * The capture happens on the next render cycle after this call.
      *
-     * @returns Promise resolving to a PNG Blob of the rendered frame.
+     * The returned promise resolves after the next render pass has completed.
+     *
+     * @returns PNG image data for the captured frame.
      *
      * @example
      * const blob = await BT.captureFrame();
@@ -448,16 +439,15 @@ export const BT = {
     },
 
     /**
-     * Captures the next rendered frame and triggers a browser file download.
-     * Convenience wrapper around captureFrame() that handles the download flow.
+     * Captures the next rendered frame and downloads it from the browser.
      *
-     * @param filename - Download filename (defaults to "blit-tech-capture.png").
+     * Convenience wrapper around {@link BT.captureFrame} that creates a temporary
+     * object URL and clicks a synthetic anchor element.
+     *
+     * @param filename - Target download filename.
      *
      * @example
-     * // Download with default filename
      * await BT.downloadFrame();
-     *
-     * // Download with custom filename
      * await BT.downloadFrame('screenshot-001.png');
      */
     downloadFrame: async (filename: string = 'blit-tech-capture.png'): Promise<void> => {
@@ -477,29 +467,20 @@ export const BT = {
 
     /**
      * Draws a sprite region from a sprite sheet.
-     * Supports texture batching for optimal performance.
      *
-     * The renderer automatically batches sprites by texture.
-     * Drawing sprites from the same SpriteSheet consecutively
-     * is more efficient than interleaving different textures.
+     * Textures internally batch sprite draws. Grouping draws from the
+     * same {@link SpriteSheet} minimizes batch flushes and reduces GPU state
+     * changes.
      *
-     * PERFORMANCE TIP: Group draw calls by texture to minimize GPU state changes.
-     *
-     * @param spriteSheet - Sprite sheet containing the source texture.
-     * @param srcRect - Source rectangle in the sprite sheet (pixel coordinates).
-     * @param destPos - Destination position on screen (top-left corner).
-     * @param tint - Optional tint color multiplied with texture (defaults to white).
+     * @param spriteSheet - Sprite sheet that owns the source texture.
+     * @param srcRect - Source rectangle within the sprite sheet, in pixels.
+     * @param destPos - Destination top-left position in display coordinates.
+     * @param tint - Optional multiplicative tint. Defaults to white.
      *
      * @example
-     * // Efficient: All from the same sprite sheet.
      * BT.drawSprite(sheet, new Rect2i(0, 0, 16, 16), new Vector2i(10, 10));
      * BT.drawSprite(sheet, new Rect2i(16, 0, 16, 16), new Vector2i(26, 10));
      * BT.drawSprite(sheet, new Rect2i(32, 0, 16, 16), new Vector2i(42, 10));
-     *
-     * // Less efficient: Interleaving textures causes batch flushes.
-     * BT.drawSprite(sheet1, ...);
-     * BT.drawSprite(sheet2, ...); // Flush + texture change
-     * BT.drawSprite(sheet1, ...); // Flush + texture change
      */
     drawSprite: (spriteSheet: SpriteSheet, srcRect: Rect2i, destPos: Vector2i, tint?: Color32): void => {
         BTAPI.instance.drawSprite(spriteSheet, srcRect, destPos, tint);

--- a/src/utils/Vector2i.test.ts
+++ b/src/utils/Vector2i.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Unit tests for {@link Vector2i}.
+ *
+ * Covers integer coercion, property aliases, shared directional singletons,
+ * arithmetic, comparisons, distance and length helpers, mutation APIs, and the
+ * zero-allocation patterns used throughout the engine.
+ */
+
 import { describe, expect, it } from 'vitest';
 
 import { Vector2i } from './Vector2i';
@@ -8,36 +16,42 @@ describe('Vector2i', () => {
     describe('Constructor', () => {
         it('should default to (0, 0)', () => {
             const v = new Vector2i();
+
             expect(v.x).toBe(0);
             expect(v.y).toBe(0);
         });
 
         it('should accept integer values', () => {
             const v = new Vector2i(3, 7);
+
             expect(v.x).toBe(3);
             expect(v.y).toBe(7);
         });
 
         it('should truncate positive floats toward zero', () => {
             const v = new Vector2i(3.7, 9.9);
+
             expect(v.x).toBe(3);
             expect(v.y).toBe(9);
         });
 
         it('should truncate negative floats toward zero', () => {
             const v = new Vector2i(-2.3, -5.8);
+
             expect(v.x).toBe(-2);
             expect(v.y).toBe(-5);
         });
 
         it('should handle negative integer values', () => {
             const v = new Vector2i(-10, -20);
+
             expect(v.x).toBe(-10);
             expect(v.y).toBe(-20);
         });
 
         it('should handle a single argument with y defaulting to 0', () => {
             const v = new Vector2i(5);
+
             expect(v.x).toBe(5);
             expect(v.y).toBe(0);
         });
@@ -50,34 +64,42 @@ describe('Vector2i', () => {
     describe('Property Aliases', () => {
         it('should return x as width', () => {
             const v = new Vector2i(42, 99);
+
             expect(v.width).toBe(42);
             expect(v.width).toBe(v.x);
         });
 
         it('should return y as height', () => {
             const v = new Vector2i(42, 99);
+
             expect(v.height).toBe(99);
             expect(v.height).toBe(v.y);
         });
 
         it('should set x via width setter and truncate floats', () => {
             const v = new Vector2i(0, 0);
+
             v.width = 7.9;
+
             expect(v.x).toBe(7);
             expect(v.width).toBe(7);
         });
 
         it('should set y via height setter and truncate floats', () => {
             const v = new Vector2i(0, 0);
+
             v.height = -3.6;
+
             expect(v.y).toBe(-3);
             expect(v.height).toBe(-3);
         });
 
         it('should set integer values via width/height without change', () => {
             const v = new Vector2i(0, 0);
+
             v.width = 100;
             v.height = 200;
+
             expect(v.x).toBe(100);
             expect(v.y).toBe(200);
         });
@@ -90,6 +112,7 @@ describe('Vector2i', () => {
     describe('Static Singletons', () => {
         it('should return (0, 0) for zero()', () => {
             const v = Vector2i.zero();
+
             expect(v.x).toBe(0);
             expect(v.y).toBe(0);
         });
@@ -104,6 +127,7 @@ describe('Vector2i', () => {
 
         it('should return (1, 1) for one()', () => {
             const v = Vector2i.one();
+
             expect(v.x).toBe(1);
             expect(v.y).toBe(1);
         });
@@ -128,6 +152,7 @@ describe('Vector2i', () => {
 
         it('should return (0, 1) for down()', () => {
             const v = Vector2i.down();
+
             expect(v.x).toBe(0);
             expect(v.y).toBe(1);
         });
@@ -138,6 +163,7 @@ describe('Vector2i', () => {
 
         it('should return (-1, 0) for left()', () => {
             const v = Vector2i.left();
+
             expect(v.x).toBe(-1);
             expect(v.y).toBe(0);
         });
@@ -148,6 +174,7 @@ describe('Vector2i', () => {
 
         it('should return (1, 0) for right()', () => {
             const v = Vector2i.right();
+
             expect(v.x).toBe(1);
             expect(v.y).toBe(0);
         });
@@ -167,6 +194,7 @@ describe('Vector2i', () => {
                 const a = new Vector2i(3, 5);
                 const b = new Vector2i(7, 11);
                 const result = a.add(b);
+
                 expect(result.x).toBe(10);
                 expect(result.y).toBe(16);
             });
@@ -174,7 +202,9 @@ describe('Vector2i', () => {
             it('should not mutate the originals', () => {
                 const a = new Vector2i(3, 5);
                 const b = new Vector2i(7, 11);
+
                 a.add(b);
+
                 expect(a.x).toBe(3);
                 expect(a.y).toBe(5);
                 expect(b.x).toBe(7);
@@ -185,6 +215,7 @@ describe('Vector2i', () => {
                 const a = new Vector2i(-10, 20);
                 const b = new Vector2i(5, -30);
                 const result = a.add(b);
+
                 expect(result.x).toBe(-5);
                 expect(result.y).toBe(-10);
             });
@@ -194,6 +225,7 @@ describe('Vector2i', () => {
             it('should add raw x,y to vector', () => {
                 const v = new Vector2i(10, 20);
                 const result = v.addXY(5, -3);
+
                 expect(result.x).toBe(15);
                 expect(result.y).toBe(17);
             });
@@ -201,13 +233,16 @@ describe('Vector2i', () => {
             it('should truncate float arguments', () => {
                 const v = new Vector2i(10, 20);
                 const result = v.addXY(1.9, 2.1);
+
                 expect(result.x).toBe(11);
                 expect(result.y).toBe(22);
             });
 
             it('should not mutate the original', () => {
                 const v = new Vector2i(10, 20);
+
                 v.addXY(5, 5);
+
                 expect(v.x).toBe(10);
                 expect(v.y).toBe(20);
             });
@@ -218,6 +253,7 @@ describe('Vector2i', () => {
                 const a = new Vector2i(10, 20);
                 const b = new Vector2i(3, 7);
                 const result = a.sub(b);
+
                 expect(result.x).toBe(7);
                 expect(result.y).toBe(13);
             });
@@ -225,7 +261,9 @@ describe('Vector2i', () => {
             it('should not mutate the originals', () => {
                 const a = new Vector2i(10, 20);
                 const b = new Vector2i(3, 7);
+
                 a.sub(b);
+
                 expect(a.x).toBe(10);
                 expect(b.x).toBe(3);
             });
@@ -233,7 +271,9 @@ describe('Vector2i', () => {
             it('should handle resulting negative values', () => {
                 const a = new Vector2i(3, 5);
                 const b = new Vector2i(10, 20);
+
                 const result = a.sub(b);
+
                 expect(result.x).toBe(-7);
                 expect(result.y).toBe(-15);
             });
@@ -243,6 +283,7 @@ describe('Vector2i', () => {
             it('should subtract raw x,y from vector', () => {
                 const v = new Vector2i(10, 20);
                 const result = v.subXY(3, 7);
+
                 expect(result.x).toBe(7);
                 expect(result.y).toBe(13);
             });
@@ -250,13 +291,16 @@ describe('Vector2i', () => {
             it('should truncate float arguments', () => {
                 const v = new Vector2i(10, 20);
                 const result = v.subXY(1.9, 2.1);
+
                 expect(result.x).toBe(9);
                 expect(result.y).toBe(18);
             });
 
             it('should not mutate the original', () => {
                 const v = new Vector2i(10, 20);
+
                 v.subXY(3, 7);
+
                 expect(v.x).toBe(10);
                 expect(v.y).toBe(20);
             });
@@ -266,13 +310,15 @@ describe('Vector2i', () => {
             it('should multiply by a scalar', () => {
                 const v = new Vector2i(3, 5);
                 const result = v.mul(4);
+
                 expect(result.x).toBe(12);
                 expect(result.y).toBe(20);
             });
 
-            it('should truncate results with non-integer scalar', () => {
+            it('should truncate results with noninteger scalar', () => {
                 const v = new Vector2i(3, 5);
                 const result = v.mul(1.5);
+
                 expect(result.x).toBe(4);
                 expect(result.y).toBe(7);
             });
@@ -280,6 +326,7 @@ describe('Vector2i', () => {
             it('should handle zero scalar', () => {
                 const v = new Vector2i(3, 5);
                 const result = v.mul(0);
+
                 expect(result.x).toBe(0);
                 expect(result.y).toBe(0);
             });
@@ -287,6 +334,7 @@ describe('Vector2i', () => {
             it('should handle negative scalar', () => {
                 const v = new Vector2i(3, 5);
                 const result = v.mul(-2);
+
                 expect(result.x).toBe(-6);
                 expect(result.y).toBe(-10);
             });
@@ -297,6 +345,7 @@ describe('Vector2i', () => {
                 const a = new Vector2i(3, 5);
                 const b = new Vector2i(2, 4);
                 const result = a.mulVec(b);
+
                 expect(result.x).toBe(6);
                 expect(result.y).toBe(20);
             });
@@ -305,6 +354,7 @@ describe('Vector2i', () => {
                 const a = new Vector2i(3, -5);
                 const b = new Vector2i(-2, 4);
                 const result = a.mulVec(b);
+
                 expect(result.x).toBe(-6);
                 expect(result.y).toBe(-20);
             });
@@ -313,6 +363,7 @@ describe('Vector2i', () => {
                 const a = new Vector2i(3, 5);
                 const b = new Vector2i(0, 0);
                 const result = a.mulVec(b);
+
                 expect(result.x).toBe(0);
                 expect(result.y).toBe(0);
             });
@@ -322,6 +373,7 @@ describe('Vector2i', () => {
             it('should divide by a scalar and truncate toward zero', () => {
                 const v = new Vector2i(10, 20);
                 const result = v.div(3);
+
                 expect(result.x).toBe(3);
                 expect(result.y).toBe(6);
             });
@@ -329,18 +381,21 @@ describe('Vector2i', () => {
             it('should truncate negative results toward zero', () => {
                 const v = new Vector2i(-7, 7);
                 const result = v.div(2);
+
                 expect(result.x).toBe(-3);
                 expect(result.y).toBe(3);
             });
 
             it('should throw on zero divisor', () => {
                 const v = new Vector2i(10, 20);
+
                 expect(() => v.div(0)).toThrow('Vector2i.div: scalar must not be zero');
             });
 
             it('should handle division by negative scalar', () => {
                 const v = new Vector2i(10, 20);
                 const result = v.div(-3);
+
                 expect(result.x).toBe(-3);
                 expect(result.y).toBe(-6);
             });
@@ -357,6 +412,7 @@ describe('Vector2i', () => {
             it('should negate negative components', () => {
                 const v = new Vector2i(-3, -5);
                 const result = v.negate();
+
                 expect(result.x).toBe(3);
                 expect(result.y).toBe(5);
             });
@@ -364,6 +420,7 @@ describe('Vector2i', () => {
             it('should handle zero vector', () => {
                 const v = new Vector2i(0, 0);
                 const result = v.negate();
+
                 // -0 from fromXYUnchecked(-0, -0) is numerically equal to 0
                 expect(result.x + 0).toBe(0);
                 expect(result.y + 0).toBe(0);
@@ -374,6 +431,7 @@ describe('Vector2i', () => {
             it('should return absolute values', () => {
                 const v = new Vector2i(-3, -5);
                 const result = v.abs();
+
                 expect(result.x).toBe(3);
                 expect(result.y).toBe(5);
             });
@@ -381,6 +439,7 @@ describe('Vector2i', () => {
             it('should keep positive values unchanged', () => {
                 const v = new Vector2i(3, 5);
                 const result = v.abs();
+
                 expect(result.x).toBe(3);
                 expect(result.y).toBe(5);
             });
@@ -388,6 +447,7 @@ describe('Vector2i', () => {
             it('should handle mixed signs', () => {
                 const v = new Vector2i(-3, 5);
                 const result = v.abs();
+
                 expect(result.x).toBe(3);
                 expect(result.y).toBe(5);
             });
@@ -398,6 +458,7 @@ describe('Vector2i', () => {
                 const a = new Vector2i(3, 10);
                 const b = new Vector2i(7, 5);
                 const result = a.min(b);
+
                 expect(result.x).toBe(3);
                 expect(result.y).toBe(5);
             });
@@ -406,6 +467,7 @@ describe('Vector2i', () => {
                 const a = new Vector2i(-5, 10);
                 const b = new Vector2i(-3, -2);
                 const result = a.min(b);
+
                 expect(result.x).toBe(-5);
                 expect(result.y).toBe(-2);
             });
@@ -414,6 +476,7 @@ describe('Vector2i', () => {
                 const a = new Vector2i(4, 4);
                 const b = new Vector2i(4, 4);
                 const result = a.min(b);
+
                 expect(result.x).toBe(4);
                 expect(result.y).toBe(4);
             });
@@ -424,6 +487,7 @@ describe('Vector2i', () => {
                 const a = new Vector2i(3, 10);
                 const b = new Vector2i(7, 5);
                 const result = a.max(b);
+
                 expect(result.x).toBe(7);
                 expect(result.y).toBe(10);
             });
@@ -432,6 +496,7 @@ describe('Vector2i', () => {
                 const a = new Vector2i(-5, 10);
                 const b = new Vector2i(-3, -2);
                 const result = a.max(b);
+
                 expect(result.x).toBe(-3);
                 expect(result.y).toBe(10);
             });
@@ -440,6 +505,7 @@ describe('Vector2i', () => {
                 const a = new Vector2i(4, 4);
                 const b = new Vector2i(4, 4);
                 const result = a.max(b);
+
                 expect(result.x).toBe(4);
                 expect(result.y).toBe(4);
             });
@@ -449,6 +515,7 @@ describe('Vector2i', () => {
             it('should clamp values within range', () => {
                 const v = new Vector2i(15, -5);
                 const result = v.clamp(0, 10);
+
                 expect(result.x).toBe(10);
                 expect(result.y).toBe(0);
             });
@@ -456,6 +523,7 @@ describe('Vector2i', () => {
             it('should leave values already in range unchanged', () => {
                 const v = new Vector2i(5, 7);
                 const result = v.clamp(0, 10);
+
                 expect(result.x).toBe(5);
                 expect(result.y).toBe(7);
             });
@@ -463,6 +531,7 @@ describe('Vector2i', () => {
             it('should truncate float bounds', () => {
                 const v = new Vector2i(15, -5);
                 const result = v.clamp(0.9, 10.9);
+
                 expect(result.x).toBe(10);
                 expect(result.y).toBe(0);
             });
@@ -474,6 +543,7 @@ describe('Vector2i', () => {
                 const minV = new Vector2i(0, 0);
                 const maxV = new Vector2i(10, 10);
                 const result = v.clampVec(minV, maxV);
+
                 expect(result.x).toBe(10);
                 expect(result.y).toBe(0);
             });
@@ -483,6 +553,7 @@ describe('Vector2i', () => {
                 const minV = new Vector2i(-10, -20);
                 const maxV = new Vector2i(20, 30);
                 const result = v.clampVec(minV, maxV);
+
                 expect(result.x).toBe(20);
                 expect(result.y).toBe(-20);
             });
@@ -492,6 +563,7 @@ describe('Vector2i', () => {
                 const minV = new Vector2i(0, 0);
                 const maxV = new Vector2i(10, 10);
                 const result = v.clampVec(minV, maxV);
+
                 expect(result.x).toBe(5);
                 expect(result.y).toBe(5);
             });
@@ -501,38 +573,44 @@ describe('Vector2i', () => {
             it('should compute dot product', () => {
                 const a = new Vector2i(3, 4);
                 const b = new Vector2i(2, 5);
+
                 expect(a.dot(b)).toBe(26);
             });
 
             it('should return zero for perpendicular vectors', () => {
                 const a = new Vector2i(1, 0);
                 const b = new Vector2i(0, 1);
+
                 expect(a.dot(b)).toBe(0);
             });
 
             it('should return negative for opposite-facing vectors', () => {
                 const a = new Vector2i(1, 0);
                 const b = new Vector2i(-1, 0);
+
                 expect(a.dot(b)).toBe(-1);
             });
         });
 
         describe('cross', () => {
-            it('should compute 2D cross product', () => {
+            it('should compute 2D cross-product', () => {
                 const a = new Vector2i(3, 4);
                 const b = new Vector2i(2, 5);
+
                 expect(a.cross(b)).toBe(7);
             });
 
             it('should return zero for parallel vectors', () => {
                 const a = new Vector2i(2, 4);
                 const b = new Vector2i(1, 2);
+
                 expect(a.cross(b)).toBe(0);
             });
 
             it('should return negative for clockwise winding', () => {
                 const a = new Vector2i(1, 0);
                 const b = new Vector2i(0, -1);
+
                 expect(a.cross(b)).toBe(-1);
             });
         });
@@ -541,6 +619,7 @@ describe('Vector2i', () => {
             it('should rotate 90 degrees counter-clockwise', () => {
                 const v = new Vector2i(1, 0);
                 const result = v.perpendicular();
+
                 // -0 from fromXYUnchecked(-0, x) is numerically equal to 0
                 expect(result.x + 0).toBe(0);
                 expect(result.y).toBe(1);
@@ -549,6 +628,7 @@ describe('Vector2i', () => {
             it('should rotate (3, 4) to (-4, 3)', () => {
                 const v = new Vector2i(3, 4);
                 const result = v.perpendicular();
+
                 expect(result.x).toBe(-4);
                 expect(result.y).toBe(3);
             });
@@ -556,6 +636,7 @@ describe('Vector2i', () => {
             it('should produce a vector with dot product zero', () => {
                 const v = new Vector2i(5, 7);
                 const perp = v.perpendicular();
+
                 expect(v.dot(perp)).toBe(0);
             });
         });
@@ -564,6 +645,7 @@ describe('Vector2i', () => {
             it('should rotate 90 degrees clockwise', () => {
                 const v = new Vector2i(1, 0);
                 const result = v.perpendicularCW();
+
                 expect(result.x).toBe(0);
                 expect(result.y).toBe(-1);
             });
@@ -571,6 +653,7 @@ describe('Vector2i', () => {
             it('should rotate (3, 4) to (4, -3)', () => {
                 const v = new Vector2i(3, 4);
                 const result = v.perpendicularCW();
+
                 expect(result.x).toBe(4);
                 expect(result.y).toBe(-3);
             });
@@ -578,6 +661,7 @@ describe('Vector2i', () => {
             it('should produce a vector with dot product zero', () => {
                 const v = new Vector2i(5, 7);
                 const perp = v.perpendicularCW();
+
                 expect(v.dot(perp)).toBe(0);
             });
         });
@@ -593,7 +677,9 @@ describe('Vector2i', () => {
                 const a = new Vector2i(3, 5);
                 const b = new Vector2i(7, 11);
                 const out = new Vector2i();
+
                 a.addTo(b, out);
+
                 expect(out.x).toBe(10);
                 expect(out.y).toBe(16);
             });
@@ -603,6 +689,7 @@ describe('Vector2i', () => {
                 const b = new Vector2i(7, 11);
                 const out = new Vector2i();
                 const returned = a.addTo(b, out);
+
                 expect(returned).toBe(out);
             });
 
@@ -610,7 +697,9 @@ describe('Vector2i', () => {
                 const a = new Vector2i(3, 5);
                 const b = new Vector2i(7, 11);
                 const out = new Vector2i();
+
                 a.addTo(b, out);
+
                 expect(a.x).toBe(3);
                 expect(b.x).toBe(7);
             });
@@ -621,7 +710,9 @@ describe('Vector2i', () => {
                 const a = new Vector2i(10, 20);
                 const b = new Vector2i(3, 7);
                 const out = new Vector2i();
+
                 a.subTo(b, out);
+
                 expect(out.x).toBe(7);
                 expect(out.y).toBe(13);
             });
@@ -630,6 +721,7 @@ describe('Vector2i', () => {
                 const a = new Vector2i(10, 20);
                 const b = new Vector2i(3, 7);
                 const out = new Vector2i();
+
                 expect(a.subTo(b, out)).toBe(out);
             });
         });
@@ -638,15 +730,19 @@ describe('Vector2i', () => {
             it('should write the scaled result to the output vector', () => {
                 const v = new Vector2i(3, 5);
                 const out = new Vector2i();
+
                 v.mulTo(4, out);
+
                 expect(out.x).toBe(12);
                 expect(out.y).toBe(20);
             });
 
-            it('should truncate non-integer results', () => {
+            it('should truncate noninteger results', () => {
                 const v = new Vector2i(3, 5);
                 const out = new Vector2i();
+
                 v.mulTo(1.5, out);
+
                 expect(out.x).toBe(4);
                 expect(out.y).toBe(7);
             });
@@ -654,6 +750,7 @@ describe('Vector2i', () => {
             it('should return the output vector', () => {
                 const v = new Vector2i(3, 5);
                 const out = new Vector2i();
+
                 expect(v.mulTo(2, out)).toBe(out);
             });
         });
@@ -662,7 +759,9 @@ describe('Vector2i', () => {
             it('should write the divided result to the output vector', () => {
                 const v = new Vector2i(10, 20);
                 const out = new Vector2i();
+
                 v.divTo(3, out);
+
                 expect(out.x).toBe(3);
                 expect(out.y).toBe(6);
             });
@@ -670,12 +769,14 @@ describe('Vector2i', () => {
             it('should throw on zero divisor', () => {
                 const v = new Vector2i(10, 20);
                 const out = new Vector2i();
+
                 expect(() => v.divTo(0, out)).toThrow('Vector2i.divTo: scalar must not be zero');
             });
 
             it('should return the output vector', () => {
                 const v = new Vector2i(10, 20);
                 const out = new Vector2i();
+
                 expect(v.divTo(2, out)).toBe(out);
             });
         });
@@ -684,7 +785,9 @@ describe('Vector2i', () => {
             it('should copy values to the output vector', () => {
                 const v = new Vector2i(42, 99);
                 const out = new Vector2i();
+
                 v.cloneTo(out);
+
                 expect(out.x).toBe(42);
                 expect(out.y).toBe(99);
             });
@@ -692,6 +795,7 @@ describe('Vector2i', () => {
             it('should return the output vector', () => {
                 const v = new Vector2i(42, 99);
                 const out = new Vector2i();
+
                 expect(v.cloneTo(out)).toBe(out);
             });
         });
@@ -700,7 +804,9 @@ describe('Vector2i', () => {
             it('should write negated values to the output vector', () => {
                 const v = new Vector2i(3, -5);
                 const out = new Vector2i();
+
                 v.negateTo(out);
+
                 expect(out.x).toBe(-3);
                 expect(out.y).toBe(5);
             });
@@ -708,6 +814,7 @@ describe('Vector2i', () => {
             it('should return the output vector', () => {
                 const v = new Vector2i(3, -5);
                 const out = new Vector2i();
+
                 expect(v.negateTo(out)).toBe(out);
             });
         });
@@ -716,7 +823,9 @@ describe('Vector2i', () => {
             it('should write absolute values to the output vector', () => {
                 const v = new Vector2i(-3, -5);
                 const out = new Vector2i();
+
                 v.absTo(out);
+
                 expect(out.x).toBe(3);
                 expect(out.y).toBe(5);
             });
@@ -724,6 +833,7 @@ describe('Vector2i', () => {
             it('should return the output vector', () => {
                 const v = new Vector2i(-3, -5);
                 const out = new Vector2i();
+
                 expect(v.absTo(out)).toBe(out);
             });
         });
@@ -733,7 +843,9 @@ describe('Vector2i', () => {
                 const a = new Vector2i(3, 10);
                 const b = new Vector2i(7, 5);
                 const out = new Vector2i();
+
                 a.minTo(b, out);
+
                 expect(out.x).toBe(3);
                 expect(out.y).toBe(5);
             });
@@ -742,6 +854,7 @@ describe('Vector2i', () => {
                 const a = new Vector2i(3, 10);
                 const b = new Vector2i(7, 5);
                 const out = new Vector2i();
+
                 expect(a.minTo(b, out)).toBe(out);
             });
         });
@@ -751,7 +864,9 @@ describe('Vector2i', () => {
                 const a = new Vector2i(3, 10);
                 const b = new Vector2i(7, 5);
                 const out = new Vector2i();
+
                 a.maxTo(b, out);
+
                 expect(out.x).toBe(7);
                 expect(out.y).toBe(10);
             });
@@ -760,6 +875,7 @@ describe('Vector2i', () => {
                 const a = new Vector2i(3, 10);
                 const b = new Vector2i(7, 5);
                 const out = new Vector2i();
+
                 expect(a.maxTo(b, out)).toBe(out);
             });
         });
@@ -768,7 +884,9 @@ describe('Vector2i', () => {
             it('should write clamped values to the output vector', () => {
                 const v = new Vector2i(15, -5);
                 const out = new Vector2i();
+
                 v.clampTo(0, 10, out);
+
                 expect(out.x).toBe(10);
                 expect(out.y).toBe(0);
             });
@@ -776,13 +894,16 @@ describe('Vector2i', () => {
             it('should return the output vector', () => {
                 const v = new Vector2i(15, -5);
                 const out = new Vector2i();
+
                 expect(v.clampTo(0, 10, out)).toBe(out);
             });
 
             it('should truncate float bounds', () => {
                 const v = new Vector2i(15, -5);
                 const out = new Vector2i();
+
                 v.clampTo(0.9, 10.9, out);
+
                 expect(out.x).toBe(10);
                 expect(out.y).toBe(0);
             });
@@ -798,6 +919,7 @@ describe('Vector2i', () => {
             it('should add another vector in place', () => {
                 const v = new Vector2i(3, 5);
                 v.addInPlace(new Vector2i(7, 11));
+
                 expect(v.x).toBe(10);
                 expect(v.y).toBe(16);
             });
@@ -805,12 +927,15 @@ describe('Vector2i', () => {
             it('should return this for chaining', () => {
                 const v = new Vector2i(3, 5);
                 const returned = v.addInPlace(new Vector2i(1, 1));
+
                 expect(returned).toBe(v);
             });
 
             it('should support chaining', () => {
                 const v = new Vector2i(1, 1);
+
                 v.addInPlace(new Vector2i(2, 2)).addInPlace(new Vector2i(3, 3));
+
                 expect(v.x).toBe(6);
                 expect(v.y).toBe(6);
             });
@@ -819,20 +944,25 @@ describe('Vector2i', () => {
         describe('addXYInPlace', () => {
             it('should add raw x,y in place', () => {
                 const v = new Vector2i(3, 5);
+
                 v.addXYInPlace(7, 11);
+
                 expect(v.x).toBe(10);
                 expect(v.y).toBe(16);
             });
 
             it('should truncate float arguments', () => {
                 const v = new Vector2i(3, 5);
+
                 v.addXYInPlace(1.9, 2.1);
+
                 expect(v.x).toBe(4);
                 expect(v.y).toBe(7);
             });
 
             it('should return this for chaining', () => {
                 const v = new Vector2i(3, 5);
+
                 expect(v.addXYInPlace(1, 1)).toBe(v);
             });
         });
@@ -840,13 +970,16 @@ describe('Vector2i', () => {
         describe('subInPlace', () => {
             it('should subtract another vector in place', () => {
                 const v = new Vector2i(10, 20);
+
                 v.subInPlace(new Vector2i(3, 7));
+
                 expect(v.x).toBe(7);
                 expect(v.y).toBe(13);
             });
 
             it('should return this for chaining', () => {
                 const v = new Vector2i(10, 20);
+
                 expect(v.subInPlace(new Vector2i(3, 7))).toBe(v);
             });
         });
@@ -854,20 +987,25 @@ describe('Vector2i', () => {
         describe('subXYInPlace', () => {
             it('should subtract raw x,y in place', () => {
                 const v = new Vector2i(10, 20);
+
                 v.subXYInPlace(3, 7);
+
                 expect(v.x).toBe(7);
                 expect(v.y).toBe(13);
             });
 
             it('should truncate float arguments', () => {
                 const v = new Vector2i(10, 20);
+
                 v.subXYInPlace(1.9, 2.1);
+
                 expect(v.x).toBe(9);
                 expect(v.y).toBe(18);
             });
 
             it('should return this for chaining', () => {
                 const v = new Vector2i(10, 20);
+
                 expect(v.subXYInPlace(3, 7)).toBe(v);
             });
         });
@@ -875,20 +1013,25 @@ describe('Vector2i', () => {
         describe('mulInPlace', () => {
             it('should multiply by scalar in place', () => {
                 const v = new Vector2i(3, 5);
+
                 v.mulInPlace(4);
+
                 expect(v.x).toBe(12);
                 expect(v.y).toBe(20);
             });
 
-            it('should truncate non-integer results', () => {
+            it('should truncate noninteger results', () => {
                 const v = new Vector2i(3, 5);
+
                 v.mulInPlace(1.5);
+
                 expect(v.x).toBe(4);
                 expect(v.y).toBe(7);
             });
 
             it('should return this for chaining', () => {
                 const v = new Vector2i(3, 5);
+
                 expect(v.mulInPlace(2)).toBe(v);
             });
         });
@@ -896,20 +1039,25 @@ describe('Vector2i', () => {
         describe('mulVecInPlace', () => {
             it('should perform component-wise multiplication in place', () => {
                 const v = new Vector2i(3, 5);
+
                 v.mulVecInPlace(new Vector2i(2, 4));
+
                 expect(v.x).toBe(6);
                 expect(v.y).toBe(20);
             });
 
             it('should handle zero components', () => {
                 const v = new Vector2i(3, 5);
+
                 v.mulVecInPlace(new Vector2i(0, 0));
+
                 expect(v.x).toBe(0);
                 expect(v.y).toBe(0);
             });
 
             it('should return this for chaining', () => {
                 const v = new Vector2i(3, 5);
+
                 expect(v.mulVecInPlace(new Vector2i(2, 4))).toBe(v);
             });
         });
@@ -917,18 +1065,22 @@ describe('Vector2i', () => {
         describe('divInPlace', () => {
             it('should divide by scalar in place', () => {
                 const v = new Vector2i(10, 20);
+
                 v.divInPlace(3);
+
                 expect(v.x).toBe(3);
                 expect(v.y).toBe(6);
             });
 
             it('should throw on zero divisor', () => {
                 const v = new Vector2i(10, 20);
+
                 expect(() => v.divInPlace(0)).toThrow('Vector2i.divInPlace: scalar must not be zero');
             });
 
             it('should return this for chaining', () => {
                 const v = new Vector2i(10, 20);
+
                 expect(v.divInPlace(2)).toBe(v);
             });
         });
@@ -936,13 +1088,16 @@ describe('Vector2i', () => {
         describe('negateInPlace', () => {
             it('should negate components in place', () => {
                 const v = new Vector2i(3, -5);
+
                 v.negateInPlace();
+
                 expect(v.x).toBe(-3);
                 expect(v.y).toBe(5);
             });
 
             it('should return this for chaining', () => {
                 const v = new Vector2i(3, -5);
+
                 expect(v.negateInPlace()).toBe(v);
             });
         });
@@ -950,48 +1105,59 @@ describe('Vector2i', () => {
         describe('absInPlace', () => {
             it('should apply absolute value in place', () => {
                 const v = new Vector2i(-3, -5);
+
                 v.absInPlace();
+
                 expect(v.x).toBe(3);
                 expect(v.y).toBe(5);
             });
 
             it('should leave positive values unchanged', () => {
                 const v = new Vector2i(3, 5);
+
                 v.absInPlace();
+
                 expect(v.x).toBe(3);
                 expect(v.y).toBe(5);
             });
 
             it('should return this for chaining', () => {
                 const v = new Vector2i(-3, -5);
+
                 expect(v.absInPlace()).toBe(v);
             });
         });
 
         describe('minInPlace', () => {
-            it('should set to component-wise minimum in place', () => {
+            it('should set to a component-wise minimum in place', () => {
                 const v = new Vector2i(7, 3);
+
                 v.minInPlace(new Vector2i(5, 10));
+
                 expect(v.x).toBe(5);
                 expect(v.y).toBe(3);
             });
 
             it('should return this for chaining', () => {
                 const v = new Vector2i(7, 3);
+
                 expect(v.minInPlace(new Vector2i(5, 10))).toBe(v);
             });
         });
 
         describe('maxInPlace', () => {
-            it('should set to component-wise maximum in place', () => {
+            it('should set to a component-wise maximum in place', () => {
                 const v = new Vector2i(7, 3);
+
                 v.maxInPlace(new Vector2i(5, 10));
+
                 expect(v.x).toBe(7);
                 expect(v.y).toBe(10);
             });
 
             it('should return this for chaining', () => {
                 const v = new Vector2i(7, 3);
+
                 expect(v.maxInPlace(new Vector2i(5, 10))).toBe(v);
             });
         });
@@ -999,20 +1165,25 @@ describe('Vector2i', () => {
         describe('clampInPlace', () => {
             it('should clamp components in place', () => {
                 const v = new Vector2i(15, -5);
+
                 v.clampInPlace(0, 10);
+
                 expect(v.x).toBe(10);
                 expect(v.y).toBe(0);
             });
 
-            it('should leave values in range unchanged', () => {
+            it('should leave values in the range unchanged', () => {
                 const v = new Vector2i(5, 7);
+
                 v.clampInPlace(0, 10);
+
                 expect(v.x).toBe(5);
                 expect(v.y).toBe(7);
             });
 
             it('should return this for chaining', () => {
                 const v = new Vector2i(15, -5);
+
                 expect(v.clampInPlace(0, 10)).toBe(v);
             });
         });
@@ -1020,20 +1191,25 @@ describe('Vector2i', () => {
         describe('clampVecInPlace', () => {
             it('should clamp to vector bounds in place', () => {
                 const v = new Vector2i(15, -5);
+
                 v.clampVecInPlace(new Vector2i(0, 0), new Vector2i(10, 10));
+
                 expect(v.x).toBe(10);
                 expect(v.y).toBe(0);
             });
 
             it('should allow asymmetric clamping', () => {
                 const v = new Vector2i(50, -50);
+
                 v.clampVecInPlace(new Vector2i(-10, -20), new Vector2i(20, 30));
+
                 expect(v.x).toBe(20);
                 expect(v.y).toBe(-20);
             });
 
             it('should return this for chaining', () => {
                 const v = new Vector2i(15, -5);
+
                 expect(v.clampVecInPlace(new Vector2i(0, 0), new Vector2i(10, 10))).toBe(v);
             });
         });
@@ -1041,20 +1217,25 @@ describe('Vector2i', () => {
         describe('set', () => {
             it('should set both components', () => {
                 const v = new Vector2i(0, 0);
+
                 v.set(42, 99);
+
                 expect(v.x).toBe(42);
                 expect(v.y).toBe(99);
             });
 
             it('should truncate float values', () => {
                 const v = new Vector2i(0, 0);
+
                 v.set(3.7, -2.3);
+
                 expect(v.x).toBe(3);
                 expect(v.y).toBe(-2);
             });
 
             it('should return this for chaining', () => {
                 const v = new Vector2i(0, 0);
+
                 expect(v.set(1, 2)).toBe(v);
             });
         });
@@ -1063,7 +1244,9 @@ describe('Vector2i', () => {
             it('should copy values from another vector', () => {
                 const v = new Vector2i(0, 0);
                 const source = new Vector2i(42, 99);
+
                 v.copyFrom(source);
+
                 expect(v.x).toBe(42);
                 expect(v.y).toBe(99);
             });
@@ -1071,13 +1254,17 @@ describe('Vector2i', () => {
             it('should not create a link between vectors', () => {
                 const v = new Vector2i(0, 0);
                 const source = new Vector2i(42, 99);
+
                 v.copyFrom(source);
+
                 source.x = 100;
+
                 expect(v.x).toBe(42);
             });
 
             it('should return this for chaining', () => {
                 const v = new Vector2i(0, 0);
+
                 expect(v.copyFrom(new Vector2i(1, 2))).toBe(v);
             });
         });
@@ -1091,16 +1278,19 @@ describe('Vector2i', () => {
         describe('magnitude', () => {
             it('should return 5 for (3, 4)', () => {
                 const v = new Vector2i(3, 4);
+
                 expect(v.magnitude()).toBe(5);
             });
 
             it('should return 0 for zero vector', () => {
                 const v = new Vector2i(0, 0);
+
                 expect(v.magnitude()).toBe(0);
             });
 
             it('should handle negative components', () => {
                 const v = new Vector2i(-3, -4);
+
                 expect(v.magnitude()).toBe(5);
             });
         });
@@ -1108,16 +1298,19 @@ describe('Vector2i', () => {
         describe('sqrMagnitude', () => {
             it('should return 25 for (3, 4)', () => {
                 const v = new Vector2i(3, 4);
+
                 expect(v.sqrMagnitude()).toBe(25);
             });
 
             it('should return 0 for zero vector', () => {
                 const v = new Vector2i(0, 0);
+
                 expect(v.sqrMagnitude()).toBe(0);
             });
 
             it('should handle (1, 1)', () => {
                 const v = new Vector2i(1, 1);
+
                 expect(v.sqrMagnitude()).toBe(2);
             });
         });
@@ -1126,18 +1319,21 @@ describe('Vector2i', () => {
             it('should compute Euclidean distance', () => {
                 const a = new Vector2i(0, 0);
                 const b = new Vector2i(3, 4);
+
                 expect(a.distanceTo(b)).toBe(5);
             });
 
-            it('should return 0 for same position', () => {
+            it('should return 0 for the same position', () => {
                 const a = new Vector2i(5, 5);
                 const b = new Vector2i(5, 5);
+
                 expect(a.distanceTo(b)).toBe(0);
             });
 
             it('should be symmetric', () => {
                 const a = new Vector2i(1, 2);
                 const b = new Vector2i(4, 6);
+
                 expect(a.distanceTo(b)).toBe(b.distanceTo(a));
             });
         });
@@ -1145,16 +1341,19 @@ describe('Vector2i', () => {
         describe('distanceToXY', () => {
             it('should compute distance to raw coordinates', () => {
                 const v = new Vector2i(0, 0);
+
                 expect(v.distanceToXY(3, 4)).toBe(5);
             });
 
             it('should truncate float arguments', () => {
                 const v = new Vector2i(0, 0);
+
                 expect(v.distanceToXY(3.9, 4.1)).toBe(5);
             });
 
             it('should handle negative coordinates', () => {
                 const v = new Vector2i(0, 0);
+
                 expect(v.distanceToXY(-3, -4)).toBe(5);
             });
         });
@@ -1163,17 +1362,20 @@ describe('Vector2i', () => {
             it('should compute squared distance', () => {
                 const a = new Vector2i(0, 0);
                 const b = new Vector2i(3, 4);
+
                 expect(a.sqrDistanceTo(b)).toBe(25);
             });
 
-            it('should return 0 for same position', () => {
+            it('should return 0 for the same position', () => {
                 const a = new Vector2i(5, 5);
+
                 expect(a.sqrDistanceTo(new Vector2i(5, 5))).toBe(0);
             });
 
             it('should be symmetric', () => {
                 const a = new Vector2i(1, 2);
                 const b = new Vector2i(4, 6);
+
                 expect(a.sqrDistanceTo(b)).toBe(b.sqrDistanceTo(a));
             });
         });
@@ -1181,16 +1383,19 @@ describe('Vector2i', () => {
         describe('sqrDistanceToXY', () => {
             it('should compute squared distance to raw coordinates', () => {
                 const v = new Vector2i(0, 0);
+
                 expect(v.sqrDistanceToXY(3, 4)).toBe(25);
             });
 
             it('should truncate float arguments', () => {
                 const v = new Vector2i(0, 0);
+
                 expect(v.sqrDistanceToXY(3.9, 4.1)).toBe(25);
             });
 
             it('should handle negative coordinates', () => {
                 const v = new Vector2i(1, 1);
+
                 expect(v.sqrDistanceToXY(-2, -3)).toBe(25);
             });
         });
@@ -1199,17 +1404,20 @@ describe('Vector2i', () => {
             it('should compute Manhattan distance', () => {
                 const a = new Vector2i(1, 2);
                 const b = new Vector2i(4, 6);
+
                 expect(a.manhattanDistanceTo(b)).toBe(7);
             });
 
-            it('should return 0 for same position', () => {
+            it('should return 0 for the same position', () => {
                 const a = new Vector2i(5, 5);
+
                 expect(a.manhattanDistanceTo(new Vector2i(5, 5))).toBe(0);
             });
 
             it('should handle negative offsets', () => {
                 const a = new Vector2i(5, 5);
                 const b = new Vector2i(2, 1);
+
                 expect(a.manhattanDistanceTo(b)).toBe(7);
             });
         });
@@ -1217,16 +1425,19 @@ describe('Vector2i', () => {
         describe('manhattanDistanceToXY', () => {
             it('should compute Manhattan distance to raw coordinates', () => {
                 const v = new Vector2i(1, 2);
+
                 expect(v.manhattanDistanceToXY(4, 6)).toBe(7);
             });
 
             it('should truncate float arguments', () => {
                 const v = new Vector2i(0, 0);
+
                 expect(v.manhattanDistanceToXY(3.9, 4.1)).toBe(7);
             });
 
             it('should handle negative coordinates', () => {
                 const v = new Vector2i(0, 0);
+
                 expect(v.manhattanDistanceToXY(-3, -4)).toBe(7);
             });
         });
@@ -1235,17 +1446,20 @@ describe('Vector2i', () => {
             it('should compute Chebyshev distance', () => {
                 const a = new Vector2i(1, 2);
                 const b = new Vector2i(4, 6);
+
                 expect(a.chebyshevDistanceTo(b)).toBe(4);
             });
 
-            it('should return 0 for same position', () => {
+            it('should return 0 for the same position', () => {
                 const a = new Vector2i(5, 5);
+
                 expect(a.chebyshevDistanceTo(new Vector2i(5, 5))).toBe(0);
             });
 
             it('should pick the larger component difference', () => {
                 const a = new Vector2i(0, 0);
                 const b = new Vector2i(10, 3);
+
                 expect(a.chebyshevDistanceTo(b)).toBe(10);
             });
         });
@@ -1253,16 +1467,19 @@ describe('Vector2i', () => {
         describe('chebyshevDistanceToXY', () => {
             it('should compute Chebyshev distance to raw coordinates', () => {
                 const v = new Vector2i(1, 2);
+
                 expect(v.chebyshevDistanceToXY(4, 6)).toBe(4);
             });
 
             it('should truncate float arguments', () => {
                 const v = new Vector2i(0, 0);
+
                 expect(v.chebyshevDistanceToXY(3.9, 4.1)).toBe(4);
             });
 
             it('should handle negative coordinates', () => {
                 const v = new Vector2i(0, 0);
+
                 expect(v.chebyshevDistanceToXY(-3, -10)).toBe(10);
             });
         });
@@ -1277,6 +1494,7 @@ describe('Vector2i', () => {
             it('should return zero vector for zero input', () => {
                 const v = new Vector2i(0, 0);
                 const result = v.normalized();
+
                 expect(result.x).toBe(0);
                 expect(result.y).toBe(0);
             });
@@ -1284,6 +1502,7 @@ describe('Vector2i', () => {
             it('should normalize (10, 0) to (1, 0)', () => {
                 const v = new Vector2i(10, 0);
                 const result = v.normalized();
+
                 expect(result.x).toBe(1);
                 expect(result.y).toBe(0);
             });
@@ -1291,6 +1510,7 @@ describe('Vector2i', () => {
             it('should normalize (0, -10) to (0, -1)', () => {
                 const v = new Vector2i(0, -10);
                 const result = v.normalized();
+
                 expect(result.x).toBe(0);
                 expect(result.y).toBe(-1);
             });
@@ -1298,6 +1518,7 @@ describe('Vector2i', () => {
             it('should normalize (-50, 0) to (-1, 0)', () => {
                 const v = new Vector2i(-50, 0);
                 const result = v.normalized();
+
                 expect(result.x).toBe(-1);
                 expect(result.y).toBe(0);
             });
@@ -1305,6 +1526,7 @@ describe('Vector2i', () => {
             it('should normalize diagonal vectors to approximate direction', () => {
                 const v = new Vector2i(10, 10);
                 const result = v.normalized();
+
                 expect(result.x).toBe(1);
                 expect(result.y).toBe(1);
             });
@@ -1320,24 +1542,28 @@ describe('Vector2i', () => {
             it('should return true for equal vectors', () => {
                 const a = new Vector2i(3, 5);
                 const b = new Vector2i(3, 5);
+
                 expect(a.equals(b)).toBe(true);
             });
 
             it('should return false for different x', () => {
                 const a = new Vector2i(3, 5);
                 const b = new Vector2i(4, 5);
+
                 expect(a.equals(b)).toBe(false);
             });
 
             it('should return false for different y', () => {
                 const a = new Vector2i(3, 5);
                 const b = new Vector2i(3, 6);
+
                 expect(a.equals(b)).toBe(false);
             });
 
             it('should return true for two zero vectors', () => {
                 const a = new Vector2i(0, 0);
                 const b = new Vector2i(0, 0);
+
                 expect(a.equals(b)).toBe(true);
             });
         });
@@ -1345,21 +1571,25 @@ describe('Vector2i', () => {
         describe('equalsXY', () => {
             it('should return true for matching coordinates', () => {
                 const v = new Vector2i(3, 5);
+
                 expect(v.equalsXY(3, 5)).toBe(true);
             });
 
             it('should return false for non-matching coordinates', () => {
                 const v = new Vector2i(3, 5);
+
                 expect(v.equalsXY(4, 5)).toBe(false);
             });
 
             it('should truncate float arguments before comparing', () => {
                 const v = new Vector2i(3, 5);
+
                 expect(v.equalsXY(3.9, 5.1)).toBe(true);
             });
 
             it('should handle negative truncation correctly', () => {
                 const v = new Vector2i(-2, -5);
+
                 expect(v.equalsXY(-2.3, -5.8)).toBe(true);
             });
         });
@@ -1367,21 +1597,25 @@ describe('Vector2i', () => {
         describe('isZero', () => {
             it('should return true for (0, 0)', () => {
                 const v = new Vector2i(0, 0);
+
                 expect(v.isZero()).toBe(true);
             });
 
             it('should return false for (1, 0)', () => {
                 const v = new Vector2i(1, 0);
+
                 expect(v.isZero()).toBe(false);
             });
 
             it('should return false for (0, 1)', () => {
                 const v = new Vector2i(0, 1);
+
                 expect(v.isZero()).toBe(false);
             });
 
             it('should return false for (-1, -1)', () => {
                 const v = new Vector2i(-1, -1);
+
                 expect(v.isZero()).toBe(false);
             });
         });
@@ -1396,6 +1630,7 @@ describe('Vector2i', () => {
             it('should create an independent copy', () => {
                 const v = new Vector2i(42, 99);
                 const c = v.clone();
+
                 expect(c.x).toBe(42);
                 expect(c.y).toBe(99);
             });
@@ -1403,13 +1638,16 @@ describe('Vector2i', () => {
             it('should not be the same reference', () => {
                 const v = new Vector2i(42, 99);
                 const c = v.clone();
+
                 expect(c).not.toBe(v);
             });
 
-            it('should not link clone to original', () => {
+            it('should not link the clone to the original', () => {
                 const v = new Vector2i(42, 99);
                 const c = v.clone();
+
                 c.x = 0;
+
                 expect(v.x).toBe(42);
             });
         });
@@ -1417,16 +1655,19 @@ describe('Vector2i', () => {
         describe('toString', () => {
             it('should format as (x, y)', () => {
                 const v = new Vector2i(3, 5);
+
                 expect(v.toString()).toBe('(3, 5)');
             });
 
             it('should handle negative values', () => {
                 const v = new Vector2i(-3, -5);
+
                 expect(v.toString()).toBe('(-3, -5)');
             });
 
             it('should handle zero vector', () => {
                 const v = new Vector2i(0, 0);
+
                 expect(v.toString()).toBe('(0, 0)');
             });
         });
@@ -1440,18 +1681,21 @@ describe('Vector2i', () => {
         describe('fromXYUnchecked', () => {
             it('should create a vector without truncation', () => {
                 const v = Vector2i.fromXYUnchecked(3, 5);
+
                 expect(v.x).toBe(3);
                 expect(v.y).toBe(5);
             });
 
             it('should NOT truncate float values', () => {
                 const v = Vector2i.fromXYUnchecked(3.7, 5.2);
+
                 expect(v.x).toBe(3.7);
                 expect(v.y).toBe(5.2);
             });
 
             it('should create a proper Vector2i instance', () => {
                 const v = Vector2i.fromXYUnchecked(1, 2);
+
                 expect(v).toBeInstanceOf(Vector2i);
             });
         });
@@ -1459,18 +1703,21 @@ describe('Vector2i', () => {
         describe('fromFloat', () => {
             it('should truncate positive floats', () => {
                 const v = Vector2i.fromFloat(3.7, 5.2);
+
                 expect(v.x).toBe(3);
                 expect(v.y).toBe(5);
             });
 
             it('should truncate negative floats toward zero', () => {
                 const v = Vector2i.fromFloat(-3.7, -5.2);
+
                 expect(v.x).toBe(-3);
                 expect(v.y).toBe(-5);
             });
 
             it('should pass through integer values', () => {
                 const v = Vector2i.fromFloat(10, 20);
+
                 expect(v.x).toBe(10);
                 expect(v.y).toBe(20);
             });
@@ -1480,17 +1727,20 @@ describe('Vector2i', () => {
             it('should compute static distance between two vectors', () => {
                 const a = new Vector2i(0, 0);
                 const b = new Vector2i(3, 4);
+
                 expect(Vector2i.distance(a, b)).toBe(5);
             });
 
             it('should return 0 for the same point', () => {
                 const a = new Vector2i(7, 7);
+
                 expect(Vector2i.distance(a, a)).toBe(0);
             });
 
             it('should be symmetric', () => {
                 const a = new Vector2i(1, 2);
                 const b = new Vector2i(4, 6);
+
                 expect(Vector2i.distance(a, b)).toBe(Vector2i.distance(b, a));
             });
         });
@@ -1499,17 +1749,20 @@ describe('Vector2i', () => {
             it('should compute squared distance between two vectors', () => {
                 const a = new Vector2i(0, 0);
                 const b = new Vector2i(3, 4);
+
                 expect(Vector2i.sqrDistance(a, b)).toBe(25);
             });
 
             it('should return 0 for the same point', () => {
                 const a = new Vector2i(7, 7);
+
                 expect(Vector2i.sqrDistance(a, a)).toBe(0);
             });
 
             it('should be symmetric', () => {
                 const a = new Vector2i(1, 2);
                 const b = new Vector2i(4, 6);
+
                 expect(Vector2i.sqrDistance(a, b)).toBe(Vector2i.sqrDistance(b, a));
             });
         });
@@ -1518,18 +1771,21 @@ describe('Vector2i', () => {
             it('should compute static dot product', () => {
                 const a = new Vector2i(3, 4);
                 const b = new Vector2i(2, 5);
+
                 expect(Vector2i.dotProduct(a, b)).toBe(26);
             });
 
             it('should return zero for perpendicular vectors', () => {
                 const a = new Vector2i(1, 0);
                 const b = new Vector2i(0, 1);
+
                 expect(Vector2i.dotProduct(a, b)).toBe(0);
             });
 
-            it('should match instance dot method', () => {
+            it('should match the instance dot method', () => {
                 const a = new Vector2i(3, 4);
                 const b = new Vector2i(2, 5);
+
                 expect(Vector2i.dotProduct(a, b)).toBe(a.dot(b));
             });
         });
@@ -1539,6 +1795,7 @@ describe('Vector2i', () => {
                 const a = new Vector2i(0, 0);
                 const b = new Vector2i(10, 20);
                 const result = Vector2i.lerp(a, b, 0);
+
                 expect(result.x).toBe(0);
                 expect(result.y).toBe(0);
             });
@@ -1547,22 +1804,25 @@ describe('Vector2i', () => {
                 const a = new Vector2i(0, 0);
                 const b = new Vector2i(10, 20);
                 const result = Vector2i.lerp(a, b, 1);
+
                 expect(result.x).toBe(10);
                 expect(result.y).toBe(20);
             });
 
-            it('should return truncated midpoint when t = 0.5', () => {
+            it('should return the truncated midpoint when t = 0.5', () => {
                 const a = new Vector2i(0, 0);
                 const b = new Vector2i(10, 20);
                 const result = Vector2i.lerp(a, b, 0.5);
+
                 expect(result.x).toBe(5);
                 expect(result.y).toBe(10);
             });
 
-            it('should truncate non-integer results', () => {
+            it('should truncate noninteger results', () => {
                 const a = new Vector2i(0, 0);
                 const b = new Vector2i(3, 7);
                 const result = Vector2i.lerp(a, b, 0.5);
+
                 expect(result.x).toBe(1);
                 expect(result.y).toBe(3);
             });
@@ -1577,11 +1837,13 @@ describe('Vector2i', () => {
         });
 
         describe('lerpTo', () => {
-            it('should write interpolated result to output vector', () => {
+            it('should write an interpolated result to the output vector', () => {
                 const a = new Vector2i(0, 0);
                 const b = new Vector2i(10, 20);
                 const out = new Vector2i();
+
                 Vector2i.lerpTo(a, b, 0.5, out);
+
                 expect(out.x).toBe(5);
                 expect(out.y).toBe(10);
             });
@@ -1590,14 +1852,17 @@ describe('Vector2i', () => {
                 const a = new Vector2i(0, 0);
                 const b = new Vector2i(10, 20);
                 const out = new Vector2i();
+
                 expect(Vector2i.lerpTo(a, b, 0.5, out)).toBe(out);
             });
 
-            it('should truncate non-integer results', () => {
+            it('should truncate noninteger results', () => {
                 const a = new Vector2i(0, 0);
                 const b = new Vector2i(3, 7);
                 const out = new Vector2i();
+
                 Vector2i.lerpTo(a, b, 0.5, out);
+
                 expect(out.x).toBe(1);
                 expect(out.y).toBe(3);
             });
@@ -1606,7 +1871,9 @@ describe('Vector2i', () => {
                 const a = new Vector2i(5, 10);
                 const b = new Vector2i(15, 30);
                 const out = new Vector2i();
+
                 Vector2i.lerpTo(a, b, 0, out);
+
                 expect(out.x).toBe(5);
                 expect(out.y).toBe(10);
             });
@@ -1615,7 +1882,9 @@ describe('Vector2i', () => {
                 const a = new Vector2i(5, 10);
                 const b = new Vector2i(15, 30);
                 const out = new Vector2i();
+
                 Vector2i.lerpTo(a, b, 1, out);
+
                 expect(out.x).toBe(15);
                 expect(out.y).toBe(30);
             });

--- a/src/utils/Vector2i.ts
+++ b/src/utils/Vector2i.ts
@@ -1,13 +1,9 @@
 /**
  * Integer 2D vector for pixel-perfect positioning.
- * Inspired by RetroBlit's Vector2i.
  *
- * Performance notes:
- * - Use static direction constants (zero, one, up, etc.) - they return cached singletons
- * - Use fromXYUnchecked() for trusted integer values in hot paths
- * - Use “To” methods (addTo, subTo, cloneTo, etc.) for zero-allocation output
- * - Use in-place methods (*InPlace) when you can mutate the source vector
- * - Bitwise |0 is used for integer truncation (truncates toward zero, not floor)
+ * Used for points, sizes, directions, and camera offsets throughout the engine.
+ * The API includes both allocation-free `*To()` / `*InPlace()` variants and
+ * convenience methods that return new vectors.
  */
 export class Vector2i {
     // #region Cached Static Vectors
@@ -18,16 +14,16 @@ export class Vector2i {
     /** The cached singleton for one vector. */
     private static readonly _one: Vector2i = Object.freeze(Vector2i.fromXYUnchecked(1, 1));
 
-    /** The cached singleton for up direction. */
+    /** The cached singleton for the up direction. */
     private static readonly _up: Vector2i = Object.freeze(Vector2i.fromXYUnchecked(0, -1));
 
-    /** The cached singleton for down direction. */
+    /** The cached singleton for the down direction. */
     private static readonly _down: Vector2i = Object.freeze(Vector2i.fromXYUnchecked(0, 1));
 
-    /** The cached singleton for left direction. */
+    /** The cached singleton for the left direction. */
     private static readonly _left: Vector2i = Object.freeze(Vector2i.fromXYUnchecked(-1, 0));
 
-    /** The cached singleton for right direction. */
+    /** The cached singleton for the right direction. */
     private static readonly _right: Vector2i = Object.freeze(Vector2i.fromXYUnchecked(1, 0));
 
     // #endregion
@@ -35,11 +31,7 @@ export class Vector2i {
     // #region Constructor
 
     /**
-     * Creates a new integer 2D vector.
-     * Values are truncated to integers using |0 (truncates toward zero).
-     *
-     * Note: For negative non-integers, |0 truncates toward zero (e.g., –1.7 becomes –1).
-     * If you need floor behavior for negative values, use Math.floor before passing.
+     * Creates an integer 2D vector, truncating inputs toward zero.
      *
      * @param x - Horizontal component (defaults to 0).
      * @param y - Vertical component (defaults to 0).
@@ -62,8 +54,7 @@ export class Vector2i {
     // #region Property Aliases
 
     /**
-     * Alias for x component, useful when treating vector as dimensions.
-     *
+     * Alias for `x` when treating the vector as a size.
      * @returns The x component as width.
      */
     get width(): number {
@@ -80,8 +71,7 @@ export class Vector2i {
     }
 
     /**
-     * Alias for y component, useful when treating vector as dimensions.
-     *
+     * Alias for `y` when treating the vector as a size.
      * @returns The y component as height.
      */
     get height(): number {
@@ -102,9 +92,173 @@ export class Vector2i {
     // #region Vector Operations
 
     /**
-     * Adds another vector to this one, returning a new vector.
+     * Returns a zero vector (0, 0).
+     * Returns a cached frozen singleton - do not modify.
      *
-     * Note: Creates a new Vector2i. Use addTo() or addInPlace() in hot paths.
+     * @returns Vector at origin (cached).
+     */
+    static zero(): Vector2i {
+        return Vector2i._zero;
+    }
+
+    /**
+     * Returns a unit vector (1, 1).
+     * Returns a cached frozen singleton - do not modify.
+     *
+     * @returns Vector with both components set to 1 (cached).
+     */
+    static one(): Vector2i {
+        return Vector2i._one;
+    }
+
+    /**
+     * Returns an up direction vector (0, –1).
+     * In screen coordinates, Y increases downward, so up is negative.
+     * Returns a cached frozen singleton - do not modify.
+     *
+     * @returns Vector pointing up (cached).
+     */
+    static up(): Vector2i {
+        return Vector2i._up;
+    }
+
+    /**
+     * Returns a down direction vector (0, 1).
+     * Returns a cached frozen singleton - do not modify.
+     *
+     * @returns Vector pointing down (cached).
+     */
+    static down(): Vector2i {
+        return Vector2i._down;
+    }
+
+    /**
+     * Returns a left-direction vector (-1, 0).
+     * Returns a cached frozen singleton - do not modify.
+     *
+     * @returns Vector pointing left (cached).
+     */
+    static left(): Vector2i {
+        return Vector2i._left;
+    }
+
+    /**
+     * Returns a right-direction vector (1, 0).
+     * Returns a cached frozen singleton - do not modify.
+     *
+     * @returns Vector pointing right (cached).
+     */
+    static right(): Vector2i {
+        return Vector2i._right;
+    }
+
+    /**
+     * Creates a Vector2i from integer values without truncation.
+     * Use this in hot paths when values are guaranteed to be integers.
+     *
+     * WARNING: Passing non-integer values will result in non-integer vector components.
+     * Only use when you’re certain the values are already integers.
+     *
+     * @param x - Horizontal component (must be integer).
+     * @param y - Vertical component (must be integer).
+     * @returns New Vector2i with the specified values.
+     */
+    static fromXYUnchecked(x: number, y: number): Vector2i {
+        const v = Object.create(Vector2i.prototype) as Vector2i;
+
+        v.x = x;
+        v.y = y;
+
+        return v;
+    }
+
+    /**
+     * Creates an integer vector from floating-point coordinates.
+     * Both values are truncated to integers using |0.
+     *
+     * Note: |0 truncates toward zero (e.g., –1.7 becomes –1, not –2).
+     *
+     * @param x - Floating-point x coordinate.
+     * @param y - Floating-point y coordinate.
+     * @returns New integer vector.
+     */
+    static fromFloat(x: number, y: number): Vector2i {
+        return new Vector2i(x | 0, y | 0);
+    }
+
+    /**
+     * Calculates distance between two vectors.
+     *
+     * @param a - First vector.
+     * @param b - Second vector.
+     * @returns Euclidean distance between a and b.
+     */
+    static distance(a: Vector2i, b: Vector2i): number {
+        const dx = b.x - a.x;
+        const dy = b.y - a.y;
+
+        return Math.sqrt(dx * dx + dy * dy);
+    }
+
+    /**
+     * Calculates squared distance between two vectors.
+     * Avoids the sqrt for performance.
+     *
+     * @param a - First vector.
+     * @param b - Second vector.
+     * @returns Squared distance between a and b.
+     */
+    static sqrDistance(a: Vector2i, b: Vector2i): number {
+        const dx = b.x - a.x;
+        const dy = b.y - a.y;
+
+        return dx * dx + dy * dy;
+    }
+
+    /**
+     * Calculates dot product of two vectors.
+     * The static version - use instance method a.dot(b) when you have vector instances.
+     *
+     * @param a - First vector.
+     * @param b - Second vector.
+     * @returns Scalar dot product.
+     */
+    static dotProduct(a: Vector2i, b: Vector2i): number {
+        return a.x * b.x + a.y * b.y;
+    }
+
+    /**
+     * Linearly interpolates between two vectors.
+     * Result is truncated to integers.
+     *
+     * @param a - Start vector.
+     * @param b - End vector.
+     * @param t - Interpolation factor (0 = a, 1 = b).
+     * @returns New interpolated vector.
+     */
+    static lerp(a: Vector2i, b: Vector2i, t: number): Vector2i {
+        return new Vector2i(a.x + (b.x - a.x) * t, a.y + (b.y - a.y) * t);
+    }
+
+    /**
+     * Linearly interpolates between two vectors and writes to the existing vector.
+     * Zero allocation alternative to lerp().
+     *
+     * @param a - Start vector.
+     * @param b - End vector.
+     * @param t - Interpolation factor (0 = a, 1 = b).
+     * @param out - Vector to write the result to.
+     * @returns The out vector for chaining.
+     */
+    static lerpTo(a: Vector2i, b: Vector2i, t: number, out: Vector2i): Vector2i {
+        out.x = (a.x + (b.x - a.x) * t) | 0;
+        out.y = (a.y + (b.y - a.y) * t) | 0;
+
+        return out;
+    }
+
+    /**
+     * Adds another vector and returns the result as a new vector.
      *
      * @param other - Vector to add.
      * @returns New vector with summed components.
@@ -115,10 +269,7 @@ export class Vector2i {
     }
 
     /**
-     * Adds x and y values to this vector, returning a new vector.
-     * Avoids creating a temporary Vector2i for the offset.
-     *
-     * Note: Creates a new Vector2i. Use addXYInPlace() in hot paths.
+     * Adds raw `x` and `y` offsets and returns the result as a new vector.
      *
      * @param x - X offset to add.
      * @param y - Y offset to add.
@@ -130,9 +281,7 @@ export class Vector2i {
     }
 
     /**
-     * Subtracts another vector from this one, returning a new vector.
-     *
-     * Note: Creates a new Vector2i. Use subTo() or subInPlace() in hot paths.
+     * Subtracts another vector and returns the result as a new vector.
      *
      * @param other - Vector to subtract.
      * @returns New vector with difference of components.
@@ -143,10 +292,7 @@ export class Vector2i {
     }
 
     /**
-     * Subtracts x and y values from this vector, returning a new vector.
-     * Avoids creating a temporary Vector2i for the offset.
-     *
-     * Note: Creates a new Vector2i. Use subXYInPlace() in hot paths.
+     * Subtracts raw `x` and `y` offsets and returns the result as a new vector.
      *
      * @param x - X offset to subtract.
      * @param y - Y offset to subtract.
@@ -157,10 +303,12 @@ export class Vector2i {
         return Vector2i.fromXYUnchecked(this.x - (x | 0), this.y - (y | 0));
     }
 
+    // #endregion
+
+    // #region Zero-Allocation Output Methods
+
     /**
-     * Multiplies this vector by a scalar, returning a new vector.
-     *
-     * Note: Creates a new Vector2i. Use mulInPlace() in hot paths.
+     * Multiplies both components by a scalar and returns a new vector.
      *
      * @param scalar - Value to multiply both components by.
      * @returns New vector with scaled components.
@@ -170,9 +318,7 @@ export class Vector2i {
     }
 
     /**
-     * Component-wise multiplication with another vector.
-     *
-     * Note: Creates a new Vector2i. Use mulVecInPlace() in hot paths.
+     * Performs component-wise multiplication with another vector.
      *
      * @param other - Vector to multiply with.
      * @returns New vector with multiplied components.
@@ -183,9 +329,7 @@ export class Vector2i {
     }
 
     /**
-     * Divides this vector by a scalar, truncating the result toward zero.
-     *
-     * Note: Creates a new Vector2i. Use divInPlace() in hot paths.
+     * Divides both components by a scalar and truncates toward zero.
      *
      * @param scalar - Value to divide both components by.
      * @returns New vector with divided and truncated components.
@@ -200,11 +344,8 @@ export class Vector2i {
     }
 
     /**
-     * Returns a new vector with negated components.
-     *
-     * Note: Creates a new Vector2i. Use negateInPlace() in hot paths.
-     *
-     * @returns New vector pointing in opposite direction.
+     * Returns a new vector with both components negated.
+     * @returns New negated vector.
      */
     negate(): Vector2i {
         // Negating integers stays integer, use unchecked.
@@ -212,11 +353,8 @@ export class Vector2i {
     }
 
     /**
-     * Returns a new vector with absolute values of components.
-     *
-     * Note: Creates a new Vector2i. Use absInPlace() in hot paths.
-     *
-     * @returns New vector with positive components.
+     * Returns a new vector with absolute component values.
+     * @returns New vector with abs(x), abs(y).
      */
     abs(): Vector2i {
         // Math.abs of integers stays integer, use unchecked.
@@ -224,9 +362,7 @@ export class Vector2i {
     }
 
     /**
-     * Returns a new vector with the component-wise minimum of this and other.
-     *
-     * Note: Creates a new Vector2i. Use minInPlace() in hot paths.
+     * Returns the component-wise minimum of this vector and another.
      *
      * @param other - Vector to compare with.
      * @returns New vector with minimum components.
@@ -236,9 +372,7 @@ export class Vector2i {
     }
 
     /**
-     * Returns a new vector with component-wise maximum of this and other.
-     *
-     * Note: Creates a new Vector2i. Use maxInPlace() in hot paths.
+     * Returns the component-wise maximum of this vector and another.
      *
      * @param other - Vector to compare with.
      * @returns New vector with maximum components.
@@ -248,9 +382,7 @@ export class Vector2i {
     }
 
     /**
-     * Returns a new vector with components clamped to the given range.
-     *
-     * Note: Creates a new Vector2i. Use clampInPlace() in hot paths.
+     * Clamps both components into a numeric range.
      *
      * @param minVal - Minimum value for both components.
      * @param maxVal - Maximum value for both components.
@@ -264,9 +396,7 @@ export class Vector2i {
     }
 
     /**
-     * Returns a new vector with components clamped to the given vector bounds.
-     *
-     * Note: Creates a new Vector2i. Use clampVecInPlace() in hot paths.
+     * Clamps both components into per-axis vector bounds.
      *
      * @param minVec - Vector with minimum values.
      * @param maxVec - Vector with maximum values.
@@ -289,10 +419,14 @@ export class Vector2i {
         return this.x * other.x + this.y * other.y;
     }
 
+    // #endregion
+
+    // #region In-Place Mutation Methods
+
     /**
      * Calculates the 2D cross-product (perpendicular dot product).
      * Returns the z-component of the 3D cross-product if vectors were in XY plane.
-     * Useful for determining, which side of a line a point is on.
+     * Useful for determining which side of a line a point is on.
      *
      * @param other - Vector to cross with.
      * @returns Scalar cross-product (positive = other is counter-clockwise from this).
@@ -318,10 +452,6 @@ export class Vector2i {
     perpendicularCW(): Vector2i {
         return Vector2i.fromXYUnchecked(this.y, -this.x);
     }
-
-    // #endregion
-
-    // #region Zero-Allocation Output Methods
 
     /**
      * Adds another vector and writes the result to an existing vector.
@@ -479,10 +609,6 @@ export class Vector2i {
         return out;
     }
 
-    // #endregion
-
-    // #region In-Place Mutation Methods
-
     /**
      * Adds another vector to this one in place.
      * Modifies this vector directly for maximum performance.
@@ -515,6 +641,10 @@ export class Vector2i {
 
         return this;
     }
+
+    // #endregion
+
+    // #region Distance Calculations
 
     /**
      * Subtracts another vector from this one in place.
@@ -684,6 +814,10 @@ export class Vector2i {
         return this;
     }
 
+    // #endregion
+
+    // #region Normalization
+
     /**
      * Clamps components to vector bounds in place.
      * Modifies this vector directly for maximum performance.
@@ -700,6 +834,10 @@ export class Vector2i {
 
         return this;
     }
+
+    // #endregion
+
+    // #region Comparison
 
     /**
      * Sets both components of this vector.
@@ -734,10 +872,6 @@ export class Vector2i {
         return this;
     }
 
-    // #endregion
-
-    // #region Distance Calculations
-
     /**
      * Calculates the Euclidean length of this vector.
      *
@@ -746,6 +880,10 @@ export class Vector2i {
     magnitude(): number {
         return Math.sqrt(this.x * this.x + this.y * this.y);
     }
+
+    // #endregion
+
+    // #region Utility
 
     /**
      * Calculates the squared magnitude (avoids the sqrt for performance).
@@ -769,6 +907,10 @@ export class Vector2i {
 
         return Math.sqrt(dx * dx + dy * dy);
     }
+
+    // #endregion
+
+    // #region Static Constructors
 
     /**
      * Calculates the Euclidean distance to raw coordinates.
@@ -848,6 +990,10 @@ export class Vector2i {
         return Math.max(Math.abs(other.x - this.x), Math.abs(other.y - this.y));
     }
 
+    // #endregion
+
+    // #region Static Factories
+
     /**
      * Calculates the Chebyshev distance to raw coordinates.
      * Avoids creating a temporary Vector2i.
@@ -859,10 +1005,6 @@ export class Vector2i {
     chebyshevDistanceToXY(x: number, y: number): number {
         return Math.max(Math.abs((x | 0) - this.x), Math.abs((y | 0) - this.y));
     }
-
-    // #endregion
-
-    // #region Normalization
 
     /**
      * Returns a direction vector pointing in the same direction.
@@ -887,10 +1029,6 @@ export class Vector2i {
         // Truncation would collapse most vectors to (0, 0).
         return new Vector2i(Math.round(this.x / mag), Math.round(this.y / mag));
     }
-
-    // #endregion
-
-    // #region Comparison
 
     /**
      * Checks if this vector equals another vector component-wise.
@@ -923,10 +1061,6 @@ export class Vector2i {
         return this.x === 0 && this.y === 0;
     }
 
-    // #endregion
-
-    // #region Utility
-
     /**
      * Creates an independent copy of this vector.
      *
@@ -946,180 +1080,6 @@ export class Vector2i {
      */
     toString(): string {
         return `(${this.x}, ${this.y})`;
-    }
-
-    // #endregion
-
-    // #region Static Constructors
-
-    /**
-     * Returns a zero vector (0, 0).
-     * Returns a cached frozen singleton - do not modify.
-     *
-     * @returns Vector at origin (cached).
-     */
-    static zero(): Vector2i {
-        return Vector2i._zero;
-    }
-
-    /**
-     * Returns a unit vector (1, 1).
-     * Returns a cached frozen singleton - do not modify.
-     *
-     * @returns Vector with both components set to 1 (cached).
-     */
-    static one(): Vector2i {
-        return Vector2i._one;
-    }
-
-    /**
-     * Returns an up direction vector (0, –1).
-     * In screen coordinates, Y increases downward, so up is negative.
-     * Returns a cached frozen singleton - do not modify.
-     *
-     * @returns Vector pointing up (cached).
-     */
-    static up(): Vector2i {
-        return Vector2i._up;
-    }
-
-    /**
-     * Returns a down direction vector (0, 1).
-     * Returns a cached frozen singleton - do not modify.
-     *
-     * @returns Vector pointing down (cached).
-     */
-    static down(): Vector2i {
-        return Vector2i._down;
-    }
-
-    /**
-     * Returns a left-direction vector (-1, 0).
-     * Returns a cached frozen singleton - do not modify.
-     *
-     * @returns Vector pointing left (cached).
-     */
-    static left(): Vector2i {
-        return Vector2i._left;
-    }
-
-    /**
-     * Returns a right-direction vector (1, 0).
-     * Returns a cached frozen singleton - do not modify.
-     *
-     * @returns Vector pointing right (cached).
-     */
-    static right(): Vector2i {
-        return Vector2i._right;
-    }
-
-    // #endregion
-
-    // #region Static Factories
-
-    /**
-     * Creates a Vector2i from integer values without truncation.
-     * Use this in hot paths when values are guaranteed to be integers.
-     *
-     * WARNING: Passing non-integer values will result in non-integer vector components.
-     * Only use when you’re certain the values are already integers.
-     *
-     * @param x - Horizontal component (must be integer).
-     * @param y - Vertical component (must be integer).
-     * @returns New Vector2i with the specified values.
-     */
-    static fromXYUnchecked(x: number, y: number): Vector2i {
-        const v = Object.create(Vector2i.prototype) as Vector2i;
-
-        v.x = x;
-        v.y = y;
-
-        return v;
-    }
-
-    /**
-     * Creates an integer vector from floating-point coordinates.
-     * Both values are truncated to integers using |0.
-     *
-     * Note: |0 truncates toward zero (e.g., –1.7 becomes –1, not –2).
-     *
-     * @param x - Floating-point x coordinate.
-     * @param y - Floating-point y coordinate.
-     * @returns New integer vector.
-     */
-    static fromFloat(x: number, y: number): Vector2i {
-        return new Vector2i(x | 0, y | 0);
-    }
-
-    /**
-     * Calculates distance between two vectors.
-     *
-     * @param a - First vector.
-     * @param b - Second vector.
-     * @returns Euclidean distance between a and b.
-     */
-    static distance(a: Vector2i, b: Vector2i): number {
-        const dx = b.x - a.x;
-        const dy = b.y - a.y;
-
-        return Math.sqrt(dx * dx + dy * dy);
-    }
-
-    /**
-     * Calculates squared distance between two vectors.
-     * Avoids the sqrt for performance.
-     *
-     * @param a - First vector.
-     * @param b - Second vector.
-     * @returns Squared distance between a and b.
-     */
-    static sqrDistance(a: Vector2i, b: Vector2i): number {
-        const dx = b.x - a.x;
-        const dy = b.y - a.y;
-
-        return dx * dx + dy * dy;
-    }
-
-    /**
-     * Calculates dot product of two vectors.
-     * The static version - use instance method a.dot(b) when you have vector instances.
-     *
-     * @param a - First vector.
-     * @param b - Second vector.
-     * @returns Scalar dot product.
-     */
-    static dotProduct(a: Vector2i, b: Vector2i): number {
-        return a.x * b.x + a.y * b.y;
-    }
-
-    /**
-     * Linearly interpolates between two vectors.
-     * Result is truncated to integers.
-     *
-     * @param a - Start vector.
-     * @param b - End vector.
-     * @param t - Interpolation factor (0 = a, 1 = b).
-     * @returns New interpolated vector.
-     */
-    static lerp(a: Vector2i, b: Vector2i, t: number): Vector2i {
-        return new Vector2i(a.x + (b.x - a.x) * t, a.y + (b.y - a.y) * t);
-    }
-
-    /**
-     * Linearly interpolates between two vectors and writes to the existing vector.
-     * Zero allocation alternative to lerp().
-     *
-     * @param a - Start vector.
-     * @param b - End vector.
-     * @param t - Interpolation factor (0 = a, 1 = b).
-     * @param out - Vector to write the result to.
-     * @returns The out vector for chaining.
-     */
-    static lerpTo(a: Vector2i, b: Vector2i, t: number, out: Vector2i): Vector2i {
-        out.x = (a.x + (b.x - a.x) * t) | 0;
-        out.y = (a.y + (b.y - a.y) * t) | 0;
-
-        return out;
     }
 
     // #endregion

--- a/src/utils/Vector2i.ts
+++ b/src/utils/Vector2i.ts
@@ -419,10 +419,6 @@ export class Vector2i {
         return this.x * other.x + this.y * other.y;
     }
 
-    // #endregion
-
-    // #region In-Place Mutation Methods
-
     /**
      * Calculates the 2D cross-product (perpendicular dot product).
      * Returns the z-component of the 3D cross-product if vectors were in XY plane.
@@ -609,6 +605,10 @@ export class Vector2i {
         return out;
     }
 
+    // #endregion
+
+    // #region In-Place Mutation Methods
+
     /**
      * Adds another vector to this one in place.
      * Modifies this vector directly for maximum performance.
@@ -641,10 +641,6 @@ export class Vector2i {
 
         return this;
     }
-
-    // #endregion
-
-    // #region Distance Calculations
 
     /**
      * Subtracts another vector from this one in place.
@@ -813,10 +809,6 @@ export class Vector2i {
 
         return this;
     }
-
-    // #endregion
-
-    // #region Normalization
 
     /**
      * Clamps components to vector bounds in place.


### PR DESCRIPTION
Trim JSDoc throughout Vector2i to concise summaries — drop hot-path notes,
allocation warnings, and redundant constructor descriptions. Rewrite the
class-level doc to describe use cases rather than implementation details.
Move static factory and direction methods (zero, one, up, down, left, right,
fromXYUnchecked, fromFloat, distance, distanceSq) above the instance methods
to co-locate all statics. Add file-level JSDoc and blank-line spacing between
arrange/act/assert steps across the full test file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Documentation Simplification and Code Reorganization

This PR refactors documentation and reorganizes code across the BlitTech utility library to improve clarity and consistency.

### Vector2i Reorganization, Documentation, and Fix
- **Documentation updates**: Replaced verbose JSDoc (implementation notes and RetroBlit references) with concise, use-case-focused descriptions; class-level docs now emphasize engine usage patterns and allocation-efficient APIs.
- **Static method co-location**: Moved static factories and helpers to the top of the class for discoverability: `zero()`, `one()`, `up()`, `down()`, `left()`, `right()`, `fromXYUnchecked()`, `fromFloat()`, `distance()`, `sqrDistance()`, `dotProduct()`, `lerp()`, and `lerpTo()`. Implementations/signatures unchanged.
- **Refined aliases**: Simplified docs for `width`/`height` as size aliases.
- **Behavioral fix**: Commit includes a functional fix for Vector2i region boundaries (and removal of a stray comment).

### BlitTech Module Documentation Simplification
- **Module/class docs**: Rewritten to emphasize re-exported runtime types and demo-facing `BT` usage.
- **Method/property docs simplified**:
  - `initialize()`: removed verbose setup sequences and examples; condensed to a simple success/failure description.
  - Hardware/timing accessors (`displaySize`, `fps`, `ticks`, `ticksReset`): clarified semantics (logical render resolution vs canvas CSS size, fixed update rate, tick meaning/reset reference).
  - Rendering ops (`clear`, `clearRect`, draw primitives, camera setters): rephrased coordinate/intent descriptions without signature changes.
  - Input helpers (gamepad/keyboard): documented explicitly as stubs returning `false`.
  - Text rendering (`print`, `printMeasure`, `printFont`): clarified fallback vs bitmap-font behavior; `printMeasure` documented to return `Vector2i.zero()` with a one-time warning.
  - Frame capture/download (`captureFrame`, `downloadFrame`): clarified promise resolution and download behavior.
  - Sprite rendering (`drawSprite`): adjusted batching/performance commentary and parameter descriptions.
- `warnOnce`: minor whitespace change (blank line after console.warn); dedup set unchanged.

### Test Infrastructure Improvements
- **File-level JSDoc**: Added top-level docs for test files (`Vector2i.test.ts`, `BlitTech.test.ts`) describing scope and coverage.
- **Test formatting**: Inserted blank lines between arrange/act/assert steps across tests for readability; added `// noinspection DuplicatedCode` to `BlitTech.test.ts`.
- **Test wording tweaks**: Minor renames and phrasing changes in test descriptions (e.g., “non-integer” → “noninteger”, “2D cross product” → “2D cross-product”) without behavioral changes.
- Adjusted a test comment in `BT.printMeasure` wording (“is 0 or 1” → “are 0 or 1”) and added a blank comment line before one test; assertions unchanged.

### Scope and Impact
- No public TypeScript signatures or exported API members were changed; changes are documentation, ordering, whitespace, test formatting, and one Vector2i region-boundary bugfix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->