### PR TITLE
feat(input): keyboard face-button remapping, defaults, and documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,8 @@ src/
     palettes/              # Built-in preset palette data (VGA, CGA, C64, etc.)
   input/
     PointerInput.ts        # DOM-backed pointer / mouse / touch / pen tracker (4 slots)
+    KeyboardInput.ts       # KeyboardEvent.code state, edges, tick repeat, beforeinput text
+    defaultKeyboardMap.ts  # Default face-button key tables; clone helpers for BT.inputMapReset
   utils/
     Bootstrap.ts           # Demo bootstrap utilities
     BootstrapHelpers.ts    # WebGPU detection, canvas lookup, error display

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ primitives, and fonts.
 - **Asset loading**: sprite sheets and bitmap fonts from images with automatic caching
 - **Pointer input**: mouse, touch, and pen unified under four pointer slots (`BT.pointerPos`, `BT.pointerDelta`,
   `BT.buttonDown` with `BTN_POINTER_A..D`); scroll delta, cursor hide/show, display-space coordinates
+- **Keyboard input**: raw keys (`BT.keyDown`, `BT.keyPressed`, `BT.keyReleased` using `KeyboardEvent.code`), virtual
+  face buttons for players 0–1 (`BT.buttonDown` with `BTN_UP`…`BTN_SELECT`), built-in default maps, remapping via
+  `BT.inputMap` / `BT.inputMapReset`, and text accumulation via `BT.inputString`
 - **Fixed timestep**: deterministic 60 FPS loop with tick counter and optional dropped-frame detection
 - **Clean API**: all engine access through the `BT` namespace
 - **Display scaling**: optional CSS upscaling via `canvasDisplaySize` for crisp pixel art
@@ -77,7 +80,8 @@ Additional documentation is available in the `docs/` directory:
   `BloomEffect`, writing custom effects, and shader attribution
 - **[Bitmap Fonts Guide](docs/bitmap-fonts.md)** — Built-in system font, `.btfont` format spec, BMFont conversion, and
   font rendering API
-- **[Input Guide](docs/input.md)** — Pointer input system, slot model, button mapping, scroll delta, and cursor control
+- **[Input Guide](docs/input.md)** — Pointer and keyboard input, slot model, face-button maps, remapping, scroll delta,
+  and cursor control
 - **[Developer Experience Guide](docs/developer-experience-guide.md)** — Development workflow and tooling (roadmap)
 
 ## Scripts
