### PR TITLE
fix(api): add beginner runtime guards and canvas error guidance

### DIFF
--- a/src/BlitTech.test.ts
+++ b/src/BlitTech.test.ts
@@ -15,6 +15,7 @@ import type { BitmapFont, HardwareSettings } from './BlitTech';
 import { BT, Palette, Rect2i, SpriteSheet, Vector2i } from './BlitTech';
 import { BTAPI } from './core/BTAPI';
 import type { FaceButtonCode } from './input/defaultKeyboardMap';
+import { DEFAULT_CONTAINER_ID } from './utils/BootstrapHelpers';
 
 // #region Helpers
 
@@ -22,6 +23,20 @@ const mockHardwareSettings = (displaySize = new Vector2i(320, 240), targetFPS = 
     displaySize,
     targetFPS,
 });
+
+function setupErrorContainer(): HTMLDivElement {
+    const container = document.createElement('div');
+    container.id = DEFAULT_CONTAINER_ID;
+    document.body.appendChild(container);
+    return container;
+}
+
+function clearErrorContainer(): void {
+    const container = document.getElementById(DEFAULT_CONTAINER_ID);
+    if (container?.parentElement) {
+        container.parentElement.removeChild(container);
+    }
+}
 
 // #endregion
 
@@ -280,6 +295,7 @@ describe('BT.paletteGet', () => {
 describe('BT.clear', () => {
     beforeEach(() => {
         vi.restoreAllMocks();
+        vi.spyOn(BTAPI.instance, 'getRenderer').mockReturnValue({} as never);
     });
 
     it('delegates to BTAPI.instance.setClearColor', () => {
@@ -294,6 +310,7 @@ describe('BT.clear', () => {
 describe('BT.clearRect', () => {
     beforeEach(() => {
         vi.restoreAllMocks();
+        vi.spyOn(BTAPI.instance, 'getRenderer').mockReturnValue({} as never);
     });
 
     it('delegates to BTAPI.instance.clearRect', () => {
@@ -313,6 +330,7 @@ describe('BT.clearRect', () => {
 describe('BT.drawPixel', () => {
     beforeEach(() => {
         vi.restoreAllMocks();
+        vi.spyOn(BTAPI.instance, 'getRenderer').mockReturnValue({} as never);
     });
 
     it('delegates to BTAPI.instance.drawPixel', () => {
@@ -323,11 +341,31 @@ describe('BT.drawPixel', () => {
 
         expect(spy).toHaveBeenCalledWith(pos, 2);
     });
+
+    it('supports (x, y, color) arguments', () => {
+        const spy = vi.spyOn(BTAPI.instance, 'drawPixel').mockReturnValue(undefined);
+
+        BT.drawPixel(5, 10, 3);
+
+        expect(spy).toHaveBeenCalledWith(expect.objectContaining({ x: 5, y: 10 }), 3);
+    });
+
+    it('shows a beginner-friendly error when drawPixel arguments are invalid', () => {
+        setupErrorContainer();
+
+        BT.drawPixel({} as never, 2 as never);
+
+        const text = document.getElementById(DEFAULT_CONTAINER_ID)?.textContent ?? '';
+        expect(text).toContain('drawPixel expects (x, y, color) or (Vector2i, Color32).');
+
+        clearErrorContainer();
+    });
 });
 
 describe('BT.drawLine', () => {
     beforeEach(() => {
         vi.restoreAllMocks();
+        vi.spyOn(BTAPI.instance, 'getRenderer').mockReturnValue({} as never);
     });
 
     it('delegates to BTAPI.instance.drawLine', () => {
@@ -344,6 +382,7 @@ describe('BT.drawLine', () => {
 describe('BT.drawRect', () => {
     beforeEach(() => {
         vi.restoreAllMocks();
+        vi.spyOn(BTAPI.instance, 'getRenderer').mockReturnValue({} as never);
     });
 
     it('delegates to BTAPI.instance.drawRect', () => {
@@ -359,6 +398,7 @@ describe('BT.drawRect', () => {
 describe('BT.drawRectFill', () => {
     beforeEach(() => {
         vi.restoreAllMocks();
+        vi.spyOn(BTAPI.instance, 'getRenderer').mockReturnValue({} as never);
     });
 
     it('delegates to BTAPI.instance.drawRectFill', () => {
@@ -915,6 +955,7 @@ describe('BT.keyReleased', () => {
 describe('BT.systemPrint', () => {
     beforeEach(() => {
         vi.restoreAllMocks();
+        vi.spyOn(BTAPI.instance, 'getRenderer').mockReturnValue({} as never);
     });
 
     it('delegates to BTAPI.instance.drawSystemText', () => {
@@ -955,6 +996,7 @@ describe('BT.systemPrintMeasure', () => {
 describe('BT.printFont', () => {
     beforeEach(() => {
         vi.restoreAllMocks();
+        vi.spyOn(BTAPI.instance, 'getRenderer').mockReturnValue({} as never);
     });
 
     it('delegates to BTAPI.instance.drawBitmapText', () => {
@@ -975,6 +1017,17 @@ describe('BT.printFont', () => {
         BT.printFont(font, new Vector2i(0, 0), 'Hi');
 
         expect(spy).toHaveBeenCalledWith(font, expect.anything(), 'Hi', undefined);
+    });
+
+    it('shows a missing await message for Promise font values', () => {
+        setupErrorContainer();
+
+        BT.printFont(Promise.resolve({}) as unknown as BitmapFont, new Vector2i(0, 0), 'Hi');
+
+        const text = document.getElementById(DEFAULT_CONTAINER_ID)?.textContent ?? '';
+        expect(text).toContain("Did you forget to use 'await' before BitmapFont.load()?");
+
+        clearErrorContainer();
     });
 });
 
@@ -1056,6 +1109,7 @@ describe('BT.drawSprite', () => {
 
     beforeEach(() => {
         vi.restoreAllMocks();
+        vi.spyOn(BTAPI.instance, 'getRenderer').mockReturnValue({} as never);
     });
 
     it('delegates to BTAPI.instance.drawSprite', () => {
@@ -1098,6 +1152,29 @@ describe('BT.drawSprite', () => {
             BT.drawSprite(sheet, new Rect2i(0, 0, 16, 16), new Vector2i(0, 0));
             BT.drawSprite(sheet, new Rect2i(16, 0, 16, 16), new Vector2i(20, 0));
         }).not.toThrow();
+    });
+
+    it('shows a missing await message for Promise sprite sheet values', () => {
+        setupErrorContainer();
+
+        BT.drawSprite(Promise.resolve({}) as unknown as SpriteSheet, new Rect2i(0, 0, 8, 8), new Vector2i(0, 0), 0);
+
+        const text = document.getElementById(DEFAULT_CONTAINER_ID)?.textContent ?? '';
+        expect(text).toContain("Did you forget to use 'await' before SpriteSheet.load()?");
+
+        clearErrorContainer();
+    });
+
+    it('shows engine-not-ready message when drawing before bootstrap completes', () => {
+        setupErrorContainer();
+        vi.spyOn(BTAPI.instance, 'getRenderer').mockReturnValue(null);
+
+        BT.drawSprite(new SpriteSheet(mockImage), new Rect2i(0, 0, 8, 8), new Vector2i(0, 0), 0);
+
+        const text = document.getElementById(DEFAULT_CONTAINER_ID)?.textContent ?? '';
+        expect(text).toContain("The engine isn't ready yet.");
+
+        clearErrorContainer();
     });
 });
 

--- a/src/BlitTech.test.ts
+++ b/src/BlitTech.test.ts
@@ -28,7 +28,7 @@ function setupErrorContainer(): HTMLDivElement {
     const existingContainer = document.getElementById(DEFAULT_CONTAINER_ID);
 
     if (existingContainer instanceof HTMLDivElement) {
-        existingContainer.innerHTML = '';
+        existingContainer.textContent = '';
         return existingContainer;
     }
 
@@ -42,6 +42,15 @@ function clearErrorContainer(): void {
     const container = document.getElementById(DEFAULT_CONTAINER_ID);
     if (container?.parentElement) {
         container.parentElement.removeChild(container);
+    }
+}
+
+async function withErrorContainer(callback: () => void | Promise<void>): Promise<void> {
+    setupErrorContainer();
+    try {
+        await callback();
+    } finally {
+        clearErrorContainer();
     }
 }
 
@@ -357,15 +366,13 @@ describe('BT.drawPixel', () => {
         expect(spy).toHaveBeenCalledWith(expect.objectContaining({ x: 5, y: 10 }), 3);
     });
 
-    it('shows a beginner-friendly error when drawPixel arguments are invalid', () => {
-        setupErrorContainer();
+    it('shows a beginner-friendly error when drawPixel arguments are invalid', async () => {
+        await withErrorContainer(async () => {
+            BT.drawPixel({} as never, 2 as never);
 
-        BT.drawPixel({} as never, 2 as never);
-
-        const text = document.getElementById(DEFAULT_CONTAINER_ID)?.textContent ?? '';
-        expect(text).toContain('drawPixel expects (x, y, paletteIndex) or (Vector2i, paletteIndex).');
-
-        clearErrorContainer();
+            const text = document.getElementById(DEFAULT_CONTAINER_ID)?.textContent ?? '';
+            expect(text).toContain('drawPixel expects (x, y, paletteIndex) or (Vector2i, paletteIndex).');
+        });
     });
 });
 
@@ -1026,15 +1033,13 @@ describe('BT.printFont', () => {
         expect(spy).toHaveBeenCalledWith(font, expect.anything(), 'Hi', undefined);
     });
 
-    it('shows a missing await message for Promise font values', () => {
-        setupErrorContainer();
+    it('shows a missing await message for Promise font values', async () => {
+        await withErrorContainer(async () => {
+            BT.printFont(Promise.resolve({}) as unknown as BitmapFont, new Vector2i(0, 0), 'Hi');
 
-        BT.printFont(Promise.resolve({}) as unknown as BitmapFont, new Vector2i(0, 0), 'Hi');
-
-        const text = document.getElementById(DEFAULT_CONTAINER_ID)?.textContent ?? '';
-        expect(text).toContain("Did you forget to use 'await' before BitmapFont.load()?");
-
-        clearErrorContainer();
+            const text = document.getElementById(DEFAULT_CONTAINER_ID)?.textContent ?? '';
+            expect(text).toContain("Did you forget to use 'await' before BitmapFont.load()?");
+        });
     });
 });
 
@@ -1161,27 +1166,24 @@ describe('BT.drawSprite', () => {
         }).not.toThrow();
     });
 
-    it('shows a missing await message for Promise sprite sheet values', () => {
-        setupErrorContainer();
+    it('shows a missing await message for Promise sprite sheet values', async () => {
+        await withErrorContainer(async () => {
+            BT.drawSprite(Promise.resolve({}) as unknown as SpriteSheet, new Rect2i(0, 0, 8, 8), new Vector2i(0, 0), 0);
 
-        BT.drawSprite(Promise.resolve({}) as unknown as SpriteSheet, new Rect2i(0, 0, 8, 8), new Vector2i(0, 0), 0);
-
-        const text = document.getElementById(DEFAULT_CONTAINER_ID)?.textContent ?? '';
-        expect(text).toContain("Did you forget to use 'await' before SpriteSheet.load()?");
-
-        clearErrorContainer();
+            const text = document.getElementById(DEFAULT_CONTAINER_ID)?.textContent ?? '';
+            expect(text).toContain("Did you forget to use 'await' before SpriteSheet.load()?");
+        });
     });
 
-    it('shows engine-not-ready message when drawing before bootstrap completes', () => {
-        setupErrorContainer();
-        vi.spyOn(BTAPI.instance, 'getRenderer').mockReturnValue(null);
+    it('shows engine-not-ready message when drawing before bootstrap completes', async () => {
+        await withErrorContainer(async () => {
+            vi.spyOn(BTAPI.instance, 'getRenderer').mockReturnValue(null);
 
-        BT.drawSprite(new SpriteSheet(mockImage), new Rect2i(0, 0, 8, 8), new Vector2i(0, 0), 0);
+            BT.drawSprite(new SpriteSheet(mockImage), new Rect2i(0, 0, 8, 8), new Vector2i(0, 0), 0);
 
-        const text = document.getElementById(DEFAULT_CONTAINER_ID)?.textContent ?? '';
-        expect(text).toContain("The engine isn't ready yet.");
-
-        clearErrorContainer();
+            const text = document.getElementById(DEFAULT_CONTAINER_ID)?.textContent ?? '';
+            expect(text).toContain("The engine isn't ready yet.");
+        });
     });
 });
 

--- a/src/BlitTech.test.ts
+++ b/src/BlitTech.test.ts
@@ -25,6 +25,13 @@ const mockHardwareSettings = (displaySize = new Vector2i(320, 240), targetFPS = 
 });
 
 function setupErrorContainer(): HTMLDivElement {
+    const existingContainer = document.getElementById(DEFAULT_CONTAINER_ID);
+
+    if (existingContainer instanceof HTMLDivElement) {
+        existingContainer.innerHTML = '';
+        return existingContainer;
+    }
+
     const container = document.createElement('div');
     container.id = DEFAULT_CONTAINER_ID;
     document.body.appendChild(container);
@@ -356,7 +363,7 @@ describe('BT.drawPixel', () => {
         BT.drawPixel({} as never, 2 as never);
 
         const text = document.getElementById(DEFAULT_CONTAINER_ID)?.textContent ?? '';
-        expect(text).toContain('drawPixel expects (x, y, color) or (Vector2i, Color32).');
+        expect(text).toContain('drawPixel expects (x, y, paletteIndex) or (Vector2i, paletteIndex).');
 
         clearErrorContainer();
     });

--- a/src/BlitTech.ts
+++ b/src/BlitTech.ts
@@ -77,6 +77,110 @@ function resetKeyboardFaceButtonMaps(): void {
 resetKeyboardFaceButtonMaps();
 
 /**
+ * Shows a beginner-friendly runtime error in the canvas container and console.
+ *
+ * @param message - Human-readable guidance to display.
+ * @param title - Short heading for the error panel.
+ */
+function showBeginnerRuntimeError(message: string, title: string = 'Demo Error'): void {
+    displayError(title, message);
+    console.error(`[BT] ${title}: ${message}`);
+}
+
+/**
+ * Returns whether the renderer has been initialized and can accept draw calls.
+ *
+ * @returns True when drawing APIs are ready to run.
+ */
+function isRendererReady(): boolean {
+    return BTAPI.instance.getRenderer() !== null;
+}
+
+/**
+ * Shows a friendly error when a draw call is made before bootstrap finishes.
+ *
+ * @param methodName - BT method name that was called too early.
+ */
+function reportEngineNotReady(methodName: string): void {
+    showBeginnerRuntimeError(
+        `Can't use BT.${methodName}() yet because the engine is still starting.\n` +
+            "The engine isn't ready yet. Make sure all drawing happens inside update() or render().",
+        'Engine Not Ready',
+    );
+}
+
+/**
+ * Converts an unknown runtime value into a concise display type label.
+ *
+ * @param value - Runtime value to inspect.
+ * @returns A short readable type description.
+ */
+function describeRuntimeType(value: unknown): string {
+    if (value === null) {
+        return 'null';
+    }
+
+    if (value === undefined) {
+        return 'undefined';
+    }
+
+    if (value instanceof Vector2i) {
+        return 'Vector2i';
+    }
+
+    if (value instanceof Rect2i) {
+        return 'Rect2i';
+    }
+
+    if (value instanceof Color32) {
+        return 'Color32';
+    }
+
+    if (value instanceof Promise) {
+        return 'Promise (missing await?)';
+    }
+
+    if (typeof value === 'object') {
+        const ctor = (value as { constructor?: { name?: string } }).constructor?.name;
+        return ctor && ctor.length > 0 ? ctor : 'object';
+    }
+
+    return typeof value;
+}
+
+/**
+ * Shows a friendly hint when a Promise was passed instead of an awaited asset.
+ *
+ * @param loadCall - Asset loader call name to reference in the message.
+ */
+function reportMissingAwait(loadCall: string): void {
+    showBeginnerRuntimeError(`Did you forget to use 'await' before ${loadCall}?`, 'Missing await');
+}
+
+/**
+ * Runs a draw call with readiness checks and beginner-friendly error handling.
+ *
+ * @param methodName - BT method name for contextual error text.
+ * @param callback - Draw-call body to execute.
+ */
+function executeDrawCall(methodName: string, callback: () => void): void {
+    if (!isRendererReady()) {
+        reportEngineNotReady(methodName);
+        return;
+    }
+
+    try {
+        callback();
+    } catch (error) {
+        if (error instanceof Error) {
+            showBeginnerRuntimeError(error.message);
+        } else {
+            showBeginnerRuntimeError(String(error));
+        }
+    }
+}
+
+/**
  * Returns runtime keyboard `KeyboardEvent.code` list for a face button and player,
  * or `null` when there is no keyboard fallback (e.g. players 2–3 for face buttons).
  *
@@ -581,7 +685,9 @@ export const BT = {
      * @param paletteIndex - Palette index for the full-screen clear pass.
      */
     clear: (paletteIndex: number): void => {
-        BTAPI.instance.setClearColor(paletteIndex);
+        executeDrawCall('clear', () => {
+            BTAPI.instance.setClearColor(paletteIndex);
+        });
     },
 
     /**
@@ -591,7 +697,9 @@ export const BT = {
      * @param paletteIndex - Palette color index.
      */
     clearRect: (rect: Rect2i, paletteIndex: number): void => {
-        BTAPI.instance.clearRect(rect, paletteIndex);
+        executeDrawCall('clearRect', () => {
+            BTAPI.instance.clearRect(rect, paletteIndex);
+        });
     },
 
     // #endregion
@@ -601,11 +709,38 @@ export const BT = {
     /**
      * Draws a single pixel.
      *
-     * @param pos - Target pixel in display coordinates.
-     * @param paletteIndex - Palette color index.
+     * Accepts either:
+     * - `(posOrX: Vector2i, yOrColor: number)` where `yOrColor` is the palette index.
+     * - `(posOrX: number, yOrColor: number, maybeColor: number)` for `(x, y, color)`.
+     *
+     * @param posOrX - Pixel position as `Vector2i`, or x coordinate when using numeric overload.
+     * @param yOrColor - Palette index for vector overload, or y coordinate for numeric overload.
+     * @param maybeColor - Palette index when using numeric overload.
      */
-    drawPixel: (pos: Vector2i, paletteIndex: number): void => {
-        BTAPI.instance.drawPixel(pos, paletteIndex);
+    drawPixel: (posOrX: Vector2i | number, yOrColor: number, maybeColor?: number): void => {
+        executeDrawCall('drawPixel', () => {
+            if (posOrX instanceof Vector2i && typeof yOrColor === 'number' && maybeColor === undefined) {
+                BTAPI.instance.drawPixel(posOrX, yOrColor);
+                return;
+            }
+
+            if (typeof posOrX === 'number' && typeof yOrColor === 'number' && typeof maybeColor === 'number') {
+                BTAPI.instance.drawPixel(new Vector2i(posOrX, yOrColor), maybeColor);
+                return;
+            }
+
+            const typeDetails = [
+                describeRuntimeType(posOrX),
+                describeRuntimeType(yOrColor),
+                describeRuntimeType(maybeColor),
+            ]
+                .filter((part) => part !== 'undefined')
+                .join(', ');
+            showBeginnerRuntimeError(
+                `drawPixel expects (x, y, color) or (Vector2i, Color32). Got: [${typeDetails}]`,
+                'Wrong drawPixel Arguments',
+            );
+        });
     },
 
     /**
@@ -618,7 +753,9 @@ export const BT = {
      * @param paletteIndex - Palette color index.
      */
     drawLine: (p0: Vector2i, p1: Vector2i, paletteIndex: number): void => {
-        BTAPI.instance.drawLine(p0, p1, paletteIndex);
+        executeDrawCall('drawLine', () => {
+            BTAPI.instance.drawLine(p0, p1, paletteIndex);
+        });
     },
 
     /**
@@ -628,7 +765,9 @@ export const BT = {
      * @param paletteIndex - Palette color index.
      */
     drawRect: (rect: Rect2i, paletteIndex: number): void => {
-        BTAPI.instance.drawRect(rect, paletteIndex);
+        executeDrawCall('drawRect', () => {
+            BTAPI.instance.drawRect(rect, paletteIndex);
+        });
     },
 
     /**
@@ -638,7 +777,9 @@ export const BT = {
      * @param paletteIndex - Palette color index.
      */
     drawRectFill: (rect: Rect2i, paletteIndex: number): void => {
-        BTAPI.instance.drawRectFill(rect, paletteIndex);
+        executeDrawCall('drawRectFill', () => {
+            BTAPI.instance.drawRectFill(rect, paletteIndex);
+        });
     },
 
     // #endregion
@@ -1105,7 +1246,9 @@ export const BT = {
      * @param text - String to render.
      */
     systemPrint: (pos: Vector2i, paletteIndex: number, text: string): void => {
-        BTAPI.instance.drawSystemText(pos, paletteIndex, text);
+        executeDrawCall('systemPrint', () => {
+            BTAPI.instance.drawSystemText(pos, paletteIndex, text);
+        });
     },
 
     /**
@@ -1143,7 +1286,14 @@ export const BT = {
      * @param paletteOffset - Shift added to every stored glyph index before palette lookup (default 0).
      */
     printFont: (font: BitmapFont, pos: Vector2i, text: string, paletteOffset?: number): void => {
-        BTAPI.instance.drawBitmapText(font, pos, text, paletteOffset);
+        executeDrawCall('printFont', () => {
+            if (font instanceof Promise) {
+                reportMissingAwait('BitmapFont.load()');
+                return;
+            }
+
+            BTAPI.instance.drawBitmapText(font, pos, text, paletteOffset);
+        });
     },
 
     // #endregion
@@ -1231,7 +1381,14 @@ export const BT = {
      * BT.drawSprite(sheet, new Rect2i(0, 0, 16, 16), new Vector2i(10, 10), 16); // blue team
      */
     drawSprite: (spriteSheet: SpriteSheet, srcRect: Rect2i, destPos: Vector2i, paletteOffset?: number): void => {
-        BTAPI.instance.drawSprite(spriteSheet, srcRect, destPos, paletteOffset);
+        executeDrawCall('drawSprite', () => {
+            if (spriteSheet instanceof Promise) {
+                reportMissingAwait('SpriteSheet.load()');
+                return;
+            }
+
+            BTAPI.instance.drawSprite(spriteSheet, srcRect, destPos, paletteOffset);
+        });
     },
 
     /**

--- a/src/BlitTech.ts
+++ b/src/BlitTech.ts
@@ -711,7 +711,7 @@ export const BT = {
      *
      * Accepts either:
      * - `(posOrX: Vector2i, yOrColor: number)` where `yOrColor` is the palette index.
-     * - `(posOrX: number, yOrColor: number, maybeColor: number)` for `(x, y, color)`.
+     * - `(posOrX: number, yOrColor: number, maybeColor: number)` for `(x, y, paletteIndex)`.
      *
      * @param posOrX - Pixel position as `Vector2i`, or x coordinate when using numeric overload.
      * @param yOrColor - Palette index for vector overload, or y coordinate for numeric overload.
@@ -720,7 +720,7 @@ export const BT = {
     drawPixel: (posOrX: Vector2i | number, yOrColor: number, maybeColor?: number): void => {
         executeDrawCall('drawPixel', () => {
             if (posOrX instanceof Vector2i && typeof yOrColor === 'number' && maybeColor === undefined) {
-                BTAPI.instance.drawPixel(posOrX, yOrColor);
+                BTAPI.instance.drawPixel(new Vector2i(posOrX.x, posOrX.y), yOrColor);
                 return;
             }
 
@@ -737,7 +737,7 @@ export const BT = {
                 .filter((part) => part !== 'undefined')
                 .join(', ');
             showBeginnerRuntimeError(
-                `drawPixel expects (x, y, color) or (Vector2i, Color32). Got: [${typeDetails}]`,
+                `drawPixel expects (x, y, paletteIndex) or (Vector2i, paletteIndex). Got: [${typeDetails}]`,
                 'Wrong drawPixel Arguments',
             );
         });

--- a/src/assets/AssetLoader.ts
+++ b/src/assets/AssetLoader.ts
@@ -126,7 +126,8 @@ export class AssetLoader {
                 loadingPromises.delete(url);
                 reject(
                     new Error(
-                        `Can't find the image '${url}'. Make sure it's in your project folder and the path is correct.` +
+                        `Can't find the image '${url}'. Make sure it's in your project folder and the path is correct. ` +
+                            'Check for typos, wrong letter casing, or a missing file extension.' +
                             buildImageHints(url),
                     ),
                 );

--- a/src/assets/BitmapFont.ts
+++ b/src/assets/BitmapFont.ts
@@ -429,7 +429,8 @@ export class BitmapFont {
             image.onerror = () =>
                 reject(
                     new Error(
-                        `Can't find the font texture image '${src.substring(0, 50)}'. Check that the file exists and the path is spelled correctly.`,
+                        `Can't find the font texture image '${src.substring(0, 50)}'. ` +
+                            'Check for typos, wrong letter casing, or a missing file extension.',
                     ),
                 );
 

--- a/src/utils/Bootstrap.test.ts
+++ b/src/utils/Bootstrap.test.ts
@@ -180,6 +180,37 @@ describe('bootstrap', () => {
     // #region Engine initialization
 
     describe('engine initialization', () => {
+        it('should return false and call onError when demo is missing render/update', async () => {
+            setupDOM();
+            stubWebGPU();
+
+            class BrokenDemo implements IBlitTechDemo {
+                async init() {
+                    return true;
+                }
+
+                // Intentionally invalid runtime shape for beginner-mistake detection.
+                 
+                update() {}
+                 
+                render() {}
+            }
+
+            (BrokenDemo.prototype as unknown as { update?: unknown }).update = undefined;
+
+            const onError = vi.fn();
+            const result = await bootstrap(BrokenDemo as unknown as new () => IBlitTechDemo, {
+                waitForDOMReady: false,
+                onError,
+            });
+
+            expect(result).toBe(false);
+            expect(onError).toHaveBeenCalledOnce();
+            expect(document.getElementById(DEFAULT_CONTAINER_ID)?.textContent ?? '').toContain(
+                'missing update() or render()',
+            );
+        });
+
         it('should return false and call onError when BTAPI.init returns false', async () => {
             setupDOM();
 

--- a/src/utils/Bootstrap.test.ts
+++ b/src/utils/Bootstrap.test.ts
@@ -183,6 +183,7 @@ describe('bootstrap', () => {
         it('should return false and call onError when demo is missing render/update', async () => {
             setupDOM();
             stubWebGPU();
+            const initSpy = vi.spyOn(BTAPI.instance, 'init');
 
             class BrokenDemo implements IBlitTechDemo {
                 async init() {
@@ -204,9 +205,12 @@ describe('bootstrap', () => {
 
             expect(result).toBe(false);
             expect(onError).toHaveBeenCalledOnce();
+            expect(initSpy).not.toHaveBeenCalled();
             expect(document.getElementById(DEFAULT_CONTAINER_ID)?.textContent ?? '').toContain(
                 'missing update() or render()',
             );
+
+            initSpy.mockRestore();
         });
 
         it('should return false and call onError when BTAPI.init returns false', async () => {

--- a/src/utils/Bootstrap.test.ts
+++ b/src/utils/Bootstrap.test.ts
@@ -190,9 +190,7 @@ describe('bootstrap', () => {
                 }
 
                 // Intentionally invalid runtime shape for beginner-mistake detection.
-                 
                 update() {}
-                 
                 render() {}
             }
 

--- a/src/utils/Bootstrap.ts
+++ b/src/utils/Bootstrap.ts
@@ -199,6 +199,17 @@ async function initDemo(
     onError?: (error: Error) => void,
 ): Promise<BootstrapResult> {
     const demo = new DemoClass();
+
+    if (typeof demo.update !== 'function' || typeof demo.render !== 'function') {
+        return handleBootstrapError(
+            'Demo Setup Error',
+            'Your Demo class is missing update() or render(). Add both methods so the engine knows what to run each frame.',
+            new Error('Demo class is missing update() or render()'),
+            containerId,
+            onError,
+        );
+    }
+
     let initialized: boolean;
     let initError: Error | undefined;
 


### PR DESCRIPTION
Detect common beginner mistakes at runtime and show actionable messages on the canvas for pre-bootstrap draw calls, missing await on asset loads, and invalid drawPixel argument shapes. Add bootstrap checks for missing update/ render methods and improve asset error text with typo/case/extension hints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds runtime guards that detect common beginner mistakes, surface actionable error messages on the canvas, and harden bootstrap-time validation and asset error reporting.

BlitTech.ts
- Adds shared runtime-error and draw-call helpers: showBeginnerRuntimeError, isRendererReady, reportEngineNotReady, describeRuntimeType, reportMissingAwait, and executeDrawCall.
- Routes rendering APIs through executeDrawCall to block pre-bootstrap calls, run draw logic inside try/catch, display beginner-friendly errors, and log details to console.
- BT.drawPixel now supports two overloads ((Vector2i, paletteIndex) and (x, y, paletteIndex)), validates argument shapes at runtime, and reports friendly errors for invalid calls instead of silently failing.
- BT.drawSprite and BT.printFont detect Promise values (likely from a missing await) and report a “Did you forget to use 'await'…” style message rather than passing unresolved Promises into the renderer.
- Other rendering APIs moved through the guard: BT.clear, BT.clearRect, BT.drawLine, BT.drawRect, BT.drawRectFill, BT.systemPrint, plus the updated BT.drawPixel/BT.printFont/BT.drawSprite.

Bootstrap.ts
- initDemo now validates that the demo instance provides both update() and render() and that they are functions. If validation fails, bootstrap returns a handled “Demo Setup Error”, displays it, invokes onError, and prevents engine initialization.

Asset error messages
- AssetLoader.loadImage and BitmapFont.loadTexture expand image-load failure messages with actionable hints for common issues (typos, incorrect letter casing, and missing file extensions), while preserving existing hint output.

Tests
- BlitTech.test.ts: imports DEFAULT_CONTAINER_ID and adds deterministic, finally-safe DOM helper(s) to mount/clear/remove a shared error message container to avoid DOM state leaks and sink warnings; stubs BTAPI.instance.getRenderer() in renderer-dependent tests to stabilize facade paths; extends drawPixel tests for both overloads and invalid-argument error assertions; adds async tests asserting missing-await messages for BT.printFont and BT.drawSprite and an “engine isn't ready yet” case when renderer is null.
- Bootstrap.test.ts: adds a test asserting bootstrap fails gracefully and displays a missing update()/render() error for malformed demo instances.
- Tests include small formatting/whitespace fixes and clearer messaging around drawPixel tests.

Public API change
- BT.drawPixel signature broadened to (posOrX: Vector2i | number, yOrColor: number, maybeColor?: number) to support both overloads.

Overall impact
- Improves developer experience by surfacing clear, in-canvas guidance for common beginner mistakes (pre-bootstrap draw calls, missing awaits, and invalid drawPixel usage), preventing initialization with malformed demos, and expanding asset-load error guidance. Tests updated to cover and stabilize these behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->