### PR TITLE
refactor(utils): structure Rect2i benchmarks with region comments

### DIFF
--- a/src/utils/Rect2i.bench.ts
+++ b/src/utils/Rect2i.bench.ts
@@ -1,0 +1,112 @@
+// #region Imports
+
+import { bench, describe } from 'vitest';
+
+import { Rect2i } from './Rect2i';
+import { Vector2i } from './Vector2i';
+
+// #endregion
+
+// #region Constants
+
+const BASE_X = 10;
+const BASE_Y = 20;
+const BASE_WIDTH = 64;
+const BASE_HEIGHT = 48;
+const propertyAccessSink = { value: 0 };
+const BENCH_OPTIONS = {
+    iterations: 500,
+    time: 100,
+    warmupTime: 25,
+    warmupIterations: 50,
+};
+
+// #endregion
+
+// #region Benchmark Suites
+
+describe('Rect2i creation benchmarks', () => {
+    const source = Rect2i.fromValuesUnchecked(BASE_X, BASE_Y, BASE_WIDTH, BASE_HEIGHT);
+    const mutable = new Rect2i();
+
+    bench(
+        'new Rect2i()',
+        () => {
+            new Rect2i(BASE_X, BASE_Y, BASE_WIDTH, BASE_HEIGHT);
+        },
+        BENCH_OPTIONS,
+    );
+
+    bench(
+        'clone()',
+        () => {
+            source.clone();
+        },
+        BENCH_OPTIONS,
+    );
+
+    bench(
+        'set()',
+        () => {
+            mutable.set(BASE_X, BASE_Y, BASE_WIDTH, BASE_HEIGHT);
+        },
+        BENCH_OPTIONS,
+    );
+});
+
+describe('Rect2i collision benchmarks', () => {
+    const rect = Rect2i.fromValuesUnchecked(BASE_X, BASE_Y, BASE_WIDTH, BASE_HEIGHT);
+    const point = Vector2i.fromXYUnchecked(24, 32);
+    const overlapping = Rect2i.fromValuesUnchecked(30, 36, 20, 18);
+
+    bench(
+        'contains(Vector2i)',
+        () => {
+            rect.contains(point);
+        },
+        BENCH_OPTIONS,
+    );
+
+    bench(
+        'containsXY()',
+        () => {
+            rect.containsXY(24, 32);
+        },
+        BENCH_OPTIONS,
+    );
+
+    bench(
+        'intersects(Rect2i)',
+        () => {
+            rect.intersects(overlapping);
+        },
+        BENCH_OPTIONS,
+    );
+});
+
+describe('Rect2i intersection benchmarks', () => {
+    const rect = Rect2i.fromValuesUnchecked(BASE_X, BASE_Y, BASE_WIDTH, BASE_HEIGHT);
+    const overlapping = Rect2i.fromValuesUnchecked(30, 36, 20, 18);
+
+    bench(
+        'intersection()',
+        () => {
+            rect.intersection(overlapping);
+        },
+        BENCH_OPTIONS,
+    );
+});
+
+describe('Rect2i property access benchmarks', () => {
+    const rect = Rect2i.fromValuesUnchecked(BASE_X, BASE_Y, BASE_WIDTH, BASE_HEIGHT);
+
+    bench(
+        'property access x/y/width/height',
+        () => {
+            propertyAccessSink.value = rect.x + rect.y + rect.width + rect.height;
+        },
+        BENCH_OPTIONS,
+    );
+});
+
+// #endregion


### PR DESCRIPTION
Organized `Rect2i.bench.ts` using labeled region comments for improved readability. Added constants and clearly separated benchmark suites for creation, collision detection, intersections, and property access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Introduced structured benchmark file `src/utils/Rect2i.bench.ts` with organized region comments for improved readability. The file is divided into three main sections: Imports, Constants, and Benchmark Suites.

Defined shared benchmark constants including base rectangle dimensions (`BASE_X`, `BASE_Y`, `BASE_WIDTH`, `BASE_HEIGHT`), a property access sink object, and Vitest benchmark options (`BENCH_OPTIONS`) with configured iterations, timing, and warmup parameters.

Organized benchmark suites into four distinct describe blocks:

1. **Rect2i creation benchmarks**: Covers `new Rect2i()` constructor, `clone()` method, and `set()` mutation operation.

2. **Rect2i collision benchmarks**: Benchmarks collision detection methods including `contains(Vector2i)`, `containsXY(x, y)`, and `intersects(Rect2i)`.

3. **Rect2i intersection benchmarks**: Benchmarks the `intersection()` method for rectangle intersection operations.

4. **Rect2i property access benchmarks**: Benchmarks direct property reads by summing `x`, `y`, `width`, and `height` into a sink object to prevent compiler optimizations.

Each benchmark suite creates reusable test instances and executes synchronous operations under the configured Vitest bench parameters. No changes to public APIs or exported entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->