### PR TITLE
ci(ci): enable Run Tests job and fix test command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -477,12 +477,11 @@ jobs:
           }
           EOF
 
-  # Placeholder for tests - will run when tests are added
   test:
     name: Run Tests
     runs-on: ubuntu-latest
     needs: quality
-    if: false # Disabled until tests are added
+    if: github.event_name != 'pull_request' || !contains(fromJSON('["labeled","unlabeled"]'), github.event.action)
 
     steps:
       - name: Checkout code
@@ -502,11 +501,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run unit tests
-        run: pnpm test:unit
-
-      - name: Run E2E tests
-        run: pnpm test:e2e
+      - name: Run unit tests with coverage
+        run: pnpm test:unit:coverage
 
       - name: Upload coverage
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
The job had been left permanently disabled with `if: false` from when tests were first scaffolded. Switch to the standard event filter used by the other jobs so it runs on every push and PR.

Replace `pnpm test:unit` with `pnpm test:unit:coverage` so the coverage artifact is produced for the Codecov upload step. Remove the `pnpm test:e2e` step — no such script exists in package.json.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR re-enables the previously disabled "Run Tests" CI job in the GitHub Actions workflow and updates the test command to generate coverage artifacts for upload to Codecov.

## Changes

**File: `.github/workflows/ci.yml`**

The `test` job has been modified:

1. **Job enabled**: Removed the `if: false` guard that disabled the job. It now runs on every push and when PRs are labeled/unlabeled.

2. **Test command updated**: The test step now executes `pnpm test:unit:coverage` instead of `pnpm test:unit`. This change ensures that a coverage artifact is produced for the subsequent Codecov upload step.

3. **E2E tests removed**: The `pnpm test:e2e` step has been removed since this script does not exist in the project's `package.json`.

The coverage upload step remains in place with its `if: always()` condition, now properly aligned with the updated unit test command that produces the necessary coverage data.

**Lines changed**: +3/-7

<!-- end of auto-generated comment: release notes by coderabbit.ai -->