### PR TITLE
feat(ci): add benchmark job with PR comparison and regression detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,9 @@ jobs:
     name: Tier 1 Benchmarks
     runs-on: ubuntu-latest
     needs: quality
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}-benchmark
+      cancel-in-progress: true
     permissions:
       actions: read
       contents: read
@@ -199,12 +202,16 @@ jobs:
           retention-days: 14
 
       - name: Post benchmark PR comment
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
         uses: actions/github-script@v8
         env:
           BENCHMARK_COMMENT_PATH: benchmark-comment.md
         with:
           script: |
+            if (context.payload.pull_request?.head?.repo?.fork) {
+              return;
+            }
+
             const fs = require('node:fs');
             const marker = '<!-- benchmark-comparison -->';
             const body = fs.readFileSync(process.env.BENCHMARK_COMMENT_PATH, 'utf8');

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
     needs: quality
     if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'perf-tier-1')
     concurrency:
-      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.head_ref || github.ref }}-benchmark
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-benchmark
       cancel-in-progress: true
     permissions:
       actions: read
@@ -203,6 +203,7 @@ jobs:
             benchmark-comparison.json
             benchmark-comment.md
             benchmark-results.json
+          if-no-files-found: ignore
           retention-days: 14
 
       - name: Post benchmark PR comment
@@ -214,10 +215,6 @@ jobs:
           BENCHMARK_COMMENT_PATH: benchmark-comment.md
         with:
           script: |
-            if (context.payload.pull_request?.head?.repo?.fork || context.actor === 'dependabot[bot]') {
-              return;
-            }
-
             const fs = require('node:fs');
             const marker = '<!-- benchmark-comparison -->';
             const body = fs.readFileSync(process.env.BENCHMARK_COMMENT_PATH, 'utf8');
@@ -253,6 +250,10 @@ jobs:
         run: |
           node --input-type=module <<'EOF'
           import fs from 'node:fs';
+
+          if (!fs.existsSync('benchmark-comparison.json')) {
+              process.exit(0);
+          }
 
           const report = JSON.parse(fs.readFileSync('benchmark-comparison.json', 'utf8'));
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
   quality:
@@ -80,6 +81,7 @@ jobs:
     name: Tier 1 Benchmarks
     runs-on: ubuntu-latest
     needs: quality
+    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'perf-tier-1')
     concurrency:
       group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}-benchmark
       cancel-in-progress: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
     needs: quality
     if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'perf-tier-1')
     concurrency:
-      group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}-benchmark
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.head_ref || github.ref }}-benchmark
       cancel-in-progress: true
     permissions:
       actions: read
@@ -116,6 +116,7 @@ jobs:
         with:
           name: benchmark-results-current
           path: benchmark-results.json
+          if-no-files-found: error
           retention-days: 14
 
       - name: Upload main benchmark baseline
@@ -124,6 +125,7 @@ jobs:
         with:
           name: benchmark-baseline
           path: benchmark-results.json
+          if-no-files-found: error
           retention-days: 30
 
       - name: Find latest main benchmark baseline
@@ -204,13 +206,15 @@ jobs:
           retention-days: 14
 
       - name: Post benchmark PR comment
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
+        if:
+          github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && github.actor !=
+          'dependabot[bot]'
         uses: actions/github-script@v8
         env:
           BENCHMARK_COMMENT_PATH: benchmark-comment.md
         with:
           script: |
