### PR TITLE
feat(assets): add SpriteSheet.loadColorsIntoPalette for auto-registering PNG colors

### DIFF
--- a/src/assets/SpriteSheet.test.ts
+++ b/src/assets/SpriteSheet.test.ts
@@ -447,6 +447,30 @@ describe('SpriteSheet', () => {
                 /Failed to load image/,
             );
         });
+
+        it('rejects atomically when startSlot + discovered colors exceed palette size', async () => {
+            // Four distinct opaque colors, but only two slots remain starting at slot 14 in a size-16 palette.
+            const pixels = new Uint8ClampedArray([
+                10, 10, 10, 255, 100, 100, 100, 255, 200, 200, 200, 255, 250, 250, 250, 255,
+            ]);
+            stubLoad(pixels, 4, 1);
+
+            const palette = new Palette(16);
+            const startSlot = 14;
+
+            // Snapshot the target slots (and their neighbor) before the call so we can
+            // verify no partial mutation on rejection.
+            const before = [13, 14, 15].map((i) => palette.get(i));
+
+            await expect(SpriteSheet.loadColorsIntoPalette('test.png', palette, startSlot)).rejects.toThrow(
+                /do not fit in palette size 16/,
+            );
+
+            const after = [13, 14, 15].map((i) => palette.get(i));
+            expect(after[0]?.equals(before[0] as Color32)).toBe(true);
+            expect(after[1]?.equals(before[1] as Color32)).toBe(true);
+            expect(after[2]?.equals(before[2] as Color32)).toBe(true);
+        });
     });
 
     // #endregion

