### PR TITLE
refactor(api): deduplicate sprite sheet validation and font print docs

### DIFF
--- a/src/BlitTech.ts
+++ b/src/BlitTech.ts
@@ -566,21 +566,8 @@ export const BT = {
      * supplied {@link BitmapFont}. The font's underlying sprite sheet must have
      * been indexized before calling this.
      *
-     * **Palette offset semantics:** Glyph pixels are stored as palette indices starting at 1.
-     * Index 0 is always transparent and is discarded by the fragment shader. The final palette
-     * lookup is `storedIndex + paletteOffset`, so:
-     *
-     * - `paletteOffset = 0` (default): a white glyph stored at index 1 renders as `palette[1]`.
-     *   `palette[0]` is never reachable because stored indices start at 1.
-     * - `paletteOffset = N`: shifts the entire glyph color range up by N slots. A glyph stored
-     *   at index 1 renders as `palette[1 + N]`.
-     *
-     * **Out-of-range behavior:** No CPU-side validation is performed. `paletteOffset` is passed to
-     * the GPU as a `u32`. If `storedIndex + paletteOffset` exceeds the last palette index, WebGPU's
-     * robust buffer access returns 0 for every component; because the fragment shader forces alpha
-     * to 1.0, the affected pixels render as opaque black. Negative values are forbidden — a negative
-     * JS number written into a `u32` vertex attribute wraps to a large unsigned integer, which also
-     * produces out-of-bounds black pixels.
+     * Palette offset semantics and out-of-range behavior are identical to
+     * {@link BT.drawSprite}.
      *
      * @param font - Font asset used for rendering.
      * @param pos - Text origin in display coordinates.

--- a/src/core/BTAPI.test.ts
+++ b/src/core/BTAPI.test.ts
@@ -223,7 +223,7 @@ describe('BTAPI', () => {
             const mockSheet = { isIndexized: () => false } as unknown as SpriteSheet;
             const mockFont = { getSpriteSheet: () => mockSheet } as unknown as BitmapFont;
             expect(() => BTAPI.instance.drawBitmapText(mockFont, new Vector2i(0, 0), 'hi')).toThrow(
-                '[BT] drawBitmapText: sprite sheet has not been indexized.',
+                '[BT] drawBitmapText: font sprite sheet has not been indexized.',
             );
         });
 

--- a/src/core/BTAPI.test.ts
+++ b/src/core/BTAPI.test.ts
@@ -213,6 +213,18 @@ describe('BTAPI', () => {
             );
         });
 
