### PR TITLE
docs(assets): clarify reindexize vs palette-value swap in JSDoc

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -39,6 +39,7 @@
     "Playwright",
     "pnpm",
     "rects",
+    "reindexing",
     "reindexize",
     "reindexizing",
     "retroblit",

--- a/src/BlitTech.ts
+++ b/src/BlitTech.ts
@@ -553,14 +553,17 @@ export const BT = {
      * Only call this after a **palette-layout swap** — when the same colors have
      * moved to different slot positions and existing sprite indices now point to
      * the wrong slots. Each sheet re-runs exact RGBA-to-index matching against the
-     * active palette, so every opaque pixel's original color must exist in the new
-     * palette or that pixel silently becomes transparent (index 0).
+     * active palette via `SpriteSheet.reindexize()`. If any opaque pixel's original
+     * color is missing from the new palette, `reindexize()` throws, and
+     * `spritesRefresh()` catches that error and removes the affected sheet from the
+     * registry (it will no longer render).
      *
      * **Do not call this after a palette-value swap.** If you changed what color a
      * slot holds (e.g. palette animation, theme tinting), the stored indices are
      * still correct — the fragment shader picks up the new color automatically.
-     * Calling `spritesRefresh()` in that case is a no-op at best; at worst, if the
-     * original RGBA values are gone from the palette, sprites will disappear.
+     * Calling `spritesRefresh()` in that case is wasteful at best; at worst, if the
+     * original RGBA values are gone from the palette, sheets with missing colors
+     * will fail reindexing and be removed from the registry.
      *
      * Typical usage after a layout swap:
      * ```ts

--- a/src/BlitTech.ts
+++ b/src/BlitTech.ts
@@ -202,6 +202,20 @@ export const BT = {
     /**
      * Stores the active engine palette.
      *
+     * Use this to swap the **entire palette** (e.g. switch between a day and night
+     * theme). After this call the renderer uploads the new palette uniform on the
+     * next frame.
+     *
+     * **Palette-value swap (change what a slot looks like):** mutate the current
+     * palette with `palette.set(slot, newColor)` and then call `paletteSet()`. The
+     * sprite sheets' stored indices are unchanged — no {@link BT.spritesRefresh}
+     * needed.
+     *
+     * **Palette-layout swap (same colors, different slot positions):** build a new
+     * palette with the same colors at new indices, call `paletteSet()`, then call
+     * {@link BT.spritesRefresh} so every sprite sheet re-maps its original RGBA
+     * pixels against the new slot layout.
+     *
      * @param palette - Palette to make active.
      */
     paletteSet: (palette: Palette): void => {
@@ -536,8 +550,23 @@ export const BT = {
     /**
      * Re-indexizes all tracked sprite sheets against the current active palette.
      *
-     * Call after swapping or modifying the active palette to keep all loaded
-     * sprite sheets in sync with the new color-to-index mapping.
+     * Only call this after a **palette-layout swap** — when the same colors have
+     * moved to different slot positions and existing sprite indices now point to
+     * the wrong slots. Each sheet re-runs exact RGBA-to-index matching against the
+     * active palette, so every opaque pixel's original color must exist in the new
+     * palette or that pixel silently becomes transparent (index 0).
+     *
+     * **Do not call this after a palette-value swap.** If you changed what color a
+     * slot holds (e.g. palette animation, theme tinting), the stored indices are
+     * still correct — the fragment shader picks up the new color automatically.
+     * Calling `spritesRefresh()` in that case is a no-op at best; at worst, if the
+     * original RGBA values are gone from the palette, sprites will disappear.
+     *
+     * Typical usage after a layout swap:
+     * ```ts
+     * BT.paletteSet(newLayoutPalette);
+     * BT.spritesRefresh(); // re-map all sheets to the new slot positions
+     * ```
      *
      * @throws If no active palette has been set.
      */

--- a/src/assets/SpriteSheet.ts
+++ b/src/assets/SpriteSheet.ts
@@ -198,14 +198,17 @@ export class SpriteSheet {
      * BT.spritesRefresh();
      * ```
      *
-     * If the new palette does not contain a pixel's original RGBA value, that pixel
-     * maps to index 0 (transparent) and the sprite will appear to disappear.
+     * If the new palette does not contain a pixel's original RGBA value,
+     * `palette.findColor()` returns `-1` and `reindexize()` throws an `Error`
+     * with the offending color and coordinates, e.g.:
+     * `[SpriteSheet] 'sheet.png' pixel at (x, y) has color #rrggbb which is not in the active palette.`
      *
      * Must be preceded by a call to `indexize()`. The GPU texture is invalidated and
      * re-created on the next `getTexture()` call.
      *
      * @param palette - New palette used for color-to-index mapping.
      * @throws If `indexize()` has not been called yet.
+     * @throws If any opaque pixel's color is not found in the new palette.
      */
     reindexize(palette: Palette): void {
         if (this.rgbaPixels === null) {

--- a/src/assets/SpriteSheet.ts
+++ b/src/assets/SpriteSheet.ts
@@ -172,8 +172,36 @@ export class SpriteSheet {
     /**
      * Re-converts retained RGBA pixels to palette indices using a new palette.
      *
-     * Useful after a palette swap to keep all sprite sheets in sync. Must be
-     * preceded by a call to `indexize()`. The GPU texture is invalidated and
+     * Use this only when the **slot layout** of the palette has changed — that is,
+     * when the same colors now live at different index positions. It works by
+     * replaying the original RGBA data through `palette.findColor()` and assigning
+     * each opaque pixel the index of its matching color in the new palette.
+     *
+     * **Do not call this to change what color a slot displays.** If you only want
+     * to swap the visible color at a slot (e.g. animate a fire effect), mutate the
+     * palette entry directly — the stored indices remain valid and the fragment
+     * shader picks up the new color automatically on the next frame:
+     *
+     * ```ts
+     * // Palette-value swap: change what a slot looks like.
+     * // The sprite's stored indices are unchanged; no reindexize needed.
+     * palette.set(FIRE_SLOT, Color32.fromHex('#ff4400'));
+     * BT.paletteSet(palette);
+     * ```
+     *
+     * ```ts
+     * // Palette-layout swap: same colors, different slot positions.
+     * // Sprite indices now point to wrong slots, so reindexize is required.
+     * sheet.reindexize(newLayoutPalette);
+     * // Or for all sheets at once:
+     * BT.paletteSet(newLayoutPalette);
+     * BT.spritesRefresh();
+     * ```
+     *
+     * If the new palette does not contain a pixel's original RGBA value, that pixel
+     * maps to index 0 (transparent) and the sprite will appear to disappear.
+     *
+     * Must be preceded by a call to `indexize()`. The GPU texture is invalidated and
      * re-created on the next `getTexture()` call.
      *
      * @param palette - New palette used for color-to-index mapping.


### PR DESCRIPTION
Document the distinction between palette-layout swaps (reindexize / spritesRefresh) and palette-value swaps (palette.set + paletteSet) in the JSDoc for SpriteSheet.reindexize(), BT.spritesRefresh(), and BT.paletteSet().

Add code examples to reindexize() showing both patterns side-by-side so callers know not to call spritesRefresh() after a value-only palette mutation and understand when the method is actually required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This pull request updates JSDoc to clarify the distinction between two palette-change patterns (palette-layout swaps vs. palette-value swaps) and corrects earlier incorrect documentation about error handling in reindexize().

Changes to src/assets/SpriteSheet.ts
- Expanded and corrected JSDoc for reindexize():
  - Documents that reindexize() is intended only for palette slot-layout changes (colors moved to different indices) and replays retained RGBA through palette.findColor().
  - Adds clear guidance and side-by-side code examples showing palette-value swaps (mutate palette slot + BT.paletteSet(), no reindexize) versus palette-layout swaps (sheet.reindexize() or BT.paletteSet() + BT.spritesRefresh()).
  - Corrects error semantics: if palette.findColor() returns -1 for an opaque pixel, reindexize() now throws an Error with the offending pixel color and coordinates (replacing the prior, incorrect claim that it maps to index 0/transparent).
  - Documents preconditions (indexize() must have been called) and that the GPU texture is invalidated and re-created on next getTexture().
- Added @throws tags to reflect thrown errors when indexize() hasn't run or when a pixel's color is missing from the new palette.

Changes to src/BlitTech.ts
- Updated BT.paletteSet() JSDoc to describe three palette-change scenarios:
  1. Whole-palette swap: replace the active palette (renderer uploads new palette next frame).
  2. Palette-value swap: mutate a slot via palette.set(...) + BT.paletteSet() — stored sprite indices remain valid and no BT.spritesRefresh() is required.
  3. Palette-layout swap: same colors at different indices — call BT.paletteSet() then BT.spritesRefresh() so sheets re-map retained RGBA via SpriteSheet.reindexize().
- Updated BT.spritesRefresh() JSDoc to restrict its intended use to palette-layout swaps, clarify that it re-runs RGBA-to-index matching via reindexize(), and note that reindexize() errors cause the affected sheet(s) to be removed from the registry rather than silently becoming transparent. The docs also warn against calling spritesRefresh() after palette-value swaps.

Other
- cspell.json: added "reindexing" to the word list.

No public signatures or exported interfaces were changed; all modifications are documentation and comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->