### PR TITLE
feat(assets): add SpriteSheet dimension accessors and fullRect helper

### DIFF
--- a/src/assets/SpriteSheet.test.ts
+++ b/src/assets/SpriteSheet.test.ts
@@ -83,6 +83,22 @@ describe('SpriteSheet', () => {
             expect(sheet.size.x).toBe(256);
             expect(sheet.size.y).toBe(256);
         });
+
+        it('should expose width and height accessors', () => {
+            const sheet = new SpriteSheet(mockImage);
+            expect(sheet.width).toBe(256);
+            expect(sheet.height).toBe(256);
+        });
+
+        it('should return a full-sheet source rectangle', () => {
+            const sheet = new SpriteSheet(mockImage);
+            const rect = sheet.fullRect();
+
+            expect(rect.x).toBe(0);
+            expect(rect.y).toBe(0);
+            expect(rect.width).toBe(256);
+            expect(rect.height).toBe(256);
+        });
     });
 
     // #endregion

--- a/src/assets/SpriteSheet.ts
+++ b/src/assets/SpriteSheet.ts
@@ -1,5 +1,5 @@
 import { Color32 } from '../utils/Color32';
-import type { Rect2i } from '../utils/Rect2i';
+import { Rect2i } from '../utils/Rect2i';
 import { Vector2i } from '../utils/Vector2i';
 import { AssetLoader } from './AssetLoader';
 import type { Palette } from './Palette';
@@ -450,6 +450,33 @@ export class SpriteSheet {
         }
 
         return this.image;
+    }
+
+    /**
+     * Gets the sprite-sheet width in pixels.
+     *
+     * @returns Sheet width in pixels.
+     */
+    get width(): number {
+        return this.size.x;
+    }
+
+    /**
+     * Gets the sprite-sheet height in pixels.
+     *
+     * @returns Sheet height in pixels.
+     */
+    get height(): number {
+        return this.size.y;
+    }
+
+    /**
+     * Returns a source rectangle that covers the entire sprite sheet.
+     *
+     * @returns Full-sheet source rectangle.
+     */
+    fullRect(): Rect2i {
+        return new Rect2i(0, 0, this.width, this.height);
     }
 
     /**


### PR DESCRIPTION
Expose SpriteSheet width and height getters and add fullRect() for whole-sheet source rectangles in sprite draw workflows. Add unit coverage for width/height and fullRect() behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR introduces new public accessor APIs to the `SpriteSheet` class to expose sprite-sheet dimensions and provide a convenience method for retrieving the full sheet as a source rectangle. These additions facilitate sprite draw workflows by making sheet dimensions readily accessible.

## Changes to SpriteSheet.ts

Added three new public members to the `SpriteSheet` class:
- `get width(): number` - Accessor exposing the sheet width
- `get height(): number` - Accessor exposing the sheet height  
- `fullRect(): Rect2i` - Method returning a rectangle spanning the entire sheet from `(0,0)` to `(width,height)`

The `Rect2i` import was updated from type-only to a runtime import to support constructing `Rect2i` instances in the `fullRect()` method.

## Test Coverage

Added test assertions validating the new public surface area:
- Tests for the `width` and `height` accessors
- Tests for the `fullRect()` method return value

Existing test coverage for UVs, texture caching/destroy behavior, image loading flows, palette index conversions, and palette color extraction remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->