### PR TITLE
feat(renderer): rework primitive pipeline to use palette indices

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,7 @@ jobs:
         run: >
           node scripts/compare-tier-1-benchmarks.mjs --current benchmark-results.json --baseline
           baseline-artifact/benchmark-results.json --json-out benchmark-comparison.json --markdown-out
-          benchmark-comment.md --threshold 10
+          benchmark-comment.md --threshold 15
 
       - name: Upload benchmark comparison artifacts
         if: github.event_name == 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,7 +391,7 @@ jobs:
           if [ "${{ steps.find-perf-baseline.outputs.found }}" = "true" ]; then
             node scripts/compare-tier-2-perf-results.mjs \
               --current test-results/perf/perf-results.json \
-              --baseline perf-baseline-artifact/test-results/perf/perf-results.json \
+              --baseline perf-baseline-artifact/perf-results.json \
               --json-out perf-comparison.json \
               --markdown-out perf-comment.md \
               --threshold 50

--- a/src/BlitTech.test.ts
+++ b/src/BlitTech.test.ts
@@ -1,4 +1,5 @@
 // noinspection DuplicatedCode
+// @vitest-environment happy-dom
 
 /**
  * Unit tests for the public `BT` facade exported from `BlitTech.ts`.
@@ -8,7 +9,7 @@
  * suppression behavior used by facade helpers.
  */
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { BitmapFont, HardwareSettings } from './BlitTech';
 import { BT, Color32, Palette, Rect2i, SpriteSheet, Vector2i } from './BlitTech';
@@ -467,6 +468,75 @@ describe('BT.printFont', () => {
         BT.printFont(font, new Vector2i(0, 0), 'Hi');
 
         expect(spy).toHaveBeenCalledWith(font, expect.anything(), 'Hi', undefined);
+    });
+});
+
+// #endregion
+
+// #region BT.captureFrame / BT.downloadFrame
+
+describe('BT.captureFrame', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('delegates to BTAPI.instance.captureFrame and returns its result', async () => {
+        const mockBlob = new Blob(['test'], { type: 'image/png' });
+        const spy = vi.spyOn(BTAPI.instance, 'captureFrame').mockResolvedValue(mockBlob);
+
+        const result = await BT.captureFrame();
+
+        expect(spy).toHaveBeenCalledOnce();
+        expect(result).toBe(mockBlob);
+    });
+});
+
+describe('BT.downloadFrame', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('calls captureFrame, creates object URL, clicks anchor, and revokes URL', async () => {
+        const mockBlob = new Blob(['test'], { type: 'image/png' });
+
+        vi.spyOn(BTAPI.instance, 'captureFrame').mockResolvedValue(mockBlob);
+
+        const mockUrl = 'blob:mock-url';
+        const createObjectURL = vi.fn().mockReturnValue(mockUrl);
+        const revokeObjectURL = vi.fn();
+
+        vi.stubGlobal('URL', { createObjectURL, revokeObjectURL });
+
+        const mockAnchor = { href: '', download: '', click: vi.fn() };
+
+        vi.spyOn(document, 'createElement').mockReturnValue(mockAnchor as unknown as HTMLAnchorElement);
+
+        await BT.downloadFrame('screenshot.png');
+
+        expect(createObjectURL).toHaveBeenCalledWith(mockBlob);
+        expect(mockAnchor.href).toBe(mockUrl);
+        expect(mockAnchor.download).toBe('screenshot.png');
+        expect(mockAnchor.click).toHaveBeenCalledOnce();
+        expect(revokeObjectURL).toHaveBeenCalledWith(mockUrl);
+    });
+
+    it('uses the default filename when none is provided', async () => {
+        const mockBlob = new Blob(['test'], { type: 'image/png' });
+
+        vi.spyOn(BTAPI.instance, 'captureFrame').mockResolvedValue(mockBlob);
+        vi.stubGlobal('URL', { createObjectURL: vi.fn().mockReturnValue('blob:x'), revokeObjectURL: vi.fn() });
+
+        const mockAnchor = { href: '', download: '', click: vi.fn() };
+
+        vi.spyOn(document, 'createElement').mockReturnValue(mockAnchor as unknown as HTMLAnchorElement);
+
+        await BT.downloadFrame();
+
+        expect(mockAnchor.download).toBe('blit-tech-capture.png');
     });
 });
 

--- a/src/BlitTech.test.ts
+++ b/src/BlitTech.test.ts
@@ -177,12 +177,18 @@ describe('BT.paletteGet', () => {
         vi.restoreAllMocks();
     });
 
-    it('delegates to BTAPI.instance.getPalette', () => {
+    it('returns palette when one is set', () => {
         const palette = new Palette(16);
 
         vi.spyOn(BTAPI.instance, 'getPalette').mockReturnValue(palette);
 
         expect(BT.paletteGet()).toBe(palette);
+    });
+
+    it('throws when no palette is set', () => {
+        vi.spyOn(BTAPI.instance, 'getPalette').mockReturnValue(null);
+
+        expect(() => BT.paletteGet()).toThrow('No active palette. Call BT.paletteSet() first.');
     });
 });
 
@@ -197,11 +203,10 @@ describe('BT.clear', () => {
 
     it('delegates to BTAPI.instance.setClearColor', () => {
         const spy = vi.spyOn(BTAPI.instance, 'setClearColor').mockReturnValue(undefined);
-        const color = Color32.black();
 
-        BT.clear(color);
+        BT.clear(1);
 
-        expect(spy).toHaveBeenCalledWith(color);
+        expect(spy).toHaveBeenCalledWith(1);
     });
 });
 
@@ -212,12 +217,11 @@ describe('BT.clearRect', () => {
 
     it('delegates to BTAPI.instance.clearRect', () => {
         const spy = vi.spyOn(BTAPI.instance, 'clearRect').mockReturnValue(undefined);
-        const color = Color32.black();
         const rect = new Rect2i(0, 0, 100, 100);
 
-        BT.clearRect(color, rect);
+        BT.clearRect(1, rect);
 
-        expect(spy).toHaveBeenCalledWith(color, rect);
+        expect(spy).toHaveBeenCalledWith(1, rect);
     });
 });
 
@@ -233,11 +237,10 @@ describe('BT.drawPixel', () => {
     it('delegates to BTAPI.instance.drawPixel', () => {
         const spy = vi.spyOn(BTAPI.instance, 'drawPixel').mockReturnValue(undefined);
         const pos = new Vector2i(5, 10);
-        const color = Color32.red();
 
-        BT.drawPixel(pos, color);
+        BT.drawPixel(pos, 2);
 
-        expect(spy).toHaveBeenCalledWith(pos, color);
+        expect(spy).toHaveBeenCalledWith(pos, 2);
     });
 });
 
@@ -250,11 +253,10 @@ describe('BT.drawLine', () => {
         const spy = vi.spyOn(BTAPI.instance, 'drawLine').mockReturnValue(undefined);
         const p0 = new Vector2i(0, 0);
         const p1 = new Vector2i(50, 50);
-        const color = Color32.green();
 
-        BT.drawLine(p0, p1, color);
+        BT.drawLine(p0, p1, 3);
 
-        expect(spy).toHaveBeenCalledWith(p0, p1, color);
+        expect(spy).toHaveBeenCalledWith(p0, p1, 3);
     });
 });
 
@@ -266,11 +268,10 @@ describe('BT.drawRect', () => {
     it('delegates to BTAPI.instance.drawRect', () => {
         const spy = vi.spyOn(BTAPI.instance, 'drawRect').mockReturnValue(undefined);
         const rect = new Rect2i(10, 10, 40, 30);
-        const color = Color32.blue();
 
-        BT.drawRect(rect, color);
+        BT.drawRect(rect, 4);
 
-        expect(spy).toHaveBeenCalledWith(rect, color);
+        expect(spy).toHaveBeenCalledWith(rect, 4);
     });
 });
 
@@ -282,11 +283,10 @@ describe('BT.drawRectFill', () => {
     it('delegates to BTAPI.instance.drawRectFill', () => {
         const spy = vi.spyOn(BTAPI.instance, 'drawRectFill').mockReturnValue(undefined);
         const rect = new Rect2i(0, 0, 20, 20);
-        const color = Color32.white();
 
-        BT.drawRectFill(rect, color);
+        BT.drawRectFill(rect, 8);
 
-        expect(spy).toHaveBeenCalledWith(rect, color);
+        expect(spy).toHaveBeenCalledWith(rect, 8);
     });
 });
 
@@ -406,11 +406,10 @@ describe('BT.print', () => {
     it('delegates to BTAPI.instance.drawText', () => {
         const spy = vi.spyOn(BTAPI.instance, 'drawText').mockReturnValue(undefined);
         const pos = new Vector2i(10, 10);
-        const color = Color32.white();
 
-        BT.print(pos, color, 'Hello');
+        BT.print(pos, 8, 'Hello');
 
-        expect(spy).toHaveBeenCalledWith(pos, color, 'Hello');
+        expect(spy).toHaveBeenCalledWith(pos, 8, 'Hello');
     });
 });
 

--- a/src/BlitTech.test.ts
+++ b/src/BlitTech.test.ts
@@ -220,9 +220,9 @@ describe('BT.clearRect', () => {
         const spy = vi.spyOn(BTAPI.instance, 'clearRect').mockReturnValue(undefined);
         const rect = new Rect2i(0, 0, 100, 100);
 
-        BT.clearRect(1, rect);
+        BT.clearRect(rect, 1);
 
-        expect(spy).toHaveBeenCalledWith(1, rect);
+        expect(spy).toHaveBeenCalledWith(rect, 1);
     });
 });
 