@@ -175,8 +179,8 @@ class MyDemo implements IBlitTechDemo {
    */
   update(): void {
     // Demo logic at fixed timestep (60 FPS)
-    // Pointer input: BT.pointerPos(), BT.buttonDown(BT.BTN_POINTER_A)
-    // Keyboard input (BT.keyDown, BT.keyPressed) is planned but not yet implemented
+    // Pointer: BT.pointerPos(), BT.buttonDown(BT.BTN_POINTER_A)
+    // Keyboard: BT.keyDown('KeyW'), BT.buttonDown(BT.BTN_A), BT.inputMap(0, BT.BTN_A, 'Space')
   }
 
   /**
@@ -243,7 +247,9 @@ blit-tech/
 │   │       ├── display/         # Display-tier (BarrelDistortion, Scanlines, ...)
 │   │       └── presets/         # crtPipBoy, amber, green
 │   ├── input/
-│   │   └── PointerInput.ts     # DOM-backed pointer / mouse / touch / pen tracker
+│   │   ├── PointerInput.ts        # DOM-backed pointer / mouse / touch / pen tracker
+│   │   ├── KeyboardInput.ts       # Key codes, edges, repeat, text buffer
+│   │   └── defaultKeyboardMap.ts   # Default face-button key tables (VV-435)
 │   ├── utils/
 │   │   ├── Bootstrap.ts        # Demo bootstrap utilities
 │   │   ├── BootstrapHelpers.ts # WebGPU detection, error display
@@ -548,12 +554,29 @@ See the [Input Guide](docs/input.md) for the full slot model, frame-timing seman
 
 #### Keyboard
 
-Keyboard input (`BT.keyDown()`, `BT.keyPressed()`, `BT.keyReleased()`) is planned but not yet implemented. These methods
-currently return `false`. See the Blit-Tech Demos repository for workarounds using browser APIs directly.
+Raw keys use `KeyboardEvent.code` strings (for example `'KeyW'`, `'Space'`):
+
+```ts
+BT.keyDown('KeyA'); // held
+BT.keyPressed('ArrowUp', 8); // edge + optional tick repeat
+BT.keyReleased('Escape'); // release edge
+BT.inputString(); // text since last frame (filtered `beforeinput`)
+```
+
+Face buttons (`BT.BTN_UP` through `BT.BTN_SELECT`) for **players 0 and 1** read mapped keys with OR semantics. Defaults
+match `BT.DEFAULT_KEYBOARD_PLAYER1` and `BT.DEFAULT_KEYBOARD_PLAYER2`. Remap at runtime:
+
+```ts
+BT.inputMap(0, BT.BTN_UP, 'ArrowUp', 'KeyW');
+BT.inputMapReset(); // restore built-in defaults for both keyboard players
+```
+
+Players **2** and **3** have no keyboard mapping for face buttons yet (`BT.buttonDown(BTN_*, 2|3)` stays `false` until
+gamepad support lands).
 
 #### Gamepad
 
-Gamepad input (`BT.buttonDown()` with `BTN_UP..BTN_SELECT`) is planned but not yet implemented.
+Gamepad input for face buttons on players 2 and 3 (and any future pad-backed players) is not implemented yet.
 
 ## Browser Compatibility
 

--- a/docs/input.md
+++ b/docs/input.md
@@ -1,11 +1,11 @@
 # Input Guide
 
-Blit-Tech provides a DOM-backed pointer input subsystem that handles mouse, touch, and pen contacts through a unified
-four-slot model. All coordinates are returned in logical display space (the `displaySize` configured in
-`queryHardware()`), independent of the canvas's CSS or backing-buffer size.
+Blit-Tech provides DOM-backed input: **pointer** (mouse, touch, pen), **keyboard** (`KeyboardEvent.code` tracking and
+virtual face buttons for two players), and **text accumulation** for UI entry (`BT.inputString()`). Gamepad support for
+face buttons on players 2 and 3 is not implemented yet.
 
-Keyboard and gamepad input APIs exist as stubs (`BT.keyDown()`, `BT.buttonDown()` with `BTN_UP..BTN_SELECT`) but are not
-yet implemented and always return `false`.
+All pointer coordinates are returned in logical display space (the `displaySize` configured in `queryHardware()`),
+independent of the canvas's CSS or backing-buffer size.
 
 ## Pointer Slot Model
 
@@ -88,6 +88,85 @@ The mapping follows the RetroBlit canonical order, not the DOM `PointerEvent.but
 | `BTN_POINTER_C` | Middle / wheel click | 1                |
 | `BTN_POINTER_D` | Back or forward      | 3 or 4           |
 
+## Keyboard
+
+Listeners attach to the canvas during `BT.initialize()`. For reliable delivery, ensure the canvas can receive focus (for
+example `canvas.tabIndex = 0` and `canvas.focus()`). The library follows `KeyboardEvent.code` (physical-key semantics),
+not `event.key` layout text.
+
+### Raw key queries
+
+Use these for direct key checks:
+
+```ts
+// Held state
+if (BT.keyDown('KeyW')) {
+  /* W key held */
+}
+
+// Edge and optional tick-based repeat (repeat interval in fixed-update ticks)
+if (BT.keyPressed('ArrowUp', 10)) {
+  /* first press or repeat every 10 ticks while held */
+}
+
+// Release edge
+if (BT.keyReleased('Escape')) {
+  /* Escape released this frame */
+}
+```
+
+### Face buttons (players 0 and 1)
+
+Constants `BT.BTN_UP` through `BT.BTN_SELECT` map to directional pad, action buttons, shoulders, start, and select. For
+**player 0** and **player 1**, `BT.buttonDown` / `BT.buttonPressed` / `BT.buttonReleased` use per-player keyboard maps:
+each logical button is true if **any** mapped key is active (OR semantics).
+
+```ts
+// Player 0 (default: WASD-style + Space / KeyB for A, etc.)
+BT.buttonDown(BT.BTN_UP, 0);
+BT.buttonPressed(BT.BTN_A, 0);
+
+// Player 1 (default: arrow keys + alternate bindings)
+BT.buttonDown(BT.BTN_LEFT, 1);
+```
+
+Built-in defaults are exposed as read-only tables (same values the engine starts with):
+
+- `BT.DEFAULT_KEYBOARD_PLAYER1`
+- `BT.DEFAULT_KEYBOARD_PLAYER2`
+
+### Remapping (`BT.inputMap` / `BT.inputMapReset`)
+
+Override bindings at runtime. The first argument is the **zero-based player index** (`0` or `1` only; other values are
+ignored). The second is the face button constant. Remaining arguments are `KeyboardEvent.code` strings.
+
+```ts
+BT.inputMap(0, BT.BTN_A, 'Space');
+BT.inputMap(0, BT.BTN_UP, 'ArrowUp', 'KeyW'); // either key triggers UP for player 0
+BT.inputMap(1, BT.BTN_START, 'Enter', 'NumpadEnter');
+
+// Restore built-in defaults for both keyboard players (does not affect pointer or future gamepad state)
+BT.inputMapReset();
+```
+
+Pass **no** key codes to clear keyboard bindings for that player and button until you map again:
+
+```ts
+BT.inputMap(0, BT.BTN_X); // player 0 X has no keyboard keys until remapped
+```
+
+### Players 2 and 3
+
+There is **no** keyboard fallback for face buttons on players 2 and 3; `BT.buttonDown(BTN_*, 2)` and `..., 3)` stay
+`false` until gamepad support exists. Pointer buttons (`BTN_POINTER_*`) still use the second argument as the pointer
+slot index (0–3), not a gamepad player index.
+
+### Text input buffer
+
+`BT.inputString()` returns characters accumulated from filtered `beforeinput` (and Tab / Escape where needed). The
+buffer clears after each frame once the engine flushes input at end-of-frame. See public JSDoc on `BT.inputString` for
+details.
+
 ## Scroll Delta
 
 ```ts
