### PR TITLE
docs(assets): document palette effects in README, CLAUDE.md, and testing guides

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,9 @@ src/
     AssetLoader.ts         # Image loading with caching
     SpriteSheet.ts         # GPU texture wrapper
     BitmapFont.ts          # Bitmap font system (.btfont)
+    Palette.ts             # 256-entry indexed color palette
+    PaletteEffect.ts       # Palette effect system (cycle, fade, flash, swap)
+    palettes/              # Built-in preset palette data (VGA, CGA, C64, etc.)
   utils/
     Bootstrap.ts           # Demo bootstrap utilities
     BootstrapHelpers.ts    # WebGPU detection, canvas lookup, error display
@@ -113,7 +116,7 @@ pnpm test:perf           # Run Tier 2 browser/GPU frame-time benchmarks
 
 **Test tiers:**
 
-1. **Unit tests** (Vitest, node) - Pure logic: Vector2i, Rect2i, Color32, Easing, GameLoop
+1. **Unit tests** (Vitest, node) - Pure logic: Vector2i, Rect2i, Color32, Palette, PaletteEffect, Easing, GameLoop
 2. **Integration tests** (Vitest, Node + GPU mocks; happy-dom for DOM tests) - DOM and GPU code
 3. **Visual regression** (Playwright, Chromium) - Rendering output verification
 4. **Performance tests**

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ primitives, and fonts.
 
 - **WebGPU rendering** with dual-pipeline architecture (primitives + sprites)
 - **Palette system**: 256-entry indexed color palette with built-in presets (VGA, CGA, C64, Game Boy, PICO-8, NES)
+- **Palette effects**: cycling, fade, flash, swap with easing functions -- animated color manipulation each frame
 - **Primitive drawing**: pixels, lines, rectangles (outline and filled)
 - **Sprite system**: sprite sheets, palette-indexed textures, palette offset for color variations, automatic texture
   batching
@@ -206,6 +207,7 @@ blit-tech/
 │   │   ├── AssetLoader.ts      # Image loading with caching
 │   │   ├── BitmapFont.ts       # Bitmap font system (.btfont)
 │   │   ├── Palette.ts          # 256-entry indexed color palette
+│   │   ├── PaletteEffect.ts    # Palette effect system (cycle, fade, flash, swap)
 │   │   ├── SpriteSheet.ts      # GPU texture wrapper with palette indexization
 │   │   └── palettes/           # Built-in preset palette data (VGA, CGA, C64, etc.)
 │   ├── core/
@@ -306,6 +308,35 @@ Palette.nes(); // NES 64-color
 const json = palette.toJSON();
 const restored = Palette.fromJSON(json);
 ```
+
+### Palette Effects
+
+Animated palette effects run automatically each frame, modifying palette entries in place. The renderer picks up changes
+via the dirty flag and re-uploads the palette to the GPU.
+
+```ts
+// Cycle a range of palette entries (creates flowing water, fire, etc.)
+BT.paletteCycle(start, end, speed); // speed: steps/second (positive=forward, negative=backward)
+
+// Smooth fade between palettes (day/night transitions, etc.)
+BT.paletteFade(targetPalette, durationMs); // fade entire palette
+BT.paletteFade(targetPalette, durationMs, 'ease-in-out'); // with easing
+BT.paletteFadeRange(start, end, targetPalette, durationMs, 'ease-out'); // fade a sub-range only
+
+// Flash all palette entries to a single color (lightning, damage, etc.)
+BT.paletteFlash(Color32.white(), 200); // 200ms flash
+
+// Swap two palette entries instantly
+BT.paletteSwap(indexA, indexB);
+
+// Remove all active effects
+BT.paletteClearEffects();
+```
+
+Available easing functions: `'linear'`, `'ease-in'`, `'ease-out'`, `'ease-in-out'`.
+
+Effects are processed after `demo.render()` but before the GPU upload in `Renderer.endFrame()`, so user code and effects
+never conflict. Multiple effects can run simultaneously on different palette ranges.
 
 ### Drawing Primitives
 

--- a/docs/performance-testing.md
+++ b/docs/performance-testing.md
@@ -62,6 +62,7 @@ Current benchmark files:
 - `src/utils/Color32.bench.ts`
 - `src/utils/Rect2i.bench.ts`
 - `src/assets/BitmapFont.bench.ts`
+- `src/assets/PaletteEffect.bench.ts`
 
 ### Tier 1 Metrics
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -12,6 +12,7 @@ Pure logic with no GPU dependencies. Tests run in Node.js for maximum speed.
 - **Rect2i** - intersection, containment, computed properties
 - **Color32** - color math, conversions, blending
 - **Palette** - construction, set/get, named aliases, serialization, GPU float layout, preset factories
+- **PaletteEffect** - manager lifecycle, CycleEffect rotation, FadeEffect/FadeRangeEffect lerp, FlashEffect, paletteSwap
 - **Easing** - boundary values, monotonicity, midpoint checks for all easing curves
 - **GameLoop** - constructor validation, tick counter
 - **IBlitTechDemo** - default hardware settings


### PR DESCRIPTION
Add Palette Effects API section to README with code examples, update architecture trees and test tier listings to include PaletteEffect, Easing, and PaletteEffect.bench.ts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

This pull request adds comprehensive documentation for the Palette Effects API across multiple documentation files.

### Documentation Updates

**README.md** introduces a new "Palette Effects" API section documenting the palette manipulation feature, which enables animated, per-frame palette updates via a dirty-flag GPU mechanism. The documentation covers new `BT` calls for:
- Cycling palette ranges
- Fading entire palettes and sub-ranges with optional easing
- Flashing all palette entries
- Swapping two palette indices
- Clearing active effects

Includes details on supported easing function names and execution timing relative to `demo.render()` and `Renderer.endFrame()`. Also extended the project structure section to reference the new `src/assets/PaletteEffect.ts` module.

**CLAUDE.md** updates the Unit tests tier description to expand the "Pure logic" module list, adding `Palette` and `PaletteEffect` to the existing coverage (`Vector2i`, `Rect2i`, `Color32`, `Easing`, `GameLoop`).

**docs/testing.md** adds `PaletteEffect` to the Tier 1 unit tests list of pure-logic modules, documenting coverage for the manager lifecycle, `CycleEffect` rotation, `FadeEffect`/`FadeRangeEffect` lerp behavior, `FlashEffect`, and `paletteSwap`.

**docs/performance-testing.md** includes `src/assets/PaletteEffect.bench.ts` in the documented list of Tier 1 CPU benchmark files.

### Scope

Documentation-only changes with no modifications to exported or public TypeScript signatures.

### Statistics

- Total lines changed: +37/-1
- Estimated code review effort: Low to Medium

<!-- end of auto-generated comment: release notes by coderabbit.ai -->