### PR TITLE
chore(claude): update skills

### DIFF
--- a/.claude/skills/deep-review/SKILL.md
+++ b/.claude/skills/deep-review/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Comprehensive code review with AI analysis, security audit, and PR-ready summary
+description: Comprehensive code review with AI analysis, security audit, and PR-ready summary.
 ---
 
 # Deep Review
@@ -25,7 +25,7 @@ pushing significant changes or creating pull requests.
    - Report any vulnerabilities found (moderate and above)
 
 3. **Gather change context**
-   - Run `git diff origin/main...HEAD` to see all changes vs main
+   - Run `git diff origin/main...HEAD` to see all changes vs. main
    - Run `git log origin/main..HEAD --oneline` to see commit history
    - Identify which files changed and their purpose
 
@@ -73,7 +73,7 @@ pushing significant changes or creating pull requests.
 
 #### Critical Issues
 
-- [File:Line] Description (must fix before merge)
+- [File:Line] Description (must fix before the merge)
 
 #### Warnings
 

--- a/.claude/skills/format/SKILL.md
+++ b/.claude/skills/format/SKILL.md
@@ -1,10 +1,10 @@
 ---
-description: Format all code files using Biome and Prettier, then verify formatting passes
+description: Format all code files using Biome and Prettier, then verify formatting passes.
 ---
 
 # Format Code
 
-Format all code files using the project's formatters and verify results.
+Format all code files using the project’s formatters and verify results.
 
 ## Usage
 
@@ -37,7 +37,7 @@ Format all code files using the project's formatters and verify results.
 
 ## Formatting Rules
 
-- Indent: 4 spaces (2 for JSON/YAML/Markdown)
+- Indent: four spaces (two for JSON/YAML/Markdown)
 - Line width: 120 characters
 - Quotes: Single quotes
 - Semicolons: Always

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -1,10 +1,10 @@
 ---
-description: Create a pull request with automatic quality checks, conventional commit, and gh CLI
+description: Create a pull request with automatic quality checks, conventional commit, and gh CLI.
 ---
 
 # Create Pull Request
 
-Create a pull request with automatic quality checks and proper commit message.
+Create a pull request with automatic quality checks, and a proper commit message.
 
 ## Usage
 
@@ -17,13 +17,13 @@ The description after `/pr` becomes the commit subject.
 ## Steps
 
 1. **Verify branch**
-   - Confirm current branch is not `main` or `master`
+   - Confirm the current branch is not `main` or `master`
    - Run `git status` to see all changes
 
 2. **Run quality checks**
    - Execute `pnpm preflight` (all checks)
    - If any check fails, stop and report errors
-   - Do not proceed with failing checks
+   - Don’t proceed with failing checks
 
 3. **Review changes**
    - Run `git diff` to review all modifications
@@ -32,7 +32,7 @@ The description after `/pr` becomes the commit subject.
 
 4. **Create commit**
    - Stage relevant files with `git add`
-   - Generate conventional commit message:
+   - Generate a conventional commit message:
      - Format: `<type>(<scope>): <description>`
      - Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`
      - Scopes: `renderer`, `camera`, `assets`, `api`, `utils`, `ci`, `docs`
@@ -43,7 +43,7 @@ The description after `/pr` becomes the commit subject.
 5. **Push and create PR**
    - Push to remote: `git push -u origin HEAD`
    - Create PR using `gh pr create` with:
-     - Title matching commit message
+     - Title matching the commit message
      - Body with summary and test plan
      - Link to related issues if any
 
@@ -53,6 +53,6 @@ The description after `/pr` becomes the commit subject.
 ## Requirements
 
 - `gh` CLI must be installed and authenticated
-- Current branch must not be `main` or `master`
+- The current branch mustn’t be `main` or `master`
 - All quality checks must pass
 - All commits must be signed off (DCO)

--- a/.claude/skills/preflight/SKILL.md
+++ b/.claude/skills/preflight/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Run all quality checks (format, lint, typecheck, spellcheck, knip) before committing
+description: Run all quality checks (format, lint, typecheck, spellcheck, knip) before committing.
 ---
 
 # Preflight Checks

--- a/.claude/skills/quick-format/SKILL.md
+++ b/.claude/skills/quick-format/SKILL.md
@@ -1,10 +1,10 @@
 ---
-description: Quickly format all code files without verification steps
+description: Quickly format all code files without verification steps.
 ---
 
 # Quick Format
 
-Rapidly format all code files using the project's formatters. Streamlined version of `/format` that skips verification
+Rapidly format all code files using the project’s formatters - streamlined version of `/format` that skips verification
 steps for maximum speed.
 
 ## Usage
@@ -22,11 +22,11 @@ steps for maximum speed.
 
 2. **Brief confirmation**
    - Report completion
-   - Note any files that couldn't be formatted (usually indicates syntax errors)
+   - Note any files that couldn’t be formatted (usually indicate syntax errors)
 
 ## When to Use
 
-- Quick cleanup after manual edits
+- A quick cleanup after manual edits
 - Before running other checks
 - When you know you just need formatting (not verification)
 - To fix formatting issues reported by CI or hooks

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -17,7 +17,7 @@ Review current changes against project rules and quality standards.
 1. **Gather changes**
    - Run `git diff` to see all unstaged modifications
    - Run `git diff --cached` to see staged changes
-   - List, which files were modified and what changed
+   - List which files were modified and what changed
 
 2. **Run automated checks**
    - `pnpm lint` - Report any lint issues

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Review current changes against project rules, conventions, and quality standards
+description: Review current changes against project rules, conventions, and quality standards.
 ---
 
 # Review Changes
@@ -17,7 +17,7 @@ Review current changes against project rules and quality standards.
 1. **Gather changes**
    - Run `git diff` to see all unstaged modifications
    - Run `git diff --cached` to see staged changes
-   - List which files were modified and what changed
+   - List, which files were modified and what changed
 
 2. **Run automated checks**
    - `pnpm lint` - Report any lint issues
@@ -54,5 +54,5 @@ Review current changes against project rules and quality standards.
 
 ## Summary
 
-Overall assessment of the changes and readiness for commit.
+Overall assessment of the changes and readiness for a commit.
 ```

