### PR TITLE
feat(utils): add tick-based Timer helper for update loop intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ primitives, and fonts.
 - **Gamepad input**: up to four players via standard Gamepad API (`BT.gamepadConnected`, `BT.gamepadCount`,
   `BT.getAxis`), with stick dead zone and face-button support through `BT.button*`
 - **Fixed timestep**: deterministic update loop with tick counter and timing helpers (`BT.deltaSeconds`,
-  `BT.timeSeconds`)
+  `BT.timeSeconds`, `Timer`)
 - **Clean API**: all engine access through the `BT` namespace
 - **Display scaling**: `canvasDisplaySize` drives the WebGPU drawing buffer and CSS size for crisp pixel art; engine
   `defaultConfig()` uses a `640x480` output for `320x240` logical (2x nearest) when a demo omits `configure()`
@@ -317,6 +317,12 @@ BT.deltaSeconds(); // Fixed-step seconds per update
 BT.timeSeconds(); // Fixed-step elapsed seconds
 BT.ticks(); // Get current tick count
 BT.ticksReset(); // Reset tick counter
+
+// Optional helper for periodic update events.
+const spawnTimer = new Timer(180); // fire every 180 ticks
+if (spawnTimer.tick(BT.ticks())) {
+  spawnParticle();
+}
 ```
 
 A palette must be set via `BT.paletteSet()` before any draw calls are made. The recommended place is `init()` in the
@@ -550,6 +556,9 @@ Color32.transparent();
 SpriteSheet.load(url); // Load sprite sheet (static method)
 SpriteSheet.loadIndexed(url, palette, startSlot, options?); // Register colors + load + indexize
 BitmapFont.load(url); // Load bitmap font (static method)
+
+// Timing helper
+new Timer(intervalTicks); // Fixed-tick interval helper for update loops
 ```
 
 ### Input

--- a/src/BlitTech.ts
+++ b/src/BlitTech.ts
@@ -49,6 +49,7 @@ import type { EasingFunction } from './utils/Easing';
 import { applyEasing } from './utils/Easing';
 import { noActivePaletteError } from './utils/errorMessages';
 import { Rect2i } from './utils/Rect2i';
+import { Timer } from './utils/Timer';
 import { Vector2i } from './utils/Vector2i';
 
 /** Runtime face-button → key-code lists for keyboard player 0 (mutable via {@link BT.inputMap}). */
@@ -1472,6 +1473,7 @@ export {
     RollLine,
     Scanlines,
     SpriteSheet,
+    Timer,
     Vector2i,
     Vignette,
 };

