### PR TITLE
fix(utils): rewrite Color32 fromHex errors with beginner-friendly guidance

### DIFF
--- a/src/utils/Color32.test.ts
+++ b/src/utils/Color32.test.ts
@@ -247,6 +247,9 @@ describe('fromUint32', () => {
 });
 
 describe('fromHex', () => {
+    const invalidHexMessage =
+        "isn't a valid hex color. Use a format like '#FF0000' (red), '#00FF00' (green), or '#0000FF' (blue). You can also use short form like '#F00'.";
+
     it('parses #RGB shorthand (expands nibbles)', () => {
         const c = Color32.fromHex('#F00');
         expect(c.r).toBe(255);
@@ -292,9 +295,21 @@ describe('fromHex', () => {
     });
 
     it('throws on invalid hex string', () => {
-        expect(() => Color32.fromHex('#XYZ')).toThrow('Invalid hex color');
-        expect(() => Color32.fromHex('#12')).toThrow('Invalid hex color');
-        expect(() => Color32.fromHex('#123456789')).toThrow('Invalid hex color');
+        expect(() => Color32.fromHex('#XYZ')).toThrow(invalidHexMessage);
+        expect(() => Color32.fromHex('#12')).toThrow(invalidHexMessage);
+        expect(() => Color32.fromHex('#123456789')).toThrow(invalidHexMessage);
+    });
+
+    it('throws the beginner-friendly message for invalid 6-digit format', () => {
+        expect(() => Color32.fromHex('#GGGGGG')).toThrow(invalidHexMessage);
+    });
+
+    it('throws the beginner-friendly message for invalid 8-digit alpha', () => {
+        expect(() => Color32.fromHex('#112233GG')).toThrow(invalidHexMessage);
+    });
+
+    it('throws the beginner-friendly message for invalid 4-digit shorthand alpha', () => {
+        expect(() => Color32.fromHex('#FFFZ')).toThrow(invalidHexMessage);
     });
 });
 

--- a/src/utils/Color32.test.ts
+++ b/src/utils/Color32.test.ts
@@ -304,8 +304,16 @@ describe('fromHex', () => {
         expect(() => Color32.fromHex('#GGGGGG')).toThrow(invalidHexMessage);
     });
 
+    it('throws when a 6-digit token contains trailing non-hex characters', () => {
+        expect(() => Color32.fromHex('#12345Z')).toThrow(invalidHexMessage);
+    });
+
     it('throws the beginner-friendly message for invalid 8-digit alpha', () => {
         expect(() => Color32.fromHex('#112233GG')).toThrow(invalidHexMessage);
+    });
+
+    it('throws when 8-digit alpha contains a non-hex character', () => {
+        expect(() => Color32.fromHex('#1122334Z')).toThrow(invalidHexMessage);
     });
 
     it('throws the beginner-friendly message for invalid 4-digit shorthand alpha', () => {

--- a/src/utils/Color32.ts
+++ b/src/utils/Color32.ts
@@ -259,7 +259,9 @@ export class Color32 {
             const rgb = parseInt(hex.substring(start, start + 6), 16);
 
             if (Number.isNaN(rgb)) {
-                throw new Error(`Invalid hex color: ${hex}`);
+                throw new Error(
+                    `The color '${hex}' isn't a valid hex color. Use a format like '#FF0000' (red), '#00FF00' (green), or '#0000FF' (blue). You can also use short form like '#F00'.`,
+                );
             }
 
             r = (rgb >> 16) & 0xff;
@@ -270,7 +272,9 @@ export class Color32 {
                 a = parseInt(hex.substring(start + 6, start + 8), 16);
 
                 if (Number.isNaN(a)) {
-                    throw new Error(`Invalid hex color: ${hex}`);
+                    throw new Error(
+                        `The color '${hex}' isn't a valid hex color. Use a format like '#FF0000' (red), '#00FF00' (green), or '#0000FF' (blue). You can also use short form like '#F00'.`,
+                    );
                 }
             }
         } else if (len === 3 || len === 4) {
@@ -279,7 +283,9 @@ export class Color32 {
             const rgb = parseInt(hex.substring(start, start + 3), 16);
 
             if (Number.isNaN(rgb)) {
-                throw new Error(`Invalid hex color: ${hex}`);
+                throw new Error(
+                    `The color '${hex}' isn't a valid hex color. Use a format like '#FF0000' (red), '#00FF00' (green), or '#0000FF' (blue). You can also use short form like '#F00'.`,
+                );
             }
 
             r = ((rgb >> 8) & 0xf) * 17;
@@ -290,13 +296,17 @@ export class Color32 {
                 const parsedA = parseInt(hex.charAt(start + 3), 16);
 
                 if (Number.isNaN(parsedA)) {
-                    throw new Error(`Invalid hex color: ${hex}`);
+                    throw new Error(
+                        `The color '${hex}' isn't a valid hex color. Use a format like '#FF0000' (red), '#00FF00' (green), or '#0000FF' (blue). You can also use short form like '#F00'.`,
+                    );
                 }
 
                 a = parsedA * 17;
             }
         } else {
-            throw new Error(`Invalid hex color: ${hex}`);
+            throw new Error(
+                `The color '${hex}' isn't a valid hex color. Use a format like '#FF0000' (red), '#00FF00' (green), or '#0000FF' (blue). You can also use short form like '#F00'.`,
+            );
         }
 
         // Validation passed, use unchecked factory.

--- a/src/utils/Color32.ts
+++ b/src/utils/Color32.ts
@@ -13,6 +13,9 @@ export const INV_255 = 1 / 255;
 /** Precomputed lookup table for byte-to-hex conversion. */
 const HEX_TABLE: string[] = new Array(256);
 
+/** Strict hex token validator used for exact substring checks in fromHex parsing. */
+const HEX_TOKEN_PATTERN = /^[0-9A-Fa-f]+$/;
+
 for (let i = 0; i < 256; i++) {
     // eslint-disable-next-line security/detect-object-injection
     HEX_TABLE[i] = i.toString(16).padStart(2, '0');
@@ -256,57 +259,31 @@ export class Color32 {
 
         if (len === 6 || len === 8) {
             // Parse RGB as a single integer, then extract bytes (reduces parseInt calls).
-            const rgb = parseInt(hex.substring(start, start + 6), 16);
-
-            if (Number.isNaN(rgb)) {
-                throw new Error(
-                    `The color '${hex}' isn't a valid hex color. Use a format like '#FF0000' (red), '#00FF00' (green), or '#0000FF' (blue). You can also use short form like '#F00'.`,
-                );
-            }
+            const rgb = parseHexToken(hex, start, 6);
 
             r = (rgb >> 16) & 0xff;
             g = (rgb >> 8) & 0xff;
             b = rgb & 0xff;
 
             if (len === 8) {
-                a = parseInt(hex.substring(start + 6, start + 8), 16);
-
-                if (Number.isNaN(a)) {
-                    throw new Error(
-                        `The color '${hex}' isn't a valid hex color. Use a format like '#FF0000' (red), '#00FF00' (green), or '#0000FF' (blue). You can also use short form like '#F00'.`,
-                    );
-                }
+                a = parseHexToken(hex, start + 6, 2);
             }
         } else if (len === 3 || len === 4) {
             // Parse RGB as a single integer, then extract nibbles and expand to bytes.
             // For a short hex, each digit represents a nibble that expands: F -> FF (0xF * 17 = 0xFF).
-            const rgb = parseInt(hex.substring(start, start + 3), 16);
-
-            if (Number.isNaN(rgb)) {
-                throw new Error(
-                    `The color '${hex}' isn't a valid hex color. Use a format like '#FF0000' (red), '#00FF00' (green), or '#0000FF' (blue). You can also use short form like '#F00'.`,
-                );
-            }
+            const rgb = parseHexToken(hex, start, 3);
 
             r = ((rgb >> 8) & 0xf) * 17;
             g = ((rgb >> 4) & 0xf) * 17;
             b = (rgb & 0xf) * 17;
 
             if (len === 4) {
-                const parsedA = parseInt(hex.charAt(start + 3), 16);
-
-                if (Number.isNaN(parsedA)) {
-                    throw new Error(
-                        `The color '${hex}' isn't a valid hex color. Use a format like '#FF0000' (red), '#00FF00' (green), or '#0000FF' (blue). You can also use short form like '#F00'.`,
-                    );
-                }
+                const parsedA = parseHexToken(hex, start + 3, 1);
 
                 a = parsedA * 17;
             }
         } else {
-            throw new Error(
-                `The color '${hex}' isn't a valid hex color. Use a format like '#FF0000' (red), '#00FF00' (green), or '#0000FF' (blue). You can also use short form like '#F00'.`,
-            );
+            throwInvalidHex(hex);
         }
 
         // Validation passed, use unchecked factory.
@@ -763,6 +740,35 @@ export function clampByte(n: number): number {
     // Bitwise operations: if n < 0, use 0; if n > 255, use 255; else truncate n.
     // This is faster than Math.max(0, Math.min(255, n)) | 0.
     return n < 0 ? 0 : n > 255 ? 255 : n | 0;
+}
+
+/**
+ * Throws a standardized beginner-friendly error for invalid hex colors.
+ *
+ * @param hex - Original input string.
+ */
+function throwInvalidHex(hex: string): never {
+    throw new Error(
+        `The color '${hex}' isn't a valid hex color. Use a format like '#FF0000' (red), '#00FF00' (green), or '#0000FF' (blue). You can also use short form like '#F00'.`,
+    );
+}
+
+/**
+ * Parses an exact-length hex substring and rejects partial/invalid tokens.
+ *
+ * @param hex - Original full hex string.
+ * @param start - Token start index in the full string.
+ * @param length - Expected token length.
+ * @returns Parsed base-16 number.
+ */
+function parseHexToken(hex: string, start: number, length: number): number {
+    const token = hex.substring(start, start + length);
+
+    if (token.length !== length || !HEX_TOKEN_PATTERN.test(token)) {
+        throwInvalidHex(hex);
+    }
+
+    return parseInt(token, 16);
 }
 
 // #endregion


### PR DESCRIPTION
Replace the Color32.fromHex() invalid-hex throw text with clearer, actionable wording and concrete valid examples for beginners.

Expand Color32.fromHex() invalid-input tests to cover each parsing failure branch while asserting the new guidance message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Color32.fromHex() error message improvements

Refactor Color32.fromHex() to validate hex substrings strictly and route all parsing failures through centralized helpers that throw a single, beginner-friendly error message. The new message lists accepted formats and gives concrete valid examples (#FF0000, #00FF00, #0000FF) and the short form (#F00), replacing the previous generic "Invalid hex color: ${hex}".

Parsing hardening:
- Enforce exact-length and hex-character checks for tokens so partially valid inputs (e.g. `#12345Z`) fail consistently rather than partially parsing.
- Consolidate failure handling via throwInvalidHex() + parseHexToken() helpers used for all supported formats (#RGB, #RGBA, #RRGGBB, #RRGGBBAA).

Tests:
- Expanded and refined invalid-input tests to cover each parsing-failure branch and assert the updated guidance message. Cases now include non-hex characters, too-short and too-long lengths, invalid 6-digit/8-digit forms (including non-hex trailing characters), invalid alpha in 8-digit forms, and invalid 4-digit shorthand alpha. Tests use a shared invalidHexMessage constant to assert message consistency.

Public API:
- No exported or public entity signatures were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->