### PR TITLE
docs(assets): expand and clarify BitmapFont documentation

### DIFF
--- a/src/assets/BitmapFont.test.ts
+++ b/src/assets/BitmapFont.test.ts
@@ -29,6 +29,51 @@ type FontData = {
 };
 
 /**
+ * Creates a stub Image class for use with `vi.stubGlobal('Image', ...)`.
+ *
+ * @param opts           - Configuration options.
+ * @param opts.fireError - When true, fires `onerror` instead of `onload` on src assignment.
+ * @param opts.onSrcSet  - Optional callback invoked with the assigned src value before the load/error event.
+ * @param opts.width     - Reported image width (default 64).
+ * @param opts.height    - Reported image height (default 16).
+ */
+function createStubImage({
+    fireError = false,
+    onSrcSet,
+    width = 64,
+    height = 16,
+}: {
+    fireError?: boolean;
+    onSrcSet?: (src: string) => void;
+    width?: number;
+    height?: number;
+} = {}) {
+    return class {
+        onload: (() => void) | null = null;
+        onerror: (() => void) | null = null;
+        width = width;
+        height = height;
+
+        private _src = '';
+
+        get src(): string {
+            return this._src;
+        }
+
+        set src(value: string) {
+            this._src = value;
+            onSrcSet?.(value);
+
+            if (fireError) {
+                this.onerror?.();
+            } else {
+                this.onload?.();
+            }
+        }
+    };
+}
+
+/**
  * Canonical fixture returned by mocked font fetches.
  *
  * Includes ASCII glyphs plus one extended Unicode glyph so the tests can cover
@@ -56,26 +101,7 @@ describe('BitmapFont', () => {
 
     beforeEach(async () => {
         // Stub Image to fire onload synchronously.
-        vi.stubGlobal(
-            'Image',
-            class {
-                onload: (() => void) | null = null;
-                onerror: (() => void) | null = null;
-                width = 64;
-                height = 16;
-
-                private _src = '';
-
-                get src(): string {
-                    return this._src;
-                }
-
-                set src(value: string) {
-                    this._src = value;
-                    this.onload?.();
-                }
-            },
-        );
+        vi.stubGlobal('Image', createStubImage());
 
         // Stub fetch to return the mock font data.
         vi.stubGlobal(
@@ -279,23 +305,7 @@ describe('BitmapFont', () => {
         });
 
         it('should throw when the font texture image fails to load', async () => {
-            vi.stubGlobal(
-                'Image',
-                class {
-                    onload: (() => void) | null = null;
-                    onerror: (() => void) | null = null;
-                    private _src = '';
-
-                    get src(): string {
-                        return this._src;
-                    }
-
-                    set src(value: string) {
-                        this._src = value;
-                        this.onerror?.(); // fire error instead of load
-                    }
-                },
-            );
+            vi.stubGlobal('Image', createStubImage({ fireError: true }));
             vi.stubGlobal(
                 'fetch',
                 vi.fn().mockResolvedValue({
@@ -312,24 +322,11 @@ describe('BitmapFont', () => {
 
             vi.stubGlobal(
                 'Image',
-                class {
-                    onload: (() => void) | null = null;
-                    onerror: (() => void) | null = null;
-                    width = 64;
-                    height = 16;
-
-                    private _src = '';
-
-                    get src(): string {
-                        return this._src;
-                    }
-
-                    set src(value: string) {
-                        this._src = value;
-                        capturedSrc = value;
-                        this.onload?.();
-                    }
-                },
+                createStubImage({
+                    onSrcSet: (src) => {
+                        capturedSrc = src;
+                    },
+                }),
             );
 
             vi.stubGlobal(

--- a/src/assets/BitmapFont.test.ts
+++ b/src/assets/BitmapFont.test.ts
@@ -124,10 +124,16 @@ describe('BitmapFont', () => {
             font.measureText(`str-${i}`);
         }
 
-        // The 257th entry triggers FIFO eviction of the first entry.
-        expect(() => font.measureText('overflow')).not.toThrow();
+        // The 257th entry triggers FIFO eviction of 'str-0' (oldest).
+        font.measureText('overflow');
 
-        // Font still measures correctly after eviction.
+        // Verify the oldest entry was actually removed from the cache.
+        const cache = (font as unknown as { measureCache: Map<string, number> }).measureCache;
+
+        expect(cache.has('str-0')).toBe(false);
+        expect(cache.has('overflow')).toBe(true);
+
+        // Font still measures correctly after eviction (recomputed on cache miss).
         expect(font.measureText('A')).toBe(9);
     });
 
@@ -292,6 +298,30 @@ describe('BitmapFont', () => {
         });
 
         it('should resolve a relative texture path relative to the font URL', async () => {
+            let capturedSrc = '';
+
+            vi.stubGlobal(
+                'Image',
+                class {
+                    onload: (() => void) | null = null;
+                    onerror: (() => void) | null = null;
+                    width = 64;
+                    height = 16;
+
+                    private _src = '';
+
+                    get src(): string {
+                        return this._src;
+                    }
+
+                    set src(value: string) {
+                        this._src = value;
+                        capturedSrc = value;
+                        this.onload?.();
+                    }
+                },
+            );
+
             vi.stubGlobal(
                 'fetch',
                 vi.fn().mockResolvedValue({
@@ -303,6 +333,7 @@ describe('BitmapFont', () => {
             const loaded = await BitmapFont.load('fonts/test.btfont');
 
             expect(loaded).toBeDefined();
+            expect(capturedSrc).toBe('fonts/font-atlas.png');
         });
     });
 

--- a/src/assets/BitmapFont.test.ts
+++ b/src/assets/BitmapFont.test.ts
@@ -18,13 +18,23 @@ import { BitmapFont } from './BitmapFont';
 
 // #region Test Fixtures
 
+type GlyphData = { x: number; y: number; w: number; h: number; ox: number; oy: number; adv: number };
+type FontData = {
+    name: string;
+    size: number;
+    lineHeight: number;
+    baseline: number;
+    texture: string;
+    glyphs: Record<string, GlyphData>;
+};
+
 /**
  * Canonical fixture returned by mocked font fetches.
  *
  * Includes ASCII glyphs plus one extended Unicode glyph so the tests can cover
  * both the fast ASCII lookup table and the fallback Unicode map path.
  */
