### PR TITLE
docs(core): improve GameLoop documentation and test formatting

### DIFF
--- a/src/core/GameLoop.test.ts
+++ b/src/core/GameLoop.test.ts
@@ -170,7 +170,7 @@ describe('GameLoop', () => {
             expect(onUpdate).toHaveBeenCalledTimes(8);
         });
 
-        it('should call onRender exactly once per a frame regardless of update step count', () => {
+        it('should call onRender exactly once per frame regardless of update step count', () => {
             const onRender = vi.fn();
             const loop = new GameLoop(10, vi.fn(), onRender);
             const p = loop as unknown as PrivateLoop;

--- a/src/core/GameLoop.test.ts
+++ b/src/core/GameLoop.test.ts
@@ -1,3 +1,17 @@
+/**
+ * Unit tests for {@link GameLoop}.
+ *
+ * Verifies the fixed-timestep loop contract:
+ * - constructor validation for invalid update intervals
+ * - public tick-counter and stop behavior
+ * - start-up scheduling through `requestAnimationFrame`
+ * - internal tick processing, including multiple updates per frame
+ * - accumulator clamping to avoid runaway catch-up work
+ *
+ * Private frame-advance behavior is exercised through a narrow type cast so
+ * the suite can validate timing semantics without changing production APIs.
+ */
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { GameLoop } from './GameLoop';
@@ -8,14 +22,15 @@ describe('GameLoop', () => {
     describe('constructor', () => {
         it('should accept a valid positive update interval', () => {
             const loop = new GameLoop(16.67, vi.fn(), vi.fn());
+
             expect(loop).toBeDefined();
         });
 
-        it('should throw on zero interval', () => {
+        it('should throw on a zero interval', () => {
             expect(() => new GameLoop(0, vi.fn(), vi.fn())).toThrow('finite positive number');
         });
 
-        it('should throw on negative interval', () => {
+        it('should throw on a negative interval', () => {
             expect(() => new GameLoop(-16, vi.fn(), vi.fn())).toThrow('finite positive number');
         });
 
@@ -23,11 +38,11 @@ describe('GameLoop', () => {
             expect(() => new GameLoop(NaN, vi.fn(), vi.fn())).toThrow('finite positive number');
         });
 
-        it('should throw on Infinity interval', () => {
+        it('should throw on an Infinity interval', () => {
             expect(() => new GameLoop(Infinity, vi.fn(), vi.fn())).toThrow('finite positive number');
         });
 
-        it('should throw on negative Infinity interval', () => {
+        it('should throw on a negative Infinity interval', () => {
             expect(() => new GameLoop(-Infinity, vi.fn(), vi.fn())).toThrow('finite positive number');
         });
     });
@@ -39,6 +54,7 @@ describe('GameLoop', () => {
     describe('getTicks', () => {
         it('should return 0 initially', () => {
             const loop = new GameLoop(16.67, vi.fn(), vi.fn());
+
             expect(loop.getTicks()).toBe(0);
         });
     });
@@ -46,8 +62,11 @@ describe('GameLoop', () => {
     describe('resetTicks', () => {
         it('should reset tick count to 0', () => {
             const loop = new GameLoop(16.67, vi.fn(), vi.fn());
+
             (loop as unknown as { ticks: number }).ticks = 5;
+
             loop.resetTicks();
+
             expect(loop.getTicks()).toBe(0);
         });
     });
@@ -55,6 +74,7 @@ describe('GameLoop', () => {
     describe('stop', () => {
         it('should not throw when called before start', () => {
             const loop = new GameLoop(16.67, vi.fn(), vi.fn());
+
             expect(() => loop.stop()).not.toThrow();
         });
     });
@@ -74,15 +94,21 @@ describe('GameLoop', () => {
 
         it('should call requestAnimationFrame when started', () => {
             const loop = new GameLoop(16.67, vi.fn(), vi.fn());
+
             loop.start();
+
             expect(requestAnimationFrame).toHaveBeenCalledOnce();
         });
 
         it('should not call requestAnimationFrame again if already running', () => {
             const loop = new GameLoop(16.67, vi.fn(), vi.fn());
+
             loop.start();
+
             const callsBefore = (requestAnimationFrame as ReturnType<typeof vi.fn>).mock.calls.length;
+
             loop.start();
+
             expect((requestAnimationFrame as ReturnType<typeof vi.fn>).mock.calls.length).toBe(callsBefore);
         });
     });
@@ -111,7 +137,9 @@ describe('GameLoop', () => {
             const onUpdate = vi.fn();
             const onRender = vi.fn();
             const loop = new GameLoop(16.67, onUpdate, onRender);
+
             (loop as unknown as PrivateLoop).tick(100);
+
             expect(onUpdate).not.toHaveBeenCalled();
             expect(onRender).not.toHaveBeenCalled();
         });
@@ -121,9 +149,11 @@ describe('GameLoop', () => {
             const onRender = vi.fn();
             const loop = new GameLoop(10, onUpdate, onRender);
             const p = loop as unknown as PrivateLoop;
+
             p.isRunning = true;
             p.lastUpdateTime = 0;
             p.tick(20); // 20ms delta at 10ms interval = 2 update steps
+
             expect(onUpdate).toHaveBeenCalledTimes(2);
             expect(onRender).toHaveBeenCalledOnce();
         });
@@ -132,37 +162,45 @@ describe('GameLoop', () => {
             const onUpdate = vi.fn();
             const loop = new GameLoop(10, onUpdate, vi.fn());
             const p = loop as unknown as PrivateLoop;
+
             p.isRunning = true;
             p.lastUpdateTime = 0;
             p.tick(10000); // huge pause — MAX_STEPS = 8 caps at 8 updates
+
             expect(onUpdate).toHaveBeenCalledTimes(8);
         });
 
-        it('should call onRender exactly once per frame regardless of update step count', () => {
+        it('should call onRender exactly once per a frame regardless of update step count', () => {
             const onRender = vi.fn();
             const loop = new GameLoop(10, vi.fn(), onRender);
             const p = loop as unknown as PrivateLoop;
+
             p.isRunning = true;
             p.lastUpdateTime = 0;
             p.tick(10000); // many steps, but one render
+
             expect(onRender).toHaveBeenCalledOnce();
         });
 
         it('should increment tick count by the number of update steps', () => {
             const loop = new GameLoop(10, vi.fn(), vi.fn());
             const p = loop as unknown as PrivateLoop;
+
             p.isRunning = true;
             p.lastUpdateTime = 0;
             p.tick(30); // 30ms at 10ms interval = 3 steps
+
             expect(loop.getTicks()).toBe(3);
         });
 
         it('should schedule the next frame via requestAnimationFrame', () => {
             const loop = new GameLoop(10, vi.fn(), vi.fn());
             const p = loop as unknown as PrivateLoop;
+
             p.isRunning = true;
             p.lastUpdateTime = 0;
             p.tick(10);
+
             expect(requestAnimationFrame).toHaveBeenCalled();
         });
     });

--- a/src/core/GameLoop.ts
+++ b/src/core/GameLoop.ts
@@ -6,10 +6,8 @@
  * Implements the accumulator pattern to ensure update() runs at a deterministic
  * rate regardless of frame timing irregularities. render() runs at the browser's
  * native refresh rate.
- *
- * PERFORMANCE CRITICAL: The inner loop runs every frame at 60+ FPS.
- * The accumulator prevents the spiral-of-death by capping the number of update
- * steps per frame to MAX_STEPS.
+ * The accumulator prevents a spiral-of-death catch-up burst by capping the
+ * number of fixed updates processed in a single frame.
  */
 export class GameLoop {
     // #region Constants
@@ -70,9 +68,9 @@ export class GameLoop {
 
     /**
      * Starts the loop.
-     * Uses a double requestAnimationFrame delay before the first tick to ensure
-     * the canvas is fully ready. This fixes timing issues in Electron and some
-     * browsers where the canvas may not be initialized on the first frame.
+     *
+     * Uses a double `requestAnimationFrame` delay before the first tick, so the
+     * surrounding rendering surface is fully ready before timing begins.
      */
     public start(): void {
         if (this.isRunning) {
@@ -92,7 +90,7 @@ export class GameLoop {
 
     /**
      * Stops the loop.
-     * The current frame will complete before the loop exits.
+     * The current frame, if already running, is allowed to finish.
      */
     public stop(): void {
         this.isRunning = false;
@@ -100,7 +98,7 @@ export class GameLoop {
 
     /**
      * Gets the current tick count.
-     * Ticks increment once per fixed update call (e.g., 60 times/second at 60 FPS).
+     * Ticks increment once per fixed update step.
      *
      * @returns Number of update ticks since the loop started or since the last reset.
      */
@@ -120,7 +118,10 @@ export class GameLoop {
     // #region Private Loop
 
     /**
-     * Single frame tick — called by requestAnimationFrame each frame.
+     * Processes one animation frame.
+     *
+     * Advances the accumulator, runs zero or more fixed updates, renders once,
+     * and schedules the next frame while the loop remains active.
      *
      * @param currentTime - High-resolution timestamp provided by rAF, in milliseconds.
      */


### PR DESCRIPTION
- Add comprehensive module documentation to test suite
- Expand JSDoc for public methods and private frame-advance logic
- Clarify fixed-timestep contract, accumulator behavior, and frame timing
- Add blank lines throughout tests for improved readability
- Simplify and refine method descriptions for clarity


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR improves documentation and test formatting for the GameLoop module, clarifying behavioral semantics and enhancing code readability without modifying any runtime logic.

## Changes

### GameLoop.ts (Documentation Updates)
- Refined JSDoc descriptions to clarify behavioral semantics:
  - Updated performance notes to use "capping the number of fixed updates processed in a single frame" instead of inner-loop terminology
  - Generalized `start()` documentation to describe how double `requestAnimationFrame` delay ensures the rendering surface is ready
  - Clarified `stop()` behavior to note the current frame "if already running, is allowed to finish"
  - Emphasized in `getTicks()` that ticks increment per fixed update step
  - Expanded `tick()` documentation to describe accumulator advancement, zero-or-more fixed updates, single render, and next frame scheduling while active
- No changes to code logic, control flow, method signatures, or runtime behavior

### GameLoop.test.ts (Test Documentation & Formatting)
- Added comprehensive file-level JSDoc describing test scope: constructor interval validation, tick counting and stop behavior, `requestAnimationFrame` scheduling, fixed-timestep tick processing with multiple updates per frame, and accumulator clamping
- Added blank lines throughout test cases for improved readability
- Minor adjustment to test description string from "per frame regardless of update step count" to "per a frame regardless of update step count"
- No changes to test logic, assertions, setup/teardown, or execution flow

## Impact
- Low review effort
- Documentation-only changes
- Improves clarity of fixed-timestep contract, accumulator behavior, and frame timing semantics
- No alterations to exported APIs or public entity declarations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->