### PR TITLE
fix(assets): rewrite asset load errors with beginner-friendly guidance

### DIFF
--- a/src/assets/AssetLoader.test.ts
+++ b/src/assets/AssetLoader.test.ts
@@ -177,7 +177,9 @@ describe('AssetLoader', () => {
         });
 
         it('should reject when the image fails to load', async () => {
-            await expect(AssetLoader.loadImage('fail.png')).rejects.toThrow('Failed to load image: fail.png');
+            await expect(AssetLoader.loadImage('fail.png')).rejects.toThrow(
+                "Can't find the image 'fail.png'. Make sure it's in your project folder and the path is correct.",
+            );
         });
 
         it('should not cache images that failed to load', async () => {
@@ -193,7 +195,19 @@ describe('AssetLoader', () => {
 
         it('should reject loadImages when any image fails', async () => {
             await expect(AssetLoader.loadImages(['ok.png', 'fail.png'])).rejects.toThrow(
-                'Failed to load image: fail.png',
+                "Can't find the image 'fail.png'. Make sure it's in your project folder and the path is correct.",
+            );
+        });
+
+        it('should include a path hint when an image URL is missing / or ./', async () => {
+            await expect(AssetLoader.loadImage('fail/sprites/hero.png')).rejects.toThrow(
+                "Did you mean '/images/fail/sprites/hero.png' or './images/fail/sprites/hero.png'?",
+            );
+        });
+
+        it('should suggest .png when a font extension is used for an image URL', async () => {
+            await expect(AssetLoader.loadImage('fail/sprites/hero.btfont')).rejects.toThrow(
+                "This looks like a font file. For images, use a file that ends with '.png'.",
             );
         });
     });

--- a/src/assets/AssetLoader.test.ts
+++ b/src/assets/AssetLoader.test.ts
@@ -210,6 +210,12 @@ describe('AssetLoader', () => {
                 "This looks like a font file. For images, use a file that ends with '.png'.",
             );
         });
+
+        it('should not suggest font extension fix for png URLs with query suffixes', async () => {
+            await expect(AssetLoader.loadImage('fail/sprites/hero.png?v=1')).rejects.not.toThrow(
+                "This looks like a font file. For images, use a file that ends with '.png'.",
+            );
+        });
     });
 
     // #endregion

--- a/src/assets/AssetLoader.ts
+++ b/src/assets/AssetLoader.ts
@@ -49,8 +49,17 @@ function buildImageHints(url: string): string {
         hints.push(`Did you mean '/images/${url}' or './images/${url}'?`);
     }
 
-    const slashIndex = url.lastIndexOf('/');
-    const fileName = slashIndex >= 0 ? url.slice(slashIndex + 1) : url;
+    const queryIndex = url.indexOf('?');
+    const hashIndex = url.indexOf('#');
+    let cleanUrl = url;
+    const cutIndex = queryIndex === -1 ? hashIndex : hashIndex === -1 ? queryIndex : Math.min(queryIndex, hashIndex);
+
+    if (cutIndex !== -1) {
+        cleanUrl = url.slice(0, cutIndex);
+    }
+
+    const slashIndex = cleanUrl.lastIndexOf('/');
+    const fileName = slashIndex >= 0 ? cleanUrl.slice(slashIndex + 1) : cleanUrl;
     const dotIndex = fileName.lastIndexOf('.');
     const extension = dotIndex >= 0 ? fileName.slice(dotIndex).toLowerCase() : '';
     const knownImageExtensions = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp']);

--- a/src/assets/AssetLoader.ts
+++ b/src/assets/AssetLoader.ts
@@ -18,6 +18,54 @@ const loadingPromises = new Map<string, Promise<HTMLImageElement>>();
 
 // #endregion
 
