### PR TITLE
feat(blit-tech): add vitest benchmarking infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ coverage-visual/
 playwright-report/
 test-results/
 .vitest/
+benchmark-results.json
 
 # Claude Code local settings
 .claude/settings.local.json

--- a/knip.json
+++ b/knip.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
-  "entry": ["src/**/*.test.ts"],
+  "entry": ["src/**/*.test.ts", "src/**/*.bench.ts"],
   "project": ["src/**/*.ts"],
   "ignoreExportsUsedInFile": true,
   "ignoreDependencies": ["vite-plugin-istanbul"],

--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
     "test:unit": "vitest run",
     "test:unit:watch": "vitest watch",
     "test:unit:coverage": "vitest run --coverage",
+    "bench": "vitest bench",
+    "bench:json": "vitest bench --outputJson benchmark-results.json",
     "test:visual": "playwright test",
     "test:visual:update": "playwright test --update-snapshots",
     "test:visual:coverage": "VISUAL_COVERAGE=1 playwright test && nyc report --reporter=lcov --reporter=text-summary --temp-dir=.nyc_output --report-dir=coverage-visual",

--- a/src/utils/Vector2i.bench.ts
+++ b/src/utils/Vector2i.bench.ts
@@ -1,0 +1,19 @@
+import { bench, describe } from 'vitest';
+
+import { Vector2i } from './Vector2i';
+
+describe('Vector2i benchmarks', () => {
+    const a = Vector2i.fromXYUnchecked(17, 23);
+    const b = Vector2i.fromXYUnchecked(5, 11);
+
+    bench(
+        'add',
+        () => {
+            a.add(b);
+        },
+        {
+            iterations: 2_000,
+            warmupIterations: 200,
+        },
+    );
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -27,5 +27,11 @@ export default defineConfig({
         setupFiles: ['src/__test__/setup.ts'],
         reporters: ['default'],
         testTimeout: 10_000,
+
+        benchmark: {
+            include: ['src/**/*.bench.ts'],
+            exclude: ['node_modules', 'dist'],
+            reporters: ['default'],
+        },
     },
 });


### PR DESCRIPTION
Introduced Vitest benchmarking support with new `bench` and `bench:json` npm scripts, updated .gitignore for benchmark results, and added example benchmark `Vector2i.bench.ts`. Configured Vitest to include/exclude benchmark files and set up default benchmarking reporters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Vitest benchmarking infrastructure

This pull request introduces comprehensive benchmarking support using Vitest, along with tooling updates to support the new benchmark files.

### Changes Made

**Configuration Updates:**
- Modified `vitest.config.ts` to add a dedicated `benchmark` configuration block under `test`, specifying benchmark file discovery via `include: ['src/**/*.bench.ts']`, with appropriate exclusions for `node_modules` and `dist`.
- Updated `knip.json` to recognize `src/**/*.bench.ts` files as entry points for static analysis, extending the existing test file recognition.
- Added `benchmark-results.json` to `.gitignore` to prevent benchmark result artifacts from being tracked in version control.

**npm Scripts:**
- Added `bench` script to run `vitest bench` for executing benchmarks.
- Added `bench:json` script to run `vitest bench` with JSON output targeting `benchmark-results.json` for structured benchmark result storage.

**Example Benchmark:**
- Created `src/utils/Vector2i.bench.ts`, a reference benchmark file demonstrating the benchmarking setup. The benchmark tests the `add` method of the `Vector2i` class with configured warm-up iterations (200) and primary iterations (2,000).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->