### PR TITLE
docs(renderer): refine JSDoc and reorder regions in SpritePipeline

### DIFF
--- a/src/render/SpritePipeline.test.ts
+++ b/src/render/SpritePipeline.test.ts
@@ -1,3 +1,17 @@
+/**
+ * Unit tests for {@link SpritePipeline}.
+ *
+ * Covers sprite and bitmap-text batching behavior:
+ * - construction and pre-initialization safety
+ * - encode/reset behavior with and without queued sprite data
+ * - sprite draw batching for shared textures and texture switches
+ * - camera-offset handling, transparent tinting, and overflow safety
+ * - bitmap-font rendering paths, including skipped missing glyphs
+ *
+ * The tests rely on WebGPU mock helpers plus lightweight sprite-sheet/font
+ * fixtures to verify draw-call grouping without requiring real GPU resources.
+ */
+
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import {
@@ -18,6 +32,7 @@ import { SpritePipeline } from './SpritePipeline';
 describe('SpritePipeline constructor', () => {
     it('creates an instance without error', () => {
         const pipeline = new SpritePipeline();
+
         expect(pipeline).toBeDefined();
         expect(pipeline).toBeInstanceOf(SpritePipeline);
     });
@@ -30,6 +45,7 @@ describe('SpritePipeline constructor', () => {
 describe('pre-initialization safety', () => {
     it('reset() can be called multiple times safely', () => {
         const pipeline = new SpritePipeline();
+
         expect(() => {
             pipeline.reset();
             pipeline.reset();
@@ -39,6 +55,7 @@ describe('pre-initialization safety', () => {
 
     it('setCameraOffset() accepts a Vector2i', () => {
         const pipeline = new SpritePipeline();
+
         expect(() => {
             pipeline.setCameraOffset(new Vector2i(10, 20));
         }).not.toThrow();
@@ -46,6 +63,7 @@ describe('pre-initialization safety', () => {
 
     it('setCameraOffset() accepts zero vector', () => {
         const pipeline = new SpritePipeline();
+
         expect(() => {
             pipeline.setCameraOffset(Vector2i.zero());
         }).not.toThrow();
@@ -62,6 +80,7 @@ describe('with initialized pipeline', () => {
 
     beforeAll(async () => {
         installMockNavigatorGPU();
+
         await pipeline.initialize(device, new Vector2i(320, 240));
     });
 
@@ -69,9 +88,11 @@ describe('with initialized pipeline', () => {
         uninstallMockNavigatorGPU();
     });
 
-    it('encodePass with empty buffer is a no-op', () => {
+    it('encodePass with an empty buffer is a no-op', () => {
         pipeline.reset();
+
         const renderPass = createMockRenderPassEncoder();
+
         expect(() => {
             pipeline.encodePass(renderPass);
         }).not.toThrow();
@@ -81,6 +102,7 @@ describe('with initialized pipeline', () => {
         pipeline.reset();
 
         let drawCalled = false;
+
         const renderPass = {
             ...createMockRenderPassEncoder(),
             draw: () => {
@@ -89,6 +111,7 @@ describe('with initialized pipeline', () => {
         } as unknown as GPURenderPassEncoder;
 
         pipeline.encodePass(renderPass);
+
         expect(drawCalled).toBe(false);
     });
 
@@ -105,9 +128,11 @@ describe('with initialized pipeline', () => {
     it('setCameraOffset affects subsequent state without error', () => {
         pipeline.reset();
         pipeline.setCameraOffset(new Vector2i(100, 50));
+
         expect(() => {
             pipeline.encodePass(createMockRenderPassEncoder());
         }).not.toThrow();
+
         pipeline.setCameraOffset(Vector2i.zero());
     });
 });
@@ -123,6 +148,7 @@ describe('drawSprite', () => {
 
     beforeAll(async () => {
         installMockNavigatorGPU();
+
         await pipeline.initialize(device, new Vector2i(320, 240));
     });
 
@@ -132,7 +158,9 @@ describe('drawSprite', () => {
 
     it('does not throw with valid arguments', () => {
         pipeline.reset();
+
         const sheet = new SpriteSheet(mockImage);
+
         expect(() => {
             pipeline.drawSprite(sheet, new Rect2i(0, 0, 16, 16), new Vector2i(10, 20));
         }).not.toThrow();
@@ -140,7 +168,9 @@ describe('drawSprite', () => {
 
     it('with explicit tint color does not throw', () => {
         pipeline.reset();
+
         const sheet = new SpriteSheet(mockImage);
+
         expect(() => {
             pipeline.drawSprite(sheet, new Rect2i(0, 0, 16, 16), new Vector2i(0, 0), Color32.red());
         }).not.toThrow();
@@ -148,7 +178,9 @@ describe('drawSprite', () => {
 
     it('with fully transparent tint does not throw', () => {
         pipeline.reset();
+
         const sheet = new SpriteSheet(mockImage);
+
         expect(() => {
             pipeline.drawSprite(sheet, new Rect2i(0, 0, 16, 16), new Vector2i(0, 0), new Color32(255, 255, 255, 0));
         }).not.toThrow();
@@ -156,10 +188,13 @@ describe('drawSprite', () => {
 
     it('causes a draw call in encodePass', () => {
         pipeline.reset();
+
         const sheet = new SpriteSheet(mockImage);
+
         pipeline.drawSprite(sheet, new Rect2i(0, 0, 16, 16), new Vector2i(0, 0));
 
         let drawCallCount = 0;
+
         const renderPass = {
             ...createMockRenderPassEncoder(),
             draw: () => {
@@ -168,17 +203,21 @@ describe('drawSprite', () => {
         } as unknown as GPURenderPassEncoder;
 
         pipeline.encodePass(renderPass);
+
         expect(drawCallCount).toBe(1);
     });
 
     it('multiple calls from the same sheet produce one draw call', () => {
         pipeline.reset();
+
         const sheet = new SpriteSheet(mockImage);
+
         pipeline.drawSprite(sheet, new Rect2i(0, 0, 16, 16), new Vector2i(0, 0));
         pipeline.drawSprite(sheet, new Rect2i(16, 0, 16, 16), new Vector2i(20, 0));
         pipeline.drawSprite(sheet, new Rect2i(32, 0, 16, 16), new Vector2i(40, 0));
 
         let drawCallCount = 0;
+
         const renderPass = {
             ...createMockRenderPassEncoder(),
             draw: () => {
@@ -187,17 +226,21 @@ describe('drawSprite', () => {
         } as unknown as GPURenderPassEncoder;
 
         pipeline.encodePass(renderPass);
+
         expect(drawCallCount).toBe(1);
     });
 
     it('calls from different sheets produce separate draw calls', () => {
         pipeline.reset();
+
         const sheetA = new SpriteSheet({ width: 64, height: 64 } as HTMLImageElement);
         const sheetB = new SpriteSheet({ width: 128, height: 128 } as HTMLImageElement);
+
         pipeline.drawSprite(sheetA, new Rect2i(0, 0, 16, 16), new Vector2i(0, 0));
         pipeline.drawSprite(sheetB, new Rect2i(0, 0, 16, 16), new Vector2i(20, 0));
 
         let drawCallCount = 0;
+
         const renderPass = {
             ...createMockRenderPassEncoder(),
             draw: () => {
@@ -206,18 +249,22 @@ describe('drawSprite', () => {
         } as unknown as GPURenderPassEncoder;
 
         pipeline.encodePass(renderPass);
+
         expect(drawCallCount).toBe(2);
     });
 
     it('interleaved sheets produce one draw call per texture switch', () => {
         pipeline.reset();
+
         const sheetA = new SpriteSheet({ width: 64, height: 64 } as HTMLImageElement);
         const sheetB = new SpriteSheet({ width: 128, height: 128 } as HTMLImageElement);
+
         pipeline.drawSprite(sheetA, new Rect2i(0, 0, 16, 16), new Vector2i(0, 0));
         pipeline.drawSprite(sheetB, new Rect2i(0, 0, 16, 16), new Vector2i(20, 0));
         pipeline.drawSprite(sheetA, new Rect2i(0, 0, 16, 16), new Vector2i(40, 0));
 
         let drawCallCount = 0;
+
         const renderPass = {
             ...createMockRenderPassEncoder(),
             draw: () => {
@@ -226,16 +273,20 @@ describe('drawSprite', () => {
         } as unknown as GPURenderPassEncoder;
 
         pipeline.encodePass(renderPass);
+
         expect(drawCallCount).toBe(3);
     });
 
     it('after reset produces no draw calls', () => {
         pipeline.reset();
+
         const sheet = new SpriteSheet(mockImage);
+
         pipeline.drawSprite(sheet, new Rect2i(0, 0, 16, 16), new Vector2i(0, 0));
         pipeline.reset();
 
         let drawCallCount = 0;
+
         const renderPass = {
             ...createMockRenderPassEncoder(),
             draw: () => {
@@ -244,23 +295,30 @@ describe('drawSprite', () => {
         } as unknown as GPURenderPassEncoder;
 
         pipeline.encodePass(renderPass);
+
         expect(drawCallCount).toBe(0);
     });
 
     it('with camera offset does not throw', () => {
         pipeline.reset();
+
         pipeline.setCameraOffset(new Vector2i(50, 50));
+
         const sheet = new SpriteSheet(mockImage);
+
         expect(() => {
             pipeline.drawSprite(sheet, new Rect2i(0, 0, 16, 16), new Vector2i(10, 10));
             pipeline.encodePass(createMockRenderPassEncoder());
         }).not.toThrow();
+
         pipeline.setCameraOffset(Vector2i.zero());
     });
 
     it('a single-pixel srcRect does not throw', () => {
         pipeline.reset();
+
         const sheet = new SpriteSheet(mockImage);
+
         expect(() => {
             pipeline.drawSprite(sheet, new Rect2i(0, 0, 1, 1), new Vector2i(5, 5));
             pipeline.encodePass(createMockRenderPassEncoder());
@@ -269,6 +327,7 @@ describe('drawSprite', () => {
 
     it('multiple frame cycles work without error', () => {
         const sheet = new SpriteSheet(mockImage);
+
         expect(() => {
             for (let i = 0; i < 5; i++) {
                 pipeline.reset();
@@ -280,18 +339,21 @@ describe('drawSprite', () => {
 
     it('buffer overflow triggers console.warn and does not crash', () => {
         pipeline.reset();
+
         const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
         const sheet = new SpriteSheet(mockImage);
 
         try {
-            // MAX_SPRITE_VERTICES = 50000, each sprite = 6 vertices * 8 floats
-            // 50000 / 6 = ~8333 sprites max; draw more to trigger overflow
+            // MAX_SPRITE_VERTICES = 50,000, each sprite = 6 vertices * 8 floats
+            // 50,000 / 6 = ~8333 sprites max; draw more to trigger overflow
             for (let i = 0; i < 8400; i++) {
                 pipeline.drawSprite(sheet, new Rect2i(0, 0, 8, 8), new Vector2i(0, 0));
             }
 
             expect(warnSpy).toHaveBeenCalled();
+
             const msg = warnSpy.mock.calls.find((c) => String(c[0]).includes('capacity exceeded'));
+
             expect(msg).toBeDefined();
 
             expect(() => {
@@ -332,6 +394,7 @@ describe('drawBitmapText', () => {
 
     beforeAll(async () => {
         installMockNavigatorGPU();
+
         await pipeline.initialize(device, new Vector2i(320, 240));
     });
 
@@ -341,7 +404,9 @@ describe('drawBitmapText', () => {
 
     it('renders characters that have glyphs', () => {
         pipeline.reset();
+
         const sheet = new SpriteSheet(mockImage);
+
         const font = makeMockFont(
             {
                 A: makeGlyph(0, 8, 0, 0, 9),
@@ -354,6 +419,7 @@ describe('drawBitmapText', () => {
 
         let drawCallCount = 0;
         let totalVertices = 0;
+
         const renderPass = {
             ...createMockRenderPassEncoder(),
             draw: (vertexCount: number) => {
@@ -363,12 +429,14 @@ describe('drawBitmapText', () => {
         } as unknown as GPURenderPassEncoder;
 
         pipeline.encodePass(renderPass);
+
         expect(drawCallCount).toBe(1); // Same texture = 1 batch
         expect(totalVertices).toBe(12); // 2 characters * 6 vertices
     });
 
     it('silently skips characters without glyphs', () => {
         pipeline.reset();
+
         const sheet = new SpriteSheet(mockImage);
         const font = makeMockFont(
             {
@@ -381,6 +449,7 @@ describe('drawBitmapText', () => {
         pipeline.drawBitmapText(font, new Vector2i(0, 0), 'AZA');
 
         let totalVertices = 0;
+
         const renderPass = {
             ...createMockRenderPassEncoder(),
             draw: (vertexCount: number) => {
@@ -389,17 +458,20 @@ describe('drawBitmapText', () => {
         } as unknown as GPURenderPassEncoder;
 
         pipeline.encodePass(renderPass);
+
         expect(totalVertices).toBe(12); // Only 2 'A' glyphs rendered
     });
 
     it('empty string produces no draw calls', () => {
         pipeline.reset();
+
         const sheet = new SpriteSheet(mockImage);
         const font = makeMockFont({}, sheet);
 
         pipeline.drawBitmapText(font, new Vector2i(0, 0), '');
 
         let drawCallCount = 0;
+
         const renderPass = {
             ...createMockRenderPassEncoder(),
             draw: () => {
@@ -408,12 +480,15 @@ describe('drawBitmapText', () => {
         } as unknown as GPURenderPassEncoder;
 
         pipeline.encodePass(renderPass);
+
         expect(drawCallCount).toBe(0);
     });
 
     it('applies custom tint color without error', () => {
         pipeline.reset();
+
         const sheet = new SpriteSheet(mockImage);
+
         const font = makeMockFont(
             {
                 X: makeGlyph(0, 8, 0, 0, 9),

--- a/src/render/SpritePipeline.ts
+++ b/src/render/SpritePipeline.ts
@@ -7,19 +7,17 @@ import { Vector2i } from '../utils/Vector2i';
 // #region Configuration
 
 /**
- * Maximum number of sprite vertices per a frame.
- * Each vertex uses 8 floats (x, y, u, v, r, g, b, a).
- * 50k vertices = ~1.6 MB buffer, supports ~8.3k sprites per a frame.
+ * Maximum number of sprite vertices retained for a frame.
  */
 const MAX_SPRITE_VERTICES = 50000;
 
 // #endregion
 
 /**
- * WebGPU sprite rendering pipeline.
- * Handles textured quads (sprites, bitmap text) with tinting.
- * Batches draws by texture to minimize GPU state changes.
- * Vertices are accumulated per-frame and drawn at frame end via encodePass().
+ * Batched WebGPU pipeline for textured quads.
+ *
+ * The pipeline collects sprite and bitmap-text vertices during a frame, groups
+ * them by texture, and emits one draw call per texture batch in `encodePass()`.
  */
 export class SpritePipeline {
     // #region State
@@ -55,7 +53,7 @@ export class SpritePipeline {
     /** Currently bound texture for sprite rendering. */
     private currentTexture: GPUTexture | null = null;
 
-    /** Currently bound bind group for sprite rendering. */
+    /** Currently bound group for sprite rendering. */
     private currentBindGroup: GPUBindGroup | null = null;
 
     /** Cache of texture bind groups for reuse. WeakMap allows GC to collect destroyed textures. */
@@ -82,8 +80,8 @@ export class SpritePipeline {
     // #region Constructor
 
     /**
-     * Creates a new SpritePipeline.
-     * Call initialize() before any drawing operations.
+     * Creates an empty sprite pipeline.
+     * Call `initialize()` before encoding GPU work.
      */
     constructor() {
         this.vertices = new Float32Array(MAX_SPRITE_VERTICES * 8);
@@ -94,20 +92,132 @@ export class SpritePipeline {
     // #region Initialization
 
     /**
-     * Initializes the WebGPU pipeline, GPU buffers, and sampler.
-     * Must be called before any drawing operations.
+     * Initializes the GPU pipeline state, vertex buffer, and sampler.
      *
      * @param device - WebGPU device for GPU operations.
      * @param displaySize - Render target resolution in pixels.
      */
     async initialize(device: GPUDevice, displaySize: Vector2i): Promise<void> {
         this.device = device;
+
         await this.createPipeline(displaySize);
     }
 
+    // #endregion
+
+    // #region Camera
+
     /**
-     * Creates the WGSL shader, render pipeline, GPU buffers, and sampler for textured sprites.
-     * Vertices contain position, UV coordinates, and tint color.
+     * Sets the camera offset applied to all drawing operations.
+     *
+     * @param offset - Camera position in pixels.
+     */
+    setCameraOffset(offset: Vector2i): void {
+        this.cameraOffset = offset;
+    }
+
+    /**
+     * Draws a sprite region from a sprite sheet.
+     *
+     * @param spriteSheet - Source sprite sheet.
+     * @param srcRect - Region to copy from the sprite sheet.
+     * @param destPos - Screen position to draw at.
+     * @param tint - Tint color multiplied with texture (defaults to white).
+     */
+    drawSprite(spriteSheet: SpriteSheet, srcRect: Rect2i, destPos: Vector2i, tint: Color32 = Color32.white()): void {
+        const texture = spriteSheet.getTexture(this.device as GPUDevice);
+        const uvs = spriteSheet.getUVs(srcRect);
+
+        // Use a pre-allocated vector for size to avoid allocation.
+        this.tempSize.set(srcRect.width, srcRect.height);
+
+        this.drawTexturedQuad(texture, destPos, this.tempSize, uvs.u0, uvs.v0, uvs.u1, uvs.v1, tint);
+    }
+
+    /**
+     * Draws text using a bitmap font.
+     * Renders each character as a textured sprite using glyph metadata from the font.
+     *
+     * @param font - Bitmap font with character glyphs.
+     * @param pos - Text position (top-left corner).
+     * @param text - String to render.
+     * @param color - Text color multiplied with font texture.
+     */
+    drawBitmapText(font: BitmapFont, pos: Vector2i, text: string, color: Color32 = Color32.white()): void {
+        const spriteSheet = font.getSpriteSheet();
+        let cursorX = pos.x;
+        const len = text.length;
+
+        // The optimized loop using charCodeAt and getGlyphByCode for ASCII fast-path.
+        for (let i = 0; i < len; i++) {
+            const code = text.charCodeAt(i);
+            const glyph = font.getGlyphByCode(code);
+
+            if (glyph) {
+                // Use a pre-allocated vector to avoid allocation per character.
+                this.tempVec.set(cursorX + glyph.offsetX, pos.y + glyph.offsetY);
+                this.drawSprite(spriteSheet, glyph.rect, this.tempVec, color);
+
+                cursorX += glyph.advance;
+            }
+        }
+    }
+
+    // #endregion
+
+    // #region Drawing
+
+    /**
+     * Uploads accumulated sprite data and encodes draw calls for each texture batch.
+     * No-op when nothing has been queued for the current frame.
+     *
+     * @param renderPass - Active render pass encoder.
+     */
+    encodePass(renderPass: GPURenderPassEncoder): void {
+        // Flush any remaining vertices into the batch queue.
+        this.flushCurrentBatch();
+
+        if (this.batches.length === 0 || this.totalVertices === 0) {
+            return;
+        }
+
+        // Upload all sprite vertices at once.
+        // Safe assertions: these resources are created in initialize() before any rendering.
+        (this.device as GPUDevice).queue.writeBuffer(
+            this.vertexBuffer as GPUBuffer,
+            0,
+            this.vertices.buffer,
+            0,
+            this.totalVertices * 8 * 4,
+        );
+
+        renderPass.setPipeline(this.pipeline as GPURenderPipeline);
+        renderPass.setVertexBuffer(0, this.vertexBuffer as GPUBuffer);
+
+        // Draw each batch with its own bind group (texture).
+        for (const batch of this.batches) {
+            renderPass.setBindGroup(0, batch.bindGroup);
+            renderPass.draw(batch.vertexCount, 1, batch.vertexStart, 0);
+        }
+    }
+
+    // #endregion
+
+    // #region Frame Rendering
+
+    /**
+     * Clears all per-frame batching state.
+     */
+    reset(): void {
+        this.vertexCount = 0;
+        this.totalVertices = 0;
+        this.batches = [];
+        this.currentTexture = null;
+        this.currentBindGroup = null;
+    }
+
+    /**
+     * Creates shader modules, pipeline state, GPU buffers, and the sprite sampler.
      *
      * @param displaySize - Render target resolution in pixels.
      */
@@ -233,126 +343,12 @@ export class SpritePipeline {
 
     // #endregion
 
-    // #region Camera
-
-    /**
-     * Sets the camera offset applied to all drawing operations.
-     *
-     * @param offset - Camera position in pixels.
-     */
-    setCameraOffset(offset: Vector2i): void {
-        this.cameraOffset = offset;
-    }
-
-    // #endregion
-
-    // #region Drawing
-
-    /**
-     * Draws a sprite region from a sprite sheet.
-     *
-     * @param spriteSheet - Source sprite sheet.
-     * @param srcRect - Region to copy from the sprite sheet.
-     * @param destPos - Screen position to draw at.
-     * @param tint - Tint color multiplied with texture (defaults to white).
-     */
-    drawSprite(spriteSheet: SpriteSheet, srcRect: Rect2i, destPos: Vector2i, tint: Color32 = Color32.white()): void {
-        const texture = spriteSheet.getTexture(this.device as GPUDevice);
-        const uvs = spriteSheet.getUVs(srcRect);
-
-        // Use a pre-allocated vector for size to avoid allocation.
-        this.tempSize.set(srcRect.width, srcRect.height);
-
-        this.drawTexturedQuad(texture, destPos, this.tempSize, uvs.u0, uvs.v0, uvs.u1, uvs.v1, tint);
-    }
-
-    /**
-     * Draws text using a bitmap font.
-     * Renders each character as a textured sprite.
-     *
-     * @param font - Bitmap font with character glyphs.
-     * @param pos - Text position (top-left corner).
-     * @param text - String to render.
-     * @param color - Text color multiplied with font texture.
-     */
-    drawBitmapText(font: BitmapFont, pos: Vector2i, text: string, color: Color32 = Color32.white()): void {
-        const spriteSheet = font.getSpriteSheet();
-        let cursorX = pos.x;
-        const len = text.length;
-
-        // The optimized loop using charCodeAt and getGlyphByCode for ASCII fast-path.
-        for (let i = 0; i < len; i++) {
-            const code = text.charCodeAt(i);
-            const glyph = font.getGlyphByCode(code);
-
-            if (glyph) {
-                // Use a pre-allocated vector to avoid allocation per character.
-                this.tempVec.set(cursorX + glyph.offsetX, pos.y + glyph.offsetY);
-                this.drawSprite(spriteSheet, glyph.rect, this.tempVec, color);
-                cursorX += glyph.advance;
-            }
-        }
-    }
-
-    // #endregion
-
-    // #region Frame Rendering
-
-    /**
-     * Encodes all accumulated sprite batches into the given render pass.
-     * Flushes the current batch, uploads all vertex data to GPU, and issues draw calls.
-     * No-op if no sprites were accumulated this frame.
-     *
-     * @param renderPass - Active render pass encoder.
-     */
-    encodePass(renderPass: GPURenderPassEncoder): void {
-        // Flush any remaining vertices into the batch queue.
-        this.flushCurrentBatch();
-
-        if (this.batches.length === 0 || this.totalVertices === 0) {
-            return;
-        }
-
-        // Upload all sprite vertices at once.
-        // Safe assertions: these resources are created in initialize() before any rendering.
-        (this.device as GPUDevice).queue.writeBuffer(
-            this.vertexBuffer as GPUBuffer,
-            0,
-            this.vertices.buffer,
-            0,
-            this.totalVertices * 8 * 4,
-        );
-
-        renderPass.setPipeline(this.pipeline as GPURenderPipeline);
-        renderPass.setVertexBuffer(0, this.vertexBuffer as GPUBuffer);
-
-        // Draw each batch with its own bind group (texture).
-        for (const batch of this.batches) {
-            renderPass.setBindGroup(0, batch.bindGroup);
-            renderPass.draw(batch.vertexCount, 1, batch.vertexStart, 0);
-        }
-    }
-
-    /**
-     * Resets all per-frame state.
-     * Call at the start and end of each frame.
-     */
-    reset(): void {
-        this.vertexCount = 0;
-        this.totalVertices = 0;
-        this.batches = [];
-        this.currentTexture = null;
-        this.currentBindGroup = null;
-    }
-
-    // #endregion
-
     // #region Private Helpers
 
     /**
      * Draws a textured quad (two triangles) to the screen.
-     * Handles texture switching and batch flushing.
-     * Ensures complete quads are added atomically to prevent partial geometry.
+     * Handles texture switching and keeps quad emission atomic, so partial quads
+     * are never left in the frame buffer.
      *
      * @param texture - GPU texture to sample from.
      * @param pos - Screen position (top-left corner).
@@ -427,12 +423,13 @@ export class SpritePipeline {
     private hasSpaceForQuad(): boolean {
         const index = (this.totalVertices + this.vertexCount) * 8;
         const quadSize = 6 * 8; // 6 vertices * 8 floats per vertex
+
         return index + quadSize <= this.vertices.length;
     }
 
     /**
      * Saves the current sprite batch and prepares for a new texture.
-     * Called automatically when texture changes or at frame end.
+     * Called automatically when the active texture changes or before encoding.
      */
     private flushCurrentBatch(): void {
         if (this.vertexCount === 0 || !this.currentBindGroup) {
@@ -452,7 +449,7 @@ export class SpritePipeline {
 
     /**
      * Adds a sprite vertex to the batch.
-     * Assumes buffer space was pre-checked via hasSpaceForQuad() in drawTexturedQuad().
+     * Assumes buffer space has already been reserved by `drawTexturedQuad()`.
      *
      * @param x - X position in pixels.
      * @param y - Y position in pixels.
@@ -482,10 +479,10 @@ export class SpritePipeline {
 
     /**
      * Gets or creates a bind group for a texture.
-     * Bind groups are cached for reuse.
+     * Bind groups are cached per texture for reuse across frames.
      *
      * @param texture - GPU texture to create the bind group for.
-     * @returns Bind group containing uniform buffer, sampler and texture.
+     * @returns Bind group containing uniform buffer, sampler, and texture.
      */
     private getOrCreateBindGroup(texture: GPUTexture): GPUBindGroup {
         const existingBindGroup = this.textureBindGroups.get(texture);


### PR DESCRIPTION
- Improve class, constructor, and method JSDoc in SpritePipeline.ts for clearer intent (batching, frame lifecycle, encode semantics)
- Mark MAX_SPRITE_VERTICES comment as concise one-liner
- Reorder #region blocks so public API (Camera, Drawing, Frame Rendering) precedes private createPipeline implementation
- Add module-level JSDoc block to SpritePipeline.test.ts describing covered behaviour
- Add blank lines throughout test suite for readability
- Fix comment number format: "50k" -> "50,000"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Refine JSDoc and reorder regions in SpritePipeline

This PR improves documentation and organization in SpritePipeline by refining JSDoc comments, reordering code regions, and adding new public API methods.

### Changes to SpritePipeline.ts

**Documentation improvements:**
- Enhanced class JSDoc to clarify batching and GPU work encoding semantics
- Updated `MAX_SPRITE_VERTICES` comment to describe "vertices retained for a frame"
- Rewrote pipeline and batching descriptions to emphasize "batched WebGPU pipeline" with one draw call per texture batch emitted in `encodePass()`
- Refined constructor and method documentation to clarify lifecycle and frame semantics

**Code organization:**
- Reordered #region blocks so public API (Camera, Drawing, Frame Rendering) appears before private `createPipeline` implementation

**New public methods:**
- `setCameraOffset(offset: Vector2i): void` – sets camera offset for sprite positioning
- `drawSprite(spriteSheet: SpriteSheet, srcRect: Rect2i, destPos: Vector2i, tint?: Color32): void` – queues textured quad vertices for a sprite sheet region
- `drawBitmapText(font: BitmapFont, pos: Vector2i, text: string, color?: Color32): void` – iterates over characters, fetches glyphs, and draws each via `drawSprite`
- `encodePass(renderPass: GPURenderPassEncoder): void` – flushes the current batch, writes accumulated vertex data to GPU, and issues one draw per texture batch
- `reset(): void` – clears per-frame batching state

Private implementation details remain structurally unchanged; batching by texture and buffer overflow handling are preserved.

### Changes to SpritePipeline.test.ts

- Added comprehensive module-level JSDoc block describing covered SpritePipeline behaviors and test approach
- Added blank lines throughout the test suite for improved readability
- Updated numeric formatting in comments from "50k" to "50,000" to match the actual `MAX_SPRITE_VERTICES` constant value

**Lines changed:** +78/-3 (test file); +131/-134 (main file)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->