### PR TITLE
refactor(api): rename initialize to init across engine lifecycle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ fantasy-console-style API.
 ## Architecture
 
 All engine functionality is accessed through the static `BT` namespace. Demos implement the `IBlitTechDemo` interface
-(`queryHardware`, `initialize`, `update`, `render`).
+(`queryHardware`, `init`, `update`, `render`).
 
 ```text
 src/

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ class MyDemo implements IBlitTechDemo {
    *
    * @returns Promise resolving to true when initialization succeeds.
    */
-  async initialize(): Promise<boolean> {
+  async init(): Promise<boolean> {
     // Define the palette — all rendering uses indices into this table.
     const palette = new Palette(16);
     palette.set(BG, new Color32(20, 30, 40, 255));
@@ -213,7 +213,7 @@ if (!checkWebGPUSupport()) {
 } else {
   const canvas = getCanvas('my-canvas-id');
   if (canvas) {
-    await BT.initialize(new MyDemo(), canvas);
+    await BT.init(new MyDemo(), canvas);
   }
 }
 ```
@@ -303,15 +303,15 @@ getCanvas(canvasId?); // Get canvas element safely
 ### Initialization
 
 ```ts
-BT.initialize(demo, canvas); // Start the engine (low-level)
+BT.init(demo, canvas); // Start the engine (low-level)
 BT.displaySize(); // Get display resolution
 BT.fps(); // Get target FPS
 BT.ticks(); // Get current tick count
 BT.ticksReset(); // Reset tick counter
 ```
 
-A palette must be set via `BT.paletteSet()` before any draw calls are made. The recommended place is `initialize()` in
-the demo, before loading any sprite sheets.
+A palette must be set via `BT.paletteSet()` before any draw calls are made. The recommended place is `init()` in the
+demo, before loading any sprite sheets.
 
 ### Palette
 
@@ -395,7 +395,7 @@ return {
   targetFPS: 60,
 };
 
-// In initialize(): mix and match effects from both tiers.
+// In init(): mix and match effects from both tiers.
 BT.effectAdd(new PixelGlitch()); // tier='pixel' on the effect routes automatically
 BT.effectAdd(new BarrelDistortion());
 BT.effectAdd(new Scanlines());

--- a/docs/input.md
+++ b/docs/input.md
@@ -90,7 +90,7 @@ The mapping follows the RetroBlit canonical order, not the DOM `PointerEvent.but
 
 ## Keyboard
 
-Listeners attach to the canvas during `BT.initialize()`. For reliable delivery, ensure the canvas can receive focus (for
+Listeners attach to the canvas during `BT.init()`. For reliable delivery, ensure the canvas can receive focus (for
 example `canvas.tabIndex = 0` and `canvas.focus()`). The library follows `KeyboardEvent.code` (physical-key semantics),
 not `event.key` layout text.
 
@@ -212,7 +212,7 @@ scroll while the canvas has focus.
 ## Cursor Control
 
 ```ts
-// In initialize(): hide the OS cursor and draw your own crosshair / sprite
+// In init(): hide the OS cursor and draw your own crosshair / sprite
 BT.hideCursor();
 
 // Restore at any time
@@ -245,7 +245,7 @@ means:
 - `contextmenu` with `preventDefault()` — prevents the OS context menu on right-click so `BTN_POINTER_B` works.
 
 `detach()` reverses all three and removes all event listeners. This happens automatically when the engine stops or when
-`demo.initialize()` throws.
+`demo.init()` throws.
 
 ## Coordinate Conversion
 
@@ -266,6 +266,6 @@ Coordinates are clamped to `[0, displaySize - 1]` on each axis. The conversion i
 - Default keyboard tables live in `defaultKeyboardMap.ts`; runtime remaps are stored in the `BT` facade and reset with
   `BT.inputMapReset()`.
 - The `POINTER_SLOT_COUNT` constant (value `4`) is exported for demos that iterate over slots.
-- `PointerInput`, `KeyboardInput`, and `GamepadInput` are created and attached inside `BTAPI.initialize()`, so they are
-  ready before `demo.initialize()` runs.
+- `PointerInput`, `KeyboardInput`, and `GamepadInput` are created and attached inside `BTAPI.init()`, so they are ready
+  before `demo.init()` runs.
 - `stop()` calls `detach()` on all three input subsystems and clears references to prevent listener leaks.

--- a/docs/post-process-effects.md
+++ b/docs/post-process-effects.md
@@ -31,7 +31,7 @@ class Demo {
     };
   }
 
