### PR TITLE
fix(utils): improve WebGPU browser error messages with per-browser guidance and dev preview utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ primitives, and fonts.
 - **pnpm** v10.26.2 or higher
 - A **WebGPU-compatible browser**:
   - Chrome/Edge 113+ (Windows, macOS, Linux, Android)
-  - Firefox Nightly (with `dom.webgpu.enabled` in `about:config`)
-  - Safari 18+ (macOS/iOS)
+  - Firefox 141+ on Windows; 145+/147+ on macOS; Nightly on Linux and Android
+  - Safari 26+ (macOS Tahoe / iOS 26); or Safari 18–25 with WebGPU enabled via Feature Flags
 
 ## Installation
 
@@ -191,7 +191,7 @@ import { BT, checkWebGPUSupport, displayError, getCanvas } from '../src/BlitTech
 
 // Manual initialization with custom error handling
 if (!checkWebGPUSupport()) {
-  displayError('WebGPU Not Supported', 'Please use Chrome 113+ or Safari 18+');
+  displayError('WebGPU Not Supported', 'Please use Chrome 113+, Safari 26+, or Firefox 141+ on Windows.');
 } else {
   const canvas = getCanvas('my-canvas-id');
   if (canvas) {
@@ -444,11 +444,11 @@ future use. See the Blit-Tech Demos repository for workarounds using browser API
 
 WebGPU support varies by browser:
 
-| Browser     | Version | Status                      |
-| ----------- | ------- | --------------------------- |
-| Chrome/Edge | 113+    | Enabled by default          |
-| Firefox     | Nightly | Enable `dom.webgpu.enabled` |
-| Safari      | 18+     | Enabled by default          |
+| Browser     | Version        | Status                                                       |
+| ----------- | -------------- | ------------------------------------------------------------ |
+| Chrome/Edge | 113+           | Enabled by default                                           |
+| Firefox     | 141+ (Windows) | Enabled by default; 145+/147+ on macOS; Nightly on Linux     |
+| Safari      | 26+            | Enabled by default; Safari 18–25 available via Feature Flags |
 
 The engine displays an error message if the browser doesn’t support WebGPU.
 

--- a/README.md
+++ b/README.md
@@ -191,7 +191,10 @@ import { BT, checkWebGPUSupport, displayError, getCanvas } from '../src/BlitTech
 
 // Manual initialization with custom error handling
 if (!checkWebGPUSupport()) {
-  displayError('WebGPU Not Supported', 'Please use Chrome 113+, Safari 26+, or Firefox 141+ on Windows.');
+  displayError(
+    'WebGPU Not Supported',
+    'Please use a WebGPU-compatible browser (Chrome/Edge 113+, Firefox 141+ on Windows, Safari 18+ with Feature Flags or Safari 26+).',
+  );
 } else {
   const canvas = getCanvas('my-canvas-id');
   if (canvas) {
@@ -444,11 +447,11 @@ future use. See the Blit-Tech Demos repository for workarounds using browser API
 
 WebGPU support varies by browser:
 
-| Browser     | Version        | Status                                                       |
-| ----------- | -------------- | ------------------------------------------------------------ |
-| Chrome/Edge | 113+           | Enabled by default                                           |
-| Firefox     | 141+ (Windows) | Enabled by default; 145+/147+ on macOS; Nightly on Linux     |
-| Safari      | 26+            | Enabled by default; Safari 18–25 available via Feature Flags |
+| Browser     | Version        | Status                                                           |
+| ----------- | -------------- | ---------------------------------------------------------------- |
+| Chrome/Edge | 113+           | Enabled by default                                               |
+| Firefox     | 141+ (Windows) | Enabled by default; 145+/147+ on macOS; Nightly on Linux/Android |
+| Safari      | 26+            | Enabled by default; Safari 18–25 available via Feature Flags     |
 
 The engine displays an error message if the browser doesn’t support WebGPU.
 

--- a/docs/developer-experience-guide.md
+++ b/docs/developer-experience-guide.md
@@ -76,7 +76,7 @@ Read and follow the [Code of Conduct](CODE_OF_CONDUCT.md).
 - Node.js v20 or higher,
 - pnpm v10.24.0 or higher,
 - Git,
-- A WebGPU-compatible browser (Chrome 113+, Edge 113+, Safari 18+).
+- A WebGPU-compatible browser (Chrome 113+, Edge 113+, Safari 26+, Firefox 141+ on Windows).
 
 ### Setup
 

--- a/src/BlitTech.ts
+++ b/src/BlitTech.ts
@@ -20,7 +20,7 @@ import type { HardwareSettings, IBlitTechDemo } from './core/IBlitTechDemo';
 import { defaultHardwareSettings } from './core/IBlitTechDemo';
 import type { BootstrapOptions } from './utils/Bootstrap';
 import { bootstrap } from './utils/Bootstrap';
-import { checkWebGPUSupport, displayError, getCanvas } from './utils/BootstrapHelpers';
+import { checkWebGPUSupport, displayError, getCanvas, previewWebGPUErrors } from './utils/BootstrapHelpers';
 import { Color32 } from './utils/Color32';
 import type { EasingFunction } from './utils/Easing';
 import { applyEasing } from './utils/Easing';
@@ -693,6 +693,7 @@ export {
     displayError,
     getCanvas,
     Palette,
+    previewWebGPUErrors,
     Rect2i,
     SpriteSheet,
     Vector2i,

--- a/src/utils/Bootstrap.ts
+++ b/src/utils/Bootstrap.ts
@@ -73,7 +73,7 @@ interface BootstrapResult {
  * @returns Plain-text error message with per-browser guidance.
  */
 function buildWebGPUNotSupportedMessage(): string {
-    return `WebGPU isn't available in this browser.\n\n${getWebGPUInstructions(detectBrowser())}`;
+    return getWebGPUInstructions(detectBrowser());
 }
 
 /** Error message for initialization failure. */

--- a/src/utils/BootstrapHelpers.test.ts
+++ b/src/utils/BootstrapHelpers.test.ts
@@ -248,9 +248,21 @@ describe('BootstrapHelpers', () => {
             expect(msg).toContain('Update Safari');
         });
 
-        it('should mention macOS Sonoma for Safari 18+', () => {
+        it('should advise enabling WebGPU via Feature Flags for Safari 18-25', () => {
             const msg = getWebGPUInstructions({ name: 'safari', version: 18 });
-            expect(msg).toContain('Sonoma');
+            expect(msg).toContain('Feature Flags');
+            expect(msg).toContain('Develop');
+        });
+
+        it('should mention macOS Tahoe 26 as the upgrade target for Safari 18-25', () => {
+            const msg = getWebGPUInstructions({ name: 'safari', version: 25 });
+            expect(msg).toContain('Tahoe 26');
+        });
+
+        it('should say WebGPU is enabled by default for Safari 26+', () => {
+            const msg = getWebGPUInstructions({ name: 'safari', version: 26 });
+            expect(msg).toContain('enabled by default');
+            expect(msg).toContain('Feature Flags');
         });
 
         it('should list supported browsers for an unknown browser', () => {

--- a/src/utils/BootstrapHelpers.ts
+++ b/src/utils/BootstrapHelpers.ts
@@ -33,6 +33,13 @@ const FIREFOX_NIGHTLY_URL = 'https://www.mozilla.org/firefox/channel/desktop/';
 
 // #endregion
 
+// #region Module State
+
+/** Stored keydown handler for previewWebGPUErrors, used to remove the previous listener on re-entry. */
+let previewKeyHandler: ((e: KeyboardEvent) => void) | null = null;
+
+// #endregion
+
 // #region Types
 
 /**
@@ -335,8 +342,9 @@ export function getWebGPUInstructions(browser: BrowserInfo): string {
         case 'safari':
             if (browser.version < MIN_SAFARI_VERSION) {
                 return (
-                    `Update Safari to version ${MIN_SAFARI_DEFAULT_VERSION} or later to use WebGPU. ` +
-                    `Safari ${MIN_SAFARI_DEFAULT_VERSION} is included with macOS Tahoe 26 or later.`
+                    `Update Safari to version ${MIN_SAFARI_VERSION} or later to use WebGPU. ` +
+                    `Safari ${MIN_SAFARI_VERSION}–${MIN_SAFARI_DEFAULT_VERSION - 1} supports WebGPU via Feature Flags; ` +
+                    `Safari ${MIN_SAFARI_DEFAULT_VERSION}+ (macOS Tahoe 26) has it enabled by default.`
                 );
             }
 
@@ -589,14 +597,21 @@ export function previewWebGPUErrors(containerId: string = DEFAULT_CONTAINER_ID):
         container.appendChild(nav);
     };
 
-    // Arrow-key navigation.
-    document.addEventListener('keydown', (e: KeyboardEvent) => {
+    // Arrow-key navigation. Remove any previously registered handler first so
+    // repeated calls don't stack multiple listeners.
+    if (previewKeyHandler) {
+        document.removeEventListener('keydown', previewKeyHandler);
+    }
+
+    previewKeyHandler = (e: KeyboardEvent): void => {
         if (e.key === 'ArrowLeft') {
             show((current - 1 + entries.length) % entries.length);
         } else if (e.key === 'ArrowRight') {
             show((current + 1) % entries.length);
         }
-    });
+    };
+
+    document.addEventListener('keydown', previewKeyHandler);
 
     show(current);
 }

--- a/src/utils/BootstrapHelpers.ts
+++ b/src/utils/BootstrapHelpers.ts
@@ -16,8 +16,14 @@ export const DEFAULT_CONTAINER_ID = 'canvas-container';
 /** Minimum Chrome/Edge major version that supports WebGPU. */
 const MIN_CHROME_EDGE_VERSION = 113;
 
-/** Minimum Safari major version that supports WebGPU. */
+/** Minimum Safari major version where WebGPU is available (behind Feature Flags on 18-25, default on 26+). */
 const MIN_SAFARI_VERSION = 18;
+
+/** Minimum Safari major version where WebGPU is enabled by default. */
+const MIN_SAFARI_DEFAULT_VERSION = 26;
+
+/** Minimum Firefox major version that ships WebGPU enabled by default on Windows. */
+const MIN_FIREFOX_VERSION = 141;
 
 /** Download URL for Chrome. */
 const DOWNLOAD_CHROME_URL = 'https://www.google.com/chrome';
@@ -94,10 +100,29 @@ export function checkWebGPUSupport(): boolean {
 }
 
 /**
+ * Appends text to an element, converting newline characters to `<br>` elements.
+ * Safe against XSS: all text is inserted via createTextNode, never innerHTML.
+ *
+ * @param element - Target element to append into.
+ * @param text - Plain text, optionally containing newline characters.
+ */
+function appendTextWithLineBreaks(element: HTMLElement, text: string): void {
+    const lines = text.split('\n');
+
+    lines.forEach((line, index) => {
+        element.appendChild(document.createTextNode(line));
+
+        if (index < lines.length - 1) {
+            element.appendChild(document.createElement('br'));
+        }
+    });
+}
+
+/**
  * Displays an error message in the page UI.
  * Replaces the container's content with a styled error box.
  *
- * SECURITY: This function renders content safely using textContent to prevent XSS attacks.
+ * SECURITY: This function renders content safely using createTextNode to prevent XSS attacks.
  * All text (including code) is treated as plain text, not interpreted as markup.
  *
  * @param title - Error heading text displayed prominently.
@@ -129,26 +154,26 @@ export function displayError(title: string, content: ErrorContent, containerId: 
             color: white;
             background: oklch(44.4% 0.177 26.899);
             box-shadow: 0 0 0 4px black inset;
-            max-width: 600px;
+            max-width: 640px;
             margin: 0 auto;
             font-family: monospace;
         `;
 
         const heading = document.createElement('h2');
         const msg = document.createElement('p');
-        const consoleMsg = document.createElement('p');
 
-        heading.style.cssText = 'margin-top: 0; font-size: 18px;';
-        msg.style.cssText = 'margin: 20px 0; line-height: 1.6;';
-        consoleMsg.style.cssText = 'margin-top: 20px; font-size: 12px; opacity: 0.66;';
+        heading.style.cssText = 'margin: 0 0 28px; font-size: 18px;';
+        msg.style.cssText = 'margin: 0; line-height: 1.8; text-align: left; white-space: pre-wrap;';
 
         heading.textContent = title;
 
         // Handle content - either plain string or object with code formatting.
+        // appendTextWithLineBreaks is used instead of textContent so that \n produces
+        // visible line breaks, making numbered step lists readable in the error panel.
         if (typeof content === 'string') {
-            msg.textContent = content; // Plain text rendering
+            appendTextWithLineBreaks(msg, content);
         } else {
-            msg.textContent = content.text; // Plain text rendering
+            appendTextWithLineBreaks(msg, content.text);
 
             if (content.code) {
                 // Add code block using DOM for safety.
@@ -166,11 +191,8 @@ export function displayError(title: string, content: ErrorContent, containerId: 
             }
         }
 
-        consoleMsg.textContent = 'Check the browser console for more details.';
-
         errorDiv.appendChild(heading);
         errorDiv.appendChild(msg);
-        errorDiv.appendChild(consoleMsg);
 
         // Clear existing children safely using DOM methods (avoids innerHTML).
         while (container.firstChild) {
@@ -257,9 +279,12 @@ export function getWebGPUInstructions(browser: BrowserInfo): string {
             }
 
             return (
-                'WebGPU may be disabled in the Chrome settings.\n' +
-                'To enable it: visit chrome://flags in the address bar, search for WebGPU, ' +
-                'and set it to Enabled. Then restart Chrome.'
+                'WebGPU is supported in this version of Chrome but is not available.\n\n' +
+                '1. Check that hardware acceleration is on: open chrome://settings/system in the address bar ' +
+                'and confirm "Use graphics acceleration when available" is enabled, then relaunch Chrome.\n' +
+                '2. Make sure the page is served over https or http://localhost, not plain http.\n' +
+                '3. If your GPU is blocklisted, open chrome://flags/#enable-unsafe-webgpu, ' +
+                'set "Unsafe WebGPU Support" to Enabled, and relaunch Chrome.'
             );
 
         case 'edge':
@@ -268,46 +293,80 @@ export function getWebGPUInstructions(browser: BrowserInfo): string {
             }
 
             return (
-                'WebGPU may be disabled in the Edge settings.\n' +
-                'To enable it: visit edge://flags in the address bar, search for WebGPU, ' +
-                'and set it to Enabled. Then restart Edge.'
+                'WebGPU is supported in this version of Edge but is not available.\n\n' +
+                '1. Check that hardware acceleration is on: open edge://settings/system in the address bar ' +
+                'and confirm "Use hardware acceleration when available" is enabled, then relaunch Edge.\n' +
+                '2. Make sure the page is served over https or http://localhost, not plain http.\n' +
+                '3. If your GPU is blocklisted, open edge://flags/#enable-unsafe-webgpu, ' +
+                'set "Unsafe WebGPU Support" to Enabled, and relaunch Edge.'
             );
 
         case 'firefox-nightly':
             return (
-                'Enable WebGPU in Firefox Nightly:\n' +
+                'Enable WebGPU in Firefox Nightly:\n\n' +
                 '1. Type about:config in the address bar and press Enter.\n' +
-                '2. Search for dom.webgpu.enabled.\n' +
-                '3. Double-click the entry to set it to true.\n' +
-                '4. Restart Firefox Nightly.'
+                '2. Accept the risk warning to proceed.\n' +
+                '3. Search for dom.webgpu.enabled.\n' +
+                '4. Double-click the entry to set it to true.\n' +
+                '5. Restart Firefox Nightly.'
             );
 
         case 'firefox':
+            if (browser.version >= MIN_FIREFOX_VERSION) {
+                return (
+                    'WebGPU support in Firefox depends on your operating system:\n\n' +
+                    `- Windows: enabled by default in Firefox ${MIN_FIREFOX_VERSION}+.\n` +
+                    '- Mac (Apple Silicon): enabled by default in Firefox 145+ on macOS 26, ' +
+                    'or Firefox 147+ on all macOS versions.\n' +
+                    '- Linux and Android: available in Firefox Nightly only, ' +
+                    'not yet in stable.\n\n' +
+                    'If you are on a supported OS and WebGPU is still unavailable, ' +
+                    'open about:config, confirm dom.webgpu.enabled is set to true, ' +
+                    'and restart Firefox.'
+                );
+            }
+
             return (
-                'WebGPU requires Firefox Nightly.\n' +
-                `Download Firefox Nightly at ${FIREFOX_NIGHTLY_URL} ` +
-                'then enable dom.webgpu.enabled in about:config.'
+                'WebGPU is not yet available in this version of Firefox.\n' +
+                `Update to Firefox ${MIN_FIREFOX_VERSION} or later (Windows), or download Firefox Nightly ` +
+                `at ${FIREFOX_NIGHTLY_URL} and enable dom.webgpu.enabled in about:config.`
             );
 
         case 'safari':
             if (browser.version < MIN_SAFARI_VERSION) {
                 return (
-                    `Update Safari to version ${MIN_SAFARI_VERSION} or later to use WebGPU.\n` +
-                    `Safari ${MIN_SAFARI_VERSION} requires macOS Sonoma 14.4 or later.`
+                    `Update Safari to version ${MIN_SAFARI_DEFAULT_VERSION} or later to use WebGPU. ` +
+                    `Safari ${MIN_SAFARI_DEFAULT_VERSION} is included with macOS Tahoe 26 or later.`
+                );
+            }
+
+            if (browser.version < MIN_SAFARI_DEFAULT_VERSION) {
+                return (
+                    `Safari ${MIN_SAFARI_VERSION}-${MIN_SAFARI_DEFAULT_VERSION - 1} supports WebGPU but it must be enabled manually. ` +
+                    'To enable WebGPU in Safari:\n\n' +
+                    '1. Open Safari Settings (Command + Comma) and go to the Advanced tab.\n' +
+                    '2. Check "Show features for web developers" to enable the Develop menu.\n' +
+                    '3. From the menu bar, choose Develop > Feature Flags.\n' +
+                    '4. Search for "WebGPU" and enable it.\n' +
+                    '5. Restart Safari.\n\n' +
+                    `Alternatively, update to Safari ${MIN_SAFARI_DEFAULT_VERSION} (macOS Tahoe 26) where WebGPU is on by default.`
                 );
             }
 
             return (
-                `WebGPU requires Safari ${MIN_SAFARI_VERSION}+ on macOS Sonoma 14.4 or later.\n` +
-                'Check that hardware acceleration is enabled: Safari menu → Settings → Advanced → ' +
-                'uncheck "Use hardware acceleration" and re-enable it.'
+                `WebGPU is enabled by default in Safari ${MIN_SAFARI_DEFAULT_VERSION} but appears to be unavailable. ` +
+                'If you disabled it via Feature Flags, re-enable it:\n\n' +
+                '1. Open Safari Settings (Command + Comma) and go to the Advanced tab.\n' +
+                '2. Check "Show features for web developers" to enable the Develop menu.\n' +
+                '3. From the menu bar, choose Develop > Feature Flags.\n' +
+                '4. Search for "WebGPU" and enable it.\n' +
+                '5. Restart Safari.'
             );
 
         default:
             return (
-                "WebGPU isn't available in this browser.\n" +
                 `Supported browsers: Chrome ${MIN_CHROME_EDGE_VERSION}+, Microsoft Edge ${MIN_CHROME_EDGE_VERSION}+, ` +
-                `Firefox Nightly (with dom.webgpu.enabled flag), Safari ${MIN_SAFARI_VERSION}+.`
+                `Firefox ${MIN_FIREFOX_VERSION}+ (Windows / Mac 145+) or Firefox Nightly, Safari ${MIN_SAFARI_DEFAULT_VERSION}+.`
             );
     }
 }

--- a/src/utils/BootstrapHelpers.ts
+++ b/src/utils/BootstrapHelpers.ts
@@ -374,7 +374,8 @@ export function getWebGPUInstructions(browser: BrowserInfo): string {
         default:
             return (
                 `Supported browsers: Chrome ${MIN_CHROME_EDGE_VERSION}+, Microsoft Edge ${MIN_CHROME_EDGE_VERSION}+, ` +
-                `Firefox ${MIN_FIREFOX_VERSION}+ (Windows / Mac 145+) or Firefox Nightly, Safari ${MIN_SAFARI_DEFAULT_VERSION}+.`
+                `Firefox ${MIN_FIREFOX_VERSION}+ (Windows / Mac 145+) or Firefox Nightly, ` +
+                `Safari ${MIN_SAFARI_VERSION}+ (${MIN_SAFARI_VERSION}–${MIN_SAFARI_DEFAULT_VERSION - 1} via Feature Flags, ${MIN_SAFARI_DEFAULT_VERSION}+ by default).`
             );
     }
 }
@@ -543,6 +544,11 @@ function buildErrorPreviewEntries(): ReadonlyArray<ErrorPreviewEntry> {
  * previewWebGPUErrors();
  */
 export function previewWebGPUErrors(containerId: string = DEFAULT_CONTAINER_ID): void {
+    // Bail out before touching the global key handler if the container is missing.
+    if (!document.getElementById(containerId)) {
+        return;
+    }
+
     const entries = buildErrorPreviewEntries();
     let current = 0;
 
@@ -573,6 +579,7 @@ export function previewWebGPUErrors(containerId: string = DEFAULT_CONTAINER_ID):
 
         const prevBtn = document.createElement('button');
 
+        prevBtn.type = 'button';
         prevBtn.textContent = '<< Prev';
         prevBtn.style.cssText = 'padding: 4px 12px; font-family: monospace; cursor: pointer;';
         prevBtn.addEventListener('click', () => {
@@ -585,6 +592,7 @@ export function previewWebGPUErrors(containerId: string = DEFAULT_CONTAINER_ID):
 
         const nextBtn = document.createElement('button');
 
+        nextBtn.type = 'button';
         nextBtn.textContent = 'Next >>';
         nextBtn.style.cssText = 'padding: 4px 12px; font-family: monospace; cursor: pointer;';
         nextBtn.addEventListener('click', () => {

--- a/src/utils/BootstrapHelpers.ts
+++ b/src/utils/BootstrapHelpers.ts
@@ -342,3 +342,204 @@ export function getCanvas(canvasId: string = DEFAULT_CANVAS_ID): HTMLCanvasEleme
 }
 
 // #endregion
+
+// #region Dev Utilities
+
+/**
+ * Preview entry describing a single error variant.
+ */
+interface ErrorPreviewEntry {
+    /** Short human-readable label shown in the navigation bar. */
+    readonly label: string;
+
+    /** Error panel heading. */
+    readonly title: string;
+
+    /** Error panel body content. */
+    readonly content: ErrorContent;
+}
+
+/**
+ * Returns all distinct error message variants used by the engine.
+ * Covers every browser/version branch of {@link getWebGPUInstructions} plus the
+ * three non-WebGPU error types (canvas, initialization, unexpected).
+ *
+ * @returns Array of preview entries, one per error variant.
+ */
+function buildErrorPreviewEntries(): ReadonlyArray<ErrorPreviewEntry> {
+    return [
+        // WebGPU not supported — Chrome
+        {
+            label: 'Chrome, outdated (< 113)',
+            title: 'WebGPU Not Supported',
+            content: getWebGPUInstructions({ name: 'chrome', version: 100 }),
+        },
+        {
+            label: 'Chrome, current (>= 113)',
+            title: 'WebGPU Not Supported',
+            content: getWebGPUInstructions({ name: 'chrome', version: 130 }),
+        },
+
+        // WebGPU not supported — Edge
+        {
+            label: 'Edge, outdated (< 113)',
+            title: 'WebGPU Not Supported',
+            content: getWebGPUInstructions({ name: 'edge', version: 100 }),
+        },
+        {
+            label: 'Edge, current (>= 113)',
+            title: 'WebGPU Not Supported',
+            content: getWebGPUInstructions({ name: 'edge', version: 130 }),
+        },
+
+        // WebGPU not supported — Firefox
+        {
+            label: 'Firefox Nightly',
+            title: 'WebGPU Not Supported',
+            content: getWebGPUInstructions({ name: 'firefox-nightly', version: 130 }),
+        },
+        {
+            label: 'Firefox stable, outdated (< 141)',
+            title: 'WebGPU Not Supported',
+            content: getWebGPUInstructions({ name: 'firefox', version: 130 }),
+        },
+        {
+            label: 'Firefox stable, current (>= 141)',
+            title: 'WebGPU Not Supported',
+            content: getWebGPUInstructions({ name: 'firefox', version: 141 }),
+        },
+
+        // WebGPU not supported — Safari
+        {
+            label: 'Safari, outdated (< 18)',
+            title: 'WebGPU Not Supported',
+            content: getWebGPUInstructions({ name: 'safari', version: 17 }),
+        },
+        {
+            label: 'Safari 18-25, Feature Flags required',
+            title: 'WebGPU Not Supported',
+            content: getWebGPUInstructions({ name: 'safari', version: 18 }),
+        },
+        {
+            label: 'Safari 26+, enabled by default',
+            title: 'WebGPU Not Supported',
+            content: getWebGPUInstructions({ name: 'safari', version: 26 }),
+        },
+
+        // WebGPU not supported — unknown browser
+        {
+            label: 'Unknown browser',
+            title: 'WebGPU Not Supported',
+            content: getWebGPUInstructions({ name: 'unknown', version: 0 }),
+        },
+
+        // Non-WebGPU errors
+        {
+            label: 'Canvas element not found',
+            title: 'Canvas Error',
+            content:
+                "Failed to find the canvas element with the id 'blit-tech-canvas'.\n\n" +
+                'Make sure the HTML includes a canvas element with the correct ID.',
+        },
+        {
+            label: 'Initialization failed (with error)',
+            title: 'Initialization Failed',
+            content: {
+                text: 'The engine failed to initialize. Check the console for details.',
+                code: "TypeError: Cannot read properties of undefined (reading 'requestDevice')",
+            },
+        },
+        {
+            label: 'Unexpected error during bootstrap',
+            title: 'Unexpected Error',
+            content: {
+                text: 'An unexpected error occurred during initialization:',
+                code: 'RangeError: Maximum call stack size exceeded',
+            },
+        },
+    ];
+}
+
+/**
+ * Cycles through every error message variant for visual testing.
+ *
+ * Renders each variant in the error container with Prev/Next navigation buttons.
+ * Arrow keys also cycle through variants once the function has been called.
+ *
+ * Intended for **development use only**. Do not call this in production demos.
+ *
+ * @param containerId - Container element ID. Default: 'canvas-container'
+ *
+ * @example
+ * // Call once during development to inspect all error layouts:
+ * import { previewWebGPUErrors } from 'blit-tech';
+ * previewWebGPUErrors();
+ */
+export function previewWebGPUErrors(containerId: string = DEFAULT_CONTAINER_ID): void {
+    const entries = buildErrorPreviewEntries();
+    let current = 0;
+
+    const show = (index: number): void => {
+        current = index;
+
+        // eslint-disable-next-line security/detect-object-injection
+        const entry = entries[index];
+
+        if (!entry) {
+            return;
+        }
+
+        displayError(entry.title, entry.content, containerId);
+
+        const container = document.getElementById(containerId);
+
+        if (!container) {
+            return;
+        }
+
+        // Navigation bar appended below the error box.
+        const nav = document.createElement('div');
+
+        nav.style.cssText =
+            'display: flex; align-items: center; justify-content: center; gap: 16px; ' +
+            'margin-top: 12px; font-family: monospace; font-size: 12px; color: #aaa;';
+
+        const prevBtn = document.createElement('button');
+
+        prevBtn.textContent = '<< Prev';
+        prevBtn.style.cssText = 'padding: 4px 12px; font-family: monospace; cursor: pointer;';
+        prevBtn.addEventListener('click', () => {
+            show((current - 1 + entries.length) % entries.length);
+        });
+
+        const counter = document.createElement('span');
+
+        counter.textContent = `${index + 1} / ${entries.length}  —  ${entry.label}`;
+
+        const nextBtn = document.createElement('button');
+
+        nextBtn.textContent = 'Next >>';
+        nextBtn.style.cssText = 'padding: 4px 12px; font-family: monospace; cursor: pointer;';
+        nextBtn.addEventListener('click', () => {
+            show((current + 1) % entries.length);
+        });
+
+        nav.appendChild(prevBtn);
+        nav.appendChild(counter);
+        nav.appendChild(nextBtn);
+        container.appendChild(nav);
+    };
+
+    // Arrow-key navigation.
+    document.addEventListener('keydown', (e: KeyboardEvent) => {
+        if (e.key === 'ArrowLeft') {
+            show((current - 1 + entries.length) % entries.length);
+        } else if (e.key === 'ArrowRight') {
+            show((current + 1) % entries.length);
+        }
+    });
+
+    show(current);
+}
+
+// #endregion


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes

This PR improves WebGPU browser error messaging with per-browser/version guidance, refactors the error UI rendering, and adds a development preview utility for error variants.

### Documentation
- README.md and docs/developer-experience-guide.md updated with OS/version-specific WebGPU requirements:
  - Firefox: clarified Windows requirement (141+) and version-dependent guidance elsewhere
  - Safari: clarified WebGPU is enabled by default on 26+, while 18–25 require enabling via Feature Flags / Develop → Experimental Features
  - Chrome & Edge: remain at 113+

### Runtime / Error UX
- src/utils/BootstrapHelpers.ts
  - Added browser/version constants (MIN_SAFARI_VERSION = 18, MIN_SAFARI_DEFAULT_VERSION = 26, MIN_FIREFOX_VERSION = 141).
  - getWebGPUInstructions() now returns granular, browser- and version-aware instructions:
    - Chrome/Edge: checklist (hardware acceleration, HTTPS/localhost, enable-unsafe-webgpu when blocklisted)
    - Firefox: OS/version-aware guidance (update, Nightly + dom.webgpu.enabled)
    - Safari: three-tier handling (<18 update, 18–25 Feature Flags/manual enabling, 26+ enabled by default)
  - Removed the hardcoded "WebGPU isn't available..." prefix from buildWebGPUNotSupportedMessage().
  - displayError(): UI improvements (styling, sizing, monospace, improved line-wrapping) and safe rendering that preserves newline breaks by inserting TextNodes and <br> elements; removed the extra console paragraph.
  - Added development-only preview machinery:
    - Internal ErrorPreviewEntry type and buildErrorPreviewEntries() enumerating all instruction branches and non-WebGPU errors
    - Module-level keydown handler tracking to avoid stacked listeners
    - Exported previewWebGPUErrors(containerId?: string): renders interactive Prev/Next UI and supports ArrowLeft/ArrowRight navigation, calling displayError() for each variant

### Public API
- src/BlitTech.ts
  - Re-exports previewWebGPUErrors from src/utils/BootstrapHelpers to expose the preview utility via the main entrypoint.

### Tests
- src/utils/BootstrapHelpers.test.ts
  - Updated assertions to reflect Safari version-specific messaging: Feature Flags instructions for 18, upgrade guidance for 18–25 (validated at 25), and default-enabled messaging for 26+.

### Minor
- src/utils/Bootstrap.ts
  - buildWebGPUNotSupportedMessage() simplified to return getWebGPUInstructions(detectBrowser()) without the previous generic header.

### Files Modified
- README.md (+11/-8)
- docs/developer-experience-guide.md (+1/-1)
- src/BlitTech.ts (+2/-1)
- src/utils/Bootstrap.ts (+1/-1)
- src/utils/BootstrapHelpers.ts (+315/-32)
- src/utils/BootstrapHelpers.test.ts (+14/-2)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->