+// #region Error Helpers
+
+/**
+ * Returns whether a URL is absolute or uses a special browser scheme.
+ *
+ * @param url - Path or URL to inspect.
+ * @returns True when the URL already has an explicit scheme.
+ */
+function isExplicitUrl(url: string): boolean {
+    const lowerUrl = url.toLowerCase();
+    return (
+        lowerUrl.startsWith('//') ||
+        lowerUrl.includes('://') ||
+        lowerUrl.startsWith('data:') ||
+        lowerUrl.startsWith('blob:')
+    );
+}
+
+/**
+ * Appends beginner-friendly path and extension hints for image URLs.
+ *
+ * @param url - Failing image path.
+ * @returns Extra hint text (or empty string when no hint applies).
+ */
+function buildImageHints(url: string): string {
+    const hints: string[] = [];
+
+    if (!isExplicitUrl(url) && !url.startsWith('/') && !url.startsWith('./')) {
+        hints.push(`Did you mean '/images/${url}' or './images/${url}'?`);
+    }
+
+    const slashIndex = url.lastIndexOf('/');
+    const fileName = slashIndex >= 0 ? url.slice(slashIndex + 1) : url;
+    const dotIndex = fileName.lastIndexOf('.');
+    const extension = dotIndex >= 0 ? fileName.slice(dotIndex).toLowerCase() : '';
+    const knownImageExtensions = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp']);
+
+    if (extension === '.btfont') {
+        hints.push("This looks like a font file. For images, use a file that ends with '.png'.");
+    } else if (extension !== '' && !knownImageExtensions.has(extension)) {
+        hints.push(`The extension '${extension}' does not look like an image file. Did you mean '.png'?`);
+    }
+
+    return hints.length > 0 ? ` ${hints.join(' ')}` : '';
+}
+
+// #endregion
+
 /**
  * Shared image-loading utility for runtime asset code.
  *
@@ -67,7 +115,12 @@ export class AssetLoader {
 
             img.onerror = () => {
                 loadingPromises.delete(url);
-                reject(new Error(`Failed to load image: ${url}`));
+                reject(
+                    new Error(
+                        `Can't find the image '${url}'. Make sure it's in your project folder and the path is correct.` +
+                            buildImageHints(url),
+                    ),
+                );
             };
 
             img.src = url;

--- a/src/assets/BitmapFont.test.ts
+++ b/src/assets/BitmapFont.test.ts
@@ -267,7 +267,17 @@ describe('BitmapFont', () => {
         it('should throw when fetch returns a non-ok response', async () => {
             vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found' }));
 
-            await expect(BitmapFont.load('missing.btfont')).rejects.toThrow('Failed to load font');
+            await expect(BitmapFont.load('missing.btfont')).rejects.toThrow(
+                "Can't find the font file 'missing.btfont'",
+            );
+        });
+
+        it('should use a server-side message for non-404 font load failures', async () => {
+            vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500, statusText: 'Server Error' }));
+
+            await expect(BitmapFont.load('missing.btfont')).rejects.toThrow(
+                "The server had a problem loading the font file 'missing.btfont'. Try refreshing the page.",
+            );
         });
 
         it('should throw when font JSON is missing the texture field', async () => {
@@ -285,7 +295,9 @@ describe('BitmapFont', () => {
                 }),
             );
 
-            await expect(BitmapFont.load('bad.btfont')).rejects.toThrow('Invalid font file');
+            await expect(BitmapFont.load('bad.btfont')).rejects.toThrow(
+                "The font file 'bad.btfont' is broken or not a valid .btfont file. Check that it's the right file.",
+            );
         });
 
         it('should throw when font JSON is missing the glyphs field', async () => {
@@ -303,7 +315,9 @@ describe('BitmapFont', () => {
                 }),
             );
 
-            await expect(BitmapFont.load('bad.btfont')).rejects.toThrow('Invalid font file');
+            await expect(BitmapFont.load('bad.btfont')).rejects.toThrow(
+                "The font file 'bad.btfont' is broken or not a valid .btfont file. Check that it's the right file.",
+            );
         });
 
         it('should throw when the font texture image fails to load', async () => {
@@ -316,7 +330,23 @@ describe('BitmapFont', () => {
                 }),
             );
 
-            await expect(BitmapFont.load('test.btfont')).rejects.toThrow('Failed to load font texture');
+            await expect(BitmapFont.load('test.btfont')).rejects.toThrow("Can't find the font texture image");
+        });
+
+        it('should suggest .btfont when the font URL extension is wrong', async () => {
+            vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found' }));
+
+            await expect(BitmapFont.load('missing.json')).rejects.toThrow(
+                "The extension '.json' looks wrong for this file. Did you mean '.btfont'?",
+            );
+        });
+
+        it('should suggest absolute and relative paths when font URL omits / or ./', async () => {
+            vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found' }));
+
+            await expect(BitmapFont.load('pixel-font.btfont')).rejects.toThrow(
+                "Did you mean '/fonts/pixel-font.btfont' or './fonts/pixel-font.btfont'?",
+            );
         });
 
         it('should resolve a relative texture path relative to the font URL', async () => {

--- a/src/assets/BitmapFont.ts
+++ b/src/assets/BitmapFont.ts
@@ -252,14 +252,17 @@ export class BitmapFont {
         const response = await fetch(url);
 
         if (!response.ok) {
-            throw new Error(`Failed to load font: ${url} (${response.status} ${response.statusText})`);
+            throw new Error(BitmapFont.buildFontLoadErrorMessage(url, response.status));
         }
 
         const data: FontFileData = await response.json();
 
         // Validate required fields.
         if (!data.texture || !data.glyphs) {
-            throw new Error(`Invalid font file: ${url} - missing texture or glyphs`);
+            throw new Error(
+                `The font file '${url}' is broken or not a valid .btfont file. Check that it's the right file.` +
+                    BitmapFont.buildExtensionHint(url, '.btfont'),
+            );
         }
 
         // Load texture – either from data URI or relative path.
@@ -324,6 +327,85 @@ export class BitmapFont {
         return BitmapFont.loadImage(textureUrl);
     }
 
+    /**
+     * Returns a user-friendly load error for a font request.
+     *
+     * @param url - Font file path that failed to load.
+     * @param status - HTTP status code from fetch.
+     * @returns Beginner-friendly message with useful hints.
+     */
+    private static buildFontLoadErrorMessage(url: string, status: number): string {
+        const statusMessage =
+            status === 404
+                ? `Can't find the font file '${url}'. Check that the file exists and the path is spelled correctly.`
+                : `The server had a problem loading the font file '${url}'. Try refreshing the page.`;
+
+        const hints: string[] = [];
+        const pathHint = BitmapFont.buildPathHint(url, 'fonts');
+        const extensionHint = BitmapFont.buildExtensionHint(url, '.btfont');
+
+        if (pathHint) {
+            hints.push(pathHint);
+        }
+
+        if (extensionHint) {
+            hints.push(extensionHint);
+        }
+
+        return hints.length > 0 ? `${statusMessage} ${hints.join(' ')}` : statusMessage;
+    }
+
+    /**
+     * Suggests common absolute and relative URL forms when the path looks ambiguous.
+     *
+     * @param url - Original URL string.
+     * @param folderName - Typical folder prefix to suggest.
+     * @returns Hint text or an empty string.
+     */
+    private static buildPathHint(url: string, folderName: string): string {
+        if (BitmapFont.isExplicitUrl(url) || url.startsWith('/') || url.startsWith('./')) {
+            return '';
+        }
+
+        return `Did you mean '/${folderName}/${url}' or './${folderName}/${url}'?`;
+    }
+
+    /**
+     * Suggests a corrected extension when the URL uses a different file type.
+     *
+     * @param url - Original URL string.
+     * @param expectedExtension - Extension that should be used.
+     * @returns Hint text or an empty string.
+     */
+    private static buildExtensionHint(url: string, expectedExtension: string): string {
+        const slashIndex = url.lastIndexOf('/');
+        const fileName = slashIndex >= 0 ? url.slice(slashIndex + 1) : url;
+        const dotIndex = fileName.lastIndexOf('.');
+        const extension = dotIndex >= 0 ? fileName.slice(dotIndex).toLowerCase() : '';
+
+        if (extension === '' || extension === expectedExtension) {
+            return '';
+        }
+
+        return `The extension '${extension}' looks wrong for this file. Did you mean '${expectedExtension}'?`;
+    }
+
+    /**
+     * Returns whether the URL already has an explicit scheme or protocol.
+     *
+     * @param url - URL to inspect.
+     * @returns True when no relative-path hint is needed.
+     */
+    private static isExplicitUrl(url: string): boolean {
+        const lowerUrl = url.toLowerCase();
+        return (
+            lowerUrl.startsWith('//') ||
+            lowerUrl.includes('://') ||
+            lowerUrl.startsWith('data:') ||
+            lowerUrl.startsWith('blob:')
+        );
+    }
+
     // #endregion
 
     // #region Glyph Access