-  async initialize() {
+  async init() {
     // ... palette, sprites ...
 
     // Pixel tier: chunky glitch on the 320x240 framebuffer

--- a/src/BlitTech.test.ts
+++ b/src/BlitTech.test.ts
@@ -25,40 +25,40 @@ const mockHardwareSettings = (displaySize = new Vector2i(320, 240), targetFPS = 
 
 // #endregion
 
-// #region BT.initialize
+// #region BT.init
 
-describe('BT.initialize', () => {
+describe('BT.init', () => {
     beforeEach(() => {
         vi.restoreAllMocks();
     });
 
-    it('delegates to BTAPI.instance.initialize and returns its result', async () => {
-        const spy = vi.spyOn(BTAPI.instance, 'initialize').mockResolvedValue(true);
+    it('delegates to BTAPI.instance.init and returns its result', async () => {
+        const spy = vi.spyOn(BTAPI.instance, 'init').mockResolvedValue(true);
         const demo = {
             queryHardware: vi.fn(),
-            initialize: vi.fn(),
+            init: vi.fn(),
             update: vi.fn(),
             render: vi.fn(),
         };
         const canvas = {} as HTMLCanvasElement;
 
-        const result = await BT.initialize(demo, canvas);
+        const result = await BT.init(demo, canvas);
 
         expect(spy).toHaveBeenCalledWith(demo, canvas);
         expect(result).toBe(true);
     });
 
     it('forwards a failure result from BTAPI', async () => {
-        vi.spyOn(BTAPI.instance, 'initialize').mockResolvedValue(false);
+        vi.spyOn(BTAPI.instance, 'init').mockResolvedValue(false);
 
         const demo = {
             queryHardware: vi.fn(),
-            initialize: vi.fn(),
+            init: vi.fn(),
             update: vi.fn(),
             render: vi.fn(),
         };
 
-        const result = await BT.initialize(demo, {} as HTMLCanvasElement);
+        const result = await BT.init(demo, {} as HTMLCanvasElement);
 
         expect(result).toBe(false);
     });

--- a/src/BlitTech.ts
+++ b/src/BlitTech.ts
@@ -278,8 +278,8 @@ export const BT = {
      * @param canvas - Canvas used as the engine render target.
      * @returns `true` when initialization succeeds; otherwise `false`.
      */
-    initialize: async (demo: IBlitTechDemo, canvas: HTMLCanvasElement): Promise<boolean> => {
-        return await BTAPI.instance.initialize(demo, canvas);
+    init: async (demo: IBlitTechDemo, canvas: HTMLCanvasElement): Promise<boolean> => {
+        return await BTAPI.instance.init(demo, canvas);
     },
 
     // #endregion
@@ -704,7 +704,7 @@ export const BT = {
     /**
      * Hides the native OS cursor while the pointer is over the canvas.
      *
-     * Call once from `initialize()` when the demo draws its own crosshair or
+     * Call once from `init()` when the demo draws its own crosshair or
      * cursor sprite in place of the system arrow. The cursor is restored
      * automatically when the engine shuts down.
      *

--- a/src/BlitTech.ts
+++ b/src/BlitTech.ts
@@ -384,7 +384,7 @@ export const BT = {
 
     // #endregion
 
-    // #region Palette Effects
+    // #region Palette Effects API
 
     /**
      * Starts rotating a range of palette entries at a constant speed.
@@ -480,7 +480,7 @@ export const BT = {
 
     // #endregion
 
-    // #region Post-Process Effects
+    // #region Post-Process Effects API
 
     /**
      * Appends a fullscreen post-processing effect to whichever chain matches
@@ -540,7 +540,7 @@ export const BT = {
 
     // #endregion
 
-    // #region Rendering - Clear Operations
+    // #region Rendering API - Clear Operations
 
     /**
      * Sets the frame clear color using a palette index.
@@ -566,7 +566,7 @@ export const BT = {
 
     // #endregion
 
-    // #region Rendering - Primitives
+    // #region Rendering API - Primitives
 
     /**
      * Draws a single pixel.
@@ -613,7 +613,7 @@ export const BT = {
 
     // #endregion
 
-    // #region Camera
+    // #region Camera API
 
     /**
      * Sets the global camera offset applied to subsequent draw calls.
@@ -642,7 +642,7 @@ export const BT = {
 
     // #endregion
 
-    // #region Input - Pointer
+    // #region Input API - Pointer
 
     /**
      * Returns the position of the pointer in the given slot, in display coordinates.
@@ -726,7 +726,7 @@ export const BT = {
 
     // #endregion
 
-    // #region Input - Buttons
+    // #region Input API - Buttons
 
     /**
      * Checks whether a button is currently held.
@@ -993,7 +993,7 @@ export const BT = {
 
     // #endregion
 
-    // #region Input - Keyboard
+    // #region Input API - Keyboard
 
     /**
      * Checks whether a keyboard key is currently held.
@@ -1047,7 +1047,7 @@ export const BT = {
 
     // #endregion
 
-    // #region Text Rendering
+    // #region Text Rendering API
 
     /**
      * Draws text using the built-in 6x14 system font.
@@ -1103,7 +1103,7 @@ export const BT = {
 
     // #endregion
 
-    // #region Frame Capture
+    // #region Frame Capture API
 
     /**
      * Captures the next rendered frame as a PNG blob.
@@ -1147,7 +1147,7 @@ export const BT = {
 
     // #endregion
 
-    // #region Sprite Rendering
+    // #region Rendering API - Sprites
 
     /**
      * Draws a sprite region from an indexed sprite sheet.

--- a/src/core/BTAPI.test.ts
+++ b/src/core/BTAPI.test.ts
@@ -44,7 +44,7 @@ function makeMockDemo(targetFPS = 60, initResult = true): IBlitTechDemo {
             canvasDisplaySize: new Vector2i(640, 480),
             targetFPS,
         }),
-        initialize: vi.fn().mockResolvedValue(initResult),
+        init: vi.fn().mockResolvedValue(initResult),
         update: vi.fn(),
         render: vi.fn(),
     };
@@ -286,23 +286,23 @@ describe('BTAPI', () => {
 
     // #endregion
 
-    // #region initialize()
+    // #region init()
 
-    describe('initialize', () => {
+    describe('init', () => {
         it('should return false for NaN targetFPS', async () => {
-            const result = await BTAPI.instance.initialize(makeMockDemo(NaN), makeMockCanvas());
+            const result = await BTAPI.instance.init(makeMockDemo(NaN), makeMockCanvas());
 
             expect(result).toBe(false);
         });
 
         it('should return false for zero targetFPS', async () => {
-            const result = await BTAPI.instance.initialize(makeMockDemo(0), makeMockCanvas());
+            const result = await BTAPI.instance.init(makeMockDemo(0), makeMockCanvas());
 
             expect(result).toBe(false);
         });
 
         it('should return false for negative targetFPS', async () => {
-            const result = await BTAPI.instance.initialize(makeMockDemo(-30), makeMockCanvas());
+            const result = await BTAPI.instance.init(makeMockDemo(-30), makeMockCanvas());
 
             expect(result).toBe(false);
         });
@@ -310,7 +310,7 @@ describe('BTAPI', () => {
         it('should return false when navigator.gpu is absent', async () => {
             uninstallMockNavigatorGPU();
 
-            const result = await BTAPI.instance.initialize(makeMockDemo(), makeMockCanvas());
+            const result = await BTAPI.instance.init(makeMockDemo(), makeMockCanvas());
 
             expect(result).toBe(false);
         });
@@ -328,7 +328,7 @@ describe('BTAPI', () => {
                 configurable: true,
             });
 
-            const result = await BTAPI.instance.initialize(makeMockDemo(), makeMockCanvas());
+            const result = await BTAPI.instance.init(makeMockDemo(), makeMockCanvas());
 
             expect(result).toBe(false);
         });
@@ -353,20 +353,20 @@ describe('BTAPI', () => {
                 configurable: true,
             });
 
-            const result = await BTAPI.instance.initialize(makeMockDemo(), makeMockCanvas());
+            const result = await BTAPI.instance.init(makeMockDemo(), makeMockCanvas());
 
             expect(result).toBe(false);
         });
 
-        it('should return false when demo.initialize() returns false', async () => {
-            const result = await BTAPI.instance.initialize(makeMockDemo(60, false), makeMockCanvas());
+        it('should return false when demo.init() returns false', async () => {
+            const result = await BTAPI.instance.init(makeMockDemo(60, false), makeMockCanvas());
 
             expect(result).toBe(false);
         });
 
         it('should return true and populate accessors on success', async () => {
             const canvas = makeMockCanvas();
-            const result = await BTAPI.instance.initialize(makeMockDemo(), canvas);
+            const result = await BTAPI.instance.init(makeMockDemo(), canvas);
 
             expect(result).toBe(true);
             expect(BTAPI.instance.getDevice()).not.toBeNull();
@@ -380,7 +380,7 @@ describe('BTAPI', () => {
         });
 
         it('stop detaches pointer and keyboard input so subsequent accessors return null', async () => {
-            await BTAPI.instance.initialize(makeMockDemo(), makeMockCanvas());
+            await BTAPI.instance.init(makeMockDemo(), makeMockCanvas());
 
             expect(BTAPI.instance.getPointer()).not.toBeNull();
             expect(BTAPI.instance.getKeyboard()).not.toBeNull();
@@ -393,10 +393,10 @@ describe('BTAPI', () => {
             expect(BTAPI.instance.getGamepad()).toBeNull();
         });
 
-        it('double initialize without stop detaches prior pointer and keyboard before reattaching', async () => {
+        it('double init without stop detaches prior pointer and keyboard before reattaching', async () => {
             const canvas = makeMockCanvas();
 
-            await BTAPI.instance.initialize(makeMockDemo(), canvas);
+            await BTAPI.instance.init(makeMockDemo(), canvas);
 
             const pointerBefore = BTAPI.instance.getPointer();
             const keyboardBefore = BTAPI.instance.getKeyboard();
@@ -406,7 +406,7 @@ describe('BTAPI', () => {
 
             vi.mocked(canvas.removeEventListener).mockClear();
 
-            await BTAPI.instance.initialize(makeMockDemo(), canvas);
+            await BTAPI.instance.init(makeMockDemo(), canvas);
 
             expect(BTAPI.instance.getPointer()).not.toBe(pointerBefore);
             expect(BTAPI.instance.getKeyboard()).not.toBe(keyboardBefore);
@@ -418,7 +418,7 @@ describe('BTAPI', () => {
         });
 
         it('should start the game loop on success', async () => {
-            await BTAPI.instance.initialize(makeMockDemo(), makeMockCanvas());
+            await BTAPI.instance.init(makeMockDemo(), makeMockCanvas());
 
             expect(requestAnimationFrame).toHaveBeenCalled();
         });
@@ -433,7 +433,7 @@ describe('BTAPI', () => {
                 }),
             );
 
-            await BTAPI.instance.initialize(makeMockDemo(), makeMockCanvas());
+            await BTAPI.instance.init(makeMockDemo(), makeMockCanvas());
 
             const gamepad = BTAPI.instance.getGamepad();
             expect(gamepad).not.toBeNull();
@@ -467,13 +467,13 @@ describe('BTAPI', () => {
         });
 
         it('stop should not throw after successful initialization', async () => {
-            await BTAPI.instance.initialize(makeMockDemo(), makeMockCanvas());
+            await BTAPI.instance.init(makeMockDemo(), makeMockCanvas());
 
             expect(() => BTAPI.instance.stop()).not.toThrow();
         });
 
         it('captureFrame returns a blob after successful initialization', async () => {
-            await BTAPI.instance.initialize(makeMockDemo(), makeMockCanvas());
+            await BTAPI.instance.init(makeMockDemo(), makeMockCanvas());
 
             const renderer = BTAPI.instance.getRenderer();
 
@@ -526,20 +526,20 @@ describe('BTAPI', () => {
             };
         }
 
-        it('effectAdd throws before initialize', () => {
+        it('effectAdd throws before init', () => {
             expect(() => BTAPI.instance.effectAdd(makeStubEffect())).toThrow('renderer not initialized');
         });
 
-        it('effectRemove throws before initialize', () => {
+        it('effectRemove throws before init', () => {
             expect(() => BTAPI.instance.effectRemove(makeStubEffect())).toThrow('renderer not initialized');
         });
 
-        it('effectClear throws before initialize', () => {
+        it('effectClear throws before init', () => {
             expect(() => BTAPI.instance.effectClear()).toThrow('renderer not initialized');
         });
 
-        it('effectAdd / effectClear delegate to the renderer after initialize', async () => {
-            await BTAPI.instance.initialize(makeMockDemo(), makeMockCanvas());
+        it('effectAdd / effectClear delegate to the renderer after init', async () => {
+            await BTAPI.instance.init(makeMockDemo(), makeMockCanvas());
 
             const renderer = BTAPI.instance.getRenderer();
             expect(renderer).not.toBeNull();
@@ -557,8 +557,8 @@ describe('BTAPI', () => {
             expect(clearSpy).toHaveBeenCalled();
         });
 
-        it('effectRemove delegates to the renderer after initialize', async () => {
-            await BTAPI.instance.initialize(makeMockDemo(), makeMockCanvas());
+        it('effectRemove delegates to the renderer after init', async () => {
+            await BTAPI.instance.init(makeMockDemo(), makeMockCanvas());
 
             const renderer = BTAPI.instance.getRenderer();
             const removeSpy = vi.spyOn(renderer as NonNullable<typeof renderer>, 'removeEffect');

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -22,7 +22,7 @@ import { Vector2i } from '../utils/Vector2i';
 import type { FrameDropCallback, FrameDropEvent } from './GameLoop';
 import { GameLoop } from './GameLoop';
 import type { HardwareSettings, IBlitTechDemo } from './IBlitTechDemo';
-import { initializeWebGPU } from './WebGPUContext';
+import { initWebGPU } from './WebGPUContext';
 
 /**
  * Central runtime facade for Blit-Tech engine services.
@@ -94,13 +94,13 @@ export class BTAPI {
     /** Built-in 6x14 system font for BT.systemPrint(). */
     private systemFont: BitmapFont | null = null;
 
-    /** Pointer / mouse / touch input subsystem. Created during {@link initialize}. */
+    /** Pointer / mouse / touch input subsystem. Created during {@link init}. */
     private pointer: PointerInput | null = null;
 
-    /** Keyboard input (VV-134). Created during {@link initialize}. */
+    /** Keyboard input (VV-134). Created during {@link init}. */
     private keyboard: KeyboardInput | null = null;
 
-    /** Gamepad input (VV-135). Created during {@link initialize}. */
+    /** Gamepad input (VV-135). Created during {@link init}. */
     private gamepad: GamepadInput | null = null;
 
     // TODO: Additional subsystems for future implementation:
@@ -110,13 +110,13 @@ export class BTAPI {
 
     // #region Singleton / Constructor
 
-    /** Singleton instance of BTAPI. */
-    private static _instance: BTAPI | null = null;
-
     /**
      * Private constructor to enforce singleton access via `BTAPI.instance`.
      */
     private constructor() {}
+
+    /** Singleton instance of BTAPI. */
+    private static _instance: BTAPI | null = null;
 
     // #endregion
 
@@ -140,62 +140,19 @@ export class BTAPI {
     // #region Initialization
 
     /**
-     * Removes pointer, keyboard, and gamepad subsystems.
-     *
-     * Pointer/keyboard detach DOM listeners; gamepad detaches polling state and
-     * clears subsystem references.
-     */
-    private clearInputSubsystems(): void {
-        this.pointer?.detach();
-        this.pointer = null;
-        this.keyboard?.detach();
-        this.keyboard = null;
-        this.gamepad?.detach();
-        this.gamepad = null;
-    }
-
-    /**
-     * Runs the demo's async {@link IBlitTechDemo.initialize}. On throw or
-     * `false`, clears input subsystems that were attached earlier in the init
-     * sequence.
-     *
-     * @param demo - Active demo instance.
-     * @returns `true` when the demo reports success.
-     */
-    private async runDemoInitialize(demo: IBlitTechDemo): Promise<boolean> {
-        try {
-            const ok = await demo.initialize();
-
-            if (!ok) {
-                console.error('[BT] Demo initialization failed');
-                this.clearInputSubsystems();
-
-                return false;
-            }
-
-            return true;
-        } catch (err) {
-            console.error('[BT] Demo initialization threw', err);
-            this.clearInputSubsystems();
-
-            return false;
-        }
-    }
-
-    /**
      * Initializes the engine for a demo and starts the main loop on success.
      *
      * The initialization sequence is:
      * - query hardware settings from the demo
      * - initialize WebGPU and create the renderer
-     * - run the demo's async `initialize()`
+     * - run the demo's async `init()`
      * - start the fixed-timestep game loop
      *
      * @param demo - Demo implementing the IBlitTechDemo interface.
      * @param canvas - HTML canvas element for WebGPU rendering.
      * @returns `true` when initialization succeeds; otherwise `false`.
      */
-    public async initialize(demo: IBlitTechDemo, canvas: HTMLCanvasElement): Promise<boolean> {
+    public async init(demo: IBlitTechDemo, canvas: HTMLCanvasElement): Promise<boolean> {
         console.log(`[BT] Initializing engine v${BTAPI.VERSION_MAJOR}.${BTAPI.VERSION_MINOR}.${BTAPI.VERSION_PATCH}`);
 
         this.demo = demo;
@@ -222,11 +179,7 @@ export class BTAPI {
         });
 
         // Initialize WebGPU.
-        const webGPUResult = await initializeWebGPU(
-            canvas,
-            this.hwSettings.displaySize,
-            this.hwSettings.canvasDisplaySize,
-        );
+        const webGPUResult = await initWebGPU(canvas, this.hwSettings.displaySize, this.hwSettings.canvasDisplaySize);
 
         if (!webGPUResult) {
             console.error('[BT] Failed to initialize WebGPU');
@@ -250,7 +203,7 @@ export class BTAPI {
             this.hwSettings.outputUpscaleFilter ?? 'nearest',
         );
 
-        if (!(await this.renderer.initialize())) {
+        if (!(await this.renderer.init())) {
             console.error('[BT] Failed to initialize renderer');
 
             return false;
@@ -282,7 +235,7 @@ export class BTAPI {
         // Initialize the demo.
         console.log('[BT] Initializing demo');
 
-        if (!(await this.runDemoInitialize(demo))) {
+        if (!(await this.runDemoInit(demo))) {
             return false;
         }
 
@@ -342,10 +295,6 @@ export class BTAPI {
         this.clearInputSubsystems();
     }
 
-    // #endregion
-
-    // #region Demo State Accessors
-
     /**
      * Gets the current tick count.
      * Ticks increment once per fixed update step (target rate set by `targetFPS`).
@@ -364,6 +313,10 @@ export class BTAPI {
         this.loop?.resetTicks();
     }
 
+    // #endregion
+
+    // #region Demo State Accessors
+
     /**
      * Gets the hardware settings returned by the active demo.
      *
@@ -372,10 +325,6 @@ export class BTAPI {
     public getHardwareSettings(): HardwareSettings | null {
         return this.hwSettings;
     }
-
-    // #endregion
-
-    // #region WebGPU Resource Accessors
 
     /**
      * Gets the initialized WebGPU device.
@@ -394,6 +343,10 @@ export class BTAPI {
     public getContext(): GPUCanvasContext | null {
         return this.context;
     }
+
+    // #endregion
+
+    // #region WebGPU Resource Accessors
 
     /**
      * Gets the canvas bound during initialization.
@@ -473,10 +426,6 @@ export class BTAPI {
         this.renderer?.setPalette(palette);
     }
 
-    // #endregion
-
-    // #region Rendering API - Clear Operations
-
     /**
      * Sets the background clear color for each frame using a palette index.
      *
@@ -500,7 +449,7 @@ export class BTAPI {
 
     // #endregion
 
-    // #region Rendering API - Primitives
+    // #region Rendering API - Clear Operations
 
     /**
      * Draws a single pixel at the specified position.
@@ -525,6 +474,10 @@ export class BTAPI {
         this.assertPaletteIndex(paletteIndex);
         this.renderer?.drawLine(p0, p1, paletteIndex);
     }
+
+    // #endregion
+
+    // #region Rendering API - Primitives
 
     /**
      * Draws a rectangle outline (unfilled).
@@ -583,10 +536,6 @@ export class BTAPI {
         return this.systemFont;
     }
 
-    // #endregion
-
-    // #region Rendering API - Sprites
-
     /**
      * Draws a sprite region from an indexed sprite sheet.
      * The renderer batches compatible sprite draws internally.
@@ -618,6 +567,10 @@ export class BTAPI {
         this.requireIndexizedSheet(font.getSpriteSheet(), 'drawBitmapText', 'font sprite sheet');
         this.renderer?.drawBitmapText(font, pos, text, paletteOffset);
     }
+
+    // #endregion
+
+    // #region Rendering API - Sprites
 
     /**
      * Re-indexizes all tracked sprite sheets against the current active palette.
@@ -652,10 +605,6 @@ export class BTAPI {
         console.log(`[BT] Refreshed ${refreshed} sprite sheet(s) against current palette`);
     }
 
-    // #endregion
-
-    // #region Frame Capture API
-
     /**
      * Captures the next rendered frame as a PNG blob.
      * The capture occurs on the next completed render cycle.
@@ -671,10 +620,6 @@ export class BTAPI {
         return this.renderer.captureFrame();
     }
 
-    // #endregion
-
-    // #region Camera API
-
     /**
      * Sets the camera offset for scrolling effects.
      * The offset is applied to subsequent renderer draw calls.
@@ -685,6 +630,10 @@ export class BTAPI {
         this.renderer?.setCameraOffset(offset);
     }
 
+    // #endregion
+
+    // #region Frame Capture API
+
     /**
      * Gets the current camera offset.
      *
@@ -694,28 +643,15 @@ export class BTAPI {
         return this.renderer?.getCameraOffset() ?? Vector2i.zero();
     }
 
+    // #endregion
+
+    // #region Camera API
+
     /**
      * Resets the camera offset to (0, 0).
      */
     public resetCamera(): void {
         this.renderer?.resetCamera();
-    }
-
-    // #endregion
-
-    // #region Palette Effects API
-
-    /**
-     * Validates that a duration is a finite, non-negative number.
-     *
-     * @param method - Calling method name for the error message.
-     * @param durationMs - Duration to validate.
-     * @throws Error if the duration is not finite or is negative.
-     */
-    private assertFiniteDuration(method: string, durationMs: number): void {
-        if (!Number.isFinite(durationMs) || durationMs < 0) {
-            throw new Error(`[BT] ${method}: durationMs must be a finite non-negative number, got ${durationMs}.`);
-        }
     }
 
     /**
@@ -757,6 +693,10 @@ export class BTAPI {
         this.assertFiniteDuration('paletteFade', durationMs);
         this.paletteEffects.add(new FadeEffect(this.palette, target, durationMs, easing));
     }
+
+    // #endregion
+
+    // #region Palette Effects API
 
     /**
      * Fades only a subset of palette indices toward a target over time.
@@ -824,10 +764,6 @@ export class BTAPI {
         this.paletteEffects.clear();
     }
 
-    // #endregion
-
-    // #region Post-Process Effects API
-
     /**
      * Appends a fullscreen post-processing effect to the chain.
      *
@@ -874,6 +810,66 @@ export class BTAPI {
         }
 
         this.renderer.clearEffects();
+    }
+
+    // #endregion
+
+    // #region Post-Process Effects API
+
+    /**
+     * Removes pointer, keyboard, and gamepad subsystems.
+     *
+     * Pointer/keyboard detach DOM listeners; gamepad detaches polling state and
+     * clears subsystem references.
+     */
+    private clearInputSubsystems(): void {
+        this.pointer?.detach();
+        this.pointer = null;
+        this.keyboard?.detach();
+        this.keyboard = null;
+        this.gamepad?.detach();
+        this.gamepad = null;
+    }
+
+    /**
+     * Runs the demo's async {@link IBlitTechDemo.init}. On throw or
+     * `false`, clears input subsystems that were attached earlier in the init
+     * sequence.
+     *
+     * @param demo - Active demo instance.
+     * @returns `true` when the demo reports success.
+     */
+    private async runDemoInit(demo: IBlitTechDemo): Promise<boolean> {
+        try {
+            const ok = await demo.init();
+
+            if (!ok) {
+                console.error('[BT] Demo initialization failed');
+                this.clearInputSubsystems();
+
+                return false;
+            }
+
+            return true;
+        } catch (err) {
+            console.error('[BT] Demo initialization threw', err);
+            this.clearInputSubsystems();
+
+            return false;
+        }
+    }
+
+    /**
+     * Validates that a duration is a finite, non-negative number.
+     *
+     * @param method - Calling method name for the error message.
+     * @param durationMs - Duration to validate.
+     * @throws Error if the duration is not finite or is negative.
+     */
+    private assertFiniteDuration(method: string, durationMs: number): void {
+        if (!Number.isFinite(durationMs) || durationMs < 0) {
+            throw new Error(`[BT] ${method}: durationMs must be a finite non-negative number, got ${durationMs}.`);
+        }
     }
 
     // #endregion

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -609,6 +609,10 @@ export class BTAPI {
         console.log(`[BT] Refreshed ${refreshed} sprite sheet(s) against current palette`);
     }
 
+    // #endregion
+
+    // #region Frame Capture API
+
     /**
      * Captures the next rendered frame as a PNG blob.
      * The capture occurs on the next completed render cycle.
@@ -624,6 +628,10 @@ export class BTAPI {
         return this.renderer.captureFrame();
     }
 
+    // #endregion
+
+    // #region Camera API
+
     /**
      * Sets the camera offset for scrolling effects.
      * The offset is applied to subsequent renderer draw calls.
@@ -633,10 +641,6 @@ export class BTAPI {
     public setCameraOffset(offset: Vector2i): void {
         this.renderer?.setCameraOffset(offset);
     }
-
-    // #endregion
-
-    // #region Camera API
 
     /**
      * Gets the current camera offset.
@@ -653,6 +657,10 @@ export class BTAPI {
     public resetCamera(): void {
         this.renderer?.resetCamera();
     }
+
+    // #endregion
+
+    // #region Palette Effects API
 
     /**
      * Starts rotating a range of palette entries at a constant speed.
@@ -693,10 +701,6 @@ export class BTAPI {
         this.assertFiniteDuration('paletteFade', durationMs);
         this.paletteEffects.add(new FadeEffect(this.palette, target, durationMs, easing));
     }
-
-    // #endregion
-
-    // #region Palette Effects API
 
     /**
      * Fades only a subset of palette indices toward a target over time.
@@ -863,19 +867,6 @@ export class BTAPI {
         }
     }
 
-    /**
-     * Validates that a duration is a finite, non-negative number.
-     *
-     * @param method - Calling method name for the error message.
-     * @param durationMs - Duration to validate.
-     * @throws Error if the duration is not finite or is negative.
-     */
-    private assertFiniteDuration(method: string, durationMs: number): void {
-        if (!Number.isFinite(durationMs) || durationMs < 0) {
-            throw new Error(`[BT] ${method}: durationMs must be a finite non-negative number, got ${durationMs}.`);
-        }
-    }
-
     // #endregion
 
     // #region Private Helpers
@@ -914,6 +905,19 @@ export class BTAPI {
         }
 
         this.spriteSheets.add(sheet);
+    }
+
+    /**
+     * Validates that a duration is a finite, non-negative number.
+     *
+     * @param method - Calling method name for the error message.
+     * @param durationMs - Duration to validate.
+     * @throws Error if the duration is not finite or is negative.
+     */
+    private assertFiniteDuration(method: string, durationMs: number): void {
+        if (!Number.isFinite(durationMs) || durationMs < 0) {
+            throw new Error(`[BT] ${method}: durationMs must be a finite non-negative number, got ${durationMs}.`);
+        }
     }
 
     /**

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -396,6 +396,10 @@ export class BTAPI {
         return this.gamepad;
     }
 
+    // #endregion
+
+    // #region Rendering API - Palette
+
     /**
      * Gets the active engine palette.
      *
@@ -426,6 +430,10 @@ export class BTAPI {
         this.renderer?.setPalette(palette);
     }
 
+    // #endregion
+
+    // #region Rendering API - Clear Operations
+
     /**
      * Sets the background clear color for each frame using a palette index.
      *
@@ -446,10 +454,6 @@ export class BTAPI {
         this.assertPaletteIndex(paletteIndex);
         this.renderer?.clearRect(rect, paletteIndex);
     }
-
-    // #endregion
-
-    // #region Rendering API - Clear Operations
 
     /**
      * Draws a single pixel at the specified position.
@@ -632,7 +636,7 @@ export class BTAPI {
 
     // #endregion
 
-    // #region Frame Capture API
+    // #region Camera API
 
     /**
      * Gets the current camera offset.
@@ -642,10 +646,6 @@ export class BTAPI {
     public getCameraOffset(): Vector2i {
         return this.renderer?.getCameraOffset() ?? Vector2i.zero();
     }
-
-    // #endregion
-
-    // #region Camera API
 
     /**
      * Resets the camera offset to (0, 0).
@@ -764,6 +764,10 @@ export class BTAPI {
         this.paletteEffects.clear();
     }
 
+    // #endregion
+
+    // #region Post-Process Effects API
+
     /**
      * Appends a fullscreen post-processing effect to the chain.
      *
@@ -814,7 +818,7 @@ export class BTAPI {
 
     // #endregion
 
-    // #region Post-Process Effects API
+    // #region Private — Initialization Helpers
 
     /**
      * Removes pointer, keyboard, and gamepad subsystems.

--- a/src/core/IBlitTechDemo.ts
+++ b/src/core/IBlitTechDemo.ts
@@ -60,7 +60,7 @@ export interface HardwareSettings {
  *
  * Engine lifecycle order:
  * 1. queryHardware() - Called first to configure display/FPS
- * 2. initialize() - Called after WebGPU setup, load assets here
+ * 2. init() - Called after WebGPU setup, load assets here
  * 3. update() - Fixed timestep via accumulator (may run 0..N times per frame)
  * 4. render() - Called once per requestAnimationFrame (browser refresh rate)
  */
@@ -79,7 +79,7 @@ export interface IBlitTechDemo {
      *
      * @returns Promise that resolves to true if successful, false to abort.
      */
-    initialize(): Promise<boolean>;
+    init(): Promise<boolean>;
 
     /**
      * Called zero or more times per frame at the fixed timestep declared by

--- a/src/core/WebGPUContext.test.ts
+++ b/src/core/WebGPUContext.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for {@link initializeWebGPU}.
+ * Unit tests for {@link initWebGPU}.
  *
  * Covers the WebGPU bootstrap path used during engine initialization:
  * - graceful failure when WebGPU support, adapters, devices, or canvas context
@@ -19,7 +19,7 @@ import {
     uninstallMockNavigatorGPU,
 } from '../__test__/webgpu-mock';
 import { Vector2i } from '../utils/Vector2i';
-import { initializeWebGPU } from './WebGPUContext';
+import { initWebGPU } from './WebGPUContext';
 
 // #region Helpers
 
@@ -34,7 +34,7 @@ function createMockCanvas(webgpuContext: unknown = createMockGPUCanvasContext())
 
 // #endregion
 
-describe('initializeWebGPU', () => {
+describe('initWebGPU', () => {
     const displaySize = new Vector2i(320, 240);
 
     afterEach(() => {
@@ -53,7 +53,7 @@ describe('initializeWebGPU', () => {
         });
 
         const canvas = createMockCanvas();
-        const result = await initializeWebGPU(canvas, displaySize);
+        const result = await initWebGPU(canvas, displaySize);
 
         expect(result).toBeNull();
     });
@@ -76,7 +76,7 @@ describe('initializeWebGPU', () => {
         });
 
         const canvas = createMockCanvas();
-        const result = await initializeWebGPU(canvas, displaySize);
+        const result = await initWebGPU(canvas, displaySize);
 
         expect(result).toBeNull();
     });
@@ -99,7 +99,7 @@ describe('initializeWebGPU', () => {
         });
 
         const canvas = createMockCanvas();
-        const result = await initializeWebGPU(canvas, displaySize);
+        const result = await initWebGPU(canvas, displaySize);
 
         expect(result).toBeNull();
     });
@@ -112,7 +112,7 @@ describe('initializeWebGPU', () => {
         installMockNavigatorGPU();
 
         const canvas = createMockCanvas(null);
-        const result = await initializeWebGPU(canvas, displaySize);
+        const result = await initWebGPU(canvas, displaySize);
 
         expect(result).toBeNull();
     });
@@ -126,7 +126,7 @@ describe('initializeWebGPU', () => {
 
         const canvas = createMockCanvas();
 
-        const result = await initializeWebGPU(canvas, displaySize);
+        const result = await initWebGPU(canvas, displaySize);
 
         expect(result).not.toBeNull();
         expect(result?.device).toBeDefined();
@@ -138,7 +138,7 @@ describe('initializeWebGPU', () => {
 
         const canvas = createMockCanvas();
 
-        await initializeWebGPU(canvas, displaySize);
+        await initWebGPU(canvas, displaySize);
 
         expect(canvas.width).toBe(320);
         expect(canvas.height).toBe(240);
@@ -150,7 +150,7 @@ describe('initializeWebGPU', () => {
         const canvas = createMockCanvas();
         const canvasDisplaySize = new Vector2i(640, 480);
 
-        await initializeWebGPU(canvas, displaySize, canvasDisplaySize);
+        await initWebGPU(canvas, displaySize, canvasDisplaySize);
 
         expect(canvas.style.width).toBe('640px');
         expect(canvas.style.height).toBe('480px');
@@ -161,7 +161,7 @@ describe('initializeWebGPU', () => {
 
         const canvas = createMockCanvas();
 
-        await initializeWebGPU(canvas, displaySize);
+        await initWebGPU(canvas, displaySize);
 
         expect(canvas.style.width).toBe('');
         expect(canvas.style.height).toBe('');

--- a/src/core/WebGPUContext.ts
+++ b/src/core/WebGPUContext.ts
@@ -37,7 +37,7 @@ export interface WebGPUContextResult {
  * @param canvasDisplaySize - Optional output drawing-buffer size in pixels.
  * @returns Initialized device, context, and drawing-buffer size, or null on failure.
  */
-export async function initializeWebGPU(
+export async function initWebGPU(
     canvas: HTMLCanvasElement,
     displaySize: Vector2i,
     canvasDisplaySize?: Vector2i,

--- a/src/input/GamepadInput.ts
+++ b/src/input/GamepadInput.ts
@@ -399,8 +399,6 @@ export class GamepadInput {
         return count;
     }
 
-    // #endregion
-
     // #region Private
 
     /**
@@ -718,6 +716,8 @@ export class GamepadInput {
             this.firstPressTick[i]?.clear();
         }
     }
+
+    // #endregion
 }
 
 // #endregion

--- a/src/input/KeyboardInput.ts
+++ b/src/input/KeyboardInput.ts
@@ -257,8 +257,6 @@ export class KeyboardInput {
         return codes.some((c) => this.prevHeld.has(c));
     }
 
-    // #endregion
-
     // #region Private
 
     /**
@@ -373,3 +371,5 @@ export class KeyboardInput {
 
     // #endregion
 }
+
+// #endregion

--- a/src/render/PrimitivePipeline.test.ts
+++ b/src/render/PrimitivePipeline.test.ts
@@ -67,7 +67,7 @@ describe('pre-initialization safety', () => {
         }).not.toThrow();
     });
 
-    it('drawRectFill() does not throw before initialize', () => {
+    it('drawRectFill() does not throw before init', () => {
         const pipeline = new PrimitivePipeline();
         const rect = new Rect2i(0, 0, 10, 10);
 
@@ -76,7 +76,7 @@ describe('pre-initialization safety', () => {
         }).not.toThrow();
     });
 
-    it('drawPixel() does not throw before initialize', () => {
+    it('drawPixel() does not throw before init', () => {
         const pipeline = new PrimitivePipeline();
         const pos = new Vector2i(5, 5);
 
@@ -85,7 +85,7 @@ describe('pre-initialization safety', () => {
         }).not.toThrow();
     });
 
-    it('drawPixelXY() does not throw before initialize', () => {
+    it('drawPixelXY() does not throw before init', () => {
         const pipeline = new PrimitivePipeline();
 
         expect(() => {
@@ -93,7 +93,7 @@ describe('pre-initialization safety', () => {
         }).not.toThrow();
     });
 
-    it('drawLine() with horizontal line does not throw before initialize', () => {
+    it('drawLine() with horizontal line does not throw before init', () => {
         const pipeline = new PrimitivePipeline();
         const p0 = new Vector2i(0, 10);
         const p1 = new Vector2i(100, 10);
@@ -103,7 +103,7 @@ describe('pre-initialization safety', () => {
         }).not.toThrow();
     });
 
-    it('drawLine() with vertical line does not throw before initialize', () => {
+    it('drawLine() with vertical line does not throw before init', () => {
         const pipeline = new PrimitivePipeline();
         const p0 = new Vector2i(10, 0);
         const p1 = new Vector2i(10, 100);
@@ -113,7 +113,7 @@ describe('pre-initialization safety', () => {
         }).not.toThrow();
     });
 
-    it('drawLine() with diagonal line does not throw before initialize', () => {
+    it('drawLine() with diagonal line does not throw before init', () => {
         const pipeline = new PrimitivePipeline();
         const p0 = new Vector2i(0, 0);
         const p1 = new Vector2i(50, 30);
@@ -123,7 +123,7 @@ describe('pre-initialization safety', () => {
         }).not.toThrow();
     });
 
-    it('drawRect() does not throw before initialize', () => {
+    it('drawRect() does not throw before init', () => {
         const pipeline = new PrimitivePipeline();
         const rect = new Rect2i(5, 5, 20, 20);
 
@@ -132,7 +132,7 @@ describe('pre-initialization safety', () => {
         }).not.toThrow();
     });
 
-    it('clearRect() does not throw before initialize', () => {
+    it('clearRect() does not throw before init', () => {
         const pipeline = new PrimitivePipeline();
         const rect = new Rect2i(0, 0, 100, 100);
 
@@ -155,7 +155,7 @@ describe('with initialized pipeline', () => {
 
         const paletteBuffer = createMockPaletteBuffer();
 
-        await pipeline.initialize(device, new Vector2i(320, 240), paletteBuffer);
+        await pipeline.init(device, new Vector2i(320, 240), paletteBuffer);
     });
 
     afterAll(() => {
@@ -267,7 +267,7 @@ describe('vertex count verification', () => {
 
         const paletteBuffer = createMockPaletteBuffer();
 
-        await pipeline.initialize(device, new Vector2i(320, 240), paletteBuffer);
+        await pipeline.init(device, new Vector2i(320, 240), paletteBuffer);
     });
 
     afterAll(() => {

--- a/src/render/PrimitivePipeline.ts
+++ b/src/render/PrimitivePipeline.ts
@@ -35,7 +35,7 @@ const VERTEX_STRIDE = VALUES_PER_VERTEX * 4;
 export class PrimitivePipeline {
     // #region State
 
-    /** WebGPU device, set during initialize(). */
+    /** WebGPU device, set during init(). */
     private device: GPUDevice | null = null;
 
     /** Render pipeline for palette-indexed geometry. */
@@ -91,7 +91,7 @@ export class PrimitivePipeline {
 
     /**
      * Creates an empty primitive pipeline.
-     * Call `initialize()` before encoding GPU work.
+     * Call `init()` before encoding GPU work.
      */
     constructor() {
         this.vertexArrayBuffer = new ArrayBuffer(MAX_PRIMITIVE_VERTICES * VERTEX_STRIDE);
@@ -110,7 +110,7 @@ export class PrimitivePipeline {
      * @param displaySize - Render target resolution in pixels.
      * @param paletteBuffer - Shared palette uniform buffer (256 x vec4f = 4096 bytes).
      */
-    async initialize(device: GPUDevice, displaySize: Vector2i, paletteBuffer: GPUBuffer): Promise<void> {
+    async init(device: GPUDevice, displaySize: Vector2i, paletteBuffer: GPUBuffer): Promise<void> {
         this.device = device;
         await this.createPipeline(displaySize, paletteBuffer);
     }
@@ -298,7 +298,7 @@ export class PrimitivePipeline {
         }
 
         // Upload all vertex data at once.
-        // Safe assertions: these resources are created in initialize() before any rendering.
+        // Safe assertions: these resources are created in init() before any rendering.
         (this.device as GPUDevice).queue.writeBuffer(
             this.vertexBuffer as GPUBuffer,
             0,

--- a/src/render/PrimitivePipeline.ts
+++ b/src/render/PrimitivePipeline.ts
@@ -338,6 +338,13 @@ export class PrimitivePipeline {
     private async createPipeline(displaySize: Vector2i, paletteBuffer: GPUBuffer): Promise<void> {
         const device = this.device as GPUDevice;
 
+        this.uniformBuffer?.destroy();
+        this.uniformBuffer = null;
+        this.vertexBuffer?.destroy();
+        this.vertexBuffer = null;
+        this.bindGroup = null;
+        this.pipeline = null;
+
         const shaderModule = device.createShaderModule({
             label: 'Primitive Shader',
             code: `

--- a/src/render/Renderer.test.ts
+++ b/src/render/Renderer.test.ts
@@ -216,7 +216,7 @@ describe('with initialized renderer', () => {
     beforeAll(async () => {
         installMockNavigatorGPU();
 
-        const result = await renderer.initialize();
+        const result = await renderer.init();
 
         expect(result).toBe(true);
 
@@ -227,9 +227,9 @@ describe('with initialized renderer', () => {
         uninstallMockNavigatorGPU();
     });
 
-    it('initialize returns true on success', async () => {
+    it('init returns true on success', async () => {
         const r = new Renderer(device, context, displaySize);
-        const result = await r.initialize();
+        const result = await r.init();
 
         expect(result).toBe(true);
     });
@@ -387,7 +387,7 @@ describe('resolveClearColor fallbacks', () => {
 
         installMockNavigatorGPU();
 
-        await r.initialize();
+        await r.init();
 
         // No setPalette() call — endFrame() resolves clear color to black via fallback.
         expect(() => r.endFrame()).not.toThrow();
@@ -400,7 +400,7 @@ describe('resolveClearColor fallbacks', () => {
 
         installMockNavigatorGPU();
 
-        await r.initialize();
+        await r.init();
 
         // Spy on the prototype so the reference stored by setPalette also throws.
         const getSpy = vi.spyOn(Palette.prototype, 'get').mockImplementation(() => {
@@ -462,7 +462,7 @@ describe('frame capture', () => {
             },
         );
 
-        await renderer.initialize();
+        await renderer.init();
         renderer.setPalette(createTestPalette());
 
         const promise = renderer.captureFrame();
@@ -498,7 +498,7 @@ describe('frame capture', () => {
 
         installMockNavigatorGPU();
 
-        await renderer.initialize();
+        await renderer.init();
         renderer.setPalette(createTestPalette());
 
         // Stub browser APIs for PNG conversion.
@@ -559,7 +559,7 @@ describe('frame capture', () => {
 
         installMockNavigatorGPU();
 
-        await renderer.initialize();
+        await renderer.init();
         renderer.setPalette(createTestPalette());
 
         renderer.beginFrame();
@@ -590,7 +590,7 @@ describe('endFrame error paths', () => {
 
         installMockNavigatorGPU();
 
-        await renderer.initialize();
+        await renderer.init();
         renderer.setPalette(createTestPalette());
 
         const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -634,7 +634,7 @@ describe('endFrame error paths', () => {
 
         installMockNavigatorGPU();
 
-        await renderer.initialize();
+        await renderer.init();
         renderer.setPalette(createTestPalette());
 
         const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -655,7 +655,7 @@ describe('endFrame error paths', () => {
     });
 });
 
-describe('initialize error paths', () => {
+describe('init error paths', () => {
     it('returns false when pipeline creation throws', async () => {
         const throwingDevice = {
             ...createMockGPUDevice(),
@@ -671,7 +671,7 @@ describe('initialize error paths', () => {
         const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
         try {
-            const result = await renderer.initialize();
+            const result = await renderer.init();
 
             expect(result).toBe(false);
             expect(errorSpy).toHaveBeenCalled();
@@ -715,7 +715,7 @@ describe('palette dirty-flag auto-propagation', () => {
 
         installMockNavigatorGPU();
 
-        await renderer.initialize();
+        await renderer.init();
 
         const palette = new Palette(16);
 
@@ -743,7 +743,7 @@ describe('palette dirty-flag auto-propagation', () => {
 
         installMockNavigatorGPU();
 
-        await renderer.initialize();
+        await renderer.init();
 
         const palette = new Palette(16);
 
@@ -777,7 +777,7 @@ describe('palette dirty-flag auto-propagation', () => {
 
         installMockNavigatorGPU();
 
-        await renderer.initialize();
+        await renderer.init();
 
         const palette = new Palette(16);
 
@@ -841,28 +841,28 @@ describe('post-process effects', () => {
         };
     }
 
-    it('addEffect throws before initialize', () => {
+    it('addEffect throws before init', () => {
         const r = new Renderer(createMockGPUDevice(), createMockGPUCanvasContext(), new Vector2i(320, 240));
 
         expect(() => r.addEffect(createStubEffect())).toThrow(/not initialized/);
     });
 
-    it('removeEffect throws before initialize', () => {
+    it('removeEffect throws before init', () => {
         const r = new Renderer(createMockGPUDevice(), createMockGPUCanvasContext(), new Vector2i(320, 240));
 
         expect(() => r.removeEffect(createStubEffect())).toThrow(/not initialized/);
     });
 
-    it('clearEffects throws before initialize', () => {
+    it('clearEffects throws before init', () => {
         const r = new Renderer(createMockGPUDevice(), createMockGPUCanvasContext(), new Vector2i(320, 240));
 
         expect(() => r.clearEffects()).toThrow(/not initialized/);
     });
 
-    it('addEffect / clearEffects work after initialize', async () => {
+    it('addEffect / clearEffects work after init', async () => {
         const r = new Renderer(createMockGPUDevice(), createMockGPUCanvasContext(), new Vector2i(320, 240));
 
-        await r.initialize();
+        await r.init();
 
         const effect = createStubEffect();
 
@@ -889,7 +889,7 @@ describe('post-process effects', () => {
 
         const r = new Renderer(device, createMockGPUCanvasContext(), new Vector2i(320, 240));
 
-        await r.initialize();
+        await r.init();
         r.setPalette(createTestPalette());
 
         r.beginFrame();
@@ -903,7 +903,7 @@ describe('post-process effects', () => {
         const device = createMockGPUDevice();
         const r = new Renderer(device, createMockGPUCanvasContext(), new Vector2i(320, 240));
 
-        await r.initialize();
+        await r.init();
         r.setPalette(createTestPalette());
 
         const effect = createStubEffect();
@@ -926,7 +926,7 @@ describe('post-process effects', () => {
         const device = createMockGPUDevice();
         const r = new Renderer(device, createMockGPUCanvasContext(), new Vector2i(320, 240));
 
-        await r.initialize();
+        await r.init();
         r.setPalette(createTestPalette());
 
         const effectA = createStubEffect();
@@ -969,7 +969,7 @@ describe('post-process effects', () => {
 
         const r = new Renderer(device, context, new Vector2i(320, 240));
 
-        await r.initialize();
+        await r.init();
         r.setPalette(createTestPalette());
 
         const effect = createStubEffect();
@@ -1019,7 +1019,7 @@ describe('post-process effects', () => {
 
         const r = new Renderer(device, context, new Vector2i(320, 240));
 
-        await r.initialize();
+        await r.init();
         r.setPalette(createTestPalette());
 
         r.beginFrame();

--- a/src/render/Renderer.test.ts
+++ b/src/render/Renderer.test.ts
@@ -127,7 +127,7 @@ describe('pre-initialization methods', () => {
 
 // #endregion
 
-// #region Camera
+// #region Camera API
 
 describe('camera operations', () => {
     it('getCameraOffset returns a copy, not the internal reference', () => {
@@ -418,7 +418,7 @@ describe('resolveClearColor fallbacks', () => {
 
 // #endregion
 
-// #region Frame Capture
+// #region Frame Capture API
 
 describe('frame capture', () => {
     it('captureFrame returns a promise', async () => {
@@ -803,7 +803,7 @@ describe('palette dirty-flag auto-propagation', () => {
 
 // #endregion
 
-// #region Post-Process Effects
+// #region Post-Process Effects API
 
 describe('post-process effects', () => {
     // Install/uninstall via beforeEach/afterEach so an assertion failure in any

--- a/src/render/Renderer.ts
+++ b/src/render/Renderer.ts
@@ -343,6 +343,10 @@ export class Renderer {
         this.submitFrame(commandEncoder, swapTexture);
     }
 
+    // #endregion
+
+    // #region Rendering API - Primitives
+
     /**
      * Draws a filled rectangle using two triangles.
      *
@@ -397,7 +401,7 @@ export class Renderer {
 
     // #endregion
 
-    // #region Rendering API - Primitives
+    // #region Rendering API - Sprites
 
     /**
      * Draws a sprite region from an indexed sprite sheet.
@@ -424,6 +428,10 @@ export class Renderer {
         this.sprites.drawBitmapText(font, pos, text, paletteOffset);
     }
 
+    // #endregion
+
+    // #region Frame Capture API
+
     /**
      * Captures the next rendered frame as a PNG blob.
      * The capture happens on the next `endFrame()` call.
@@ -434,6 +442,10 @@ export class Renderer {
     captureFrame(): Promise<Blob> {
         return this.frameCapture.requestCapture();
     }
+
+    // #endregion
+
+    // #region Camera API
 
     /**
      * Sets the camera offset for scrolling.
@@ -456,10 +468,6 @@ export class Renderer {
         return this.cameraOffset.clone();
     }
 
-    // #endregion
-
-    // #region Rendering API - Sprites
-
     /**
      * Resets the camera to the origin (0, 0).
      */
@@ -468,6 +476,10 @@ export class Renderer {
         this.primitives.setCameraOffset(this.cameraOffset);
         this.sprites.setCameraOffset(this.cameraOffset);
     }
+
+    // #endregion
+
+    // #region Post-Process Effects API
 
     /**
      * Appends a fullscreen post-processing effect to the chain matching its
@@ -497,10 +509,6 @@ export class Renderer {
         chain.add(effect);
     }
 
-    // #endregion
-
-    // #region Frame Capture API
-
     /**
      * Removes a previously registered post-processing effect.
      *
@@ -525,10 +533,6 @@ export class Renderer {
         }
     }
 
-    // #endregion
-
-    // #region Camera API
-
     /**
      * Removes every registered post-processing effect across both tiers.
      *
@@ -542,6 +546,10 @@ export class Renderer {
         this.pixelChain.clear();
         this.displayChain.clear();
     }
+
+    // #endregion
+
+    // #region Private — frame encoding
 
     /**
      * Tries to acquire the swap-chain texture and validate its dimensions.
@@ -583,10 +591,6 @@ export class Renderer {
             this.palette.clearDirty();
         }
     }
-
-    // #endregion
-
-    // #region Post-Process Effects API
 
     /**
      * Encodes the primitive + sprite scene render pass into the supplied target view.

--- a/src/render/Renderer.ts
+++ b/src/render/Renderer.ts
@@ -397,7 +397,7 @@ export class Renderer {
 
     // #endregion
 
-    // #region Primitive Drawing
+    // #region Rendering API - Primitives
 
     /**
      * Draws a sprite region from an indexed sprite sheet.
@@ -458,7 +458,7 @@ export class Renderer {
 
     // #endregion
 
-    // #region Sprite Drawing
+    // #region Rendering API - Sprites
 
     /**
      * Resets the camera to the origin (0, 0).
@@ -499,7 +499,7 @@ export class Renderer {
 
     // #endregion
 
-    // #region Frame Capture
+    // #region Frame Capture API
 
     /**
      * Removes a previously registered post-processing effect.
@@ -527,7 +527,7 @@ export class Renderer {
 
     // #endregion
 
-    // #region Camera
+    // #region Camera API
 
     /**
      * Removes every registered post-processing effect across both tiers.
@@ -586,7 +586,7 @@ export class Renderer {
 
     // #endregion
 
-    // #region Post-Process Effects
+    // #region Post-Process Effects API
 
     /**
      * Encodes the primitive + sprite scene render pass into the supplied target view.

--- a/src/render/Renderer.ts
+++ b/src/render/Renderer.ts
@@ -183,9 +183,9 @@ export class Renderer {
      *
      * @returns `true` when GPU resources are ready; otherwise `false`.
      */
-    async initialize(): Promise<boolean> {
+    async init(): Promise<boolean> {
         try {
-            // Release any GPU resources from a previous initialize() call (e.g.
+            // Release any GPU resources from a previous init() call (e.g.
             // device-loss recovery) so nothing leaks.
             this.paletteBuffer?.destroy();
             this.paletteBuffer = null;
@@ -208,14 +208,14 @@ export class Renderer {
 
             // Mark the palette dirty so the new buffer is populated on the first
             // endFrame(), even if the palette data has not changed since the last
-            // initialize() call (e.g. after a WebGPU device-loss recovery).
+            // init() call (e.g. after a WebGPU device-loss recovery).
             this.paletteDirty = true;
 
             // Primitive and sprite pipelines run at logical resolution. The
             // viewport is automatic since each pass binds a target view; only
             // the camera scaling here cares about logical size.
-            await this.primitives.initialize(this.device, this.displaySize, this.paletteBuffer);
-            await this.sprites.initialize(this.device, this.displaySize, this.paletteBuffer);
+            await this.primitives.init(this.device, this.displaySize, this.paletteBuffer);
+            await this.sprites.init(this.device, this.displaySize, this.paletteBuffer);
 
             this.swapFormat = navigator.gpu.getPreferredCanvasFormat();
 
@@ -343,6 +343,206 @@ export class Renderer {
     }
 
     /**
+     * Draws a filled rectangle using two triangles.
+     *
+     * @param rect - Rectangle bounds in pixel coordinates.
+     * @param paletteIndex - Palette color index.
+     */
+    drawRectFill(rect: Rect2i, paletteIndex: number): void {
+        this.primitives.drawRectFill(rect, paletteIndex);
+    }
+
+    /**
+     * Draws a single pixel as a 1x1 filled rectangle.
+     *
+     * @param pos - Pixel position.
+     * @param paletteIndex - Palette color index.
+     */
+    drawPixel(pos: Vector2i, paletteIndex: number): void {
+        this.drawPixelXYInternal(pos.x, pos.y, paletteIndex);
+    }
+
+    /**
+     * Draws a line using optimized quad rendering for axis-aligned lines,
+     * falling back to Bresenham's algorithm for diagonal lines.
+     *
+     * @param p0 - Start point.
+     * @param p1 - End point.
+     * @param paletteIndex - Palette color index.
+     */
+    drawLine(p0: Vector2i, p1: Vector2i, paletteIndex: number): void {
+        this.primitives.drawLine(p0, p1, paletteIndex);
+    }
+
+    /**
+     * Draws a rectangle outline using four 1-pixel quads.
+     *
+     * @param rect - Rectangle bounds.
+     * @param paletteIndex - Palette color index.
+     */
+    drawRect(rect: Rect2i, paletteIndex: number): void {
+        this.primitives.drawRect(rect, paletteIndex);
+    }
+
+    /**
+     * Fills a rectangular region with a palette-indexed color.
+     *
+     * @param rect - Region to fill in pixel coordinates.
+     * @param paletteIndex - Palette color index.
+     */
+    clearRect(rect: Rect2i, paletteIndex: number): void {
+        this.primitives.clearRect(rect, paletteIndex);
+    }
+
+    // #endregion
+
+    // #region Primitive Drawing
+
+    /**
+     * Draws a sprite region from an indexed sprite sheet.
+     *
+     * @param spriteSheet - Source sprite sheet (must have been indexized).
+     * @param srcRect - Region to copy from the sprite sheet.
+     * @param destPos - Screen position to draw at.
+     * @param paletteOffset - Palette index offset applied at draw time (default 0).
+     */
+    drawSprite(spriteSheet: SpriteSheet, srcRect: Rect2i, destPos: Vector2i, paletteOffset: number = 0): void {
+        this.sprites.drawSprite(spriteSheet, srcRect, destPos, paletteOffset);
+    }
+
+    /**
+     * Draws text using a bitmap font through the indexed sprite pipeline.
+     * Renders each character as a textured sprite.
+     *
+     * @param font - Bitmap font with character glyphs (underlying sheet must be indexized).
+     * @param pos - Text position (top-left corner).
+     * @param text - String to render.
+     * @param paletteOffset - Palette index offset applied to all glyphs (default 0).
+     */
+    drawBitmapText(font: BitmapFont, pos: Vector2i, text: string, paletteOffset: number = 0): void {
+        this.sprites.drawBitmapText(font, pos, text, paletteOffset);
+    }
+
+    /**
+     * Captures the next rendered frame as a PNG blob.
+     * The capture happens on the next `endFrame()` call.
+     * If a capture is already pending, the previous one is rejected.
+     *
+     * @returns Promise resolving to a PNG Blob of the rendered frame.
+     */
+    captureFrame(): Promise<Blob> {
+        return this.frameCapture.requestCapture();
+    }
+
+    /**
+     * Sets the camera offset for scrolling.
+     * The offset is propagated to both internal pipelines.
+     *
+     * @param offset - Camera position in pixels.
+     */
+    setCameraOffset(offset: Vector2i): void {
+        this.cameraOffset = offset.clone();
+        this.primitives.setCameraOffset(this.cameraOffset);
+        this.sprites.setCameraOffset(this.cameraOffset);
+    }
+
+    /**
+     * Gets the current camera offset.
+     *
+     * @returns Copy of the current camera position.
+     */
+    getCameraOffset(): Vector2i {
+        return this.cameraOffset.clone();
+    }
+
+    // #endregion
+
+    // #region Sprite Drawing
+
+    /**
+     * Resets the camera to the origin (0, 0).
+     */
+    resetCamera(): void {
+        this.cameraOffset = Vector2i.zero();
+        this.primitives.setCameraOffset(this.cameraOffset);
+        this.sprites.setCameraOffset(this.cameraOffset);
+    }
+
+    /**
+     * Appends a fullscreen post-processing effect to the chain matching its
+     * declared {@link Effect.tier}.
+     *
+     * - `tier='pixel'` -> pixel chain (logical resolution).
+     * - `tier='display'` -> display chain (output resolution); requires
+     *   `canvasDisplaySize` to be set in `queryHardware()`.
+     *
+     * @param effect - Effect instance to append.
+     * @throws If the renderer has not been initialized.
+     * @throws If a `'display'` effect is added while the output drawing buffer
+     *   matches the logical display size (no canvasDisplaySize was set).
+     */
+    addEffect(effect: Effect): void {
+        if (!this.pixelChain || !this.displayChain) {
+            throw new Error('Renderer.addEffect: renderer not initialized.');
+        }
+
+        if (effect.tier === 'display' && !this.displayTierEnabled) {
+            throw new Error(
+                'Renderer.addEffect: display-tier effects require canvasDisplaySize to be set in queryHardware().',
+            );
+        }
+
+        const chain = effect.tier === 'pixel' ? this.pixelChain : this.displayChain;
+        chain.add(effect);
+    }
+
+    // #endregion
+
+    // #region Frame Capture
+
+    /**
+     * Removes a previously registered post-processing effect.
+     *
+     * Dispatches to the chain matching {@link Effect.tier}. If the effect is
+     * not found in the expected chain (e.g. it was never added), a defensive
+     * fallback tries the other chain. Removing an effect that was never added
+     * is a no-op.
+     *
+     * @param effect - Effect instance to remove.
+     * @throws If the renderer has not been initialized.
+     */
+    removeEffect(effect: Effect): void {
+        if (!this.pixelChain || !this.displayChain) {
+            throw new Error('Renderer.removeEffect: renderer not initialized.');
+        }
+
+        const [primary, fallback] =
+            effect.tier === 'pixel' ? [this.pixelChain, this.displayChain] : [this.displayChain, this.pixelChain];
+
+        if (!primary.remove(effect)) {
+            fallback.remove(effect);
+        }
+    }
+
+    // #endregion
+
+    // #region Camera
+
+    /**
+     * Removes every registered post-processing effect across both tiers.
+     *
+     * @throws If the renderer has not been initialized.
+     */
+    clearEffects(): void {
+        if (!this.pixelChain || !this.displayChain) {
+            throw new Error('Renderer.clearEffects: renderer not initialized.');
+        }
+
+        this.pixelChain.clear();
+        this.displayChain.clear();
+    }
+
+    /**
      * Tries to acquire the swap-chain texture and validate its dimensions.
      * Returns null and resets pipeline state when the texture is unavailable.
      *
@@ -382,6 +582,10 @@ export class Renderer {
             this.palette.clearDirty();
         }
     }
+
+    // #endregion
+
+    // #region Post-Process Effects
 
     /**
      * Encodes the primitive + sprite scene render pass into the supplied target view.
@@ -478,210 +682,6 @@ export class Renderer {
         // persisting across frames.
         this.primitives.reset();
         this.sprites.reset();
-    }
-
-    // #endregion
-
-    // #region Primitive Drawing
-
-    /**
-     * Draws a filled rectangle using two triangles.
-     *
-     * @param rect - Rectangle bounds in pixel coordinates.
-     * @param paletteIndex - Palette color index.
-     */
-    drawRectFill(rect: Rect2i, paletteIndex: number): void {
-        this.primitives.drawRectFill(rect, paletteIndex);
-    }
-
-    /**
-     * Draws a single pixel as a 1x1 filled rectangle.
-     *
-     * @param pos - Pixel position.
-     * @param paletteIndex - Palette color index.
-     */
-    drawPixel(pos: Vector2i, paletteIndex: number): void {
-        this.drawPixelXYInternal(pos.x, pos.y, paletteIndex);
-    }
-
-    /**
-     * Draws a line using optimized quad rendering for axis-aligned lines,
-     * falling back to Bresenham's algorithm for diagonal lines.
-     *
-     * @param p0 - Start point.
-     * @param p1 - End point.
-     * @param paletteIndex - Palette color index.
-     */
-    drawLine(p0: Vector2i, p1: Vector2i, paletteIndex: number): void {
-        this.primitives.drawLine(p0, p1, paletteIndex);
-    }
-
-    /**
-     * Draws a rectangle outline using four 1-pixel quads.
-     *
-     * @param rect - Rectangle bounds.
-     * @param paletteIndex - Palette color index.
-     */
-    drawRect(rect: Rect2i, paletteIndex: number): void {
-        this.primitives.drawRect(rect, paletteIndex);
-    }
-
-    /**
-     * Fills a rectangular region with a palette-indexed color.
-     *
-     * @param rect - Region to fill in pixel coordinates.
-     * @param paletteIndex - Palette color index.
-     */
-    clearRect(rect: Rect2i, paletteIndex: number): void {
-        this.primitives.clearRect(rect, paletteIndex);
-    }
-
-    // #endregion
-
-    // #region Sprite Drawing
-
-    /**
-     * Draws a sprite region from an indexed sprite sheet.
-     *
-     * @param spriteSheet - Source sprite sheet (must have been indexized).
-     * @param srcRect - Region to copy from the sprite sheet.
-     * @param destPos - Screen position to draw at.
-     * @param paletteOffset - Palette index offset applied at draw time (default 0).
-     */
-    drawSprite(spriteSheet: SpriteSheet, srcRect: Rect2i, destPos: Vector2i, paletteOffset: number = 0): void {
-        this.sprites.drawSprite(spriteSheet, srcRect, destPos, paletteOffset);
-    }
-
-    /**
-     * Draws text using a bitmap font through the indexed sprite pipeline.
-     * Renders each character as a textured sprite.
-     *
-     * @param font - Bitmap font with character glyphs (underlying sheet must be indexized).
-     * @param pos - Text position (top-left corner).
-     * @param text - String to render.
-     * @param paletteOffset - Palette index offset applied to all glyphs (default 0).
-     */
-    drawBitmapText(font: BitmapFont, pos: Vector2i, text: string, paletteOffset: number = 0): void {
-        this.sprites.drawBitmapText(font, pos, text, paletteOffset);
-    }
-
-    // #endregion
-
-    // #region Frame Capture
-
-    /**
-     * Captures the next rendered frame as a PNG blob.
-     * The capture happens on the next `endFrame()` call.
-     * If a capture is already pending, the previous one is rejected.
-     *
-     * @returns Promise resolving to a PNG Blob of the rendered frame.
-     */
-    captureFrame(): Promise<Blob> {
-        return this.frameCapture.requestCapture();
-    }
-
-    // #endregion
-
-    // #region Camera
-
-    /**
-     * Sets the camera offset for scrolling.
-     * The offset is propagated to both internal pipelines.
-     *
-     * @param offset - Camera position in pixels.
-     */
-    setCameraOffset(offset: Vector2i): void {
-        this.cameraOffset = offset.clone();
-        this.primitives.setCameraOffset(this.cameraOffset);
-        this.sprites.setCameraOffset(this.cameraOffset);
-    }
-
-    /**
-     * Gets the current camera offset.
-     *
-     * @returns Copy of the current camera position.
-     */
-    getCameraOffset(): Vector2i {
-        return this.cameraOffset.clone();
-    }
-
-    /**
-     * Resets the camera to the origin (0, 0).
-     */
-    resetCamera(): void {
-        this.cameraOffset = Vector2i.zero();
-        this.primitives.setCameraOffset(this.cameraOffset);
-        this.sprites.setCameraOffset(this.cameraOffset);
-    }
-
-    // #endregion
-
-    // #region Post-Process Effects
-
-    /**
-     * Appends a fullscreen post-processing effect to the chain matching its
-     * declared {@link Effect.tier}.
-     *
-     * - `tier='pixel'` -> pixel chain (logical resolution).
-     * - `tier='display'` -> display chain (output resolution); requires
-     *   `canvasDisplaySize` to be set in `queryHardware()`.
-     *
-     * @param effect - Effect instance to append.
-     * @throws If the renderer has not been initialized.
-     * @throws If a `'display'` effect is added while the output drawing buffer
-     *   matches the logical display size (no canvasDisplaySize was set).
-     */
-    addEffect(effect: Effect): void {
-        if (!this.pixelChain || !this.displayChain) {
-            throw new Error('Renderer.addEffect: renderer not initialized.');
-        }
-
-        if (effect.tier === 'display' && !this.displayTierEnabled) {
-            throw new Error(
-                'Renderer.addEffect: display-tier effects require canvasDisplaySize to be set in queryHardware().',
-            );
-        }
-
-        const chain = effect.tier === 'pixel' ? this.pixelChain : this.displayChain;
-        chain.add(effect);
-    }
-
-    /**
-     * Removes a previously registered post-processing effect.
-     *
-     * Dispatches to the chain matching {@link Effect.tier}. If the effect is
-     * not found in the expected chain (e.g. it was never added), a defensive
-     * fallback tries the other chain. Removing an effect that was never added
-     * is a no-op.
-     *
-     * @param effect - Effect instance to remove.
-     * @throws If the renderer has not been initialized.
-     */
-    removeEffect(effect: Effect): void {
-        if (!this.pixelChain || !this.displayChain) {
-            throw new Error('Renderer.removeEffect: renderer not initialized.');
-        }
-
-        const [primary, fallback] =
-            effect.tier === 'pixel' ? [this.pixelChain, this.displayChain] : [this.displayChain, this.pixelChain];
-
-        if (!primary.remove(effect)) {
-            fallback.remove(effect);
-        }
-    }
-
-    /**
-     * Removes every registered post-processing effect across both tiers.
-     *
-     * @throws If the renderer has not been initialized.
-     */
-    clearEffects(): void {
-        if (!this.pixelChain || !this.displayChain) {
-            throw new Error('Renderer.clearEffects: renderer not initialized.');
-        }
-
-        this.pixelChain.clear();
-        this.displayChain.clear();
     }
 
     // #endregion

--- a/src/render/Renderer.ts
+++ b/src/render/Renderer.ts
@@ -198,6 +198,7 @@ export class Renderer {
             this.sceneTex?.destroy();
             this.sceneTex = null;
             this.sceneTexView = null;
+            this.lastFrameMs = 0;
 
             // Create shared palette uniform buffer (256 entries x vec4f).
             this.paletteBuffer = this.device.createBuffer({

--- a/src/render/SpritePipeline.test.ts
+++ b/src/render/SpritePipeline.test.ts
@@ -81,7 +81,7 @@ describe('with initialized pipeline', () => {
     beforeAll(async () => {
         installMockNavigatorGPU();
 
-        await pipeline.initialize(device, new Vector2i(320, 240), createMockPaletteBuffer());
+        await pipeline.init(device, new Vector2i(320, 240), createMockPaletteBuffer());
     });
 
     afterAll(() => {
@@ -149,7 +149,7 @@ describe('drawSprite', () => {
     beforeAll(async () => {
         installMockNavigatorGPU();
 
-        await pipeline.initialize(device, new Vector2i(320, 240), createMockPaletteBuffer());
+        await pipeline.init(device, new Vector2i(320, 240), createMockPaletteBuffer());
     });
 
     afterAll(() => {
@@ -395,7 +395,7 @@ describe('drawBitmapText', () => {
     beforeAll(async () => {
         installMockNavigatorGPU();
 
-        await pipeline.initialize(device, new Vector2i(320, 240), createMockPaletteBuffer());
+        await pipeline.init(device, new Vector2i(320, 240), createMockPaletteBuffer());
     });
 
     afterAll(() => {

--- a/src/render/SpritePipeline.ts
+++ b/src/render/SpritePipeline.ts
@@ -36,7 +36,7 @@ const VERTEX_STRIDE = 20;
 export class SpritePipeline {
     // #region State
 
-    /** WebGPU device, set during initialize(). */
+    /** WebGPU device, set during init(). */
     private device: GPUDevice | null = null;
 
     /** Render pipeline for indexed sprites. */
@@ -104,7 +104,7 @@ export class SpritePipeline {
 
     /**
      * Creates an empty sprite pipeline.
-     * Call `initialize()` before encoding GPU work.
+     * Call `init()` before encoding GPU work.
      */
     constructor() {
         this.vertexArrayBuffer = new ArrayBuffer(MAX_SPRITE_VERTICES * VERTEX_STRIDE);
@@ -123,7 +123,7 @@ export class SpritePipeline {
      * @param displaySize - Render target resolution in pixels.
      * @param paletteBuffer - Shared palette uniform buffer (256 x vec4f).
      */
-    async initialize(device: GPUDevice, displaySize: Vector2i, paletteBuffer: GPUBuffer): Promise<void> {
+    async init(device: GPUDevice, displaySize: Vector2i, paletteBuffer: GPUBuffer): Promise<void> {
         this.device = device;
         this.paletteBuffer = paletteBuffer;
 
@@ -209,7 +209,7 @@ export class SpritePipeline {
         }
 
         // Upload all sprite vertices at once.
-        // Safe assertions: these resources are created in initialize() before any rendering.
+        // Safe assertions: these resources are created in init() before any rendering.
         (this.device as GPUDevice).queue.writeBuffer(
             this.vertexBuffer as GPUBuffer,
             0,
@@ -512,7 +512,7 @@ export class SpritePipeline {
             return existing;
         }
 
-        // Safe assertions: pipeline is created in initialize() before any drawing.
+        // Safe assertions: pipeline is created in init() before any drawing.
         const bindGroup = (this.device as GPUDevice).createBindGroup({
             label: 'Sprite Texture Bind Group',
             layout: (this.pipeline as GPURenderPipeline).getBindGroupLayout(1),

--- a/src/render/effects/FullscreenEffect.ts
+++ b/src/render/effects/FullscreenEffect.ts
@@ -48,35 +48,25 @@ export abstract class FullscreenEffect implements Effect {
 
     /** WGSL fragment shader source. Must declare `Params`, `src`, `samp`. */
     protected abstract readonly fragmentShader: string;
-
-    /** Writes the per-frame uniform values into {@link uniformData}. */
-    protected abstract writeUniforms(deltaMs: number, sourceSize: Vector2i): void;
+    protected device: GPUDevice | null = null;
 
     // #region GPU State
-
-    protected device: GPUDevice | null = null;
     protected pipeline: GPURenderPipeline | null = null;
     protected uniformBuffer: GPUBuffer | null = null;
     protected sampler: GPUSampler | null = null;
     protected bindGroupLayout: GPUBindGroupLayout | null = null;
-
     /**
      * Backing array for the uniform block. Lazily allocated in {@link init}
      * after subclass constants are set on `this`.
      */
     protected uniformData: Float32Array | null = null;
-
     /**
      * Per-source-view bind group cache. The chain ping-pongs between two
      * stable views, so a `WeakMap` keyed by view is safe.
      * Reassigned on every `dispose()` so stale bind groups are not reused
-     * after a re-initialize cycle.
+     * after a re-init cycle.
      */
     private bindGroups = new WeakMap<GPUTextureView, GPUBindGroup>();
-
-    // #endregion
-
-    // #region Effect lifecycle
 
     /**
      * Creates the GPU pipeline, uniform buffer, sampler, and bind-group layout.
@@ -125,6 +115,10 @@ export abstract class FullscreenEffect implements Effect {
             addressModeV: 'clamp-to-edge',
         });
     }
+
+    // #endregion
+
+    // #region Effect lifecycle
 
     /**
      * Calls {@link writeUniforms} then uploads the uniform block to the GPU.
@@ -186,6 +180,9 @@ export abstract class FullscreenEffect implements Effect {
         this.uniformData = null;
         this.bindGroups = new WeakMap();
     }
+
+    /** Writes the per-frame uniform values into {@link uniformData}. */
+    protected abstract writeUniforms(deltaMs: number, sourceSize: Vector2i): void;
 
     // #endregion
 

--- a/src/utils/Bootstrap.test.ts
+++ b/src/utils/Bootstrap.test.ts
@@ -6,7 +6,7 @@
  * Covers the DOM-facing startup flow:
  * - optional waiting for `DOMContentLoaded`
  * - WebGPU support validation and canvas lookup failures
- * - success and failure paths around `BTAPI.initialize()`
+ * - success and failure paths around `BTAPI.init()`
  * - default and custom canvas/container identifiers
  * - propagation of success and error callbacks
  *
@@ -30,7 +30,7 @@ class MockDemo implements IBlitTechDemo {
         return { displaySize: new Vector2i(320, 240), targetFPS: 60 };
     }
 
-    async initialize() {
+    async init() {
         return true;
     }
 
@@ -81,7 +81,7 @@ function unstubWebGPU(): void {
 
 describe('bootstrap', () => {
     beforeEach(() => {
-        vi.spyOn(BTAPI.instance, 'initialize').mockResolvedValue(true);
+        vi.spyOn(BTAPI.instance, 'init').mockResolvedValue(true);
         Object.defineProperty(document, 'readyState', { value: 'complete', writable: true, configurable: true });
     });
 
@@ -185,12 +185,12 @@ describe('bootstrap', () => {
     // #region Engine initialization
 
     describe('engine initialization', () => {
-        it('should return false and call onError when BTAPI.initialize returns false', async () => {
+        it('should return false and call onError when BTAPI.init returns false', async () => {
             setupDOM();
 
             stubWebGPU();
 
-            vi.spyOn(BTAPI.instance, 'initialize').mockResolvedValue(false);
+            vi.spyOn(BTAPI.instance, 'init').mockResolvedValue(false);
 
             const onError = vi.fn();
             const result = await bootstrap(MockDemo, { waitForDOMReady: false, onError });
@@ -199,12 +199,12 @@ describe('bootstrap', () => {
             expect(onError).toHaveBeenCalledOnce();
         });
 
-        it('should return false and call onError when BTAPI.initialize throws', async () => {
+        it('should return false and call onError when BTAPI.init throws', async () => {
             setupDOM();
 
             stubWebGPU();
 
-            vi.spyOn(BTAPI.instance, 'initialize').mockRejectedValue(new Error('Init exploded'));
+            vi.spyOn(BTAPI.instance, 'init').mockRejectedValue(new Error('Init exploded'));
 
             const onError = vi.fn();
             const result = await bootstrap(MockDemo, { waitForDOMReady: false, onError });
@@ -277,13 +277,13 @@ describe('bootstrap', () => {
     // #region Unexpected errors
 
     describe('unexpected errors', () => {
-        it('should return false when BTAPI.initialize throws synchronously', async () => {
+        it('should return false when BTAPI.init throws synchronously', async () => {
             setupDOM();
 
             stubWebGPU();
 
-            vi.spyOn(BTAPI.instance, 'initialize').mockImplementation(() => {
-                throw new Error('The synchronous throw from initialize');
+            vi.spyOn(BTAPI.instance, 'init').mockImplementation(() => {
+                throw new Error('The synchronous throw from init');
             });
 
             const onError = vi.fn();

--- a/src/utils/Bootstrap.ts
+++ b/src/utils/Bootstrap.ts
@@ -191,7 +191,7 @@ function validateCanvas(
  * @param onError - Optional error callback.
  * @returns BootstrapResult with success status.
  */
-async function initializeDemo(
+async function initDemo(
     DemoClass: DemoConstructor,
     canvas: HTMLCanvasElement,
     containerId: string,
@@ -203,7 +203,7 @@ async function initializeDemo(
     let initError: Error | undefined;
 
     try {
-        initialized = await BTAPI.instance.initialize(demo, canvas);
+        initialized = await BTAPI.instance.init(demo, canvas);
     } catch (err) {
         initError = err instanceof Error ? err : new Error(String(err));
         console.error('[BT] Engine initialization threw an unexpected error:', initError);
@@ -308,7 +308,7 @@ export async function bootstrap(DemoClass: DemoConstructor, options: BootstrapOp
                     canvas.focus();
                 }
 
-                const initResult = await initializeDemo(DemoClass, canvas, containerId, onSuccess, onError);
+                const initResult = await initDemo(DemoClass, canvas, containerId, onSuccess, onError);
 
                 success = initResult.success;
             }

--- a/tests/visual/fixtures/camera.html
+++ b/tests/visual/fixtures/camera.html
@@ -12,7 +12,7 @@
 
 <body>
     <div id="canvas-container">
-        <canvas id="blit-tech-canvas" width="320" height="240"></canvas>
+        <canvas height="240" id="blit-tech-canvas" width="320"></canvas>
     </div>
 
     <script type="module">
@@ -38,7 +38,7 @@
                 };
             }
 
-            async initialize() {
+            async init() {
                 const palette = new Palette(16);
                 palette.set(BLACK, Color32.black());
                 palette.set(RED, Color32.red());

--- a/tests/visual/fixtures/fonts.html
+++ b/tests/visual/fixtures/fonts.html
@@ -12,7 +12,7 @@
 
 <body>
     <div id="canvas-container">
-        <canvas id="blit-tech-canvas" width="320" height="240"></canvas>
+        <canvas height="240" id="blit-tech-canvas" width="320"></canvas>
     </div>
 
     <script type="module">
@@ -37,7 +37,7 @@
                 };
             }
 
-            async initialize() {
+            async init() {
                 const palette = new Palette(16);
                 palette.set(BLACK, Color32.black());
                 palette.set(RED, Color32.red());

--- a/tests/visual/fixtures/mixed.html
+++ b/tests/visual/fixtures/mixed.html
@@ -12,7 +12,7 @@
 
 <body>
     <div id="canvas-container">
-        <canvas id="blit-tech-canvas" width="320" height="240"></canvas>
+        <canvas height="240" id="blit-tech-canvas" width="320"></canvas>
     </div>
 
     <script type="module">
@@ -62,7 +62,7 @@
                 };
             }
 
-            async initialize() {
+            async init() {
                 const palette = new Palette(16);
                 palette.set(1,        new Color32(0,   0,   0,   255));
                 palette.set(2,        new Color32(255, 0,   0,   255));

--- a/tests/visual/fixtures/post-process.html
+++ b/tests/visual/fixtures/post-process.html
@@ -79,7 +79,7 @@
                 return cfg;
             }
 
-            async initialize() {
+            async init() {
                 const palette = new Palette(16);
                 palette.set(BLACK, Color32.black());
                 palette.set(RED, Color32.red());

--- a/tests/visual/fixtures/primitives.html
+++ b/tests/visual/fixtures/primitives.html
@@ -12,7 +12,7 @@
 
 <body>
     <div id="canvas-container">
-        <canvas id="blit-tech-canvas" width="320" height="240"></canvas>
+        <canvas height="240" id="blit-tech-canvas" width="320"></canvas>
     </div>
 
     <script type="module">
@@ -39,7 +39,7 @@
                 };
             }
 
-            async initialize() {
+            async init() {
                 // Create and activate a test palette.
                 const palette = new Palette(16);
                 palette.set(BLACK, Color32.black());

--- a/tests/visual/fixtures/sprites.html
+++ b/tests/visual/fixtures/sprites.html
@@ -12,7 +12,7 @@
 
 <body>
     <div id="canvas-container">
-        <canvas id="blit-tech-canvas" width="320" height="240"></canvas>
+        <canvas height="240" id="blit-tech-canvas" width="320"></canvas>
     </div>
 
     <script type="module">
@@ -31,7 +31,7 @@
 
         // Create a minimal 16x16 sprite sheet from a canvas.
         // 4 tiles of 8x8: red (top-left), green (top-right), blue (bottom-left), yellow (bottom-right).
-        // The colors used here must match the palette entries set in initialize().
+        // The colors used here must match the palette entries set in init().
         function createSpriteImage() {
             const c = document.createElement('canvas');
             c.width = 16;
@@ -72,7 +72,7 @@
                 };
             }
 
-            async initialize() {
+            async init() {
                 const palette = new Palette(16);
                 palette.set(BLACK,  new Color32(0,   0,   0,   255));
                 palette.set(RED,    new Color32(255, 0,   0,   255));


### PR DESCRIPTION
Renames IBlitTechDemo.initialize(), BT.initialize(), BTAPI.initialize(), Renderer.initialize(), PrimitivePipeline.initialize(), SpritePipeline.initialize(), and initializeWebGPU() to their shorter init equivalents. Updates all tests, visual fixtures, and docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes

This pull request renames the engine initialization API surface from initialize to init across lifecycle hooks, entry points, tests, visual fixtures, and docs.

### Public API Changes

- IBlitTechDemo.initialize() → IBlitTechDemo.init()
- BT.initialize() → BT.init()
- BTAPI.initialize() → BTAPI.init()
- initializeWebGPU() → initWebGPU()
- Renderer.initialize() → Renderer.init()
- PrimitivePipeline.initialize() → PrimitivePipeline.init()
- SpritePipeline.initialize() → SpritePipeline.init()

### Implementation Details

- BTAPI initialization flow updated to call the new init() helpers and rename internal helpers (e.g., runDemoInitialize → runDemoInit / initializeDemo → initDemo).
- WebGPU startup entrypoint renamed and re-exported as initWebGPU; call sites updated.
- Renderer.init preserves prior control flow for GPU resource lifecycle (dispose/recreate palette buffers, post-process chains, scene textures) and reorganizes frame-encoding helpers under a dedicated private region. Init/re-init releases previous GPU resources to avoid leaks.
- PrimitivePipeline.init and SpritePipeline.init are the new GPU resource setup entrypoints. PrimitivePipeline.createPipeline now destroys and nulls existing uniform/vertex buffers, bind group, and pipeline before recreating to avoid leaking GPU resources on re-entrant init() calls.
- Region headers and file sectioning were standardized across BT, BTAPI, Renderer, pipelines, and input modules (reorganizes file regions and fixes region nesting for KeyboardInput and GamepadInput).
- Internal helpers and comments updated to use init() terminology (e.g., runDemoInit, initDemo, demo.init()).

### Testing Updates

- All affected test suites updated to use init(): BlitTech.test.ts, core/BTAPI.test.ts, core/WebGPUContext.test.ts, render/Renderer.test.ts, render/PrimitivePipeline.test.ts, render/SpritePipeline.test.ts, utils/Bootstrap.test.ts, and many effect/pipeline tests.
- Tests add/adjust coverage asserting that post-process API methods (addEffect/removeEffect/clearEffects) throw before init and work after init.
- Pipeline tests extended to cover pre-init safety for draw methods and preserve existing draw-vertex count and overflow behavior.
- WebGPU context tests changed to import and validate initWebGPU.

### Documentation Updates

- README, docs/input.md, docs/post-process-effects.md, CLAUDE.md, and other docs updated to use init() in examples and lifecycle descriptions.
- JSDoc/comments across affected files updated to instruct callers to use init() before encoding GPU work.

### Visual Fixtures

- Visual test fixtures in tests/visual/fixtures (camera.html, fonts.html, mixed.html, post-process.html, primitives.html, sprites.html) updated to rename demo lifecycle methods to init(); some canvas attribute ordering/explicit height attributes were standardized.

### Other Notes

- No behavioral changes to public APIs beyond the renames; the refactor focuses on renaming, cleaning up re-init paths, and preventing GPU resource leaks during repeated initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->