### PR TITLE
fix(examples): use BT.systemPrint in visual test fixtures

### DIFF
--- a/tests/visual/fixtures/fonts.html
+++ b/tests/visual/fixtures/fonts.html
@@ -59,11 +59,11 @@
 
                 // Use placeholder text rendering (drawText via PrimitivePipeline).
                 // Each character is rendered as a 6x8 colored block.
-                BT.print(new Vector2i(10, 10), WHITE, 'Hello World');
-                BT.print(new Vector2i(10, 30), RED, 'Red Text');
-                BT.print(new Vector2i(10, 50), GREEN, 'Green Text');
-                BT.print(new Vector2i(10, 70), CYAN, 'ABCDEFGHIJ');
-                BT.print(new Vector2i(10, 90), YELLOW, '0123456789');
+                BT.systemPrint(new Vector2i(10, 10), WHITE, 'Hello World');
+                BT.systemPrint(new Vector2i(10, 30), RED, 'Red Text');
+                BT.systemPrint(new Vector2i(10, 50), GREEN, 'Green Text');
+                BT.systemPrint(new Vector2i(10, 70), CYAN, 'ABCDEFGHIJ');
+                BT.systemPrint(new Vector2i(10, 90), YELLOW, '0123456789');
 
                 window.__RENDER_COMPLETE__ = true;
             }

--- a/tests/visual/fixtures/mixed.html
+++ b/tests/visual/fixtures/mixed.html
@@ -111,7 +111,7 @@
                 }
 
                 // Placeholder text.
-                BT.print(new Vector2i(10, 110), WHITE, 'Mixed Test');
+                BT.systemPrint(new Vector2i(10, 110), WHITE, 'Mixed Test');
 
                 // Draw sprites on top (sprite pipeline renders after primitives).
                 const sheet = this.spriteSheet;

--- a/tests/visual/fixtures/perf-fonts.html
+++ b/tests/visual/fixtures/perf-fonts.html
@@ -74,7 +74,7 @@
                 for (let i = 0; i < lines.length; i++) {
                     this.pos.x = 8;
                     this.pos.y = 8 + i * 10;
-                    BT.print(this.pos, WHITE, lines[i]);
+                    BT.systemPrint(this.pos, WHITE, lines[i]);
                 }
 
                 recordFrame(perf);

--- a/tests/visual/fixtures/perf-mixed.html
+++ b/tests/visual/fixtures/perf-mixed.html
@@ -99,7 +99,7 @@
                     BT.drawSprite(this.spriteSheet, this.sourceRect, this.destPos);
                 }
 
-                BT.print(this.textPos, WHITE, text);
+                BT.systemPrint(this.textPos, WHITE, text);
 
                 recordFrame(perf);
             }


### PR DESCRIPTION
The visual test fixtures called BT.print(), which was removed when the text API was split into BT.systemPrint() (built-in 6x14 font) and BT.printFont() (custom bitmap fonts). Without this, the demo render() threw on every frame and __RENDER_COMPLETE__ was never set, causing fonts.spec.ts and mixed.spec.ts to time out at 30s.

The signature is identical (pos, paletteIndex, text), so this is a one-for-one rename across fonts.html, mixed.html, perf-fonts.html, and perf-mixed.html.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR updates four visual test fixtures that were calling the removed `BT.print()` API method. Following the split of the text API into `BT.systemPrint()` (built-in 6x14 font) and `BT.printFont()` (custom bitmap fonts), these fixtures were throwing errors on every frame during rendering, preventing `__RENDER_COMPLETE__` from being set and causing `fonts.spec.ts` and `mixed.spec.ts` to timeout at 30 seconds.

## Changes

The fix performs a one-for-one replacement of `BT.print()` calls with `BT.systemPrint()` across four files:

- **tests/visual/fixtures/fonts.html**: Updates five text-rendering calls in the `render()` method, replacing `BT.print` with `BT.systemPrint` while preserving the same starting positions, palette color indices, and text content.

- **tests/visual/fixtures/mixed.html**: Switches the placeholder text rendering from `BT.print` to `BT.systemPrint`, maintaining the same coordinates and color.

- **tests/visual/fixtures/perf-fonts.html**: Updates the performance test's text drawing API in the render loop from `BT.print()` to `BT.systemPrint()`, keeping all surrounding control flow and positioning intact.

- **tests/visual/fixtures/perf-mixed.html**: Changes the render loop's text drawing call from `BT.print()` to `BT.systemPrint()` for the performance text, with all other rendering and control flow logic unchanged.

All function signatures remain identical (pos, paletteIndex, text), and no other rendering, sprite drawing, or control-flow logic is modified in any of the files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->