@@ -126,6 +205,8 @@ means:
 
 - Any pointer event that fires between two frames is visible as a transition on the **next** `update()` call.
 - `pointerDelta()` reflects movement between the last `update()` and the current one.
+- Keyboard held keys and edges follow the same end-of-frame snapshot timing as pointer input (`KeyboardInput.endFrame`
+  aligns with pointer flush).
 - `buttonPressed()` / `buttonReleased()` edges are never lost even when a press and release both arrive in the same
   inter-frame gap (they appear as pressed-then-released across consecutive frames).
 
@@ -154,8 +235,10 @@ Coordinates are clamped to `[0, displaySize - 1]` on each axis. The conversion i
 
 ## Implementation Notes
 
-- `PointerInput` is internal to the engine; import from `blit-tech` and access through `BT.*` methods.
+- `PointerInput` and `KeyboardInput` are internal; import from `blit-tech` and access through `BT.*` methods.
+- Default keyboard tables live in `defaultKeyboardMap.ts`; runtime remaps are stored in the `BT` facade and reset with
+  `BT.inputMapReset()`.
 - The `POINTER_SLOT_COUNT` constant (value `4`) is exported for demos that iterate over slots.
-- `PointerInput` is created and `attach()`-ed inside `BTAPI.initialize()`, so it is ready before `demo.initialize()`
-  runs.
-- `stop()` calls `detach()` and clears the reference to prevent DOM listener leaks.
+- `PointerInput` and `KeyboardInput` are created and `attach()`-ed inside `BTAPI.initialize()`, so they are ready before
+  `demo.initialize()` runs.
+- `stop()` calls `detach()` on both subsystems and clears references to prevent DOM listener leaks.

--- a/docs/input.md
+++ b/docs/input.md
@@ -121,6 +121,9 @@ Constants `BT.BTN_UP` through `BT.BTN_SELECT` map to directional pad, action but
 **player 0** and **player 1**, `BT.buttonDown` / `BT.buttonPressed` / `BT.buttonReleased` use per-player keyboard maps:
 each logical button is true if **any** mapped key is active (OR semantics).
 