-            if (context.payload.pull_request?.head?.repo?.fork) {
+            if (context.payload.pull_request?.head?.repo?.fork || context.actor === 'dependabot[bot]') {
               return;
             }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,184 @@ jobs:
           path: dist/
           retention-days: 7
 
+  benchmark:
+    name: Tier 1 Benchmarks
+    runs-on: ubuntu-latest
+    needs: quality
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.26.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run Tier 1 benchmarks
+        run: pnpm bench:json
+
+      - name: Upload current benchmark results
+        uses: actions/upload-artifact@v7
+        with:
+          name: benchmark-results-current
+          path: benchmark-results.json
+          retention-days: 14
+
+      - name: Upload main benchmark baseline
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v7
+        with:
+          name: benchmark-baseline
+          path: benchmark-results.json
+          retention-days: 30
+
+      - name: Find latest main benchmark baseline
+        id: find-baseline
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const workflowId = 'ci.yml';
+            const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: workflowId,
+              branch: 'main',
+              event: 'push',
+              status: 'completed',
+              per_page: 100,
+            });
+
+            for (const run of runs) {
+              if (run.conclusion !== 'success') {
+                continue;
+              }
+
+              const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: run.id,
+                per_page: 100,
+              });
+              const baselineArtifact = artifacts.find(
+                (artifact) => artifact.name === 'benchmark-baseline' && artifact.expired === false,
+              );
+
+              if (!baselineArtifact) {
+                continue;
+              }
+
+              core.setOutput('found', 'true');
+              core.setOutput('download-url', baselineArtifact.archive_download_url);
+              core.setOutput('artifact-id', String(baselineArtifact.id));
+              core.setOutput('run-id', String(run.id));
+              return;
+            }
+
+            core.setOutput('found', 'false');
+
+      - name: Download main benchmark baseline
+        if: github.event_name == 'pull_request' && steps.find-baseline.outputs.found == 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          BASELINE_URL: ${{ steps.find-baseline.outputs.download-url }}
+        run: |
+          mkdir -p baseline-artifact
+          curl --fail --location \
+            --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+            --header "Accept: application/vnd.github+json" \
+            "${BASELINE_URL}" \
+            --output baseline-artifact.zip
+          unzip -o baseline-artifact.zip -d baseline-artifact
+
+      - name: Compare benchmark results
+        if: github.event_name == 'pull_request'
+        run: >
+          node scripts/compare-benchmarks.mjs --current benchmark-results.json --baseline
+          baseline-artifact/benchmark-results.json --json-out benchmark-comparison.json --markdown-out
+          benchmark-comment.md --threshold 10
+
+      - name: Upload benchmark comparison artifacts
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v7
+        with:
+          name: benchmark-comparison
+          path: |
+            benchmark-comparison.json
+            benchmark-comment.md
+            benchmark-results.json
+          retention-days: 14
+
+      - name: Post benchmark PR comment
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v8
+        env:
+          BENCHMARK_COMMENT_PATH: benchmark-comment.md
+        with:
+          script: |
+            const fs = require('node:fs');
+            const marker = '<!-- benchmark-comparison -->';
+            const body = fs.readFileSync(process.env.BENCHMARK_COMMENT_PATH, 'utf8');
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const existingComment = comments.find((comment) =>
+              comment.user?.type === 'Bot' && comment.body?.includes(marker),
+            );
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.id,
+                body,
+              });
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });
+
+      - name: Fail on benchmark regressions
+        if: github.event_name == 'pull_request'
+        run: |
+          node --input-type=module <<'EOF'
+          import fs from 'node:fs';
+
+          const report = JSON.parse(fs.readFileSync('benchmark-comparison.json', 'utf8'));
+
+          if (!report.hasBaseline) {
+              process.exit(0);
+          }
+
+          const hasFailures = report.summary.regressions > 0 || report.summary.missingBenchmarks > 0;
+
+          if (hasFailures) {
+              process.exit(1);
+          }
+          EOF
+
   # Placeholder for tests - will run when tests are added
   test:
     name: Run Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ jobs:
   quality:
     name: Code Quality
     runs-on: ubuntu-latest
+    if:
+      github.event_name != 'pull_request' || !contains(fromJSON('["labeled","unlabeled"]'), github.event.action) ||
+      github.event.label.name == 'perf-tier-1'
 
     steps:
       - name: Checkout code
@@ -46,6 +49,9 @@ jobs:
     name: Build Library
     runs-on: ubuntu-latest
     needs: quality
+    if:
+      github.event_name != 'pull_request' || !contains(fromJSON('["labeled","unlabeled"]'), github.event.action) ||
+      github.event.label.name == 'perf-tier-1'
 
     steps:
       - name: Checkout code
@@ -126,7 +132,7 @@ jobs:
           name: benchmark-baseline
           path: benchmark-results.json
           if-no-files-found: error
-          retention-days: 30
+          retention-days: 90
 
       - name: Find latest main benchmark baseline
         id: find-baseline