--- a/src/BlitTech.ts
+++ b/src/BlitTech.ts
@@ -206,12 +206,17 @@ export const BT = {
     /**
      * Gets the active engine palette.
      *
-     * Lazily creates a default VGA palette if none has been set yet.
-     *
      * @returns Active palette.
+     * @throws Error if no palette has been set.
      */
     paletteGet: (): Palette => {
-        return BTAPI.instance.getPalette();
+        const palette = BTAPI.instance.getPalette();
+
+        if (!palette) {
+            throw new Error('No active palette. Call BT.paletteSet() first.');
+        }
+
+        return palette;
     },
 
     // #endregion
@@ -219,25 +224,25 @@ export const BT = {
     // #region Rendering - Clear Operations
 
     /**
-     * Sets the frame clear color.
+     * Sets the frame clear color using a palette index.
      *
      * The renderer uses this color when clearing the full display at the start
      * of the next frame.
      *
-     * @param color - Color used for the full-screen clear pass.
+     * @param paletteIndex - Palette index for the full-screen clear pass.
      */
-    clear: (color: Color32): void => {
-        BTAPI.instance.setClearColor(color);
+    clear: (paletteIndex: number): void => {
+        BTAPI.instance.setClearColor(paletteIndex);
     },
 
     /**
-     * Fills a rectangular display region with a solid color.
+     * Fills a rectangular display region with a palette-indexed color.
      *
-     * @param color - Fill color applied to the region.
+     * @param paletteIndex - Palette color index.
      * @param rect - Rectangle in display pixel coordinates.
      */
-    clearRect: (color: Color32, rect: Rect2i): void => {
-        BTAPI.instance.clearRect(color, rect);
+    clearRect: (paletteIndex: number, rect: Rect2i): void => {
+        BTAPI.instance.clearRect(paletteIndex, rect);
     },
 
     // #endregion
@@ -248,10 +253,10 @@ export const BT = {
      * Draws a single pixel.
      *
      * @param pos - Target pixel in display coordinates.
-     * @param color - Pixel color.
+     * @param paletteIndex - Palette color index.
      */
-    drawPixel: (pos: Vector2i, color: Color32): void => {
-        BTAPI.instance.drawPixel(pos, color);
+    drawPixel: (pos: Vector2i, paletteIndex: number): void => {
+        BTAPI.instance.drawPixel(pos, paletteIndex);
     },
 
     /**
@@ -261,30 +266,30 @@ export const BT = {
      *
      * @param p0 - Start position in display coordinates.
      * @param p1 - End position in display coordinates.
-     * @param color - Line color.
+     * @param paletteIndex - Palette color index.
      */
-    drawLine: (p0: Vector2i, p1: Vector2i, color: Color32): void => {
-        BTAPI.instance.drawLine(p0, p1, color);
+    drawLine: (p0: Vector2i, p1: Vector2i, paletteIndex: number): void => {
+        BTAPI.instance.drawLine(p0, p1, paletteIndex);
     },
 
     /**
      * Draws an unfilled rectangle outline.
      *
      * @param rect - Rectangle bounds in display coordinates.
-     * @param color - Outline color.
+     * @param paletteIndex - Palette color index.
      */
-    drawRect: (rect: Rect2i, color: Color32): void => {
-        BTAPI.instance.drawRect(rect, color);
+    drawRect: (rect: Rect2i, paletteIndex: number): void => {
+        BTAPI.instance.drawRect(rect, paletteIndex);
     },
 
     /**
      * Draws a filled rectangle.
      *
      * @param rect - Rectangle bounds in display coordinates.
-     * @param color - Fill color.
+     * @param paletteIndex - Palette color index.
      */
-    drawRectFill: (rect: Rect2i, color: Color32): void => {
-        BTAPI.instance.drawRectFill(rect, color);
+    drawRectFill: (rect: Rect2i, paletteIndex: number): void => {
+        BTAPI.instance.drawRectFill(rect, paletteIndex);
     },
 
     // #endregion
@@ -416,11 +421,11 @@ export const BT = {
      * prefer {@link BT.printFont}.
      *
      * @param pos - Text origin in display coordinates.
-     * @param color - Text color.
+     * @param paletteIndex - Palette color index.
      * @param text - String to render.
      */
-    print: (pos: Vector2i, color: Color32, text: string): void => {
-        BTAPI.instance.drawText(pos, color, text);
+    print: (pos: Vector2i, paletteIndex: number, text: string): void => {
+        BTAPI.instance.drawText(pos, paletteIndex, text);
     },
 
     /**

--- a/src/BlitTech.ts
+++ b/src/BlitTech.ts
@@ -238,11 +238,11 @@ export const BT = {
     /**
      * Fills a rectangular display region with a palette-indexed color.
      *
-     * @param paletteIndex - Palette color index.
      * @param rect - Rectangle in display pixel coordinates.
+     * @param paletteIndex - Palette color index.
      */
-    clearRect: (paletteIndex: number, rect: Rect2i): void => {
-        BTAPI.instance.clearRect(paletteIndex, rect);
+    clearRect: (rect: Rect2i, paletteIndex: number): void => {
+        BTAPI.instance.clearRect(rect, paletteIndex);
     },
 
     // #endregion

--- a/src/__test__/webgpu-mock.ts
+++ b/src/__test__/webgpu-mock.ts
@@ -135,6 +135,28 @@ export function createMockGPUCanvasContext(): GPUCanvasContext {
 
 // #endregion
 
+// #region Palette Buffer
+
+/**
+ * Creates a mock GPUBuffer matching the real 4096-byte palette uniform layout.
+ * Returns a plain object — does not call device.createBuffer.
+ *
+ * @returns Mock GPUBuffer stub.
+ */
+export function createMockPaletteBuffer(): GPUBuffer {
+    return {
+        size: 256 * 4 * 4,
+        usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+        label: 'Mock Palette Buffer',
+        mapAsync: () => Promise.resolve(),
+        getMappedRange: () => new ArrayBuffer(256 * 4 * 4),
+        unmap: () => {},
+        destroy: () => {},
+    } as unknown as GPUBuffer;
+}
+
+// #endregion
+
 // #region Navigator GPU
 
 /**

--- a/src/assets/Palette.ts
+++ b/src/assets/Palette.ts
@@ -443,11 +443,23 @@ export class Palette {
     public toFloat32Array(): Float32Array {
         const floats = new Float32Array(GPU_PALETTE_SIZE * GPU_FLOATS_PER_COLOR);
 
-        for (let i = 0; i < this.size; i++) {
-            this.colorAt(i).writeToFloat32Array(floats, i * GPU_FLOATS_PER_COLOR);
-        }
+        this.toFloat32ArrayInto(floats);
 
         return floats;
+    }
+
+    /**
+     * Writes the palette into an existing Float32Array in the fixed-size GPU uniform layout.
+     *
+     * The target must be at least `256 * 4` floats long. Entries beyond the active
+     * palette size are left unchanged.
+     *
+     * @param target - Pre-allocated float buffer to write normalized RGBA values into.
+     */
+    public toFloat32ArrayInto(target: Float32Array): void {
+        for (let i = 0; i < this.size; i++) {
+            this.colorAt(i).writeToFloat32Array(target, i * GPU_FLOATS_PER_COLOR);
+        }
     }
 
     /**

--- a/src/core/BTAPI.test.ts
+++ b/src/core/BTAPI.test.ts
@@ -22,7 +22,6 @@ import {
 import type { BitmapFont } from '../assets/BitmapFont';
 import { Palette } from '../assets/Palette';
 import type { SpriteSheet } from '../assets/SpriteSheet';
-import { Color32 } from '../utils/Color32';
 import { Rect2i } from '../utils/Rect2i';
 import { Vector2i } from '../utils/Vector2i';
 import { BTAPI } from './BTAPI';
@@ -151,11 +150,8 @@ describe('BTAPI', () => {
             expect(BTAPI.instance.getHardwareSettings()).toBeNull();
         });
 
-        it('getPalette should lazily create a VGA palette before init', () => {
-            const palette = BTAPI.instance.getPalette();
-
-            expect(palette).toBeInstanceOf(Palette);
-            expect(palette.size).toBe(256);
+        it('getPalette should return null before palette is set', () => {
+            expect(BTAPI.instance.getPalette()).toBeNull();
         });
 
         it('getCameraOffset should return a zero vector before init', () => {
@@ -176,33 +172,31 @@ describe('BTAPI', () => {
         });
 
         it('setClearColor should not throw before init', () => {
-            expect(() => BTAPI.instance.setClearColor(Color32.red())).not.toThrow();
+            expect(() => BTAPI.instance.setClearColor(1)).not.toThrow();
         });
 
         it('clearRect should not throw before init', () => {
-            expect(() => BTAPI.instance.clearRect(Color32.red(), new Rect2i(0, 0, 10, 10))).not.toThrow();
+            expect(() => BTAPI.instance.clearRect(1, new Rect2i(0, 0, 10, 10))).not.toThrow();
         });
 
         it('drawPixel should not throw before init', () => {
-            expect(() => BTAPI.instance.drawPixel(new Vector2i(0, 0), Color32.red())).not.toThrow();
+            expect(() => BTAPI.instance.drawPixel(new Vector2i(0, 0), 2)).not.toThrow();
         });
 
         it('drawLine should not throw before init', () => {
-            expect(() =>
-                BTAPI.instance.drawLine(new Vector2i(0, 0), new Vector2i(10, 10), Color32.red()),
-            ).not.toThrow();
+            expect(() => BTAPI.instance.drawLine(new Vector2i(0, 0), new Vector2i(10, 10), 3)).not.toThrow();
         });
 
         it('drawRect should not throw before init', () => {
-            expect(() => BTAPI.instance.drawRect(new Rect2i(0, 0, 10, 10), Color32.red())).not.toThrow();
+            expect(() => BTAPI.instance.drawRect(new Rect2i(0, 0, 10, 10), 4)).not.toThrow();
         });
 
         it('drawRectFill should not throw before init', () => {
-            expect(() => BTAPI.instance.drawRectFill(new Rect2i(0, 0, 10, 10), Color32.red())).not.toThrow();
+            expect(() => BTAPI.instance.drawRectFill(new Rect2i(0, 0, 10, 10), 5)).not.toThrow();
         });
 
         it('drawText should not throw before init', () => {
-            expect(() => BTAPI.instance.drawText(new Vector2i(0, 0), Color32.white(), 'test')).not.toThrow();
+            expect(() => BTAPI.instance.drawText(new Vector2i(0, 0), 8, 'test')).not.toThrow();
         });
 
         it('drawSprite should not throw before init', () => {

--- a/src/core/BTAPI.test.ts
+++ b/src/core/BTAPI.test.ts
@@ -331,6 +331,44 @@ describe('BTAPI', () => {
 
             expect(() => BTAPI.instance.stop()).not.toThrow();
         });
+
+        it('captureFrame returns a blob after successful initialization', async () => {
+            await BTAPI.instance.initialize(makeMockDemo(), makeMockCanvas());
+
+            const renderer = BTAPI.instance.getRenderer();
+
+            expect(renderer).not.toBeNull();
+
+            const mockBlob = new Blob(['test'], { type: 'image/png' });
+
+            vi.spyOn(renderer as NonNullable<typeof renderer>, 'captureFrame').mockResolvedValue(mockBlob);
+
+            const result = await BTAPI.instance.captureFrame();
+
+            expect(result).toBe(mockBlob);
+        });
+    });
+
+    // #endregion
+
+    // #region assertPaletteIndex
+
+    describe('assertPaletteIndex', () => {
+        it('throws when index is negative (no palette set)', () => {
+            expect(() => BTAPI.instance.drawPixel(new Vector2i(0, 0), -1)).toThrow(
+                'is not a valid non-negative integer',
+            );
+        });
+
+        it('throws when index is out of range for the active palette', () => {
+            const palette = new Palette(16);
+
+            BTAPI.instance.setPalette(palette);
+
+            expect(() => BTAPI.instance.drawPixel(new Vector2i(0, 0), 20)).toThrow(
+                'Palette index 20 out of range for palette of size 16.',
+            );
+        });
     });
 
     // #endregion

--- a/src/core/BTAPI.test.ts
+++ b/src/core/BTAPI.test.ts
@@ -176,7 +176,7 @@ describe('BTAPI', () => {
         });
 
         it('clearRect should not throw before init', () => {
-            expect(() => BTAPI.instance.clearRect(1, new Rect2i(0, 0, 10, 10))).not.toThrow();
+            expect(() => BTAPI.instance.clearRect(new Rect2i(0, 0, 10, 10), 1)).not.toThrow();
         });
 
         it('drawPixel should not throw before init', () => {

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -1,5 +1,5 @@
 import type { BitmapFont } from '../assets/BitmapFont';
-import { Palette } from '../assets/Palette';
+import type { Palette } from '../assets/Palette';
 import type { SpriteSheet } from '../assets/SpriteSheet';
 import { Renderer } from '../render/Renderer';
 import type { Color32 } from '../utils/Color32';
@@ -285,25 +285,22 @@ export class BTAPI {
     }
 
     /**
-     * Gets the active engine palette, creating the default VGA palette lazily.
+     * Gets the active engine palette.
      *
-     * @returns Active palette instance.
+     * @returns Active palette, or null if none has been set.
      */
-    public getPalette(): Palette {
-        if (!this.palette) {
-            this.palette = Palette.vga();
-        }
-
+    public getPalette(): Palette | null {
         return this.palette;
     }
 
     /**
-     * Sets the active engine palette.
+     * Sets the active engine palette and propagates it to the renderer.
      *
      * @param palette - Palette to store as the active engine palette.
      */
     public setPalette(palette: Palette): void {
         this.palette = palette;
+        this.renderer?.setPalette(palette);
     }
 
     // #endregion
@@ -311,22 +308,24 @@ export class BTAPI {
     // #region Rendering API - Clear Operations
 
     /**
-     * Sets the background clear color for each frame.
+     * Sets the background clear color for each frame using a palette index.
      *
-     * @param color - Color to clear the screen with.
+     * @param paletteIndex - Palette index for the clear color.
      */
-    public setClearColor(color: Color32): void {
-        this.renderer?.setClearColor(color);
+    public setClearColor(paletteIndex: number): void {
+        this.assertPaletteIndex(paletteIndex);
+        this.renderer?.setClearColor(paletteIndex);
     }
 
     /**
-     * Fills a rectangular region with a solid color.
+     * Fills a rectangular region with a palette-indexed color.
      *
-     * @param color - Fill color.
+     * @param paletteIndex - Palette color index.
      * @param rect - Region to fill in pixel coordinates.
      */
-    public clearRect(color: Color32, rect: Rect2i): void {
-        this.renderer?.clearRect(color, rect);
+    public clearRect(paletteIndex: number, rect: Rect2i): void {
+        this.assertPaletteIndex(paletteIndex);
+        this.renderer?.clearRect(paletteIndex, rect);
     }
 
     // #endregion
@@ -337,10 +336,11 @@ export class BTAPI {
      * Draws a single pixel at the specified position.
      *
      * @param pos - Pixel coordinates.
-     * @param color - Pixel color.
+     * @param paletteIndex - Palette color index.
      */
-    public drawPixel(pos: Vector2i, color: Color32): void {
-        this.renderer?.drawPixel(pos, color);
+    public drawPixel(pos: Vector2i, paletteIndex: number): void {
+        this.assertPaletteIndex(paletteIndex);
+        this.renderer?.drawPixel(pos, paletteIndex);
     }
 
     /**
@@ -349,30 +349,33 @@ export class BTAPI {
      *
      * @param p0 - Start point.
      * @param p1 - End point.
-     * @param color - Line color.
+     * @param paletteIndex - Palette color index.
      */
-    public drawLine(p0: Vector2i, p1: Vector2i, color: Color32): void {
-        this.renderer?.drawLine(p0, p1, color);
+    public drawLine(p0: Vector2i, p1: Vector2i, paletteIndex: number): void {
+        this.assertPaletteIndex(paletteIndex);
+        this.renderer?.drawLine(p0, p1, paletteIndex);
     }
 
     /**
      * Draws a rectangle outline (unfilled).
      *
      * @param rect - Rectangle bounds.
-     * @param color - Outline color.
+     * @param paletteIndex - Palette color index.
      */
-    public drawRect(rect: Rect2i, color: Color32): void {
-        this.renderer?.drawRect(rect, color);
+    public drawRect(rect: Rect2i, paletteIndex: number): void {
+        this.assertPaletteIndex(paletteIndex);
+        this.renderer?.drawRect(rect, paletteIndex);
     }
 
     /**
      * Draws a filled rectangle.
      *
      * @param rect - Rectangle bounds.
-     * @param color - Fill color.
+     * @param paletteIndex - Palette color index.
      */
-    public drawRectFill(rect: Rect2i, color: Color32): void {
-        this.renderer?.drawRectFill(rect, color);
+    public drawRectFill(rect: Rect2i, paletteIndex: number): void {
+        this.assertPaletteIndex(paletteIndex);
+        this.renderer?.drawRectFill(rect, paletteIndex);
     }
 
     /**
@@ -380,11 +383,12 @@ export class BTAPI {
      * For proper text rendering, use drawBitmapText() instead.
      *
      * @param pos - Text position (top-left corner).
-     * @param color - Text color.
+     * @param paletteIndex - Palette color index.
      * @param text - String to display.
      */
-    public drawText(pos: Vector2i, color: Color32, text: string): void {
-        this.renderer?.drawText(pos, color, text);
+    public drawText(pos: Vector2i, paletteIndex: number, text: string): void {
+        this.assertPaletteIndex(paletteIndex);
+        this.renderer?.drawText(pos, paletteIndex, text);
     }
 
     // #endregion
@@ -464,6 +468,26 @@ export class BTAPI {
      */
     public resetCamera(): void {
         this.renderer?.resetCamera();
+    }
+
+    // #endregion
+
+    // #region Private Helpers
+
+    /**
+     * Validates that a palette index is a non-negative integer within the active palette.
+     *
+     * @param index - Palette index to validate.
+     * @throws Error if no palette is set or the index is out of range.
+     */
+    private assertPaletteIndex(index: number): void {
+        if (!this.palette) {
+            return;
+        }
+
+        if (!Number.isInteger(index) || index < 0 || index >= this.palette.size) {
+            throw new Error(`Palette index ${index} out of range for palette of size ${this.palette.size}.`);
+        }
     }
 
     // #endregion

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -475,17 +475,22 @@ export class BTAPI {
     // #region Private Helpers
 
     /**
-     * Validates that a palette index is a non-negative integer within the active palette.
+     * Validates that a palette index is a non-negative integer and, when a palette
+     * is active, that the index is within its range.
+     *
+     * The non-integer/negative check always runs regardless of palette state.
+     * The range check only runs when a palette has been set.
      *
      * @param index - Palette index to validate.
-     * @throws Error if no palette is set or the index is out of range.
+     * @throws Error if the index is not a non-negative integer.
+     * @throws Error if a palette is active and the index is out of its range.
      */
     private assertPaletteIndex(index: number): void {
-        if (!this.palette) {
-            return;
+        if (!Number.isInteger(index) || index < 0) {
+            throw new Error(`Palette index ${index} is not a valid non-negative integer.`);
         }
 
-        if (!Number.isInteger(index) || index < 0 || index >= this.palette.size) {
+        if (this.palette && index >= this.palette.size) {
             throw new Error(`Palette index ${index} out of range for palette of size ${this.palette.size}.`);
         }
     }

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -320,12 +320,12 @@ export class BTAPI {
     /**
      * Fills a rectangular region with a palette-indexed color.
      *
-     * @param paletteIndex - Palette color index.
      * @param rect - Region to fill in pixel coordinates.
+     * @param paletteIndex - Palette color index.
      */
-    public clearRect(paletteIndex: number, rect: Rect2i): void {
+    public clearRect(rect: Rect2i, paletteIndex: number): void {
         this.assertPaletteIndex(paletteIndex);
-        this.renderer?.clearRect(paletteIndex, rect);
+        this.renderer?.clearRect(rect, paletteIndex);
     }
 
     // #endregion

--- a/src/core/GameLoop.test.ts
+++ b/src/core/GameLoop.test.ts
@@ -115,6 +115,43 @@ describe('GameLoop', () => {
 
     // #endregion
 
+    // #region start (RAF flush)
+
+    describe('start (RAF flush)', () => {
+        afterEach(() => {
+            vi.unstubAllGlobals();
+        });
+
+        it('sets lastUpdateTime after flushing nested RAF callbacks', () => {
+            const rafCallbacks: Array<(time?: number) => void> = [];
+
+            vi.stubGlobal(
+                'requestAnimationFrame',
+                vi.fn((cb: (time?: number) => void) => {
+                    rafCallbacks.push(cb);
+
+                    return rafCallbacks.length;
+                }),
+            );
+
+            const loop = new GameLoop(16.67, vi.fn(), vi.fn());
+            const p = loop as unknown as { lastUpdateTime: number };
+
+            loop.start();
+
+            // Execute outer RAF callback.
+            rafCallbacks[0]?.();
+
+            // Execute inner RAF callback — sets lastUpdateTime and schedules first tick.
+            rafCallbacks[1]?.();
+
+            expect(p.lastUpdateTime).toBeGreaterThan(0);
+            expect(rafCallbacks).toHaveLength(3);
+        });
+    });
+
+    // #endregion
+
     // #region tick (private)
 
     describe('tick (via type cast)', () => {

--- a/src/core/WebGPUContext.test.ts
+++ b/src/core/WebGPUContext.test.ts
@@ -44,21 +44,18 @@ describe('initializeWebGPU', () => {
     // #region No WebGPU support
 
     it('should return null when navigator.gpu is absent', async () => {
+        // Use Object.defineProperty to install a navigator without .gpu — direct
+        // property deletion throws in Node.js when navigator is null/non-writable.
+        Object.defineProperty(globalThis, 'navigator', {
+            value: { userAgent: 'test' },
+            writable: true,
+            configurable: true,
+        });
+
         const canvas = createMockCanvas();
-        const nav = globalThis.navigator as unknown as Record<string, unknown>;
-        const originalGpu = nav?.gpu;
+        const result = await initializeWebGPU(canvas, displaySize);
 
-        try {
-            delete nav.gpu;
-
-            const result = await initializeWebGPU(canvas, displaySize);
-
-            expect(result).toBeNull();
-        } finally {
-            if (originalGpu !== undefined) {
-                nav.gpu = originalGpu;
-            }
-        }
+        expect(result).toBeNull();
     });
 
     // #endregion

--- a/src/render/PrimitivePipeline.test.ts
+++ b/src/render/PrimitivePipeline.test.ts
@@ -137,7 +137,7 @@ describe('pre-initialization safety', () => {
         const rect = new Rect2i(0, 0, 100, 100);
 
         expect(() => {
-            pipeline.clearRect(1, rect);
+            pipeline.clearRect(rect, 1);
         }).not.toThrow();
     });
 

--- a/src/render/PrimitivePipeline.test.ts
+++ b/src/render/PrimitivePipeline.test.ts
@@ -20,10 +20,22 @@ import {
     installMockNavigatorGPU,
     uninstallMockNavigatorGPU,
 } from '../__test__/webgpu-mock';
-import { Color32 } from '../utils/Color32';
 import { Rect2i } from '../utils/Rect2i';
 import { Vector2i } from '../utils/Vector2i';
 import { PrimitivePipeline } from './PrimitivePipeline';
+
+// #region Test Helpers
+
+/** Creates a mock palette buffer matching the real 4096-byte uniform layout. */
+function createMockPaletteBuffer(device: GPUDevice): GPUBuffer {
+    return device.createBuffer({
+        label: 'Test Palette Buffer',
+        size: 256 * 4 * 4,
+        usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    });
+}
+
+// #endregion
 
 // #region Constructor
 
@@ -70,29 +82,26 @@ describe('pre-initialization safety', () => {
     it('drawRectFill() does not throw before initialize', () => {
         const pipeline = new PrimitivePipeline();
         const rect = new Rect2i(0, 0, 10, 10);
-        const color = Color32.red();
 
         expect(() => {
-            pipeline.drawRectFill(rect, color);
+            pipeline.drawRectFill(rect, 1);
         }).not.toThrow();
     });
 
     it('drawPixel() does not throw before initialize', () => {
         const pipeline = new PrimitivePipeline();
         const pos = new Vector2i(5, 5);
-        const color = Color32.green();
 
         expect(() => {
-            pipeline.drawPixel(pos, color);
+            pipeline.drawPixel(pos, 2);
         }).not.toThrow();
     });
 
     it('drawPixelXY() does not throw before initialize', () => {
         const pipeline = new PrimitivePipeline();
-        const color = Color32.blue();
 
         expect(() => {
-            pipeline.drawPixelXY(3, 7, color);
+            pipeline.drawPixelXY(3, 7, 3);
         }).not.toThrow();
     });
 
@@ -100,10 +109,9 @@ describe('pre-initialization safety', () => {
         const pipeline = new PrimitivePipeline();
         const p0 = new Vector2i(0, 10);
         const p1 = new Vector2i(100, 10);
-        const color = Color32.white();
 
         expect(() => {
-            pipeline.drawLine(p0, p1, color);
+            pipeline.drawLine(p0, p1, 4);
         }).not.toThrow();
     });
 
@@ -111,10 +119,9 @@ describe('pre-initialization safety', () => {
         const pipeline = new PrimitivePipeline();
         const p0 = new Vector2i(10, 0);
         const p1 = new Vector2i(10, 100);
-        const color = Color32.yellow();
 
         expect(() => {
-            pipeline.drawLine(p0, p1, color);
+            pipeline.drawLine(p0, p1, 5);
         }).not.toThrow();
     });
 
@@ -122,40 +129,36 @@ describe('pre-initialization safety', () => {
         const pipeline = new PrimitivePipeline();
         const p0 = new Vector2i(0, 0);
         const p1 = new Vector2i(50, 30);
-        const color = Color32.cyan();
 
         expect(() => {
-            pipeline.drawLine(p0, p1, color);
+            pipeline.drawLine(p0, p1, 6);
         }).not.toThrow();
     });
 
     it('drawRect() does not throw before initialize', () => {
         const pipeline = new PrimitivePipeline();
         const rect = new Rect2i(5, 5, 20, 20);
-        const color = Color32.magenta();
 
         expect(() => {
-            pipeline.drawRect(rect, color);
+            pipeline.drawRect(rect, 7);
         }).not.toThrow();
     });
 
     it('clearRect() does not throw before initialize', () => {
         const pipeline = new PrimitivePipeline();
         const rect = new Rect2i(0, 0, 100, 100);
-        const color = Color32.black();
 
         expect(() => {
-            pipeline.clearRect(color, rect);
+            pipeline.clearRect(1, rect);
         }).not.toThrow();
     });
 
     it('drawText() does not throw before initialize', () => {
         const pipeline = new PrimitivePipeline();
         const pos = new Vector2i(10, 10);
-        const color = Color32.white();
 
         expect(() => {
-            pipeline.drawText(pos, color, 'Hello');
+            pipeline.drawText(pos, 8, 'Hello');
         }).not.toThrow();
     });
 });
@@ -171,7 +174,9 @@ describe('with initialized pipeline', () => {
     beforeAll(async () => {
         installMockNavigatorGPU();
 
-        await pipeline.initialize(device, new Vector2i(320, 240));
+        const paletteBuffer = createMockPaletteBuffer(device);
+
+        await pipeline.initialize(device, new Vector2i(320, 240), paletteBuffer);
     });
 
     afterAll(() => {
@@ -193,9 +198,9 @@ describe('with initialized pipeline', () => {
 
         const rect = new Rect2i(0, 0, 10, 10);
 
-        pipeline.drawRectFill(rect, Color32.red());
-        pipeline.drawPixel(new Vector2i(5, 5), Color32.green());
-        pipeline.drawLine(new Vector2i(0, 0), new Vector2i(20, 0), Color32.blue());
+        pipeline.drawRectFill(rect, 1);
+        pipeline.drawPixel(new Vector2i(5, 5), 2);
+        pipeline.drawLine(new Vector2i(0, 0), new Vector2i(20, 0), 3);
 
         const renderPass = createMockRenderPassEncoder();
 
@@ -207,7 +212,7 @@ describe('with initialized pipeline', () => {
     it('reset followed by encodePass produces no draw calls', () => {
         pipeline.reset();
 
-        pipeline.drawRectFill(new Rect2i(0, 0, 5, 5), Color32.white());
+        pipeline.drawRectFill(new Rect2i(0, 0, 5, 5), 1);
 
         pipeline.reset();
 
@@ -227,7 +232,7 @@ describe('with initialized pipeline', () => {
     it('encodePass calls draw on render pass when vertices exist', () => {
         pipeline.reset();
 
-        pipeline.drawRectFill(new Rect2i(10, 10, 20, 20), Color32.red());
+        pipeline.drawRectFill(new Rect2i(10, 10, 20, 20), 1);
 
         let drawCalled = false;
 
@@ -248,7 +253,7 @@ describe('with initialized pipeline', () => {
             for (let i = 0; i < 5; i++) {
                 pipeline.reset();
 
-                pipeline.drawPixel(new Vector2i(i, i), Color32.white());
+                pipeline.drawPixel(new Vector2i(i, i), 8);
                 pipeline.encodePass(createMockRenderPassEncoder());
 
                 pipeline.reset();
@@ -262,7 +267,7 @@ describe('with initialized pipeline', () => {
         pipeline.setCameraOffset(new Vector2i(100, 50));
 
         expect(() => {
-            pipeline.drawRectFill(new Rect2i(0, 0, 10, 10), Color32.red());
+            pipeline.drawRectFill(new Rect2i(0, 0, 10, 10), 1);
             pipeline.encodePass(createMockRenderPassEncoder());
         }).not.toThrow();
 
@@ -281,7 +286,9 @@ describe('vertex count verification', () => {
     beforeAll(async () => {
         installMockNavigatorGPU();
 
-        await pipeline.initialize(device, new Vector2i(320, 240));
+        const paletteBuffer = createMockPaletteBuffer(device);
+
+        await pipeline.initialize(device, new Vector2i(320, 240), paletteBuffer);
     });
 
     afterAll(() => {
@@ -291,7 +298,7 @@ describe('vertex count verification', () => {
     it('drawRectFill produces six vertices (two triangles)', () => {
         pipeline.reset();
 
-        pipeline.drawRectFill(new Rect2i(0, 0, 10, 10), Color32.red());
+        pipeline.drawRectFill(new Rect2i(0, 0, 10, 10), 1);
 
         let totalVertices = 0;
         const renderPass = {
@@ -309,7 +316,7 @@ describe('vertex count verification', () => {
     it('drawPixel produces six vertices (1x1 filled rect)', () => {
         pipeline.reset();
 
-        pipeline.drawPixel(new Vector2i(5, 5), Color32.green());
+        pipeline.drawPixel(new Vector2i(5, 5), 2);
 
         let totalVertices = 0;
 
@@ -328,7 +335,7 @@ describe('vertex count verification', () => {
     it('horizontal line uses a single quad (six vertices)', () => {
         pipeline.reset();
 
-        pipeline.drawLine(new Vector2i(0, 10), new Vector2i(100, 10), Color32.white());
+        pipeline.drawLine(new Vector2i(0, 10), new Vector2i(100, 10), 4);
 
         let totalVertices = 0;
         const renderPass = {
@@ -345,7 +352,7 @@ describe('vertex count verification', () => {
     it('vertical line uses a single quad (six vertices)', () => {
         pipeline.reset();
 
-        pipeline.drawLine(new Vector2i(10, 0), new Vector2i(10, 50), Color32.white());
+        pipeline.drawLine(new Vector2i(10, 0), new Vector2i(10, 50), 4);
 
         let totalVertices = 0;
 
@@ -365,7 +372,7 @@ describe('vertex count verification', () => {
         pipeline.reset();
 
         // A 45-degree diagonal from (0,0) to (4,4) = 5 pixels
-        pipeline.drawLine(new Vector2i(0, 0), new Vector2i(4, 4), Color32.white());
+        pipeline.drawLine(new Vector2i(0, 0), new Vector2i(4, 4), 8);
 
         let totalVertices = 0;
 
@@ -385,7 +392,7 @@ describe('vertex count verification', () => {
         pipeline.reset();
 
         // height=2 means y1-y0 = 1, which is NOT > 1, so no vertical sides
-        pipeline.drawRect(new Rect2i(0, 0, 10, 2), Color32.red());
+        pipeline.drawRect(new Rect2i(0, 0, 10, 2), 1);
 
         let totalVertices = 0;
 
@@ -405,7 +412,7 @@ describe('vertex count verification', () => {
     it('drawRect with height > two includes all four sides', () => {
         pipeline.reset();
 
-        pipeline.drawRect(new Rect2i(0, 0, 10, 10), Color32.red());
+        pipeline.drawRect(new Rect2i(0, 0, 10, 10), 1);
 
         let totalVertices = 0;
 
@@ -425,7 +432,7 @@ describe('vertex count verification', () => {
     it('drawText produces six vertices per character', () => {
         pipeline.reset();
 
-        pipeline.drawText(new Vector2i(0, 0), Color32.white(), 'Hi');
+        pipeline.drawText(new Vector2i(0, 0), 8, 'Hi');
 
         let totalVertices = 0;
 
@@ -450,7 +457,7 @@ describe('vertex count verification', () => {
             // Fill buffer: 50,000 max vertices, each drawRectFill uses 6 vertices
             // ~8333 rects fill the buffer; drawing more should trigger a warning
             for (let i = 0; i < 8400; i++) {
-                pipeline.drawRectFill(new Rect2i(0, 0, 1, 1), Color32.white());
+                pipeline.drawRectFill(new Rect2i(0, 0, 1, 1), 1);
             }
 
             expect(warnSpy).toHaveBeenCalled();

--- a/src/render/PrimitivePipeline.test.ts
+++ b/src/render/PrimitivePipeline.test.ts
@@ -16,6 +16,7 @@ import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import {
     createMockGPUDevice,
+    createMockPaletteBuffer,
     createMockRenderPassEncoder,
     installMockNavigatorGPU,
     uninstallMockNavigatorGPU,
@@ -23,19 +24,6 @@ import {
 import { Rect2i } from '../utils/Rect2i';
 import { Vector2i } from '../utils/Vector2i';
 import { PrimitivePipeline } from './PrimitivePipeline';
-
-// #region Test Helpers
-
-/** Creates a mock palette buffer matching the real 4096-byte uniform layout. */
-function createMockPaletteBuffer(device: GPUDevice): GPUBuffer {
-    return device.createBuffer({
-        label: 'Test Palette Buffer',
-        size: 256 * 4 * 4,
-        usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
-    });
-}
-
-// #endregion
 
 // #region Constructor
 
@@ -174,7 +162,7 @@ describe('with initialized pipeline', () => {
     beforeAll(async () => {
         installMockNavigatorGPU();
 
-        const paletteBuffer = createMockPaletteBuffer(device);
+        const paletteBuffer = createMockPaletteBuffer();
 
         await pipeline.initialize(device, new Vector2i(320, 240), paletteBuffer);
     });
@@ -286,7 +274,7 @@ describe('vertex count verification', () => {
     beforeAll(async () => {
         installMockNavigatorGPU();
 
-        const paletteBuffer = createMockPaletteBuffer(device);
+        const paletteBuffer = createMockPaletteBuffer();
 
         await pipeline.initialize(device, new Vector2i(320, 240), paletteBuffer);
     });

--- a/src/render/PrimitivePipeline.ts
+++ b/src/render/PrimitivePipeline.ts
@@ -305,10 +305,10 @@ export class PrimitivePipeline {
      * Fills a rectangular region with a palette-indexed color.
      * Alias for `drawRectFill()` kept for renderer API consistency.
      *
-     * @param paletteIndex - Palette color index.
      * @param rect - Region to fill.
+     * @param paletteIndex - Palette color index.
      */
-    clearRect(paletteIndex: number, rect: Rect2i): void {
+    clearRect(rect: Rect2i, paletteIndex: number): void {
         this.drawRectFill(rect, paletteIndex);
     }
 

--- a/src/render/PrimitivePipeline.ts
+++ b/src/render/PrimitivePipeline.ts
@@ -1,4 +1,3 @@
-import type { Color32 } from '../utils/Color32';
 import { Rect2i } from '../utils/Rect2i';
 import { Vector2i } from '../utils/Vector2i';
 
@@ -12,13 +11,26 @@ import { Vector2i } from '../utils/Vector2i';
  */
 const MAX_PRIMITIVE_VERTICES = 50000;
 
+/**
+ * Number of 4-byte values per vertex: x (f32), y (f32), paletteIndex (u32).
+ */
+const VALUES_PER_VERTEX = 3;
+
+/**
+ * Byte stride per vertex (3 values x 4 bytes each = 12 bytes).
+ */
+const VERTEX_STRIDE = VALUES_PER_VERTEX * 4;
+
 // #endregion
 
 /**
- * Batched WebGPU pipeline for solid-color primitives.
+ * Batched WebGPU pipeline for palette-indexed primitives.
  *
  * The pipeline collects CPU-side vertices for pixels, lines, rectangles, and
  * placeholder text during a frame, then uploads and draws them in `encodePass()`.
+ *
+ * Each vertex stores a palette index instead of an RGBA color. The fragment
+ * shader performs a flat lookup into a 256-entry palette uniform buffer.
  */
 export class PrimitivePipeline {
     // #region State
@@ -26,20 +38,29 @@ export class PrimitivePipeline {
     /** WebGPU device, set during initialize(). */
     private device: GPUDevice | null = null;
 
-    /** Render pipeline for colored geometry. */
+    /** Render pipeline for palette-indexed geometry. */
     private pipeline: GPURenderPipeline | null = null;
 
     /** Uniform buffer containing screen resolution. */
     private uniformBuffer: GPUBuffer | null = null;
 
-    /** Bind group for the uniform buffer. */
+    /** Bind group for the uniform and palette buffers. */
     private bindGroup: GPUBindGroup | null = null;
 
     /** GPU vertex buffer. */
     private vertexBuffer: GPUBuffer | null = null;
 
-    /** CPU-side vertex data (6 floats per vertex: x, y, r, g, b, a). */
-    private readonly vertices: Float32Array;
+    /**
+     * CPU-side vertex data backing buffer.
+     * Shared between {@link vertexFloats} and {@link vertexIndices} views.
+     */
+    private readonly vertexArrayBuffer: ArrayBuffer;
+
+    /** Float view for writing position values (x, y). */
+    private readonly vertexFloats: Float32Array;
+
+    /** Uint32 view for writing palette index values. */
+    private readonly vertexIndices: Uint32Array;
 
     /** Number of vertices in the current (unflushed) batch. */
     private vertexCount: number = 0;
@@ -73,7 +94,9 @@ export class PrimitivePipeline {
      * Call `initialize()` before encoding GPU work.
      */
     constructor() {
-        this.vertices = new Float32Array(MAX_PRIMITIVE_VERTICES * 6);
+        this.vertexArrayBuffer = new ArrayBuffer(MAX_PRIMITIVE_VERTICES * VERTEX_STRIDE);
+        this.vertexFloats = new Float32Array(this.vertexArrayBuffer);
+        this.vertexIndices = new Uint32Array(this.vertexArrayBuffer);
     }
 
     // #endregion
@@ -85,10 +108,11 @@ export class PrimitivePipeline {
      *
      * @param device - WebGPU device for GPU operations.
      * @param displaySize - Render target resolution in pixels.
+     * @param paletteBuffer - Shared palette uniform buffer (256 x vec4f = 4096 bytes).
      */
-    async initialize(device: GPUDevice, displaySize: Vector2i): Promise<void> {
+    async initialize(device: GPUDevice, displaySize: Vector2i, paletteBuffer: GPUBuffer): Promise<void> {
         this.device = device;
-        await this.createPipeline(displaySize);
+        await this.createPipeline(displaySize, paletteBuffer);
     }
 
     // #endregion
@@ -112,26 +136,21 @@ export class PrimitivePipeline {
      * Draws a filled rectangle using two triangles.
      *
      * @param rect - Rectangle bounds in pixel coordinates.
-     * @param color - Fill color.
+     * @param paletteIndex - Palette color index.
      */
-    drawRectFill(rect: Rect2i, color: Color32): void {
+    drawRectFill(rect: Rect2i, paletteIndex: number): void {
         const x0 = rect.x;
         const y0 = rect.y;
         const x1 = rect.x + rect.width;
         const y1 = rect.y + rect.height;
 
-        const r = color.r / 255;
-        const g = color.g / 255;
-        const b = color.b / 255;
-        const a = color.a / 255;
+        this.addVertex(x0, y0, paletteIndex);
+        this.addVertex(x1, y0, paletteIndex);
+        this.addVertex(x0, y1, paletteIndex);
 
-        this.addVertex(x0, y0, r, g, b, a);
-        this.addVertex(x1, y0, r, g, b, a);
-        this.addVertex(x0, y1, r, g, b, a);
-
-        this.addVertex(x1, y0, r, g, b, a);
-        this.addVertex(x1, y1, r, g, b, a);
-        this.addVertex(x0, y1, r, g, b, a);
+        this.addVertex(x1, y0, paletteIndex);
+        this.addVertex(x1, y1, paletteIndex);
+        this.addVertex(x0, y1, paletteIndex);
     }
 
     /**
@@ -139,18 +158,12 @@ export class PrimitivePipeline {
      * Each character is rendered as a small filled rectangle.
      *
      * @param pos - Text position (top-left corner).
-     * @param color - Text color.
+     * @param paletteIndex - Palette color index.
      * @param text - String to display.
      */
-    drawText(pos: Vector2i, color: Color32, text: string): void {
+    drawText(pos: Vector2i, paletteIndex: number, text: string): void {
         const charWidth = 6;
         const charHeight = 8;
-
-        // Pre-compute color values once for all characters.
-        const r = color.r / 255;
-        const g = color.g / 255;
-        const b = color.b / 255;
-        const a = color.a / 255;
 
         for (let i = 0; i < text.length; i++) {
             const x0 = pos.x + i * charWidth;
@@ -159,13 +172,13 @@ export class PrimitivePipeline {
             const y1 = y0 + charHeight;
 
             // Draw directly without allocating Rect2i.
-            this.addVertex(x0, y0, r, g, b, a);
-            this.addVertex(x1, y0, r, g, b, a);
-            this.addVertex(x0, y1, r, g, b, a);
+            this.addVertex(x0, y0, paletteIndex);
+            this.addVertex(x1, y0, paletteIndex);
+            this.addVertex(x0, y1, paletteIndex);
 
-            this.addVertex(x1, y0, r, g, b, a);
-            this.addVertex(x1, y1, r, g, b, a);
-            this.addVertex(x0, y1, r, g, b, a);
+            this.addVertex(x1, y0, paletteIndex);
+            this.addVertex(x1, y1, paletteIndex);
+            this.addVertex(x0, y1, paletteIndex);
         }
     }
 
@@ -173,12 +186,12 @@ export class PrimitivePipeline {
      * Draws a single pixel as a 1x1 filled rectangle.
      *
      * @param pos - Pixel position.
-     * @param color - Pixel color.
+     * @param paletteIndex - Palette color index.
      */
-    drawPixel(pos: Vector2i, color: Color32): void {
+    drawPixel(pos: Vector2i, paletteIndex: number): void {
         // Use pre-allocated rect to avoid allocation per pixel.
         this.tempRect.set(pos.x, pos.y, 1, 1);
-        this.drawRectFill(this.tempRect, color);
+        this.drawRectFill(this.tempRect, paletteIndex);
     }
 
     /**
@@ -187,26 +200,20 @@ export class PrimitivePipeline {
      *
      * @param x - X position.
      * @param y - Y position.
-     * @param color - Pixel color.
+     * @param paletteIndex - Palette color index.
      */
-    drawPixelXY(x: number, y: number, color: Color32): void {
-        // Direct vertex addition without any object allocation.
-        const r = color.r / 255;
-        const g = color.g / 255;
-        const b = color.b / 255;
-        const a = color.a / 255;
-
+    drawPixelXY(x: number, y: number, paletteIndex: number): void {
         // Draw 1x1 rectangle (2 triangles = 6 vertices).
         const x1 = x + 1;
         const y1 = y + 1;
 
-        this.addVertex(x, y, r, g, b, a);
-        this.addVertex(x1, y, r, g, b, a);
-        this.addVertex(x, y1, r, g, b, a);
+        this.addVertex(x, y, paletteIndex);
+        this.addVertex(x1, y, paletteIndex);
+        this.addVertex(x, y1, paletteIndex);
 
-        this.addVertex(x1, y, r, g, b, a);
-        this.addVertex(x1, y1, r, g, b, a);
-        this.addVertex(x, y1, r, g, b, a);
+        this.addVertex(x1, y, paletteIndex);
+        this.addVertex(x1, y1, paletteIndex);
+        this.addVertex(x, y1, paletteIndex);
     }
 
     /**
@@ -218,9 +225,9 @@ export class PrimitivePipeline {
      *
      * @param p0 - Start point.
      * @param p1 - End point.
-     * @param color - Line color.
+     * @param paletteIndex - Palette color index.
      */
-    drawLine(p0: Vector2i, p1: Vector2i, color: Color32): void {
+    drawLine(p0: Vector2i, p1: Vector2i, paletteIndex: number): void {
         // Vector2i already guarantees integers, but |0 ensures the 32-bit int for bitwise ops.
         const x0 = p0.x | 0;
         const y0 = p0.y | 0;
@@ -235,7 +242,7 @@ export class PrimitivePipeline {
             const maxX = Math.max(x0, x1);
 
             this.tempRect.set(minX, y0, maxX - minX + 1, 1);
-            this.drawRectFill(this.tempRect, color);
+            this.drawRectFill(this.tempRect, paletteIndex);
 
             return;
         }
@@ -246,13 +253,13 @@ export class PrimitivePipeline {
             const maxY = Math.max(y0, y1);
 
             this.tempRect.set(x0, minY, 1, maxY - minY + 1);
-            this.drawRectFill(this.tempRect, color);
+            this.drawRectFill(this.tempRect, paletteIndex);
 
             return;
         }
 
         // Diagonal lines: fall back to Bresenham for pixel-perfect rendering.
-        this.drawLineBresenham(x0, y0, x1, y1, color);
+        this.drawLineBresenham(x0, y0, x1, y1, paletteIndex);
     }
 
     /**
@@ -260,9 +267,9 @@ export class PrimitivePipeline {
      * Emits quads directly rather than delegating to `drawLine()`.
      *
      * @param rect - Rectangle bounds.
-     * @param color - Outline color.
+     * @param paletteIndex - Palette color index.
      */
-    drawRect(rect: Rect2i, color: Color32): void {
+    drawRect(rect: Rect2i, paletteIndex: number): void {
         const x0 = rect.x;
         const y0 = rect.y;
         const x1 = rect.x + rect.width - 1;
@@ -273,36 +280,36 @@ export class PrimitivePipeline {
 
         // Top line (horizontal): from (x0, y0) to (x1, y0), 1px tall.
         this.tempRect.set(x0, y0, x1 - x0 + 1, 1);
-        this.drawRectFill(this.tempRect, color);
+        this.drawRectFill(this.tempRect, paletteIndex);
 
         // Bottom line (horizontal): from (x0, y1) to (x1, y1), 1px tall.
         this.tempRect.set(x0, y1, x1 - x0 + 1, 1);
-        this.drawRectFill(this.tempRect, color);
+        this.drawRectFill(this.tempRect, paletteIndex);
 
         // Left line (vertical): from (x0, y0+1) to (x0, y1-1), 1px wide.
         // Shortened to avoid corner overlap with top/bottom lines.
         if (y1 - y0 > 1) {
             this.tempRect.set(x0, y0 + 1, 1, y1 - y0 - 1);
-            this.drawRectFill(this.tempRect, color);
+            this.drawRectFill(this.tempRect, paletteIndex);
         }
 
         // Right line (vertical): from (x1, y0+1) to (x1, y1-1), 1px wide.
         // Shortened to avoid corner overlap with top/bottom lines.
         if (y1 - y0 > 1) {
             this.tempRect.set(x1, y0 + 1, 1, y1 - y0 - 1);
-            this.drawRectFill(this.tempRect, color);
+            this.drawRectFill(this.tempRect, paletteIndex);
         }
     }
 
     /**
-     * Fills a rectangular region with a solid color.
+     * Fills a rectangular region with a palette-indexed color.
      * Alias for `drawRectFill()` kept for renderer API consistency.
      *
-     * @param color - Fill color.
+     * @param paletteIndex - Palette color index.
      * @param rect - Region to fill.
      */
-    clearRect(color: Color32, rect: Rect2i): void {
-        this.drawRectFill(rect, color);
+    clearRect(paletteIndex: number, rect: Rect2i): void {
+        this.drawRectFill(rect, paletteIndex);
     }
 
     /**
@@ -324,9 +331,9 @@ export class PrimitivePipeline {
         (this.device as GPUDevice).queue.writeBuffer(
             this.vertexBuffer as GPUBuffer,
             0,
-            this.vertices.buffer,
+            this.vertexArrayBuffer,
             0,
-            this.totalVertices * 6 * 4,
+            this.totalVertices * VERTEX_STRIDE,
         );
 
         renderPass.setPipeline(this.pipeline as GPURenderPipeline);
@@ -355,70 +362,53 @@ export class PrimitivePipeline {
      * Creates shader modules, pipeline state, and GPU buffers for primitive draws.
      *
      * @param displaySize - Render target resolution in pixels.
+     * @param paletteBuffer - Shared palette uniform buffer.
      */
-    private async createPipeline(displaySize: Vector2i): Promise<void> {
+    private async createPipeline(displaySize: Vector2i, paletteBuffer: GPUBuffer): Promise<void> {
         const device = this.device as GPUDevice;
 
         const shaderModule = device.createShaderModule({
             label: 'Primitive Shader',
             code: `
-                /**
-                 * Vertex input structure for primitive rendering.
-                 */
-                struct VertexInput {
-                    // Position in clip space.
-                    @location(0) position: vec2<f32>,
-
-                    // Color in RGBA.
-                    @location(1) color: vec4<f32>,
-                }
-
-                /**
-                 * Vertex output structure for primitive rendering.
-                 */
-                struct VertexOutput {
-                    // Position in clip space.
-                    @builtin(position) position: vec4<f32>,
-
-                    // Color in RGBA.
-                    @location(0) color: vec4<f32>,
-                }
-
-                /**
-                 * Uniforms for primitive rendering.
-                 */
                 struct Uniforms {
-                    // Resolution in pixels.
                     resolution: vec2<f32>,
                 }
 
-                /**
-                 * Uniforms for primitive rendering.
-                 */
-                @group(0) @binding(0) var<uniform> uniforms: Uniforms;
+                struct Palette {
+                    colors: array<vec4<f32>, 256>,
+                }
 
-                /**
-                 * Vertex shader main function.
-                 */
+                @group(0) @binding(0) var<uniform> uniforms: Uniforms;
+                @group(0) @binding(1) var<uniform> palette: Palette;
+
+                struct VertexInput {
+                    @location(0) position: vec2<f32>,
+                    @location(1) paletteIndex: u32,
+                }
+
+                struct VertexOutput {
+                    @builtin(position) position: vec4<f32>,
+                    @location(0) @interpolate(flat) paletteIndex: u32,
+                }
+
                 @vertex
                 fn vs_main(input: VertexInput) -> VertexOutput {
-                    // Output vertex.
                     var output: VertexOutput;
 
-                    // Convert from pixel coordinates to clip space (-1 to 1).
                     let clipX = (input.position.x / uniforms.resolution.x) * 2.0 - 1.0;
                     let clipY = 1.0 - (input.position.y / uniforms.resolution.y) * 2.0;
 
-                    // Set the position of the vertex in clip space.
                     output.position = vec4<f32>(clipX, clipY, 0.0, 1.0);
-                    output.color = input.color;
+                    output.paletteIndex = input.paletteIndex;
 
                     return output;
                 }
 
                 @fragment
                 fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
-                    return input.color;
+                    let color = palette.colors[input.paletteIndex];
+                    if (color.a == 0.0) { discard; }
+                    return vec4<f32>(color.rgb, 1.0);
                 }
             `,
         });
@@ -431,10 +421,10 @@ export class PrimitivePipeline {
                 entryPoint: 'vs_main',
                 buffers: [
                     {
-                        arrayStride: 6 * 4, // 6 floats * 4 bytes
+                        arrayStride: VERTEX_STRIDE,
                         attributes: [
                             { shaderLocation: 0, offset: 0, format: 'float32x2' }, // position
-                            { shaderLocation: 1, offset: 2 * 4, format: 'float32x4' }, // color
+                            { shaderLocation: 1, offset: 2 * 4, format: 'uint32' }, // paletteIndex
                         ],
                     },
                 ],
@@ -445,10 +435,6 @@ export class PrimitivePipeline {
                 targets: [
                     {
                         format: navigator.gpu.getPreferredCanvasFormat(),
-                        blend: {
-                            color: { srcFactor: 'src-alpha', dstFactor: 'one-minus-src-alpha', operation: 'add' },
-                            alpha: { srcFactor: 'one', dstFactor: 'one-minus-src-alpha', operation: 'add' },
-                        },
                     },
                 ],
             },
@@ -467,12 +453,15 @@ export class PrimitivePipeline {
         this.bindGroup = device.createBindGroup({
             label: 'Primitive Bind Group',
             layout: (this.pipeline as GPURenderPipeline).getBindGroupLayout(0),
-            entries: [{ binding: 0, resource: { buffer: this.uniformBuffer } }],
+            entries: [
+                { binding: 0, resource: { buffer: this.uniformBuffer } },
+                { binding: 1, resource: { buffer: paletteBuffer } },
+            ],
         });
 
         this.vertexBuffer = device.createBuffer({
             label: 'Primitive Vertex Buffer',
-            size: this.vertices.byteLength,
+            size: this.vertexArrayBuffer.byteLength,
             usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
         });
     }
@@ -490,9 +479,9 @@ export class PrimitivePipeline {
      * @param y0 - Start Y coordinate.
      * @param x1 - End X coordinate.
      * @param y1 - End Y coordinate.
-     * @param color - Line color.
+     * @param paletteIndex - Palette color index.
      */
-    private drawLineBresenham(x0: number, y0: number, x1: number, y1: number, color: Color32): void {
+    private drawLineBresenham(x0: number, y0: number, x1: number, y1: number, paletteIndex: number): void {
         const dx = Math.abs(x1 - x0);
         const dy = Math.abs(y1 - y0);
         const sx = x0 < x1 ? 1 : -1;
@@ -501,15 +490,9 @@ export class PrimitivePipeline {
         let cx = x0;
         let cy = y0;
 
-        // Pre-compute color values once for the entire line.
-        const r = color.r / 255;
-        const g = color.g / 255;
-        const b = color.b / 255;
-        const a = color.a / 255;
-
         while (true) {
             // Draw pixel directly without creating Vector2i.
-            this.addPixelVertices(cx, cy, r, g, b, a);
+            this.addPixelVertices(cx, cy, paletteIndex);
 
             if (cx === x1 && cy === y1) {
                 break;
@@ -533,23 +516,20 @@ export class PrimitivePipeline {
      *
      * @param x - X position.
      * @param y - Y position.
-     * @param r - Red component (0-1).
-     * @param g - Green component (0-1).
-     * @param b - Blue component (0-1).
-     * @param a - Alpha component (0-1).
+     * @param paletteIndex - Palette color index.
      */
-    private addPixelVertices(x: number, y: number, r: number, g: number, b: number, a: number): void {
-        // Ensure space for complete pixel (6 vertices) to prevent partial geometry
-        const index = (this.totalVertices + this.vertexCount) * 6;
+    private addPixelVertices(x: number, y: number, paletteIndex: number): void {
+        // Ensure space for complete pixel (6 vertices) to prevent partial geometry.
+        const index = (this.totalVertices + this.vertexCount) * VALUES_PER_VERTEX;
+        const pixelValues = 6 * VALUES_PER_VERTEX; // 6 vertices * 3 values
 
-        if (index + 36 > this.vertices.length) {
-            // 6 vertices * 6 floats
+        if (index + pixelValues > this.vertexFloats.length) {
             if (this.vertexCount > 0) {
                 this.earlyFlush();
             }
 
-            // Check again after flush - if still no space, buffer is exhausted
-            if ((this.totalVertices + this.vertexCount) * 6 + 36 > this.vertices.length) {
+            // Check again after flush - if still no space, buffer is exhausted.
+            if ((this.totalVertices + this.vertexCount) * VALUES_PER_VERTEX + pixelValues > this.vertexFloats.length) {
                 console.warn('[PrimitivePipeline] Buffer exhausted, pixel dropped');
 
                 return;
@@ -559,13 +539,13 @@ export class PrimitivePipeline {
         const x1 = x + 1;
         const y1 = y + 1;
 
-        this.addVertex(x, y, r, g, b, a);
-        this.addVertex(x1, y, r, g, b, a);
-        this.addVertex(x, y1, r, g, b, a);
+        this.addVertex(x, y, paletteIndex);
+        this.addVertex(x1, y, paletteIndex);
+        this.addVertex(x, y1, paletteIndex);
 
-        this.addVertex(x1, y, r, g, b, a);
-        this.addVertex(x1, y1, r, g, b, a);
-        this.addVertex(x, y1, r, g, b, a);
+        this.addVertex(x1, y, paletteIndex);
+        this.addVertex(x1, y1, paletteIndex);
+        this.addVertex(x, y1, paletteIndex);
     }
 
     /**
@@ -574,21 +554,18 @@ export class PrimitivePipeline {
      *
      * @param x - X position in pixels.
      * @param y - Y position in pixels.
-     * @param r - Red component (0-1).
-     * @param g - Green component (0-1).
-     * @param b - Blue component (0-1).
-     * @param a - Alpha component (0-1).
+     * @param paletteIndex - Palette color index (written as uint32).
      */
-    private addVertex(x: number, y: number, r: number, g: number, b: number, a: number): void {
-        const index = (this.totalVertices + this.vertexCount) * 6;
+    private addVertex(x: number, y: number, paletteIndex: number): void {
+        const index = (this.totalVertices + this.vertexCount) * VALUES_PER_VERTEX;
 
-        if (index + 6 > this.vertices.length) {
+        if (index + VALUES_PER_VERTEX > this.vertexFloats.length) {
             this.earlyFlush();
 
             // Re-check after flush - if still no space, buffer is exhausted for this frame.
-            const newIndex = (this.totalVertices + this.vertexCount) * 6;
+            const newIndex = (this.totalVertices + this.vertexCount) * VALUES_PER_VERTEX;
 
-            if (newIndex + 6 > this.vertices.length) {
+            if (newIndex + VALUES_PER_VERTEX > this.vertexFloats.length) {
                 console.warn('[PrimitivePipeline] Primitive buffer capacity exceeded for this frame, vertex dropped');
                 return;
             }
@@ -596,13 +573,13 @@ export class PrimitivePipeline {
             // Space available after flush, continue with vertex addition below.
         }
 
+        // Position stored as float32 via the float view.
         // eslint-disable-next-line security/detect-object-injection
-        this.vertices[index] = x - this.cameraOffset.x;
-        this.vertices[index + 1] = y - this.cameraOffset.y;
-        this.vertices[index + 2] = r;
-        this.vertices[index + 3] = g;
-        this.vertices[index + 4] = b;
-        this.vertices[index + 5] = a;
+        this.vertexFloats[index] = x - this.cameraOffset.x;
+        this.vertexFloats[index + 1] = y - this.cameraOffset.y;
+
+        // Palette index stored as uint32 via the uint view.
+        this.vertexIndices[index + 2] = paletteIndex;
 
         this.vertexCount++;
     }
@@ -610,7 +587,7 @@ export class PrimitivePipeline {
     /**
      * Records the current vertex batch and resets the vertex count.
      * Used for early flush when the buffer is full mid-frame.
-     * Does not write to GPU — encodePass() uploads all batches at once.
+     * Does not write to GPU -- encodePass() uploads all batches at once.
      */
     private earlyFlush(): void {
         if (this.vertexCount === 0) {

--- a/src/render/Renderer.test.ts
+++ b/src/render/Renderer.test.ts
@@ -109,7 +109,7 @@ describe('pre-initialization methods', () => {
 
         expect(() => {
             renderer.beginFrame();
-        }).toThrow('Cannot begin frame: no active palette. Call BT.paletteSet() first.');
+        }).toThrow('Cannot begin frame: no active palette. Call setPalette() first.');
     });
 
     it('beginFrame succeeds with active palette', () => {
@@ -185,7 +185,7 @@ describe('palette enforcement', () => {
 
         renderer.setPalette(palette);
 
-        expect(renderer.getPalette()).toBe(palette);
+        expect(renderer.getPalette()).toEqual(palette);
     });
 
     it('getPalette returns null when no palette is set', () => {
@@ -304,7 +304,7 @@ describe('with initialized renderer', () => {
         renderer.beginFrame();
 
         expect(() => {
-            renderer.clearRect(1, new Rect2i(0, 0, 320, 240));
+            renderer.clearRect(new Rect2i(0, 0, 320, 240), 1);
         }).not.toThrow();
 
         renderer.endFrame();

--- a/src/render/Renderer.test.ts
+++ b/src/render/Renderer.test.ts
@@ -185,7 +185,13 @@ describe('palette enforcement', () => {
 
         renderer.setPalette(palette);
 
-        expect(renderer.getPalette()).toEqual(palette);
+        const result = renderer.getPalette();
+
+        expect(result).not.toBeNull();
+        expect(result).not.toBe(palette);
+        expect(result!.size).toBe(palette.size);
+        expect(result!.get(1)).toEqual(palette.get(1));
+        expect(result!.get(8)).toEqual(palette.get(8));
     });
 
     it('getPalette returns null when no palette is set', () => {
@@ -250,7 +256,7 @@ describe('with initialized renderer', () => {
         }).not.toThrow();
     });
 
-    it('drawPixel delegates without throwing', () => {
+    it('drawPixel delegates without throwing at (10,10)', () => {
         renderer.beginFrame();
 
         expect(() => {
@@ -260,7 +266,7 @@ describe('with initialized renderer', () => {
         renderer.endFrame();
     });
 
-    it('drawPixel delegates without throwing', () => {
+    it('drawPixel delegates without throwing at (15,25)', () => {
         renderer.beginFrame();
 
         expect(() => {
@@ -404,16 +410,16 @@ describe('resolveClearColor fallbacks', () => {
 
         await r.initialize();
 
-        const palette = createTestPalette();
-
-        vi.spyOn(palette, 'get').mockImplementation(() => {
+        // Spy on the prototype so the clone stored by setPalette also throws.
+        const getSpy = vi.spyOn(Palette.prototype, 'get').mockImplementation(() => {
             throw new Error('get error');
         });
 
-        r.setPalette(palette);
+        r.setPalette(createTestPalette());
 
         expect(() => r.endFrame()).not.toThrow();
 
+        getSpy.mockRestore();
         uninstallMockNavigatorGPU();
     });
 });

--- a/src/render/Renderer.test.ts
+++ b/src/render/Renderer.test.ts
@@ -260,11 +260,11 @@ describe('with initialized renderer', () => {
         renderer.endFrame();
     });
 
-    it('drawPixelXY delegates without throwing', () => {
+    it('drawPixel delegates without throwing', () => {
         renderer.beginFrame();
 
         expect(() => {
-            renderer.drawPixelXY(new Vector2i(15, 25), 3);
+            renderer.drawPixel(new Vector2i(15, 25), 3);
         }).not.toThrow();
 
         renderer.endFrame();

--- a/src/render/Renderer.test.ts
+++ b/src/render/Renderer.test.ts
@@ -21,7 +21,9 @@ import {
     installMockNavigatorGPU,
     uninstallMockNavigatorGPU,
 } from '../__test__/webgpu-mock';
+import type { BitmapFont } from '../assets/BitmapFont';
 import { Palette } from '../assets/Palette';
+import type { SpriteSheet } from '../assets/SpriteSheet';
 import { Color32 } from '../utils/Color32';
 import { Rect2i } from '../utils/Rect2i';
 import { Vector2i } from '../utils/Vector2i';
@@ -338,9 +340,83 @@ describe('with initialized renderer', () => {
             renderer.endFrame();
         }).not.toThrow();
     });
+
+    it('drawSprite delegates without throwing', () => {
+        renderer.beginFrame();
+
+        const mockTexture = {
+            createView: () => ({}),
+            width: 8,
+            height: 8,
+        } as unknown as GPUTexture;
+
+        const mockSheet = {
+            getTexture: () => mockTexture,
+            getUVs: () => ({ u0: 0, v0: 0, u1: 1, v1: 1 }),
+        } as unknown as SpriteSheet;
+
+        expect(() => {
+            renderer.drawSprite(mockSheet, new Rect2i(0, 0, 8, 8), new Vector2i(10, 10));
+        }).not.toThrow();
+
+        renderer.endFrame();
+    });
+
+    it('drawBitmapText delegates without throwing', () => {
+        renderer.beginFrame();
+
+        // Empty text — loop does not execute so glyph methods are never called.
+        const mockFont = {
+            getSpriteSheet: () => ({}),
+            getGlyphByCode: () => null,
+        } as unknown as BitmapFont;
+
+        expect(() => {
+            renderer.drawBitmapText(mockFont, new Vector2i(0, 0), '');
+        }).not.toThrow();
+
+        renderer.endFrame();
+    });
 });
 
 // #endregion
+
+// #region resolveClearColor Fallbacks
+
+describe('resolveClearColor fallbacks', () => {
+    it('returns black (no throw) when no palette is set', async () => {
+        const r = new Renderer(createMockGPUDevice(), createMockGPUCanvasContext(), new Vector2i(320, 240));
+
+        installMockNavigatorGPU();
+
+        await r.initialize();
+
+        // No setPalette() call — endFrame() resolves clear color to black via fallback.
+        expect(() => r.endFrame()).not.toThrow();
+
+        uninstallMockNavigatorGPU();
+    });
+
+    it('returns black (no throw) when palette.get throws', async () => {
+        const r = new Renderer(createMockGPUDevice(), createMockGPUCanvasContext(), new Vector2i(320, 240));
+
+        installMockNavigatorGPU();
+
+        await r.initialize();
+
+        const palette = createTestPalette();
+
+        vi.spyOn(palette, 'get').mockImplementation(() => {
+            throw new Error('get error');
+        });
+
+        r.setPalette(palette);
+
+        expect(() => r.endFrame()).not.toThrow();
+
+        uninstallMockNavigatorGPU();
+    });
+});
 
 // #region Frame Capture
 

--- a/src/render/Renderer.test.ts
+++ b/src/render/Renderer.test.ts
@@ -5,7 +5,8 @@
  * - constructor behavior and pre-initialization safety
  * - camera state ownership and copy semantics
  * - successful renderer initialization and repeated frame lifecycles
- * - delegation of primitive drawing calls during active frames
+ * - delegation of palette-indexed primitive drawing calls during active frames
+ * - palette enforcement (beginFrame throws without active palette)
  * - frame capture flow and error handling during presentation
  *
  * The suite uses mocked WebGPU devices, contexts, and browser image APIs so
@@ -20,10 +21,31 @@ import {
     installMockNavigatorGPU,
     uninstallMockNavigatorGPU,
 } from '../__test__/webgpu-mock';
+import { Palette } from '../assets/Palette';
 import { Color32 } from '../utils/Color32';
 import { Rect2i } from '../utils/Rect2i';
 import { Vector2i } from '../utils/Vector2i';
 import { Renderer } from './Renderer';
+
+// #region Test Helpers
+
+/** Creates a small 16-color test palette with known color assignments. */
+function createTestPalette(): Palette {
+    const palette = new Palette(16);
+
+    palette.set(1, Color32.black());
+    palette.set(2, Color32.red());
+    palette.set(3, Color32.green());
+    palette.set(4, Color32.blue());
+    palette.set(5, Color32.yellow());
+    palette.set(6, Color32.cyan());
+    palette.set(7, Color32.magenta());
+    palette.set(8, Color32.white());
+
+    return palette;
+}
+
+// #endregion
 
 // #region Constructor
 
@@ -48,7 +70,7 @@ describe('pre-initialization methods', () => {
         const renderer = new Renderer(createMockGPUDevice(), createMockGPUCanvasContext(), new Vector2i(320, 240));
 
         expect(() => {
-            renderer.setClearColor(Color32.blue());
+            renderer.setClearColor(1);
         }).not.toThrow();
     });
 
@@ -80,8 +102,18 @@ describe('pre-initialization methods', () => {
         expect(offset.y).toBe(0);
     });
 
-    it('beginFrame does not throw before initialize', () => {
+    it('beginFrame throws without active palette', () => {
         const renderer = new Renderer(createMockGPUDevice(), createMockGPUCanvasContext(), new Vector2i(320, 240));
+
+        expect(() => {
+            renderer.beginFrame();
+        }).toThrow('Cannot begin frame: no active palette. Call BT.paletteSet() first.');
+    });
+
+    it('beginFrame succeeds with active palette', () => {
+        const renderer = new Renderer(createMockGPUDevice(), createMockGPUCanvasContext(), new Vector2i(320, 240));
+
+        renderer.setPalette(createTestPalette());
 
         expect(() => {
             renderer.beginFrame();
@@ -142,6 +174,27 @@ describe('camera operations', () => {
 
 // #endregion
 
+// #region Palette Enforcement
+
+describe('palette enforcement', () => {
+    it('setPalette stores and returns palette', () => {
+        const renderer = new Renderer(createMockGPUDevice(), createMockGPUCanvasContext(), new Vector2i(320, 240));
+        const palette = createTestPalette();
+
+        renderer.setPalette(palette);
+
+        expect(renderer.getPalette()).toBe(palette);
+    });
+
+    it('getPalette returns null when no palette is set', () => {
+        const renderer = new Renderer(createMockGPUDevice(), createMockGPUCanvasContext(), new Vector2i(320, 240));
+
+        expect(renderer.getPalette()).toBeNull();
+    });
+});
+
+// #endregion
+
 // #region Initialized Renderer
 
 describe('with initialized renderer', () => {
@@ -156,6 +209,8 @@ describe('with initialized renderer', () => {
         const result = await renderer.initialize();
 
         expect(result).toBe(true);
+
+        renderer.setPalette(createTestPalette());
     });
 
     afterAll(() => {
@@ -197,7 +252,7 @@ describe('with initialized renderer', () => {
         renderer.beginFrame();
 
         expect(() => {
-            renderer.drawPixel(new Vector2i(10, 10), Color32.red());
+            renderer.drawPixel(new Vector2i(10, 10), 2);
         }).not.toThrow();
 
         renderer.endFrame();
@@ -207,7 +262,7 @@ describe('with initialized renderer', () => {
         renderer.beginFrame();
 
         expect(() => {
-            renderer.drawPixelXY(15, 25, Color32.green());
+            renderer.drawPixelXY(15, 25, 3);
         }).not.toThrow();
 
         renderer.endFrame();
@@ -217,7 +272,7 @@ describe('with initialized renderer', () => {
         renderer.beginFrame();
 
         expect(() => {
-            renderer.drawRectFill(new Rect2i(5, 5, 20, 20), Color32.blue());
+            renderer.drawRectFill(new Rect2i(5, 5, 20, 20), 4);
         }).not.toThrow();
 
         renderer.endFrame();
@@ -227,7 +282,7 @@ describe('with initialized renderer', () => {
         renderer.beginFrame();
 
         expect(() => {
-            renderer.drawLine(new Vector2i(0, 0), new Vector2i(50, 50), Color32.yellow());
+            renderer.drawLine(new Vector2i(0, 0), new Vector2i(50, 50), 5);
         }).not.toThrow();
 
         renderer.endFrame();
@@ -237,7 +292,7 @@ describe('with initialized renderer', () => {
         renderer.beginFrame();
 
         expect(() => {
-            renderer.drawRect(new Rect2i(10, 10, 30, 30), Color32.cyan());
+            renderer.drawRect(new Rect2i(10, 10, 30, 30), 6);
         }).not.toThrow();
 
         renderer.endFrame();
@@ -247,7 +302,7 @@ describe('with initialized renderer', () => {
         renderer.beginFrame();
 
         expect(() => {
-            renderer.clearRect(Color32.black(), new Rect2i(0, 0, 320, 240));
+            renderer.clearRect(1, new Rect2i(0, 0, 320, 240));
         }).not.toThrow();
 
         renderer.endFrame();
@@ -257,7 +312,7 @@ describe('with initialized renderer', () => {
         renderer.beginFrame();
 
         expect(() => {
-            renderer.drawText(new Vector2i(10, 10), Color32.white(), 'Test');
+            renderer.drawText(new Vector2i(10, 10), 8, 'Test');
         }).not.toThrow();
 
         renderer.endFrame();
@@ -267,7 +322,7 @@ describe('with initialized renderer', () => {
         renderer.beginFrame();
 
         expect(() => {
-            renderer.setClearColor(new Color32(64, 128, 192, 255));
+            renderer.setClearColor(4);
         }).not.toThrow();
 
         renderer.endFrame();
@@ -276,7 +331,7 @@ describe('with initialized renderer', () => {
     it('camera operations work within a frame cycle', () => {
         renderer.beginFrame();
         renderer.setCameraOffset(new Vector2i(50, 50));
-        renderer.drawRectFill(new Rect2i(0, 0, 10, 10), Color32.red());
+        renderer.drawRectFill(new Rect2i(0, 0, 10, 10), 2);
         renderer.resetCamera();
 
         expect(() => {
@@ -332,6 +387,7 @@ describe('frame capture', () => {
         );
 
         await renderer.initialize();
+        renderer.setPalette(createTestPalette());
 
         const promise = renderer.captureFrame();
 
@@ -367,6 +423,7 @@ describe('frame capture', () => {
         installMockNavigatorGPU();
 
         await renderer.initialize();
+        renderer.setPalette(createTestPalette());
 
         // Stub browser APIs for PNG conversion.
         vi.stubGlobal(
@@ -427,6 +484,7 @@ describe('frame capture', () => {
         installMockNavigatorGPU();
 
         await renderer.initialize();
+        renderer.setPalette(createTestPalette());
 
         renderer.beginFrame();
         renderer.endFrame();
@@ -457,12 +515,13 @@ describe('endFrame error paths', () => {
         installMockNavigatorGPU();
 
         await renderer.initialize();
+        renderer.setPalette(createTestPalette());
 
         const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
         try {
             renderer.beginFrame();
-            renderer.drawRectFill(new Rect2i(0, 0, 10, 10), Color32.red());
+            renderer.drawRectFill(new Rect2i(0, 0, 10, 10), 2);
 
             expect(() => {
                 renderer.endFrame();
@@ -500,6 +559,7 @@ describe('endFrame error paths', () => {
         installMockNavigatorGPU();
 
         await renderer.initialize();
+        renderer.setPalette(createTestPalette());
 
         const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 

--- a/src/render/Renderer.test.ts
+++ b/src/render/Renderer.test.ts
@@ -264,7 +264,7 @@ describe('with initialized renderer', () => {
         renderer.beginFrame();
 
         expect(() => {
-            renderer.drawPixelXY(15, 25, 3);
+            renderer.drawPixelXY(new Vector2i(15, 25), 3);
         }).not.toThrow();
 
         renderer.endFrame();

--- a/src/render/Renderer.ts
+++ b/src/render/Renderer.ts
@@ -126,7 +126,7 @@ export class Renderer {
      * @param palette - Palette to use for color lookups and GPU upload.
      */
     setPalette(palette: Palette): void {
-        this.palette = palette;
+        this.palette = palette.clone();
         this.paletteDirty = true;
     }
 
@@ -150,7 +150,7 @@ export class Renderer {
      */
     beginFrame(): void {
         if (!this.palette) {
-            throw new Error('Cannot begin frame: no active palette. Call BT.paletteSet() first.');
+            throw new Error('Cannot begin frame: no active palette. Call setPalette() first.');
         }
 
         this.primitives.reset();
@@ -325,11 +325,11 @@ export class Renderer {
     /**
      * Fills a rectangular region with a palette-indexed color.
      *
-     * @param paletteIndex - Palette color index.
      * @param rect - Region to fill in pixel coordinates.
+     * @param paletteIndex - Palette color index.
      */
-    clearRect(paletteIndex: number, rect: Rect2i): void {
-        this.primitives.clearRect(paletteIndex, rect);
+    clearRect(rect: Rect2i, paletteIndex: number): void {
+        this.primitives.clearRect(rect, paletteIndex);
     }
 
     // #endregion

--- a/src/render/Renderer.ts
+++ b/src/render/Renderer.ts
@@ -285,19 +285,18 @@ export class Renderer {
      * @param paletteIndex - Palette color index.
      */
     drawPixel(pos: Vector2i, paletteIndex: number): void {
-        this.primitives.drawPixel(pos, paletteIndex);
+        this.drawPixelXYInternal(pos.x, pos.y, paletteIndex);
     }
 
     /**
-     * Draws a single pixel at raw coordinates.
-     * More efficient than `drawPixel()` when coordinates are already unpacked.
+     * Draws a single pixel at integer coordinates.
+     * Enforces integer coordinates per rendering guidelines.
      *
-     * @param x - X position.
-     * @param y - Y position.
+     * @param pos - Pixel position.
      * @param paletteIndex - Palette color index.
      */
-    drawPixelXY(x: number, y: number, paletteIndex: number): void {
-        this.primitives.drawPixelXY(x, y, paletteIndex);
+    drawPixelXY(pos: Vector2i, paletteIndex: number): void {
+        this.drawPixelXYInternal(pos.x, pos.y, paletteIndex);
     }
 
     /**
@@ -413,6 +412,18 @@ export class Renderer {
     // #endregion
 
     // #region Private Helpers
+
+    /**
+     * Fast-path pixel draw using raw integer coordinates.
+     * Avoids Vector2i unpacking overhead when coordinates are already available as numbers.
+     *
+     * @param x - X position.
+     * @param y - Y position.
+     * @param paletteIndex - Palette color index.
+     */
+    private drawPixelXYInternal(x: number, y: number, paletteIndex: number): void {
+        this.primitives.drawPixelXY(x, y, paletteIndex);
+    }
 
     /**
      * Resolves the clear palette index into a Color32 for the render pass.

--- a/src/render/Renderer.ts
+++ b/src/render/Renderer.ts
@@ -55,6 +55,9 @@ export class Renderer {
     /** GPU uniform buffer for the 256-entry palette. */
     private paletteBuffer: GPUBuffer | null = null;
 
+    /** Reusable staging buffer for GPU palette uploads. Avoids per-frame allocation. */
+    private readonly paletteStaging = new Float32Array(256 * 4);
+
     /** True when the palette has changed and needs to be re-uploaded to the GPU. */
     private paletteDirty: boolean = false;
 
@@ -198,9 +201,8 @@ export class Renderer {
 
         // Upload palette to GPU only when it has changed.
         if (this.palette && this.paletteBuffer && this.paletteDirty) {
-            const paletteData = this.palette.toFloat32Array();
-
-            this.device.queue.writeBuffer(this.paletteBuffer, 0, paletteData.buffer);
+            this.palette.toFloat32ArrayInto(this.paletteStaging);
+            this.device.queue.writeBuffer(this.paletteBuffer, 0, this.paletteStaging);
             this.paletteDirty = false;
         }
 

--- a/src/render/Renderer.ts
+++ b/src/render/Renderer.ts
@@ -1,4 +1,5 @@
 import type { BitmapFont } from '../assets/BitmapFont';
+import type { Palette } from '../assets/Palette';
 import type { SpriteSheet } from '../assets/SpriteSheet';
 import { Color32 } from '../utils/Color32';
 import { FrameCapture } from '../utils/FrameCapture';
@@ -7,12 +8,21 @@ import { Vector2i } from '../utils/Vector2i';
 import { PrimitivePipeline } from './PrimitivePipeline';
 import { SpritePipeline } from './SpritePipeline';
 
+// #region Configuration
+
+/**
+ * GPU palette uniform buffer size: 256 entries x 4 floats x 4 bytes = 4096 bytes.
+ */
+const PALETTE_BUFFER_SIZE = 256 * 4 * 4;
+
+// #endregion
+
 /**
  * High-level renderer that coordinates primitive and sprite pipelines.
  *
- * `Renderer` owns frame begin/end, clear color, camera state, and frame capture.
- * Actual draw batching is delegated to {@link PrimitivePipeline} and
- * {@link SpritePipeline}.
+ * `Renderer` owns frame begin/end, clear color, camera state, palette buffer,
+ * and frame capture. Actual draw batching is delegated to
+ * {@link PrimitivePipeline} and {@link SpritePipeline}.
  */
 export class Renderer {
     // #region State
@@ -26,8 +36,8 @@ export class Renderer {
     /** Render target resolution in pixels. */
     private readonly displaySize: Vector2i;
 
-    /** Current clear color for the background. */
-    private currentClearColor: Color32 = Color32.black();
+    /** Palette index used for the frame clear color. Defaults to 0 (transparent). */
+    private clearPaletteIndex: number = 0;
 
     /** Camera offset for scrolling effects. */
     private cameraOffset: Vector2i = Vector2i.zero();
@@ -37,9 +47,19 @@ export class Renderer {
 
     // #endregion
 
+    // #region Palette State
+
+    /** Active palette for color lookups and GPU upload. */
+    private palette: Palette | null = null;
+
+    /** GPU uniform buffer for the 256-entry palette. */
+    private paletteBuffer: GPUBuffer | null = null;
+
+    // #endregion
+
     // #region Pipelines
 
-    /** Pipeline for colored geometry (pixels, lines, rectangles). */
+    /** Pipeline for palette-indexed geometry (pixels, lines, rectangles). */
     private readonly primitives: PrimitivePipeline;
 
     /** Pipeline for textured quads (sprites, bitmap text). */
@@ -75,8 +95,15 @@ export class Renderer {
      */
     async initialize(): Promise<boolean> {
         try {
-            await this.primitives.initialize(this.device, this.displaySize);
-            await this.sprites.initialize(this.device, this.displaySize);
+            // Create shared palette uniform buffer (256 entries x vec4f).
+            this.paletteBuffer = this.device.createBuffer({
+                label: 'Palette Uniform Buffer',
+                size: PALETTE_BUFFER_SIZE,
+                usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+            });
+
+            await this.primitives.initialize(this.device, this.displaySize, this.paletteBuffer);
+            await this.sprites.initialize(this.device, this.displaySize, this.paletteBuffer);
 
             return true;
         } catch (error) {
@@ -88,28 +115,57 @@ export class Renderer {
 
     // #endregion
 
+    // #region Palette
+
+    /**
+     * Sets the active palette used for rendering.
+     *
+     * @param palette - Palette to use for color lookups and GPU upload.
+     */
+    setPalette(palette: Palette): void {
+        this.palette = palette;
+    }
+
+    /**
+     * Returns the active palette, or null if none has been set.
+     *
+     * @returns Active palette instance.
+     */
+    getPalette(): Palette | null {
+        return this.palette;
+    }
+
+    // #endregion
+
     // #region Frame Management
 
     /**
      * Begins a new frame by clearing all per-frame batching state.
+     *
+     * @throws Error if no palette has been set via {@link setPalette}.
      */
     beginFrame(): void {
+        if (!this.palette) {
+            throw new Error('Cannot begin frame: no active palette. Call BT.paletteSet() first.');
+        }
+
         this.primitives.reset();
         this.sprites.reset();
     }
 
     /**
-     * Sets the background clear color for this frame.
+     * Sets the background clear color for this frame using a palette index.
      *
-     * @param color - Color to clear the screen with.
+     * @param paletteIndex - Palette index for the clear color.
      */
-    setClearColor(color: Color32): void {
-        this.currentClearColor = color.clone();
+    setClearColor(paletteIndex: number): void {
+        this.clearPaletteIndex = paletteIndex;
     }
 
     /**
      * Ends the current frame and presents to the screen.
-     * Encodes both pipelines into a render pass and submits the command buffer.
+     * Uploads the palette uniform buffer, encodes both pipelines into a render
+     * pass, and submits the command buffer.
      */
     endFrame(): void {
         // Get the current texture to render to.
@@ -136,6 +192,16 @@ export class Renderer {
             return;
         }
 
+        // Upload palette to GPU before encoding the render pass.
+        if (this.palette && this.paletteBuffer) {
+            const paletteData = this.palette.toFloat32Array();
+
+            this.device.queue.writeBuffer(this.paletteBuffer, 0, paletteData.buffer);
+        }
+
+        // Resolve clear color from palette.
+        const clearColor = this.resolveClearColor();
+
         const textureView = texture.createView();
         const commandEncoder = this.device.createCommandEncoder({ label: 'Render Commands' });
 
@@ -145,10 +211,10 @@ export class Renderer {
                 {
                     view: textureView,
                     clearValue: {
-                        r: this.currentClearColor.r / 255,
-                        g: this.currentClearColor.g / 255,
-                        b: this.currentClearColor.b / 255,
-                        a: this.currentClearColor.a / 255,
+                        r: clearColor.r / 255,
+                        g: clearColor.g / 255,
+                        b: clearColor.b / 255,
+                        a: clearColor.a / 255,
                     },
                     loadOp: 'clear',
                     storeOp: 'store',
@@ -189,10 +255,10 @@ export class Renderer {
      * Draws a filled rectangle using two triangles.
      *
      * @param rect - Rectangle bounds in pixel coordinates.
-     * @param color - Fill color.
+     * @param paletteIndex - Palette color index.
      */
-    drawRectFill(rect: Rect2i, color: Color32): void {
-        this.primitives.drawRectFill(rect, color);
+    drawRectFill(rect: Rect2i, paletteIndex: number): void {
+        this.primitives.drawRectFill(rect, paletteIndex);
     }
 
     /**
@@ -200,21 +266,21 @@ export class Renderer {
      * Each character is rendered as a small filled rectangle.
      *
      * @param pos - Text position (top-left corner).
-     * @param color - Text color.
+     * @param paletteIndex - Palette color index.
      * @param text - String to display.
      */
-    drawText(pos: Vector2i, color: Color32, text: string): void {
-        this.primitives.drawText(pos, color, text);
+    drawText(pos: Vector2i, paletteIndex: number, text: string): void {
+        this.primitives.drawText(pos, paletteIndex, text);
     }
 
     /**
      * Draws a single pixel as a 1x1 filled rectangle.
      *
      * @param pos - Pixel position.
-     * @param color - Pixel color.
+     * @param paletteIndex - Palette color index.
      */
-    drawPixel(pos: Vector2i, color: Color32): void {
-        this.primitives.drawPixel(pos, color);
+    drawPixel(pos: Vector2i, paletteIndex: number): void {
+        this.primitives.drawPixel(pos, paletteIndex);
     }
 
     /**
@@ -223,10 +289,10 @@ export class Renderer {
      *
      * @param x - X position.
      * @param y - Y position.
-     * @param color - Pixel color.
+     * @param paletteIndex - Palette color index.
      */
-    drawPixelXY(x: number, y: number, color: Color32): void {
-        this.primitives.drawPixelXY(x, y, color);
+    drawPixelXY(x: number, y: number, paletteIndex: number): void {
+        this.primitives.drawPixelXY(x, y, paletteIndex);
     }
 
     /**
@@ -235,30 +301,30 @@ export class Renderer {
      *
      * @param p0 - Start point.
      * @param p1 - End point.
-     * @param color - Line color.
+     * @param paletteIndex - Palette color index.
      */
-    drawLine(p0: Vector2i, p1: Vector2i, color: Color32): void {
-        this.primitives.drawLine(p0, p1, color);
+    drawLine(p0: Vector2i, p1: Vector2i, paletteIndex: number): void {
+        this.primitives.drawLine(p0, p1, paletteIndex);
     }
 
     /**
      * Draws a rectangle outline using four 1-pixel quads.
      *
      * @param rect - Rectangle bounds.
-     * @param color - Outline color.
+     * @param paletteIndex - Palette color index.
      */
-    drawRect(rect: Rect2i, color: Color32): void {
-        this.primitives.drawRect(rect, color);
+    drawRect(rect: Rect2i, paletteIndex: number): void {
+        this.primitives.drawRect(rect, paletteIndex);
     }
 
     /**
-     * Fills a rectangular region with a solid color.
+     * Fills a rectangular region with a palette-indexed color.
      *
-     * @param color - Fill color.
-     * @param rect - Region to fill.
+     * @param paletteIndex - Palette color index.
+     * @param rect - Region to fill in pixel coordinates.
      */
-    clearRect(color: Color32, rect: Rect2i): void {
-        this.primitives.clearRect(color, rect);
+    clearRect(paletteIndex: number, rect: Rect2i): void {
+        this.primitives.clearRect(paletteIndex, rect);
     }
 
     // #endregion
@@ -337,6 +403,28 @@ export class Renderer {
         this.cameraOffset = Vector2i.zero();
         this.primitives.setCameraOffset(this.cameraOffset);
         this.sprites.setCameraOffset(this.cameraOffset);
+    }
+
+    // #endregion
+
+    // #region Private Helpers
+
+    /**
+     * Resolves the clear palette index into a Color32 for the render pass.
+     * Falls back to black if no palette is available.
+     *
+     * @returns Resolved clear color.
+     */
+    private resolveClearColor(): Color32 {
+        if (!this.palette) {
+            return Color32.black();
+        }
+
+        try {
+            return this.palette.get(this.clearPaletteIndex);
+        } catch {
+            return Color32.black();
+        }
     }
 
     // #endregion

--- a/src/render/Renderer.ts
+++ b/src/render/Renderer.ts
@@ -131,6 +131,12 @@ export class Renderer {
     setPalette(palette: Palette): void {
         this.palette = palette.clone();
         this.paletteDirty = true;
+
+        // If the new palette is smaller than the current clear index, reset to 0
+        // (transparent) so resolveClearColor does not warn on every endFrame().
+        if (this.clearPaletteIndex >= this.palette.size) {
+            this.clearPaletteIndex = 0;
+        }
     }
 
     /**

--- a/src/render/Renderer.ts
+++ b/src/render/Renderer.ts
@@ -108,6 +108,11 @@ export class Renderer {
                 usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
             });
 
+            // Mark the palette dirty so the new buffer is populated on the first
+            // endFrame(), even if the palette data has not changed since the last
+            // initialize() call (e.g. after a WebGPU device-loss recovery).
+            this.paletteDirty = true;
+
             await this.primitives.initialize(this.device, this.displaySize, this.paletteBuffer);
             await this.sprites.initialize(this.device, this.displaySize, this.paletteBuffer);
 

--- a/src/render/Renderer.ts
+++ b/src/render/Renderer.ts
@@ -301,17 +301,6 @@ export class Renderer {
      * @param paletteIndex - Palette color index.
      */
     drawPixel(pos: Vector2i, paletteIndex: number): void {
-        this.drawPixelXY(pos, paletteIndex);
-    }
-
-    /**
-     * Draws a single pixel at integer coordinates.
-     * Enforces integer coordinates per rendering guidelines.
-     *
-     * @param pos - Pixel position.
-     * @param paletteIndex - Palette color index.
-     */
-    drawPixelXY(pos: Vector2i, paletteIndex: number): void {
         this.drawPixelXYInternal(pos.x, pos.y, paletteIndex);
     }
 

--- a/src/render/Renderer.ts
+++ b/src/render/Renderer.ts
@@ -301,7 +301,7 @@ export class Renderer {
      * @param paletteIndex - Palette color index.
      */
     drawPixel(pos: Vector2i, paletteIndex: number): void {
-        this.drawPixelXYInternal(pos.x, pos.y, paletteIndex);
+        this.drawPixelXY(pos, paletteIndex);
     }
 
     /**

--- a/src/render/Renderer.ts
+++ b/src/render/Renderer.ts
@@ -134,12 +134,15 @@ export class Renderer {
     }
 
     /**
-     * Returns the active palette, or null if none has been set.
+     * Returns a copy of the active palette, or null if none has been set.
      *
-     * @returns Active palette instance.
+     * Returns a clone so callers cannot mutate the internal palette and bypass
+     * the dirty flag that drives GPU re-upload.
+     *
+     * @returns Clone of the active palette instance, or null.
      */
     getPalette(): Palette | null {
-        return this.palette;
+        return this.palette?.clone() ?? null;
     }
 
     // #endregion
@@ -440,7 +443,9 @@ export class Renderer {
 
         try {
             return this.palette.get(this.clearPaletteIndex);
-        } catch {
+        } catch (error) {
+            console.warn('[Renderer] resolveClearColor: clearPaletteIndex out of range, falling back to black:', error);
+
             return Color32.black();
         }
     }

--- a/src/render/Renderer.ts
+++ b/src/render/Renderer.ts
@@ -55,6 +55,9 @@ export class Renderer {
     /** GPU uniform buffer for the 256-entry palette. */
     private paletteBuffer: GPUBuffer | null = null;
 
+    /** True when the palette has changed and needs to be re-uploaded to the GPU. */
+    private paletteDirty: boolean = false;
+
     // #endregion
 
     // #region Pipelines
@@ -124,6 +127,7 @@ export class Renderer {
      */
     setPalette(palette: Palette): void {
         this.palette = palette;
+        this.paletteDirty = true;
     }
 
     /**
@@ -192,11 +196,12 @@ export class Renderer {
             return;
         }
 
-        // Upload palette to GPU before encoding the render pass.
-        if (this.palette && this.paletteBuffer) {
+        // Upload palette to GPU only when it has changed.
+        if (this.palette && this.paletteBuffer && this.paletteDirty) {
             const paletteData = this.palette.toFloat32Array();
 
             this.device.queue.writeBuffer(this.paletteBuffer, 0, paletteData.buffer);
+            this.paletteDirty = false;
         }
 
         // Resolve clear color from palette.

--- a/src/render/SpritePipeline.test.ts
+++ b/src/render/SpritePipeline.test.ts
@@ -27,6 +27,19 @@ import { Rect2i } from '../utils/Rect2i';
 import { Vector2i } from '../utils/Vector2i';
 import { SpritePipeline } from './SpritePipeline';
 
+// #region Test Helpers
+
+/** Creates a mock palette buffer matching the real 4096-byte uniform layout. */
+function createMockPaletteBuffer(device: GPUDevice): GPUBuffer {
+    return device.createBuffer({
+        label: 'Test Palette Buffer',
+        size: 256 * 4 * 4,
+        usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    });
+}
+
+// #endregion
+
 // #region Constructor
 
 describe('SpritePipeline constructor', () => {
@@ -81,7 +94,7 @@ describe('with initialized pipeline', () => {
     beforeAll(async () => {
         installMockNavigatorGPU();
 
-        await pipeline.initialize(device, new Vector2i(320, 240));
+        await pipeline.initialize(device, new Vector2i(320, 240), createMockPaletteBuffer(device));
     });
 
     afterAll(() => {
@@ -149,7 +162,7 @@ describe('drawSprite', () => {
     beforeAll(async () => {
         installMockNavigatorGPU();
 
-        await pipeline.initialize(device, new Vector2i(320, 240));
+        await pipeline.initialize(device, new Vector2i(320, 240), createMockPaletteBuffer(device));
     });
 
     afterAll(() => {
@@ -395,7 +408,7 @@ describe('drawBitmapText', () => {
     beforeAll(async () => {
         installMockNavigatorGPU();
 
-        await pipeline.initialize(device, new Vector2i(320, 240));
+        await pipeline.initialize(device, new Vector2i(320, 240), createMockPaletteBuffer(device));
     });
 
     afterAll(() => {

--- a/src/render/SpritePipeline.test.ts
+++ b/src/render/SpritePipeline.test.ts
@@ -16,6 +16,7 @@ import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import {
     createMockGPUDevice,
+    createMockPaletteBuffer,
     createMockRenderPassEncoder,
     installMockNavigatorGPU,
     uninstallMockNavigatorGPU,
@@ -26,19 +27,6 @@ import { Color32 } from '../utils/Color32';
 import { Rect2i } from '../utils/Rect2i';
 import { Vector2i } from '../utils/Vector2i';
 import { SpritePipeline } from './SpritePipeline';
-
-// #region Test Helpers
-
-/** Creates a mock palette buffer matching the real 4096-byte uniform layout. */
-function createMockPaletteBuffer(device: GPUDevice): GPUBuffer {
-    return device.createBuffer({
-        label: 'Test Palette Buffer',
-        size: 256 * 4 * 4,
-        usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
-    });
-}
-
-// #endregion
 
 // #region Constructor
 
@@ -94,7 +82,7 @@ describe('with initialized pipeline', () => {
     beforeAll(async () => {
         installMockNavigatorGPU();
 
-        await pipeline.initialize(device, new Vector2i(320, 240), createMockPaletteBuffer(device));
+        await pipeline.initialize(device, new Vector2i(320, 240), createMockPaletteBuffer());
     });
 
     afterAll(() => {
@@ -162,7 +150,7 @@ describe('drawSprite', () => {
     beforeAll(async () => {
         installMockNavigatorGPU();
 
-        await pipeline.initialize(device, new Vector2i(320, 240), createMockPaletteBuffer(device));
+        await pipeline.initialize(device, new Vector2i(320, 240), createMockPaletteBuffer());
     });
 
     afterAll(() => {
@@ -408,7 +396,7 @@ describe('drawBitmapText', () => {
     beforeAll(async () => {
         installMockNavigatorGPU();
 
-        await pipeline.initialize(device, new Vector2i(320, 240), createMockPaletteBuffer(device));
+        await pipeline.initialize(device, new Vector2i(320, 240), createMockPaletteBuffer());
     });
 
     afterAll(() => {

--- a/src/render/SpritePipeline.ts
+++ b/src/render/SpritePipeline.ts
@@ -34,6 +34,10 @@ export class SpritePipeline {
     /** Nearest-neighbor sampler for pixel-perfect rendering. */
     private sampler: GPUSampler | null = null;
 
+    /** Shared palette uniform buffer (stored for VV-426 indexed sprite pipeline). */
+    // @ts-expect-error Stored for VV-426 indexed sprite pipeline, not yet consumed.
+    private paletteBuffer: GPUBuffer | null = null;
+
     /** GPU vertex buffer. */
     private vertexBuffer: GPUBuffer | null = null;
 
@@ -96,9 +100,11 @@ export class SpritePipeline {
      *
      * @param device - WebGPU device for GPU operations.
      * @param displaySize - Render target resolution in pixels.
+     * @param paletteBuffer - Shared palette uniform buffer (stored for VV-426).
      */
-    async initialize(device: GPUDevice, displaySize: Vector2i): Promise<void> {
+    async initialize(device: GPUDevice, displaySize: Vector2i, paletteBuffer: GPUBuffer): Promise<void> {
         this.device = device;
+        this.paletteBuffer = paletteBuffer;
 
         await this.createPipeline(displaySize);
     }

--- a/tests/visual/fixtures/camera.html
+++ b/tests/visual/fixtures/camera.html
@@ -16,10 +16,19 @@
     </div>
 
     <script type="module">
-        import { bootstrap, BT, Color32, Rect2i, Vector2i } from 'blit-tech';
+        import { bootstrap, BT, Color32, Palette, Rect2i, Vector2i } from 'blit-tech';
 
         window.__RENDER_COMPLETE__ = false;
         window.__INIT_FAILED__ = false;
+
+        // Palette indices for this test.
+        const BLACK = 1;
+        const RED = 2;
+        const GREEN = 3;
+        const BLUE = 4;
+        const YELLOW = 5;
+        const CYAN = 6;
+        const WHITE = 8;
 
         class CameraTest {
             queryHardware() {
@@ -30,36 +39,46 @@
             }
 
             async initialize() {
+                const palette = new Palette(16);
+                palette.set(BLACK, Color32.black());
+                palette.set(RED, Color32.red());
+                palette.set(GREEN, Color32.green());
+                palette.set(BLUE, Color32.blue());
+                palette.set(YELLOW, Color32.yellow());
+                palette.set(CYAN, Color32.cyan());
+                palette.set(8, Color32.white());
+                BT.paletteSet(palette);
+
                 return true;
             }
 
             update() {}
 
             render() {
-                BT.clear(Color32.black());
+                BT.clear(BLACK);
 
                 // Apply camera offset: shift everything left by 50px and up by 30px.
                 BT.cameraSet(new Vector2i(50, 30));
 
                 // Draw a grid of colored rectangles at known world positions.
                 // With camera (50, 30), a rect at world (60, 40) appears at screen (10, 10).
-                BT.drawRectFill(new Rect2i(60, 40, 20, 20), Color32.red());
+                BT.drawRectFill(new Rect2i(60, 40, 20, 20), RED);
 
                 // World (110, 40) -> screen (60, 10).
-                BT.drawRectFill(new Rect2i(110, 40, 20, 20), Color32.green());
+                BT.drawRectFill(new Rect2i(110, 40, 20, 20), GREEN);
 
                 // World (60, 90) -> screen (10, 60).
-                BT.drawRectFill(new Rect2i(60, 90, 20, 20), Color32.blue());
+                BT.drawRectFill(new Rect2i(60, 90, 20, 20), BLUE);
 
                 // World (110, 90) -> screen (60, 60).
-                BT.drawRectFill(new Rect2i(110, 90, 20, 20), Color32.yellow());
+                BT.drawRectFill(new Rect2i(110, 90, 20, 20), YELLOW);
 
                 // Draw a line crossing the viewport.
                 // World (50, 30) -> screen (0, 0) to world (370, 270) -> screen (320, 240).
-                BT.drawLine(new Vector2i(50, 30), new Vector2i(370, 270), Color32.white());
+                BT.drawLine(new Vector2i(50, 30), new Vector2i(370, 270), WHITE);
 
                 // Draw a rect outline at the edge of the viewport.
-                BT.drawRect(new Rect2i(55, 35, 260, 200), Color32.cyan());
+                BT.drawRect(new Rect2i(55, 35, 260, 200), CYAN);
 
                 // Reset camera after drawing.
                 BT.cameraReset();

--- a/tests/visual/fixtures/fonts.html
+++ b/tests/visual/fixtures/fonts.html
@@ -16,10 +16,18 @@
     </div>
 
     <script type="module">
-        import { bootstrap, BT, Color32, Vector2i } from 'blit-tech';
+        import { bootstrap, BT, Color32, Palette, Vector2i } from 'blit-tech';
 
         window.__RENDER_COMPLETE__ = false;
         window.__INIT_FAILED__ = false;
+
+        // Palette indices.
+        const BLACK = 1;
+        const RED = 2;
+        const GREEN = 3;
+        const YELLOW = 5;
+        const CYAN = 6;
+        const WHITE = 8;
 
         class FontsTest {
             queryHardware() {
@@ -30,21 +38,32 @@
             }
 
             async initialize() {
+                const palette = new Palette(16);
+                palette.set(BLACK, Color32.black());
+                palette.set(RED, Color32.red());
+                palette.set(GREEN, Color32.green());
+                palette.set(4, Color32.blue());
+                palette.set(YELLOW, Color32.yellow());
+                palette.set(CYAN, Color32.cyan());
+                palette.set(7, Color32.magenta());
+                palette.set(WHITE, Color32.white());
+                BT.paletteSet(palette);
+
                 return true;
             }
 
             update() {}
 
             render() {
-                BT.clear(Color32.black());
+                BT.clear(BLACK);
 
                 // Use placeholder text rendering (drawText via PrimitivePipeline).
                 // Each character is rendered as a 6x8 colored block.
-                BT.print(new Vector2i(10, 10), Color32.white(), 'Hello World');
-                BT.print(new Vector2i(10, 30), Color32.red(), 'Red Text');
-                BT.print(new Vector2i(10, 50), Color32.green(), 'Green Text');
-                BT.print(new Vector2i(10, 70), Color32.cyan(), 'ABCDEFGHIJ');
-                BT.print(new Vector2i(10, 90), Color32.yellow(), '0123456789');
+                BT.print(new Vector2i(10, 10), WHITE, 'Hello World');
+                BT.print(new Vector2i(10, 30), RED, 'Red Text');
+                BT.print(new Vector2i(10, 50), GREEN, 'Green Text');
+                BT.print(new Vector2i(10, 70), CYAN, 'ABCDEFGHIJ');
+                BT.print(new Vector2i(10, 90), YELLOW, '0123456789');
 
                 window.__RENDER_COMPLETE__ = true;
             }

--- a/tests/visual/fixtures/mixed.html
+++ b/tests/visual/fixtures/mixed.html
@@ -16,10 +16,18 @@
     </div>
 
     <script type="module">
-        import { bootstrap, BT, Color32, Rect2i, SpriteSheet, Vector2i } from 'blit-tech';
+        import { bootstrap, BT, Color32, Palette, Rect2i, SpriteSheet, Vector2i } from 'blit-tech';
 
         window.__RENDER_COMPLETE__ = false;
         window.__INIT_FAILED__ = false;
+
+        // Palette indices for this test.
+        const BG_COLOR = 9;
+        const DARK_RED = 10;
+        const GREEN = 3;
+        const YELLOW = 5;
+        const CYAN = 6;
+        const WHITE = 8;
 
         // Create a small checkerboard sprite.
         function createCheckerImage() {
@@ -55,6 +63,19 @@
             }
 
             async initialize() {
+                const palette = new Palette(16);
+                palette.set(1, Color32.black());
+                palette.set(2, Color32.red());
+                palette.set(GREEN, Color32.green());
+                palette.set(4, Color32.blue());
+                palette.set(YELLOW, Color32.yellow());
+                palette.set(CYAN, Color32.cyan());
+                palette.set(7, Color32.magenta());
+                palette.set(WHITE, Color32.white());
+                palette.set(BG_COLOR, new Color32(32, 32, 64, 255));
+                palette.set(DARK_RED, new Color32(128, 0, 0, 255));
+                BT.paletteSet(palette);
+
                 const img = await createCheckerImage();
 
                 this.spriteSheet = new SpriteSheet(img);
@@ -65,33 +86,33 @@
             update() {}
 
             render() {
-                BT.clear(new Color32(32, 32, 64, 255));
+                BT.clear(BG_COLOR);
 
                 // Draw primitives first (these render in the primitives pipeline).
-                // Red filled rect as background.
-                BT.drawRectFill(new Rect2i(10, 10, 100, 80), new Color32(128, 0, 0, 255));
+                // Dark red filled rect as background.
+                BT.drawRectFill(new Rect2i(10, 10, 100, 80), DARK_RED);
 
                 // Green rect outline.
-                BT.drawRect(new Rect2i(8, 8, 104, 84), Color32.green());
+                BT.drawRect(new Rect2i(8, 8, 104, 84), GREEN);
 
                 // Yellow horizontal line.
-                BT.drawLine(new Vector2i(10, 100), new Vector2i(110, 100), Color32.yellow());
+                BT.drawLine(new Vector2i(10, 100), new Vector2i(110, 100), YELLOW);
 
                 // White diagonal line.
-                BT.drawLine(new Vector2i(120, 10), new Vector2i(180, 70), Color32.white());
+                BT.drawLine(new Vector2i(120, 10), new Vector2i(180, 70), WHITE);
 
                 // Cyan pixels.
                 for (let i = 0; i < 10; i++) {
-                    BT.drawPixel(new Vector2i(130 + i * 5, 80), Color32.cyan());
+                    BT.drawPixel(new Vector2i(130 + i * 5, 80), CYAN);
                 }
 
                 // Placeholder text.
-                BT.print(new Vector2i(10, 110), Color32.white(), 'Mixed Test');
+                BT.print(new Vector2i(10, 110), WHITE, 'Mixed Test');
 
                 // Draw sprites on top (these render in the sprite pipeline, after primitives).
                 const sheet = this.spriteSheet;
                 if (sheet) {
-                    // Sprite at (20, 20) - should overlap the red filled rect.
+                    // Sprite at (20, 20) - should overlap the dark red filled rect.
                     BT.drawSprite(sheet, new Rect2i(0, 0, 8, 8), new Vector2i(20, 20));
 
                     // Row of sprites.

--- a/tests/visual/fixtures/perf-common.js
+++ b/tests/visual/fixtures/perf-common.js
@@ -81,6 +81,34 @@ export function repeatText(seed, length) {
     return seed.repeat(Math.ceil(length / seed.length)).slice(0, length);
 }
 
+/**
+ * Creates and activates a default 16-color test palette.
+ * Index 0 is transparent (never set — left as zero alpha).
+ * Indices 1-10 cover common test colors.
+ *
+ * @param {object} BT - The BT namespace.
+ * @param {object} Color32 - The Color32 class.
+ * @returns {object} The created palette.
+ */
+export function installDefaultTestPalette(BT, Color32) {
+    const palette = BT.paletteCreate(16);
+
+    palette.set(1, Color32.black());
+    palette.set(2, Color32.red());
+    palette.set(3, Color32.green());
+    palette.set(4, Color32.blue());
+    palette.set(5, Color32.yellow());
+    palette.set(6, Color32.cyan());
+    palette.set(7, Color32.white());
+    palette.set(8, new Color32(32, 32, 64, 255));
+    palette.set(9, new Color32(16, 24, 40, 255));
+    palette.set(10, new Color32(128, 0, 0, 255));
+
+    BT.paletteSet(palette);
+
+    return palette;
+}
+
 export function createSpriteImage(primaryColor, secondaryColor) {
     const canvas = document.createElement('canvas');
     canvas.width = 8;

--- a/tests/visual/fixtures/perf-fonts.html
+++ b/tests/visual/fixtures/perf-fonts.html
@@ -16,7 +16,7 @@
     </div>
 
     <script type="module">
-        import { bootstrap, BT, Color32, Vector2i } from 'blit-tech';
+        import { bootstrap, BT, Color32, Palette, Vector2i } from 'blit-tech';
 
         import { initializePerfState, markInitFailed, readNumberParam, recordFrame, repeatText } from './perf-common.js';
 
@@ -35,6 +35,10 @@
             lines: lines.length,
         });
 
+        // Palette indices.
+        const BLACK = 1;
+        const WHITE = 8;
+
         class PerfFontsTest {
             pos = new Vector2i();
 
@@ -46,6 +50,11 @@
             }
 
             async initialize() {
+                const palette = new Palette(16);
+                palette.set(BLACK, Color32.black());
+                palette.set(WHITE, Color32.white());
+                BT.paletteSet(palette);
+
                 return true;
             }
 
@@ -56,12 +65,12 @@
                     return;
                 }
 
-                BT.clear(Color32.black());
+                BT.clear(BLACK);
 
                 for (let i = 0; i < lines.length; i++) {
                     this.pos.x = 8;
                     this.pos.y = 8 + i * 10;
-                    BT.print(this.pos, Color32.white(), lines[i]);
+                    BT.print(this.pos, WHITE, lines[i]);
                 }
 
                 recordFrame(perf);

--- a/tests/visual/fixtures/perf-fonts.html
+++ b/tests/visual/fixtures/perf-fonts.html
@@ -16,9 +16,16 @@
     </div>
 
     <script type="module">
-        import { bootstrap, BT, Color32, Palette, Vector2i } from 'blit-tech';
+        import { bootstrap, BT, Color32, Vector2i } from 'blit-tech';
 
-        import { initializePerfState, markInitFailed, readNumberParam, recordFrame, repeatText } from './perf-common.js';
+        import {
+            initializePerfState,
+            installDefaultTestPalette,
+            markInitFailed,
+            readNumberParam,
+            recordFrame,
+            repeatText,
+        } from './perf-common.js';
 
         const charCount = Math.max(1, readNumberParam('chars', 400) | 0);
         const lineWidth = Math.max(1, readNumberParam('lineWidth', 40) | 0);
@@ -50,10 +57,7 @@
             }
 
             async initialize() {
-                const palette = new Palette(16);
-                palette.set(BLACK, Color32.black());
-                palette.set(WHITE, Color32.white());
-                BT.paletteSet(palette);
+                installDefaultTestPalette(BT, Color32);
 
                 return true;
             }

--- a/tests/visual/fixtures/perf-fonts.html
+++ b/tests/visual/fixtures/perf-fonts.html
@@ -44,7 +44,7 @@
 
         // Palette indices.
         const BLACK = 1;
-        const WHITE = 8;
+        const WHITE = 7;
 
         class PerfFontsTest {
             pos = new Vector2i();

--- a/tests/visual/fixtures/perf-mixed.html
+++ b/tests/visual/fixtures/perf-mixed.html
@@ -16,11 +16,12 @@
     </div>
 
     <script type="module">
-        import { bootstrap, BT, Color32, Palette, Rect2i, SpriteSheet, Vector2i } from 'blit-tech';
+        import { bootstrap, BT, Color32, Rect2i, SpriteSheet, Vector2i } from 'blit-tech';
 
         import {
             createSpriteImage,
             initializePerfState,
+            installDefaultTestPalette,
             markInitFailed,
             readNumberParam,
             recordFrame,
@@ -61,17 +62,7 @@
             }
 
             async initialize() {
-                const palette = new Palette(16);
-                palette.set(1, Color32.black());
-                palette.set(2, Color32.red());
-                palette.set(3, Color32.green());
-                palette.set(BLUE, Color32.blue());
-                palette.set(YELLOW, Color32.yellow());
-                palette.set(6, Color32.cyan());
-                palette.set(7, Color32.magenta());
-                palette.set(WHITE, Color32.white());
-                palette.set(BG_COLOR, new Color32(16, 24, 40, 255));
-                BT.paletteSet(palette);
+                installDefaultTestPalette(BT, Color32);
 
                 const image = await createSpriteImage('#ffffff', '#888888');
 

--- a/tests/visual/fixtures/perf-mixed.html
+++ b/tests/visual/fixtures/perf-mixed.html
@@ -43,7 +43,7 @@
         const BG_COLOR = 9;
         const BLUE = 4;
         const YELLOW = 5;
-        const WHITE = 8;
+        const WHITE = 7;
 
         class PerfMixedTest {
             spriteSheet = null;

--- a/tests/visual/fixtures/perf-mixed.html
+++ b/tests/visual/fixtures/perf-mixed.html
@@ -16,7 +16,7 @@
     </div>
 
     <script type="module">
-        import { bootstrap, BT, Color32, Rect2i, SpriteSheet, Vector2i } from 'blit-tech';
+        import { bootstrap, BT, Color32, Palette, Rect2i, SpriteSheet, Vector2i } from 'blit-tech';
 
         import {
             createSpriteImage,
@@ -38,6 +38,12 @@
             sprites: spriteCount,
         });
 
+        // Palette indices.
+        const BG_COLOR = 9;
+        const BLUE = 4;
+        const YELLOW = 5;
+        const WHITE = 8;
+
         class PerfMixedTest {
             spriteSheet = null;
             rect = new Rect2i();
@@ -55,6 +61,18 @@
             }
 
             async initialize() {
+                const palette = new Palette(16);
+                palette.set(1, Color32.black());
+                palette.set(2, Color32.red());
+                palette.set(3, Color32.green());
+                palette.set(BLUE, Color32.blue());
+                palette.set(YELLOW, Color32.yellow());
+                palette.set(6, Color32.cyan());
+                palette.set(7, Color32.magenta());
+                palette.set(WHITE, Color32.white());
+                palette.set(BG_COLOR, new Color32(16, 24, 40, 255));
+                BT.paletteSet(palette);
+
                 const image = await createSpriteImage('#ffffff', '#888888');
 
                 this.spriteSheet = new SpriteSheet(image);
@@ -69,11 +87,11 @@
                     return;
                 }
 
-                BT.clear(new Color32(16, 24, 40, 255));
+                BT.clear(BG_COLOR);
 
                 for (let i = 0; i < rectCount; i++) {
                     this.rect.set((i * 11) % 320, (i * 7) % 240, 10 + (i % 18), 6 + (i % 10));
-                    BT.drawRectFill(this.rect, Color32.blue());
+                    BT.drawRectFill(this.rect, BLUE);
                 }
 
                 for (let i = 0; i < lineCount; i++) {
@@ -81,7 +99,7 @@
                     this.p0.y = (i * 5) % 240;
                     this.p1.x = (this.p0.x + 30 + (i % 40)) % 320;
                     this.p1.y = (this.p0.y + 12 + (i % 40)) % 240;
-                    BT.drawLine(this.p0, this.p1, Color32.yellow());
+                    BT.drawLine(this.p0, this.p1, YELLOW);
                 }
 
                 for (let i = 0; i < spriteCount; i++) {
@@ -90,7 +108,7 @@
                     BT.drawSprite(this.spriteSheet, this.sourceRect, this.destPos);
                 }
 
-                BT.print(this.textPos, Color32.white(), text);
+                BT.print(this.textPos, WHITE, text);
 
                 recordFrame(perf);
             }

--- a/tests/visual/fixtures/perf-primitives.html
+++ b/tests/visual/fixtures/perf-primitives.html
@@ -39,7 +39,7 @@
         const BLACK = 1;
         const RED = 2;
         const GREEN = 3;
-        const WHITE = 8;
+        const WHITE = 7;
 
         class PerfPrimitivesTest {
             rect = new Rect2i();

--- a/tests/visual/fixtures/perf-primitives.html
+++ b/tests/visual/fixtures/perf-primitives.html
@@ -16,7 +16,7 @@
     </div>
 
     <script type="module">
-        import { bootstrap, BT, Color32, Rect2i, Vector2i } from 'blit-tech';
+        import { bootstrap, BT, Color32, Palette, Rect2i, Vector2i } from 'blit-tech';
 
         import { initializePerfState, markInitFailed, readNumberParam, recordFrame } from './perf-common.js';
 
@@ -28,6 +28,12 @@
             pixels: pixelCount,
             rects: rectCount,
         });
+
+        // Palette indices.
+        const BLACK = 1;
+        const RED = 2;
+        const GREEN = 3;
+        const WHITE = 8;
 
         class PerfPrimitivesTest {
             rect = new Rect2i();
@@ -43,6 +49,17 @@
             }
 
             async initialize() {
+                const palette = new Palette(16);
+                palette.set(BLACK, Color32.black());
+                palette.set(RED, Color32.red());
+                palette.set(GREEN, Color32.green());
+                palette.set(4, Color32.blue());
+                palette.set(5, Color32.yellow());
+                palette.set(6, Color32.cyan());
+                palette.set(7, Color32.magenta());
+                palette.set(WHITE, Color32.white());
+                BT.paletteSet(palette);
+
                 return true;
             }
 
@@ -53,11 +70,11 @@
                     return;
                 }
 
-                BT.clear(Color32.black());
+                BT.clear(BLACK);
 
                 for (let i = 0; i < rectCount; i++) {
                     this.rect.set((i * 7) % 320, (i * 11) % 240, 6 + (i % 12), 4 + (i % 8));
-                    BT.drawRectFill(this.rect, Color32.red());
+                    BT.drawRectFill(this.rect, RED);
                 }
 
                 for (let i = 0; i < lineCount; i++) {
@@ -65,13 +82,13 @@
                     this.p0.y = (i * 3) % 240;
                     this.p1.x = (this.p0.x + 24 + (i % 32)) % 320;
                     this.p1.y = (this.p0.y + 24 + (i % 32)) % 240;
-                    BT.drawLine(this.p0, this.p1, Color32.green());
+                    BT.drawLine(this.p0, this.p1, GREEN);
                 }
 
                 for (let i = 0; i < pixelCount; i++) {
                     this.pixel.x = (i * 13) % 320;
                     this.pixel.y = (i * 17) % 240;
-                    BT.drawPixel(this.pixel, Color32.white());
+                    BT.drawPixel(this.pixel, WHITE);
                 }
 
                 recordFrame(perf);

--- a/tests/visual/fixtures/perf-primitives.html
+++ b/tests/visual/fixtures/perf-primitives.html
@@ -16,9 +16,15 @@
     </div>
 
     <script type="module">
-        import { bootstrap, BT, Color32, Palette, Rect2i, Vector2i } from 'blit-tech';
+        import { bootstrap, BT, Color32, Rect2i, Vector2i } from 'blit-tech';
 
-        import { initializePerfState, markInitFailed, readNumberParam, recordFrame } from './perf-common.js';
+        import {
+            initializePerfState,
+            installDefaultTestPalette,
+            markInitFailed,
+            readNumberParam,
+            recordFrame,
+        } from './perf-common.js';
 
         const rectCount = Math.max(0, readNumberParam('rects', 120) | 0);
         const lineCount = Math.max(0, readNumberParam('lines', 80) | 0);
@@ -49,16 +55,7 @@
             }
 
             async initialize() {
-                const palette = new Palette(16);
-                palette.set(BLACK, Color32.black());
-                palette.set(RED, Color32.red());
-                palette.set(GREEN, Color32.green());
-                palette.set(4, Color32.blue());
-                palette.set(5, Color32.yellow());
-                palette.set(6, Color32.cyan());
-                palette.set(7, Color32.magenta());
-                palette.set(WHITE, Color32.white());
-                BT.paletteSet(palette);
+                installDefaultTestPalette(BT, Color32);
 
                 return true;
             }

--- a/tests/visual/fixtures/perf-sprites.html
+++ b/tests/visual/fixtures/perf-sprites.html
@@ -16,7 +16,7 @@
     </div>
 
     <script type="module">
-        import { bootstrap, BT, Color32, Rect2i, SpriteSheet, Vector2i } from 'blit-tech';
+        import { bootstrap, BT, Color32, Palette, Rect2i, SpriteSheet, Vector2i } from 'blit-tech';
 
         import {
             createSpriteImage,
@@ -34,6 +34,9 @@
             textureMode,
         });
 
+        // Palette indices.
+        const BLACK = 1;
+
         class PerfSpritesTest {
             spriteSheets = [];
             sourceRect = new Rect2i(0, 0, 8, 8);
@@ -47,6 +50,11 @@
             }
 
             async initialize() {
+                const palette = new Palette(16);
+                palette.set(BLACK, Color32.black());
+                palette.set(2, Color32.white());
+                BT.paletteSet(palette);
+
                 const [firstImage, secondImage] = await Promise.all([
                     createSpriteImage('#ff3366', '#ffcc00'),
                     createSpriteImage('#33ccff', '#6633ff'),
@@ -64,7 +72,7 @@
                     return;
                 }
 
-                BT.clear(Color32.black());
+                BT.clear(BLACK);
 
                 for (let i = 0; i < spriteCount; i++) {
                     this.destPos.x = (i * 9) % 320;

--- a/tests/visual/fixtures/perf-sprites.html
+++ b/tests/visual/fixtures/perf-sprites.html
@@ -16,11 +16,12 @@
     </div>
 
     <script type="module">
-        import { bootstrap, BT, Color32, Palette, Rect2i, SpriteSheet, Vector2i } from 'blit-tech';
+        import { bootstrap, BT, Color32, Rect2i, SpriteSheet, Vector2i } from 'blit-tech';
 
         import {
             createSpriteImage,
             initializePerfState,
+            installDefaultTestPalette,
             markInitFailed,
             readNumberParam,
             readStringParam,
@@ -50,10 +51,7 @@
             }
 
             async initialize() {
-                const palette = new Palette(16);
-                palette.set(BLACK, Color32.black());
-                palette.set(2, Color32.white());
-                BT.paletteSet(palette);
+                installDefaultTestPalette(BT, Color32);
 
                 const [firstImage, secondImage] = await Promise.all([
                     createSpriteImage('#ff3366', '#ffcc00'),

--- a/tests/visual/fixtures/primitives.html
+++ b/tests/visual/fixtures/primitives.html
@@ -16,11 +16,20 @@
     </div>
 
     <script type="module">
-        import { bootstrap, BT, Color32, Rect2i, Vector2i } from 'blit-tech';
+        import { bootstrap, BT, Color32, Palette, Rect2i, Vector2i } from 'blit-tech';
 
         // Signal test readiness regardless of success/failure.
         window.__RENDER_COMPLETE__ = false;
         window.__INIT_FAILED__ = false;
+
+        // Palette indices for this test.
+        const BLACK = 1;
+        const RED = 2;
+        const GREEN = 3;
+        const BLUE = 4;
+        const YELLOW = 5;
+        const CYAN = 6;
+        const WHITE = 8;
 
         class PrimitivesTest {
             queryHardware() {
@@ -31,32 +40,43 @@
             }
 
             async initialize() {
+                // Create and activate a test palette.
+                const palette = new Palette(16);
+                palette.set(BLACK, Color32.black());
+                palette.set(RED, Color32.red());
+                palette.set(GREEN, Color32.green());
+                palette.set(BLUE, Color32.blue());
+                palette.set(YELLOW, Color32.yellow());
+                palette.set(CYAN, Color32.cyan());
+                palette.set(8, Color32.white());
+                BT.paletteSet(palette);
+
                 return true;
             }
 
             update() {}
 
             render() {
-                BT.clear(Color32.black());
+                BT.clear(BLACK);
 
                 // Draw known patterns for visual regression.
                 // Red pixel at (10, 10).
-                BT.drawPixel(new Vector2i(10, 10), Color32.red());
+                BT.drawPixel(new Vector2i(10, 10), RED);
 
                 // Green horizontal line from (20, 20) to (100, 20).
-                BT.drawLine(new Vector2i(20, 20), new Vector2i(100, 20), Color32.green());
+                BT.drawLine(new Vector2i(20, 20), new Vector2i(100, 20), GREEN);
 
                 // Blue vertical line from (120, 10) to (120, 100).
-                BT.drawLine(new Vector2i(120, 10), new Vector2i(120, 100), Color32.blue());
+                BT.drawLine(new Vector2i(120, 10), new Vector2i(120, 100), BLUE);
 
                 // Yellow filled rect at (140, 10, 40, 30).
-                BT.drawRectFill(new Rect2i(140, 10, 40, 30), Color32.yellow());
+                BT.drawRectFill(new Rect2i(140, 10, 40, 30), YELLOW);
 
                 // Cyan rect outline at (200, 10, 50, 40).
-                BT.drawRect(new Rect2i(200, 10, 50, 40), Color32.cyan());
+                BT.drawRect(new Rect2i(200, 10, 50, 40), CYAN);
 
                 // White diagonal line.
-                BT.drawLine(new Vector2i(10, 50), new Vector2i(60, 100), Color32.white());
+                BT.drawLine(new Vector2i(10, 50), new Vector2i(60, 100), WHITE);
 
                 // Signal render complete.
                 window.__RENDER_COMPLETE__ = true;

--- a/tests/visual/fixtures/sprites.html
+++ b/tests/visual/fixtures/sprites.html
@@ -16,11 +16,14 @@
     </div>
 
     <script type="module">
-        import { bootstrap, BT, Color32, Rect2i, SpriteSheet, Vector2i } from 'blit-tech';
+        import { bootstrap, BT, Color32, Palette, Rect2i, SpriteSheet, Vector2i } from 'blit-tech';
 
         // Signal test readiness regardless of success/failure.
         window.__RENDER_COMPLETE__ = false;
         window.__INIT_FAILED__ = false;
+
+        // Palette indices.
+        const BLACK = 1;
 
         // Create a minimal 16x16 sprite sheet from a canvas.
         // 4 tiles of 8x8: red, green, blue, yellow.
@@ -65,6 +68,11 @@
             }
 
             async initialize() {
+                const palette = new Palette(16);
+                palette.set(BLACK, Color32.black());
+                palette.set(2, Color32.white());
+                BT.paletteSet(palette);
+
                 const img = await createSpriteImage();
 
                 this.spriteSheet = new SpriteSheet(img);
@@ -75,7 +83,7 @@
             update() {}
 
             render() {
-                BT.clear(Color32.black());
+                BT.clear(BLACK);
 
                 const sheet = this.spriteSheet;
                 if (!sheet) return;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
         coverage: {
             provider: 'v8',
             include: ['src/**/*.ts'],
-            exclude: ['src/**/*.test.ts', 'src/__test__/**'],
+            exclude: ['src/**/*.test.ts', 'src/**/*.bench.ts', 'src/__test__/**'],
             thresholds: {
                 statements: 80,
                 branches: 80,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR reworks the rendering stack to use palette indices (numbers) instead of Color32 values for primitive drawing. Colors are resolved from a shared GPU palette uniform (256 RGBA vec4 entries). Public rendering APIs, GPU pipelines and WGSL, renderer state, palette utilities, tests, and visual fixtures were updated to the indexed-palette model.

## Key Changes

### Architecture & runtime API
- Renderer
  - Adds renderer-level palette state and a GPU uniform buffer: setPalette(palette: Palette), getPalette(): Palette | null, paletteBuffer (GPU uniform), paletteStaging Float32Array, and paletteDirty tracking.
  - Creates a shared 256-entry palette uniform buffer during initialize() and passes it to PrimitivePipeline.initialize(...) and SpritePipeline.initialize(...).
  - Replaces stored clear color with numeric clearPaletteIndex and adds resolveClearColor() fallback logic (resolves to black and warns on missing/out-of-range indices).
  - beginFrame() now throws if no palette has been set.
  - endFrame() uploads palette data to the GPU only when paletteDirty.
  - Adds private helpers drawPixelXYInternal(...) and resolveClearColor().

- BTAPI
  - getPalette(): Palette | null (no longer lazily creates a default VGA palette).
  - setPalette() forwards the provided palette to the renderer when present.
  - Drawing APIs accept paletteIndex: number (instead of Color32) and validate indices via a new assertPaletteIndex() — index must be a non-negative integer and, when a palette exists, within palette.size.

- BT facade
  - BT.paletteGet() now throws Error('No active palette. Call BT.paletteSet() first.') if no active palette.
  - Facade helpers (clear, clearRect, drawPixel, drawLine, drawRect, drawRectFill, print, setClearColor) accept paletteIndex: number and delegate to BTAPI.

### GPU pipelines & shaders
- PrimitivePipeline
  - Switched per-vertex RGBA to per-vertex paletteIndex: vertex layout now contains float32 x,y and uint32 paletteIndex; backing ArrayBuffer views, stride/byte-size calculations, and upload logic updated accordingly.
  - encodePass() writes the new backing buffer. WGSL vertex stage passes a flat paletteIndex; fragment stage samples the 256-entry palette uniform and discards fragments whose palette alpha == 0.0.
  - initialize(...) signature changed to initialize(device, displaySize, paletteBuffer: GPUBuffer).
  - Render pipeline blend config simplified/removed; bind group expanded to include resolution uniform and palette buffer.

- SpritePipeline
  - initialize(...) now accepts paletteBuffer: GPUBuffer and stores it (annotated as intentionally unused in this diff).

### Palette utilities
- Palette
  - Added public toFloat32ArrayInto(target: Float32Array): void to write normalized RGBA floats into a provided preallocated Float32Array for the GPU uniform.
  - toFloat32Array() now delegates to toFloat32ArrayInto().

### Tests, test helpers & visual fixtures
- Tests updated to use numeric palette indices and to cover palette behaviors and error paths:
  - src/BlitTech.test.ts: sets Vitest env, expands BT.paletteGet tests (success + throw), updates facade rendering tests to use numeric indices, and adds BT.captureFrame/BT.downloadFrame tests.
  - src/core/BTAPI.test.ts: pre-init getPalette() returns null, added assertPaletteIndex tests and a captureFrame delegation test.
  - src/render/PrimitivePipeline.test.ts and src/render/SpritePipeline.test.ts: tests now create/install a mock palette buffer (createMockPaletteBuffer()) and pass it to initialize().
  - src/render/Renderer.test.ts: adds tests enforcing beginFrame requires a palette, set/get palette coverage (get returns clone), clear-color fallback behavior, capture/delegation tests, and updates primitive tests to use indices.
  - src/__test__/webgpu-mock.ts: added createMockPaletteBuffer() helper returning a stub GPUBuffer sized for the palette uniform.
  - GameLoop.test.ts: added an RAF-flush start test.
  - Visual fixtures and perf fixtures: updated to create/set Palette(16) or invoke installDefaultTestPalette and use palette index constants (camera.html, fonts.html, mixed.html, primitives.html, sprites.html, perf-*.html).
  - Added tests/visual/fixtures/perf-common.js: installDefaultTestPalette(BT, Color32).
  - vitest.config.ts: excludes benchmark files (src/**/*.bench.ts) from coverage.
- Commit test fixes: tests hardened to correctly spy on Palette.prototype.get and to assert palette clone semantics.

## API surface & signature changes (breaking)
- Many method signatures changed: Color32 parameters replaced by paletteIndex: number across Renderer, BTAPI, BT facade, PrimitivePipeline, SpritePipeline, and related helpers. Notable changes:
  - Renderer: setPalette/getPalette added; setClearColor(paletteIndex: number); drawRectFill(rect, paletteIndex); drawText(pos, paletteIndex, text); drawPixel(..., paletteIndex); drawPixelXY(..., paletteIndex); drawLine(..., paletteIndex); drawRect(..., paletteIndex); clearRect(rect, paletteIndex); beginFrame() requires a palette.
  - BT.paletteGet() now throws if no palette is active; BT.clear/clearRect/drawPixel/drawLine/drawRect/drawRectFill/print accept numeric indices.
  - BTAPI.getPalette(): Palette | null and assertPaletteIndex(index: number) added.
  - PrimitivePipeline.initialize(device, displaySize, paletteBuffer: GPUBuffer).
  - SpritePipeline.initialize(device, displaySize, paletteBuffer: GPUBuffer).

## Breaking changes & migration notes
- Callers must create and set a Palette via BT.paletteSet(palette) before calling beginFrame() or performing palette-indexed drawing.
- Replace Color32.*() call-sites with palette index constants or lookups; BTAPI.getPalette() may return null and BT.paletteGet() now throws if unset.
- Pipeline initialization signatures require a paletteBuffer (Renderer.initialize supplies it; tests and pipelines updated accordingly).

## Files/areas with significant edits
- Core/runtime: src/render/Renderer.ts, src/core/BTAPI.ts, src/BlitTech.ts
- GPU pipeline & shaders: src/render/PrimitivePipeline.ts, src/render/SpritePipeline.ts
- Palette utilities: src/assets/Palette.ts
- Tests & fixtures: many test files under src/**/*.test.ts and tests/visual/fixtures/*
- Test helper: src/__test__/webgpu-mock.ts
- Config/CI: vitest.config.ts, .github/workflows/ci.yml

## Review effort
- High: Renderer, BTAPI, BlitTech facade, PrimitivePipeline (WGSL/shader/vertex layout + buffer upload), and public API/type changes.
- Medium: tests, SpritePipeline, Palette helper, visual fixtures and helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->