+For mapped face buttons, `BT.buttonPressed` is edge-only (no repeat interval parameter). Use
+`BT.keyPressed(code, repeatRate)` when you need tick-based repeat behavior.
+
 ```ts
 // Player 0 (default: WASD-style + Space / KeyB for A, etc.)
 BT.buttonDown(BT.BTN_UP, 0);

--- a/docs/input.md
+++ b/docs/input.md
@@ -208,7 +208,7 @@ means:
 
 - Any pointer event that fires between two frames is visible as a transition on the **next** `update()` call.
 - `pointerDelta()` reflects movement between the last `update()` and the current one.
-- Keyboard held keys and edges follow the same end-of-frame snapshot timing as pointer input (`KeyboardInput.endFrame`
+- Keyboard-held keys and edges follow the same end-of-frame snapshot timing as pointer input (`KeyboardInput.endFrame`
   aligns with pointer flush).
 - `buttonPressed()` / `buttonReleased()` edges are never lost even when a press and release both arrive in the same
   inter-frame gap (they appear as pressed-then-released across consecutive frames).

--- a/src/BlitTech.test.ts
+++ b/src/BlitTech.test.ts
@@ -14,6 +14,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { BitmapFont, HardwareSettings } from './BlitTech';
 import { BT, Palette, Rect2i, SpriteSheet, Vector2i } from './BlitTech';
 import { BTAPI } from './core/BTAPI';
+import type { FaceButtonCode } from './input/defaultKeyboardMap';
 
 // #region Helpers
 
@@ -413,6 +414,96 @@ describe('BT.buttonReleased', () => {
 
         expect(BT.buttonReleased(BT.BTN_POINTER_C, 2)).toBe(true);
         expect(isButtonReleased).toHaveBeenCalledWith(BT.BTN_POINTER_C, 2);
+    });
+});
+
+// #endregion
+
+// #region BT.inputMap / BT.inputMapReset
+
+describe('BT.inputMap / BT.inputMapReset', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+        BT.inputMapReset();
+    });
+
+    it('remaps player 0 face buttons through the keyboard subsystem', () => {
+        const isButtonDown = vi.fn().mockReturnValue(true);
+        vi.spyOn(BTAPI.instance, 'getKeyboard').mockReturnValue({ isButtonDown } as never);
+
+        BT.inputMap(0, BT.BTN_A, 'KeyZ');
+
+        expect(BT.buttonDown(BT.BTN_A, 0)).toBe(true);
+        expect(isButtonDown).toHaveBeenCalledWith(['KeyZ']);
+    });
+
+    it('remaps player 1 independently of player 0', () => {
+        const isButtonDown = vi.fn().mockImplementation((codes: readonly string[]) => codes.includes('Numpad9'));
+        vi.spyOn(BTAPI.instance, 'getKeyboard').mockReturnValue({ isButtonDown } as never);
+
+        BT.inputMap(0, BT.BTN_A, 'KeyX');
+        BT.inputMap(1, BT.BTN_A, 'Numpad9');
+
+        BT.buttonDown(BT.BTN_A, 0);
+        expect(isButtonDown).toHaveBeenLastCalledWith(['KeyX']);
+
+        BT.buttonDown(BT.BTN_A, 1);
+        expect(isButtonDown).toHaveBeenLastCalledWith(['Numpad9']);
+    });
+
+    it('passes multiple keys per button for OR semantics', () => {
+        const isButtonDown = vi.fn().mockReturnValue(true);
+        vi.spyOn(BTAPI.instance, 'getKeyboard').mockReturnValue({ isButtonDown } as never);
+
+        BT.inputMap(0, BT.BTN_UP, 'ArrowUp', 'KeyW');
+
+        BT.buttonDown(BT.BTN_UP, 0);
+        expect(isButtonDown).toHaveBeenCalledWith(['ArrowUp', 'KeyW']);
+    });
+
+    it('restores default key lists for both keyboard players', () => {
+        const isButtonDown = vi.fn().mockReturnValue(false);
+        vi.spyOn(BTAPI.instance, 'getKeyboard').mockReturnValue({ isButtonDown } as never);
+
+        BT.inputMap(0, BT.BTN_UP, 'F1');
+        BT.inputMap(1, BT.BTN_UP, 'F2');
+        BT.inputMapReset();
+
+        BT.buttonDown(BT.BTN_UP, 0);
+        expect(isButtonDown).toHaveBeenCalledWith([...BT.DEFAULT_KEYBOARD_PLAYER1[BT.BTN_UP as FaceButtonCode]]);
+
+        BT.buttonDown(BT.BTN_UP, 1);
+        expect(isButtonDown).toHaveBeenCalledWith([...BT.DEFAULT_KEYBOARD_PLAYER2[BT.BTN_UP as FaceButtonCode]]);
+    });
+
+    it('ignores remap attempts for unsupported keyboard players', () => {
+        const isButtonDown = vi.fn().mockReturnValue(false);
+        vi.spyOn(BTAPI.instance, 'getKeyboard').mockReturnValue({ isButtonDown } as never);
+
+        BT.inputMap(2, BT.BTN_A, 'KeyZ');
+
+        BT.buttonDown(BT.BTN_A, 0);
+        expect(isButtonDown).toHaveBeenCalledWith([...BT.DEFAULT_KEYBOARD_PLAYER1[BT.BTN_A as FaceButtonCode]]);
+    });
+
+    it('ignores remap attempts with out-of-range face button ids', () => {
+        const isButtonDown = vi.fn().mockReturnValue(false);
+        vi.spyOn(BTAPI.instance, 'getKeyboard').mockReturnValue({ isButtonDown } as never);
+
+        BT.inputMap(0, 99, 'KeyZ');
+
+        BT.buttonDown(BT.BTN_A, 0);
+        expect(isButtonDown).toHaveBeenCalledWith([...BT.DEFAULT_KEYBOARD_PLAYER1[BT.BTN_A as FaceButtonCode]]);
+    });
+
+    it('allows clearing keyboard bindings with an empty key list', () => {
+        const isButtonDown = vi.fn().mockReturnValue(false);
+        vi.spyOn(BTAPI.instance, 'getKeyboard').mockReturnValue({ isButtonDown } as never);
+
+        BT.inputMap(0, BT.BTN_A);
+
+        BT.buttonDown(BT.BTN_A, 0);
+        expect(isButtonDown).toHaveBeenCalledWith([]);
     });
 });
 

--- a/src/BlitTech.test.ts
+++ b/src/BlitTech.test.ts
@@ -349,7 +349,7 @@ describe('BT.buttonDown', () => {
         vi.restoreAllMocks();
     });
 
-    it('returns false for gamepad buttons (not yet implemented)', () => {
+    it('returns false for face buttons when keyboard is unavailable', () => {
         expect(BT.buttonDown(BT.BTN_A)).toBe(false);
     });
 
@@ -378,7 +378,7 @@ describe('BT.buttonPressed', () => {
         vi.restoreAllMocks();
     });
 
-    it('returns false for gamepad buttons (not yet implemented)', () => {
+    it('returns false for face buttons when keyboard is unavailable', () => {
         expect(BT.buttonPressed(BT.BTN_B)).toBe(false);
     });
 
@@ -400,7 +400,7 @@ describe('BT.buttonReleased', () => {
         vi.restoreAllMocks();
     });
 
-    it('returns false for gamepad buttons (not yet implemented)', () => {
+    it('returns false for face buttons when keyboard is unavailable', () => {
         expect(BT.buttonReleased(BT.BTN_X)).toBe(false);
     });
 

--- a/src/BlitTech.ts
+++ b/src/BlitTech.ts
@@ -17,7 +17,12 @@ import { Palette } from './assets/Palette';
 import { SpriteSheet } from './assets/SpriteSheet';
 import { BTAPI } from './core/BTAPI';
 import { defaultHardwareSettings, type HardwareSettings, type IBlitTechDemo } from './core/IBlitTechDemo';
-import { DEFAULT_KEYBOARD_PLAYER1, DEFAULT_KEYBOARD_PLAYER2, type FaceButtonCode } from './input/defaultKeyboardMap';
+import {
+    createDefaultKeyboardRuntimeMaps,
+    DEFAULT_KEYBOARD_PLAYER1,
+    DEFAULT_KEYBOARD_PLAYER2,
+    type FaceButtonCode,
+} from './input/defaultKeyboardMap';
 import { BarrelDistortion } from './render/effects/display/BarrelDistortion';
 import { Bloom } from './render/effects/display/Bloom';
 import { ChromaticAberration } from './render/effects/display/ChromaticAberration';
@@ -41,25 +46,44 @@ import { applyEasing } from './utils/Easing';
 import { Rect2i } from './utils/Rect2i';
 import { Vector2i } from './utils/Vector2i';
 
+/** Runtime face-button → key-code lists for keyboard player 0 (mutable via {@link BT.inputMap}). */
+let keyboardFaceButtonKeysPlayer0: Map<number, string[]>;
+
+/** Runtime face-button → key-code lists for keyboard player 1 (mutable via {@link BT.inputMap}). */
+let keyboardFaceButtonKeysPlayer1: Map<number, string[]>;
+
 /**
- * Returns default keyboard `KeyboardEvent.code` list for a face button and player,
+ * Replaces runtime keyboard maps with fresh copies of {@link DEFAULT_KEYBOARD_PLAYER1} /
+ * {@link DEFAULT_KEYBOARD_PLAYER2}.
+ */
+function resetKeyboardFaceButtonMaps(): void {
+    const [m0, m1] = createDefaultKeyboardRuntimeMaps();
+
+    keyboardFaceButtonKeysPlayer0 = m0;
+    keyboardFaceButtonKeysPlayer1 = m1;
+}
+
+resetKeyboardFaceButtonMaps();
+
+/**
+ * Returns runtime keyboard `KeyboardEvent.code` list for a face button and player,
  * or `null` when there is no keyboard fallback (e.g. players 2–3 for face buttons).
  *
  * @param button - Face button constant (`BT.BTN_UP` … `BT.BTN_SELECT`).
  * @param player - Zero-based player index.
  * @returns Key codes for that mapping, or `null` if unsupported.
  */
-function defaultFaceButtonKeys(button: number, player: number): readonly string[] | null {
+function faceButtonKeys(button: number, player: number): readonly string[] | null {
     if (button < 0 || button > 11) {
         return null;
     }
 
     if (player === 0) {
-        return DEFAULT_KEYBOARD_PLAYER1[button as FaceButtonCode];
+        return keyboardFaceButtonKeysPlayer0.get(button as FaceButtonCode) ?? null;
     }
 
     if (player === 1) {
-        return DEFAULT_KEYBOARD_PLAYER2[button as FaceButtonCode];
+        return keyboardFaceButtonKeysPlayer1.get(button as FaceButtonCode) ?? null;
     }
 
     return null;
@@ -645,9 +669,10 @@ export const BT = {
      * (matches RetroBlit canonical, not DOM `PointerEvent.button` index).
      * Touch / pen slots only support `A`; B/C/D return `false`.
      *
-     * For `BTN_UP`…`BTN_SELECT`, players `0` and `1` use the default keyboard
-     * maps (`BT.DEFAULT_KEYBOARD_PLAYER1` / `BT.DEFAULT_KEYBOARD_PLAYER2`).
-     * Players `2` and `3` have no keyboard mapping (gamepad when VV-135 lands).
+     * For `BTN_UP`…`BTN_SELECT`, players `0` and `1` use the runtime keyboard maps
+     * (defaults match `BT.DEFAULT_KEYBOARD_PLAYER1` / `BT.DEFAULT_KEYBOARD_PLAYER2`;
+     * customize with {@link BT.inputMap}). Players `2` and `3` have no keyboard
+     * mapping (gamepad when VV-135 lands).
      * Pointer codes (`BTN_POINTER_*`) use the `player` argument as the pointer slot.
      *
      * @param button - Button constant from the `BTN_*` set.
@@ -660,7 +685,7 @@ export const BT = {
             return BTAPI.instance.getPointer()?.isButtonDown(button, player) ?? false;
         }
 
-        const keys = defaultFaceButtonKeys(button, player);
+        const keys = faceButtonKeys(button, player);
 
         if (keys) {
             return BTAPI.instance.getKeyboard()?.isButtonDown(keys) ?? false;
@@ -686,7 +711,7 @@ export const BT = {
             return BTAPI.instance.getPointer()?.isButtonPressed(button, player) ?? false;
         }
 
-        const keys = defaultFaceButtonKeys(button, player);
+        const keys = faceButtonKeys(button, player);
 
         if (keys) {
             const tick = BTAPI.instance.getTicks();
@@ -714,7 +739,7 @@ export const BT = {
             return BTAPI.instance.getPointer()?.isButtonReleased(button, player) ?? false;
         }
 
-        const keys = defaultFaceButtonKeys(button, player);
+        const keys = faceButtonKeys(button, player);
 
         if (keys) {
             return BTAPI.instance.getKeyboard()?.isButtonReleased(keys) ?? false;
@@ -722,6 +747,45 @@ export const BT = {
 
         // TODO: Implement gamepad input (VV-135).
         return false;
+    },
+
+    /**
+     * Assigns one or more `KeyboardEvent.code` values to a face button for a keyboard player.
+     *
+     * Logical button state is the OR of all listed keys. Only players `0` and `1`
+     * support keyboard; other indices no-op. Button must be `BT.BTN_UP` …
+     * `BT.BTN_SELECT` (`0`…`11`); out-of-range values no-op. Pass an empty key list
+     * to clear keyboard bindings for that button until remapped again.
+     *
+     * @param player - Zero-based player index (`0` or `1`).
+     * @param button - Face button constant.
+     * @param keys - DOM key codes (for example `'Space'`, `'KeyW'`).
+     */
+    inputMap: (player: number, button: number, ...keys: string[]): void => {
+        if (player !== 0 && player !== 1) {
+            return;
+        }
+
+        if (button < 0 || button > 11) {
+            return;
+        }
+
+        const codes = [...keys];
+
+        if (player === 0) {
+            keyboardFaceButtonKeysPlayer0.set(button, codes);
+        } else {
+            keyboardFaceButtonKeysPlayer1.set(button, codes);
+        }
+    },
+
+    /**
+     * Restores built-in default keyboard maps for players `0` and `1` (VV-435).
+     *
+     * Same tables as `BT.DEFAULT_KEYBOARD_PLAYER1` and `BT.DEFAULT_KEYBOARD_PLAYER2`.
+     */
+    inputMapReset: (): void => {
+        resetKeyboardFaceButtonMaps();
     },
 
     // #endregion

--- a/src/input/defaultKeyboardMap.ts
+++ b/src/input/defaultKeyboardMap.ts
@@ -49,7 +49,7 @@ export const DEFAULT_KEYBOARD_PLAYER2: Readonly<Record<FaceButtonCode, readonly 
  *
  * Used by {@link BT.inputMapReset} so exported defaults are never mutated.
  *
- * @param source - One player's default record (player 1 or 2 table).
+ * @param source - One player's default record (`DEFAULT_KEYBOARD_PLAYER1` or `DEFAULT_KEYBOARD_PLAYER2`).
  * @returns Map with keys `0`…`11` and copied string arrays.
  */
 export function cloneDefaultKeyboardPlayerMap(

--- a/src/input/defaultKeyboardMap.ts
+++ b/src/input/defaultKeyboardMap.ts
@@ -43,3 +43,37 @@ export const DEFAULT_KEYBOARD_PLAYER2: Readonly<Record<FaceButtonCode, readonly 
     10: ['Backspace', 'NumpadDivide'],
     11: [],
 };
+
+/**
+ * Deep-copies default face-button rows into a mutable map (`button` → `KeyboardEvent.code` list).
+ *
+ * Used by {@link BT.inputMapReset} so exported defaults are never mutated.
+ *
+ * @param source - One player's default record (player 1 or 2 table).
+ * @returns Map with keys `0`…`11` and copied string arrays.
+ */
+export function cloneDefaultKeyboardPlayerMap(
+    source: Readonly<Record<FaceButtonCode, readonly string[]>>,
+): Map<number, string[]> {
+    const result = new Map<number, string[]>();
+
+    for (let button = 0; button <= 11; button++) {
+        const codes = source[button as FaceButtonCode];
+
+        result.set(button, [...codes]);
+    }
+
+    return result;
+}
+
+/**
+ * Fresh runtime maps for keyboard players 0 and 1 from built-in defaults.
+ *
+ * @returns Tuple `[player0Map, player1Map]`.
+ */
+export function createDefaultKeyboardRuntimeMaps(): [Map<number, string[]>, Map<number, string[]>] {
+    return [
+        cloneDefaultKeyboardPlayerMap(DEFAULT_KEYBOARD_PLAYER1),
+        cloneDefaultKeyboardPlayerMap(DEFAULT_KEYBOARD_PLAYER2),
+    ];
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR adds runtime-configurable keyboard face-button mappings for players 0 and 1, immutable default maps with cloning helpers, reset semantics, expanded tests, and documentation describing keyboard/input semantics and remapping. Face-button keyboard fallback remains unsupported for players 2 and 3.

## Key Changes

### New Public APIs
- BT.inputMap(player, button, ...keys) — Set or clear KeyboardEvent.code bindings for face buttons (player 0 or 1). Calling without keys clears the binding. Supports multiple keys (OR semantics).
- BT.inputMapReset() — Restore built-in default keyboard mappings by recreating the runtime maps.

### Core Implementation
- src/BlitTech.ts
  - Replaced static/default lookups with mutable runtime Map-backed per-player face-button maps for keyboard players 0 and 1.
  - BT.buttonDown, BT.buttonPressed, and BT.buttonReleased now consult these runtime maps for BTN_UP … BTN_SELECT; players 2+ return null/unsupported for keyboard face-button fallback.
  - Added internal resetKeyboardFaceButtonMaps() and faceButtonKeys() helpers.
- src/input/defaultKeyboardMap.ts
  - DEFAULT_KEYBOARD_PLAYER1 and DEFAULT_KEYBOARD_PLAYER2 remain exported read-only defaults.
  - Added cloneDefaultKeyboardPlayerMap(source) to deep-copy per-button arrays into a mutable Map.
  - Added createDefaultKeyboardRuntimeMaps() to produce fresh runtime maps for both keyboard players, used by inputMapReset to avoid mutating exported defaults.

### Documentation
- docs/input.md — Comprehensive Keyboard section: DOM-backed KeyboardEvent.code model, canvas focus requirements, raw key queries (held/edge/repeat), face-button mapping/remapping semantics (OR across keys, edge-only buttonPressed for mapped face buttons), BT.inputString() text buffer, explicit note that players 2–3 have no keyboard fallback, and frame-timing alignment with pointer input.
- README.md — Features and Quick Start updated to document keyboard input, default maps, and remapping APIs.
- CLAUDE.md — Architecture updated to list KeyboardInput.ts and defaultKeyboardMap.ts in the input subsystem.

### Testing
- src/BlitTech.test.ts — New and updated tests:
  - Verifies BT.buttonDown/Pressed/Released behavior when keyboard subsystem is unavailable.
  - Tests BT.inputMap / BT.inputMapReset: per-player independence (0 vs 1), OR semantics for multiple keys, reset restores defaults for both keyboard players, ignoring remap calls for unsupported player indexes and out-of-range face-button ids, and clearing bindings by calling without keys.

## Behavioural Notes / Risk
- Public behavior change: BT.buttonDown / BT.buttonPressed / BT.buttonReleased now rely on mutable runtime mappings for players 0–1 rather than fixed table lookups. New public APIs add runtime remapping surface. Risk rated Medium due to new APIs and altered default-resolution behavior for face-button state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: introduces new public input APIs and changes how `BT.button*` resolves face buttons via mutable runtime maps, which could affect input behavior across demos if mis-mapped or reset unexpectedly.
> 
> **Overview**
> Adds runtime keyboard remapping for face-button input on players **0–1** via new `BT.inputMap()` / `BT.inputMapReset()`, switching `BT.buttonDown`/`buttonPressed`/`buttonReleased` to consult mutable per-player key lists rather than static defaults.
> 
> Extends `defaultKeyboardMap.ts` with cloning helpers so built-in default tables remain immutable, and adds unit coverage for remapping, reset-to-defaults, ignored invalid players/buttons, and clearing bindings.
> 
> Updates `README.md`, `docs/input.md`, and `CLAUDE.md` to document keyboard raw-key queries, face-button mapping semantics, runtime remapping, and the current limitation that players **2–3** have no keyboard face-button support.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab5acdffa14190990b662d61c6868bfe0265e2a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->