### PR TITLE
feat(api): add opt-in dropped-frame detection with auto-calibrated baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ primitives, and fonts.
 - **Bitmap fonts**: variable-width font rendering with palette offset support
 - **Camera system**: scrolling with offset and reset
 - **Asset loading**: sprite sheets and bitmap fonts from images with automatic caching
-- **Fixed timestep**: deterministic 60 FPS loop with tick counter
+- **Fixed timestep**: deterministic 60 FPS loop with tick counter and optional dropped-frame detection
 - **Clean API**: all engine access through the `BT` namespace
 - **Display scaling**: optional CSS upscaling via `canvasDisplaySize` for crisp pixel art
 
@@ -139,6 +139,7 @@ class MyDemo implements IBlitTechDemo {
       displaySize: new Vector2i(320, 240), // Internal rendering resolution
       canvasDisplaySize: new Vector2i(640, 480), // Optional: CSS display size (2× upscale)
       targetFPS: 60,
+      // detectDroppedFrames: true, // Optional: log a console warning on missed vsync
     };
   }
 

--- a/cspell.json
+++ b/cspell.json
@@ -64,6 +64,7 @@
     "Vitest",
     "vsync",
     "Václav",
+    "vsync",
     "WebGPU",
     "WGSL",
     "xadvance",