--- a/src/assets/SpriteSheet.test.ts
+++ b/src/assets/SpriteSheet.test.ts
@@ -345,6 +345,112 @@ describe('SpriteSheet', () => {
 
     // #endregion
 
+    // #region loadColorsIntoPalette
+
+    describe('loadColorsIntoPalette', () => {
+        afterEach(() => {
+            vi.restoreAllMocks();
+            vi.unstubAllGlobals();
+        });
+
+        function stubLoad(pixels: Uint8ClampedArray, w: number, h: number) {
+            vi.stubGlobal('OffscreenCanvas', makeOffscreenCanvasMock(pixels, w, h));
+            vi.spyOn(AssetLoader, 'loadImage').mockResolvedValue({ width: w, height: h } as HTMLImageElement);
+        }
+
+        it('returns colors sorted darkest-first by luminance by default', async () => {
+            // Three opaque pixels: bright white, medium red, near-black blue.
+            // Scan order: white, red, blue. Luminance order: blue < red < white.
+            const pixels = new Uint8ClampedArray([255, 255, 255, 255, 200, 0, 0, 255, 0, 0, 30, 255]);
+            stubLoad(pixels, 3, 1);
+
+            const palette = new Palette(16);
+            const colors = await SpriteSheet.loadColorsIntoPalette('test.png', palette, 1);
+
+            expect(colors).toHaveLength(3);
+            expect(colors[0]?.b).toBe(30); // darkest first (blue)
+            expect(colors[1]?.r).toBe(200); // red middle
+            expect(colors[2]?.r).toBe(255); // brightest last (white)
+        });
+
+        it('preserves scan order when sort: "none"', async () => {
+            const pixels = new Uint8ClampedArray([255, 255, 255, 255, 200, 0, 0, 255, 0, 0, 30, 255]);
+            stubLoad(pixels, 3, 1);
+
+            const palette = new Palette(16);
+            const colors = await SpriteSheet.loadColorsIntoPalette('test.png', palette, 1, { sort: 'none' });
+
+            expect(colors).toHaveLength(3);
+            expect(colors[0]?.r).toBe(255); // white first (scan order)
+            expect(colors[1]?.r).toBe(200); // red second
+            expect(colors[2]?.b).toBe(30); // blue third
+        });
+
+        it('deduplicates identical opaque pixels on RGB', async () => {
+            // Same red pixel three times.
+            const pixels = new Uint8ClampedArray([255, 0, 0, 255, 255, 0, 0, 255, 255, 0, 0, 255]);
+            stubLoad(pixels, 3, 1);
+
+            const palette = new Palette(16);
+            const colors = await SpriteSheet.loadColorsIntoPalette('test.png', palette, 1);
+
+            expect(colors).toHaveLength(1);
+            expect(colors[0]?.r).toBe(255);
+            expect(colors[0]?.g).toBe(0);
+            expect(colors[0]?.b).toBe(0);
+        });
+
+        it('skips alpha=0 pixels and does not consume a palette slot', async () => {
+            // Two transparent + one opaque red. Only the red should be registered.
+            const pixels = new Uint8ClampedArray([0, 0, 0, 0, 99, 99, 99, 0, 200, 50, 25, 255]);
+            stubLoad(pixels, 3, 1);
+
+            const palette = new Palette(16);
+            const colors = await SpriteSheet.loadColorsIntoPalette('test.png', palette, 5);
+
+            expect(colors).toHaveLength(1);
+            expect(palette.get(5).r).toBe(200);
+        });
+
+        it('forces alpha to 255 even when source alpha is partial', async () => {
+            // Source has alpha=128 — should be stored as 255 to match indexize() lookup.
+            const pixels = new Uint8ClampedArray([200, 100, 50, 128]);
+            stubLoad(pixels, 1, 1);
+
+            const palette = new Palette(16);
+            const colors = await SpriteSheet.loadColorsIntoPalette('test.png', palette, 1);
+
+            expect(colors).toHaveLength(1);
+            expect(colors[0]?.a).toBe(255);
+            expect(palette.get(1).a).toBe(255);
+        });
+
+        it('writes colors into consecutive palette slots starting at startSlot', async () => {
+            // Three distinct opaque colors arranged darkest-to-brightest in scan order
+            // so the default luminance sort does not reshuffle them.
+            const pixels = new Uint8ClampedArray([10, 10, 10, 255, 100, 100, 100, 255, 250, 250, 250, 255]);
+            stubLoad(pixels, 3, 1);
+
+            const palette = new Palette(16);
+            await SpriteSheet.loadColorsIntoPalette('test.png', palette, 4);
+
+            expect(palette.get(4).r).toBe(10);
+            expect(palette.get(5).r).toBe(100);
+            expect(palette.get(6).r).toBe(250);
+        });
+
+        it('rejects when AssetLoader.loadImage rejects', async () => {
+            vi.spyOn(AssetLoader, 'loadImage').mockRejectedValue(new Error('Failed to load image: missing.png'));
+
+            const palette = new Palette(16);
+            await expect(SpriteSheet.loadColorsIntoPalette('missing.png', palette, 1)).rejects.toThrow(
+                /Failed to load image/,
+            );
+        });
+    });
+
+    // #endregion
+
     // #region fromIndexedPixels
 
     describe('fromIndexedPixels', () => {

--- a/src/assets/SpriteSheet.ts
+++ b/src/assets/SpriteSheet.ts
@@ -115,6 +115,11 @@ export class SpriteSheet {
      * Image loading goes through {@link AssetLoader.loadImage}, so the call
      * shares cache and in-flight deduplication with {@link SpriteSheet.load}.
      *
+     * The destination range is validated before any write, so the palette is
+     * never left partially mutated: if the collected colors would not fit
+     * (`startSlot < 1` or `startSlot + count > palette.size`), the method
+     * throws without touching any slot.
+     *
      * @param url - Path or URL to the PNG file.
      * @param palette - Target palette to populate.
      * @param startSlot - First palette slot to write into.
@@ -122,6 +127,7 @@ export class SpriteSheet {
      * @param options.sort - Color ordering. Defaults to `'luminance'`.
      * @returns Registered colors in palette-write order.
      * @throws Error if the image cannot be loaded.
+     * @throws RangeError if the discovered colors do not fit in the palette starting at `startSlot`.
      */
     static async loadColorsIntoPalette(
         url: string,
@@ -174,6 +180,26 @@ export class SpriteSheet {
                 const l2 = c2.r * 0.299 + c2.g * 0.587 + c2.b * 0.114;
                 return l1 - l2;
             });
+        }
+
+        // Validate the full destination range up front so a mid-loop palette.set()
+        // throw (out-of-range slot, or opaque color at reserved slot 0) cannot
+        // leave the palette partially mutated. All collected colors are opaque,
+        // so startSlot must be at least 1.
+        if (collected.length > 0) {
+            if (startSlot < 1) {
+                throw new RangeError(
+                    `[SpriteSheet] loadColorsIntoPalette: startSlot ${startSlot} is invalid (slot 0 is reserved for transparency).`,
+                );
+            }
+
+            const endSlot = startSlot + collected.length - 1;
+
+            if (endSlot >= palette.size) {
+                throw new RangeError(
+                    `[SpriteSheet] loadColorsIntoPalette: ${collected.length} colors do not fit in palette size ${palette.size} starting at slot ${startSlot}.`,
+                );
+            }
         }
 
         collected.forEach((color, i) => {

--- a/src/assets/SpriteSheet.ts
+++ b/src/assets/SpriteSheet.ts
@@ -99,6 +99,91 @@ export class SpriteSheet {
     }
 
     /**
+     * Walks a PNG's pixels and registers every unique opaque color into the
+     * supplied palette starting at `startSlot`.
+     *
+     * Pixels with alpha 0 are skipped — they map to the engine's transparent
+     * sentinel slot 0 at draw time. Opaque pixels are deduplicated on RGB and
+     * stored with alpha forced to 255, matching the lookup performed by
+     * `indexize()` so a subsequent `sheet.indexize(palette)` call resolves
+     * without throwing on missing colors.
+     *
+     * By default colors are sorted darkest-first by perceived luminance
+     * (`0.299*r + 0.587*g + 0.114*b`); pass `{ sort: 'none' }` to keep the
+     * row-major scan order of the source image.
+     *
+     * Image loading goes through {@link AssetLoader.loadImage}, so the call
+     * shares cache and in-flight deduplication with {@link SpriteSheet.load}.
+     *
+     * @param url - Path or URL to the PNG file.
+     * @param palette - Target palette to populate.
+     * @param startSlot - First palette slot to write into.
+     * @param options - Optional configuration.
+     * @param options.sort - Color ordering. Defaults to `'luminance'`.
+     * @returns Registered colors in palette-write order.
+     * @throws Error if the image cannot be loaded.
+     */
+    static async loadColorsIntoPalette(
+        url: string,
+        palette: Palette,
+        startSlot: number,
+        options?: { sort?: 'luminance' | 'none' },
+    ): Promise<Color32[]> {
+        const image = await AssetLoader.loadImage(url);
+        const w = image.width;
+        const h = image.height;
+
+        const canvas = new OffscreenCanvas(w, h);
+        const ctx = canvas.getContext('2d') as OffscreenCanvasRenderingContext2D;
+        ctx.imageSmoothingEnabled = false;
+        ctx.drawImage(image, 0, 0);
+
+        const { data } = ctx.getImageData(0, 0, w, h);
+
+        const seen = new Set<number>();
+        const collected: Color32[] = [];
+
+        for (let i = 0; i < data.length; i += 4) {
+            const a = data[i + 3] ?? 0;
+
+            if (a === 0) {
+                continue;
+            }
+
+            // eslint-disable-next-line security/detect-object-injection
+            const r = data[i] ?? 0;
+            const g = data[i + 1] ?? 0;
+            const b = data[i + 2] ?? 0;
+
+            // Pack RGB into a single 24-bit integer for fast Set lookup.
+            const key = (r << 16) | (g << 8) | b;
+
+            if (seen.has(key)) {
+                continue;
+            }
+
+            seen.add(key);
+            collected.push(new Color32(r, g, b, 255));
+        }
+
+        const sortMode = options?.sort ?? 'luminance';
+
+        if (sortMode === 'luminance') {
+            collected.sort((c1, c2) => {
+                const l1 = c1.r * 0.299 + c1.g * 0.587 + c1.b * 0.114;
+                const l2 = c2.r * 0.299 + c2.g * 0.587 + c2.b * 0.114;
+                return l1 - l2;
+            });
+        }
+
+        collected.forEach((color, i) => {
+            palette.set(startSlot + i, color);
+        });
+
+        return collected;
+    }
+
+    /**
      * Creates a sprite sheet from pre-computed palette-indexed pixel data.
      *
      * The resulting sheet is immediately indexized -- its `getTexture()` call


### PR DESCRIPTION
Walks a PNG's pixels via AssetLoader (sharing its cache) and registers every unique opaque color into the supplied palette starting at `startSlot`. Pixels with alpha 0 are skipped; opaque pixels are deduplicated on RGB and stored with alpha forced to 255 so a subsequent `sheet.indexize(palette)` resolves cleanly. Colors are sorted darkest-first by perceived luminance by default, with `{ sort: 'none' }` available to preserve scan order.

Covered by seven unit tests: default luminance sort, scan-order mode, RGB dedup, alpha-0 skip, partial-alpha normalization, consecutive slot writes from startSlot, and loadImage rejection propagation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR introduces SpriteSheet.loadColorsIntoPalette, a new static method that automates registering PNG colors into a Palette. The method loads a PNG via AssetLoader.loadImage, reads pixels through an OffscreenCanvas, scans for unique opaque colors, and writes them into consecutive palette slots starting at a given startSlot.

### Key features

- Color extraction: Scans PNG pixels and deduplicates opaque colors by RGB.
- Alpha handling: Skips fully transparent pixels (alpha = 0) and normalizes partial alpha to 255 when storing colors so subsequent sheet.indexize(palette) resolves correctly.
- Sorting options: Defaults to sorting collected colors by perceived luminance (darkest-first); supports { sort: 'none' } to preserve scan order.
- Slot assignment: Writes discovered colors contiguously into palette indices beginning at startSlot.
- Upfront validation & atomic writes: Validates startSlot >= 1 and that startSlot + discoveredColorCount <= palette.size before any palette.set() calls; throws RangeError and leaves the palette unchanged if the range is invalid.
- Error propagation: Propagates AssetLoader.loadImage rejections.

### Changes

- Added method: static async loadColorsIntoPalette(url: string, palette: Palette, startSlot: number, options?: { sort?: 'luminance' | 'none' }): Promise<Color32[]> in SpriteSheet.
- Tests: Seven unit tests covering default luminance sort, scan-order mode, RGB dedup, alpha-0 skip, partial-alpha normalization, consecutive slot writes from startSlot, loadImage rejection propagation, plus a regression test ensuring no partial palette mutation when the destination range is out of bounds.
- Test utilities: Per-test Vitest mock restoration and helpers that stub OffscreenCanvas image-data and AssetLoader.loadImage.

### Impact

Additive, non-breaking change that provides a convenient, safe utility for populating palettes from PNG assets while reusing AssetLoader's cache.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->