@@ -339,7 +421,12 @@ export class BitmapFont {
             const image = new Image();
 
             image.onload = () => resolve(image);
-            image.onerror = () => reject(new Error(`Failed to load font texture: ${src.substring(0, 50)}`));
+            image.onerror = () =>
+                reject(
+                    new Error(
+                        `Can't find the font texture image '${src.substring(0, 50)}'. Check that the file exists and the path is spelled correctly.`,
+                    ),
+                );
 
             image.src = src;
         });

--- a/src/assets/BitmapFont.ts
+++ b/src/assets/BitmapFont.ts
@@ -379,7 +379,12 @@ export class BitmapFont {
      */
     private static buildExtensionHint(url: string, expectedExtension: string): string {
         const slashIndex = url.lastIndexOf('/');
-        const fileName = slashIndex >= 0 ? url.slice(slashIndex + 1) : url;
+        const rawFileName = slashIndex >= 0 ? url.slice(slashIndex + 1) : url;
+        const queryIndex = rawFileName.indexOf('?');
+        const hashIndex = rawFileName.indexOf('#');
+        const cutIndex =
+            queryIndex === -1 ? hashIndex : hashIndex === -1 ? queryIndex : Math.min(queryIndex, hashIndex);
+        const fileName = cutIndex === -1 ? rawFileName : rawFileName.slice(0, cutIndex);
         const dotIndex = fileName.lastIndexOf('.');
         const extension = dotIndex >= 0 ? fileName.slice(dotIndex).toLowerCase() : '';
 


### PR DESCRIPTION
Rewrite bitmap font and image loading errors to be clearer and more actionable for beginners, including status-specific font messages and friendlier invalid file wording.

Add common mistake hints for missing `/` or `./` path prefixes and wrong file extensions, and update asset loader/font tests to verify the new messaging behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR improves error messages for bitmap font and image asset loading to be more beginner-friendly and actionable.

### Changes in AssetLoader.ts

- Added isExplicitUrl(url) to detect absolute or special-scheme URLs.
- Added buildImageHints(url) to append beginner-friendly path and extension hints:
  - Suggests "/images/…" and "./images/…" when a URL omits leading '/' or './'.
  - Strips query/hash fragments before inspecting the extension so hints don't trigger for URLs like ".png?v=1".
  - Suggests using ".png" when the URL ends with a font extension (".btfont") or flags unknown non-image extensions.
- Updated AssetLoader.loadImage() to reject with:
  "Can't find the image '{url}'. Make sure it's in your project folder and the path is correct." plus any buildImageHints(url).

### Changes in BitmapFont.ts

- Added BitmapFont.buildFontLoadErrorMessage(url, status) to produce status-specific fetch failure messages:
  - 404 → "Can't find the font file '{url}'. Check that the file exists and the path is spelled correctly."
  - non-404 → "The server had a problem loading the font file '{url}'. Try refreshing the page."
  - Appends path and extension hints when applicable.
- Added BitmapFont.buildPathHint(url, folderName) to suggest "/{folder}/{url}" and "./{folder}/{url}" when the URL omits leading '/' or './' and is not explicit.
- Added BitmapFont.buildExtensionHint(url, expectedExtension) which:
  - Strips query/hash fragments before checking the extension.
  - Suggests the expected extension (e.g., ".btfont") when the current extension looks wrong.
- Added BitmapFont.isExplicitUrl(url) helper.
- Updated BitmapFont.load() and related error paths to use the new helpers:
  - Fetch failures use buildFontLoadErrorMessage.
  - Missing required fields throw: "The font file '{url}' is broken or not a valid .btfont file. Check that it's the right file." plus an extension hint when applicable.
  - Texture image load failures now produce a clearer "Can't find the font texture image" message.

### Test Updates

- src/assets/AssetLoader.test.ts:
  - Updated expectations to match the new image failure message and included hints.
  - Added assertions for path-prefix hints, font-extension suggestion, and a regression case ensuring extension hints do not trigger for image URLs with query suffixes.

- src/assets/BitmapFont.test.ts:
  - Updated/added tests to assert:
    - Status-specific fetch failure messages (404 vs non-404).
    - Error message for missing texture or glyphs fields.
    - Clear message when the font texture image fails to load.
    - Extension hint suggesting ".btfont" when the font URL has the wrong extension.
    - Path hint suggesting "/fonts/…" and "./fonts/…" when the font URL omits leading '/' or './'.
    - Relative texture paths are resolved relative to the .btfont file.

No public API signatures were changed; updates are limited to internal helpers, error messages, and tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->