### PR TITLE
refactor(palette): auto-propagate palette mutations via dirty flag

### DIFF
--- a/src/assets/Palette.test.ts
+++ b/src/assets/Palette.test.ts
@@ -228,3 +228,71 @@ describe('Palette', () => {
 });
 
 // #endregion
+
+// #region Palette dirty flag
+
+describe('Palette dirty flag', () => {
+    it('starts clean after construction', () => {
+        expect(new Palette(16).dirty).toBe(false);
+    });
+
+    it('becomes dirty after set()', () => {
+        const palette = new Palette(16);
+
+        palette.set(1, new Color32(255, 0, 0, 255));
+
+        expect(palette.dirty).toBe(true);
+    });
+
+    it('clearDirty() resets the flag', () => {
+        const palette = new Palette(16);
+
+        palette.set(1, new Color32(255, 0, 0, 255));
+        palette.clearDirty();
+
+        expect(palette.dirty).toBe(false);
+    });
+
+    it('becomes dirty after copyFrom()', () => {
+        const src = new Palette(16);
+        const dest = new Palette(16);
+
+        dest.copyFrom(src);
+
+        expect(dest.dirty).toBe(true);
+    });
+
+    it('clone() returns a non-dirty palette regardless of source state', () => {
+        const palette = new Palette(16);
+
+        palette.set(1, new Color32(255, 0, 0, 255));
+
+        expect(palette.dirty).toBe(true);
+        expect(palette.clone().dirty).toBe(false);
+    });
+
+    it('setting index 0 to transparent does not mark dirty', () => {
+        const palette = new Palette(16);
+
+        palette.set(0, new Color32(0, 0, 0, 0));
+
+        expect(palette.dirty).toBe(false);
+    });
+
+    it('remains dirty through multiple set() calls until cleared', () => {
+        const palette = new Palette(16);
+
+        palette.set(1, new Color32(255, 0, 0, 255));
+        palette.set(2, new Color32(0, 255, 0, 255));
+        palette.set(3, new Color32(0, 0, 255, 255));
+        palette.clearDirty();
+
+        expect(palette.dirty).toBe(false);
+
+        palette.set(4, new Color32(255, 255, 0, 255));
+
+        expect(palette.dirty).toBe(true);
+    });
+});
+
+// #endregion

