### PR TITLE
docs(core): improve WebGPUContext documentation and error messages

### DIFF
--- a/src/render/PrimitivePipeline.test.ts
+++ b/src/render/PrimitivePipeline.test.ts
@@ -1,3 +1,17 @@
+/**
+ * Unit tests for {@link PrimitivePipeline}.
+ *
+ * Covers the CPU-side primitive batching path:
+ * - construction and pre-initialization safety of public drawing methods
+ * - encode/reset behavior before and after buffered draws
+ * - camera-offset handling across frame-style reset/encode cycles
+ * - vertex-count expectations for filled rects, pixels, lines, outlines, text,
+ *   and clear operations
+ *
+ * GPU-facing behavior is exercised with the local WebGPU mock device and render
+ * pass encoder helpers so the tests can validate command emission deterministically.
+ */
+
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import {
@@ -16,6 +30,7 @@ import { PrimitivePipeline } from './PrimitivePipeline';
 describe('PrimitivePipeline constructor', () => {
     it('creates an instance without error', () => {
         const pipeline = new PrimitivePipeline();
+
         expect(pipeline).toBeDefined();
         expect(pipeline).toBeInstanceOf(PrimitivePipeline);
     });
@@ -28,6 +43,7 @@ describe('PrimitivePipeline constructor', () => {
 describe('pre-initialization safety', () => {
     it('reset() can be called multiple times safely', () => {
         const pipeline = new PrimitivePipeline();
+
         expect(() => {
             pipeline.reset();
             pipeline.reset();
@@ -37,6 +53,7 @@ describe('pre-initialization safety', () => {
 
     it('setCameraOffset() accepts a Vector2i', () => {
         const pipeline = new PrimitivePipeline();
+
         expect(() => {
             pipeline.setCameraOffset(new Vector2i(10, 20));
         }).not.toThrow();
@@ -44,6 +61,7 @@ describe('pre-initialization safety', () => {
 
     it('setCameraOffset() accepts zero vector', () => {
         const pipeline = new PrimitivePipeline();
+
         expect(() => {
             pipeline.setCameraOffset(Vector2i.zero());
         }).not.toThrow();
@@ -53,6 +71,7 @@ describe('pre-initialization safety', () => {
         const pipeline = new PrimitivePipeline();
         const rect = new Rect2i(0, 0, 10, 10);
         const color = Color32.red();
+
         expect(() => {
             pipeline.drawRectFill(rect, color);
         }).not.toThrow();
@@ -62,6 +81,7 @@ describe('pre-initialization safety', () => {
         const pipeline = new PrimitivePipeline();
         const pos = new Vector2i(5, 5);
         const color = Color32.green();
+
         expect(() => {
             pipeline.drawPixel(pos, color);
         }).not.toThrow();
@@ -70,6 +90,7 @@ describe('pre-initialization safety', () => {
     it('drawPixelXY() does not throw before initialize', () => {
         const pipeline = new PrimitivePipeline();
         const color = Color32.blue();
+
         expect(() => {
             pipeline.drawPixelXY(3, 7, color);
         }).not.toThrow();
@@ -80,6 +101,7 @@ describe('pre-initialization safety', () => {
         const p0 = new Vector2i(0, 10);
         const p1 = new Vector2i(100, 10);
         const color = Color32.white();
+
         expect(() => {
             pipeline.drawLine(p0, p1, color);
         }).not.toThrow();
@@ -90,6 +112,7 @@ describe('pre-initialization safety', () => {
         const p0 = new Vector2i(10, 0);
         const p1 = new Vector2i(10, 100);
         const color = Color32.yellow();
+
         expect(() => {
             pipeline.drawLine(p0, p1, color);
         }).not.toThrow();
@@ -100,6 +123,7 @@ describe('pre-initialization safety', () => {
         const p0 = new Vector2i(0, 0);
         const p1 = new Vector2i(50, 30);
         const color = Color32.cyan();
+
         expect(() => {
             pipeline.drawLine(p0, p1, color);
         }).not.toThrow();
@@ -109,6 +133,7 @@ describe('pre-initialization safety', () => {
         const pipeline = new PrimitivePipeline();
         const rect = new Rect2i(5, 5, 20, 20);
         const color = Color32.magenta();
+
         expect(() => {
             pipeline.drawRect(rect, color);
         }).not.toThrow();
@@ -118,6 +143,7 @@ describe('pre-initialization safety', () => {
         const pipeline = new PrimitivePipeline();
         const rect = new Rect2i(0, 0, 100, 100);
         const color = Color32.black();
+
         expect(() => {
             pipeline.clearRect(color, rect);
         }).not.toThrow();
@@ -127,6 +153,7 @@ describe('pre-initialization safety', () => {
         const pipeline = new PrimitivePipeline();
         const pos = new Vector2i(10, 10);
         const color = Color32.white();
+
         expect(() => {
             pipeline.drawText(pos, color, 'Hello');
         }).not.toThrow();
@@ -143,6 +170,7 @@ describe('with initialized pipeline', () => {
 
     beforeAll(async () => {
         installMockNavigatorGPU();
+
         await pipeline.initialize(device, new Vector2i(320, 240));
     });
 
@@ -150,9 +178,11 @@ describe('with initialized pipeline', () => {
         uninstallMockNavigatorGPU();
     });
 
-    it('encodePass with empty buffer is a no-op', () => {
+    it('encodePass with an empty buffer is a no-op', () => {
         pipeline.reset();
+
         const renderPass = createMockRenderPassEncoder();
+
         expect(() => {
             pipeline.encodePass(renderPass);
         }).not.toThrow();
@@ -160,12 +190,15 @@ describe('with initialized pipeline', () => {
 
     it('encodePass after drawing primitives completes without error', () => {
         pipeline.reset();
+
         const rect = new Rect2i(0, 0, 10, 10);
+
         pipeline.drawRectFill(rect, Color32.red());
         pipeline.drawPixel(new Vector2i(5, 5), Color32.green());
         pipeline.drawLine(new Vector2i(0, 0), new Vector2i(20, 0), Color32.blue());
 
         const renderPass = createMockRenderPassEncoder();
+
         expect(() => {
             pipeline.encodePass(renderPass);
         }).not.toThrow();
@@ -173,7 +206,9 @@ describe('with initialized pipeline', () => {
 
     it('reset followed by encodePass produces no draw calls', () => {
         pipeline.reset();
+
         pipeline.drawRectFill(new Rect2i(0, 0, 5, 5), Color32.white());
+
         pipeline.reset();
 
         let drawCalled = false;
@@ -185,14 +220,17 @@ describe('with initialized pipeline', () => {
         } as unknown as GPURenderPassEncoder;
 
         pipeline.encodePass(renderPass);
+
         expect(drawCalled).toBe(false);
     });
 
     it('encodePass calls draw on render pass when vertices exist', () => {
         pipeline.reset();
+
         pipeline.drawRectFill(new Rect2i(10, 10, 20, 20), Color32.red());
 
         let drawCalled = false;
+
         const renderPass = {
             ...createMockRenderPassEncoder(),
             draw: () => {
@@ -201,6 +239,7 @@ describe('with initialized pipeline', () => {
         } as unknown as GPURenderPassEncoder;
 
         pipeline.encodePass(renderPass);
+
         expect(drawCalled).toBe(true);
     });
 
@@ -208,8 +247,10 @@ describe('with initialized pipeline', () => {
         expect(() => {
             for (let i = 0; i < 5; i++) {
                 pipeline.reset();
+
                 pipeline.drawPixel(new Vector2i(i, i), Color32.white());
                 pipeline.encodePass(createMockRenderPassEncoder());
+
                 pipeline.reset();
             }
         }).not.toThrow();
@@ -217,11 +258,14 @@ describe('with initialized pipeline', () => {
 
     it('setCameraOffset affects subsequent draws without error', () => {
         pipeline.reset();
+
         pipeline.setCameraOffset(new Vector2i(100, 50));
+
         expect(() => {
             pipeline.drawRectFill(new Rect2i(0, 0, 10, 10), Color32.red());
             pipeline.encodePass(createMockRenderPassEncoder());
         }).not.toThrow();
+
         pipeline.setCameraOffset(Vector2i.zero());
     });
 });
@@ -236,6 +280,7 @@ describe('vertex count verification', () => {
 
     beforeAll(async () => {
         installMockNavigatorGPU();
+
         await pipeline.initialize(device, new Vector2i(320, 240));
     });
 
@@ -243,8 +288,9 @@ describe('vertex count verification', () => {
         uninstallMockNavigatorGPU();
     });
 
-    it('drawRectFill produces 6 vertices (two triangles)', () => {
+    it('drawRectFill produces six vertices (two triangles)', () => {
         pipeline.reset();
+
         pipeline.drawRectFill(new Rect2i(0, 0, 10, 10), Color32.red());
 
         let totalVertices = 0;
@@ -256,14 +302,17 @@ describe('vertex count verification', () => {
         } as unknown as GPURenderPassEncoder;
 
         pipeline.encodePass(renderPass);
+
         expect(totalVertices).toBe(6);
     });
 
-    it('drawPixel produces 6 vertices (1x1 filled rect)', () => {
+    it('drawPixel produces six vertices (1x1 filled rect)', () => {
         pipeline.reset();
+
         pipeline.drawPixel(new Vector2i(5, 5), Color32.green());
 
         let totalVertices = 0;
+
         const renderPass = {
             ...createMockRenderPassEncoder(),
             draw: (vertexCount: number) => {
@@ -272,11 +321,13 @@ describe('vertex count verification', () => {
         } as unknown as GPURenderPassEncoder;
 
         pipeline.encodePass(renderPass);
+
         expect(totalVertices).toBe(6);
     });
 
-    it('horizontal line uses a single quad (6 vertices)', () => {
+    it('horizontal line uses a single quad (six vertices)', () => {
         pipeline.reset();
+
         pipeline.drawLine(new Vector2i(0, 10), new Vector2i(100, 10), Color32.white());
 
         let totalVertices = 0;
@@ -291,11 +342,13 @@ describe('vertex count verification', () => {
         expect(totalVertices).toBe(6);
     });
 
-    it('vertical line uses a single quad (6 vertices)', () => {
+    it('vertical line uses a single quad (six vertices)', () => {
         pipeline.reset();
+
         pipeline.drawLine(new Vector2i(10, 0), new Vector2i(10, 50), Color32.white());
 
         let totalVertices = 0;
+
         const renderPass = {
             ...createMockRenderPassEncoder(),
             draw: (vertexCount: number) => {
@@ -304,15 +357,18 @@ describe('vertex count verification', () => {
         } as unknown as GPURenderPassEncoder;
 
         pipeline.encodePass(renderPass);
+
         expect(totalVertices).toBe(6);
     });
 
-    it('diagonal line uses 6 vertices per pixel (Bresenham)', () => {
+    it('diagonal line uses six vertices per a pixel (Bresenham)', () => {
         pipeline.reset();
+
         // A 45-degree diagonal from (0,0) to (4,4) = 5 pixels
         pipeline.drawLine(new Vector2i(0, 0), new Vector2i(4, 4), Color32.white());
 
         let totalVertices = 0;
+
         const renderPass = {
             ...createMockRenderPassEncoder(),
             draw: (vertexCount: number) => {
@@ -321,15 +377,18 @@ describe('vertex count verification', () => {
         } as unknown as GPURenderPassEncoder;
 
         pipeline.encodePass(renderPass);
+
         expect(totalVertices).toBe(5 * 6); // 5 pixels * 6 vertices each
     });
 
-    it('drawRect with height <= 2 skips vertical side lines', () => {
+    it('drawRect with height <= two skips vertical side lines', () => {
         pipeline.reset();
+
         // height=2 means y1-y0 = 1, which is NOT > 1, so no vertical sides
         pipeline.drawRect(new Rect2i(0, 0, 10, 2), Color32.red());
 
         let totalVertices = 0;
+
         const renderPass = {
             ...createMockRenderPassEncoder(),
             draw: (vertexCount: number) => {
@@ -338,15 +397,18 @@ describe('vertex count verification', () => {
         } as unknown as GPURenderPassEncoder;
 
         pipeline.encodePass(renderPass);
+
         // Only top + bottom lines = 2 quads = 12 vertices (no left/right)
         expect(totalVertices).toBe(12);
     });
 
-    it('drawRect with height > 2 includes all four sides', () => {
+    it('drawRect with height > two includes all four sides', () => {
         pipeline.reset();
+
         pipeline.drawRect(new Rect2i(0, 0, 10, 10), Color32.red());
 
         let totalVertices = 0;
+
         const renderPass = {
             ...createMockRenderPassEncoder(),
             draw: (vertexCount: number) => {
@@ -355,15 +417,18 @@ describe('vertex count verification', () => {
         } as unknown as GPURenderPassEncoder;
 
         pipeline.encodePass(renderPass);
+
         // 4 sides = 4 quads = 24 vertices
         expect(totalVertices).toBe(24);
     });
 
-    it('drawText produces 6 vertices per character', () => {
+    it('drawText produces six vertices per character', () => {
         pipeline.reset();
+
         pipeline.drawText(new Vector2i(0, 0), Color32.white(), 'Hi');
 
         let totalVertices = 0;
+
         const renderPass = {
             ...createMockRenderPassEncoder(),
             draw: (vertexCount: number) => {
@@ -372,22 +437,26 @@ describe('vertex count verification', () => {
         } as unknown as GPURenderPassEncoder;
 
         pipeline.encodePass(renderPass);
+
         expect(totalVertices).toBe(2 * 6); // 2 characters * 6 vertices each
     });
 
     it('buffer overflow triggers console.warn and does not crash', () => {
         pipeline.reset();
+
         const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
         try {
-            // Fill buffer: 50000 max vertices, each drawRectFill uses 6 vertices
-            // ~8333 rects fill the buffer; drawing more should trigger warn
+            // Fill buffer: 50,000 max vertices, each drawRectFill uses 6 vertices
+            // ~8333 rects fill the buffer; drawing more should trigger a warning
             for (let i = 0; i < 8400; i++) {
                 pipeline.drawRectFill(new Rect2i(0, 0, 1, 1), Color32.white());
             }
 
             expect(warnSpy).toHaveBeenCalled();
+
             const msg = warnSpy.mock.calls.find((c) => String(c[0]).includes('capacity exceeded'));
+
             expect(msg).toBeDefined();
 
             // encodePass should still work without crashing

--- a/src/render/PrimitivePipeline.ts
+++ b/src/render/PrimitivePipeline.ts
@@ -91,6 +91,10 @@ export class PrimitivePipeline {
         await this.createPipeline(displaySize);
     }
 
+    // #endregion
+
+    // #region Camera
+
     /**
      * Sets the camera offset applied to all drawing operations.
      *
@@ -102,7 +106,7 @@ export class PrimitivePipeline {
 
     // #endregion
 
-    // #region Camera
+    // #region Drawing
 
     /**
      * Draws a filled rectangle using two triangles.
@@ -129,10 +133,6 @@ export class PrimitivePipeline {
         this.addVertex(x1, y1, r, g, b, a);
         this.addVertex(x0, y1, r, g, b, a);
     }
-
-    // #endregion
-
-    // #region Drawing
 
     /**
      * Draws placeholder text as colored blocks.
@@ -401,12 +401,12 @@ export class PrimitivePipeline {
                  * Vertex shader main function.
                  */
                 @vertex
-                fn vs_main(input: VertexInput) → VertexOutput {
+                fn vs_main(input: VertexInput) -> VertexOutput {
                     // Output vertex.
                     var output: VertexOutput;
 
                     // Convert from pixel coordinates to clip space (-1 to 1).
-                    let clipX = (input.position.x / uniforms.resolution.x) * 2.0–1.0;
+                    let clipX = (input.position.x / uniforms.resolution.x) * 2.0 - 1.0;
                     let clipY = 1.0 - (input.position.y / uniforms.resolution.y) * 2.0;
 
                     // Set the position of the vertex in clip space.

--- a/src/render/PrimitivePipeline.ts
+++ b/src/render/PrimitivePipeline.ts
@@ -5,9 +5,7 @@ import { Vector2i } from '../utils/Vector2i';
 // #region Configuration
 
 /**
- * Maximum number of primitive vertices per a frame.
- * Each vertex uses 6 floats (x, y, r, g, b, a).
- * 50k vertices = ~1.2 MB buffer, supports ~8.3k quads per a frame.
+ * Maximum number of primitive vertices retained for a frame.
  *
  * Note: Axis-aligned lines are optimized to use 6 vertices total instead of
  * 6 vertices per pixel, dramatically reducing buffer requirements.
@@ -17,9 +15,10 @@ const MAX_PRIMITIVE_VERTICES = 50000;
 // #endregion
 
 /**
- * WebGPU primitive rendering pipeline.
- * Handles colored geometry (pixels, lines, rectangles) using a batch-rendered vertex buffer.
- * Vertices are accumulated per-frame and drawn at frame end via encodePass().
+ * Batched WebGPU pipeline for solid-color primitives.
+ *
+ * The pipeline collects CPU-side vertices for pixels, lines, rectangles, and
+ * placeholder text during a frame, then uploads and draws them in `encodePass()`.
  */
 export class PrimitivePipeline {
     // #region State
@@ -70,8 +69,8 @@ export class PrimitivePipeline {
     // #region Constructor
 
     /**
-     * Creates a new PrimitivePipeline.
-     * Call initialize() before any drawing operations.
+     * Creates an empty primitive pipeline.
+     * Call `initialize()` before encoding GPU work.
      */
     constructor() {
         this.vertices = new Float32Array(MAX_PRIMITIVE_VERTICES * 6);
@@ -82,8 +81,7 @@ export class PrimitivePipeline {
     // #region Initialization
 
     /**
-     * Initializes the WebGPU pipeline and GPU buffers.
-     * Must be called before any drawing operations.
+     * Initializes the GPU pipeline state and backing buffers.
      *
      * @param device - WebGPU device for GPU operations.
      * @param displaySize - Render target resolution in pixels.
@@ -94,8 +92,267 @@ export class PrimitivePipeline {
     }
 
     /**
-     * Creates the WGSL shader, render pipeline, and GPU buffers for colored primitives.
-     * Vertices contain position (2D) and color (RGBA).
+     * Sets the camera offset applied to all drawing operations.
+     *
+     * @param offset - Camera position in pixels.
+     */
+    setCameraOffset(offset: Vector2i): void {
+        this.cameraOffset = offset;
+    }
+
+    // #endregion
+
+    // #region Camera
+
+    /**
+     * Draws a filled rectangle using two triangles.
+     *
+     * @param rect - Rectangle bounds in pixel coordinates.
+     * @param color - Fill color.
+     */
+    drawRectFill(rect: Rect2i, color: Color32): void {
+        const x0 = rect.x;
+        const y0 = rect.y;
+        const x1 = rect.x + rect.width;
+        const y1 = rect.y + rect.height;
+
+        const r = color.r / 255;
+        const g = color.g / 255;
+        const b = color.b / 255;
+        const a = color.a / 255;
+
+        this.addVertex(x0, y0, r, g, b, a);
+        this.addVertex(x1, y0, r, g, b, a);
+        this.addVertex(x0, y1, r, g, b, a);
+
+        this.addVertex(x1, y0, r, g, b, a);
+        this.addVertex(x1, y1, r, g, b, a);
+        this.addVertex(x0, y1, r, g, b, a);
+    }
+
+    // #endregion
+
+    // #region Drawing
+
+    /**
+     * Draws placeholder text as colored blocks.
+     * Each character is rendered as a small filled rectangle.
+     *
+     * @param pos - Text position (top-left corner).
+     * @param color - Text color.
+     * @param text - String to display.
+     */
+    drawText(pos: Vector2i, color: Color32, text: string): void {
+        const charWidth = 6;
+        const charHeight = 8;
+
+        // Pre-compute color values once for all characters.
+        const r = color.r / 255;
+        const g = color.g / 255;
+        const b = color.b / 255;
+        const a = color.a / 255;
+
+        for (let i = 0; i < text.length; i++) {
+            const x0 = pos.x + i * charWidth;
+            const x1 = x0 + charWidth - 1;
+            const y0 = pos.y;
+            const y1 = y0 + charHeight;
+
+            // Draw directly without allocating Rect2i.
+            this.addVertex(x0, y0, r, g, b, a);
+            this.addVertex(x1, y0, r, g, b, a);
+            this.addVertex(x0, y1, r, g, b, a);
+
+            this.addVertex(x1, y0, r, g, b, a);
+            this.addVertex(x1, y1, r, g, b, a);
+            this.addVertex(x0, y1, r, g, b, a);
+        }
+    }
+
+    /**
+     * Draws a single pixel as a 1x1 filled rectangle.
+     *
+     * @param pos - Pixel position.
+     * @param color - Pixel color.
+     */
+    drawPixel(pos: Vector2i, color: Color32): void {
+        // Use pre-allocated rect to avoid allocation per pixel.
+        this.tempRect.set(pos.x, pos.y, 1, 1);
+        this.drawRectFill(this.tempRect, color);
+    }
+
+    /**
+     * Draws a single pixel at raw coordinates.
+     * More efficient than `drawPixel()` when coordinates are already unpacked.
+     *
+     * @param x - X position.
+     * @param y - Y position.
+     * @param color - Pixel color.
+     */
+    drawPixelXY(x: number, y: number, color: Color32): void {
+        // Direct vertex addition without any object allocation.
+        const r = color.r / 255;
+        const g = color.g / 255;
+        const b = color.b / 255;
+        const a = color.a / 255;
+
+        // Draw 1x1 rectangle (2 triangles = 6 vertices).
+        const x1 = x + 1;
+        const y1 = y + 1;
+
+        this.addVertex(x, y, r, g, b, a);
+        this.addVertex(x1, y, r, g, b, a);
+        this.addVertex(x, y1, r, g, b, a);
+
+        this.addVertex(x1, y, r, g, b, a);
+        this.addVertex(x1, y1, r, g, b, a);
+        this.addVertex(x, y1, r, g, b, a);
+    }
+
+    /**
+     * Draws a line using optimized quad rendering for axis-aligned lines,
+     * falling back to Bresenham's algorithm for diagonal lines.
+     *
+     * Horizontal and vertical lines are emitted as a single quad. Diagonal
+     * lines fall back to Bresenham-style pixel steps for pixel-art fidelity.
+     *
+     * @param p0 - Start point.
+     * @param p1 - End point.
+     * @param color - Line color.
+     */
+    drawLine(p0: Vector2i, p1: Vector2i, color: Color32): void {
+        // Vector2i already guarantees integers, but |0 ensures the 32-bit int for bitwise ops.
+        const x0 = p0.x | 0;
+        const y0 = p0.y | 0;
+        const x1 = p1.x | 0;
+        const y1 = p1.y | 0;
+
+        // Optimization: Axis-aligned lines use a single quad (6 vertices total).
+        // This provides ~600x vertex reduction for typical grid lines.
+        if (y0 === y1) {
+            // Horizontal line: single 1px-tall quad.
+            const minX = Math.min(x0, x1);
+            const maxX = Math.max(x0, x1);
+
+            this.tempRect.set(minX, y0, maxX - minX + 1, 1);
+            this.drawRectFill(this.tempRect, color);
+
+            return;
+        }
+
+        if (x0 === x1) {
+            // Vertical line: single 1px-wide quad.
+            const minY = Math.min(y0, y1);
+            const maxY = Math.max(y0, y1);
+
+            this.tempRect.set(x0, minY, 1, maxY - minY + 1);
+            this.drawRectFill(this.tempRect, color);
+
+            return;
+        }
+
+        // Diagonal lines: fall back to Bresenham for pixel-perfect rendering.
+        this.drawLineBresenham(x0, y0, x1, y1, color);
+    }
+
+    /**
+     * Draws a rectangle outline using four 1-pixel quads.
+     * Emits quads directly rather than delegating to `drawLine()`.
+     *
+     * @param rect - Rectangle bounds.
+     * @param color - Outline color.
+     */
+    drawRect(rect: Rect2i, color: Color32): void {
+        const x0 = rect.x;
+        const y0 = rect.y;
+        const x1 = rect.x + rect.width - 1;
+        const y1 = rect.y + rect.height - 1;
+
+        // Draw 4-line quads directly using the pre-allocated tempRect.
+        // This avoids 4 function calls to drawLine and their overhead.
+
+        // Top line (horizontal): from (x0, y0) to (x1, y0), 1px tall.
+        this.tempRect.set(x0, y0, x1 - x0 + 1, 1);
+        this.drawRectFill(this.tempRect, color);
+
+        // Bottom line (horizontal): from (x0, y1) to (x1, y1), 1px tall.
+        this.tempRect.set(x0, y1, x1 - x0 + 1, 1);
+        this.drawRectFill(this.tempRect, color);
+
+        // Left line (vertical): from (x0, y0+1) to (x0, y1-1), 1px wide.
+        // Shortened to avoid corner overlap with top/bottom lines.
+        if (y1 - y0 > 1) {
+            this.tempRect.set(x0, y0 + 1, 1, y1 - y0 - 1);
+            this.drawRectFill(this.tempRect, color);
+        }
+
+        // Right line (vertical): from (x1, y0+1) to (x1, y1-1), 1px wide.
+        // Shortened to avoid corner overlap with top/bottom lines.
+        if (y1 - y0 > 1) {
+            this.tempRect.set(x1, y0 + 1, 1, y1 - y0 - 1);
+            this.drawRectFill(this.tempRect, color);
+        }
+    }
+
+    /**
+     * Fills a rectangular region with a solid color.
+     * Alias for `drawRectFill()` kept for renderer API consistency.
+     *
+     * @param color - Fill color.
+     * @param rect - Region to fill.
+     */
+    clearRect(color: Color32, rect: Rect2i): void {
+        this.drawRectFill(rect, color);
+    }
+
+    /**
+     * Uploads accumulated primitive vertices and encodes draw calls.
+     * No-op when nothing has been queued for the current frame.
+     *
+     * @param renderPass - Active render pass encoder.
+     */
+    encodePass(renderPass: GPURenderPassEncoder): void {
+        // Flush any remaining vertices into the batch queue.
+        this.earlyFlush();
+
+        if (this.batches.length === 0 || this.totalVertices === 0) {
+            return;
+        }
+
+        // Upload all vertex data at once.
+        // Safe assertions: these resources are created in initialize() before any rendering.
+        (this.device as GPUDevice).queue.writeBuffer(
+            this.vertexBuffer as GPUBuffer,
+            0,
+            this.vertices.buffer,
+            0,
+            this.totalVertices * 6 * 4,
+        );
+
+        renderPass.setPipeline(this.pipeline as GPURenderPipeline);
+        renderPass.setBindGroup(0, this.bindGroup as GPUBindGroup);
+        renderPass.setVertexBuffer(0, this.vertexBuffer as GPUBuffer);
+
+        for (const batch of this.batches) {
+            renderPass.draw(batch.vertexCount, 1, batch.vertexStart, 0);
+        }
+    }
+
+    // #endregion
+
+    // #region Frame Rendering
+
+    /**
+     * Clears per-frame batching state.
+     */
+    reset(): void {
+        this.vertexCount = 0;
+        this.totalVertices = 0;
+        this.batches = [];
+    }
+
+    /**
+     * Creates shader modules, pipeline state, and GPU buffers for primitive draws.
      *
      * @param displaySize - Render target resolution in pixels.
      */
@@ -144,12 +401,12 @@ export class PrimitivePipeline {
                  * Vertex shader main function.
                  */
                 @vertex
-                fn vs_main(input: VertexInput) -> VertexOutput {
+                fn vs_main(input: VertexInput) → VertexOutput {
                     // Output vertex.
                     var output: VertexOutput;
 
                     // Convert from pixel coordinates to clip space (-1 to 1).
-                    let clipX = (input.position.x / uniforms.resolution.x) * 2.0 - 1.0;
+                    let clipX = (input.position.x / uniforms.resolution.x) * 2.0–1.0;
                     let clipY = 1.0 - (input.position.y / uniforms.resolution.y) * 2.0;
 
                     // Set the position of the vertex in clip space.
@@ -222,294 +479,12 @@ export class PrimitivePipeline {
 
     // #endregion
 
-    // #region Camera
-
-    /**
-     * Sets the camera offset applied to all drawing operations.
-     *
-     * @param offset - Camera position in pixels.
-     */
-    setCameraOffset(offset: Vector2i): void {
-        this.cameraOffset = offset;
-    }
-
-    // #endregion
-
-    // #region Drawing
-
-    /**
-     * Draws a filled rectangle using two triangles.
-     *
-     * @param rect - Rectangle bounds in pixel coordinates.
-     * @param color - Fill color.
-     */
-    drawRectFill(rect: Rect2i, color: Color32): void {
-        const x0 = rect.x;
-        const y0 = rect.y;
-        const x1 = rect.x + rect.width;
-        const y1 = rect.y + rect.height;
-
-        const r = color.r / 255;
-        const g = color.g / 255;
-        const b = color.b / 255;
-        const a = color.a / 255;
-
-        this.addVertex(x0, y0, r, g, b, a);
-        this.addVertex(x1, y0, r, g, b, a);
-        this.addVertex(x0, y1, r, g, b, a);
-
-        this.addVertex(x1, y0, r, g, b, a);
-        this.addVertex(x1, y1, r, g, b, a);
-        this.addVertex(x0, y1, r, g, b, a);
-    }
-
-    /**
-     * Draws placeholder text as colored blocks.
-     * Each character is rendered as a small filled rectangle.
-     *
-     * @param pos - Text position (top-left corner).
-     * @param color - Text color.
-     * @param text - String to display.
-     */
-    drawText(pos: Vector2i, color: Color32, text: string): void {
-        const charWidth = 6;
-        const charHeight = 8;
-
-        // Pre-compute color values once for all characters.
-        const r = color.r / 255;
-        const g = color.g / 255;
-        const b = color.b / 255;
-        const a = color.a / 255;
-
-        for (let i = 0; i < text.length; i++) {
-            const x0 = pos.x + i * charWidth;
-            const x1 = x0 + charWidth - 1;
-            const y0 = pos.y;
-            const y1 = y0 + charHeight;
-
-            // Draw directly without allocating Rect2i.
-            this.addVertex(x0, y0, r, g, b, a);
-            this.addVertex(x1, y0, r, g, b, a);
-            this.addVertex(x0, y1, r, g, b, a);
-
-            this.addVertex(x1, y0, r, g, b, a);
-            this.addVertex(x1, y1, r, g, b, a);
-            this.addVertex(x0, y1, r, g, b, a);
-        }
-    }
-
-    /**
-     * Draws a single pixel as a 1x1 filled rectangle.
-     *
-     * @param pos - Pixel position.
-     * @param color - Pixel color.
-     */
-    drawPixel(pos: Vector2i, color: Color32): void {
-        // Use pre-allocated rect to avoid allocation per pixel.
-        this.tempRect.set(pos.x, pos.y, 1, 1);
-        this.drawRectFill(this.tempRect, color);
-    }
-
-    /**
-     * Draws a single pixel at raw coordinates.
-     * More efficient than drawPixel() as it avoids Vector2i parameter.
-     * Use this in hot paths where you have x, y values directly.
-     *
-     * @param x - X position.
-     * @param y - Y position.
-     * @param color - Pixel color.
-     * @returns Nothing.
-     */
-    drawPixelXY(x: number, y: number, color: Color32): void {
-        // Direct vertex addition without any object allocation.
-        const r = color.r / 255;
-        const g = color.g / 255;
-        const b = color.b / 255;
-        const a = color.a / 255;
-
-        // Draw 1x1 rectangle (2 triangles = 6 vertices).
-        const x1 = x + 1;
-        const y1 = y + 1;
-
-        this.addVertex(x, y, r, g, b, a);
-        this.addVertex(x1, y, r, g, b, a);
-        this.addVertex(x, y1, r, g, b, a);
-
-        this.addVertex(x1, y, r, g, b, a);
-        this.addVertex(x1, y1, r, g, b, a);
-        this.addVertex(x, y1, r, g, b, a);
-    }
-
-    /**
-     * Draws a line using optimized quad rendering for axis-aligned lines,
-     * falling back to Bresenham's algorithm for diagonal lines.
-     *
-     * Performance Characteristics
-     *   - Axis-aligned lines (horizontal/vertical): Optimized to use a single quad
-     *     (6 vertices total). A 600px horizontal line uses 6 vertices.
-     *   - Diagonal lines: Use Bresenham's algorithm for pixel-perfect retro rendering.
-     *     Each pixel along the line is rendered as a separate quad (6 vertices per pixel).
-     *     A 100px diagonal line may use 600+ vertices. This is intentional for authentic
-     *     pixel-art aesthetics but should be considered when drawing many diagonal lines.
-     *
-     * For complex curves or many diagonal lines, consider:
-     *   - Using filled rectangles where possible
-     *   - Reducing the number of line segments
-     *   - Pre-rendering to a texture for static content
-     *
-     * @param p0 - Start point.
-     * @param p1 - End point.
-     * @param color - Line color.
-     */
-    drawLine(p0: Vector2i, p1: Vector2i, color: Color32): void {
-        // Vector2i already guarantees integers, but |0 ensures the 32-bit int for bitwise ops.
-        const x0 = p0.x | 0;
-        const y0 = p0.y | 0;
-        const x1 = p1.x | 0;
-        const y1 = p1.y | 0;
-
-        // Optimization: Axis-aligned lines use a single quad (6 vertices total).
-        // This provides ~600x vertex reduction for typical grid lines.
-        if (y0 === y1) {
-            // Horizontal line: single 1px-tall quad.
-            const minX = Math.min(x0, x1);
-            const maxX = Math.max(x0, x1);
-
-            this.tempRect.set(minX, y0, maxX - minX + 1, 1);
-            this.drawRectFill(this.tempRect, color);
-
-            return;
-        }
-
-        if (x0 === x1) {
-            // Vertical line: single 1px-wide quad.
-            const minY = Math.min(y0, y1);
-            const maxY = Math.max(y0, y1);
-
-            this.tempRect.set(x0, minY, 1, maxY - minY + 1);
-            this.drawRectFill(this.tempRect, color);
-
-            return;
-        }
-
-        // Diagonal lines: fall back to Bresenham for pixel-perfect rendering.
-        this.drawLineBresenham(x0, y0, x1, y1, color);
-    }
-
-    /**
-     * Draws a rectangle outline using four 1-pixel quads.
-     * Optimized to directly emit quads instead of calling drawLine 4 times,
-     * reducing function call overhead.
-     *
-     * @param rect - Rectangle bounds.
-     * @param color - Outline color.
-     */
-    drawRect(rect: Rect2i, color: Color32): void {
-        const x0 = rect.x;
-        const y0 = rect.y;
-        const x1 = rect.x + rect.width - 1;
-        const y1 = rect.y + rect.height - 1;
-
-        // Draw 4 line quads directly using the pre-allocated tempRect.
-        // This avoids 4 function calls to drawLine and their overhead.
-
-        // Top line (horizontal): from (x0, y0) to (x1, y0), 1px tall.
-        this.tempRect.set(x0, y0, x1 - x0 + 1, 1);
-        this.drawRectFill(this.tempRect, color);
-
-        // Bottom line (horizontal): from (x0, y1) to (x1, y1), 1px tall.
-        this.tempRect.set(x0, y1, x1 - x0 + 1, 1);
-        this.drawRectFill(this.tempRect, color);
-
-        // Left line (vertical): from (x0, y0+1) to (x0, y1-1), 1px wide.
-        // Shortened to avoid corner overlap with top/bottom lines.
-        if (y1 - y0 > 1) {
-            this.tempRect.set(x0, y0 + 1, 1, y1 - y0 - 1);
-            this.drawRectFill(this.tempRect, color);
-        }
-
-        // Right line (vertical): from (x1, y0+1) to (x1, y1-1), 1px wide.
-        // Shortened to avoid corner overlap with top/bottom lines.
-        if (y1 - y0 > 1) {
-            this.tempRect.set(x1, y0 + 1, 1, y1 - y0 - 1);
-            this.drawRectFill(this.tempRect, color);
-        }
-    }
-
-    /**
-     * Fills a rectangular region with a solid color.
-     * Alias for drawRectFill for API consistency.
-     *
-     * @param color - Fill color.
-     * @param rect - Region to fill.
-     */
-    clearRect(color: Color32, rect: Rect2i): void {
-        this.drawRectFill(rect, color);
-    }
-
-    // #endregion
-
-    // #region Frame Rendering
-
-    /**
-     * Encodes all accumulated primitives into the given render pass.
-     * Uploads vertex data to GPU, sets the pipeline, and issues the draw call.
-     * No-op if no vertices were accumulated this frame.
-     *
-     * @param renderPass - Active render pass encoder.
-     */
-    encodePass(renderPass: GPURenderPassEncoder): void {
-        // Flush any remaining vertices into the batch queue.
-        this.earlyFlush();
-
-        if (this.batches.length === 0 || this.totalVertices === 0) {
-            return;
-        }
-
-        // Upload all vertex data at once.
-        // Safe assertions: these resources are created in initialize() before any rendering.
-        (this.device as GPUDevice).queue.writeBuffer(
-            this.vertexBuffer as GPUBuffer,
-            0,
-            this.vertices.buffer,
-            0,
-            this.totalVertices * 6 * 4,
-        );
-
-        renderPass.setPipeline(this.pipeline as GPURenderPipeline);
-        renderPass.setBindGroup(0, this.bindGroup as GPUBindGroup);
-        renderPass.setVertexBuffer(0, this.vertexBuffer as GPUBuffer);
-
-        for (const batch of this.batches) {
-            renderPass.draw(batch.vertexCount, 1, batch.vertexStart, 0);
-        }
-    }
-
-    /**
-     * Resets all per-frame state.
-     * Call at the start and end of each frame.
-     */
-    reset(): void {
-        this.vertexCount = 0;
-        this.totalVertices = 0;
-        this.batches = [];
-    }
-
-    // #endregion
-
     // #region Private Helpers
 
     /**
      * Draws a diagonal line using Bresenham's line algorithm.
-     * Produces pixel-perfect lines without antialiasing, matching classic retro aesthetics.
-     *
-     * ## Performance Note
-     *
-     * This method renders each pixel as a separate 1x1 quad (6 vertices per pixel).
-     * A 100px diagonal line generates ~600 vertices. This approach is intentional
-     * to achieve authentic pixel-art rendering where each pixel is a discrete unit,
-     * but it means diagonal lines are significantly more expensive than axis-aligned
-     * lines (which use only 6 vertices total regardless of length).
+     * Produces pixel-perfect lines without antialiasing by emitting 1x1 quads
+     * for each stepped pixel.
      *
      * @param x0 - Start X coordinate.
      * @param y0 - Start Y coordinate.
@@ -554,7 +529,7 @@ export class PrimitivePipeline {
 
     /**
      * Adds vertices for a single pixel (6 vertices for 2 triangles).
-     * Internal method for optimized pixel drawing without object allocation.
+     * Internal helper used by the Bresenham path.
      *
      * @param x - X position.
      * @param y - Y position.
@@ -566,6 +541,7 @@ export class PrimitivePipeline {
     private addPixelVertices(x: number, y: number, r: number, g: number, b: number, a: number): void {
         // Ensure space for complete pixel (6 vertices) to prevent partial geometry
         const index = (this.totalVertices + this.vertexCount) * 6;
+
         if (index + 36 > this.vertices.length) {
             // 6 vertices * 6 floats
             if (this.vertexCount > 0) {
@@ -575,6 +551,7 @@ export class PrimitivePipeline {
             // Check again after flush - if still no space, buffer is exhausted
             if ((this.totalVertices + this.vertexCount) * 6 + 36 > this.vertices.length) {
                 console.warn('[PrimitivePipeline] Buffer exhausted, pixel dropped');
+
                 return;
             }
         }
@@ -593,7 +570,7 @@ export class PrimitivePipeline {
 
     /**
      * Adds a single vertex to the primitive batch.
-     * Writes data to GPU and resets the batch if the buffer is full, then adds the vertex.
+     * Flushes batching state first if the frame buffer has been filled.
      *
      * @param x - X position in pixels.
      * @param y - Y position in pixels.
@@ -601,7 +578,6 @@ export class PrimitivePipeline {
      * @param g - Green component (0-1).
      * @param b - Blue component (0-1).
      * @param a - Alpha component (0-1).
-     * @returns Nothing.
      */
     private addVertex(x: number, y: number, r: number, g: number, b: number, a: number): void {
         const index = (this.totalVertices + this.vertexCount) * 6;
@@ -611,6 +587,7 @@ export class PrimitivePipeline {
 
             // Re-check after flush - if still no space, buffer is exhausted for this frame.
             const newIndex = (this.totalVertices + this.vertexCount) * 6;
+
             if (newIndex + 6 > this.vertices.length) {
                 console.warn('[PrimitivePipeline] Primitive buffer capacity exceeded for this frame, vertex dropped');
                 return;


### PR DESCRIPTION
- Add comprehensive module documentation to test suite
- Expand JSDoc for initializeWebGPU function and result type
- Clarify canvas configuration and context initialization steps
- Add blank lines throughout tests for improved readability
- Refine error messages for consistency and clarity


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes to `src/render/PrimitivePipeline.test.ts`

Added a comprehensive module-level JSDoc describing the tests' scope and coverage (CPU-side primitive batching, pre-initialization safety, encode/reset behavior, camera-offset handling, vertex-count expectations, and GPU-facing validation using WebGPU mocks). Renamed several test titles for clarity (e.g., numeric variants → word form; "no-op" → "an empty buffer is a no-op"), inserted blank lines to separate setup/actions/assertions, and made minor inline comment wording adjustments (e.g., expected warning text). No assertions, control flow, mocked interactions, or test logic were changed.

## Changes to `src/render/PrimitivePipeline.ts`

Expanded and clarified module-, class-, and method-level JSDoc and inline comments to better describe intent and usage:

- Clarified `MAX_PRIMITIVE_VERTICES` meaning ("vertices retained for a frame") and noted optimization rationale.
- Reframed `PrimitivePipeline` as a CPU-side batched solid-color primitive collector that uploads and issues draws during `encodePass()`.
- Updated docstrings for constructor, `encodePass()`, `reset()`, and public drawing APIs (`drawPixelXY`, `drawLine`, `drawRect`, `drawRectFill`, `clearRect`) to emphasize behavior and consistency (direct quad emission, when batching is flushed).
- Simplified helper docstrings (`drawLineBresenham`, `addPixelVertices`) and made `addVertex` doc clearer about flushing when capacity would be exceeded.
- Refined error/warning message wording for consistency and clarity.
- Repositioned the `createPipeline(displaySize)` implementation and added blank lines in implementations to improve readability.

No public API signatures or functional behavior were changed; control flow and batching logic remain the same.

## Other changes

- Commit-level fix: replaced Unicode punctuation in a WGSL shader and corrected region labels (renderer-related cleanup).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->