### PR TITLE
feat(utils): add Rec.601 Color32 luminance accessor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,8 @@ Dual WebGPU pipeline architecture:
 
 - Prefer `SpriteSheet.loadIndexed(...)` for demo/game sprite setup; use manual `loadColorsIntoPalette` + `load` +
   `indexize` only for advanced flows
+- Prefer `Color32#luminance` for perceived brightness calculations instead of duplicating `0.299*r + 0.587*g + 0.114*b`
+  at call sites
 - Prefer fixed-step helpers `BT.deltaSeconds()` / `BT.timeSeconds()` over hardcoded `1 / TARGET_FPS` in update loops
 - Prefer `BT.cameraClamp(...)` (or `clampCameraToWorld(...)` in utility code) over ad-hoc clamp math
 

--- a/src/assets/Palette.test.ts
+++ b/src/assets/Palette.test.ts
@@ -56,7 +56,7 @@ describe('Palette', () => {
         expect(palette.get(5).equals(color)).toBe(true);
         expect(palette.get(5)).not.toBe(color);
         expect(() => palette.get(16)).toThrow('The color number 16 is too big');
-        expect(() => palette.set(-1, color)).toThrow('The color number -1 is too big');
+        expect(() => palette.set(-1, color)).toThrow('0 or higher');
     });
 
     it('get() returns a defensive copy — mutating the result does not change the stored entry', () => {

--- a/src/assets/SpriteSheet.test.ts
+++ b/src/assets/SpriteSheet.test.ts
@@ -434,6 +434,8 @@ describe('SpriteSheet', () => {
             expect(colors[0]?.b).toBe(30); // darkest first (blue)
             expect(colors[1]?.r).toBe(200); // red middle
             expect(colors[2]?.r).toBe(255); // brightest last (white)
+            expect(colors[0]?.luminance).toBeLessThanOrEqual(colors[1]?.luminance ?? 0);
+            expect(colors[1]?.luminance).toBeLessThanOrEqual(colors[2]?.luminance ?? 0);
         });
 
         it('preserves scan order when sort: "none"', async () => {

--- a/src/assets/SpriteSheet.ts
+++ b/src/assets/SpriteSheet.ts
@@ -161,7 +161,7 @@ export class SpriteSheet {
      * without throwing on missing colors.
      *
      * By default colors are sorted darkest-first by perceived luminance
-     * (`0.299*r + 0.587*g + 0.114*b`); pass `{ sort: 'none' }` to keep the
+     * ({@link Color32.luminance}); pass `{ sort: 'none' }` to keep the
      * row-major scan order of the source image.
      *
      * Image loading goes through {@link AssetLoader.loadImage}, so the call
@@ -228,9 +228,7 @@ export class SpriteSheet {
 
         if (sortMode === 'luminance') {
             collected.sort((c1, c2) => {
-                const l1 = c1.r * 0.299 + c1.g * 0.587 + c1.b * 0.114;
-                const l2 = c2.r * 0.299 + c2.g * 0.587 + c2.b * 0.114;
-                return l1 - l2;
+                return c1.luminance - c2.luminance;
             });
         }
 

--- a/src/utils/Color32.bench.ts
+++ b/src/utils/Color32.bench.ts
@@ -240,9 +240,9 @@ describe('Color32 utility benchmarks', () => {
     );
 
     bench(
-        'luminance()',
+        'luminance',
         () => {
-            color.luminance();
+            Math.trunc(color.luminance);
         },
         BENCH_OPTIONS,
     );

--- a/src/utils/Color32.test.ts
+++ b/src/utils/Color32.test.ts
@@ -918,27 +918,33 @@ describe('copyFrom', () => {
 // #region Utility
 
 describe('luminance', () => {
-    it('returns approximately 1.0 for white', () => {
+    it('returns 255 for white', () => {
         const c = new Color32(255, 255, 255, 255);
 
-        expect(c.luminance()).toBeCloseTo(1.0, 3);
+        expect(c.luminance).toBeCloseTo(255, 5);
     });
 
-    it('returns approximately 0.0 for black', () => {
+    it('returns 0 for black', () => {
         const c = new Color32(0, 0, 0, 255);
 
-        expect(c.luminance()).toBeCloseTo(0.0, 5);
+        expect(c.luminance).toBeCloseTo(0, 5);
     });
 
-    it('uses WCAG coefficients (green contributes most)', () => {
-        const r = new Color32(255, 0, 0, 255).luminance();
-        const g = new Color32(0, 255, 0, 255).luminance();
-        const b = new Color32(0, 0, 255, 255).luminance();
+    it('uses Rec.601 coefficients (green contributes most)', () => {
+        const r = new Color32(255, 0, 0, 255).luminance;
+        const g = new Color32(0, 255, 0, 255).luminance;
+        const b = new Color32(0, 0, 255, 255).luminance;
 
         // Green should have the highest luminance contribution
         expect(g).toBeGreaterThan(r);
         expect(g).toBeGreaterThan(b);
         expect(r).toBeGreaterThan(b);
+    });
+
+    it('matches known Rec.601 output for a mixed color', () => {
+        const c = new Color32(120, 65, 210, 255);
+
+        expect(c.luminance).toBeCloseTo(97.975, 3);
     });
 });
 

--- a/src/utils/Color32.ts
+++ b/src/utils/Color32.ts
@@ -711,14 +711,12 @@ export class Color32 {
     // #region Utility Methods
 
     /**
-     * Calculates the perceived luminance (brightness) of the color.
-     * Uses the standard relative luminance formula from WCAG.
+     * Perceived (Rec. 601) luminance of this color, ignoring alpha.
      *
-     * @returns Luminance value in range 0.0-1.0.
+     * @returns Luminance value in range 0-255 using 0.299*R + 0.587*G + 0.114*B.
      */
-    luminance(): number {
-        // Use standard relative luminance coefficients.
-        return (0.2126 * this.r + 0.7152 * this.g + 0.0722 * this.b) * INV_255;
+    get luminance(): number {
+        return this.r * 0.299 + this.g * 0.587 + this.b * 0.114;
     }
 
     // #endregion


### PR DESCRIPTION
Replace Color32 luminance with a 0..255 Rec.601 getter and migrate SpriteSheet luminance sorting to use the shared accessor. Update Color32 tests/bench and project guidance to prefer Color32#luminance over inline luminance formulas.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes Overview

This PR replaces the previous WCAG-based luminance implementation with a Rec.601-compliant accessor on Color32. The former luminance() method is now a luminance getter that returns a 0–255 byte-scale luminance computed as 0.299*R + 0.587*G + 0.114*B (alpha ignored). SpriteSheet luminance sorting is migrated to use the shared Color32.luminance accessor; sorting semantics remain unchanged.

## Key Changes

src/utils/Color32.ts
- Replaced method luminance(): number with getter get luminance(): number.
- Implementation changed from WCAG relative luminance (0.0–1.0) to Rec.601 byte-scale luminance (0–255). Alpha is ignored.

src/assets/SpriteSheet.ts
- loadColorsIntoPalette() now sorts using Color32.luminance instead of an inline weighted RGB formula.
- JSDoc updated to reference {@link Color32.luminance}.

Tests & Benchmarks
- src/utils/Color32.test.ts updated to access c.luminance (property) and expect byte-scale values; added a mixed-color regression assertion.
- src/assets/SpriteSheet.test.ts updated to assert colors are ordered by non-increasing luminance.
- src/utils/Color32.bench.ts updated to read color.luminance (property) and apply Math.trunc(...) where appropriate.
- CLAUDE.md updated to prefer using Color32#luminance instead of duplicating the luminance formula at call sites.
- src/assets/Palette.test.ts adjusted a thrown-error assertion wording for a negative index to match refactored text ("0 or higher").

## Impact

Consumers should switch to the Color32.luminance accessor where needed. The change centralizes luminance computation, enforces Rec.601 coefficients, and keeps existing sort order behavior in SpriteSheet while changing returned value scale (0–255).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/126)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->