--- a/docs/performance-best-practices.md
+++ b/docs/performance-best-practices.md
@@ -238,10 +238,13 @@ if (elapsedTime >= 1.0) {
 
 If your `update()` or `render()` takes too long:
 
-1. **Profile with browser dev tools** - Find the actual bottleneck
-2. **Reduce draw calls** - Cull off-screen objects
-3. **Optimize hot loops** - Use pre-allocation in tight loops
-4. **Simplify logic** - Can you defer expensive operations?
+1. **Confirm the symptom** - Set `detectDroppedFrames: true` in `queryHardware()` to log a console warning whenever the
+   browser misses a vsync deadline. The detector auto-calibrates to the actual rAF cadence so it works on any refresh
+   rate (60 / 120 / 144 Hz, etc.) and on Firefox where rAF often fires at the display rate rather than at `targetFPS`.
+2. **Profile with browser dev tools** - Find the actual bottleneck
+3. **Reduce draw calls** - Cull off-screen objects
+4. **Optimize hot loops** - Use pre-allocation in tight loops
+5. **Simplify logic** - Can you defer expensive operations?
 
 ---
 

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -15,6 +15,7 @@ import type { Color32 } from '../utils/Color32';
 import type { EasingFunction } from '../utils/Easing';
 import type { Rect2i } from '../utils/Rect2i';
 import { Vector2i } from '../utils/Vector2i';
+import type { FrameDropCallback, FrameDropEvent } from './GameLoop';
 import { GameLoop } from './GameLoop';
 import type { HardwareSettings, IBlitTechDemo } from './IBlitTechDemo';
 import { initializeWebGPU } from './WebGPUContext';
@@ -209,6 +210,9 @@ export class BTAPI {
 
         // Start the loop. The GameLoop's double-RAF delay ensures the canvas is
         // fully ready before the first tick.
+        const onFrameDrop: FrameDropCallback | undefined =
+            this.hwSettings.detectDroppedFrames === true ? (event) => this.handleFrameDrop(event) : undefined;
+
         this.loop = new GameLoop(
             updateInterval,
             () => this.demo?.update(),
@@ -227,6 +231,7 @@ export class BTAPI {
                     this.renderer.endFrame();
                 }
             },
+            onFrameDrop,
         );
 
         this.loop.start();
@@ -698,6 +703,23 @@ export class BTAPI {
     // #endregion
 
     // #region Private Helpers
+
+    /**
+     * Logs a dropped-frame event from the {@link GameLoop} as a console warning.
+     *
+     * One line per event. The {@link GameLoop} auto-calibrates its baseline
+     * to the actual rAF cadence, so sustained slowness re-baselines instead
+     * of generating sustained log spam, leaving only genuine missed-vsync
+     * events to be reported here.
+     *
+     * @param event - Dropped-frame event.
+     */
+    private handleFrameDrop(event: FrameDropEvent): void {
+        console.warn(
+            `[BT] Dropped ${event.droppedFrames} frame(s) ` +
+                `(frame time ${event.deltaTime.toFixed(1)}ms, expected ${event.expectedInterval.toFixed(1)}ms)`,
+        );
+    }
 
     /**
      * Validates that a sprite sheet has been indexized and registers it for refresh tracking.

--- a/src/core/GameLoop.test.ts
+++ b/src/core/GameLoop.test.ts
@@ -7,6 +7,7 @@
  * - start-up scheduling through `requestAnimationFrame`
  * - internal tick processing, including multiple updates per frame
  * - accumulator clamping to avoid runaway catch-up work
+ * - optional dropped-frame detection callback
  *
  * Private frame-advance behavior is exercised through a narrow type cast so
  * the suite can validate timing semantics without changing production APIs.
@@ -14,6 +15,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { FrameDropEvent } from './GameLoop';
 import { GameLoop } from './GameLoop';
 
 describe('GameLoop', () => {
@@ -239,6 +241,209 @@ describe('GameLoop', () => {
             p.tick(10);
 
             expect(requestAnimationFrame).toHaveBeenCalled();
+        });
+    });
+
+    // #endregion
+
+    // #region Frame-drop detection
+
+    describe('frame-drop detection', () => {
+        type PrivateLoop = {
+            tick: (currentTime: number) => void;
+            isRunning: boolean;
+            lastUpdateTime: number;
+            accumulator: number;
+            recentDeltas: number[];
+        };
+
+        /**
+         * Pre-populates the rolling baseline window so that the next tick is
+         * evaluated against an established baseline rather than skipped during
+         * warm-up.
+         */
+        const primeBaseline = (loop: GameLoop, sampleMs: number, count: number = 16): void => {
+            const p = loop as unknown as PrivateLoop;
+
+            for (let i = 0; i < count; i++) {
+                p.recentDeltas.push(sampleMs);
+            }
+        };
+
+        beforeEach(() => {
+            vi.stubGlobal('requestAnimationFrame', vi.fn());
+        });
+
+        afterEach(() => {
+            vi.unstubAllGlobals();
+        });
+
+        it('should not invoke the callback when delta is within the baseline', () => {
+            const onFrameDrop = vi.fn();
+            const loop = new GameLoop(16.67, vi.fn(), vi.fn(), onFrameDrop);
+            const p = loop as unknown as PrivateLoop;
+
+            primeBaseline(loop, 16.67);
+
+            p.isRunning = true;
+            p.lastUpdateTime = 0;
+            p.tick(16.67); // exactly one baseline interval
+
+            expect(onFrameDrop).not.toHaveBeenCalled();
+        });
+
+        it('should not invoke the callback when delta is just under the 1.5x threshold', () => {
+            const onFrameDrop = vi.fn();
+            const loop = new GameLoop(16.67, vi.fn(), vi.fn(), onFrameDrop);
+            const p = loop as unknown as PrivateLoop;
+
+            primeBaseline(loop, 16.67);
+
+            p.isRunning = true;
+            p.lastUpdateTime = 0;
+            p.tick(16.67 * 1.49);
+
+            expect(onFrameDrop).not.toHaveBeenCalled();
+        });
+
+        it('should invoke the callback when delta exceeds 1.5x the baseline', () => {
+            const onFrameDrop = vi.fn();
+            const loop = new GameLoop(16.67, vi.fn(), vi.fn(), onFrameDrop);
+            const p = loop as unknown as PrivateLoop;
+
+            primeBaseline(loop, 16.67);
+
+            p.isRunning = true;
+            p.lastUpdateTime = 0;
+            p.tick(50); // ~3 baseline intervals
+
+            expect(onFrameDrop).toHaveBeenCalledOnce();
+
+            const event = onFrameDrop.mock.calls[0]?.[0] as FrameDropEvent;
+
+            expect(event.droppedFrames).toBe(2); // round(50 / 16.67) - 1 = 2
+            expect(event.deltaTime).toBe(50);
+            expect(event.expectedInterval).toBeCloseTo(16.67);
+        });
+
+        it('should report at least one dropped frame even when the gap is just past the threshold', () => {
+            const onFrameDrop = vi.fn();
+            const loop = new GameLoop(10, vi.fn(), vi.fn(), onFrameDrop);
+            const p = loop as unknown as PrivateLoop;
+
+            primeBaseline(loop, 10);
+
+            p.isRunning = true;
+            p.lastUpdateTime = 0;
+            p.tick(16); // 1.6x baseline - between 1 and 2 in raw frame terms
+
+            expect(onFrameDrop).toHaveBeenCalledOnce();
+
+            const event = onFrameDrop.mock.calls[0]?.[0] as FrameDropEvent;
+
+            expect(event.droppedFrames).toBeGreaterThanOrEqual(1);
+        });
+
+        it('should auto-calibrate the baseline to the actual rAF cadence', () => {
+            // Configured for 60 FPS but the browser fires rAF at 120 Hz
+            // (common on a 120 Hz display in Firefox / Chrome with vsync at
+            // the native rate). A missed vsync (~16.67 ms) at 120 Hz would
+            // sit far below 1.5x of the configured 16.67 ms updateInterval
+            // and would not be reported in a naive implementation.
+            const onFrameDrop = vi.fn();
+            const loop = new GameLoop(16.67, vi.fn(), vi.fn(), onFrameDrop);
+            const p = loop as unknown as PrivateLoop;
+
+            primeBaseline(loop, 8.33); // 120 Hz cadence
+
+            p.isRunning = true;
+            p.lastUpdateTime = 0;
+            p.tick(16.67); // one missed vsync at 120 Hz
+
+            expect(onFrameDrop).toHaveBeenCalledOnce();
+
+            const event = onFrameDrop.mock.calls[0]?.[0] as FrameDropEvent;
+
+            expect(event.expectedInterval).toBeCloseTo(8.33);
+            expect(event.droppedFrames).toBe(1);
+        });
+
+        it('should detect drops on a 144 Hz display even with a low targetFPS', () => {
+            // Worst-case mismatch: updateInterval = 33.33 ms (targetFPS = 30)
+            // but rAF fires at 144 Hz (~6.94 ms). A single missed vsync of
+            // ~13.88 ms is less than half the configured updateInterval but
+            // is still a real visible stutter, and must be reported.
+            const onFrameDrop = vi.fn();
+            const loop = new GameLoop(33.33, vi.fn(), vi.fn(), onFrameDrop);
+            const p = loop as unknown as PrivateLoop;
+
+            primeBaseline(loop, 6.94); // 144 Hz cadence
+
+            p.isRunning = true;
+            p.lastUpdateTime = 0;
+            p.tick(13.88); // one missed vsync at 144 Hz
+
+            expect(onFrameDrop).toHaveBeenCalledOnce();
+
+            const event = onFrameDrop.mock.calls[0]?.[0] as FrameDropEvent;
+
+            expect(event.expectedInterval).toBeCloseTo(6.94);
+            expect(event.droppedFrames).toBe(1);
+            expect(event.deltaTime).toBe(13.88);
+        });
+
+        it('should skip detection during the warm-up window', () => {
+            const onFrameDrop = vi.fn();
+            const loop = new GameLoop(16.67, vi.fn(), vi.fn(), onFrameDrop);
+            const p = loop as unknown as PrivateLoop;
+
+            // No priming: rolling window is empty. Even a huge gap should not
+            // fire because the baseline has not been established.
+            p.isRunning = true;
+            p.lastUpdateTime = 0;
+            p.tick(100);
+
+            expect(onFrameDrop).not.toHaveBeenCalled();
+        });
+
+        it('should suppress the callback when the gap looks like a backgrounded tab', () => {
+            const onFrameDrop = vi.fn();
+            const loop = new GameLoop(16.67, vi.fn(), vi.fn(), onFrameDrop);
+            const p = loop as unknown as PrivateLoop;
+
+            primeBaseline(loop, 16.67);
+
+            p.isRunning = true;
+            p.lastUpdateTime = 0;
+            p.tick(5000); // 5 seconds, clearly a tab switch or pause
+
+            expect(onFrameDrop).not.toHaveBeenCalled();
+        });
+
+        it('should not pollute the baseline with backgrounded gaps', () => {
+            const onFrameDrop = vi.fn();
+            const loop = new GameLoop(16.67, vi.fn(), vi.fn(), onFrameDrop);
+            const p = loop as unknown as PrivateLoop;
+
+            primeBaseline(loop, 16.67);
+
+            const lengthBefore = p.recentDeltas.length;
+
+            p.isRunning = true;
+            p.lastUpdateTime = 0;
+            p.tick(5000); // backgrounded gap
+
+            expect(p.recentDeltas.length).toBe(lengthBefore);
+        });
+
+        it('should be a no-op when no callback is provided', () => {
+            const loop = new GameLoop(16.67, vi.fn(), vi.fn());
+            const p = loop as unknown as PrivateLoop;
+
+            p.isRunning = true;
+            p.lastUpdateTime = 0;
+
+            expect(() => p.tick(100)).not.toThrow();
         });
     });
 

