### PR TITLE
fix(api): sync error-preview wording and route GPU failures to canvas

### DIFF
--- a/src/core/BTAPI.test.ts
+++ b/src/core/BTAPI.test.ts
@@ -23,6 +23,7 @@ import type { BitmapFont } from '../assets/BitmapFont';
 import { Palette } from '../assets/Palette';
 import type { SpriteSheet } from '../assets/SpriteSheet';
 import type { Effect } from '../render/effects/Effect';
+import { WEBGPU_ADAPTER_MESSAGE } from '../utils/errorMessages';
 import { Rect2i } from '../utils/Rect2i';
 import { Vector2i } from '../utils/Vector2i';
 import { BTAPI } from './BTAPI';
@@ -315,7 +316,7 @@ describe('BTAPI', () => {
             expect(result).toBe(false);
         });
 
-        it('should return false when WebGPU adapter is unavailable', async () => {
+        it('should throw with WEBGPU_ADAPTER_MESSAGE when WebGPU adapter is unavailable', async () => {
             Object.defineProperty(globalThis, 'navigator', {
                 value: {
                     gpu: {
@@ -328,9 +329,7 @@ describe('BTAPI', () => {
                 configurable: true,
             });
 
-            const result = await BTAPI.instance.init(makeMockDemo(), makeMockCanvas());
-
-            expect(result).toBe(false);
+            await expect(BTAPI.instance.init(makeMockDemo(), makeMockCanvas())).rejects.toThrow(WEBGPU_ADAPTER_MESSAGE);
         });
 
         it('should return false when renderer initialization fails', async () => {

--- a/src/core/WebGPUContext.test.ts
+++ b/src/core/WebGPUContext.test.ts
@@ -18,6 +18,7 @@ import {
     installMockNavigatorGPU,
     uninstallMockNavigatorGPU,
 } from '../__test__/webgpu-mock';
+import { WEBGPU_ADAPTER_MESSAGE, WEBGPU_DEVICE_MESSAGE } from '../utils/errorMessages';
 import { Vector2i } from '../utils/Vector2i';
 import { initWebGPU } from './WebGPUContext';
 
@@ -62,7 +63,7 @@ describe('initWebGPU', () => {
 
     // #region Adapter failures
 
-    it('should return null when requestAdapter returns null', async () => {
+    it('should throw with WEBGPU_ADAPTER_MESSAGE when requestAdapter returns null', async () => {
         Object.defineProperty(globalThis, 'navigator', {
             value: {
                 gpu: {
@@ -76,12 +77,11 @@ describe('initWebGPU', () => {
         });
 
         const canvas = createMockCanvas();
-        const result = await initWebGPU(canvas, displaySize);
 
-        expect(result).toBeNull();
+        await expect(initWebGPU(canvas, displaySize)).rejects.toThrow(WEBGPU_ADAPTER_MESSAGE);
     });
 
-    it('should return null when requestDevice throws', async () => {
+    it('should throw with WEBGPU_DEVICE_MESSAGE when requestDevice throws', async () => {
         Object.defineProperty(globalThis, 'navigator', {
             value: {
                 gpu: {
@@ -99,9 +99,8 @@ describe('initWebGPU', () => {
         });
 
         const canvas = createMockCanvas();
-        const result = await initWebGPU(canvas, displaySize);
 
-        expect(result).toBeNull();
+        await expect(initWebGPU(canvas, displaySize)).rejects.toThrow(WEBGPU_DEVICE_MESSAGE);
     });
 
     // #endregion

--- a/src/core/WebGPUContext.ts
+++ b/src/core/WebGPUContext.ts
@@ -1,3 +1,4 @@
+import { WEBGPU_ADAPTER_MESSAGE, WEBGPU_DEVICE_MESSAGE } from '../utils/errorMessages';
 import type { Vector2i } from '../utils/Vector2i';
 
 // #region Types
@@ -35,7 +36,10 @@ export interface WebGPUContextResult {
  * @param canvas - HTML canvas element to configure for WebGPU rendering.
  * @param displaySize - Internal logical rendering resolution in pixels.
  * @param canvasDisplaySize - Optional output drawing-buffer size in pixels.
- * @returns Initialized device, context, and drawing-buffer size, or null on failure.
+ * @returns Initialized device, context, and drawing-buffer size, or null when WebGPU
+ *          is absent or the canvas context could not be obtained.
+ * @throws Error with a user-friendly message when the adapter or device cannot be
+ *         created (hardware acceleration disabled, drivers too old, resource exhaustion).
  */
 export async function initWebGPU(
     canvas: HTMLCanvasElement,
@@ -61,7 +65,7 @@ export async function initWebGPU(
         console.error('[BT]   3. Running in an incompatible environment (VM, remote desktop, etc.)');
         console.error('[BT] Browser:', navigator.userAgent);
 
-        return null;
+        throw new Error(WEBGPU_ADAPTER_MESSAGE);
     }
 
     // Request device.
@@ -72,7 +76,7 @@ export async function initWebGPU(
     } catch (err) {
         console.error('[BT] Failed to get WebGPU device:', err);
 
-        return null;
+        throw new Error(WEBGPU_DEVICE_MESSAGE, { cause: err });
     }
 
     // Drawing buffer = canvasDisplaySize when provided, else logical displaySize.

--- a/src/utils/Bootstrap.ts
+++ b/src/utils/Bootstrap.ts
@@ -17,6 +17,7 @@ import {
     getCanvas,
     getWebGPUInstructions,
 } from './BootstrapHelpers';
+import { CANVAS_NOT_FOUND_MESSAGE, INIT_FAILED_MESSAGE } from './errorMessages';
 
 // #region Types
 
@@ -75,10 +76,6 @@ interface BootstrapResult {
 function buildWebGPUNotSupportedMessage(): string {
     return getWebGPUInstructions(detectBrowser());
 }
-
-/** Error message for initialization failure. */
-const INIT_FAILED_MESSAGE =
-    'Something went wrong starting the engine. Check the browser console (press F12) for details.';
 
 // #endregion
 
@@ -171,7 +168,7 @@ function validateCanvas(
     } else {
         result = handleBootstrapError(
             'Canvas Error',
-            `Can't find the canvas on the page. Make sure your HTML has a <canvas id='${canvasId}'> element.`,
+            CANVAS_NOT_FOUND_MESSAGE(canvasId),
             new Error(`Canvas element '${canvasId}' not found`),
             containerId,
             onError,

--- a/src/utils/BootstrapHelpers.test.ts
+++ b/src/utils/BootstrapHelpers.test.ts
@@ -3,6 +3,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+    buildErrorPreviewEntries,
     checkWebGPUSupport,
     DEFAULT_CANVAS_ID,
     DEFAULT_CONTAINER_ID,
@@ -11,6 +12,12 @@ import {
     getCanvas,
     getWebGPUInstructions,
 } from './BootstrapHelpers';
+import {
+    CANVAS_NOT_FOUND_MESSAGE,
+    INIT_FAILED_MESSAGE,
+    WEBGPU_ADAPTER_MESSAGE,
+    WEBGPU_DEVICE_MESSAGE,
+} from './errorMessages';
 
 // #region Constants
 
@@ -268,6 +275,67 @@ describe('BootstrapHelpers', () => {
         it('should list supported browsers for an unknown browser', () => {
             const msg = getWebGPUInstructions({ name: 'unknown', version: 0 });
             expect(msg).toContain('Chrome 113');
+        });
+    });
+
+    // #endregion
+
+    // #region buildErrorPreviewEntries
+
+    describe('buildErrorPreviewEntries', () => {
+        it('canvas-not-found entry uses CANVAS_NOT_FOUND_MESSAGE', () => {
+            const entries = buildErrorPreviewEntries();
+            const entry = entries.find((e) => e.label === 'Canvas element not found');
+
+            expect(entry).toBeDefined();
+            expect(entry?.content).toBe(CANVAS_NOT_FOUND_MESSAGE(DEFAULT_CANVAS_ID));
+        });
+
+        it('init-failed entry text uses INIT_FAILED_MESSAGE', () => {
+            const entries = buildErrorPreviewEntries();
+            const entry = entries.find((e) => e.label === 'Initialization failed (with error)');
+
+            expect(entry).toBeDefined();
+
+            const content = entry?.content;
+
+            expect(typeof content).toBe('object');
+
+            if (typeof content === 'object' && content !== null && 'text' in content) {
+                expect(content.text).toBe(INIT_FAILED_MESSAGE);
+            }
+        });
+
+        it('adapter-unavailable entry uses WEBGPU_ADAPTER_MESSAGE in code slot', () => {
+            const entries = buildErrorPreviewEntries();
+            const entry = entries.find((e) => e.label === 'WebGPU adapter unavailable');
+
+            expect(entry).toBeDefined();
+
+            const content = entry?.content;
+
+            expect(typeof content).toBe('object');
+
+            if (typeof content === 'object' && content !== null && 'code' in content) {
+                expect(content.code).toBe(WEBGPU_ADAPTER_MESSAGE);
+                expect((content as { text: string }).text).toBe(INIT_FAILED_MESSAGE);
+            }
+        });
+
+        it('device-unavailable entry uses WEBGPU_DEVICE_MESSAGE in code slot', () => {
+            const entries = buildErrorPreviewEntries();
+            const entry = entries.find((e) => e.label === 'WebGPU device unavailable');
+
+            expect(entry).toBeDefined();
+
+            const content = entry?.content;
+
+            expect(typeof content).toBe('object');
+
+            if (typeof content === 'object' && content !== null && 'code' in content) {
+                expect(content.code).toBe(WEBGPU_DEVICE_MESSAGE);
+                expect((content as { text: string }).text).toBe(INIT_FAILED_MESSAGE);
+            }
         });
     });
 

--- a/src/utils/BootstrapHelpers.ts
+++ b/src/utils/BootstrapHelpers.ts
@@ -33,6 +33,13 @@ const FIREFOX_NIGHTLY_URL = 'https://www.mozilla.org/firefox/channel/desktop/';
 
 // #endregion
 
+import {
+    CANVAS_NOT_FOUND_MESSAGE,
+    INIT_FAILED_MESSAGE,
+    WEBGPU_ADAPTER_MESSAGE,
+    WEBGPU_DEVICE_MESSAGE,
+} from './errorMessages';
+
 // #region Module State
 
 /** Stored keydown handler for previewWebGPUErrors, used to remove the previous listener on re-entry. */
@@ -430,11 +437,14 @@ interface ErrorPreviewEntry {
 /**
  * Returns all distinct error message variants used by the engine.
  * Covers every browser/version branch of {@link getWebGPUInstructions} plus the
- * three non-WebGPU error types (canvas, initialization, unexpected).
+ * non-WebGPU error types (canvas, initialization, adapter, device, unexpected).
+ *
+ * Exported for testing: the test suite verifies that canvas / init-failed /
+ * adapter / device entries use the exact same strings as production bootstrap.
  *
  * @returns Array of preview entries, one per error variant.
  */
-function buildErrorPreviewEntries(): ReadonlyArray<ErrorPreviewEntry> {
+export function buildErrorPreviewEntries(): ReadonlyArray<ErrorPreviewEntry> {
     return [
         // WebGPU not supported — Chrome
         {
@@ -505,16 +515,30 @@ function buildErrorPreviewEntries(): ReadonlyArray<ErrorPreviewEntry> {
         {
             label: 'Canvas element not found',
             title: 'Canvas Error',
-            content:
-                "Failed to find the canvas element with the id 'blit-tech-canvas'.\n\n" +
-                'Make sure the HTML includes a canvas element with the correct ID.',
+            content: CANVAS_NOT_FOUND_MESSAGE(DEFAULT_CANVAS_ID),
         },
         {
             label: 'Initialization failed (with error)',
             title: 'Initialization Failed',
             content: {
-                text: 'The engine failed to initialize. Check the console for details.',
+                text: INIT_FAILED_MESSAGE,
                 code: "TypeError: Cannot read properties of undefined (reading 'requestDevice')",
+            },
+        },
+        {
+            label: 'WebGPU adapter unavailable',
+            title: 'Initialization Failed',
+            content: {
+                text: INIT_FAILED_MESSAGE,
+                code: WEBGPU_ADAPTER_MESSAGE,
+            },
+        },
+        {
+            label: 'WebGPU device unavailable',
+            title: 'Initialization Failed',
+            content: {
+                text: INIT_FAILED_MESSAGE,
+                code: WEBGPU_DEVICE_MESSAGE,
             },
         },
         {

--- a/src/utils/errorMessages.test.ts
+++ b/src/utils/errorMessages.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    CANVAS_NOT_FOUND_MESSAGE,
+    INIT_FAILED_MESSAGE,
+    WEBGPU_ADAPTER_MESSAGE,
+    WEBGPU_DEVICE_MESSAGE,
+} from './errorMessages';
+
+describe('errorMessages', () => {
+    describe('CANVAS_NOT_FOUND_MESSAGE', () => {
+        it('should interpolate the canvas ID into the message', () => {
+            expect(CANVAS_NOT_FOUND_MESSAGE('blit-tech-canvas')).toContain('blit-tech-canvas');
+        });
+
+        it('should produce different messages for different canvas IDs', () => {
+            expect(CANVAS_NOT_FOUND_MESSAGE('canvas-a')).not.toBe(CANVAS_NOT_FOUND_MESSAGE('canvas-b'));
+        });
+
+        it('should mention canvas element syntax', () => {
+            expect(CANVAS_NOT_FOUND_MESSAGE('my-canvas')).toContain('<canvas');
+        });
+    });
+
+    describe('INIT_FAILED_MESSAGE', () => {
+        it('should be a non-empty string', () => {
+            expect(typeof INIT_FAILED_MESSAGE).toBe('string');
+            expect(INIT_FAILED_MESSAGE.length).toBeGreaterThan(0);
+        });
+
+        it('should mention F12 for console access', () => {
+            expect(INIT_FAILED_MESSAGE).toContain('F12');
+        });
+    });
+
+    describe('WEBGPU_ADAPTER_MESSAGE', () => {
+        it('should be a non-empty string', () => {
+            expect(typeof WEBGPU_ADAPTER_MESSAGE).toBe('string');
+            expect(WEBGPU_ADAPTER_MESSAGE.length).toBeGreaterThan(0);
+        });
+
+        it('should mention hardware acceleration', () => {
+            expect(WEBGPU_ADAPTER_MESSAGE).toContain('hardware acceleration');
+        });
+    });
+
+    describe('WEBGPU_DEVICE_MESSAGE', () => {
+        it('should be a non-empty string', () => {
+            expect(typeof WEBGPU_DEVICE_MESSAGE).toBe('string');
+            expect(WEBGPU_DEVICE_MESSAGE.length).toBeGreaterThan(0);
+        });
+
+        it('should suggest closing other tabs or restarting', () => {
+            expect(WEBGPU_DEVICE_MESSAGE).toContain('closing other tabs');
+        });
+    });
+});

--- a/src/utils/errorMessages.ts
+++ b/src/utils/errorMessages.ts
@@ -1,0 +1,44 @@
+/**
+ * Shared user-facing error message strings for the Blit-Tech bootstrap path.
+ *
+ * Both the production bootstrap (Bootstrap.ts) and the error-preview demo
+ * (BootstrapHelpers.ts) import from here, guaranteeing they can never drift
+ * apart.
+ */
+
+/**
+ * Returns the canvas-not-found error message for the given canvas element ID.
+ *
+ * @param canvasId - The canvas element ID that was searched for.
+ * @returns User-facing error string.
+ */
+export function CANVAS_NOT_FOUND_MESSAGE(canvasId: string): string {
+    return `Can't find the canvas on the page. Make sure your HTML has a <canvas id='${canvasId}'> element.`;
+}
+
+/**
+ * Generic engine initialization failure message.
+ *
+ * Shown when the engine returns false for any reason not covered by a more
+ * specific GPU failure message.
+ */
+export const INIT_FAILED_MESSAGE =
+    'Something went wrong starting the engine. Check the browser console (press F12) for details.';
+
+/**
+ * Friendly message for a WebGPU adapter failure.
+ *
+ * Shown when `requestAdapter()` resolves to null (hardware acceleration
+ * disabled, drivers too old, or running in a VM / remote desktop).
+ */
+export const WEBGPU_ADAPTER_MESSAGE =
+    "Your computer's graphics card couldn't start WebGPU. Try updating your browser, or check that hardware acceleration is enabled.";
+
+/**
+ * Friendly message for a WebGPU device failure.
+ *
+ * Shown when `requestDevice()` rejects (GPU resource exhaustion or a
+ * transient driver error).
+ */
+export const WEBGPU_DEVICE_MESSAGE =
+    "Couldn't connect to the graphics card. Try closing other tabs or restarting the browser.";


### PR DESCRIPTION
Extract CANVAS_NOT_FOUND_MESSAGE, INIT_FAILED_MESSAGE, WEBGPU_ADAPTER_MESSAGE, and WEBGPU_DEVICE_MESSAGE into a new shared module (src/utils/errorMessages.ts) so Bootstrap.ts and the previewWebGPUErrors demo can never drift apart.

Bootstrap.ts and BootstrapHelpers.ts now both import from errorMessages.ts. The two stale strings in buildErrorPreviewEntries are replaced with the live constants.

WebGPUContext.ts adapter and device failures now throw typed Error objects carrying the friendly hardware messages instead of returning null. The throw propagates through BTAPI.init to Bootstrap's catch path, where the message appears in the error panel's code slot alongside INIT_FAILED_MESSAGE.

Two new preview entries added: "WebGPU adapter unavailable" and "WebGPU device unavailable", both mirroring the structure Bootstrap actually renders.

Tests updated throughout: WebGPUContext and BTAPI adapter tests now assert rejects.toThrow instead of toBeNull/toBe(false); new BootstrapHelpers tests pin each preview entry to its shared constant; errorMessages.test.ts covers all four exports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR centralizes error messaging and improves WebGPU failure handling by extracting shared error constants into a new module and routing GPU failures as thrown errors to the error panel.

## Key Changes

**New Module: `src/utils/errorMessages.ts`**
- Exports four shared error message constants and one function:
  - `CANVAS_NOT_FOUND_MESSAGE(canvasId)`: Function producing a canvas-not-found message with the requested element ID
  - `INIT_FAILED_MESSAGE`: Engine initialization failure message
  - `WEBGPU_ADAPTER_MESSAGE`: WebGPU adapter acquisition failure message  
  - `WEBGPU_DEVICE_MESSAGE`: WebGPU device connection/rejection failure message
- Serves as the single source of truth for error text across Bootstrap.ts and preview demos

**Error Handling in `src/core/WebGPUContext.ts`**
- Changes adapter and device acquisition failures from returning `null` to throwing typed `Error` objects:
  - Adapter failures: throws `new Error(WEBGPU_ADAPTER_MESSAGE)`
  - Device failures: throws `new Error(WEBGPU_DEVICE_MESSAGE, { cause: err })`
- These thrown errors propagate through BTAPI.init to Bootstrap's error handler
- Updated JSDoc to document that adapter/device failures throw user-friendly errors
- Preserves existing `null` returns for unsupported navigator.gpu and missing canvas context

**Bootstrap and Helpers Updates**
- `src/utils/Bootstrap.ts` now imports and uses `CANVAS_NOT_FOUND_MESSAGE` and `INIT_FAILED_MESSAGE` from the new module instead of defining them locally
- `src/utils/BootstrapHelpers.ts`:
  - Now imports all four error messages from errorMessages module
  - Exports `buildErrorPreviewEntries()` function (previously internal) for testability
  - Updates preview entries to use shared constants
  - Adds two new preview entries: "WebGPU adapter unavailable" and "WebGPU device unavailable"
  - Sets appropriate code/text values matching the actual error messages

**Test Updates**
- `src/core/BTAPI.test.ts` and `src/core/WebGPUContext.test.ts`: Updated assertions to expect `rejects.toThrow` with specific error messages instead of `toBeNull`/`toBe(false)` checks
- `src/utils/BootstrapHelpers.test.ts`: Adds new test suite for `buildErrorPreviewEntries()` with assertions verifying each preview entry uses the correct shared message constants
- `src/utils/errorMessages.test.ts`: New comprehensive test file verifying all four exported constants with checks for interpolation, content validation, and specific message properties

## Impact

GPU failures now display user-friendly messages directly in the error panel with consistent wording across all error surfaces, and all error messages are centrally managed to prevent inconsistencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->