### PR TITLE
feat(utils): add Color32 named color registry and management APIs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ Dual WebGPU pipeline architecture:
 
 - `Vector2i` - integer 2D vector. Constructor auto-floors. Has `width`/`height` aliases.
 - `Rect2i` - integer rectangle. Methods: `contains()`, `intersects()`, `intersection()`.
-- `Color32` - 32-bit RGBA (0-255). Static colors, hex/RGB parsing, float array conversion.
+- `Color32` - 32-bit RGBA (0-255). Static colors, hex parsing, named-color registry, float array conversion.
 
 ## Critical Rules
 

--- a/README.md
+++ b/README.md
@@ -546,6 +546,15 @@ Color32.cyan();
 Color32.magenta();
 Color32.transparent();
 
+// String helpers
+Color32.fromHex('#ff8800'); // Parse #RGB/#RGBA/#RRGGBB/#RRGGBBAA (leading # optional)
+Color32.resolveNamedColor('cornflowerblue'); // Resolve named color singleton (case-insensitive)
+
+// Named color registry extensions
+Color32.registerColor('my-ui-accent', new Color32(64, 128, 255)); // Add new name, throws if duplicate
+Color32.updateColor('my-ui-accent', new Color32(80, 180, 255)); // Replace existing name
+Color32.unregisterColor('my-ui-accent'); // Remove existing name
+
 // Assets
 SpriteSheet.load(url); // Load sprite sheet (static method)
 SpriteSheet.loadIndexed(url, palette, startSlot, options?); // Register colors + load + indexize

--- a/src/utils/Color32.test.ts
+++ b/src/utils/Color32.test.ts
@@ -287,6 +287,29 @@ describe('named color registry', () => {
         );
     });
 