--- a/src/core/GameLoop.test.ts
+++ b/src/core/GameLoop.test.ts
@@ -255,19 +255,26 @@ describe('GameLoop', () => {
             lastUpdateTime: number;
             accumulator: number;
             recentDeltas: number[];
+            deltaHead: number;
+            deltaCount: number;
         };
 
         /**
-         * Pre-populates the rolling baseline window so that the next tick is
+         * Pre-populates the ring-buffer baseline so that the next tick is
          * evaluated against an established baseline rather than skipped during
-         * warm-up.
+         * warm-up. Caller is responsible for passing a `count` no greater than
+         * the configured `BASELINE_WINDOW` (60); all current callers use 16.
          */
         const primeBaseline = (loop: GameLoop, sampleMs: number, count: number = 16): void => {
             const p = loop as unknown as PrivateLoop;
 
             for (let i = 0; i < count; i++) {
-                p.recentDeltas.push(sampleMs);
+                // eslint-disable-next-line security/detect-object-injection -- test helper, index is a bounded loop counter
+                p.recentDeltas[i] = sampleMs;
             }
+
+            p.deltaHead = count;
+            p.deltaCount = count;
         };
 
         beforeEach(() => {
@@ -427,13 +434,15 @@ describe('GameLoop', () => {
 
             primeBaseline(loop, 16.67);
 
-            const lengthBefore = p.recentDeltas.length;
+            const countBefore = p.deltaCount;
+            const headBefore = p.deltaHead;
 
             p.isRunning = true;
             p.lastUpdateTime = 0;
             p.tick(5000); // backgrounded gap
 
-            expect(p.recentDeltas.length).toBe(lengthBefore);
+            expect(p.deltaCount).toBe(countBefore);
+            expect(p.deltaHead).toBe(headBefore);
         });
 
         it('should be a no-op when no callback is provided', () => {

--- a/src/core/GameLoop.ts
+++ b/src/core/GameLoop.ts
@@ -117,11 +117,18 @@ export class GameLoop {
     private readonly onFrameDrop: FrameDropCallback | null;
 
     /**
-     * Rolling window of recent rAF deltas, in milliseconds. The shortest
-     * value approximates the browser's actual vsync interval and is used as
-     * the baseline for drop detection.
+     * Ring buffer of recent rAF deltas, in milliseconds. Pre-allocated to
+     * {@link BASELINE_WINDOW} so writes are O(1) and no allocation occurs on
+     * the hot path. The shortest sample approximates the browser's actual
+     * vsync interval and is used as the baseline for drop detection.
      */
-    private readonly recentDeltas: number[] = [];
+    private readonly recentDeltas: number[] = new Array<number>(GameLoop.BASELINE_WINDOW).fill(0);
+
+    /** Next write index in {@link recentDeltas}; advances modulo BASELINE_WINDOW. */
+    private deltaHead: number = 0;
+
+    /** Number of valid samples in {@link recentDeltas}; saturates at BASELINE_WINDOW. */
+    private deltaCount: number = 0;
 
     // #endregion
 
@@ -275,26 +282,34 @@ export class GameLoop {
             return;
         }
 
-        // Append to the rolling window, trimming the oldest sample if full.
-        this.recentDeltas.push(deltaTime);
+        // Ring-buffer write: O(1) overwrite of the oldest slot.
+        this.recentDeltas[this.deltaHead] = deltaTime;
+        this.deltaHead = (this.deltaHead + 1) % GameLoop.BASELINE_WINDOW;
 
-        if (this.recentDeltas.length > GameLoop.BASELINE_WINDOW) {
-            this.recentDeltas.shift();
+        if (this.deltaCount < GameLoop.BASELINE_WINDOW) {
+            this.deltaCount++;
         }
 
         // Wait until enough samples have accumulated to trust the baseline.
-        if (this.recentDeltas.length < GameLoop.BASELINE_WARMUP_SAMPLES) {
+        if (this.deltaCount < GameLoop.BASELINE_WARMUP_SAMPLES) {
             return;
         }
 
         // Baseline = shortest recent delta. Robust to slow frames since drops
         // can only stretch deltas, never shorten them.
         let baseline = Number.POSITIVE_INFINITY;
+        let seen = 0;
 
         for (const sample of this.recentDeltas) {
+            if (seen >= this.deltaCount) {
+                break;
+            }
+
             if (sample < baseline) {
                 baseline = sample;
             }
+
+            seen++;
         }
 
         if (deltaTime <= baseline * GameLoop.DROP_THRESHOLD_MULTIPLIER) {

--- a/src/core/GameLoop.ts
+++ b/src/core/GameLoop.ts
@@ -1,3 +1,45 @@
+// #region Types
+
+/**
+ * Information passed to a {@link GameLoop} dropped-frame callback.
+ *
+ * Emitted when the time between consecutive `requestAnimationFrame` callbacks
+ * exceeds the auto-calibrated baseline, indicating the browser missed one or
+ * more vsync deadlines.
+ */
+export interface FrameDropEvent {
+    /**
+     * Estimated number of refresh intervals skipped.
+     *
+     * Computed as `round(deltaTime / expectedInterval) - 1`, clamped to a
+     * minimum of 1.
+     */
+    readonly droppedFrames: number;
+
+    /** Actual time between rAF callbacks, in milliseconds. */
+    readonly deltaTime: number;
+
+    /**
+     * Auto-calibrated baseline interval, in milliseconds. The shortest rAF
+     * delta observed in the rolling window, which approximates the browser's
+     * actual vsync interval (so detection works on 60 Hz, 120 Hz, 144 Hz,
+     * etc., regardless of the configured `targetFPS`).
+     */
+    readonly expectedInterval: number;
+}
+
+/**
+ * Callback invoked once per frame whose delta exceeded the drop threshold.
+ *
+ * Called from inside the rAF handler on the same frame the drop is detected.
+ * Keep the callback cheap; coalescing/rate-limiting is the caller's responsibility.
+ *
+ * @param event - Details of the detected drop.
+ */
+export type FrameDropCallback = (event: FrameDropEvent) => void;
+
+// #endregion
+
 // #region GameLoop Class
 
 /**
@@ -8,12 +50,43 @@
  * native refresh rate.
  * The accumulator prevents a spiral-of-death catch-up burst by capping the
  * number of fixed updates processed in a single frame.
+ *
+ * Optionally detects dropped frames by comparing each rAF delta against an
+ * auto-calibrated baseline. The baseline is the shortest delta observed in a
+ * rolling window of recent frames, which tracks the browser's actual vsync
+ * interval (so detection works for any display refresh rate, including the
+ * common Firefox case where rAF fires at the display's native rate rather
+ * than at `targetFPS`). When the delta exceeds {@link DROP_THRESHOLD_MULTIPLIER}
+ * times the baseline (and is shorter than {@link BACKGROUND_THRESHOLD_MS} to
+ * filter out tab-switch pauses), the supplied callback is invoked.
  */
 export class GameLoop {
     // #region Constants
 
     /** Maximum update steps per frame to prevent spiral-of-death after long pauses. */
     private static readonly MAX_STEPS = 8;
+
+    /**
+     * Frame must be at least this many times the auto-calibrated baseline to
+     * be reported as a drop. 1.5x corresponds to a missed vsync deadline.
+     */
+    private static readonly DROP_THRESHOLD_MULTIPLIER = 1.5;
+
+    /**
+     * Gaps longer than this (in ms) are filtered out as likely tab-switch or
+     * page-visibility pauses, which would otherwise generate huge spurious drops.
+     */
+    private static readonly BACKGROUND_THRESHOLD_MS = 1000;
+
+    /** Number of recent rAF deltas retained when computing the rolling baseline. */
+    private static readonly BASELINE_WINDOW = 60;
+
+    /**
+     * Minimum samples required before the baseline is trusted enough to drive
+     * detection. Avoids false positives during page-load warm-up where a few
+     * rAF callbacks may fire with unusual cadence.
+     */
+    private static readonly BASELINE_WARMUP_SAMPLES = 8;
 
     // #endregion
 
@@ -40,6 +113,16 @@ export class GameLoop {
     /** Callback invoked once per rendered frame. */
     private readonly onRender: () => void;
 
+    /** Optional callback invoked when a dropped frame is detected. */
+    private readonly onFrameDrop: FrameDropCallback | null;
+
+    /**
+     * Rolling window of recent rAF deltas, in milliseconds. The shortest
+     * value approximates the browser's actual vsync interval and is used as
+     * the baseline for drop detection.
+     */
+    private readonly recentDeltas: number[] = [];
+
     // #endregion
 
     // #region Constructor
@@ -50,9 +133,10 @@ export class GameLoop {
      * @param updateInterval - Milliseconds between fixed update steps (1000 / targetFPS).
      * @param onUpdate - Called once per fixed update step at the target rate.
      * @param onRender - Called once per rendered frame at the browser's refresh rate.
+     * @param onFrameDrop - Optional callback invoked when a dropped frame is detected.
      * @throws {Error} If updateInterval is not a finite positive number.
      */
-    constructor(updateInterval: number, onUpdate: () => void, onRender: () => void) {
+    constructor(updateInterval: number, onUpdate: () => void, onRender: () => void, onFrameDrop?: FrameDropCallback) {
         if (!Number.isFinite(updateInterval) || updateInterval <= 0) {
             throw new Error(`GameLoop updateInterval must be a finite positive number, got: ${updateInterval}`);
         }
@@ -60,6 +144,7 @@ export class GameLoop {
         this.updateInterval = updateInterval;
         this.onUpdate = onUpdate;
         this.onRender = onRender;
+        this.onFrameDrop = onFrameDrop ?? null;
     }
 
     // #endregion
@@ -133,6 +218,8 @@ export class GameLoop {
         const deltaTime = currentTime - this.lastUpdateTime;
         this.lastUpdateTime = currentTime;
 
+        this.detectFrameDrop(deltaTime);
+
         this.accumulator += deltaTime;
 
         // Clamp accumulator to prevent spiral-of-death after long pauses.
@@ -156,6 +243,71 @@ export class GameLoop {
         this.onRender();
 
         requestAnimationFrame((t) => this.tick(t));
+    }
+
+    /**
+     * Reports a dropped-frame event when the rAF gap exceeds the auto-calibrated baseline.
+     *
+     * The baseline is the shortest rAF delta observed in a rolling window of
+     * recent frames, which approximates the browser's actual vsync interval.
+     * This makes detection work regardless of display refresh rate or how the
+     * configured `targetFPS` relates to it.
+     *
+     * Skips reporting when:
+     * - no callback was supplied
+     * - the gap looks like a tab-switch / page-visibility pause (>= 1000 ms)
+     * - the warm-up window has not yet collected enough samples
+     * - the gap is within normal jitter of the baseline
+     *
+     * Background-pause gaps are also excluded from the rolling sample set so
+     * they cannot pollute the baseline.
+     *
+     * @param deltaTime - Milliseconds elapsed since the previous tick.
+     */
+    private detectFrameDrop(deltaTime: number): void {
+        if (!this.onFrameDrop) {
+            return;
+        }
+
+        // Tab-switch / huge gap: skip detection AND skip the rolling window so
+        // the baseline stays representative of real frames.
+        if (deltaTime >= GameLoop.BACKGROUND_THRESHOLD_MS) {
+            return;
+        }
+
+        // Append to the rolling window, trimming the oldest sample if full.
+        this.recentDeltas.push(deltaTime);
+
+        if (this.recentDeltas.length > GameLoop.BASELINE_WINDOW) {
+            this.recentDeltas.shift();
+        }
+
+        // Wait until enough samples have accumulated to trust the baseline.
+        if (this.recentDeltas.length < GameLoop.BASELINE_WARMUP_SAMPLES) {
+            return;
+        }
+
+        // Baseline = shortest recent delta. Robust to slow frames since drops
+        // can only stretch deltas, never shorten them.
+        let baseline = Number.POSITIVE_INFINITY;
+
+        for (const sample of this.recentDeltas) {
+            if (sample < baseline) {
+                baseline = sample;
+            }
+        }
+
+        if (deltaTime <= baseline * GameLoop.DROP_THRESHOLD_MULTIPLIER) {
+            return;
+        }
+
+        const droppedFrames = Math.max(1, Math.round(deltaTime / baseline) - 1);
+
+        this.onFrameDrop({
+            droppedFrames,
+            deltaTime,
+            expectedInterval: baseline,
+        });
     }
 
     // #endregion

--- a/src/core/IBlitTechDemo.ts
+++ b/src/core/IBlitTechDemo.ts
@@ -20,11 +20,18 @@ export interface HardwareSettings {
     targetFPS: number;
 
     /**
-     * When true, the engine logs a coalesced warning to the console whenever
-     * the browser misses one or more vsync deadlines (the gap between
-     * consecutive `requestAnimationFrame` callbacks exceeds `1.5 / targetFPS`
-     * seconds). Useful for spotting stutters during development. Defaults to
-     * `false`.
+     * When true, the engine logs a `console.warn` whenever it detects that
+     * the browser missed one or more vsync deadlines. Useful for spotting
+     * stutters during development. Defaults to `false`.
+     *
+     * Detection runs in `GameLoop.detectFrameDrop()` and uses an
+     * auto-calibrated baseline -- the shortest `requestAnimationFrame` delta
+     * observed in a rolling window of recent frames -- rather than a fixed
+     * `1.5 / targetFPS` threshold. A frame is reported as dropped when its
+     * rAF delta exceeds 1.5x that baseline, which makes detection work on
+     * any display refresh rate (60 / 120 / 144 Hz, etc.) and on browsers
+     * such as Firefox where rAF often fires at the display rate rather than
+     * at `targetFPS`.
      */
     detectDroppedFrames?: boolean;
 }

--- a/src/core/IBlitTechDemo.ts
+++ b/src/core/IBlitTechDemo.ts
@@ -18,6 +18,15 @@ export interface HardwareSettings {
 
     /** Target fixed-update rate in frames per second. */
     targetFPS: number;
+
+    /**
+     * When true, the engine logs a coalesced warning to the console whenever
+     * the browser misses one or more vsync deadlines (the gap between
+     * consecutive `requestAnimationFrame` callbacks exceeds `1.5 / targetFPS`
+     * seconds). Useful for spotting stutters during development. Defaults to
+     * `false`.
+     */
+    detectDroppedFrames?: boolean;
 }
 
 /**


### PR DESCRIPTION
Adds `HardwareSettings.detectDroppedFrames` so demos can opt into a console warning whenever the browser misses one or more vsync deadlines.

`GameLoop` gains an optional `onFrameDrop` callback. Detection compares each rAF delta against an auto-calibrated baseline - the shortest delta in a 60-frame rolling window, which approximates the browser's actual vsync interval.

This makes detection work on any refresh rate, including the common Firefox case where rAF fires at the display's native rate rather than at targetFPS (e.g. 8.3 ms on a 120 Hz display, well below 1.5x of a 60 FPS `updateInterval`).

An 8-frame warm-up suppresses page-load jitter and gaps over 1000 ms are treated as tab-switch pauses and excluded from both detection and the rolling window.

`BTAPI` logs each event as a single `console.warn`. Sustained slowness self recalibrates as the window fills with longer samples, so only genuine missed-vsync events generate output.

Includes 9 new `GameLoop` tests covering threshold edges, warm-up, high-refresh auto-calibration, and background-pause filtering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

Adds an opt-in dropped-frame detection feature that logs a single console.warn when the browser misses one or more vsync deadlines. Detection auto-calibrates to the observed rAF cadence so it works across refresh rates (e.g., 60Hz, 120Hz).

## Key features

- Auto-calibrated baseline: uses the shortest rAF delta in a 60-frame rolling window to approximate the display vsync interval.
- Warm-up: an 8-frame warm-up suppresses page-load jitter before detection starts.
- Background pause filtering: gaps >= 1000 ms are treated as tab-switch/background pauses and excluded from detection and the rolling window.
- Threshold: a delta > 1.5× baseline triggers a FrameDropEvent; reported droppedFrames ≈ delta / expectedInterval (clamped to at least 1).
- Self-recalibration: sustained slowdowns update the rolling window so only genuine missed-vsync events generate warnings.
- Single-line logging: BTAPI.handleFrameDrop emits one console.warn per detected event (includes droppedFrames, deltaTime formatted to 1 decimal ms, and expectedInterval formatted to 1 decimal ms).
- Opt-in: detection is disabled by default to avoid console noise.

## Implementation details

- API / types:
  - Added optional HardwareSettings.detectDroppedFrames?: boolean in src/core/IBlitTechDemo.ts.
  - Added exported FrameDropEvent and FrameDropCallback in src/core/GameLoop.ts.
  - GameLoop constructor updated to accept onFrameDrop?: FrameDropCallback (constructor(updateInterval, onUpdate, onRender, onFrameDrop?)).

- GameLoop:
  - New detectFrameDrop(deltaTime) routine maintains a preallocated 60-frame ring buffer (refactor replaced push/shift with indexed writes), skips detection during an 8-frame warm-up, ignores gaps >= 1000 ms, uses the minimum window delta as expectedInterval, and invokes onFrameDrop when delta > 1.5× baseline; estimates droppedFrames from delta/expectedInterval.
  - detectFrameDrop is executed before accumulator processing in tick.

- BTAPI:
  - BTAPI.initialize wires detectDroppedFrames into the loop by supplying an onFrameDrop that forwards events to BTAPI.handleFrameDrop, which logs a single console.warn per event.
  - Warnings are not batched.

- Tests:
  - Added 9 tests in src/core/GameLoop.test.ts covering threshold edges, minimum dropped-frame reporting, warm-up suppression, baseline auto-calibration (high-refresh scenarios), background-pause filtering/exclusion from the rolling window, ring-buffer internals (deltaCount/deltaHead), and no-op behavior when no callback is provided.

## Documentation

- README Quick Start includes a commented detectDroppedFrames example.
- docs/performance-best-practices.md updated to add dropped-frame detection as the first diagnostic step when update()/render() appears slow.
- cspell.json updated to include "vsync" (duplicate entry added).

## Notable commit

- refactor(api): switched the dropped-frame buffer to a fixed-size preallocated ring buffer and updated JSDoc; tests updated to assert ring-buffer internals. Threshold behavior clarified as 1.5× the auto-calibrated baseline.

## Migration / review notes

- Opt-in via HardwareSettings.detectDroppedFrames to avoid noise.
- Additive public API: new types and optional constructor parameter; existing callers remain compatible but must opt in or supply onFrameDrop for logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->