--- a/.claude/skills/spellcheck/SKILL.md
+++ b/.claude/skills/spellcheck/SKILL.md
@@ -1,10 +1,10 @@
 ---
-description: Run cspell spellcheck across the project, fix typos and add legitimate words to the dictionary
+description: Run cspell spellcheck across the project, fix typos and add legitimate words to the dictionary.
 ---
 
 # Spellcheck
 
-Run project-wide spellcheck, then fix all reported errors.
+Run the project-wide spellcheck, then fix all reported errors.
 
 ## Usage
 
@@ -19,17 +19,17 @@ Run project-wide spellcheck, then fix all reported errors.
    - Capture the full error output
 
 2. **Analyze each error** For every word flagged by cspell, determine if it is:
-   - **A typo** -- a misspelled word in source code, comments, strings, or content
-   - **A legitimate term** -- a technical term, brand name, abbreviation, or proper noun that cspell does not know
+   - **A typo** – a misspelled word in source code, comments, strings, or content
+   - **A legitimate term** – a technical term, brand name, abbreviation, or proper noun that cspell doesn’t know
 
 3. **Fix typos in source files**
    - Open the file and fix the misspelled word in place
-   - Do NOT add typos to the dictionary
+   - Don’t add typos to the dictionary
 
 4. **Add legitimate words to `cspell.json`**
    - Add the word to the `words` array in `cspell.json`
    - Keep the array sorted alphabetically (case-insensitive)
-   - Do not add duplicates
+   - Don’t add duplicates
 
 5. **Re-run spellcheck**
    - Execute `pnpm spellcheck` again to confirm all errors are resolved

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Run tests - unit tests, coverage, visual regression, or watch mode
+description: Run tests - unit tests, coverage, visual regression, or watch mode.
 ---
 
 # Run Tests
@@ -18,7 +18,7 @@ Run the test suite with various options.
 
 ## Steps
 
-1. **Determine test scope** from the user's arguments:
+1. **Determine test scope** from the user’s arguments:
    - No arguments: Run `pnpm test:unit` (all Vitest tests)
    - `coverage`: Run `pnpm test:coverage` (with coverage thresholds)
    - `watch`: Run `pnpm test:watch` (interactive watch mode)
@@ -28,10 +28,10 @@ Run the test suite with various options.
 2. **Report results**
    - If all tests pass: Confirm success with pass count
    - If tests fail: Report specific failures with file locations and assertion details
-   - If coverage: Report coverage percentages vs 80% threshold
+   - If coverage: Report coverage percentages vs. 80% threshold
 
 3. **Suggest fixes for failures**
-   - For assertion errors: Show expected vs actual values
+   - For assertion errors: Show expected vs. actual values
    - For type errors in tests: Check test imports and types
    - For coverage gaps: Identify untested functions/branches
    - For visual regression: Suggest `pnpm test:visual:update` if change is intentional
@@ -42,5 +42,5 @@ Run the test suite with various options.
 - Visual tests are in `tests/visual/`
 - Use `describe`/`it` from vitest (not `test`)
 - Use `// #region` / `// #endregion` in test files over ~100 lines
-- Follow the same code style as source (4-space indent, single quotes, semicolons)
+- Follow the same code style as the source (four-space indent, single quotes, semicolons)
 - No emoji in test descriptions


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This pull request updates the Claude skills documentation across multiple files with style and formatting improvements. All changes are documentation-only with no functional modifications to any operational steps or commands.

## Changes Made

The PR updates documentation in eight skill files:

- **`.claude/skills/deep-review/SKILL.md`** - Added trailing period to description, adjusted spacing ("vs. main"), and refined output template wording ("must fix before the merge")

- **`.claude/skills/format/SKILL.md`** - Added trailing period to description, updated indent rule formatting from numeral ("4 spaces") to word form ("four spaces")

- **`.claude/skills/pr/SKILL.md`** - Added trailing period to description, refined grammar and style throughout instructions (e.g., "Don't proceed", "Title matching the commit message", "mustn't")

- **`.claude/skills/preflight/SKILL.md`** - Added trailing period to description

- **`.claude/skills/quick-format/SKILL.md`** - Added trailing period to description, adjusted intro wording, updated "When to Use" bullet from "Quick cleanup" to "A quick cleanup"

- **`.claude/skills/review/SKILL.md`** - Added trailing period to description, refined checklist and summary wording

- **`.claude/skills/spellcheck/SKILL.md`** - Added trailing period to description, updated typography (en dashes, "doesn't" instead of "does not"), refined instruction wording

- **`.claude/skills/test/SKILL.md`** - Added trailing period to description, updated typography with curly apostrophes, changed "4-space indent" to "four-space indent", adjusted spacing ("vs. 80% threshold")

## Summary

These are consistent documentation updates across the skills directory, focusing on punctuation consistency, typography improvements, and minor wording refinements. No skill behavior, workflow steps, or commands are altered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->