--- a/src/assets/Palette.test.ts
+++ b/src/assets/Palette.test.ts
@@ -37,8 +37,12 @@ describe('Palette', () => {
 
         palette.set(0, new Color32(12, 34, 56, 0));
 
-        expect(palette.get(0)).toBe(Color32.transparent());
-        expect(Object.isFrozen(palette.get(0))).toBe(true);
+        expect(palette.get(0).equals(Color32.transparent())).toBe(true);
+
+        // get() returns a clone, so mutating the result must not change the stored entry.
+        const copy = palette.get(0);
+        copy.r = 99;
+        expect(palette.get(0).equals(Color32.transparent())).toBe(true);
     });
 
     it('sets and gets entries within range and throws out of range', () => {
@@ -51,6 +55,19 @@ describe('Palette', () => {
         expect(palette.get(5)).not.toBe(color);
         expect(() => palette.get(16)).toThrow('Palette index 16 out of range (palette size: 16)');
         expect(() => palette.set(-1, color)).toThrow('Palette index -1 out of range (palette size: 16)');
+    });
+
+    it('get() returns a defensive copy — mutating the result does not change the stored entry', () => {
+        const palette = new Palette(16);
+
+        palette.set(3, new Color32(10, 20, 30, 255));
+
+        const copy = palette.get(3);
+        copy.r = 99;
+        copy.g = 99;
+        copy.b = 99;
+
+        expect(palette.get(3).equals(new Color32(10, 20, 30, 255))).toBe(true);
     });
 
     it('supports named indices and named color lookups', () => {

--- a/src/assets/Palette.ts
+++ b/src/assets/Palette.ts
@@ -139,6 +139,15 @@ export class Palette {
     private readonly namedIndices = new Map<string, number>();
 
     /**
+     * True when colors have been mutated since the last GPU upload.
+     *
+     * Set by {@link set} and {@link copyFrom}. Cleared by {@link clearDirty} after
+     * the renderer has uploaded the updated palette uniform buffer. Not set by the
+     * constructor — initial upload is always triggered by {@link Renderer.setPalette}.
+     */
+    private _dirty: boolean = false;
+
+    /**
      * Creates a new palette with the requested indexed size.
      *
      * @param size - Palette size. Must be one of `2, 4, 16, 32, 64, 128, 256`.
@@ -308,6 +317,7 @@ export class Palette {
 
         // eslint-disable-next-line security/detect-object-injection -- Index range is validated by assertIndexInRange above
         this.colors[index] = color.clone();
+        this._dirty = true;
     }
 
     /**
@@ -366,12 +376,17 @@ export class Palette {
     /**
      * Creates a deep copy of the palette, including named indices.
      *
+     * The returned clone starts with a clean dirty flag regardless of the source
+     * palette's state. When passed to {@link Renderer.setPalette}, the renderer's
+     * own dirty flag ensures the first upload.
+     *
      * @returns Independent palette clone.
      */
     public clone(): Palette {
         const clone = new Palette(this.size);
 
         clone.copyFrom(this);
+        clone.clearDirty();
 
         return clone;
     }
@@ -379,9 +394,10 @@ export class Palette {
     /**
      * Copies colors and named indices from another palette into this one.
      *
-     * Entries outside the source palette range are reset to transparent in the
-     * destination. Named indices that do not fit inside the destination size
-     * are ignored.
+     * Marks the palette dirty so the renderer will re-upload the uniform buffer on
+     * the next frame. Entries outside the source palette range are reset to
+     * transparent in the destination. Named indices that do not fit inside the
+     * destination size are ignored.
      *
      * @param other - Source palette to copy from.
      */
@@ -407,6 +423,32 @@ export class Palette {
                 this.namedIndices.set(name, index);
             }
         }
+
+        this._dirty = true;
+    }
+
+    /**
+     * True when colors have been mutated since the last GPU upload.
+     *
+     * The renderer checks this flag each frame and re-uploads the palette uniform
+     * buffer when it is set, then calls {@link clearDirty} to reset it. Palette
+     * animation works automatically — no per-frame {@link BT.paletteSet} required.
+     *
+     * @returns `true` if any color has been written via {@link set} or {@link copyFrom}
+     *   since the last call to {@link clearDirty}.
+     */
+    public get dirty(): boolean {
+        return this._dirty;
+    }
+
+    /**
+     * Clears the dirty flag after the renderer has uploaded the palette to the GPU.
+     *
+     * Do not call this from application code. It is part of the internal renderer
+     * contract between {@link Palette} and {@link Renderer}.
+     */
+    public clearDirty(): void {
+        this._dirty = false;
     }
 
     /**

--- a/src/assets/Palette.ts
+++ b/src/assets/Palette.ts
@@ -132,8 +132,8 @@ export class Palette {
     /** Number of usable palette entries. */
     public readonly size: number;
 
-    /** Mutable indexed color entries. Index `0` is always transparent. */
-    public readonly colors: Color32[];
+    /** Indexed color entries. Index `0` is always transparent. */
+    private readonly colors: Color32[];
 
     /** Optional human-readable aliases for palette indices. */
     private readonly namedIndices = new Map<string, number>();
@@ -321,16 +321,19 @@ export class Palette {
     }
 
     /**
-     * Returns the color stored at a palette index.
+     * Returns a copy of the color stored at a palette index.
+     *
+     * Returns a clone so callers cannot mutate internal state without going
+     * through {@link set}, which keeps the dirty flag accurate.
      *
      * @param index - Palette index to read.
-     * @returns Stored color entry.
+     * @returns Clone of the stored color entry.
      * @throws Error if the index is invalid.
      */
     public get(index: number): Color32 {
         this.assertIndexInRange(index);
 
-        return this.colorAt(index);
+        return this.colorAt(index).clone();
     }
 
     /**

--- a/src/render/Renderer.test.ts
+++ b/src/render/Renderer.test.ts
@@ -7,6 +7,7 @@
  * - successful renderer initialization and repeated frame lifecycles
  * - delegation of palette-indexed primitive drawing calls during active frames
  * - palette enforcement (beginFrame throws without active palette)
+ * - palette dirty-flag auto-propagation (mutations visible without re-calling setPalette)
  * - frame capture flow and error handling during presentation
  *
  * The suite uses mocked WebGPU devices, contexts, and browser image APIs so
@@ -410,7 +411,7 @@ describe('resolveClearColor fallbacks', () => {
 
         await r.initialize();
 
-        // Spy on the prototype so the clone stored by setPalette also throws.
+        // Spy on the prototype so the reference stored by setPalette also throws.
         const getSpy = vi.spyOn(Palette.prototype, 'get').mockImplementation(() => {
             throw new Error('get error');
         });
@@ -688,6 +689,124 @@ describe('initialize error paths', () => {
 
             uninstallMockNavigatorGPU();
         }
+    });
+});
+
+// #endregion
+
+// #region Palette dirty-flag auto-propagation
+
+describe('palette dirty-flag auto-propagation', () => {
+    it('setPalette stores a reference, not a clone', () => {
+        const renderer = new Renderer(createMockGPUDevice(), createMockGPUCanvasContext(), new Vector2i(320, 240));
+        const palette = createTestPalette();
+
+        renderer.setPalette(palette);
+
+        // Mutate the original after setPalette — the renderer must see the change.
+        palette.set(1, new Color32(99, 99, 99, 255));
+
+        // getPalette() returns a clone, so compare by value rather than reference.
+        expect(renderer.getPalette()!.get(1)).toEqual(new Color32(99, 99, 99, 255));
+    });
+
+    it('getPalette still returns a clone, not the internal reference', () => {
+        const renderer = new Renderer(createMockGPUDevice(), createMockGPUCanvasContext(), new Vector2i(320, 240));
+        const palette = createTestPalette();
+
+        renderer.setPalette(palette);
+
+        expect(renderer.getPalette()).not.toBe(palette);
+    });
+
+    it('palette.dirty is cleared after endFrame uploads', async () => {
+        const renderer = new Renderer(createMockGPUDevice(), createMockGPUCanvasContext(), new Vector2i(320, 240));
+
+        installMockNavigatorGPU();
+
+        await renderer.initialize();
+
+        const palette = new Palette(16);
+
+        renderer.setPalette(palette);
+
+        // Dirty the palette AFTER setPalette, simulating per-frame animation.
+        palette.set(1, new Color32(200, 100, 50, 255));
+
+        expect(palette.dirty).toBe(true);
+
+        renderer.beginFrame();
+        renderer.endFrame();
+
+        // Renderer must clear the dirty flag as part of the GPU upload.
+        expect(palette.dirty).toBe(false);
+
+        uninstallMockNavigatorGPU();
+    });
+
+    it('palette.dirty drives upload without requiring a new paletteSet call', async () => {
+        const device = createMockGPUDevice();
+        const writeBufferSpy = vi.spyOn(device.queue, 'writeBuffer');
+
+        const renderer = new Renderer(device, createMockGPUCanvasContext(), new Vector2i(320, 240));
+
+        installMockNavigatorGPU();
+
+        await renderer.initialize();
+
+        const palette = new Palette(16);
+
+        renderer.setPalette(palette);
+
+        // First frame — initial upload due to paletteDirty.
+        renderer.beginFrame();
+        renderer.endFrame();
+
+        const callsAfterFirstFrame = writeBufferSpy.mock.calls.length;
+
+        // Mutate palette without calling BT.paletteSet() again.
+        palette.set(1, new Color32(255, 0, 128, 255));
+
+        // Second frame — must re-upload because palette.dirty is true.
+        renderer.beginFrame();
+        renderer.endFrame();
+
+        expect(writeBufferSpy.mock.calls.length).toBeGreaterThan(callsAfterFirstFrame);
+
+        writeBufferSpy.mockRestore();
+
+        uninstallMockNavigatorGPU();
+    });
+
+    it('no GPU upload happens when palette is clean and paletteDirty is false', async () => {
+        const device = createMockGPUDevice();
+        const writeBufferSpy = vi.spyOn(device.queue, 'writeBuffer');
+
+        const renderer = new Renderer(device, createMockGPUCanvasContext(), new Vector2i(320, 240));
+
+        installMockNavigatorGPU();
+
+        await renderer.initialize();
+
+        const palette = new Palette(16);
+
+        renderer.setPalette(palette);
+
+        // First frame — initial upload.
+        renderer.beginFrame();
+        renderer.endFrame();
+
+        const callsAfterFirstFrame = writeBufferSpy.mock.calls.length;
+
+        // No mutation — second frame should NOT upload.
+        renderer.beginFrame();
+        renderer.endFrame();
+
+        expect(writeBufferSpy.mock.calls.length).toBe(callsAfterFirstFrame);
+
+        writeBufferSpy.mockRestore();
+
+        uninstallMockNavigatorGPU();
     });
 });
 

--- a/src/render/Renderer.ts
+++ b/src/render/Renderer.ts
@@ -58,7 +58,11 @@ export class Renderer {
     /** Reusable staging buffer for GPU palette uploads. Avoids per-frame allocation. */
     private readonly paletteStaging = new Float32Array(256 * 4);
 
-    /** True when the palette has changed and needs to be re-uploaded to the GPU. */
+    /**
+     * True after {@link setPalette} is called, guaranteeing at least one upload
+     * even when the palette was never mutated via {@link Palette.set}.
+     * Per-frame mutations are detected separately via {@link Palette.dirty}.
+     */
     private paletteDirty: boolean = false;
 
     // #endregion
@@ -131,10 +135,16 @@ export class Renderer {
     /**
      * Sets the active palette used for rendering.
      *
+     * Stores a reference to the supplied palette — no clone is made. Subsequent
+     * calls to {@link Palette.set} or {@link Palette.copyFrom} on the same object
+     * will be detected via {@link Palette.dirty} and uploaded automatically at the
+     * start of the next frame. {@link paletteDirty} is set to guarantee the initial
+     * upload even when the palette has never been mutated through {@link Palette.set}.
+     *
      * @param palette - Palette to use for color lookups and GPU upload.
      */
     setPalette(palette: Palette): void {
-        this.palette = palette.clone();
+        this.palette = palette;
         this.paletteDirty = true;
 
         // If the new palette is smaller than the current clear index, reset to 0
@@ -145,10 +155,13 @@ export class Renderer {
     }
 
     /**
-     * Returns a copy of the active palette, or null if none has been set.
+     * Returns a snapshot of the active palette, or null if none has been set.
      *
-     * Returns a clone so callers cannot mutate the internal palette and bypass
-     * the dirty flag that drives GPU re-upload.
+     * Returns a clone to prevent callers from accidentally mutating the active
+     * palette through the returned reference in ways that may be surprising.
+     * To intentionally update palette colors, mutate the original palette object
+     * that was passed to {@link setPalette} — changes will auto-propagate via the
+     * dirty flag on the next frame.
      *
      * @returns Clone of the active palette instance, or null.
      */
@@ -214,10 +227,14 @@ export class Renderer {
         }
 
         // Upload palette to GPU only when it has changed.
-        if (this.palette && this.paletteBuffer && this.paletteDirty) {
+        // paletteDirty covers the initial upload after setPalette() is called with a
+        // palette that has not been mutated via set(). palette.dirty covers subsequent
+        // per-frame mutations made directly on the active palette object.
+        if (this.palette && this.paletteBuffer && (this.paletteDirty || this.palette.dirty)) {
             this.palette.toFloat32ArrayInto(this.paletteStaging);
             this.device.queue.writeBuffer(this.paletteBuffer, 0, this.paletteStaging);
             this.paletteDirty = false;
+            this.palette.clearDirty();
         }
 
         // Resolve clear color from palette.


### PR DESCRIPTION
Renderer.setPalette() cloned the palette at call time, making any palette.set() calls after BT.paletteSet() invisible to the GPU until paletteSet() was called again. This broke palette animation silently — the workaround was a redundant BT.paletteSet(this.palette) at the end of every update(), present in 14 demos.

Add a _dirty flag to Palette, set by set() and copyFrom(), cleared by clearDirty() after each GPU upload. Renderer.setPalette() now stores a reference instead of a clone. endFrame() checks paletteDirty (initial upload) and palette.dirty (per-frame mutations) before calling writeBuffer, eliminating the per-frame clone allocation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This change introduces a dirty-flag mechanism to Palette and updates Renderer to reference palettes directly so per-frame Palette mutations auto-propagate to the GPU without redundant Renderer.setPalette() calls or per-frame clone allocations.

## Problem solved
Renderer.setPalette() previously cloned the Palette, so later Palette.set() calls were invisible to the GPU until setPalette() was called again. That broke palette animation in demos and caused a per-frame clone allocation cost and redundant palette-set calls.

## Changes

### Palette (src/assets/Palette.ts)
- Made internal colors storage private (was public readonly).
- get(index) now returns a defensive clone of the stored Color32 to prevent external mutation bypassing the dirty flag.
- Introduced internal `_dirty` boolean with a public `dirty` getter.
- Added public `clearDirty()` to reset the flag.
- set() now sets `_dirty = true` for non-trivial changes (setting index 0 to full transparency does not mark dirty).
- copyFrom() now marks the destination palette dirty.
- clone() deep-copies but clears the dirty flag on the clone so clones start clean.
- Tests updated to assert value equality, defensive get() behavior, and getNamedColor transitively.

### Renderer (src/render/Renderer.ts)
- setPalette(palette) now stores the passed Palette reference instead of cloning it, but still sets `paletteDirty = true` to force an initial GPU upload.
- endFrame() upload condition changed from only `this.paletteDirty` to `(this.paletteDirty || this.palette?.dirty)`. After upload, the renderer calls `this.palette.clearDirty()` to reset per-palette dirty state.
- getPalette() continues to return a snapshot (clone) and docs updated to clarify that callers should mutate the original palette passed to setPalette() for updates to propagate.

### Tests
- Palette.test.ts: expanded tests verifying defensive get(), dirty-flag lifecycle (construction, set, copyFrom, clearDirty, clone behavior), and immutability isolation.
- Renderer.test.ts: tests asserting setPalette stores a reference (so later palette.set() mutations are observed), getPalette returns a snapshot, palette uploads occur on initial set and on subsequent per-frame mutations when dirty, and no redundant uploads occur when clean.

## Result
Per-frame Palette mutations now automatically propagate to the GPU when the Palette is dirty, eliminating the need for redundant BT.paletteSet(this.palette) calls and avoiding per-frame clone allocations while preserving defensive isolation of returned Color32 instances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->