### PR TITLE
feat(utils): add browser detection and per-browser WebGPU error guidance

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -50,6 +50,7 @@
     "Rollup",
     "RRGGBB",
     "RRGGBBAA",
+    "Sonoma",
     "spritesheet",
     "subsystem",
     "subsystems",

--- a/src/utils/Bootstrap.ts
+++ b/src/utils/Bootstrap.ts
@@ -132,7 +132,10 @@ function validateWebGPU(containerId: string, onError?: (error: Error) => void): 
         result = { success: true };
     } else {
         console.error("[BT] WebGPU isn't supported in this browser.");
-        console.error('[BT] Browser: ', navigator.userAgent);
+        console.error(
+            '[BT] Browser: ',
+            typeof navigator !== 'undefined' ? navigator.userAgent : 'navigator unavailable',
+        );
 
         result = handleBootstrapError(
             'WebGPU Not Supported',

--- a/src/utils/Bootstrap.ts
+++ b/src/utils/Bootstrap.ts
@@ -12,8 +12,10 @@ import {
     checkWebGPUSupport,
     DEFAULT_CANVAS_ID,
     DEFAULT_CONTAINER_ID,
+    detectBrowser,
     displayError,
     getCanvas,
+    getWebGPUInstructions,
 } from './BootstrapHelpers';
 
 // #region Types
@@ -64,14 +66,15 @@ interface BootstrapResult {
 
 // #region Error Messages
 
-/** Error message for WebGPU not supported. */
-const WEBGPU_NOT_SUPPORTED_MESSAGE =
-    'The browser does not support WebGPU.\n\n' +
-    'Supported browsers:\n' +
-    'Chrome/Edge 113+\n' +
-    'Firefox Nightly (with the flag enabled)\n' +
-    'Safari 18+\n\n' +
-    'Please update the browser or try a different one.';
+/**
+ * Builds a browser-specific WebGPU not-supported message.
+ * Detects the current browser and returns actionable instructions.
+ *
+ * @returns Plain-text error message with per-browser guidance.
+ */
+function buildWebGPUNotSupportedMessage(): string {
+    return `WebGPU isn't available in this browser.\n\n${getWebGPUInstructions(detectBrowser())}`;
+}
 
 /** Error message for initialization failure. */
 const INIT_FAILED_MESSAGE = 'The engine failed to initialize. Check the console for details.';
@@ -128,10 +131,13 @@ function validateWebGPU(containerId: string, onError?: (error: Error) => void): 
     if (checkWebGPUSupport()) {
         result = { success: true };
     } else {
+        console.error("[BT] WebGPU isn't supported in this browser.");
+        console.error('[BT] Browser: ', navigator.userAgent);
+
         result = handleBootstrapError(
             'WebGPU Not Supported',
-            WEBGPU_NOT_SUPPORTED_MESSAGE,
-            new Error('WebGPU is not supported in this browser'),
+            buildWebGPUNotSupportedMessage(),
+            new Error("WebGPU isn't supported in this browser"),
             containerId,
             onError,
         );

--- a/src/utils/BootstrapHelpers.test.ts
+++ b/src/utils/BootstrapHelpers.test.ts
@@ -6,8 +6,10 @@ import {
     checkWebGPUSupport,
     DEFAULT_CANVAS_ID,
     DEFAULT_CONTAINER_ID,
+    detectBrowser,
     displayError,
     getCanvas,
+    getWebGPUInstructions,
 } from './BootstrapHelpers';
 
 // #region Constants
@@ -68,7 +70,7 @@ describe('BootstrapHelpers', () => {
             }
         });
 
-        it('should return null when the element is not a canvas', () => {
+        it("should return null when the element isn't a canvas", () => {
             const div = document.createElement('div');
             div.id = DEFAULT_CANVAS_ID;
             document.body.appendChild(div);
@@ -115,17 +117,145 @@ describe('BootstrapHelpers', () => {
             expect(container?.querySelector('code')?.textContent).toBe('stack trace here');
         });
 
-        it('should render object content without code block when code is omitted', () => {
+        it('should render object content without a code block when code is omitted', () => {
             displayError('Error Title', { text: 'An error occurred' });
             const container = document.getElementById(DEFAULT_CONTAINER_ID);
             expect(container?.querySelector('code')).toBeNull();
         });
 
-        it('should fall back to console.error when container is not found', () => {
+        it("should fall back to console.error when the container isn't found", () => {
             const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
             displayError('Error', 'Message', 'nonexistent-container-id');
             expect(consoleSpy).toHaveBeenCalled();
             consoleSpy.mockRestore();
+        });
+    });
+
+    // #endregion
+
+    // #region detectBrowser
+
+    describe('detectBrowser', () => {
+        function withUA(ua: string, fn: () => void): void {
+            const original = navigator.userAgent;
+            Object.defineProperty(navigator, 'userAgent', { value: ua, configurable: true });
+
+            try {
+                fn();
+            } finally {
+                Object.defineProperty(navigator, 'userAgent', { value: original, configurable: true });
+            }
+        }
+
+        it('should detect Chrome', () => {
+            withUA(
+                'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+                () => {
+                    const result = detectBrowser();
+                    expect(result.name).toBe('chrome');
+                    expect(result.version).toBe(120);
+                },
+            );
+        });
+
+        it('should detect Edge (Chromium)', () => {
+            withUA(
+                'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/113.0.0.0',
+                () => {
+                    const result = detectBrowser();
+                    expect(result.name).toBe('edge');
+                    expect(result.version).toBe(113);
+                },
+            );
+        });
+
+        it('should detect Firefox stable', () => {
+            withUA('Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:130.0) Gecko/20100101 Firefox/130.0', () => {
+                const result = detectBrowser();
+                expect(result.name).toBe('firefox');
+                expect(result.version).toBe(130);
+            });
+        });
+
+        it('should detect Firefox Nightly', () => {
+            withUA(
+                'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:134.0) Gecko/20100101 Firefox/134.0 Nightly/20241201',
+                () => {
+                    const result = detectBrowser();
+                    expect(result.name).toBe('firefox-nightly');
+                    expect(result.version).toBe(134);
+                },
+            );
+        });
+
+        it('should detect Safari', () => {
+            withUA(
+                'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15',
+                () => {
+                    const result = detectBrowser();
+                    expect(result.name).toBe('safari');
+                    expect(result.version).toBe(18);
+                },
+            );
+        });
+
+        it('should return unknown for an unrecognized user agent', () => {
+            withUA('Mozilla/5.0 (compatible; SomeUnknownBrowser/1.0)', () => {
+                const result = detectBrowser();
+                expect(result.name).toBe('unknown');
+                expect(result.version).toBe(0);
+            });
+        });
+    });
+
+    // #endregion
+
+    // #region getWebGPUInstructions
+
+    describe('getWebGPUInstructions', () => {
+        it('should advise updating Chrome when the version is below 113', () => {
+            const msg = getWebGPUInstructions({ name: 'chrome', version: 112 });
+            expect(msg).toContain('Update Chrome');
+        });
+
+        it('should point Chrome 113+ users to chrome://flags', () => {
+            const msg = getWebGPUInstructions({ name: 'chrome', version: 113 });
+            expect(msg).toContain('chrome://flags');
+        });
+
+        it('should advise updating Edge when the version is below 113', () => {
+            const msg = getWebGPUInstructions({ name: 'edge', version: 110 });
+            expect(msg).toContain('Update Microsoft Edge');
+        });
+
+        it('should point Edge 113+ users to edge://flags', () => {
+            const msg = getWebGPUInstructions({ name: 'edge', version: 113 });
+            expect(msg).toContain('edge://flags');
+        });
+
+        it('should tell Firefox Nightly users to use about:config', () => {
+            const msg = getWebGPUInstructions({ name: 'firefox-nightly', version: 134 });
+            expect(msg).toContain('about:config');
+        });
+
+        it('should tell Firefox stable users to download Nightly', () => {
+            const msg = getWebGPUInstructions({ name: 'firefox', version: 130 });
+            expect(msg).toContain('Firefox Nightly');
+        });
+
+        it('should advise updating Safari when the version is below 18', () => {
+            const msg = getWebGPUInstructions({ name: 'safari', version: 17 });
+            expect(msg).toContain('Update Safari');
+        });
+
+        it('should mention macOS Sonoma for Safari 18+', () => {
+            const msg = getWebGPUInstructions({ name: 'safari', version: 18 });
+            expect(msg).toContain('Sonoma');
+        });
+
+        it('should list supported browsers for an unknown browser', () => {
+            const msg = getWebGPUInstructions({ name: 'unknown', version: 0 });
+            expect(msg).toContain('Chrome 113');
         });
     });
 

--- a/src/utils/BootstrapHelpers.ts
+++ b/src/utils/BootstrapHelpers.ts
@@ -19,7 +19,7 @@ export const DEFAULT_CONTAINER_ID = 'canvas-container';
 
 /**
  * Content that can be displayed in an error message.
- * Use string for plain text, or object for text with code formatting.
+ * Use string for plain text or object for text with code formatting.
  */
 export type ErrorContent =
     | string
@@ -27,6 +27,40 @@ export type ErrorContent =
           text: string;
           code?: string;
       };
+
+/**
+ * Detected browser identity and major version.
+ */
+export interface BrowserInfo {
+    /** Detected browser name. 'unknown' when the UA cannot be matched. */
+    name: 'chrome' | 'edge' | 'firefox' | 'firefox-nightly' | 'safari' | 'unknown';
+
+    /** Major version number, or 0 when the version cannot be parsed. */
+    version: number;
+}
+
+// #endregion
+
+// #region Internal Helpers
+
+/**
+ * Parses a major version number from a user-agent token like "Chrome/120.0.0.0".
+ *
+ * @param ua - Full user-agent string.
+ * @param token - Token prefix to search for, e.g. "Chrome/".
+ * @returns Major version number, or 0 if not found.
+ */
+function parseMajorVersion(ua: string, token: string): number {
+    const idx = ua.indexOf(token);
+
+    if (idx === -1) {
+        return 0;
+    }
+
+    const version = parseInt(ua.slice(idx + token.length), 10);
+
+    return Number.isNaN(version) ? 0 : version;
+}
 
 // #endregion
 
@@ -137,6 +171,132 @@ export function displayError(title: string, content: ErrorContent, containerId: 
         const message = typeof content === 'string' ? content : `${content.text}\n${content.code ?? ''}`;
 
         console.error(`[BT] ${title}: ${message}`);
+    }
+}
+
+/**
+ * Detects the current browser from the navigator user-agent string.
+ *
+ * Detection order matters: Edge UAs also contain "Chrome", so Edge is checked first.
+ * Firefox Nightly UAs contain both "Firefox" and "Nightly".
+ * Safari UAs contain "Safari" and "Version" but not "Chrome" or "Edg".
+ *
+ * @returns Detected browser name and major version.
+ *
+ * @example
+ * const { name, version } = detectBrowser();
+ * // name: 'chrome', version: 120
+ */
+export function detectBrowser(): BrowserInfo {
+    if (typeof navigator === 'undefined') {
+        return { name: 'unknown', version: 0 };
+    }
+
+    const ua = navigator.userAgent;
+
+    // Edge must be checked before Chrome — Edge UAs also contain "Chrome/".
+    if (ua.includes('Edg/')) {
+        return { name: 'edge', version: parseMajorVersion(ua, 'Edg/') };
+    }
+
+    if (ua.includes('Chrome/')) {
+        return { name: 'chrome', version: parseMajorVersion(ua, 'Chrome/') };
+    }
+
+    // Firefox Nightly UAs contain "Nightly" in addition to "Firefox/".
+    if (ua.includes('Firefox/')) {
+        if (ua.includes('Nightly')) {
+            return { name: 'firefox-nightly', version: parseMajorVersion(ua, 'Firefox/') };
+        }
+
+        return { name: 'firefox', version: parseMajorVersion(ua, 'Firefox/') };
+    }
+
+    // Safari UAs contain "Version/X" for the Safari release version.
+    // Chrome/Edge also include "Safari/" so they must already be ruled out above.
+    if (ua.includes('Safari/') && ua.includes('Version/')) {
+        return { name: 'safari', version: parseMajorVersion(ua, 'Version/') };
+    }
+
+    return { name: 'unknown', version: 0 };
+}
+
+/**
+ * Returns actionable, browser-specific instructions for enabling WebGPU.
+ *
+ * The message is plain text suitable for display in the error panel.
+ *
+ * @param browser - Detected browser from {@link detectBrowser}.
+ * @returns Human-readable instructions string.
+ *
+ * @example
+ * const info = detectBrowser();
+ * const instructions = getWebGPUInstructions(info);
+ * displayError('WebGPU Not Available', instructions);
+ */
+export function getWebGPUInstructions(browser: BrowserInfo): string {
+    switch (browser.name) {
+        case 'chrome':
+            if (browser.version < 113) {
+                return (
+                    'Update Chrome to version 113 or later to use WebGPU.\n' +
+                    'Download the latest version at google.com/chrome'
+                );
+            }
+
+            return (
+                'WebGPU may be disabled in the Chrome settings.\n' +
+                'To enable it: visit chrome://flags in the address bar, search for WebGPU, ' +
+                'and set it to Enabled. Then restart Chrome.'
+            );
+
+        case 'edge':
+            if (browser.version < 113) {
+                return 'Update Microsoft Edge to version 113 or later to use WebGPU.';
+            }
+
+            return (
+                'WebGPU may be disabled in the Edge settings.\n' +
+                'To enable it: visit edge://flags in the address bar, search for WebGPU, ' +
+                'and set it to Enabled. Then restart Edge.'
+            );
+
+        case 'firefox-nightly':
+            return (
+                'Enable WebGPU in Firefox Nightly:\n' +
+                '1. Type about:config in the address bar and press Enter.\n' +
+                '2. Search for dom.webgpu.enabled.\n' +
+                '3. Double-click the entry to set it to true.\n' +
+                '4. Restart Firefox Nightly.'
+            );
+
+        case 'firefox':
+            return (
+                'WebGPU requires Firefox Nightly.\n' +
+                'Download Firefox Nightly at mozilla.org/firefox/channel/desktop/ ' +
+                'then enable dom.webgpu.enabled in about:config.'
+            );
+
+        case 'safari':
+            if (browser.version < 18) {
+                return (
+                    'Update Safari to version 18 or later to use WebGPU.\n' +
+                    'Safari 18 requires macOS Sonoma 14.4 or later.'
+                );
+            }
+
+            return (
+                'WebGPU requires Safari 18+ on macOS Sonoma 14.4 or later.\n' +
+                'Check that hardware acceleration is enabled: Safari menu &rarr; Settings &rarr; Advanced &rarr; ' +
+                'uncheck "Use hardware acceleration" and re-enable it.'
+            );
+
+        default:
+            return (
+                "WebGPU isn't available in this browser.\n" +
+                'Supported browsers: Chrome 113+, Microsoft Edge 113+, ' +
+                'Firefox Nightly (with dom.webgpu.enabled flag), Safari 18+.'
+            );
     }
 }
 

--- a/src/utils/BootstrapHelpers.ts
+++ b/src/utils/BootstrapHelpers.ts
@@ -20,10 +20,10 @@ const MIN_CHROME_EDGE_VERSION = 113;
 const MIN_SAFARI_VERSION = 18;
 
 /** Download URL for Chrome. */
-const DOWNLOAD_CHROME_URL = 'google.com/chrome';
+const DOWNLOAD_CHROME_URL = 'https://www.google.com/chrome';
 
 /** Download URL for Firefox Nightly. */
-const FIREFOX_NIGHTLY_URL = 'mozilla.org/firefox/channel/desktop/';
+const FIREFOX_NIGHTLY_URL = 'https://www.mozilla.org/firefox/channel/desktop/';
 
 // #endregion
 
@@ -204,7 +204,7 @@ export function detectBrowser(): BrowserInfo {
         return { name: 'unknown', version: 0 };
     }
 
-    const ua = navigator.userAgent;
+    const ua = typeof navigator.userAgent === 'string' ? navigator.userAgent : '';
 
     // Edge must be checked before Chrome — Edge UAs also contain "Chrome/".
     if (ua.includes('Edg/')) {

--- a/src/utils/BootstrapHelpers.ts
+++ b/src/utils/BootstrapHelpers.ts
@@ -13,6 +13,18 @@ export const DEFAULT_CANVAS_ID = 'blit-tech-canvas';
 /** Default container element ID for error display. */
 export const DEFAULT_CONTAINER_ID = 'canvas-container';
 
+/** Minimum Chrome/Edge major version that supports WebGPU. */
+const MIN_CHROME_EDGE_VERSION = 113;
+
+/** Minimum Safari major version that supports WebGPU. */
+const MIN_SAFARI_VERSION = 18;
+
+/** Download URL for Chrome. */
+const DOWNLOAD_CHROME_URL = 'google.com/chrome';
+
+/** Download URL for Firefox Nightly. */
+const FIREFOX_NIGHTLY_URL = 'mozilla.org/firefox/channel/desktop/';
+
 // #endregion
 
 // #region Types
@@ -237,10 +249,10 @@ export function detectBrowser(): BrowserInfo {
 export function getWebGPUInstructions(browser: BrowserInfo): string {
     switch (browser.name) {
         case 'chrome':
-            if (browser.version < 113) {
+            if (browser.version < MIN_CHROME_EDGE_VERSION) {
                 return (
-                    'Update Chrome to version 113 or later to use WebGPU.\n' +
-                    'Download the latest version at google.com/chrome'
+                    `Update Chrome to version ${MIN_CHROME_EDGE_VERSION} or later to use WebGPU.\n` +
+                    `Download the latest version at ${DOWNLOAD_CHROME_URL}`
                 );
             }
 
@@ -251,8 +263,8 @@ export function getWebGPUInstructions(browser: BrowserInfo): string {
             );
 
         case 'edge':
-            if (browser.version < 113) {
-                return 'Update Microsoft Edge to version 113 or later to use WebGPU.';
+            if (browser.version < MIN_CHROME_EDGE_VERSION) {
+                return `Update Microsoft Edge to version ${MIN_CHROME_EDGE_VERSION} or later to use WebGPU.`;
             }
 
             return (
@@ -273,20 +285,20 @@ export function getWebGPUInstructions(browser: BrowserInfo): string {
         case 'firefox':
             return (
                 'WebGPU requires Firefox Nightly.\n' +
-                'Download Firefox Nightly at mozilla.org/firefox/channel/desktop/ ' +
+                `Download Firefox Nightly at ${FIREFOX_NIGHTLY_URL} ` +
                 'then enable dom.webgpu.enabled in about:config.'
             );
 
         case 'safari':
-            if (browser.version < 18) {
+            if (browser.version < MIN_SAFARI_VERSION) {
                 return (
-                    'Update Safari to version 18 or later to use WebGPU.\n' +
-                    'Safari 18 requires macOS Sonoma 14.4 or later.'
+                    `Update Safari to version ${MIN_SAFARI_VERSION} or later to use WebGPU.\n` +
+                    `Safari ${MIN_SAFARI_VERSION} requires macOS Sonoma 14.4 or later.`
                 );
             }
 
             return (
-                'WebGPU requires Safari 18+ on macOS Sonoma 14.4 or later.\n' +
+                `WebGPU requires Safari ${MIN_SAFARI_VERSION}+ on macOS Sonoma 14.4 or later.\n` +
                 'Check that hardware acceleration is enabled: Safari menu → Settings → Advanced → ' +
                 'uncheck "Use hardware acceleration" and re-enable it.'
             );
@@ -294,8 +306,8 @@ export function getWebGPUInstructions(browser: BrowserInfo): string {
         default:
             return (
                 "WebGPU isn't available in this browser.\n" +
-                'Supported browsers: Chrome 113+, Microsoft Edge 113+, ' +
-                'Firefox Nightly (with dom.webgpu.enabled flag), Safari 18+.'
+                `Supported browsers: Chrome ${MIN_CHROME_EDGE_VERSION}+, Microsoft Edge ${MIN_CHROME_EDGE_VERSION}+, ` +
+                `Firefox Nightly (with dom.webgpu.enabled flag), Safari ${MIN_SAFARI_VERSION}+.`
             );
     }
 }

--- a/src/utils/BootstrapHelpers.ts
+++ b/src/utils/BootstrapHelpers.ts
@@ -287,7 +287,7 @@ export function getWebGPUInstructions(browser: BrowserInfo): string {
 
             return (
                 'WebGPU requires Safari 18+ on macOS Sonoma 14.4 or later.\n' +
-                'Check that hardware acceleration is enabled: Safari menu &rarr; Settings &rarr; Advanced &rarr; ' +
+                'Check that hardware acceleration is enabled: Safari menu → Settings → Advanced → ' +
                 'uncheck "Use hardware acceleration" and re-enable it.'
             );
 


### PR DESCRIPTION
Replace the static WebGPU-not-supported message with dynamic, browser-specific instructions. detectBrowser() parses the UA string to identify Chrome, Edge, Firefox, Firefox Nightly, and Safari along with their major versions. getWebGPUInstructions() maps each browser to actionable guidance (flags pages, download links, version requirements). Bootstrap.ts now logs the user agent on failure and calls buildWebGPUNotSupportedMessage() to compose the error.

Full unit test coverage added for both new helpers across all supported browsers and version thresholds. "Sonoma" added to the cspell dictionary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR replaces the static "WebGPU not supported" message with dynamic, browser-specific WebGPU error guidance. It detects the user's browser and major version from the user-agent string and composes tailored, actionable instructions for enabling or obtaining WebGPU support.

## Key Changes

### New Browser Detection and Guidance
- Added `BrowserInfo` interface describing detected browser name (chrome, edge, firefox, firefox-nightly, safari, or unknown) and major version.
- Implemented `detectBrowser()` to safely parse the user-agent (guards against missing `navigator`) and detect Chrome, Edge (Chromium), Firefox (including Nightly), and Safari, extracting major versions via `parseMajorVersion()`.
- Implemented `getWebGPUInstructions()` to return plain-text, browser-specific guidance (flag pages, download links, minimum-version hints) with version thresholds (Chrome/Edge: <113 considered too old; Safari: <18 considered too old) and a fallback message for unknown browsers.
- Extracted magic numbers and URLs into named constants (MIN_CHROME_EDGE_VERSION, MIN_SAFARI_VERSION, DOWNLOAD_CHROME_URL, FIREFOX_NIGHTLY_URL) for clarity and reuse.

### Bootstrap Error Handling
- Replaced the static `WEBGPU_NOT_SUPPORTED_MESSAGE` in `src/utils/Bootstrap.ts` with `buildWebGPUNotSupportedMessage()` that uses the new helpers to produce a tailored message.
- Added diagnostic console logging of the user agent on WebGPU validation failure (guards access to `navigator.userAgent` to avoid exceptions in SSR/Node).
- Adjusted wording from "WebGPU is not supported" to "WebGPU isn't supported".
- Ensured Safari instructions use a Unicode arrow (→) so text renders correctly when set via textContent.

### Tests
- Added comprehensive unit tests for `detectBrowser()` covering Chrome, Edge, Firefox stable, Firefox Nightly, Safari, and unknown UAs with version extraction.
- Added tests for `getWebGPUInstructions()` asserting browser/version-specific guidance and fallback behavior (including Safari mentioning "Sonoma").
- Updated existing test descriptions/assertions to use consistent wording (“isn't”).

### Configuration
- Updated `cspell.json` to add "Sonoma" to the dictionary to allow macOS version references in guidance.

## Files Changed
- `cspell.json`: add "Sonoma"
- `src/utils/BootstrapHelpers.ts`: add `BrowserInfo`, `parseMajorVersion`, `detectBrowser`, `getWebGPUInstructions`, and constants for thresholds/URLs
- `src/utils/Bootstrap.ts`: dynamic WebGPU error message generation, UA logging, wording/Unicode fix
- `src/utils/BootstrapHelpers.test.ts`: added/expanded tests and updated test wording

## Notes
- No public API signatures were changed; the bootstrap public API remains the same.
- Tests cover the new detection/guidance logic and ensure message content aligns with browser/version cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->