+        it('drawSprite should register the sheet for spritesRefresh tracking', () => {
+            const palette = new Palette(16);
+            const reindexize = vi.fn();
+            const mockSheet = { isIndexized: () => true, reindexize } as unknown as SpriteSheet;
+
+            BTAPI.instance.setPalette(palette);
+            BTAPI.instance.drawSprite(mockSheet, new Rect2i(0, 0, 16, 16), new Vector2i(0, 0));
+            BTAPI.instance.spritesRefresh();
+
+            expect(reindexize).toHaveBeenCalledWith(palette);
+        });
+
         it('drawBitmapText should not throw before init', () => {
             const mockSheet = { isIndexized: () => true } as unknown as SpriteSheet;
             const mockFont = { getSpriteSheet: () => mockSheet } as unknown as BitmapFont;
@@ -225,6 +237,19 @@ describe('BTAPI', () => {
             expect(() => BTAPI.instance.drawBitmapText(mockFont, new Vector2i(0, 0), 'hi')).toThrow(
                 '[BT] drawBitmapText: font sprite sheet has not been indexized.',
             );
+        });
+
+        it('drawBitmapText should register the font sheet for spritesRefresh tracking', () => {
+            const palette = new Palette(16);
+            const reindexize = vi.fn();
+            const mockSheet = { isIndexized: () => true, reindexize } as unknown as SpriteSheet;
+            const mockFont = { getSpriteSheet: () => mockSheet } as unknown as BitmapFont;
+
+            BTAPI.instance.setPalette(palette);
+            BTAPI.instance.drawBitmapText(mockFont, new Vector2i(0, 0), 'hi');
+            BTAPI.instance.spritesRefresh();
+
+            expect(reindexize).toHaveBeenCalledWith(palette);
         });
 
         it('setCameraOffset should not throw before init', () => {

--- a/src/core/BTAPI.test.ts
+++ b/src/core/BTAPI.test.ts
@@ -206,10 +206,25 @@ describe('BTAPI', () => {
             ).not.toThrow();
         });
 
+        it('drawSprite should throw when sprite sheet is not indexized', () => {
+            const mockSheet = { isIndexized: () => false } as unknown as SpriteSheet;
+            expect(() => BTAPI.instance.drawSprite(mockSheet, new Rect2i(0, 0, 16, 16), new Vector2i(0, 0))).toThrow(
+                '[BT] drawSprite: sprite sheet has not been indexized.',
+            );
+        });
+
         it('drawBitmapText should not throw before init', () => {
             const mockSheet = { isIndexized: () => true } as unknown as SpriteSheet;
             const mockFont = { getSpriteSheet: () => mockSheet } as unknown as BitmapFont;
             expect(() => BTAPI.instance.drawBitmapText(mockFont, new Vector2i(0, 0), 'hi')).not.toThrow();
+        });
+
+        it('drawBitmapText should throw when font sprite sheet is not indexized', () => {
+            const mockSheet = { isIndexized: () => false } as unknown as SpriteSheet;
+            const mockFont = { getSpriteSheet: () => mockSheet } as unknown as BitmapFont;
+            expect(() => BTAPI.instance.drawBitmapText(mockFont, new Vector2i(0, 0), 'hi')).toThrow(
+                '[BT] drawBitmapText: sprite sheet has not been indexized.',
+            );
         });
 
         it('setCameraOffset should not throw before init', () => {

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -457,7 +457,7 @@ export class BTAPI {
      */
     public drawBitmapText(font: BitmapFont, pos: Vector2i, text: string, paletteOffset: number = 0): void {
         this.assertPaletteIndex(paletteOffset);
-        this.requireIndexizedSheet(font.getSpriteSheet(), 'drawBitmapText');
+        this.requireIndexizedSheet(font.getSpriteSheet(), 'drawBitmapText', 'font sprite sheet');
         this.renderer?.drawBitmapText(font, pos, text, paletteOffset);
     }
 
@@ -675,12 +675,13 @@ export class BTAPI {
      *
      * @param sheet - Sprite sheet to validate.
      * @param method - Calling method name for the error message.
+     * @param label - Human-readable name for the sheet used in the error message (default `'sprite sheet'`).
      * @throws If the sprite sheet has not been indexized.
      */
-    private requireIndexizedSheet(sheet: SpriteSheet, method: string): void {
+    private requireIndexizedSheet(sheet: SpriteSheet, method: string, label: string = 'sprite sheet'): void {
         if (!sheet.isIndexized()) {
             throw new Error(
-                `[BT] ${method}: sprite sheet has not been indexized.` +
+                `[BT] ${method}: ${label} has not been indexized.` +
                     ' Call spriteSheet.indexize(palette) after setting a palette.',
             );
         }

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -441,15 +441,7 @@ export class BTAPI {
      */
     public drawSprite(spriteSheet: SpriteSheet, srcRect: Rect2i, destPos: Vector2i, paletteOffset: number = 0): void {
         this.assertPaletteIndex(paletteOffset);
-
-        if (!spriteSheet.isIndexized()) {
-            throw new Error(
-                '[BT] drawSprite: sprite sheet has not been indexized.' +
-                    ' Call spriteSheet.indexize(palette) after setting a palette.',
-            );
-        }
-
-        this.spriteSheets.add(spriteSheet);
+        this.requireIndexizedSheet(spriteSheet, 'drawSprite');
         this.renderer?.drawSprite(spriteSheet, srcRect, destPos, paletteOffset);
     }
 
@@ -465,17 +457,7 @@ export class BTAPI {
      */
     public drawBitmapText(font: BitmapFont, pos: Vector2i, text: string, paletteOffset: number = 0): void {
         this.assertPaletteIndex(paletteOffset);
-
-        const sheet = font.getSpriteSheet();
-
-        if (!sheet.isIndexized()) {
-            throw new Error(
-                '[BT] drawBitmapText: font sprite sheet has not been indexized.' +
-                    ' Call spriteSheet.indexize(palette) after setting a palette.',
-            );
-        }
-
-        this.spriteSheets.add(sheet);
+        this.requireIndexizedSheet(font.getSpriteSheet(), 'drawBitmapText');
         this.renderer?.drawBitmapText(font, pos, text, paletteOffset);
     }
 
@@ -687,6 +669,24 @@ export class BTAPI {
     // #endregion
 
     // #region Private Helpers
+
+    /**
+     * Validates that a sprite sheet has been indexized and registers it for refresh tracking.
+     *
+     * @param sheet - Sprite sheet to validate.
+     * @param method - Calling method name for the error message.
+     * @throws If the sprite sheet has not been indexized.
+     */
+    private requireIndexizedSheet(sheet: SpriteSheet, method: string): void {
+        if (!sheet.isIndexized()) {
+            throw new Error(
+                `[BT] ${method}: sprite sheet has not been indexized.` +
+                    ' Call spriteSheet.indexize(palette) after setting a palette.',
+            );
+        }
+
+        this.spriteSheets.add(sheet);
+    }
 
     /**
      * Validates that a palette index is a non-negative integer and, when a palette


### PR DESCRIPTION
Extract `requireIndexizedSheet()` private helper in `BTAPI` to eliminate
the identical indexization check and `spriteSheets.add()` pattern shared
by `drawSprite()` and `drawBitmapText()`.

Replace the duplicated palette offset semantics block in `BT.printFont()`
JSDoc with a cross-reference to `BT.drawSprite()`, which carries the
canonical description.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR refactors the sprite sheet indexization logic in BTAPI by extracting a new private helper method `requireIndexizedSheet()` to eliminate code duplication across `drawSprite()` and `drawBitmapText()`. The helper centralizes the `isIndexized()` validation, error throwing with contextual method names and labels, and sprite sheet registration for refresh tracking.

Additionally, the JSDoc for `BT.printFont()` has been updated to remove the detailed, inline description of palette offset semantics and out-of-range wrapping behavior, replacing it with a cross-reference to `BT.drawSprite()` as the canonical documentation source. This eliminates redundant documentation while maintaining semantic accuracy.

The test suite has been expanded with comprehensive coverage for the new logic, including:
- Throw-path validation confirming both `drawSprite()` and `drawBitmapText()` raise appropriate errors when provided sheets are not indexized
- Verification that the error messages include the correct method name and human-readable sheet label
- Validation that `requireIndexizedSheet()` properly registers sheets with the `spritesRefresh` registry and triggers reindexization callbacks when palettes are active

The refactoring preserves all existing control flow and error conditions while consolidating the validation logic into a single, reusable implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->