### PR TITLE
docs(assets): improve AssetLoader documentation and use nullish coalescing

### DIFF
--- a/src/assets/AssetLoader.test.ts
+++ b/src/assets/AssetLoader.test.ts
@@ -1,3 +1,17 @@
+/**
+ * Unit tests for {@link AssetLoader}.
+ *
+ * Verifies the image-loading contract exposed to the rest of the asset
+ * pipeline:
+ * - cache inspection and reset helpers
+ * - single, batched, and concurrent image loads
+ * - deduplication of in-flight requests
+ * - rejection and cache cleanup when loads fail
+ *
+ * Browser image loading is simulated with stubbed `Image` globals so the suite
+ * stays deterministic and does not depend on network or DOM behavior.
+ */
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AssetLoader } from './AssetLoader';
@@ -33,6 +47,7 @@ describe('AssetLoader', () => {
                     onerror: (() => void) | null = null;
                     width = 100;
                     height = 100;
+
                     set src(_: string) {
                         this.onload?.();
                     }
@@ -79,7 +94,9 @@ describe('AssetLoader', () => {
 
                     set src(value: string) {
                         this._src = value;
+
                         createCount++;
+
                         this.onload?.();
                     }
                 },
@@ -159,7 +176,7 @@ describe('AssetLoader', () => {
             vi.unstubAllGlobals();
         });
 
-        it('should reject when image fails to load', async () => {
+        it('should reject when the image fails to load', async () => {
             await expect(AssetLoader.loadImage('fail.png')).rejects.toThrow('Failed to load image: fail.png');
         });
 

--- a/src/assets/AssetLoader.ts
+++ b/src/assets/AssetLoader.ts
@@ -1,34 +1,44 @@
 // #region Module State
 
 /**
- * Cache of loaded images by URL.
- * Prevents reloading the same image multiple times.
+ * Successfully loaded images keyed by request URL.
+ *
+ * This acts as the resolved asset cache for callers that want instant reuse of
+ * images that have already completed loading.
  */
 const loadedImages = new Map<string, HTMLImageElement>();
 
 /**
- * Map of in-progress image load promises by URL.
- * Deduplicates concurrent requests for the same image.
+ * In-flight image requests keyed by request URL.
+ *
+ * Keeping pending promises here lets concurrent callers share the same browser
+ * load rather than creating duplicate `Image` instances for the same asset.
  */
 const loadingPromises = new Map<string, Promise<HTMLImageElement>>();
 
 // #endregion
 
 /**
- * Simple asset loader for images and other resources.
- * Provides caching and parallel loading capabilities.
+ * Shared image-loading utility for runtime asset code.
+ *
+ * `AssetLoader` exposes a small static API that:
+ * - loads individual images or batches of images
+ * - caches successfully resolved `HTMLImageElement` instances by URL
+ * - deduplicates concurrent requests for the same URL
+ * - exposes cache inspection and reset helpers for engine code and tests
  */
 export class AssetLoader {
     // #region Image loading
 
     /**
-     * Loads an image from a URL with automatic caching.
-     * Returns cached image immediately if already loaded.
-     * Deduplicates concurrent requests for the same URL.
+     * Loads an image and caches the resolved element by URL.
+     *
+     * Reuses an already-cached image immediately and shares a single in-flight
+     * promise when multiple callers request the same URL concurrently.
      *
      * @param url - Path or URL to the image file.
-     * @returns Promise resolving to the loaded HTMLImageElement.
-     * @throws Error if image fails to load.
+     * @returns Loaded image element for the requested URL.
+     * @throws Error if the image cannot be loaded.
      */
     static async loadImage(url: string): Promise<HTMLImageElement> {
         // Return cached image if available.
@@ -51,15 +61,12 @@ export class AssetLoader {
 
             img.onload = () => {
                 loadedImages.set(url, img);
-
                 loadingPromises.delete(url);
-
                 resolve(img);
             };
 
             img.onerror = () => {
                 loadingPromises.delete(url);
-
                 reject(new Error(`Failed to load image: ${url}`));
             };
 
@@ -72,11 +79,11 @@ export class AssetLoader {
     }
 
     /**
-     * Loads multiple images in parallel for faster loading.
-     * All images are loaded concurrently using Promise.all.
+     * Loads multiple images concurrently.
      *
      * @param urls - Array of image paths or URLs.
-     * @returns Promise resolving to an array of loaded images in same order.
+     * @returns Loaded image elements in the same order as `urls`.
+     * @throws Error if any requested image fails to load.
      */
     static async loadImages(urls: string[]): Promise<HTMLImageElement[]> {
         return Promise.all(urls.map((url) => AssetLoader.loadImage(url)));
@@ -90,26 +97,27 @@ export class AssetLoader {
      * Checks if an image is already loaded and cached.
      *
      * @param url - Path or URL to check.
-     * @returns True if image is in cache and ready to use.
+     * @returns `true` if the image is already cached and ready to use.
      */
     static isLoaded(url: string): boolean {
         return loadedImages.has(url);
     }
 
     /**
-     * Gets a previously loaded image from the cache.
-     * Doesn't trigger a new load if not found.
+     * Returns a previously loaded image from the cache without starting a new request.
      *
      * @param url - Path or URL of the cached image.
      * @returns The cached image, or null if not loaded.
      */
     static getImage(url: string): HTMLImageElement | null {
-        return loadedImages.get(url) || null;
+        return loadedImages.get(url) ?? null;
     }
 
     /**
      * Clears all in-memory caches. In-flight image requests aren't aborted
      * and may repopulate the cache once complete.
+     *
+     * Primarily intended for tests or explicit asset-lifecycle resets.
      */
     static clear(): void {
         loadedImages.clear();


### PR DESCRIPTION
Rewrite JSDoc for AssetLoader class, module-level caches, and all public methods. Add file-level test summary and @throws tags. Replace || with ?? in getImage for idiomatic nullish handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This pull request improves the documentation and code quality of the `AssetLoader` class and its test suite.

## Changes to `src/assets/AssetLoader.ts`

**Documentation improvements:**
- Rewrote JSDoc comments for the cache-related properties to clarify their roles as "resolved" and "in-flight" caches
- Enhanced `loadImage()` documentation to explain immediate reuse of cached `HTMLImageElement`s and promise deduplication for concurrent requests
- Updated `loadImages()` JSDoc to document concurrent loading via `Promise.all`, ordered results matching input `urls`, and throwing behavior on failure
- Expanded `clear()` JSDoc to clarify its intended usage for tests or explicit lifecycle resets

**Implementation change:**
- Replaced the logical OR operator (`||`) with the nullish coalescing operator (`??`) in `getImage()` to properly handle nullish values and avoid treating cached falsy values differently

Minor whitespace adjustments were made to `onload/onerror` handlers with no control-flow changes.

## Changes to `src/assets/AssetLoader.test.ts`

- Added a file-level JSDoc block documenting the test suite's purpose and coverage, including cache management, various image loading patterns (single, batched, concurrent), in-flight deduplication, and failure handling via deterministic `Image` stubbing
- Adjusted formatting in stubbed `Image` test implementations with blank line insertions
- Updated test description from "when image fails to load" to "when the image fails to load" for grammatical consistency

No behavioral assertions or test logic were modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->