### PR TITLE
feat(blit-tech): add Playwright performance fixture for GPU frame-time benchmarks

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -26,7 +26,7 @@ export default [
             '.pnpm-store/**',
             '**/.pnpm-store/**',
             'vite.config.ts.timestamp-*',
-            'tests/**',
+            'tests/visual/**',
         ],
     },
 
@@ -167,7 +167,7 @@ export default [
 
     // Test files - relaxed rules
     {
-        files: ['**/*.test.ts', 'src/__test__/**/*.ts'],
+        files: ['**/*.test.ts', 'src/__test__/**/*.ts', 'tests/perf/**/*.ts'],
         rules: {
             'jsdoc/require-jsdoc': 'off',
             'jsdoc/require-param': 'off',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -26,7 +26,7 @@ export default [
             '.pnpm-store/**',
             '**/.pnpm-store/**',
             'vite.config.ts.timestamp-*',
-            'tests/visual/**',
+            'tests/visual/**/*.html',
         ],
     },
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -154,10 +154,11 @@ export default [
 
     // Config files - relaxed rules
     {
-        files: ['*.config.js', '*.config.ts', '*.config.mjs'],
+        files: ['*.config.js', '*.config.ts', '*.config.mjs', '**/*.config.js', '**/*.config.ts', '**/*.config.mjs'],
         languageOptions: {
             globals: {
                 ...globals.node,
+                ...globals.es2022,
             },
         },
         rules: {
@@ -167,7 +168,14 @@ export default [
 
     // Test files - relaxed rules
     {
-        files: ['**/*.test.ts', 'src/__test__/**/*.ts', 'tests/perf/**/*.ts'],
+        files: ['**/*.test.ts', 'src/__test__/**/*.ts', 'tests/perf/**/*.ts', 'tests/visual/**/*.ts'],
+        languageOptions: {
+            globals: {
+                ...globals.browser,
+                ...globals.node,
+                ...globals.es2022,
+            },
+        },
         rules: {
             'jsdoc/require-jsdoc': 'off',
             'jsdoc/require-param': 'off',
@@ -175,6 +183,7 @@ export default [
             'jsdoc/require-description': 'off',
             '@typescript-eslint/no-non-null-assertion': 'off',
             '@typescript-eslint/no-explicit-any': 'off',
+            'security/detect-non-literal-fs-filename': 'off',
             'no-undef': 'off',
         },
     },

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "bench": "vitest bench",
     "bench:json": "vitest bench --outputJson benchmark-results.json",
     "test:visual": "playwright test",
+    "test:perf": "playwright test -c playwright.perf.config.ts",
     "test:visual:update": "playwright test --update-snapshots",
     "test:visual:coverage": "VISUAL_COVERAGE=1 playwright test && nyc report --reporter=lcov --reporter=text-summary --temp-dir=.nyc_output --report-dir=coverage-visual",
     "preflight": "pnpm format:check && pnpm lint && pnpm typecheck && pnpm spellcheck && pnpm knip && pnpm test:unit",

--- a/playwright.perf.config.ts
+++ b/playwright.perf.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+    testDir: 'tests/perf',
+    outputDir: 'test-results/perf',
+    timeout: 120_000,
+
+    fullyParallel: false,
+    forbidOnly: !!process.env.CI,
+    retries: process.env.CI ? 1 : 0,
+    workers: 1,
+
+    reporter: process.env.CI ? 'github' : 'list',
+
+    use: {
+        baseURL: 'http://127.0.0.1:5174',
+        screenshot: 'only-on-failure',
+        trace: 'on-first-retry',
+    },
+
+    projects: [
+        {
+            name: 'chromium-webgpu',
+            use: {
+                ...devices['Desktop Chrome'],
+                channel: 'chrome',
+                launchOptions: {
+                    args: ['--enable-unsafe-webgpu', '--enable-features=Vulkan', '--disable-gpu-sandbox'],
+                },
+            },
+        },
+    ],
+
+    webServer: {
+        command:
+            'pnpm exec vite serve tests/visual/fixtures --config tests/visual/fixtures/vite.config.ts --host 127.0.0.1 --port 5174',
+        port: 5174,
+        reuseExistingServer: !process.env.CI,
+        timeout: 30_000,
+    },
+});

--- a/playwright.perf.config.ts
+++ b/playwright.perf.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
     reporter: process.env.CI ? 'github' : 'list',
 
     use: {
-        baseURL: 'http://127.0.0.1:5174',
+        baseURL: 'http://127.0.0.1:5175',
         screenshot: 'only-on-failure',
         trace: 'on-first-retry',
     },
@@ -33,8 +33,8 @@ export default defineConfig({
 
     webServer: {
         command:
-            'pnpm exec vite serve tests/visual/fixtures --config tests/visual/fixtures/vite.config.ts --host 127.0.0.1 --port 5174',
-        port: 5174,
+            'pnpm exec vite serve tests/visual/fixtures --config tests/visual/fixtures/vite.config.ts --host 127.0.0.1 --port 5175',
+        port: 5175,
         reuseExistingServer: !process.env.CI,
         timeout: 30_000,
     },

--- a/tests/perf/perf.spec.ts
+++ b/tests/perf/perf.spec.ts
@@ -1,0 +1,216 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { expect, test } from '@playwright/test';
+
+// #region Types
+
+interface RawPerfResult {
+    frameTimes: number[];
+    frames: number;
+    scenario: string;
+    warmupFrames: number;
+    workload: Record<string, number | string>;
+}
+
+interface PerfStats {
+    frames: number;
+    max: number;
+    median: number;
+    min: number;
+    p95: number;
+    p99: number;
+}
+
+interface PerfScenarioResult {
+    fixture: string;
+    name: string;
+    stats: PerfStats;
+    workload: Record<string, number | string>;
+}
+
+interface PerfScenario {
+    fixture: string;
+    name: string;
+    query: Record<string, number | string>;
+}
+
+interface PerfWindow {
+    __INIT_FAILED__?: boolean;
+    __PERF_COMPLETE__?: boolean;
+    __PERF_RESULT__?: RawPerfResult | null;
+}
+
+// #endregion
+
+// #region Constants
+
+const PERF_RESULTS_FILE = path.resolve(process.cwd(), 'test-results/perf/perf-results.json');
+
+const perfResults: PerfScenarioResult[] = [];
+
+const perfScenarios: PerfScenario[] = [
+    {
+        fixture: 'perf-primitives.html',
+        name: 'primitives',
+        query: { frames: 100, lines: 80, pixels: 400, rects: 120, warmup: 10 },
+    },
+    {
+        fixture: 'perf-sprites.html',
+        name: 'sprites-same-texture',
+        query: { frames: 100, sprites: 800, textureMode: 'same', warmup: 10 },
+    },
+    {
+        fixture: 'perf-sprites.html',
+        name: 'sprites-alternating-textures',
+        query: { frames: 100, sprites: 800, textureMode: 'alternating', warmup: 10 },
+    },
+    {
+        fixture: 'perf-fonts.html',
+        name: 'fonts',
+        query: { chars: 480, frames: 100, lineWidth: 32, warmup: 10 },
+    },
+    {
+        fixture: 'perf-mixed.html',
+        name: 'mixed',
+        query: { chars: 160, frames: 100, lines: 100, rects: 140, sprites: 220, warmup: 10 },
+    },
+];
+
+// #endregion
+
+// #region Helpers
+
+/**
+ * Builds a fixture URL with query parameters for a perf scenario.
+ *
+ * @param fixture - Fixture HTML filename.
+ * @param query - Query parameters passed to the page.
+ * @returns Relative URL for Playwright navigation.
+ */
+function buildFixtureUrl(fixture: string, query: Record<string, number | string>): string {
+    const params = new URLSearchParams();
+
+    for (const [key, value] of Object.entries(query)) {
+        params.set(key, String(value));
+    }
+
+    return `/${fixture}?${params.toString()}`;
+}
+
+/**
+ * Computes summary statistics from a list of frame times.
+ *
+ * @param frameTimes - Recorded frame durations in milliseconds.
+ * @returns Median, tail percentiles, and min/max values.
+ */
+function computeStats(frameTimes: number[]): PerfStats {
+    const sorted = [...frameTimes].sort((left, right) => left - right);
+
+    return {
+        frames: sorted.length,
+        max: sorted[sorted.length - 1] ?? 0,
+        median: percentile(sorted, 0.5),
+        min: sorted[0] ?? 0,
+        p95: percentile(sorted, 0.95),
+        p99: percentile(sorted, 0.99),
+    };
+}
+
+/**
+ * Calculates a percentile using nearest-rank selection.
+ *
+ * @param sorted - Frame times sorted ascending.
+ * @param percentileValue - Percentile expressed as 0.0-1.0.
+ * @returns Value at the requested percentile.
+ */
+function percentile(sorted: number[], percentileValue: number): number {
+    if (sorted.length === 0) {
+        return 0;
+    }
+
+    const index = Math.min(sorted.length - 1, Math.ceil(sorted.length * percentileValue) - 1);
+
+    return sorted.at(index) ?? 0;
+}
+
+/**
+ * Writes the aggregated perf results to a machine-readable JSON file.
+ */
+function writePerfResultsFile(): void {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- Output path is a fixed test artifact location under test-results/perf
+    fs.mkdirSync(path.dirname(PERF_RESULTS_FILE), { recursive: true });
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- Output path is a fixed test artifact location under test-results/perf
+    fs.writeFileSync(
+        PERF_RESULTS_FILE,
+        JSON.stringify(
+            {
+                generatedAt: new Date().toISOString(),
+                scenarios: perfResults,
+            },
+            null,
+            2,
+        ),
+    );
+}
+
+// #endregion
+
+// #region Tests
+
+test.afterAll(() => {
+    writePerfResultsFile();
+});
+
+for (const scenario of perfScenarios) {
+    test(`collects frame-time stats for ${scenario.name}`, async ({ page }, testInfo) => {
+        await page.goto(buildFixtureUrl(scenario.fixture, scenario.query));
+
+        await page.waitForFunction(
+            () => {
+                const perfWindow = window as unknown as PerfWindow;
+
+                return perfWindow.__PERF_COMPLETE__ || perfWindow.__INIT_FAILED__;
+            },
+            { timeout: 30_000 },
+        );
+
+        const rawResult = await page.evaluate(() => {
+            const perfWindow = window as unknown as PerfWindow;
+
+            return {
+                initFailed: perfWindow.__INIT_FAILED__,
+                result: perfWindow.__PERF_RESULT__ ?? null,
+            };
+        });
+
+        test.skip(rawResult.initFailed === true, 'WebGPU not available in this environment');
+
+        expect(rawResult.result).not.toBeNull();
+
+        const result = rawResult.result as RawPerfResult;
+
+        expect(result.frameTimes.length).toBe(result.frames);
+
+        const stats = computeStats(result.frameTimes);
+        const scenarioResult: PerfScenarioResult = {
+            fixture: scenario.fixture,
+            name: scenario.name,
+            stats,
+            workload: result.workload,
+        };
+
+        perfResults.push(scenarioResult);
+
+        await testInfo.attach('perf-stats', {
+            body: JSON.stringify(scenarioResult, null, 2),
+            contentType: 'application/json',
+        });
+
+        console.log(
+            `[perf] ${scenario.name}: median=${stats.median.toFixed(2)}ms p95=${stats.p95.toFixed(2)}ms p99=${stats.p99.toFixed(2)}ms`,
+        );
+    });
+}
+
+// #endregion

--- a/tests/perf/perf.spec.ts
+++ b/tests/perf/perf.spec.ts
@@ -138,9 +138,7 @@ function percentile(sorted: number[], percentileValue: number): number {
  * Writes the aggregated perf results to a machine-readable JSON file.
  */
 function writePerfResultsFile(): void {
-    // eslint-disable-next-line security/detect-non-literal-fs-filename -- Output path is a fixed test artifact location under test-results/perf
     fs.mkdirSync(path.dirname(PERF_RESULTS_FILE), { recursive: true });
-    // eslint-disable-next-line security/detect-non-literal-fs-filename -- Output path is a fixed test artifact location under test-results/perf
     fs.writeFileSync(
         PERF_RESULTS_FILE,
         JSON.stringify(

--- a/tests/visual/coverage-fixture.ts
+++ b/tests/visual/coverage-fixture.ts
@@ -1,6 +1,7 @@
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
+
 import { test as baseTest } from '@playwright/test';
 
 const NYC_OUTPUT_DIR = path.resolve(process.cwd(), '.nyc_output');

--- a/tests/visual/fixtures/perf-common.js
+++ b/tests/visual/fixtures/perf-common.js
@@ -1,0 +1,101 @@
+export function readNumberParam(name, fallback) {
+    const params = new URLSearchParams(window.location.search);
+    const raw = params.get(name);
+
+    if (raw === null) {
+        return fallback;
+    }
+
+    const parsed = Number(raw);
+
+    return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+export function readStringParam(name, fallback) {
+    const params = new URLSearchParams(window.location.search);
+
+    return params.get(name) ?? fallback;
+}
+
+export function initializePerfState(scenario, workload) {
+    window.__PERF_COMPLETE__ = false;
+    window.__PERF_RESULT__ = null;
+    window.__INIT_FAILED__ = false;
+
+    return {
+        completed: false,
+        frameLimit: Math.max(1, readNumberParam('frames', 100) | 0),
+        frameTimes: [],
+        framesSeen: 0,
+        lastFrameAt: null,
+        scenario,
+        warmupFrames: Math.max(0, readNumberParam('warmup', 10) | 0),
+        workload,
+    };
+}
+
+export function recordFrame(state) {
+    if (state.completed) {
+        return true;
+    }
+
+    const now = performance.now();
+
+    if (state.lastFrameAt !== null) {
+        const delta = now - state.lastFrameAt;
+
+        if (state.framesSeen >= state.warmupFrames) {
+            state.frameTimes.push(delta);
+        }
+    }
+
+    state.lastFrameAt = now;
+    state.framesSeen += 1;
+
+    if (state.frameTimes.length >= state.frameLimit) {
+        window.__PERF_RESULT__ = {
+            frameTimes: state.frameTimes.slice(),
+            frames: state.frameLimit,
+            scenario: state.scenario,
+            warmupFrames: state.warmupFrames,
+            workload: state.workload,
+        };
+        window.__PERF_COMPLETE__ = true;
+        state.completed = true;
+    }
+
+    return state.completed;
+}
+
+export function markInitFailed(error) {
+    window.__INIT_FAILED__ = true;
+
+    if (error) {
+        console.error(error);
+    }
+}
+
+export function repeatText(seed, length) {
+    return seed.repeat(Math.ceil(length / seed.length)).slice(0, length);
+}
+
+export function createSpriteImage(primaryColor, secondaryColor) {
+    const canvas = document.createElement('canvas');
+    canvas.width = 8;
+    canvas.height = 8;
+    const context = canvas.getContext('2d');
+
+    for (let y = 0; y < 8; y++) {
+        for (let x = 0; x < 8; x++) {
+            context.fillStyle = (x + y) % 2 === 0 ? primaryColor : secondaryColor;
+            context.fillRect(x, y, 1, 1);
+        }
+    }
+
+    const image = new Image();
+
+    return new Promise((resolve) => {
+        image.onload = () => resolve(image);
+        image.src = canvas.toDataURL();
+    });
+}

--- a/tests/visual/fixtures/perf-common.js
+++ b/tests/visual/fixtures/perf-common.js
@@ -1,3 +1,5 @@
+/* global Image, document, window */
+
 export function readNumberParam(name, fallback) {
     const params = new URLSearchParams(window.location.search);
     const raw = params.get(name);
@@ -85,6 +87,12 @@ export function createSpriteImage(primaryColor, secondaryColor) {
     canvas.height = 8;
     const context = canvas.getContext('2d');
 
+    if (!context) {
+        markInitFailed(new Error('Failed to create 2D canvas context for perf sprite fixture'));
+
+        return Promise.reject(new Error('Failed to create 2D canvas context for perf sprite fixture'));
+    }
+
     for (let y = 0; y < 8; y++) {
         for (let x = 0; x < 8; x++) {
             context.fillStyle = (x + y) % 2 === 0 ? primaryColor : secondaryColor;
@@ -94,8 +102,14 @@ export function createSpriteImage(primaryColor, secondaryColor) {
 
     const image = new Image();
 
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
         image.onload = () => resolve(image);
+        image.onerror = () => {
+            const error = new Error('Failed to load generated perf sprite image');
+
+            markInitFailed(error);
+            reject(error);
+        };
         image.src = canvas.toDataURL();
     });
 }

--- a/tests/visual/fixtures/perf-fonts.html
+++ b/tests/visual/fixtures/perf-fonts.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <title>Perf Test: Fonts</title>
+    <style>
+        body { margin: 0; background: #000; }
+        canvas { image-rendering: pixelated; }
+    </style>
+</head>
+
+<body>
+    <div id="canvas-container">
+        <canvas id="blit-tech-canvas" width="320" height="240"></canvas>
+    </div>
+
+    <script type="module">
+        import { bootstrap, BT, Color32, Vector2i } from 'blit-tech';
+
+        import { initializePerfState, markInitFailed, readNumberParam, recordFrame, repeatText } from './perf-common.js';
+
+        const charCount = Math.max(1, readNumberParam('chars', 400) | 0);
+        const lineWidth = Math.max(1, readNumberParam('lineWidth', 40) | 0);
+        const text = repeatText('PERF TEXT 0123456789 ', charCount);
+        const lines = [];
+
+        for (let start = 0; start < text.length; start += lineWidth) {
+            lines.push(text.slice(start, start + lineWidth));
+        }
+
+        const perf = initializePerfState('fonts', {
+            charCount,
+            lineWidth,
+            lines: lines.length,
+        });
+
+        class PerfFontsTest {
+            pos = new Vector2i();
+
+            queryHardware() {
+                return {
+                    displaySize: new Vector2i(320, 240),
+                    targetFPS: 60,
+                };
+            }
+
+            async initialize() {
+                return true;
+            }
+
+            update() {}
+
+            render() {
+                if (perf.completed) {
+                    return;
+                }
+
+                BT.clear(Color32.black());
+
+                for (let i = 0; i < lines.length; i++) {
+                    this.pos.x = 8;
+                    this.pos.y = 8 + i * 10;
+                    BT.print(this.pos, Color32.white(), lines[i]);
+                }
+
+                recordFrame(perf);
+            }
+        }
+
+        bootstrap(PerfFontsTest, {
+            onError: markInitFailed,
+        });
+    </script>
+</body>
+
+</html>

--- a/tests/visual/fixtures/perf-mixed.html
+++ b/tests/visual/fixtures/perf-mixed.html
@@ -1,0 +1,105 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <title>Perf Test: Mixed</title>
+    <style>
+        body { margin: 0; background: #000; }
+        canvas { image-rendering: pixelated; }
+    </style>
+</head>
+
+<body>
+    <div id="canvas-container">
+        <canvas id="blit-tech-canvas" width="320" height="240"></canvas>
+    </div>
+
+    <script type="module">
+        import { bootstrap, BT, Color32, Rect2i, SpriteSheet, Vector2i } from 'blit-tech';
+
+        import {
+            createSpriteImage,
+            initializePerfState,
+            markInitFailed,
+            readNumberParam,
+            recordFrame,
+            repeatText,
+        } from './perf-common.js';
+
+        const rectCount = Math.max(0, readNumberParam('rects', 120) | 0);
+        const spriteCount = Math.max(0, readNumberParam('sprites', 200) | 0);
+        const lineCount = Math.max(0, readNumberParam('lines', 80) | 0);
+        const text = repeatText('MIXED PERF ', Math.max(1, readNumberParam('chars', 120) | 0));
+        const perf = initializePerfState('mixed', {
+            chars: text.length,
+            lines: lineCount,
+            rects: rectCount,
+            sprites: spriteCount,
+        });
+
+        class PerfMixedTest {
+            spriteSheet = null;
+            rect = new Rect2i();
+            sourceRect = new Rect2i(0, 0, 8, 8);
+            destPos = new Vector2i();
+            p0 = new Vector2i();
+            p1 = new Vector2i();
+            textPos = new Vector2i(8, 8);
+
+            queryHardware() {
+                return {
+                    displaySize: new Vector2i(320, 240),
+                    targetFPS: 60,
+                };
+            }
+
+            async initialize() {
+                const image = await createSpriteImage('#ffffff', '#888888');
+
+                this.spriteSheet = new SpriteSheet(image);
+
+                return true;
+            }
+
+            update() {}
+
+            render() {
+                if (perf.completed || !this.spriteSheet) {
+                    return;
+                }
+
+                BT.clear(new Color32(16, 24, 40, 255));
+
+                for (let i = 0; i < rectCount; i++) {
+                    this.rect.set((i * 11) % 320, (i * 7) % 240, 10 + (i % 18), 6 + (i % 10));
+                    BT.drawRectFill(this.rect, Color32.blue());
+                }
+
+                for (let i = 0; i < lineCount; i++) {
+                    this.p0.x = (i * 13) % 320;
+                    this.p0.y = (i * 5) % 240;
+                    this.p1.x = (this.p0.x + 30 + (i % 40)) % 320;
+                    this.p1.y = (this.p0.y + 12 + (i % 40)) % 240;
+                    BT.drawLine(this.p0, this.p1, Color32.yellow());
+                }
+
+                for (let i = 0; i < spriteCount; i++) {
+                    this.destPos.x = (i * 12) % 320;
+                    this.destPos.y = (((i * 12) / 320) | 0) * 10 % 240;
+                    BT.drawSprite(this.spriteSheet, this.sourceRect, this.destPos);
+                }
+
+                BT.print(this.textPos, Color32.white(), text);
+
+                recordFrame(perf);
+            }
+        }
+
+        bootstrap(PerfMixedTest, {
+            onError: markInitFailed,
+        });
+    </script>
+</body>
+
+</html>

--- a/tests/visual/fixtures/perf-primitives.html
+++ b/tests/visual/fixtures/perf-primitives.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <title>Perf Test: Primitives</title>
+    <style>
+        body { margin: 0; background: #000; }
+        canvas { image-rendering: pixelated; }
+    </style>
+</head>
+
+<body>
+    <div id="canvas-container">
+        <canvas id="blit-tech-canvas" width="320" height="240"></canvas>
+    </div>
+
+    <script type="module">
+        import { bootstrap, BT, Color32, Rect2i, Vector2i } from 'blit-tech';
+
+        import { initializePerfState, markInitFailed, readNumberParam, recordFrame } from './perf-common.js';
+
+        const rectCount = Math.max(0, readNumberParam('rects', 120) | 0);
+        const lineCount = Math.max(0, readNumberParam('lines', 80) | 0);
+        const pixelCount = Math.max(0, readNumberParam('pixels', 400) | 0);
+        const perf = initializePerfState('primitives', {
+            lines: lineCount,
+            pixels: pixelCount,
+            rects: rectCount,
+        });
+
+        class PerfPrimitivesTest {
+            rect = new Rect2i();
+            pixel = new Vector2i();
+            p0 = new Vector2i();
+            p1 = new Vector2i();
+
+            queryHardware() {
+                return {
+                    displaySize: new Vector2i(320, 240),
+                    targetFPS: 60,
+                };
+            }
+
+            async initialize() {
+                return true;
+            }
+
+            update() {}
+
+            render() {
+                if (perf.completed) {
+                    return;
+                }
+
+                BT.clear(Color32.black());
+
+                for (let i = 0; i < rectCount; i++) {
+                    this.rect.set((i * 7) % 320, (i * 11) % 240, 6 + (i % 12), 4 + (i % 8));
+                    BT.drawRectFill(this.rect, Color32.red());
+                }
+
+                for (let i = 0; i < lineCount; i++) {
+                    this.p0.x = (i * 5) % 320;
+                    this.p0.y = (i * 3) % 240;
+                    this.p1.x = (this.p0.x + 24 + (i % 32)) % 320;
+                    this.p1.y = (this.p0.y + 24 + (i % 32)) % 240;
+                    BT.drawLine(this.p0, this.p1, Color32.green());
+                }
+
+                for (let i = 0; i < pixelCount; i++) {
+                    this.pixel.x = (i * 13) % 320;
+                    this.pixel.y = (i * 17) % 240;
+                    BT.drawPixel(this.pixel, Color32.white());
+                }
+
+                recordFrame(perf);
+            }
+        }
+
+        bootstrap(PerfPrimitivesTest, {
+            onError: markInitFailed,
+        });
+    </script>
+</body>
+
+</html>

--- a/tests/visual/fixtures/perf-sprites.html
+++ b/tests/visual/fixtures/perf-sprites.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <title>Perf Test: Sprites</title>
+    <style>
+        body { margin: 0; background: #000; }
+        canvas { image-rendering: pixelated; }
+    </style>
+</head>
+
+<body>
+    <div id="canvas-container">
+        <canvas id="blit-tech-canvas" width="320" height="240"></canvas>
+    </div>
+
+    <script type="module">
+        import { bootstrap, BT, Color32, Rect2i, SpriteSheet, Vector2i } from 'blit-tech';
+
+        import {
+            createSpriteImage,
+            initializePerfState,
+            markInitFailed,
+            readNumberParam,
+            readStringParam,
+            recordFrame,
+        } from './perf-common.js';
+
+        const spriteCount = Math.max(0, readNumberParam('sprites', 600) | 0);
+        const textureMode = readStringParam('textureMode', 'same');
+        const perf = initializePerfState('sprites', {
+            spriteCount,
+            textureMode,
+        });
+
+        class PerfSpritesTest {
+            spriteSheets = [];
+            sourceRect = new Rect2i(0, 0, 8, 8);
+            destPos = new Vector2i();
+
+            queryHardware() {
+                return {
+                    displaySize: new Vector2i(320, 240),
+                    targetFPS: 60,
+                };
+            }
+
+            async initialize() {
+                const [firstImage, secondImage] = await Promise.all([
+                    createSpriteImage('#ff3366', '#ffcc00'),
+                    createSpriteImage('#33ccff', '#6633ff'),
+                ]);
+
+                this.spriteSheets = [new SpriteSheet(firstImage), new SpriteSheet(secondImage)];
+
+                return true;
+            }
+
+            update() {}
+
+            render() {
+                if (perf.completed) {
+                    return;
+                }
+
+                BT.clear(Color32.black());
+
+                for (let i = 0; i < spriteCount; i++) {
+                    this.destPos.x = (i * 9) % 320;
+                    this.destPos.y = ((i * 9) / 320 | 0) * 10 % 240;
+
+                    const sheet =
+                        textureMode === 'alternating'
+                            ? this.spriteSheets[i % this.spriteSheets.length]
+                            : this.spriteSheets[0];
+
+                    BT.drawSprite(sheet, this.sourceRect, this.destPos);
+                }
+
+                recordFrame(perf);
+            }
+        }
+
+        bootstrap(PerfSpritesTest, {
+            onError: markInitFailed,
+        });
+    </script>
+</body>
+
+</html>

--- a/tests/visual/fixtures/vite.config.ts
+++ b/tests/visual/fixtures/vite.config.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+
 import { defineConfig } from 'vite';
 import istanbul from 'vite-plugin-istanbul';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,6 +37,7 @@
   "include": [
     "src/**/*",
     "tests/perf/**/*.ts",
+    "tests/visual/**/*.ts",
     "vite.config.ts",
     "vitest.config.ts",
     "playwright.config.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,6 +34,14 @@
     /* Completeness */
     "skipLibCheck": true
   },
-  "include": ["src/**/*", "vite.config.ts", "vitest.config.ts", "playwright.config.ts", "*.d.ts"],
+  "include": [
+    "src/**/*",
+    "tests/perf/**/*.ts",
+    "vite.config.ts",
+    "vitest.config.ts",
+    "playwright.config.ts",
+    "playwright.perf.config.ts",
+    "*.d.ts"
+  ],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Introduced a new Playwright performance-testing suite targeting GPU frame-time benchmarks. Key changes include:

- Added `tests/perf/` directory with test scripts and performance scenarios.
- Created `playwright.perf.config.ts` for performance test configuration.
- Set up new test fixtures for visual benchmarks (`tests/visual/fixtures/perf-*.html`).
- Updated `eslint.config.js` to include `tests/perf` linting rules.
- Expanded `package.json` with new `test:perf` script for running performance tests.
- Updated `tsconfig.json` to include `tests/perf` TypeScript files in the project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds a Playwright-based performance testing suite for GPU frame-time benchmarks and supporting visual fixtures and tooling updates.

## Configuration & Infrastructure

- Added Playwright performance configuration: playwright.perf.config.ts
  - testDir: tests/perf, outputDir: test-results/perf
  - per-test timeout: 120s; single worker; fullyParallel: false
  - Chromium project with launch args enabling unsafe WebGPU, Vulkan features, and disabling the GPU sandbox
  - use.baseURL: http://127.0.0.1:5175 (webServer serves fixtures on port 5175)
  - screenshot: only-on-failure; trace: on-first-retry
  - CI settings: forbidOnly, retries=1, reporter=github; local reporter=list
  - Built-in Vite webServer serving tests/visual/fixtures using tests/visual/fixtures/vite.config.ts

- package.json
  - Added test:perf script: "playwright test -c playwright.perf.config.ts"

- tsconfig.json
  - Included tests/perf/**/*.ts, tests/visual/**/*.ts, and playwright.perf.config.ts in the compilation scope

- eslint.config.js
  - Narrowed global ignores to tests/visual/**/*.html (no longer ignore entire tests/** tree)
  - Expanded relaxed rules globs to include tests/perf/**/*.ts and tests/visual/**/*.ts
  - Added browser/node/ES2022 globals for test files and added globals.es2022 to config files
  - Disabled security/detect-non-literal-fs-filename for test files and relaxed various JSDoc/TypeScript rules

## Performance Test Framework

- tests/perf/perf.spec.ts
  - New Playwright test suite defining multiple perf scenarios (primitives, sprites (same/alternating), fonts, mixed)
  - Navigates to fixtures with scenario query params, waits for window.__PERF_COMPLETE__ or window.__INIT_FAILED__
  - Skips tests on init failure (e.g., WebGPU unavailable)
  - Validates frameTimes length, computes stats (min/max, median, p95, p99), attaches per-test JSON artifact, and aggregates all scenario results to test-results/perf/perf-results.json (timestamped)

- Tests run with a fixed baseURL pointing at the local Vite server (port 5175)

## Shared Utilities & Fixtures

- tests/visual/fixtures/perf-common.js
  - Exports helpers: readNumberParam, readStringParam, initializePerfState, recordFrame, markInitFailed, repeatText, createSpriteImage
  - Improved canvas handling: 2D context check, sprite image load error handling, markInitFailed usage on failures

- New HTML fixtures under tests/visual/fixtures:
  - perf-primitives.html — primitives workload (rects, lines, pixels)
  - perf-sprites.html — sprite blitting workload (configurable sprite count and textureMode)
  - perf-fonts.html — text/font rendering workload (configurable chars and lineWidth)
  - perf-mixed.html — combined workload mixing primitives, sprites, and text

Each fixture bootstraps a PerfXxxTest class that records frame timings via perf-common.js and routes initialization errors through markInitFailed.

## Other changes

- Minor import/whitespace cleanups in test helper files and small ESLint disable cleanups in performance test files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->