### PR TITLE
feat(assets): add palette effect system with cycling, fade, flash, and swap

### DIFF
--- a/src/BlitTech.ts
+++ b/src/BlitTech.ts
@@ -242,6 +242,102 @@ export const BT = {
 
     // #endregion
 
+    // #region Palette Effects
+
+    /**
+     * Starts rotating a range of palette entries at a constant speed.
+     *
+     * Classic water/fire/plasma animation technique. Runs indefinitely until
+     * cancelled via {@link BT.paletteClearEffects}. Uses a fractional accumulator
+     * for sub-frame precision.
+     *
+     * @param start - First palette index in the cycling range (inclusive).
+     * @param end - Last palette index in the cycling range (inclusive).
+     * @param speed - Steps per second. Positive = forward, negative = backward.
+     */
+    paletteCycle: (start: number, end: number, speed: number): void => {
+        BTAPI.instance.paletteCycle(start, end, speed);
+    },
+
+    /**
+     * Smoothly interpolates all palette entries toward a target over time.
+     *
+     * Snapshots the current palette at the moment this is called. Each frame the
+     * entries are lerped between the snapshot and target using the easing curve.
+     * Auto-removes when the fade completes.
+     *
+     * Common patterns:
+     * - Fade to black: `BT.paletteFade(blackPalette, 1000)`
+     * - Fade to white: `BT.paletteFade(whitePalette, 500)`
+     * - Cross-fade: `BT.paletteFade(nightPalette, 2000, 'ease-in-out')`
+     *
+     * @param target - Target palette to fade toward.
+     * @param durationMs - Fade duration in milliseconds.
+     * @param easing - Easing curve. Defaults to `'linear'`.
+     */
+    paletteFade: (target: Palette, durationMs: number, easing?: EasingFunction): void => {
+        BTAPI.instance.paletteFade(target, durationMs, easing);
+    },
+
+    /**
+     * Fades only a subset of palette indices toward a target over time.
+     *
+     * Same as {@link BT.paletteFade} but restricted to the range `[start, end]`.
+     * Indices outside the range are left untouched.
+     *
+     * @param start - First palette index to fade (inclusive).
+     * @param end - Last palette index to fade (inclusive).
+     * @param target - Target palette to fade toward.
+     * @param durationMs - Fade duration in milliseconds.
+     * @param easing - Easing curve. Defaults to `'linear'`.
+     */
+    paletteFadeRange: (
+        start: number,
+        end: number,
+        target: Palette,
+        durationMs: number,
+        easing?: EasingFunction,
+    ): void => {
+        BTAPI.instance.paletteFadeRange(start, end, target, durationMs, easing);
+    },
+
+    /**
+     * Temporarily sets all non-zero palette entries to a single color, then restores.
+     *
+     * Index 0 (transparent) is preserved. The original palette is saved internally
+     * and restored after the duration elapses. Auto-removes when complete.
+     *
+     * @param color - Flash color applied to all non-zero entries.
+     * @param durationMs - How long the flash lasts in milliseconds.
+     */
+    paletteFlash: (color: Color32, durationMs: number): void => {
+        BTAPI.instance.paletteFlash(color, durationMs);
+    },
+
+    /**
+     * Instantly exchanges two palette entries.
+     *
+     * This is an immediate operation, not an animated effect. The visual change
+     * takes effect on the next frame.
+     *
+     * @param indexA - First palette index.
+     * @param indexB - Second palette index.
+     */
+    paletteSwap: (indexA: number, indexB: number): void => {
+        BTAPI.instance.paletteSwap(indexA, indexB);
+    },
+
+    /**
+     * Cancels all running palette effects immediately.
+     *
+     * The palette stays at whatever state it was in when cancelled.
+     */
+    paletteClearEffects: (): void => {
+        BTAPI.instance.paletteClearEffects();
+    },
+
+    // #endregion
+
     // #region Rendering - Clear Operations
 
     /**

--- a/src/assets/Palette.ts
+++ b/src/assets/Palette.ts
@@ -337,6 +337,28 @@ export class Palette {
     }
 
     /**
+     * Returns a direct reference to the internal {@link Color32} at the given index.
+     *
+     * Unlike {@link get}, this does **not** clone the entry. Mutations on the
+     * returned object modify the palette in place without updating the dirty flag.
+     * After modifying the entry, the caller **must** call {@link markDirty} so the
+     * renderer knows to re-upload the palette to the GPU.
+     *
+     * This method exists for performance-critical paths (palette effects) where
+     * per-frame cloning is unacceptable. Normal application code should prefer
+     * {@link get} and {@link set} to keep the dirty flag accurate automatically.
+     *
+     * @param index - Palette index to access.
+     * @returns Direct reference to the internal color entry.
+     * @throws Error if the index is invalid.
+     */
+    public getRef(index: number): Color32 {
+        this.assertIndexInRange(index);
+
+        return this.colorAt(index);
+    }
+
+    /**
      * Associates a human-readable name with a palette index.
      *
      * @param name - Name to register.
@@ -452,6 +474,17 @@ export class Palette {
      */
     public clearDirty(): void {
         this._dirty = false;
+    }
+
+    /**
+     * Marks the palette as modified so the renderer re-uploads it on the next frame.
+     *
+     * Call this after mutating entries obtained via {@link getRef}. The {@link set}
+     * and {@link copyFrom} methods set the dirty flag automatically; this method is
+     * only needed when bypassing them for performance.
+     */
+    public markDirty(): void {
+        this._dirty = true;
     }
 
     /**

--- a/src/assets/PaletteEffect.bench.ts
+++ b/src/assets/PaletteEffect.bench.ts
@@ -1,0 +1,166 @@
+// #region Imports
+
+import { bench, describe } from 'vitest';
+
+import { Color32 } from '../utils/Color32';
+import { Palette } from './Palette';
+import { CycleEffect, FadeEffect, PaletteEffectManager, paletteSwap } from './PaletteEffect';
+
+// #endregion
+
+// #region Constants
+
+const BENCH_OPTIONS = {
+    iterations: 500,
+    time: 100,
+    warmupTime: 25,
+    warmupIterations: 50,
+};
+
+const PALETTE_SIZE = 256;
+
+// #endregion
+
+// #region Helpers
+
+/**
+ * Creates a palette with distinct colors for benchmarking.
+ *
+ * @returns A 256-entry palette with unique color values.
+ */
+function makePalette(): Palette {
+    const p = new Palette(PALETTE_SIZE);
+
+    for (let i = 1; i < PALETTE_SIZE; i++) {
+        p.set(i, new Color32(i, (i * 7) % 256, (i * 13) % 256));
+    }
+
+    return p;
+}
+
+/**
+ * Creates a deterministic time provider for benchmarks.
+ *
+ * @returns Object with `now()` clock and `advance(ms)` control.
+ */
+function makeTimeClock(): { now: () => number; advance: (ms: number) => void } {
+    let t = 0;
+
+    return {
+        now: () => t,
+        advance: (ms: number) => {
+            t += ms;
+        },
+    };
+}
+
+// #endregion
+
+// #region CycleEffect Benchmarks
+
+describe('CycleEffect benchmarks', () => {
+    const palette = makePalette();
+    const effect = new CycleEffect(1, 31, 60);
+
+    bench(
+        'update() 32-entry range',
+        () => {
+            effect.update(palette, 16.67);
+        },
+        BENCH_OPTIONS,
+    );
+});
+
+describe('CycleEffect large range benchmarks', () => {
+    const palette = makePalette();
+    const effect = new CycleEffect(1, 255, 60);
+
+    bench(
+        'update() 255-entry range',
+        () => {
+            effect.update(palette, 16.67);
+        },
+        BENCH_OPTIONS,
+    );
+});
+
+// #endregion
+
+// #region FadeEffect Benchmarks
+
+describe('FadeEffect benchmarks', () => {
+    const source = makePalette();
+    const target = makePalette();
+
+    // Make target different so lerp actually does work.
+    for (let i = 1; i < PALETTE_SIZE; i++) {
+        target.set(i, new Color32(255 - i, (i * 3) % 256, (i * 11) % 256));
+    }
+
+    bench(
+        'update() full 256-entry palette',
+        () => {
+            // Recreate each iteration so the effect doesn't complete.
+            const effect = new FadeEffect(source, target, 2000, 'ease-in-out');
+            effect.update(source, 16.67);
+        },
+        BENCH_OPTIONS,
+    );
+});
+
+// #endregion
+
+// #region paletteSwap Benchmarks
+
+describe('paletteSwap benchmarks', () => {
+    const palette = makePalette();
+
+    bench(
+        'swap two entries',
+        () => {
+            paletteSwap(palette, 1, 2);
+        },
+        BENCH_OPTIONS,
+    );
+});
+
+// #endregion
+
+// #region PaletteEffectManager Benchmarks
+
+describe('PaletteEffectManager benchmarks', () => {
+    const clock = makeTimeClock();
+    const palette = makePalette();
+    const manager = new PaletteEffectManager(clock.now);
+
+    // Add a mix of effects to simulate realistic usage.
+    manager.add(new CycleEffect(1, 15, 30));
+    manager.add(new CycleEffect(16, 31, -20));
+    manager.add(new CycleEffect(32, 47, 10));
+
+    bench(
+        'update() with 3 active cycle effects',
+        () => {
+            clock.advance(16.67);
+            manager.update(palette);
+        },
+        BENCH_OPTIONS,
+    );
+});
+
+describe('PaletteEffectManager empty benchmarks', () => {
+    const clock = makeTimeClock();
+    const palette = makePalette();
+    const manager = new PaletteEffectManager(clock.now);
+
+    bench(
+        'update() with no active effects',
+        () => {
+            clock.advance(16.67);
+            manager.update(palette);
+        },
+        BENCH_OPTIONS,
+    );
+});
+
+// #endregion

--- a/src/assets/PaletteEffect.test.ts
+++ b/src/assets/PaletteEffect.test.ts
@@ -1,0 +1,554 @@
+import { describe, expect, it } from 'vitest';
+
+import { Color32 } from '../utils/Color32';
+import { Palette } from './Palette';
+import {
+    CycleEffect,
+    FadeEffect,
+    FadeRangeEffect,
+    FlashEffect,
+    PaletteEffectManager,
+    paletteSwap,
+} from './PaletteEffect';
+
+// #region Helpers
+
+/** Creates a 16-entry palette with distinct colors for testing. */
+function makeTestPalette(): Palette {
+    const p = new Palette(16);
+
+    for (let i = 1; i < 16; i++) {
+        p.set(i, new Color32(i * 16, i * 8, i * 4));
+    }
+
+    return p;
+}
+
+/** Creates a controllable time provider for deterministic tests. */
+function makeTimeClock() {
+    let now = 1000;
+
+    return {
+        provider: () => now,
+        advance: (ms: number) => {
+            now += ms;
+        },
+    };
+}
+
+// #endregion
+
+// #region PaletteEffectManager
+
+describe('PaletteEffectManager', () => {
+    it('starts with zero active effects', () => {
+        const clock = makeTimeClock();
+        const manager = new PaletteEffectManager(clock.provider);
+
+        expect(manager.activeCount).toBe(0);
+    });
+
+    it('tracks added effects', () => {
+        const clock = makeTimeClock();
+        const manager = new PaletteEffectManager(clock.provider);
+        const effect: { update: () => boolean } = { update: () => true };
+
+        manager.add(effect);
+
+        expect(manager.activeCount).toBe(1);
+    });
+
+    it('removes completed effects after update', () => {
+        const clock = makeTimeClock();
+        const manager = new PaletteEffectManager(clock.provider);
+        let callCount = 0;
+
+        manager.add({
+            update: () => {
+                callCount++;
+
+                return callCount < 2; // Complete on second call.
+            },
+        });
+
+        const palette = makeTestPalette();
+
+        clock.advance(16);
+        manager.update(palette);
+
+        expect(manager.activeCount).toBe(1);
+
+        clock.advance(16);
+        manager.update(palette);
+
+        expect(manager.activeCount).toBe(0);
+    });
+
+    it('clear removes all effects', () => {
+        const clock = makeTimeClock();
+        const manager = new PaletteEffectManager(clock.provider);
+
+        manager.add({ update: () => true });
+        manager.add({ update: () => true });
+
+        expect(manager.activeCount).toBe(2);
+
+        manager.clear();
+
+        expect(manager.activeCount).toBe(0);
+    });
+
+    it('marks palette dirty after update with active effects', () => {
+        const clock = makeTimeClock();
+        const manager = new PaletteEffectManager(clock.provider);
+        const palette = makeTestPalette();
+
+        manager.add({ update: () => true });
+        palette.clearDirty();
+
+        clock.advance(16);
+        manager.update(palette);
+
+        expect(palette.dirty).toBe(true);
+    });
+
+    it('skips first-frame delta (delta is 0 on first call)', () => {
+        const clock = makeTimeClock();
+        const manager = new PaletteEffectManager(clock.provider);
+        const palette = makeTestPalette();
+        let receivedDelta = -1;
+
+        manager.add({
+            update: (_p, deltaMs) => {
+                receivedDelta = deltaMs;
+
+                return false;
+            },
+        });
+
+        manager.update(palette);
+
+        expect(receivedDelta).toBe(0);
+    });
+
+    it('computes correct delta between frames', () => {
+        const clock = makeTimeClock();
+        const manager = new PaletteEffectManager(clock.provider);
+        const palette = makeTestPalette();
+        const deltas: number[] = [];
+
+        manager.add({
+            update: (_p, deltaMs) => {
+                deltas.push(deltaMs);
+
+                return deltas.length < 3;
+            },
+        });
+
+        manager.update(palette); // First call: delta = 0.
+
+        clock.advance(16);
+        manager.update(palette); // delta = 16.
+
+        clock.advance(33);
+        manager.update(palette); // delta = 33.
+
+        expect(deltas).toEqual([0, 16, 33]);
+    });
+
+    it('supports multiple simultaneous effects', () => {
+        const clock = makeTimeClock();
+        const manager = new PaletteEffectManager(clock.provider);
+        const palette = makeTestPalette();
+        let aRan = false;
+        let bRan = false;
+
+        manager.add({
+            update: () => {
+                aRan = true;
+
+                return true;
+            },
+        });
+        manager.add({
+            update: () => {
+                bRan = true;
+
+                return true;
+            },
+        });
+
+        clock.advance(16);
+        manager.update(palette);
+
+        expect(aRan).toBe(true);
+        expect(bRan).toBe(true);
+        expect(manager.activeCount).toBe(2);
+    });
+});
+
+// #endregion
+
+// #region CycleEffect
+
+describe('CycleEffect', () => {
+    it('rotates entries forward', () => {
+        const palette = makeTestPalette();
+        const original1 = palette.get(1);
+        const original2 = palette.get(2);
+        const original3 = palette.get(3);
+        const effect = new CycleEffect(1, 3, 1); // 1 step/sec
+
+        // Advance by 1 second -> 1 full step forward.
+        effect.update(palette, 1000);
+
+        // Forward rotation: [1,2,3] -> [2,3,1]
+        expect(palette.getRef(1).equals(original2)).toBe(true);
+        expect(palette.getRef(2).equals(original3)).toBe(true);
+        expect(palette.getRef(3).equals(original1)).toBe(true);
+    });
+
+    it('rotates entries backward with negative speed', () => {
+        const palette = makeTestPalette();
+        const original1 = palette.get(1);
+        const original2 = palette.get(2);
+        const original3 = palette.get(3);
+        const effect = new CycleEffect(1, 3, -1); // -1 step/sec
+
+        effect.update(palette, 1000);
+
+        // Backward rotation: [1,2,3] -> [3,1,2]
+        expect(palette.getRef(1).equals(original3)).toBe(true);
+        expect(palette.getRef(2).equals(original1)).toBe(true);
+        expect(palette.getRef(3).equals(original2)).toBe(true);
+    });
+
+    it('uses fractional accumulator for sub-frame precision', () => {
+        const palette = makeTestPalette();
+        const original1 = palette.get(1);
+        const effect = new CycleEffect(1, 3, 2); // 2 steps/sec
+
+        // 400ms = 0.8 steps -> no rotation yet.
+        effect.update(palette, 400);
+
+        expect(palette.getRef(1).equals(original1)).toBe(true);
+
+        // 200ms more = 1.2 steps total -> 1 rotation.
+        effect.update(palette, 200);
+
+        // Should have rotated once.
+        expect(palette.getRef(1).equals(original1)).toBe(false);
+    });
+
+    it('handles multiple rotations in a single frame', () => {
+        const palette = makeTestPalette();
+        const original1 = palette.get(1);
+        const original2 = palette.get(2);
+        const original3 = palette.get(3);
+        const effect = new CycleEffect(1, 3, 1);
+
+        // 3 seconds = 3 full rotations of 3 entries -> back to original.
+        effect.update(palette, 3000);
+
+        expect(palette.getRef(1).equals(original1)).toBe(true);
+        expect(palette.getRef(2).equals(original2)).toBe(true);
+        expect(palette.getRef(3).equals(original3)).toBe(true);
+    });
+
+    it('runs indefinitely (always returns true)', () => {
+        const palette = makeTestPalette();
+        const effect = new CycleEffect(1, 3, 1);
+
+        expect(effect.update(palette, 16)).toBe(true);
+        expect(effect.update(palette, 16)).toBe(true);
+        expect(effect.update(palette, 10000)).toBe(true);
+    });
+
+    it('does nothing with speed=0', () => {
+        const palette = makeTestPalette();
+        const original1 = palette.get(1);
+        const effect = new CycleEffect(1, 3, 0);
+
+        effect.update(palette, 1000);
+
+        expect(palette.getRef(1).equals(original1)).toBe(true);
+    });
+
+    it('does nothing when start >= end', () => {
+        const palette = makeTestPalette();
+        const original5 = palette.get(5);
+        const effect = new CycleEffect(5, 5, 10);
+
+        effect.update(palette, 1000);
+
+        expect(palette.getRef(5).equals(original5)).toBe(true);
+    });
+});
+
+// #endregion
+
+// #region FadeEffect
+
+describe('FadeEffect', () => {
+    it('reaches exact target values at completion', () => {
+        const source = makeTestPalette();
+        const target = new Palette(16);
+
+        for (let i = 1; i < 16; i++) {
+            target.set(i, new Color32(255, 0, 0));
+        }
+
+        const effect = new FadeEffect(source, target, 1000);
+
+        // Complete the fade.
+        effect.update(source, 1000);
+
+        for (let i = 1; i < 16; i++) {
+            expect(source.getRef(i).r).toBe(255);
+            expect(source.getRef(i).g).toBe(0);
+            expect(source.getRef(i).b).toBe(0);
+        }
+    });
+
+    it('auto-removes when complete (returns false)', () => {
+        const source = makeTestPalette();
+        const target = new Palette(16);
+
+        for (let i = 1; i < 16; i++) {
+            target.set(i, new Color32(255, 0, 0));
+        }
+
+        const effect = new FadeEffect(source, target, 1000);
+
+        expect(effect.update(source, 500)).toBe(true);
+        expect(effect.update(source, 500)).toBe(false);
+    });
+
+    it('interpolates intermediate values correctly', () => {
+        const source = new Palette(16);
+
+        source.set(1, new Color32(0, 0, 0));
+
+        const target = new Palette(16);
+
+        target.set(1, new Color32(200, 100, 50));
+
+        const effect = new FadeEffect(source, target, 1000, 'linear');
+
+        effect.update(source, 500); // t = 0.5
+
+        // At halfway, values should be approximately half of target.
+        expect(source.getRef(1).r).toBeCloseTo(100, 0);
+        expect(source.getRef(1).g).toBeCloseTo(50, 0);
+        expect(source.getRef(1).b).toBeCloseTo(25, 0);
+    });
+
+    it('applies easing function', () => {
+        const source = new Palette(16);
+
+        source.set(1, new Color32(0, 0, 0));
+
+        const target = new Palette(16);
+
+        target.set(1, new Color32(100, 0, 0));
+
+        const effectEaseIn = new FadeEffect(source, target, 1000, 'ease-in');
+
+        effectEaseIn.update(source, 500); // t = 0.5, ease-in = 0.25
+
+        // ease-in at t=0.5 -> 0.25, so r ~= 25.
+        expect(source.getRef(1).r).toBeCloseTo(25, 0);
+    });
+
+    it('completes immediately with zero duration', () => {
+        const source = makeTestPalette();
+        const target = new Palette(16);
+
+        for (let i = 1; i < 16; i++) {
+            target.set(i, new Color32(42, 42, 42));
+        }
+
+        const effect = new FadeEffect(source, target, 0);
+        const result = effect.update(source, 0);
+
+        expect(result).toBe(false);
+        expect(source.getRef(1).r).toBe(42);
+    });
+
+    it('preserves index 0 as transparent', () => {
+        const source = makeTestPalette();
+        const target = new Palette(16);
+
+        // Set non-zero entries to white (index 0 stays transparent by Palette rules).
+        for (let i = 1; i < 16; i++) {
+            target.set(i, new Color32(255, 255, 255));
+        }
+
+        const effect = new FadeEffect(source, target, 1000);
+
+        effect.update(source, 1000);
+
+        // Index 0 should remain transparent (unmodified by the fade loop starting at 1).
+        expect(source.getRef(0).a).toBe(0);
+    });
+});
+
+// #endregion
+
+// #region FadeRangeEffect
+
+describe('FadeRangeEffect', () => {
+    it('only affects specified range', () => {
+        const source = makeTestPalette();
+        const originalOutside = source.get(1);
+        const target = new Palette(16);
+
+        for (let i = 1; i < 16; i++) {
+            target.set(i, new Color32(255, 0, 0));
+        }
+
+        const effect = new FadeRangeEffect(5, 10, source, target, 1000);
+
+        effect.update(source, 1000);
+
+        // Index 1 should be unchanged (outside range).
+        expect(source.getRef(1).equals(originalOutside)).toBe(true);
+
+        // Index 5 should be at target.
+        expect(source.getRef(5).r).toBe(255);
+        expect(source.getRef(5).g).toBe(0);
+
+        // Index 10 should be at target.
+        expect(source.getRef(10).r).toBe(255);
+    });
+
+    it('auto-removes when complete', () => {
+        const source = makeTestPalette();
+        const target = new Palette(16);
+
+        for (let i = 1; i < 16; i++) {
+            target.set(i, new Color32(255, 0, 0));
+        }
+
+        const effect = new FadeRangeEffect(5, 10, source, target, 500);
+
+        expect(effect.update(source, 250)).toBe(true);
+        expect(effect.update(source, 250)).toBe(false);
+    });
+
+    it('applies easing function', () => {
+        const source = new Palette(16);
+
+        source.set(5, new Color32(0, 0, 0));
+
+        const target = new Palette(16);
+
+        target.set(5, new Color32(100, 0, 0));
+
+        const effect = new FadeRangeEffect(5, 5, source, target, 1000, 'ease-out');
+
+        effect.update(source, 500); // t = 0.5, ease-out = 0.75
+
+        expect(source.getRef(5).r).toBeCloseTo(75, 0);
+    });
+});
+
+// #endregion
+
+// #region FlashEffect
+
+describe('FlashEffect', () => {
+    it('sets all non-zero entries to flash color', () => {
+        const palette = makeTestPalette();
+        const flashColor = new Color32(255, 255, 0);
+        const effect = new FlashEffect(flashColor, 200);
+
+        effect.update(palette, 0); // First frame: snapshot + apply.
+
+        for (let i = 1; i < 16; i++) {
+            expect(palette.getRef(i).r).toBe(255);
+            expect(palette.getRef(i).g).toBe(255);
+            expect(palette.getRef(i).b).toBe(0);
+        }
+    });
+
+    it('preserves index 0 as transparent', () => {
+        const palette = makeTestPalette();
+        const effect = new FlashEffect(new Color32(255, 255, 255), 200);
+
+        effect.update(palette, 0);
+
+        expect(palette.getRef(0).a).toBe(0);
+    });
+
+    it('restores palette after duration', () => {
+        const palette = makeTestPalette();
+        const originalColors: Color32[] = [];
+
+        for (let i = 0; i < 16; i++) {
+            originalColors.push(palette.get(i));
+        }
+
+        const effect = new FlashEffect(new Color32(255, 0, 0), 200);
+
+        effect.update(palette, 0); // Snapshot + flash.
+        effect.update(palette, 200); // Restore.
+
+        for (let i = 1; i < 16; i++) {
+            // eslint-disable-next-line security/detect-object-injection -- Safe: i is a controlled loop index
+            const original = originalColors[i];
+
+            if (original) {
+                expect(palette.getRef(i).equals(original)).toBe(true);
+            }
+        }
+    });
+
+    it('auto-removes after restore (returns false)', () => {
+        const palette = makeTestPalette();
+        const effect = new FlashEffect(new Color32(255, 0, 0), 100);
+
+        expect(effect.update(palette, 0)).toBe(true); // Flash applied.
+        expect(effect.update(palette, 50)).toBe(true); // Still flashing.
+        expect(effect.update(palette, 50)).toBe(false); // Restored.
+    });
+});
+
+// #endregion
+
+// #region paletteSwap
+
+describe('paletteSwap', () => {
+    it('exchanges two palette entries', () => {
+        const palette = makeTestPalette();
+        const color3 = palette.get(3);
+        const color7 = palette.get(7);
+
+        paletteSwap(palette, 3, 7);
+
+        expect(palette.getRef(3).equals(color7)).toBe(true);
+        expect(palette.getRef(7).equals(color3)).toBe(true);
+    });
+
+    it('marks palette dirty', () => {
+        const palette = makeTestPalette();
+
+        palette.clearDirty();
+        paletteSwap(palette, 1, 2);
+
+        expect(palette.dirty).toBe(true);
+    });
+
+    it('is a no-op when indices are the same', () => {
+        const palette = makeTestPalette();
+        const original = palette.get(5);
+
+        palette.clearDirty();
+        paletteSwap(palette, 5, 5);
+
+        expect(palette.getRef(5).equals(original)).toBe(true);
+        expect(palette.dirty).toBe(false);
+    });
+});
+
+// #endregion

--- a/src/assets/PaletteEffect.ts
+++ b/src/assets/PaletteEffect.ts
@@ -1,0 +1,458 @@
+/**
+ * Palette effect system for animated color manipulation.
+ *
+ * Effects operate on palette entries ({@link Color32} arrays) in place. The visual
+ * change happens automatically on the next frame when the renderer detects the
+ * dirty flag and re-uploads the palette uniform buffer.
+ *
+ * The {@link PaletteEffectManager} is called once per frame from the render
+ * callback, after `demo.render()` but before `Renderer.endFrame()`.
+ */
+
+import { Color32 } from '../utils/Color32';
+import type { EasingFunction } from '../utils/Easing';
+import { applyEasing } from '../utils/Easing';
+import type { Palette } from './Palette';
+
+// #region Types
+
+/**
+ * A single palette effect that runs over time.
+ *
+ * The manager calls {@link update} once per frame. The effect mutates palette
+ * entries via `palette.getRef()` and returns `true` to keep running or `false`
+ * to signal completion (the manager removes it automatically).
+ */
+export interface PaletteEffect {
+    /**
+     * Advances the effect by one frame.
+     *
+     * @param palette - Active palette to modify.
+     * @param deltaMs - Wall-clock milliseconds since the last frame.
+     * @returns `true` to keep running, `false` to remove from the manager.
+     */
+    update(palette: Palette, deltaMs: number): boolean;
+}
+
+// #endregion
+
+// #region PaletteEffectManager
+
+/**
+ * Manages active palette effects and updates them each frame.
+ *
+ * Tracks wall-clock time internally via an injectable time provider so the
+ * {@link GameLoop} callback signatures remain unchanged.
+ */
+export class PaletteEffectManager {
+    private effects: PaletteEffect[] = [];
+    private lastTime = 0;
+    private readonly timeProvider: () => number;
+
+    /**
+     * Creates a new effect manager.
+     *
+     * @param timeProvider - Clock function returning milliseconds. Defaults to
+     *   `performance.now()`. Pass a custom function for deterministic unit tests.
+     */
+    constructor(timeProvider: () => number = () => performance.now()) {
+        this.timeProvider = timeProvider;
+    }
+
+    /**
+     * Adds an effect to the active list.
+     *
+     * @param effect - Effect instance to run each frame.
+     */
+    add(effect: PaletteEffect): void {
+        this.effects.push(effect);
+    }
+
+    /**
+     * Updates all active effects and removes completed ones.
+     *
+     * Call this once per frame. Completed effects (returning `false`) are pruned
+     * in place without allocating a new array.
+     *
+     * @param palette - Active palette to pass to each effect.
+     */
+    update(palette: Palette): void {
+        const now = this.timeProvider();
+        const deltaMs = this.lastTime === 0 ? 0 : now - this.lastTime;
+
+        this.lastTime = now;
+
+        if (this.effects.length === 0) {
+            return;
+        }
+
+        // In-place compaction: keep running effects, drop completed ones.
+        let writeIdx = 0;
+
+        for (let i = 0; i < this.effects.length; i++) {
+            // eslint-disable-next-line security/detect-object-injection -- Safe: i is a controlled loop index within bounds
+            const effect = this.effects[i];
+
+            if (effect?.update(palette, deltaMs)) {
+                // eslint-disable-next-line security/detect-object-injection -- Safe: writeIdx <= i, always within bounds
+                this.effects[writeIdx] = effect;
+                writeIdx++;
+            }
+        }
+
+        this.effects.length = writeIdx;
+        palette.markDirty();
+    }
+
+    /** Removes all active effects immediately. The palette stays at its current state. */
+    clear(): void {
+        this.effects.length = 0;
+    }
+
+    /**
+     * Number of currently running effects.
+     *
+     * @returns Count of active effects in the manager.
+     */
+    get activeCount(): number {
+        return this.effects.length;
+    }
+}
+
+// #endregion
+
+// #region CycleEffect
+
+/**
+ * Rotates a range of palette entries at a constant speed.
+ *
+ * Classic water/fire/plasma animation. Runs indefinitely until cancelled
+ * via {@link PaletteEffectManager.clear}.
+ *
+ * Uses a fractional accumulator for sub-frame precision and a pre-allocated
+ * temporary {@link Color32} to avoid per-frame allocations.
+ */
+export class CycleEffect implements PaletteEffect {
+    private accumulator = 0;
+    private readonly temp = new Color32(0, 0, 0, 0);
+
+    /**
+     * Creates a palette cycling effect.
+     *
+     * @param start - First palette index in the cycling range (inclusive).
+     * @param end - Last palette index in the cycling range (inclusive).
+     * @param speed - Steps per second. Positive = forward, negative = backward.
+     */
+    constructor(
+        private readonly start: number,
+        private readonly end: number,
+        private readonly speed: number,
+    ) {}
+
+    update(palette: Palette, deltaMs: number): boolean {
+        if (this.speed === 0 || this.start >= this.end) {
+            return true;
+        }
+
+        this.accumulator += (this.speed * deltaMs) / 1000;
+
+        // Forward rotation: shift entries toward lower indices, wrap last to first.
+        while (this.accumulator >= 1) {
+            this.accumulator -= 1;
+            this.rotateForward(palette);
+        }
+
+        // Backward rotation: shift entries toward higher indices, wrap first to last.
+        while (this.accumulator <= -1) {
+            this.accumulator += 1;
+            this.rotateBackward(palette);
+        }
+
+        return true; // Runs indefinitely.
+    }
+
+    /**
+     * Shifts entries toward lower indices, wrapping the first entry to the end.
+     *
+     * @param palette - Palette whose entries are rotated.
+     */
+    private rotateForward(palette: Palette): void {
+        this.temp.copyFrom(palette.getRef(this.start));
+
+        for (let i = this.start; i < this.end; i++) {
+            palette.getRef(i).copyFrom(palette.getRef(i + 1));
+        }
+
+        palette.getRef(this.end).copyFrom(this.temp);
+    }
+
+    /**
+     * Shifts entries toward higher indices, wrapping the last entry to the start.
+     *
+     * @param palette - Palette whose entries are rotated.
+     */
+    private rotateBackward(palette: Palette): void {
+        this.temp.copyFrom(palette.getRef(this.end));
+
+        for (let i = this.end; i > this.start; i--) {
+            palette.getRef(i).copyFrom(palette.getRef(i - 1));
+        }
+
+        palette.getRef(this.start).copyFrom(this.temp);
+    }
+}
+
+// #endregion
+
+// #region FadeEffect
+
+/**
+ * Smoothly interpolates all palette entries toward a target palette over time.
+ *
+ * Snapshots the current palette at creation. Each frame computes an eased
+ * progress value and lerps between the snapshot and target. At completion,
+ * sets entries to the exact target values to avoid floating-point drift.
+ *
+ * Auto-removes when the fade completes.
+ */
+export class FadeEffect implements PaletteEffect {
+    private elapsed = 0;
+    private readonly snapshotColors: Color32[];
+    private readonly targetColors: Color32[];
+    private readonly size: number;
+
+    /**
+     * Creates a full-palette fade effect.
+     *
+     * @param sourcePalette - Snapshot of the starting palette (cloned internally).
+     * @param targetPalette - Target palette to fade toward.
+     * @param durationMs - Fade duration in milliseconds.
+     * @param easing - Easing curve to apply. Defaults to `'linear'`.
+     */
+    constructor(
+        sourcePalette: Palette,
+        targetPalette: Palette,
+        private readonly durationMs: number,
+        private readonly easing: EasingFunction = 'linear',
+    ) {
+        this.size = sourcePalette.size;
+
+        // Snapshot source colors once (one-time allocation).
+        this.snapshotColors = [];
+
+        for (let i = 0; i < this.size; i++) {
+            this.snapshotColors.push(sourcePalette.get(i));
+        }
+
+        // Cache target colors to avoid repeated cloning.
+        this.targetColors = [];
+
+        for (let i = 0; i < targetPalette.size; i++) {
+            this.targetColors.push(targetPalette.get(i));
+        }
+    }
+
+    update(palette: Palette, deltaMs: number): boolean {
+        this.elapsed += deltaMs;
+
+        const rawT = this.durationMs <= 0 ? 1 : this.elapsed / this.durationMs;
+        const t = rawT < 0 ? 0 : rawT > 1 ? 1 : rawT;
+        const easedT = applyEasing(t, this.easing);
+
+        const count = Math.min(this.size, palette.size);
+
+        for (let i = 1; i < count; i++) {
+            // eslint-disable-next-line security/detect-object-injection -- Loop index within validated bounds
+            const snap = this.snapshotColors[i];
+            // eslint-disable-next-line security/detect-object-injection -- Loop index within validated bounds
+            const tgt = this.targetColors[i];
+
+            if (!snap || !tgt) {
+                continue;
+            }
+
+            if (t >= 1) {
+                palette.getRef(i).copyFrom(tgt);
+            } else {
+                palette.getRef(i).copyFrom(snap).lerpInPlace(tgt, easedT);
+            }
+        }
+
+        return t < 1;
+    }
+}
+
+// #endregion
+
+// #region FadeRangeEffect
+
+/**
+ * Fades only a subset of palette indices toward a target palette.
+ *
+ * Identical to {@link FadeEffect} but restricted to the range `[start, end]`.
+ * Auto-removes when the fade completes.
+ */
+export class FadeRangeEffect implements PaletteEffect {
+    private elapsed = 0;
+    private readonly snapshotColors: Color32[];
+    private readonly targetColors: Color32[];
+
+    /**
+     * Creates a range-limited fade effect.
+     *
+     * @param start - First palette index to fade (inclusive).
+     * @param end - Last palette index to fade (inclusive).
+     * @param sourcePalette - Snapshot of the starting palette (cloned internally).
+     * @param targetPalette - Target palette to fade toward.
+     * @param durationMs - Fade duration in milliseconds.
+     * @param easing - Easing curve to apply. Defaults to `'linear'`.
+     */
+    constructor(
+        private readonly start: number,
+        private readonly end: number,
+        sourcePalette: Palette,
+        targetPalette: Palette,
+        private readonly durationMs: number,
+        private readonly easing: EasingFunction = 'linear',
+    ) {
+        // Snapshot only the range we care about.
+        this.snapshotColors = [];
+
+        for (let i = start; i <= end; i++) {
+            this.snapshotColors.push(sourcePalette.get(i));
+        }
+
+        this.targetColors = [];
+
+        for (let i = start; i <= end; i++) {
+            this.targetColors.push(targetPalette.get(i));
+        }
+    }
+
+    update(palette: Palette, deltaMs: number): boolean {
+        this.elapsed += deltaMs;
+
+        const rawT = this.durationMs <= 0 ? 1 : this.elapsed / this.durationMs;
+        const t = rawT < 0 ? 0 : rawT > 1 ? 1 : rawT;
+        const easedT = applyEasing(t, this.easing);
+
+        for (let i = this.start; i <= this.end; i++) {
+            const localIdx = i - this.start;
+
+            // eslint-disable-next-line security/detect-object-injection -- localIdx derived from loop bounds
+            const snap = this.snapshotColors[localIdx];
+            // eslint-disable-next-line security/detect-object-injection -- localIdx derived from loop bounds
+            const tgt = this.targetColors[localIdx];
+
+            if (!snap || !tgt) {
+                continue;
+            }
+
+            if (t >= 1) {
+                palette.getRef(i).copyFrom(tgt);
+            } else {
+                palette.getRef(i).copyFrom(snap).lerpInPlace(tgt, easedT);
+            }
+        }
+
+        return t < 1;
+    }
+}
+
+// #endregion
+
+// #region FlashEffect
+
+/**
+ * Temporarily sets all palette entries to a single color, then restores.
+ *
+ * On the first frame, snapshots all entries and overwrites them with the flash
+ * color (index 0 is preserved as transparent). After the duration elapses,
+ * restores the snapshot and auto-removes.
+ */
+export class FlashEffect implements PaletteEffect {
+    private elapsed = 0;
+    private snapshotColors: Color32[] | null = null;
+
+    /**
+     * Creates a palette flash effect.
+     *
+     * @param color - Flash color applied to all non-zero entries.
+     * @param durationMs - How long the flash lasts in milliseconds.
+     */
+    constructor(
+        private readonly color: Color32,
+        private readonly durationMs: number,
+    ) {}
+
+    update(palette: Palette, deltaMs: number): boolean {
+        // First frame: snapshot and apply flash.
+        if (this.snapshotColors === null) {
+            this.snapshotColors = [];
+
+            for (let i = 0; i < palette.size; i++) {
+                this.snapshotColors.push(palette.get(i));
+            }
+
+            for (let i = 1; i < palette.size; i++) {
+                palette.getRef(i).copyFrom(this.color);
+            }
+
+            return true;
+        }
+
+        this.elapsed += deltaMs;
+
+        if (this.elapsed >= this.durationMs) {
+            // Restore from snapshot.
+            for (let i = 1; i < palette.size; i++) {
+                // eslint-disable-next-line security/detect-object-injection -- Loop index within validated snapshot bounds
+                const saved = this.snapshotColors[i];
+
+                if (saved) {
+                    palette.getRef(i).copyFrom(saved);
+                }
+            }
+
+            return false;
+        }
+
+        // Keep flashing.
+        return true;
+    }
+}
+
+// #endregion
+
+// #region Standalone Functions
+
+/**
+ * Instantly exchanges two palette entries.
+ *
+ * This is an immediate operation, not an animated effect. It modifies the
+ * palette directly and marks it dirty for the renderer.
+ *
+ * @param palette - Palette to modify.
+ * @param indexA - First palette index.
+ * @param indexB - Second palette index.
+ */
+export function paletteSwap(palette: Palette, indexA: number, indexB: number): void {
+    if (indexA === indexB) {
+        return;
+    }
+
+    const refA = palette.getRef(indexA);
+    const refB = palette.getRef(indexB);
+
+    const tempR = refA.r;
+    const tempG = refA.g;
+    const tempB = refA.b;
+    const tempAlpha = refA.a;
+
+    refA.copyFrom(refB);
+    refB.setRGBA(tempR, tempG, tempB, tempAlpha);
+
+    palette.markDirty();
+}
+
+// #endregion

--- a/src/assets/PaletteEffect.ts
+++ b/src/assets/PaletteEffect.ts
@@ -65,6 +65,12 @@ export class PaletteEffectManager {
      * @param effect - Effect instance to run each frame.
      */
     add(effect: PaletteEffect): void {
+        // Reset the clock when waking from idle so the first update after a gap
+        // sees delta=0 instead of the entire idle duration.
+        if (this.effects.length === 0) {
+            this.lastTime = 0;
+        }
+
         this.effects.push(effect);
     }
 

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -651,6 +651,10 @@ export class BTAPI {
      * @param durationMs - How long the flash lasts in milliseconds.
      */
     public paletteFlash(color: Color32, durationMs: number): void {
+        if (!this.palette) {
+            throw new Error('[BT] Cannot flash palette: no active palette set.');
+        }
+
         this.assertFiniteDuration('paletteFlash', durationMs);
         this.paletteEffects.add(new FlashEffect(color, durationMs));
     }

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -329,6 +329,10 @@ export class BTAPI {
             console.warn('[BT] Active palette structure changed. Call BT.spritesRefresh() to update loaded sprites.');
         }
 
+        // In-flight effects hold snapshots of the old palette. Drop them so they
+        // don't apply stale colors to the new palette.
+        this.paletteEffects.clear();
+
         this.palette = palette;
         this.renderer?.setPalette(palette);
     }

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -1,7 +1,17 @@
 import type { BitmapFont } from '../assets/BitmapFont';
 import type { Palette } from '../assets/Palette';
+import {
+    CycleEffect,
+    FadeEffect,
+    FadeRangeEffect,
+    FlashEffect,
+    PaletteEffectManager,
+    paletteSwap,
+} from '../assets/PaletteEffect';
 import type { SpriteSheet } from '../assets/SpriteSheet';
 import { Renderer } from '../render/Renderer';
+import type { Color32 } from '../utils/Color32';
+import type { EasingFunction } from '../utils/Easing';
 import type { Rect2i } from '../utils/Rect2i';
 import { Vector2i } from '../utils/Vector2i';
 import { GameLoop } from './GameLoop';
@@ -71,6 +81,9 @@ export class BTAPI {
 
     /** Game loop managing fixed-timestep updates and variable-rate rendering. */
     private loop: GameLoop | null = null;
+
+    /** Manages animated palette effects (cycling, fading, flashing). */
+    private readonly paletteEffects = new PaletteEffectManager();
 
     // TODO: Additional subsystems for future implementation:
     // InputManager, AudioManager, AssetManager
@@ -196,6 +209,14 @@ export class BTAPI {
                 if (this.renderer) {
                     this.renderer.beginFrame();
                     this.demo?.render();
+
+                    // Palette effects run after demo render (so user's explicit palette
+                    // changes in render() are respected) but before endFrame (so effects
+                    // are visible this frame via the dirty-flag GPU upload).
+                    if (this.palette && this.paletteEffects.activeCount > 0) {
+                        this.paletteEffects.update(this.palette);
+                    }
+
                     this.renderer.endFrame();
                 }
             },
@@ -534,6 +555,101 @@ export class BTAPI {
      */
     public resetCamera(): void {
         this.renderer?.resetCamera();
+    }
+
+    // #endregion
+
+    // #region Palette Effects API
+
+    /**
+     * Starts rotating a range of palette entries at a constant speed.
+     *
+     * Classic water/fire/plasma animation. Runs indefinitely until cancelled
+     * via {@link paletteClearEffects}.
+     *
+     * @param start - First palette index in the cycling range (inclusive).
+     * @param end - Last palette index in the cycling range (inclusive).
+     * @param speed - Steps per second. Positive = forward, negative = backward.
+     */
+    public paletteCycle(start: number, end: number, speed: number): void {
+        this.paletteEffects.add(new CycleEffect(start, end, speed));
+    }
+
+    /**
+     * Smoothly interpolates all palette entries toward a target over time.
+     *
+     * Snapshots the current palette at start. Auto-removes when complete.
+     *
+     * @param target - Target palette to fade toward.
+     * @param durationMs - Fade duration in milliseconds.
+     * @param easing - Easing curve. Defaults to `'linear'`.
+     */
+    public paletteFade(target: Palette, durationMs: number, easing?: EasingFunction): void {
+        if (!this.palette) {
+            throw new Error('[BT] Cannot fade palette: no active palette set.');
+        }
+
+        this.paletteEffects.add(new FadeEffect(this.palette, target, durationMs, easing));
+    }
+
+    /**
+     * Fades only a subset of palette indices toward a target over time.
+     *
+     * @param start - First palette index to fade (inclusive).
+     * @param end - Last palette index to fade (inclusive).
+     * @param target - Target palette to fade toward.
+     * @param durationMs - Fade duration in milliseconds.
+     * @param easing - Easing curve. Defaults to `'linear'`.
+     */
+    public paletteFadeRange(
+        start: number,
+        end: number,
+        target: Palette,
+        durationMs: number,
+        easing?: EasingFunction,
+    ): void {
+        if (!this.palette) {
+            throw new Error('[BT] Cannot fade palette range: no active palette set.');
+        }
+
+        this.paletteEffects.add(new FadeRangeEffect(start, end, this.palette, target, durationMs, easing));
+    }
+
+    /**
+     * Temporarily sets all non-zero palette entries to a single color, then restores.
+     *
+     * Index 0 (transparent) is preserved. Auto-removes after duration.
+     *
+     * @param color - Flash color applied to all non-zero entries.
+     * @param durationMs - How long the flash lasts in milliseconds.
+     */
+    public paletteFlash(color: Color32, durationMs: number): void {
+        this.paletteEffects.add(new FlashEffect(color, durationMs));
+    }
+
+    /**
+     * Instantly exchanges two palette entries.
+     *
+     * This is an immediate operation, not an animated effect.
+     *
+     * @param indexA - First palette index.
+     * @param indexB - Second palette index.
+     */
+    public paletteSwap(indexA: number, indexB: number): void {
+        if (!this.palette) {
+            throw new Error('[BT] Cannot swap palette entries: no active palette set.');
+        }
+
+        paletteSwap(this.palette, indexA, indexB);
+    }
+
+    /**
+     * Cancels all running palette effects immediately.
+     *
+     * The palette stays at whatever state it was in when cancelled.
+     */
+    public paletteClearEffects(): void {
+        this.paletteEffects.clear();
     }
 
     // #endregion

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -562,6 +562,19 @@ export class BTAPI {
     // #region Palette Effects API
 
     /**
+     * Validates that a duration is a finite, non-negative number.
+     *
+     * @param method - Calling method name for the error message.
+     * @param durationMs - Duration to validate.
+     * @throws Error if the duration is not finite or is negative.
+     */
+    private assertFiniteDuration(method: string, durationMs: number): void {
+        if (!Number.isFinite(durationMs) || durationMs < 0) {
+            throw new Error(`[BT] ${method}: durationMs must be a finite non-negative number, got ${durationMs}.`);
+        }
+    }
+
+    /**
      * Starts rotating a range of palette entries at a constant speed.
      *
      * Classic water/fire/plasma animation. Runs indefinitely until cancelled
@@ -572,6 +585,14 @@ export class BTAPI {
      * @param speed - Steps per second. Positive = forward, negative = backward.
      */
     public paletteCycle(start: number, end: number, speed: number): void {
+        if (!Number.isFinite(speed)) {
+            throw new Error(`[BT] paletteCycle: speed must be finite, got ${speed}.`);
+        }
+
+        if (!Number.isInteger(start) || !Number.isInteger(end) || start >= end) {
+            throw new Error(`[BT] paletteCycle: start must be an integer less than end, got [${start}, ${end}].`);
+        }
+
         this.paletteEffects.add(new CycleEffect(start, end, speed));
     }
 
@@ -589,6 +610,7 @@ export class BTAPI {
             throw new Error('[BT] Cannot fade palette: no active palette set.');
         }
 
+        this.assertFiniteDuration('paletteFade', durationMs);
         this.paletteEffects.add(new FadeEffect(this.palette, target, durationMs, easing));
     }
 
@@ -612,6 +634,7 @@ export class BTAPI {
             throw new Error('[BT] Cannot fade palette range: no active palette set.');
         }
 
+        this.assertFiniteDuration('paletteFadeRange', durationMs);
         this.paletteEffects.add(new FadeRangeEffect(start, end, this.palette, target, durationMs, easing));
     }
 
@@ -624,6 +647,7 @@ export class BTAPI {
      * @param durationMs - How long the flash lasts in milliseconds.
      */
     public paletteFlash(color: Color32, durationMs: number): void {
+        this.assertFiniteDuration('paletteFlash', durationMs);
         this.paletteEffects.add(new FlashEffect(color, durationMs));
     }
 


### PR DESCRIPTION
Introduce PaletteEffectManager that runs after demo.render() and before GPU upload, with an activeCount guard to skip work when idle.

Effects:
- CycleEffect: constant-speed palette rotation (zero-alloc)
- FadeEffect/FadeRangeEffect: timed interpolation with easing
- FlashEffect: temporary color override with auto-restore
- paletteSwap: instant two-entry exchange

Add getRef() and markDirty() to Palette for zero-copy mutation. Expose all effects on the BT public facade (6 new methods). Includes 31 unit tests and Tier 1 CPU benchmarks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR adds a palette effects system to the BlitTech engine, enabling runtime animation and manipulation of color palettes. The system runs in the render loop after demo.render() and before GPU upload, and uses an activeCount guard to skip processing when idle. In-flight effects are cleared when the active palette is replaced to avoid stale snapshots.

## Core Components

**Palette API Enhancements** (`src/assets/Palette.ts`):
- Added `getRef(index)` for zero-copy direct access to internal `Color32` entries.
- Added `markDirty()` to explicitly flag the palette for renderer upload on the next frame.

**Palette Effects System** (`src/assets/PaletteEffect.ts`):
- `PaletteEffect` interface: `update(palette, deltaMs): boolean`.
- `PaletteEffectManager`:
  - Injectable time provider (defaults to `performance.now()`).
  - Per-frame delta time computation; first-frame delta is skipped (treated as 0) to avoid large accumulated gaps.
  - In-place compaction/removal of completed effects (no reallocation).
  - `activeCount` getter; adding the first effect after idle resets the manager clock to prevent a large delta spike.
  - `add(effect)`, `update(palette)`, `clear()`.
- Effects implemented:
  - `CycleEffect`: Continuous index-range rotation at configurable steps/sec, fractional accumulator, preallocated temp buffer for zero/allocation rotation.
  - `FadeEffect`: Full-palette timed interpolation with optional easing; snapshots source and converges exactly to target.
  - `FadeRangeEffect`: Range-limited fade affecting indices `[start, end]` only.
  - `FlashEffect`: Temporary color override of non-zero entries with automatic restore from snapshot after duration.
- `paletteSwap(palette, indexA, indexB)`: Instant two-entry in-place exchange; marks palette dirty.

All effects preserve transparent index 0 where applicable.

## Public API Additions

**`BT` facade** (`src/BlitTech.ts`):
- Exposed methods delegating to `BTAPI.instance`: `paletteCycle(start, end, speed)`, `paletteFade(target, durationMs, easing?)`, `paletteFadeRange(start, end, target, durationMs, easing?)`, `paletteFlash(color, durationMs)`, `paletteSwap(indexA, indexB)`, `paletteClearEffects()`.

**`BTAPI` class** (`src/core/BTAPI.ts`):
- New private field: `paletteEffects: PaletteEffectManager`.
- Integrated `paletteEffects.update(this.palette)` into the render path (after demo.render(), before renderer endFrame()), executed only when `paletteEffects.activeCount > 0` and an active palette exists.
- `setPalette(...)` now clears in-flight palette effects (`paletteEffects.clear()`) when replacing the active palette to prevent effects from applying to stale palettes.
- Added public methods implementing the palette-effect APIs and a private `assertFiniteDuration` helper for consistent duration validation.

## Validation & Behavior Notes

- Input validation added to palette-effect APIs:
  - `paletteCycle`: requires finite `speed` and integer `start < end`.
  - `paletteFade`, `paletteFadeRange`, `paletteFlash`: require finite, non-negative `durationMs`.
  - `paletteSwap`: requires an active palette; no-op if indices are identical.
- `paletteFlash` now requires an active palette before queuing (fix): ensures flashes are only queued when a palette exists to avoid invalid/no-op queueing.
- When the manager transitions from idle to active (first effect added), its internal clock is reset to avoid a large first-frame delta.
- Palette dirtiness is marked after effect updates to ensure GPU sync.
- Effects auto-remove by returning `false` from `update()` when complete.

## Testing & Benchmarks

- Unit tests: 31 tests covering manager lifecycle, effect behaviors and edge cases (zero duration, identical indices, out-of-range), easing modes, preservation of index 0, and concurrent effects (`src/assets/PaletteEffect.test.ts`).
- Benchmarks: Tier 1 CPU benchmarks for `CycleEffect.update()`, `FadeEffect.update()`, `paletteSwap()`, and `PaletteEffectManager.update()` (active vs idle scenarios) (`src/assets/PaletteEffect.bench.ts`).

## Implementation Notes

- Designed for zero/allocation hotspots: cycle rotations use preallocated buffers and manager uses in-place compaction.
- Effects snapshot source/target data as needed to ensure deterministic interpolation and correct restoration for flash.
- `getRef()` + `markDirty()` enable zero-copy external mutations while requiring explicit dirty signaling for renderer uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->