+    it('updateColor on one alias keeps both gray/grey aliases in sync', () => {
+        const originalGray = Color32.resolveNamedColor('gray');
+        if (originalGray === undefined) {
+            throw new Error('built-in gray must be registered');
+        }
+
+        try {
+            Color32.updateColor('grey', new Color32(200, 200, 200, 255));
+
+            const gray = Color32.resolveNamedColor('gray');
+            const grey = Color32.resolveNamedColor('grey');
+
+            expect(gray).toBeDefined();
+            expect(grey).toBeDefined();
+            expect(gray?.equals(new Color32(200, 200, 200, 255))).toBe(true);
+            expect(grey?.equals(new Color32(200, 200, 200, 255))).toBe(true);
+            expect(gray).toBe(grey);
+            expect(Object.isFrozen(gray)).toBe(true);
+        } finally {
+            Color32.updateColor('gray', originalGray);
+        }
+    });
+
     it('unregisterColor removes entries', () => {
         // cspell:ignore deleteme
         Color32.registerColor('deleteme', new Color32(8, 9, 10, 255));

--- a/src/utils/Color32.test.ts
+++ b/src/utils/Color32.test.ts
@@ -248,13 +248,15 @@ describe('named color registry', () => {
         // cspell:ignore mycustomcolor
         Color32.registerColor('  MyCustomColor  ', source);
 
-        const resolved = Color32.resolveNamedColor('mycustomcolor');
-        expect(resolved).toBeDefined();
-        expect(resolved).not.toBe(source);
-        expect(resolved?.equals(source)).toBe(true);
-        expect(Object.isFrozen(resolved)).toBe(true);
-
-        Color32.unregisterColor('mycustomcolor');
+        try {
+            const resolved = Color32.resolveNamedColor('mycustomcolor');
+            expect(resolved).toBeDefined();
+            expect(resolved).not.toBe(source);
+            expect(resolved?.equals(source)).toBe(true);
+            expect(Object.isFrozen(resolved)).toBe(true);
+        } finally {
+            Color32.unregisterColor('mycustomcolor');
+        }
     });
 
     it('registerColor throws on duplicates (including built-ins)', () => {
@@ -270,15 +272,17 @@ describe('named color registry', () => {
     it('updateColor replaces existing entries with frozen singleton', () => {
         Color32.registerColor('updatablecolor', new Color32(10, 20, 30, 40));
 
-        const updatedSource = new Color32(200, 201, 202, 203);
-        Color32.updateColor('  UpdatableColor  ', updatedSource);
+        try {
+            const updatedSource = new Color32(200, 201, 202, 203);
+            Color32.updateColor('  UpdatableColor  ', updatedSource);
 
-        const resolved = Color32.resolveNamedColor('updatablecolor');
-        expect(resolved?.equals(updatedSource)).toBe(true);
-        expect(resolved).not.toBe(updatedSource);
-        expect(Object.isFrozen(resolved)).toBe(true);
-
-        Color32.unregisterColor('updatablecolor');
+            const resolved = Color32.resolveNamedColor('updatablecolor');
+            expect(resolved?.equals(updatedSource)).toBe(true);
+            expect(resolved).not.toBe(updatedSource);
+            expect(Object.isFrozen(resolved)).toBe(true);
+        } finally {
+            Color32.unregisterColor('updatablecolor');
+        }
     });
 
     it('updateColor throws when entry is missing', () => {
@@ -313,10 +317,16 @@ describe('named color registry', () => {
     it('unregisterColor removes entries', () => {
         // cspell:ignore deleteme
         Color32.registerColor('deleteme', new Color32(8, 9, 10, 255));
-        expect(Color32.resolveNamedColor('deleteme')).toBeDefined();
 
-        Color32.unregisterColor('deleteme');
-        expect(Color32.resolveNamedColor('deleteme')).toBeUndefined();
+        try {
+            expect(Color32.resolveNamedColor('deleteme')).toBeDefined();
+            Color32.unregisterColor('deleteme');
+            expect(Color32.resolveNamedColor('deleteme')).toBeUndefined();
+        } finally {
+            if (Color32.resolveNamedColor('deleteme') !== undefined) {
+                Color32.unregisterColor('deleteme');
+            }
+        }
     });
 
     it('unregisterColor throws when entry is missing', () => {

--- a/src/utils/Color32.test.ts
+++ b/src/utils/Color32.test.ts
@@ -198,6 +198,111 @@ describe('static color getters', () => {
     });
 });
 
+describe('named color registry', () => {
+    it('resolves required CSS level 1 names', () => {
+        expect(Color32.resolveNamedColor('black')?.equals(Color32.black())).toBe(true);
+        expect(Color32.resolveNamedColor('white')?.equals(Color32.white())).toBe(true);
+        expect(Color32.resolveNamedColor('red')?.equals(Color32.red())).toBe(true);
+        expect(Color32.resolveNamedColor('green')?.equals(Color32.green())).toBe(true);
+        expect(Color32.resolveNamedColor('blue')?.equals(Color32.blue())).toBe(true);
+        expect(Color32.resolveNamedColor('yellow')?.equals(Color32.yellow())).toBe(true);
+        expect(Color32.resolveNamedColor('cyan')?.equals(Color32.cyan())).toBe(true);
+        expect(Color32.resolveNamedColor('magenta')?.equals(Color32.magenta())).toBe(true);
+    });
+
+    it('resolves gray and grey to the same singleton', () => {
+        const gray = Color32.resolveNamedColor('gray');
+        const grey = Color32.resolveNamedColor('grey');
+
+        expect(gray).toBeDefined();
+        expect(gray).toBe(grey);
+        expect(gray?.equals(Color32.gray(128))).toBe(true);
+    });
+
+    it('resolves common extra names', () => {
+        expect(Color32.resolveNamedColor('cornflowerblue')?.equals(Color32.fromRGBAUnchecked(100, 149, 237, 255))).toBe(
+            true,
+        );
+        expect(Color32.resolveNamedColor('tomato')?.equals(Color32.fromRGBAUnchecked(255, 99, 71, 255))).toBe(true);
+    });
+
+    it('normalizes lookup names with trim + lowercase', () => {
+        const color = Color32.resolveNamedColor('  CoRnFlOwErBlUe  ');
+        expect(color?.equals(Color32.fromRGBAUnchecked(100, 149, 237, 255))).toBe(true);
+    });
+
+    it('returns same instance on repeated lookups', () => {
+        expect(Color32.resolveNamedColor('turquoise')).toBe(Color32.resolveNamedColor('turquoise'));
+    });
+
+    it('returns undefined for unknown names', () => {
+        expect(Color32.resolveNamedColor('this-color-does-not-exist')).toBeUndefined();
+    });
+
+    it('throws on empty lookup name', () => {
+        expect(() => Color32.resolveNamedColor('   ')).toThrow('Color name cannot be empty.');
+    });
+
+    it('registerColor stores frozen singleton and normalizes the key', () => {
+        const source = new Color32(1, 2, 3, 4);
+        // cspell:ignore mycustomcolor
+        Color32.registerColor('  MyCustomColor  ', source);
+
+        const resolved = Color32.resolveNamedColor('mycustomcolor');
+        expect(resolved).toBeDefined();
+        expect(resolved).not.toBe(source);
+        expect(resolved?.equals(source)).toBe(true);
+        expect(Object.isFrozen(resolved)).toBe(true);
+
+        Color32.unregisterColor('mycustomcolor');
+    });
+
+    it('registerColor throws on duplicates (including built-ins)', () => {
+        expect(() => Color32.registerColor('RED', new Color32(1, 1, 1))).toThrow(
+            "Named color 'red' is already registered.",
+        );
+    });
+
+    it('registerColor throws on empty names', () => {
+        expect(() => Color32.registerColor('   ', new Color32(1, 2, 3))).toThrow('Color name cannot be empty.');
+    });
+
+    it('updateColor replaces existing entries with frozen singleton', () => {
+        Color32.registerColor('updatablecolor', new Color32(10, 20, 30, 40));
+
+        const updatedSource = new Color32(200, 201, 202, 203);
+        Color32.updateColor('  UpdatableColor  ', updatedSource);
+
+        const resolved = Color32.resolveNamedColor('updatablecolor');
+        expect(resolved?.equals(updatedSource)).toBe(true);
+        expect(resolved).not.toBe(updatedSource);
+        expect(Object.isFrozen(resolved)).toBe(true);
+
+        Color32.unregisterColor('updatablecolor');
+    });
+
+    it('updateColor throws when entry is missing', () => {
+        expect(() => Color32.updateColor('not-registered', new Color32(1, 2, 3))).toThrow(
+            "Named color 'not-registered' is not registered.",
+        );
+    });
+
+    it('unregisterColor removes entries', () => {
+        // cspell:ignore deleteme
+        Color32.registerColor('deleteme', new Color32(8, 9, 10, 255));
+        expect(Color32.resolveNamedColor('deleteme')).toBeDefined();
+
+        Color32.unregisterColor('deleteme');
+        expect(Color32.resolveNamedColor('deleteme')).toBeUndefined();
+    });
+
+    it('unregisterColor throws when entry is missing', () => {
+        expect(() => Color32.unregisterColor('not-registered')).toThrow(
+            "Named color 'not-registered' is not registered.",
+        );
+    });
+});
+
 // #endregion
 
 // #region Static Factory Methods

--- a/src/utils/Color32.ts
+++ b/src/utils/Color32.ts
@@ -56,6 +56,9 @@ export class Color32 {
     /** Cached singleton for magenta color. */
     private static readonly _magenta: Color32 = Object.freeze(Color32.fromRGBAUnchecked(255, 0, 255, 255));
 
+    /** Internal named-color registry used by string color resolution. */
+    private static readonly namedColors: Map<string, Color32> = Color32.createNamedColorMap();
+
     // #endregion
 
     // #region Instance Properties
@@ -194,6 +197,69 @@ export class Color32 {
      */
     static gray(value: number): Color32 {
         return new Color32(value, value, value, 255);
+    }
+
+    /**
+     * Registers a named color in the global color registry.
+     * Name matching is case-insensitive and trims surrounding whitespace.
+     *
+     * @param name - Named color key (for example `cornflowerblue`).
+     * @param color - Color value to store for that name.
+     * @throws Error when name is empty after normalization or already exists.
+     */
+    static registerColor(name: string, color: Color32): void {
+        const normalizedName = Color32.normalizeColorName(name);
+
+        if (Color32.namedColors.has(normalizedName)) {
+            throw new Error(`Named color '${normalizedName}' is already registered.`);
+        }
+
+        Color32.namedColors.set(normalizedName, Color32.freezeSingleton(color));
+    }
+
+    /**
+     * Updates an existing named color in the global color registry.
+     * Name matching is case-insensitive and trims surrounding whitespace.
+     *
+     * @param name - Existing named color key.
+     * @param color - Replacement color value.
+     * @throws Error when name is empty after normalization or not registered.
+     */
+    static updateColor(name: string, color: Color32): void {
+        const normalizedName = Color32.normalizeColorName(name);
+
+        if (!Color32.namedColors.has(normalizedName)) {
+            throw new Error(`Named color '${normalizedName}' is not registered.`);
+        }
+
+        Color32.namedColors.set(normalizedName, Color32.freezeSingleton(color));
+    }
+
+    /**
+     * Removes a named color from the global color registry.
+     * Name matching is case-insensitive and trims surrounding whitespace.
+     *
+     * @param name - Existing named color key.
+     * @throws Error when name is empty after normalization or not registered.
+     */
+    static unregisterColor(name: string): void {
+        const normalizedName = Color32.normalizeColorName(name);
+
+        if (!Color32.namedColors.delete(normalizedName)) {
+            throw new Error(`Named color '${normalizedName}' is not registered.`);
+        }
+    }
+
+    /**
+     * Looks up a named color from the global registry.
+     * Name matching is case-insensitive and trims surrounding whitespace.
+     *
+     * @param name - Named color key to resolve.
+     * @returns Frozen singleton color, or `undefined` when the name is unknown.
+     */
+    static resolveNamedColor(name: string): Color32 | undefined {
+        const normalizedName = Color32.normalizeColorName(name);
+        return Color32.namedColors.get(normalizedName);
     }
 
     // #endregion
@@ -718,6 +784,90 @@ export class Color32 {
     get luminance(): number {
         return this.r * 0.299 + this.g * 0.587 + this.b * 0.114;
     }
+
+    // #region Named Color Helpers
+
+    /**
+     * Creates the default CSS-like named-color registry.
+     *
+     * @returns Map of normalized names to frozen singleton Color32 values.
+     */
+    private static createNamedColorMap(): Map<string, Color32> {
+        const map = new Map<string, Color32>();
+        const define = (name: string, r: number, g: number, b: number, a: number = 255): void => {
+            map.set(name, Object.freeze(Color32.fromRGBAUnchecked(r, g, b, a)));
+        };
+        const alias = (name: string, target: string): void => {
+            const value = map.get(target);
+            if (value === undefined) {
+                throw new Error(`Named color alias target '${target}' is not registered.`);
+            }
+            map.set(name, value);
+        };
+
+        define('black', 0, 0, 0);
+        define('white', 255, 255, 255);
+        define('red', 255, 0, 0);
+        define('green', 0, 255, 0);
+        define('blue', 0, 0, 255);
+        define('yellow', 255, 255, 0);
+        define('cyan', 0, 255, 255);
+        define('magenta', 255, 0, 255);
+        define('gray', 128, 128, 128);
+        alias('grey', 'gray');
+
+        define('orange', 255, 165, 0);
+        define('pink', 255, 192, 203);
+        define('purple', 128, 0, 128);
+        define('brown', 165, 42, 42);
+        define('lime', 0, 255, 0);
+        define('navy', 0, 0, 128);
+        define('teal', 0, 128, 128);
+        define('maroon', 128, 0, 0);
+        define('olive', 128, 128, 0);
+        define('coral', 255, 127, 80);
+        define('gold', 255, 215, 0);
+        define('silver', 192, 192, 192);
+        define('indigo', 75, 0, 130);
+        define('violet', 238, 130, 238);
+        define('turquoise', 64, 224, 208);
+        define('salmon', 250, 128, 114);
+        define('khaki', 240, 230, 140);
+        define('plum', 221, 160, 221);
+        define('crimson', 220, 20, 60);
+        define('tomato', 255, 99, 71);
+        define('cornflowerblue', 100, 149, 237);
+
+        return map;
+    }
+
+    /**
+     * Normalizes a named-color key for case-insensitive lookups.
+     *
+     * @param name - Input color name.
+     * @returns Trimmed lowercase name.
+     * @throws Error when the normalized name is empty.
+     */
+    private static normalizeColorName(name: string): string {
+        const normalizedName = name.trim().toLowerCase();
+        if (normalizedName.length === 0) {
+            throw new Error('Color name cannot be empty.');
+        }
+
+        return normalizedName;
+    }
+
+    /**
+     * Clones and freezes a color so registry entries are immutable singletons.
+     *
+     * @param color - Source color to freeze.
+     * @returns Frozen singleton copy.
+     */
+    private static freezeSingleton(color: Color32): Color32 {
+        return Object.freeze(Color32.fromRGBAUnchecked(color.r, color.g, color.b, color.a));
+    }
+
+    // #endregion
 
     // #endregion
 }

--- a/src/utils/Color32.ts
+++ b/src/utils/Color32.ts
@@ -220,33 +220,55 @@ export class Color32 {
     /**
      * Updates an existing named color in the global color registry.
      * Name matching is case-insensitive and trims surrounding whitespace.
+     * All alias keys that share the same object reference are updated in sync.
      *
-     * @param name - Existing named color key.
+     * @param name - Existing named color key (or any alias).
      * @param color - Replacement color value.
      * @throws Error when name is empty after normalization or not registered.
      */
     static updateColor(name: string, color: Color32): void {
         const normalizedName = Color32.normalizeColorName(name);
+        const current = Color32.namedColors.get(normalizedName);
 
-        if (!Color32.namedColors.has(normalizedName)) {
+        if (current === undefined) {
             throw new Error(`Named color '${normalizedName}' is not registered.`);
         }
 
-        Color32.namedColors.set(normalizedName, Color32.freezeSingleton(color));
+        const frozen = Color32.freezeSingleton(color);
+
+        for (const [key, value] of Color32.namedColors) {
+            if (value === current) {
+                Color32.namedColors.set(key, frozen);
+            }
+        }
     }
 
     /**
      * Removes a named color from the global color registry.
      * Name matching is case-insensitive and trims surrounding whitespace.
+     * All alias keys that share the same object reference are removed in sync.
      *
-     * @param name - Existing named color key.
+     * @param name - Existing named color key (or any alias).
      * @throws Error when name is empty after normalization or not registered.
      */
     static unregisterColor(name: string): void {
         const normalizedName = Color32.normalizeColorName(name);
+        const current = Color32.namedColors.get(normalizedName);
 
-        if (!Color32.namedColors.delete(normalizedName)) {
+        if (current === undefined) {
             throw new Error(`Named color '${normalizedName}' is not registered.`);
+        }
+
+        const keysToDelete: string[] = [];
+
+        for (const [key, value] of Color32.namedColors) {
+            if (value === current) {
+                keysToDelete.push(key);
+            }
+        }
+
+        for (const key of keysToDelete) {
+            Color32.namedColors.delete(key);
         }
     }
 


### PR DESCRIPTION
Add an internal named-color lookup table with CSS-level and common extra names stored as frozen Color32 singletons for allocation-free resolution.

Expose register/update/unregister/resolve APIs with normalized key handling and duplicate/missing-name validation, and add comprehensive unit coverage plus README/CLAUDE documentation updates for the new behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

Adds a named-color registry to Color32 enabling allocation-free resolution of string color names to frozen singleton Color32 instances, plus runtime management APIs, validation, and tests.

## Changes

### Core Implementation (src/utils/Color32.ts)
- Introduces a private static namedColors Map prepopulated with CSS Level 1 names and additional common names (including a grey alias for gray).
- Stores registry values as frozen Color32 singletons created from provided color channels to ensure immutability and allocation-free reuse; registry entries are distinct frozen copies (not direct references to caller-provided objects).
- Adds public static APIs:
  - registerColor(name: string, color: Color32): void — normalizes name (trim + lowercase), rejects empty names and duplicates (including built-ins), stores a frozen singleton.
  - updateColor(name: string, color: Color32): void — updates an existing entry (throws if missing). Keeps alias keys that referenced the same singleton synchronized.
  - unregisterColor(name: string): void — removes an entry (throws if missing).
  - resolveNamedColor(name: string): Color32 | undefined — normalizes lookup and returns the frozen singleton or undefined.
- Validation behavior: register throws on duplicates; normalizeColorName throws on empty/whitespace-only input.

### Tests (src/utils/Color32.test.ts)
- Adds comprehensive Vitest coverage for named-color registry and related behaviors:
  - Verifies CSS Level 1 names and additional common names resolve correctly.
  - Validates gray/grey aliasing resolves to the same frozen singleton and remains synchronized after updates.
  - Confirms lookup normalization (trim + lowercase), repeated lookups return the same instance, unknown names return undefined, and empty/whitespace lookups throw.
  - Tests registry mutation behaviors: register stores a frozen singleton distinct from the source and rejects duplicates/empty names; update replaces entries and synchronizes aliases and throws when target missing; unregister removes entries and throws when missing.
- Test harness improvements: tests that call registerColor are wrapped with try/finally to ensure registry cleanup even if assertions fail; some finally blocks use conditional guards to account for tests that may already remove entries.

### Documentation
- README.md updated with "String helpers" (fromHex, resolveNamedColor) and "Named color registry extensions" (registerColor, updateColor, unregisterColor) documenting behavior including duplicate handling.
- CLAUDE.md wording updated to reflect Color32 capabilities: "Static colors, hex parsing, named-color registry, float array conversion."

## Notes
- No exported type/signature removals; new public static methods on Color32 are documented.
- All registry operations normalize keys and rely on frozen singleton instances to minimize allocations and maintain consistent alias behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/128)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->