--- a/scripts/compare-benchmarks.mjs
+++ b/scripts/compare-benchmarks.mjs
@@ -4,6 +4,18 @@ import path from 'node:path';
 const COMMENT_MARKER = '<!-- benchmark-comparison -->';
 const DEFAULT_THRESHOLD = 10;
 
+/**
+ * Parses CLI arguments for the benchmark comparison command.
+ *
+ * @param {string[]} argv Raw CLI arguments after the node/script prefix.
+ * @returns {{
+ *   baseline: string | null,
+ *   current: string | null,
+ *   jsonOut: string,
+ *   markdownOut: string,
+ *   threshold: number,
+ * }} Parsed command options.
+ */
 function parseArgs(argv) {
     const args = {
         baseline: null,
@@ -63,20 +75,46 @@ function parseArgs(argv) {
     return args;
 }
 
+/**
+ * Ensures that the parent directory for an output file exists.
+ *
+ * @param {string} filePath Output file path.
+ * @returns {void}
+ */
 function ensureParentDirectory(filePath) {
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
 }
 
+/**
+ * Reads and parses a JSON file from disk.
+ *
+ * @param {string} filePath JSON file path.
+ * @returns {unknown} Parsed JSON value.
+ */
 function readJsonFile(filePath) {
     return JSON.parse(fs.readFileSync(filePath, 'utf8'));
 }
 
+/**
+ * Throws when a required condition is not met.
+ *
+ * @param {unknown} condition Condition to evaluate.
+ * @param {string} message Error message for failed assertions.
+ * @returns {void}
+ */
 function assert(condition, message) {
     if (!condition) {
         throw new Error(message);
     }
 }
 
+/**
+ * Validates the top-level shape of a Vitest benchmark report before deeper parsing.
+ *
+ * @param {unknown} report Parsed benchmark report JSON.
+ * @param {string} sourceLabel Human-readable source label for error messages.
+ * @returns {void}
+ */
 function validateBenchmarkReport(report, sourceLabel) {
     assert(
         report !== null && typeof report === 'object',
@@ -85,6 +123,19 @@ function validateBenchmarkReport(report, sourceLabel) {
     assert(Array.isArray(report.files), `Invalid benchmark report in ${sourceLabel}: report.files must be an array`);
 }
 
+/**
+ * Flattens the nested Vitest benchmark report into comparable benchmark entries.
+ *
+ * @param {{ files: unknown[], __sourceLabel?: string }} report Parsed benchmark report.
+ * @returns {Array<{
+ *   matchKey: string,
+ *   label: string,
+ *   suite: string,
+ *   name: string,
+ *   hz: number,
+ *   filepath: string,
+ * }>} Flattened benchmark entries.
+ */
 function flattenBenchmarks(report) {
     const entries = [];
     const reportLabel = report.__sourceLabel ?? 'benchmark report';
@@ -138,6 +189,35 @@ function flattenBenchmarks(report) {
     return entries;
 }
 
+/**
+ * Compares the current benchmark report against an optional baseline report.
+ *
+ * @param {{ files: unknown[], __sourceLabel?: string }} currentReport Current benchmark report.
+ * @param {{ files: unknown[], __sourceLabel?: string } | null} baselineReport Baseline benchmark report, if available.
+ * @param {number} thresholdPct Maximum allowed slowdown percentage before failure.
+ * @returns {{
+ *   generatedAt: string,
+ *   hasBaseline: boolean,
+ *   thresholdPct: number,
+ *   summary: {
+ *     total: number,
+ *     compared: number,
+ *     regressions: number,
+ *     improvements: number,
+ *     pass: number,
+ *     newBenchmarks: number,
+ *     missingBenchmarks: number,
+ *   },
+ *   benchmarks: Array<{
+ *     name: string,
+ *     suite: string,
+ *     baselineHz: number | null,
+ *     currentHz: number | null,
+ *     deltaPct: number | null,
+ *     status: string,
+ *   }>,
+ * }} Comparison report used by CI and PR comments.
+ */
 function compareReports(currentReport, baselineReport, thresholdPct) {
     const currentEntries = flattenBenchmarks(currentReport);
     const baselineEntries = baselineReport ? flattenBenchmarks(baselineReport) : [];
@@ -211,6 +291,12 @@ function compareReports(currentReport, baselineReport, thresholdPct) {
     };
 }
 
+/**
+ * Formats an ops/sec value for human-readable markdown output.
+ *
+ * @param {number | null} value Benchmark throughput value.
+ * @returns {string} Formatted throughput string.
+ */
 function formatHz(value) {
     if (value === null) {
         return 'n/a';
@@ -222,6 +308,12 @@ function formatHz(value) {
     });
 }
 
+/**
+ * Formats a benchmark delta percentage for markdown output.
+ *
+ * @param {number | null} value Percentage delta relative to baseline.
+ * @returns {string} Formatted delta string.
+ */
 function formatDelta(value) {
     if (value === null) {
         return 'n/a';
@@ -232,6 +324,12 @@ function formatDelta(value) {
     return `${sign}${value.toFixed(2)}%`;
 }
 
+/**
+ * Converts an internal benchmark status into the PR comment label.
+ *
+ * @param {string} status Internal benchmark status.
+ * @returns {string} Human-readable status label.
+ */
 function formatStatus(status) {
     switch (status) {
         case 'fail':
@@ -247,10 +345,39 @@ function formatStatus(status) {
     }
 }
 
+/**
+ * Escapes a markdown table cell value.
+ *
+ * @param {string} value Raw markdown cell content.
+ * @returns {string} Escaped markdown-safe value.
+ */
 function escapeMarkdownCell(value) {
     return value.replaceAll('|', '\\|');
 }
 
+/**
+ * Builds the markdown body for the benchmark PR comment.
+ *
+ * @param {{
+ *   hasBaseline: boolean,
+ *   thresholdPct: number,
+ *   summary: {
+ *     compared: number,
+ *     regressions: number,
+ *     improvements: number,
+ *     newBenchmarks: number,
+ *     missingBenchmarks: number,
+ *   },
+ *   benchmarks: Array<{
+ *     name: string,
+ *     baselineHz: number | null,
+ *     currentHz: number | null,
+ *     deltaPct: number | null,
+ *     status: string,
+ *   }>,
+ * }} report Comparison report.
+ * @returns {string} Markdown comment body.
+ */
 function buildMarkdown(report) {
     const lines = [COMMENT_MARKER, '## Tier 1 Benchmark Comparison', ''];
 
@@ -287,11 +414,23 @@ function buildMarkdown(report) {
     return `${lines.join('\n')}\n`;
 }
 
+/**
+ * Writes a file to disk, creating parent directories when needed.
+ *
+ * @param {string} filePath Output file path.
+ * @param {string} content File contents.
+ * @returns {void}
+ */
 function writeFile(filePath, content) {
     ensureParentDirectory(filePath);
     fs.writeFileSync(filePath, content);
 }
 
+/**
+ * Runs the benchmark comparison CLI.
+ *
+ * @returns {void}
+ */
 function main() {
     const args = parseArgs(process.argv.slice(2));
     const currentReport = readJsonFile(args.current);

--- a/scripts/compare-benchmarks.mjs
+++ b/scripts/compare-benchmarks.mjs
@@ -71,16 +71,61 @@ function readJsonFile(filePath) {
     return JSON.parse(fs.readFileSync(filePath, 'utf8'));
 }
 
+function assert(condition, message) {
+    if (!condition) {
+        throw new Error(message);
+    }
+}
+
+function validateBenchmarkReport(report, sourceLabel) {
+    assert(
+        report !== null && typeof report === 'object',
+        `Invalid benchmark report in ${sourceLabel}: expected object`,
+    );
+    assert(Array.isArray(report.files), `Invalid benchmark report in ${sourceLabel}: report.files must be an array`);
+}
+
 function flattenBenchmarks(report) {
     const entries = [];
+    const reportLabel = report.__sourceLabel ?? 'benchmark report';
 
-    for (const file of report.files ?? []) {
-        for (const group of file.groups ?? []) {
-            for (const benchmark of group.benchmarks ?? []) {
-                const key = `${group.fullName} > ${benchmark.name}`;
+    validateBenchmarkReport(report, reportLabel);
+
+    for (const [fileIndex, file] of report.files.entries()) {
+        assert(file !== null && typeof file === 'object', `Invalid file entry at index ${fileIndex} in ${reportLabel}`);
+        assert(typeof file.filepath === 'string', `Invalid file.filepath at index ${fileIndex} in ${reportLabel}`);
+        assert(Array.isArray(file.groups), `Invalid file.groups for ${file.filepath} in ${reportLabel}`);
+
+        for (const [groupIndex, group] of file.groups.entries()) {
+            assert(
+                group !== null && typeof group === 'object',
+                `Invalid group entry at index ${groupIndex} for ${file.filepath} in ${reportLabel}`,
+            );
+            assert(
+                typeof group.fullName === 'string',
+                `Invalid group.fullName at index ${groupIndex} for ${file.filepath} in ${reportLabel}`,
+            );
+            assert(Array.isArray(group.benchmarks), `Invalid group.benchmarks for ${group.fullName} in ${reportLabel}`);
+
+            for (const [benchmarkIndex, benchmark] of group.benchmarks.entries()) {
+                assert(
+                    benchmark !== null && typeof benchmark === 'object',
+                    `Invalid benchmark entry at index ${benchmarkIndex} for ${group.fullName} in ${reportLabel}`,
+                );
+                assert(
+                    typeof benchmark.name === 'string',
+                    `Invalid benchmark.name at index ${benchmarkIndex} for ${group.fullName} in ${reportLabel}`,
+                );
+                assert(
+                    Number.isFinite(benchmark.hz),
+                    `Invalid benchmark.hz for ${group.fullName} > ${benchmark.name} in ${reportLabel}`,
+                );
+                const matchKey = `${file.filepath}::${group.fullName}::${benchmark.name}`;
+                const label = `${group.fullName} > ${benchmark.name}`;
 
                 entries.push({
-                    key,
+                    matchKey,
+                    label,
                     suite: group.fullName,
                     name: benchmark.name,
                     hz: benchmark.hz,
@@ -96,8 +141,8 @@ function flattenBenchmarks(report) {
 function compareReports(currentReport, baselineReport, thresholdPct) {
     const currentEntries = flattenBenchmarks(currentReport);
     const baselineEntries = baselineReport ? flattenBenchmarks(baselineReport) : [];
-    const currentByKey = new Map(currentEntries.map((entry) => [entry.key, entry]));
-    const baselineByKey = new Map(baselineEntries.map((entry) => [entry.key, entry]));
+    const currentByKey = new Map(currentEntries.map((entry) => [entry.matchKey, entry]));
+    const baselineByKey = new Map(baselineEntries.map((entry) => [entry.matchKey, entry]));
     const keys = [...new Set([...baselineByKey.keys(), ...currentByKey.keys()])].sort((left, right) =>
         left.localeCompare(right),
     );
@@ -108,7 +153,7 @@ function compareReports(currentReport, baselineReport, thresholdPct) {
 
         if (!baselineEntry) {
             return {
-                name: key,
+                name: currentEntry?.label ?? key,
                 suite: currentEntry?.suite ?? key,
                 baselineHz: null,
                 currentHz: currentEntry?.hz ?? null,
@@ -119,7 +164,7 @@ function compareReports(currentReport, baselineReport, thresholdPct) {
 
         if (!currentEntry) {
             return {
-                name: key,
+                name: baselineEntry.label,
                 suite: baselineEntry.suite,
                 baselineHz: baselineEntry.hz,
                 currentHz: null,
@@ -138,7 +183,7 @@ function compareReports(currentReport, baselineReport, thresholdPct) {
         }
 
         return {
-            name: key,
+            name: currentEntry.label,
             suite: currentEntry.suite,
             baselineHz: baselineEntry.hz,
             currentHz: currentEntry.hz,
@@ -250,7 +295,13 @@ function writeFile(filePath, content) {
 function main() {
     const args = parseArgs(process.argv.slice(2));
     const currentReport = readJsonFile(args.current);
+    currentReport.__sourceLabel = args.current;
     const baselineReport = args.baseline && fs.existsSync(args.baseline) ? readJsonFile(args.baseline) : null;
+
+    if (baselineReport !== null) {
+        baselineReport.__sourceLabel = args.baseline;
+    }
+
     const report = compareReports(currentReport, baselineReport, args.threshold);
 
     writeFile(args.jsonOut, JSON.stringify(report, null, 2));

--- a/scripts/compare-benchmarks.mjs
+++ b/scripts/compare-benchmarks.mjs
@@ -1,0 +1,260 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const COMMENT_MARKER = '<!-- benchmark-comparison -->';
+const DEFAULT_THRESHOLD = 10;
+
+function parseArgs(argv) {
+    const args = {
+        baseline: null,
+        current: null,
+        jsonOut: 'benchmark-comparison.json',
+        markdownOut: 'benchmark-comment.md',
+        threshold: DEFAULT_THRESHOLD,
+    };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        // eslint-disable-next-line security/detect-object-injection -- CLI flags are parsed from a fixed argv array shape.
+        const value = argv[index];
+        const nextValue = argv[index + 1];
+
+        if (!value.startsWith('--')) {
+            continue;
+        }
+
+        if (nextValue === undefined) {
+            throw new Error(`Missing value for argument: ${value}`);
+        }
+
+        switch (value) {
+            case '--baseline':
+                args.baseline = nextValue;
+                index += 1;
+                break;
+            case '--current':
+                args.current = nextValue;
+                index += 1;
+                break;
+            case '--json-out':
+                args.jsonOut = nextValue;
+                index += 1;
+                break;
+            case '--markdown-out':
+                args.markdownOut = nextValue;
+                index += 1;
+                break;
+            case '--threshold':
+                args.threshold = Number(nextValue);
+                index += 1;
+                break;
+            default:
+                throw new Error(`Unknown argument: ${value}`);
+        }
+    }
+
+    if (!args.current) {
+        throw new Error('The --current argument is required');
+    }
+
+    if (!Number.isFinite(args.threshold) || args.threshold < 0) {
+        throw new Error(`Invalid --threshold value: ${String(args.threshold)}`);
+    }
+
+    return args;
+}
+
+function ensureParentDirectory(filePath) {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+}
+
+function readJsonFile(filePath) {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function flattenBenchmarks(report) {
+    const entries = [];
+
+    for (const file of report.files ?? []) {
+        for (const group of file.groups ?? []) {
+            for (const benchmark of group.benchmarks ?? []) {
+                const key = `${group.fullName} > ${benchmark.name}`;
+
+                entries.push({
+                    key,
+                    suite: group.fullName,
+                    name: benchmark.name,
+                    hz: benchmark.hz,
+                    filepath: file.filepath,
+                });
+            }
+        }
+    }
+
+    return entries;
+}
+
+function compareReports(currentReport, baselineReport, thresholdPct) {
+    const currentEntries = flattenBenchmarks(currentReport);
+    const baselineEntries = baselineReport ? flattenBenchmarks(baselineReport) : [];
+    const currentByKey = new Map(currentEntries.map((entry) => [entry.key, entry]));
+    const baselineByKey = new Map(baselineEntries.map((entry) => [entry.key, entry]));
+    const keys = [...new Set([...baselineByKey.keys(), ...currentByKey.keys()])].sort((left, right) =>
+        left.localeCompare(right),
+    );
+
+    const benchmarks = keys.map((key) => {
+        const baselineEntry = baselineByKey.get(key) ?? null;
+        const currentEntry = currentByKey.get(key) ?? null;
+
+        if (!baselineEntry) {
+            return {
+                name: key,
+                suite: currentEntry?.suite ?? key,
+                baselineHz: null,
+                currentHz: currentEntry?.hz ?? null,
+                deltaPct: null,
+                status: 'new',
+            };
+        }
+
+        if (!currentEntry) {
+            return {
+                name: key,
+                suite: baselineEntry.suite,
+                baselineHz: baselineEntry.hz,
+                currentHz: null,
+                deltaPct: null,
+                status: 'missing',
+            };
+        }
+
+        const deltaPct = ((currentEntry.hz - baselineEntry.hz) / baselineEntry.hz) * 100;
+        let status = 'pass';
+
+        if (deltaPct < thresholdPct * -1) {
+            status = 'fail';
+        } else if (deltaPct > 0) {
+            status = 'improved';
+        }
+
+        return {
+            name: key,
+            suite: currentEntry.suite,
+            baselineHz: baselineEntry.hz,
+            currentHz: currentEntry.hz,
+            deltaPct,
+            status,
+        };
+    });
+
+    const summary = {
+        total: benchmarks.length,
+        compared: benchmarks.filter((benchmark) => benchmark.deltaPct !== null).length,
+        regressions: benchmarks.filter((benchmark) => benchmark.status === 'fail').length,
+        improvements: benchmarks.filter((benchmark) => benchmark.status === 'improved').length,
+        pass: benchmarks.filter((benchmark) => benchmark.status === 'pass').length,
+        newBenchmarks: benchmarks.filter((benchmark) => benchmark.status === 'new').length,
+        missingBenchmarks: benchmarks.filter((benchmark) => benchmark.status === 'missing').length,
+    };
+
+    return {
+        generatedAt: new Date().toISOString(),
+        hasBaseline: baselineReport !== null,
+        thresholdPct,
+        summary,
+        benchmarks,
+    };
+}
+
+function formatHz(value) {
+    if (value === null) {
+        return 'n/a';
+    }
+
+    return value.toLocaleString('en-US', {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+    });
+}
+
+function formatDelta(value) {
+    if (value === null) {
+        return 'n/a';
+    }
+
+    const sign = value > 0 ? '+' : '';
+
+    return `${sign}${value.toFixed(2)}%`;
+}
+
+function formatStatus(status) {
+    switch (status) {
+        case 'fail':
+            return 'FAIL';
+        case 'improved':
+            return 'IMPROVED';
+        case 'new':
+            return 'NEW';
+        case 'missing':
+            return 'MISSING';
+        default:
+            return 'PASS';
+    }
+}
+
+function escapeMarkdownCell(value) {
+    return value.replaceAll('|', '\\|');
+}
+
+function buildMarkdown(report) {
+    const lines = [COMMENT_MARKER, '## Tier 1 Benchmark Comparison', ''];
+
+    if (!report.hasBaseline) {
+        lines.push(
+            'No `main` branch benchmark baseline artifact is available yet. This run produced fresh benchmark results and uploaded them as artifacts.',
+            '',
+            `Configured regression threshold: ${report.thresholdPct}% slowdown.`,
+        );
+
+        return `${lines.join('\n')}\n`;
+    }
+
+    lines.push(
+        `Compared ${report.summary.compared} benchmarks against the latest \`main\` baseline. Regression threshold: ${report.thresholdPct}% slowdown.`,
+        '',
+        `Regressions: ${report.summary.regressions} | Improvements: ${report.summary.improvements} | New: ${report.summary.newBenchmarks} | Missing: ${report.summary.missingBenchmarks}`,
+        '',
+        '<details>',
+        '<summary>Benchmark table</summary>',
+        '',
+        '| Benchmark | Baseline ops/sec | Current ops/sec | Delta | Status |',
+        '| --- | ---: | ---: | ---: | --- |',
+    );
+
+    for (const benchmark of report.benchmarks) {
+        lines.push(
+            `| ${escapeMarkdownCell(benchmark.name)} | ${formatHz(benchmark.baselineHz)} | ${formatHz(benchmark.currentHz)} | ${formatDelta(benchmark.deltaPct)} | ${formatStatus(benchmark.status)} |`,
+        );
+    }
+
+    lines.push('', '</details>');
+
+    return `${lines.join('\n')}\n`;
+}
+
+function writeFile(filePath, content) {
+    ensureParentDirectory(filePath);
+    fs.writeFileSync(filePath, content);
+}
+
+function main() {
+    const args = parseArgs(process.argv.slice(2));
+    const currentReport = readJsonFile(args.current);
+    const baselineReport = args.baseline && fs.existsSync(args.baseline) ? readJsonFile(args.baseline) : null;
+    const report = compareReports(currentReport, baselineReport, args.threshold);
+
+    writeFile(args.jsonOut, JSON.stringify(report, null, 2));
+    writeFile(args.markdownOut, buildMarkdown(report));
+}
+
+main();


### PR DESCRIPTION
Introduced a CI workflow for Tier 1 benchmarks to automate performance comparison and regression detection in pull requests.

- Added `benchmark` job in `ci.yml` with the following steps:
  - Run benchmarks and upload results as artifacts.
  - Compare with the latest baseline from the `main` branch.
  - Generate performance comparison reports (JSON and Markdown).
  - Post a summary comment on pull requests, highlighting regressions or improvements.
  - Fail the workflow if performance regressions exceed the 10% threshold.

- Created `scripts/compare-benchmarks.mjs`:
  - Parses and compares benchmark reports.
  - Outputs detailed JSON and Markdown results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes Overview

This PR adds an automated Tier 1 benchmark CI workflow that runs on pushes to main and on PRs labeled perf-tier-1. It runs benchmarks, persists a baseline on main, compares PR results to the latest successful non-expired baseline from main, generates JSON and Markdown comparison reports, posts/updates a PR comment containing the comparison, and can fail the workflow when regressions exceed a configurable slowdown threshold (default 10%).

## Files Changed

### .github/workflows/ci.yml
- Adds "Tier 1 Benchmarks" job that:
  - Triggers on push to main and on PR events (opened, synchronize, reopened, labeled, unlabeled); the job runs for PRs only when the perf-tier-1 label is present or on pushes to main.
  - Adds job-level conditional execution to existing jobs so `quality` and `build-library` run for non-PR events or when the PR event is not a label/unlabel action, and are skipped when the PR label `perf-tier-1` is present.
  - Depends on the quality job and runs pnpm bench:json to produce benchmark-results.json.
  - Uploads current run results as artifact name benchmark-results-current and, on pushes to main, uploads the same file as benchmark-baseline. Artifact retention has been increased (baseline/current retention raised from prior values to 90 days).
  - Uses job-level concurrency with a group keyed to the workflow name and either the PR number or ref to avoid overlapping runs and cancel in-progress ones.
  - On PRs, locates the latest successful, non-expired benchmark-baseline artifact from main by scanning completed main push workflow runs (via actions/github-script). If found, the workflow downloads and unzips the baseline artifact, runs scripts/compare-benchmarks.mjs to produce benchmark-comparison.json and benchmark-comment.md, and uploads comparison artifacts (benchmark-comparison.json, benchmark-comment.md, benchmark-results.json) with if-no-files-found: ignore.
  - Posts or updates a PR comment containing the <!-- benchmark-comparison --> marker using actions/github-script; the step skips forked PRs and actions triggered by dependabot[bot].
  - Fails the PR job when the generated benchmark-comparison.json reports regressions or missing benchmarks beyond the configured threshold; if no baseline is available the job emits fresh-results semantics and exits successfully.

### scripts/compare-benchmarks.mjs
- New Node.js CLI script that compares current and optional baseline Vitest-style JSON benchmark reports and emits JSON and Markdown outputs.
- CLI options: --current (required), --baseline (optional), --json-out, --markdown-out, --threshold (number, default 10).
- Validates arguments and report shape, flattens nested reports (files → groups → benchmarks) into keyed entries (filepath::group::benchmark) for robust matching.
- For each benchmark key:
  - Marks entries as new (only in current) or missing (only in baseline).
  - For matched entries computes deltaPct = (currentHz - baselineHz) / baselineHz * 100 and sets status:
    - fail when slowdown exceeds the negative threshold,
    - improved when current > baseline,
    - pass otherwise.
- Produces a JSON comparison report including timestamp, whether a baseline was found, threshold, summary counts (total, compared, regressions, improvements, pass, new, missing) and per-benchmark details.
- Produces a Markdown PR comment prefixed with <!-- benchmark-comparison -->; if no baseline exists the comment indicates fresh results.
- Creates output directories as needed and surfaces clear validation errors for malformed inputs.

## Commits / Developer Notes
- Adds label-based conditional execution for `quality` and `build-library` jobs to avoid running full CI when only benchmarking is requested via the perf-tier-1 label.
- Increases benchmark artifact retention (baseline/current) to 90 days.
- Baseline discovery moved into an actions/github-script step that scans main push workflow runs and selects the latest successful non-expired benchmark-baseline artifact.
- Comparison logic implemented in scripts/compare-benchmarks.mjs with stricter validation and clearer output formats.

## Impact

Automates performance comparison during code review, surfaces regressions inline on PRs, and enforces a configurable regression threshold (default 10%) that can fail CI to prevent significant performance regressions from being merged.

Lines changed: +198 / -0
<!-- end of auto-generated comment: release notes by coderabbit.ai -->