--- a/src/assets/Palette.test.ts
+++ b/src/assets/Palette.test.ts
@@ -56,7 +56,7 @@ describe('Palette', () => {
         expect(palette.get(5).equals(color)).toBe(true);
         expect(palette.get(5)).not.toBe(color);
         expect(() => palette.get(16)).toThrow('The color number 16 is too big');
-        expect(() => palette.set(-1, color)).toThrow('The color number -1 is too big');
+        expect(() => palette.set(-1, color)).toThrow('0 or higher');
     });
 
     it('get() returns a defensive copy — mutating the result does not change the stored entry', () => {

--- a/src/utils/Timer.test.ts
+++ b/src/utils/Timer.test.ts
@@ -57,7 +57,7 @@ describe('Timer', () => {
             expect(timer.tick()).toBe(true);
         });
 
-        it('does not lock when current tick rewinds', () => {
+        it('does not lock when current tick rewinds shallowly', () => {
             vi.spyOn(BTAPI.instance, 'getTicks').mockReturnValue(0);
             const timer = new Timer(5);
 
@@ -65,6 +65,21 @@ describe('Timer', () => {
             expect(timer.elapsedTicks(3)).toBe(0);
             expect(timer.remainingTicks(3)).toBe(5);
             expect(timer.tick(10)).toBe(true);
+        });
+
+        it('resets baseline and does not lock after a hard tick rewind', () => {
+            vi.spyOn(BTAPI.instance, 'getTicks').mockReturnValue(0);
+            const timer = new Timer(5);
+
+            // Advance well past the interval so lastFiredTick is 1000.
+            expect(timer.tick(1000)).toBe(true);
+
+            // Hard rewind to 0 - without the guard the timer would lock until tick 1005.
+            expect(timer.tick(0)).toBe(false); // rewind detected, baseline reset to 0
+
+            // Should now fire exactly intervalTicks later.
+            expect(timer.tick(4)).toBe(false);
+            expect(timer.tick(5)).toBe(true);
         });
     });
 

--- a/src/utils/Timer.test.ts
+++ b/src/utils/Timer.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { BTAPI } from '../core/BTAPI';
+import { Timer } from './Timer';
+
+describe('Timer', () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe('constructor', () => {
+        it('stores interval and seeds baseline from current tick', () => {
+            vi.spyOn(BTAPI.instance, 'getTicks').mockReturnValue(10);
+            const timer = new Timer(30);
+
+            expect(timer.intervalTicks).toBe(30);
+            expect(timer.elapsedTicks(10)).toBe(0);
+        });
+
+        it('throws when interval is not a positive integer', () => {
+            expect(() => new Timer(0)).toThrow('positive integer');
+            expect(() => new Timer(-5)).toThrow('positive integer');
+            expect(() => new Timer(1.5)).toThrow('positive integer');
+        });
+    });
+
+    describe('tick', () => {
+        it('returns false before interval, true at interval, then resets baseline', () => {
+            const timer = new Timer(5);
+
+            expect(timer.tick(4)).toBe(false);
+            expect(timer.tick(5)).toBe(true);
+            expect(timer.tick(9)).toBe(false);
+            expect(timer.tick(10)).toBe(true);
+        });
+
+        it('fires once per call when large gaps pass', () => {
+            const timer = new Timer(5);
+
+            expect(timer.tick(20)).toBe(true);
+            expect(timer.tick(20)).toBe(false);
+            expect(timer.elapsedTicks(23)).toBe(3);
+        });
+
+        it('uses engine ticks when current tick is omitted', () => {
+            const timer = new Timer(3);
+            const spy = vi.spyOn(BTAPI.instance, 'getTicks');
+
+            spy.mockReturnValue(2);
+            expect(timer.tick()).toBe(false);
+
+            spy.mockReturnValue(3);
+            expect(timer.tick()).toBe(true);
+        });
+    });
+
+    describe('reset and helpers', () => {
+        it('resets baseline and reports elapsed and remaining ticks', () => {
+            const timer = new Timer(12);
+
+            expect(timer.elapsedTicks(5)).toBe(5);
+            expect(timer.remainingTicks(5)).toBe(7);
+
+            timer.reset(4);
+
+            expect(timer.elapsedTicks(10)).toBe(6);
+            expect(timer.remainingTicks(10)).toBe(6);
+            expect(timer.remainingTicks(20)).toBe(0);
+        });
+    });
+});

--- a/src/utils/Timer.test.ts
+++ b/src/utils/Timer.test.ts
@@ -18,6 +18,7 @@ describe('Timer', () => {
         });
 
         it('throws when interval is not a positive integer', () => {
+            vi.spyOn(BTAPI.instance, 'getTicks').mockReturnValue(0);
             expect(() => new Timer(0)).toThrow('positive integer');
             expect(() => new Timer(-5)).toThrow('positive integer');
             expect(() => new Timer(1.5)).toThrow('positive integer');
@@ -26,6 +27,7 @@ describe('Timer', () => {
 
     describe('tick', () => {
         it('returns false before interval, true at interval, then resets baseline', () => {
+            vi.spyOn(BTAPI.instance, 'getTicks').mockReturnValue(0);
             const timer = new Timer(5);
 
             expect(timer.tick(4)).toBe(false);
@@ -35,6 +37,7 @@ describe('Timer', () => {
         });
 
         it('fires once per call when large gaps pass', () => {
+            vi.spyOn(BTAPI.instance, 'getTicks').mockReturnValue(0);
             const timer = new Timer(5);
 
             expect(timer.tick(20)).toBe(true);
@@ -43,8 +46,9 @@ describe('Timer', () => {
         });
 
         it('uses engine ticks when current tick is omitted', () => {
-            const timer = new Timer(3);
             const spy = vi.spyOn(BTAPI.instance, 'getTicks');
+            spy.mockReturnValue(0);
+            const timer = new Timer(3);
 
             spy.mockReturnValue(2);
             expect(timer.tick()).toBe(false);
@@ -52,10 +56,21 @@ describe('Timer', () => {
             spy.mockReturnValue(3);
             expect(timer.tick()).toBe(true);
         });
+
+        it('does not lock when current tick rewinds', () => {
+            vi.spyOn(BTAPI.instance, 'getTicks').mockReturnValue(0);
+            const timer = new Timer(5);
+
+            expect(timer.tick(5)).toBe(true);
+            expect(timer.elapsedTicks(3)).toBe(0);
+            expect(timer.remainingTicks(3)).toBe(5);
+            expect(timer.tick(10)).toBe(true);
+        });
     });
 
     describe('reset and helpers', () => {
         it('resets baseline and reports elapsed and remaining ticks', () => {
+            vi.spyOn(BTAPI.instance, 'getTicks').mockReturnValue(0);
             const timer = new Timer(12);
 
             expect(timer.elapsedTicks(5)).toBe(5);

--- a/src/utils/Timer.ts
+++ b/src/utils/Timer.ts
@@ -1,0 +1,73 @@
+import { BTAPI } from '../core/BTAPI';
+
+/**
+ * Fixed-tick interval helper for update loops.
+ *
+ * Tracks a "last fired" tick and reports when a configured interval has elapsed.
+ * Useful for periodic events such as particle spawning, score ticks, or palette swaps.
+ */
+export class Timer {
+    /** Interval size in ticks. */
+    public readonly intervalTicks: number;
+
+    /** Tick when this timer last fired (or was reset). */
+    private lastFiredTick: number;
+
+    /**
+     * Creates a timer that fires once per fixed-tick interval.
+     *
+     * @param intervalTicks - Number of ticks required between firings; must be a positive integer.
+     */
+    public constructor(intervalTicks: number) {
+        if (!Number.isInteger(intervalTicks) || intervalTicks <= 0) {
+            throw new RangeError('Timer intervalTicks must be a positive integer.');
+        }
+
+        this.intervalTicks = intervalTicks;
+        this.lastFiredTick = BTAPI.instance.getTicks();
+    }
+
+    /**
+     * Returns true once per interval and advances the internal last-fired tick.
+     *
+     * @param currentTick - Tick to evaluate against; defaults to engine tick counter.
+     * @returns True when at least `intervalTicks` have elapsed since the last fire/reset.
+     */
+    public tick(currentTick: number = BTAPI.instance.getTicks()): boolean {
+        if (this.elapsedTicks(currentTick) < this.intervalTicks) {
+            return false;
+        }
+
+        this.lastFiredTick = currentTick;
+        return true;
+    }
+
+    /**
+     * Resets the timer baseline to a tick value.
+     *
+     * @param currentTick - Tick to reset against; defaults to engine tick counter.
+     */
+    public reset(currentTick: number = BTAPI.instance.getTicks()): void {
+        this.lastFiredTick = currentTick;
+    }
+
+    /**
+     * Returns ticks elapsed since this timer last fired or reset.
+     *
+     * @param currentTick - Tick to compare against; defaults to engine tick counter.
+     * @returns Number of elapsed ticks.
+     */
+    public elapsedTicks(currentTick: number = BTAPI.instance.getTicks()): number {
+        return currentTick - this.lastFiredTick;
+    }
+
+    /**
+     * Returns ticks remaining until the timer will fire.
+     *
+     * @param currentTick - Tick to compare against; defaults to engine tick counter.
+     * @returns Remaining ticks in `[0, intervalTicks]`.
+     */
+    public remainingTicks(currentTick: number = BTAPI.instance.getTicks()): number {
+        return Math.max(0, this.intervalTicks - this.elapsedTicks(currentTick));
+    }
+}

--- a/src/utils/Timer.ts
+++ b/src/utils/Timer.ts
@@ -34,6 +34,11 @@ export class Timer {
      * @returns True when at least `intervalTicks` have elapsed since the last fire/reset.
      */
     public tick(currentTick: number = BTAPI.instance.getTicks()): boolean {
+        if (currentTick < this.lastFiredTick) {
+            this.lastFiredTick = currentTick;
+            return false;
+        }
+
         if (this.elapsedTicks(currentTick) < this.intervalTicks) {
             return false;
         }

--- a/src/utils/Timer.ts
+++ b/src/utils/Timer.ts
@@ -58,7 +58,7 @@ export class Timer {
      * @returns Number of elapsed ticks.
      */
     public elapsedTicks(currentTick: number = BTAPI.instance.getTicks()): number {
-        return currentTick - this.lastFiredTick;
+        return Math.max(0, currentTick - this.lastFiredTick);
     }
 
     /**
@@ -68,6 +68,6 @@ export class Timer {
      * @returns Remaining ticks in `[0, intervalTicks]`.
      */
     public remainingTicks(currentTick: number = BTAPI.instance.getTicks()): number {
-        return Math.max(0, this.intervalTicks - this.elapsedTicks(currentTick));
+        return Math.min(this.intervalTicks, Math.max(0, this.intervalTicks - this.elapsedTicks(currentTick)));
     }
 }


### PR DESCRIPTION
Introduce a reusable Timer utility for fixed-timestep interval checks and export it from the public API. Add focused unit tests and README guidance for using Timer in demo/game update loops.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR adds a reusable Timer utility class for fixed-timestep (tick-based) interval checks intended for demo/game update loops. Timer is exported from the Blit‑Tech public API, includes focused unit tests, README documentation with usage guidance, and a bugfix to prevent lockups when the global tick counter rewinds.

## Changes

**Core Implementation** (`src/utils/Timer.ts`)
- New exported class `Timer` implementing a tick-based fixed-interval helper.
- Constructor validates `intervalTicks` as a positive integer and seeds the baseline from the engine tick counter (`BTAPI.instance.getTicks()`).
- Methods:
  - `tick(currentTick?: number)` — returns true once per interval and advances the last-fired baseline; defaults to engine ticks when omitted.
  - `reset(currentTick?: number)` — resets the baseline.
  - `elapsedTicks(currentTick?: number)` — returns elapsed ticks since last fire/reset.
  - `remainingTicks(currentTick?: number)` — returns remaining ticks until next fire (clamped to [0, intervalTicks]).
- Rewind guard: `tick()` now explicitly detects when `currentTick < lastFiredTick`, resets the baseline to `currentTick`, and returns false. This prevents the timer from "locking" when the engine tick counter is hard-rewound (regression fixed).

**Public API Export** (`src/BlitTech.ts`)
- `Timer` is imported and re-exported from the main Blit‑Tech entrypoint so consumers can access it from the library root.

**Documentation** (`README.md`)
- README updated to document the `Timer` helper under timing utilities and includes a usage example showing how to use `Timer` with `BT.ticks()` for periodic events.

**Test Coverage** (`src/utils/Timer.test.ts`)
- Added Vitest unit tests for `Timer`. Tests are deterministic by stubbing `BTAPI.instance.getTicks()` before constructing timers.
- Verified behaviors:
  - Constructor validation and baseline seeding.
  - Tick behavior: false before interval, true at interval, baseline reset after firing.
  - Single-fire semantics when very large tick gaps occur.
  - Using engine ticks when `tick()` is called without an argument.
  - Regression coverage for both shallow and hard tick rewinds (hard rewind test asserts baseline reset when ticks move backward from 1000→0).
  - Reset, elapsed, and remaining helpers behave as expected.
- Tests restore mocks after each case.

**Other**
- Adjusted `src/assets/Palette.test.ts` expectation to match updated error wording for out-of-range set (`'0 or higher'`).
- Commit included: fix(utils): prevent timer lock on hard tick-counter rewind.

## Notes for reviewers
- Focus review on the rewind guard in `tick()` and the semantics of setting `lastFiredTick = currentTick` on rewind to ensure it matches intended demo timing behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/127)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->