-const MOCK_FONT_DATA: object = {
+const MOCK_FONT_DATA: FontData = {
     name: 'TestFont',
     size: 12,
     lineHeight: 14,

--- a/src/assets/BitmapFont.test.ts
+++ b/src/assets/BitmapFont.test.ts
@@ -1,10 +1,30 @@
+/**
+ * Unit tests for {@link BitmapFont}.
+ *
+ * Exercises the bitmap-font workflow end to end:
+ * - loading `.btfont` JSON metadata and its backing texture
+ * - ASCII and Unicode glyph lookup paths
+ * - text measurement, cache reuse, and cache eviction
+ * - metadata defaults and relative texture resolution
+ * - failure modes for invalid font data and texture load errors
+ *
+ * The suite uses stubbed `fetch` and `Image` globals so glyph and measurement
+ * behavior can be validated without real browser I/O.
+ */
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { BitmapFont } from './BitmapFont';
 
 // #region Test Fixtures
 
-const MOCK_FONT_DATA = {
+/**
+ * Canonical fixture returned by mocked font fetches.
+ *
+ * Includes ASCII glyphs plus one extended Unicode glyph so the tests can cover
+ * both the fast ASCII lookup table and the fallback Unicode map path.
+ */
+const MOCK_FONT_DATA: object = {
     name: 'TestFont',
     size: 12,
     lineHeight: 14,
@@ -72,8 +92,9 @@ describe('BitmapFont', () => {
         expect(font.baseline).toBe(10);
     });
 
-    it('should look up ASCII glyphs via fast path', () => {
+    it('should look up ASCII glyphs via a fast path', () => {
         const glyph = font.getGlyph('A');
+
         expect(glyph).not.toBeNull();
         expect(glyph?.advance).toBe(9);
         expect(glyph?.rect.x).toBe(0);
@@ -81,20 +102,23 @@ describe('BitmapFont', () => {
 
     it('should look up Unicode glyphs via Map', () => {
         const glyph = font.getGlyph('\u00e9');
+
         expect(glyph).not.toBeNull();
         expect(glyph?.advance).toBe(7);
     });
 
     it('should measure text width with caching', () => {
         const width = font.measureText('AB');
+
         expect(width).toBe(17); // 9 (A advance) + 8 (B advance)
 
         // Second call returns the cached result.
         const cached = font.measureText('AB');
+
         expect(cached).toBe(width);
     });
 
-    it('should evict oldest entry when cache exceeds max size', () => {
+    it('should evict the oldest entry when the cache exceeds max size', () => {
         // Fill the cache with 256 unique strings.
         for (let i = 0; i < 256; i++) {
             font.measureText(`str-${i}`);
@@ -114,7 +138,7 @@ describe('BitmapFont', () => {
         expect(font.hasGlyph('Z')).toBe(false);
     });
 
-    it('should clear measure cache', () => {
+    it('should clear the measure cache', () => {
         font.measureText('A'); // Populate cache.
         font.clearMeasureCache();
 
@@ -124,7 +148,7 @@ describe('BitmapFont', () => {
 
     // #region Additional accessors
 
-    it('should return correct glyphCount', () => {
+    it('should return the correct glyphCount', () => {
         expect(font.glyphCount).toBe(3);
     });
 
@@ -132,15 +156,17 @@ describe('BitmapFont', () => {
         expect(font.getGlyph('Z')).toBeNull();
     });
 
-    it('should use Unicode Map fallback for getGlyph with high char code', () => {
+    it('should use Unicode Map fallback for getGlyph with a high-char code', () => {
         // '\u00e9' has char code 233 which is >= ASCII_CACHE_SIZE (128).
         const glyph = font.getGlyph('\u00e9');
+
         expect(glyph).not.toBeNull();
         expect(glyph?.advance).toBe(7);
     });
 
     it('should look up glyph by ASCII code with getGlyphByCode', () => {
         const glyph = font.getGlyphByCode('A'.charCodeAt(0)); // 65
+
         expect(glyph).not.toBeNull();
         expect(glyph?.advance).toBe(9);
     });
@@ -151,26 +177,31 @@ describe('BitmapFont', () => {
 
     it('should use Map fallback for getGlyphByCode with Unicode code >= 128', () => {
         const glyph = font.getGlyphByCode(0x00e9); // 233
+
         expect(glyph).not.toBeNull();
         expect(glyph?.advance).toBe(7);
     });
 
     it('should return the sprite sheet from getSpriteSheet', () => {
         const spriteSheet = font.getSpriteSheet();
+
         expect(spriteSheet).toBeDefined();
         expect(spriteSheet.size.x).toBe(64);
         expect(spriteSheet.size.y).toBe(16);
     });
 
-    it('should return correct measureTextSize width and height', () => {
+    it('should return the correct measureTextSize width and height', () => {
         const size = font.measureTextSize('AB');
+
         expect(size.width).toBe(17); // 9 + 8
         expect(size.height).toBe(14); // lineHeight
     });
 
     it('should write width and height into the provided object for measureTextSizeInto', () => {
         const result = { width: 0, height: 0 };
+
         font.measureTextSizeInto('A', result);
+
         expect(result.width).toBe(9);
         expect(result.height).toBe(14);
     });
@@ -191,6 +222,7 @@ describe('BitmapFont', () => {
     describe('load error cases', () => {
         it('should throw when fetch returns a non-ok response', async () => {
             vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found' }));
+
             await expect(BitmapFont.load('missing.btfont')).rejects.toThrow('Failed to load font');
         });
 
@@ -208,6 +240,7 @@ describe('BitmapFont', () => {
                     }),
                 }),
             );
+
             await expect(BitmapFont.load('bad.btfont')).rejects.toThrow('Invalid font file');
         });
 
@@ -225,6 +258,7 @@ describe('BitmapFont', () => {
                     }),
                 }),
             );
+
             await expect(BitmapFont.load('bad.btfont')).rejects.toThrow('Invalid font file');
         });
 
@@ -253,6 +287,7 @@ describe('BitmapFont', () => {
                     json: vi.fn().mockResolvedValue(MOCK_FONT_DATA),
                 }),
             );
+
             await expect(BitmapFont.load('test.btfont')).rejects.toThrow('Failed to load font texture');
         });
 
@@ -264,7 +299,9 @@ describe('BitmapFont', () => {
                     json: vi.fn().mockResolvedValue({ ...MOCK_FONT_DATA, texture: 'font-atlas.png' }),
                 }),
             );
+
             const loaded = await BitmapFont.load('fonts/test.btfont');
+
             expect(loaded).toBeDefined();
         });
     });
@@ -285,14 +322,16 @@ describe('BitmapFont', () => {
                     }),
                 }),
             );
+
             const f = await BitmapFont.load('minimal.btfont');
+
             expect(f.name).toBe('Unknown');
             expect(f.size).toBe(12);
             expect(f.lineHeight).toBe(12);
             expect(f.baseline).toBe(12);
         });
 
-        it('should use size as fallback for lineHeight and baseline', async () => {
+        it('should use size as a fallback for lineHeight and baseline', async () => {
             vi.stubGlobal(
                 'fetch',
                 vi.fn().mockResolvedValue({
@@ -305,7 +344,9 @@ describe('BitmapFont', () => {
                     }),
                 }),
             );
+
             const f = await BitmapFont.load('partial.btfont');
+
             expect(f.name).toBe('CustomFont');
             expect(f.size).toBe(16);
             expect(f.lineHeight).toBe(16); // Falls back to size
@@ -325,14 +366,17 @@ describe('BitmapFont', () => {
         it('should measure mixed ASCII and Unicode text', () => {
             // A(9) + e-acute(7) + B(8) = 24
             const width = font.measureText('A\u00e9B');
+
             expect(width).toBe(24);
         });
 
-        it('should return reusable object from measureTextSize', () => {
+        it('should return a reusable object from measureTextSize', () => {
             const size1 = font.measureTextSize('A');
             const size2 = font.measureTextSize('AB');
+
             // Same reference (reused object)
             expect(size1).toBe(size2);
+
             // But values reflect the latest measurement
             expect(size2.width).toBe(17);
         });

--- a/src/assets/BitmapFont.ts
+++ b/src/assets/BitmapFont.ts
@@ -4,8 +4,7 @@ import { SpriteSheet } from './SpriteSheet';
 // #region Type Definitions
 
 /**
- * Glyph data for a single character in a bitmap font.
- * Contains texture coordinates, dimensions, rendering offsets, and advance width.
+ * Runtime glyph metadata used by the renderer.
  */
 export interface Glyph {
     /** Source rectangle in the font texture atlas. */
@@ -22,8 +21,7 @@ export interface Glyph {
 }
 
 /**
- * Raw glyph data as stored in the .btfont JSON file.
- * Uses short property names for compact file size.
+ * Serialized glyph entry stored in `.btfont` files.
  */
 interface GlyphData {
     /** X position in texture atlas. */
@@ -49,8 +47,7 @@ interface GlyphData {
 }
 
 /**
- * Font file format (.btfont) structure.
- * JSON file with texture reference (embedded base64 or relative path).
+ * Serialized bitmap-font descriptor loaded from disk.
  */
 interface FontFileData {
     /** Font display name. */
@@ -77,8 +74,7 @@ interface FontFileData {
 }
 
 /**
- * Result object for text size measurements.
- * Reused to avoid allocations in hot paths.
+ * Measured text dimensions in pixels.
  */
 export interface TextSize {
     /** Width of the text in pixels. */
@@ -92,34 +88,44 @@ export interface TextSize {
 
 // #region Constants
 
-/** Maximum number of cached measurement results. */
+/**
+ * Maximum number of cached string-width measurements retained at once.
+ *
+ * The cache uses insertion order and evicts the oldest entry when it reaches
+ * this limit.
+ */
 const MAX_MEASURE_CACHE_SIZE = 256;
 
-/** Number of ASCII characters to cache for fast lookup. */
+/**
+ * Size of the direct lookup table used for ASCII glyphs (`0-127`).
+ */
 const ASCII_CACHE_SIZE = 128;
 
 // #endregion
 
 /**
- * Modern bitmap font for variable-width text rendering.
+ * Bitmap font backed by a sprite-sheet texture atlas.
  *
- * Loads from `.btfont` JSON files with embedded base64 textures.
- * Supports Unicode characters and per-glyph rendering offsets.
- *
- * Performance optimizations:
- * - ASCII glyphs cached in a direct array for O(1) lookup
- * - Text measurement results cached with LRU eviction
- * - Reusable result objects to minimize allocations
- * - Optimized loops using charCodeAt for ASCII text
- *
- * @example
- * ```ts
- * const font = await BitmapFont.load('fonts/MyFont.btfont');
- * BT.printFont(font, new Vector2i(10, 10), 'Hello World!', Color32.white());
- * ```
+ * The class is responsible for:
+ * - loading `.btfont` metadata and its referenced texture
+ * - exposing glyph lookup by character or character code
+ * - measuring string widths with a small reusable cache
+ * - providing the underlying {@link SpriteSheet} used for rendering glyph quads
  */
 export class BitmapFont {
     // #region Module State
+
+    /** Font display name. */
+    public readonly name: string;
+
+    /** Original font size in points. */
+    public readonly size: number;
+
+    /** Pixels between baselines for multi-line text. */
+    public readonly lineHeight: number;
+
+    /** Pixels from top of line to baseline. */
+    public readonly baseline: number;
 
     /** Sprite sheet containing the font texture atlas. */
     private readonly spriteSheet: SpriteSheet;
@@ -135,18 +141,6 @@ export class BitmapFont {
 
     /** Reusable result object for measureTextSize to avoid allocations. */
     private readonly textSizeResult: TextSize = { width: 0, height: 0 };
-
-    /** Font display name. */
-    public readonly name: string;
-
-    /** Original font size in points. */
-    public readonly size: number;
-
-    /** Pixels between baselines for multi-line text. */
-    public readonly lineHeight: number;
-
-    /** Pixels from top of line to baseline. */
-    public readonly baseline: number;
 
     // #endregion
 
@@ -184,22 +178,30 @@ export class BitmapFont {
 
     // #endregion
 
-    // #region Static Factory
+    // #region Metadata
 
     /**
-     * Loads a bitmap font from a .btfont JSON file.
+     * Returns the total number of glyphs loaded into the font.
      *
-     * The file format is a JSON object with:
-     * - `name`: Font display name
-     * - `size`: Original font size in points
-     * - `lineHeight`: Pixels between baselines
-     * - `baseline`: Pixels from top to baseline
-     * - `texture`: Base64 data URI or relative path to PNG
-     * - `glyphs`: Map of character to glyph data
+     * @returns Total glyph count.
+     */
+    get glyphCount(): number {
+        return this.glyphs.size;
+    }
+
+    // #endregion
+
+    // #region Loading
+
+    /**
+     * Loads a bitmap font from a `.btfont` JSON file.
+     *
+     * The font descriptor can reference either an embedded data URI or a
+     * texture file path relative to the font JSON file.
      *
      * @param url - Path to the .btfont file.
-     * @returns Promise resolving to the loaded BitmapFont.
-     * @throws Error if the file can't be loaded or parsed.
+     * @returns Loaded bitmap font instance.
+     * @throws Error if the font descriptor or texture cannot be loaded.
      */
     static async load(url: string): Promise<BitmapFont> {
         // Fetch and parse the JSON file.
@@ -256,16 +258,14 @@ export class BitmapFont {
         );
     }
 
-    // #endregion
-
-    // #region Helper Functions
+    // #region Loading Helpers
 
     /**
      * Loads a texture from either a base64 data URI or a relative path.
      *
      * @param texture - Data URI (starts with "data:") or relative path.
      * @param fontUrl - URL of the .btfont file (used to resolve relative paths).
-     * @returns Promise resolving to the loaded HTMLImageElement.
+     * @returns Loaded texture image for the font atlas.
      */
     private static loadTexture(texture: string, fontUrl: string): Promise<HTMLImageElement> {
         // Check if it's a data URI (embedded base64).
@@ -280,33 +280,35 @@ export class BitmapFont {
         return BitmapFont.loadImage(textureUrl);
     }
 
+    // #endregion
+
+    // #region Glyph Access
+
     /**
      * Loads an image from a URL or data URI.
      *
      * @param src - Image source (URL or data URI).
-     * @returns Promise resolving to the loaded HTMLImageElement.
+     * @returns Loaded image element for the font texture.
      */
     private static loadImage(src: string): Promise<HTMLImageElement> {
         return new Promise((resolve, reject) => {
             const image = new Image();
 
             image.onload = () => resolve(image);
-            image.onerror = () => reject(new Error(`Failed to load font texture: ${src.substring(0, 50)}...`));
+            image.onerror = () => reject(new Error(`Failed to load font texture: ${src.substring(0, 50)}`));
 
             image.src = src;
         });
     }
 
-    // #endregion
-
-    // #region Accessors
-
     /**
-     * Gets glyph information for a specific character.
-     * Uses fast array lookup for ASCII characters, falls back to Map for Unicode.
+     * Returns glyph data for a character.
+     *
+     * Uses the ASCII lookup table for single-byte characters and falls back to
+     * the Unicode glyph map for everything else.
      *
      * @param char - Single character to look up (supports Unicode).
-     * @returns Glyph data with source rect, offsets and advance, or null if not found.
+     * @returns Glyph metadata, or `null` when the font does not contain the character.
      */
     getGlyph(char: string): Glyph | null {
         // Fast path for ASCII characters.
@@ -324,11 +326,13 @@ export class BitmapFont {
     }
 
     /**
-     * Gets glyph information by character code.
-     * Optimized for hot paths where character code is already known.
+     * Returns glyph data by numeric character code.
+     *
+     * Uses the ASCII lookup table for codes below `128` and falls back to the
+     * Unicode glyph map for all other values.
      *
      * @param charCode - Character code to look up.
-     * @returns Glyph data or null if not found.
+     * @returns Glyph metadata, or `null` when no glyph exists for the code.
      */
     getGlyphByCode(charCode: number): Glyph | null {
         // Fast path for ASCII.
@@ -342,21 +346,12 @@ export class BitmapFont {
     }
 
     /**
-     * Gets the underlying sprite sheet for rendering.
+     * Returns the sprite sheet that owns the font texture atlas.
      *
-     * @returns The font's texture atlas as a SpriteSheet.
+     * @returns Sprite sheet used when rendering glyph quads.
      */
     getSpriteSheet(): SpriteSheet {
         return this.spriteSheet;
-    }
-
-    /**
-     * Gets the number of glyphs in this font.
-     *
-     * @returns Total glyph count.
-     */
-    get glyphCount(): number {
-        return this.glyphs.size;
     }
 
     // #endregion
@@ -364,9 +359,10 @@ export class BitmapFont {
     // #region Text Measurement
 
     /**
-     * Measures the pixel width of a text string.
-     * Results are cached for frequently measured strings.
-     * Uses optimized charCodeAt loop for better performance.
+     * Measures the horizontal pixel width of a text string.
+     *
+     * Results are cached for repeated measurements and use an optimized ASCII
+     * fast path during width calculation.
      *
      * @param text - String to measure.
      * @returns Total width in pixels.
@@ -422,14 +418,13 @@ export class BitmapFont {
     }
 
     /**
-     * Measures the pixel dimensions of a text string.
-     * For single-line text, height equals lineHeight.
+     * Measures the pixel size of a single-line text string.
      *
-     * WARNING: Returns a reusable internal object to avoid allocations.
-     * Don't store the returned reference – copy the values if needed.
+     * Returns a reusable internal object to avoid allocations. Copy the values
+     * before calling `measureTextSize()` again if you need to retain them.
      *
      * @param text - String to measure.
-     * @returns Object with width and height in pixels (reused, don't store reference).
+     * @returns Reused width/height pair for the measured text.
      */
     measureTextSize(text: string): TextSize {
         this.textSizeResult.width = this.measureText(text);
@@ -439,12 +434,11 @@ export class BitmapFont {
     }
 
     /**
-     * Measures the pixel dimensions of a text string and copies to the provided object.
-     * Use this when you need to store the result.
+     * Measures the pixel size of a single-line text string into a caller-owned object.
      *
      * @param text - String to measure.
-     * @param result - Object to store the result in.
-     * @returns The result object with width and height populated.
+     * @param result - Object that receives the measured width and height.
+     * @returns The same `result` object after being populated.
      */
     measureTextSizeInto(text: string, result: TextSize): TextSize {
         result.width = this.measureText(text);
@@ -454,11 +448,12 @@ export class BitmapFont {
     }
 
     /**
-     * Checks if the font contains a glyph for the given character.
-     * Uses fast ASCII lookup when possible.
+     * Checks whether the font contains a glyph for a character.
+     *
+     * Uses the same ASCII fast path as `getGlyph()` for single-byte characters.
      *
      * @param char - Character to check.
-     * @returns True if the font can render this character.
+     * @returns `true` if the font can render the character.
      */
     hasGlyph(char: string): boolean {
         // Fast path for ASCII.
@@ -475,8 +470,10 @@ export class BitmapFont {
     }
 
     /**
-     * Clears the text measurement cache.
-     * Call this if font metrics change or to free memory.
+     * Clears cached text measurement results.
+     *
+     * Useful after profiling, tests, or when you want to bound cache growth
+     * across distinct text workloads.
      */
     clearMeasureCache(): void {
         this.measureCache.clear();


### PR DESCRIPTION
- Add comprehensive module documentation to test suite
- Expand JSDoc comments for all public methods and interfaces
- Clarify cache behavior, lookup strategies, and performance notes
- Reorganize class sections for logical grouping
- Improve test descriptions for clarity


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes to `src/assets/BitmapFont.ts`

Public API:
- Added public readonly properties: `name`, `size`, `lineHeight`, `baseline`.
- Added public getter `glyphCount(): number` (returns `this.glyphs.size`).

Documentation and comments:
- Expanded and clarified JSDoc: characterizes glyph/file/measurement structures as serialized runtime metadata rather than format-centric/raw data.
- Added detailed loading documentation and refined the texture load failure message to "Failed to load font texture: ..." (removed prior truncation).
- Introduced logical comment regions: `Loading`, `Glyph Access`, `Text Measurement`.
- Clarified semantics for text measurement APIs (`measureTextSize` and `measureTextSizeInto`) — documented as single-line measurements and clarified reusable vs caller-owned result behavior.

Behavior:
- No behavioral changes to glyph lookup/control flow (`getGlyph`, `getGlyphByCode`, `hasGlyph`, `getSpriteSheet`) or to measurement/cache eviction algorithms; changes are documentation and API-surface additions only.

Lines changed: +89/-92
Estimated review effort: Medium

## Changes to `src/assets/BitmapFont.test.ts`

Test documentation and fixtures:
- Added a comprehensive module-level doc comment describing the end-to-end workflow under test (loading metadata + texture, ASCII/Unicode glyph lookup, measurement caching/eviction, defaults, and error modes). Notes that `fetch`/`Image` are stubbed to avoid real browser I/O.
- Introduced strongly typed `GlyphData`/`FontData` fixtures and typed `MOCK_FONT_DATA`.
- Replaced three duplicated inline `Image` stub classes with a reusable `createStubImage` factory supporting synchronous load, optional error firing, capturing assigned `src`, and configurable width/height.
- Reorganized tests and clarified test names/descriptions; minor whitespace/formatting tweaks.

Test behavior and assertions:
- Reworked cache-eviction test to directly inspect the internal `measureCache` (via casting) and assert FIFO eviction semantics (confirms removal of the oldest key `'str-0'` and presence of the overflow key) while still verifying correct measurement after eviction; removed the previous "does not throw" assertion.
- Strengthened a texture relative-path test by capturing `Image.src` and asserting that a relative `texture` entry in the `.btfont` resolves relative to the font file URL (e.g. `fonts/font-atlas.png`).
- Kept and tightened existing assertions: glyph lookup (ASCII fast path and Unicode Map), measurement results, cache reuse, cache clearing, accessor behavior (`glyphCount`, `getSpriteSheet`), and load error cases.

Lines changed: +131/-49
Estimated review effort: Medium

## API / Declarations
- Export surface changes limited to the new public properties and the `glyphCount` getter on `BitmapFont`; no other exported or declaration-level changes.

Total lines changed (both files): +220/-141
<!-- end of auto-generated comment: release notes by coderabbit.ai -->