### PR TITLE
`feat(api): wire BTAPI backend selection and add in-canvas software renderer ticker`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ src/
     IRenderer.ts           # Backend-agnostic renderer contract (interface)
     WebGpuRenderer.ts      # WebGPU concrete renderer implementing IRenderer
     SoftwareRenderer.ts    # Canvas 2D software fallback implementing IRenderer
+    SoftwareTicker.ts      # Dismissible in-canvas "SOFTWARE RENDERER" status banner (software mode only)
     PrimitivePipeline.ts   # Batched colored geometry (pixels, lines, rects)
     SpritePipeline.ts      # Batched textured quads (sprites, bitmap text)
     PostProcessChain.ts    # Tier-aware fullscreen effect chain
@@ -77,7 +78,9 @@ Two backends selectable via `HardwareSettings.renderer` (default `'webgpu'`):
      Auto-batched by texture.
 - **Software** (`'software'`): Canvas 2D fallback. Supports palette rendering, rects, Bresenham lines, indexed sprite
   blits, and bitmap text. Post-process/fullscreen effects throw a clear error directing users to the WebGPU backend.
-  Force at runtime with the `?renderer=software` URL query parameter.
+  Activates automatically when WebGPU init fails; force explicitly via `HardwareSettings.renderer: 'software'` or the
+  `?renderer=software` URL query parameter. A dismissible in-canvas ticker banner is rendered each frame when this
+  backend is active. Use `BTAPI.getActiveBackend()` to query which backend started (`'webgpu' | 'software' | null`).
 
 ### Core Types
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ primitives, and fonts.
 
 ## Features
 
-- **WebGPU rendering** with dual-pipeline architecture (primitives + sprites); **Canvas 2D software fallback** for
-  environments without WebGPU — select via `HardwareSettings.renderer: 'software'` or `?renderer=software` URL param
+- **WebGPU rendering** with dual-pipeline architecture (primitives + sprites); **Canvas 2D software fallback** that
+  activates automatically when WebGPU is unavailable — or force it via `HardwareSettings.renderer: 'software'` or
+  `?renderer=software` URL param. A dismissible in-canvas "SOFTWARE RENDERER" banner confirms fallback mode is active
 - **Palette system**: 256-entry indexed color palette with built-in presets (VGA, CGA, C64, Game Boy, PICO-8, NES)
 - **Palette effects**: cycling, fade, flash, swap with easing functions -- animated color manipulation each frame
 - **Post-process effects**: two-tier system — pixel-tier effects (chunky glitch, mosaic) at logical resolution, plus
@@ -657,7 +658,10 @@ WebGPU support varies by browser:
 | Firefox     | 141+ (Windows) | Enabled by default; 145+/147+ on macOS; Nightly on Linux/Android |
 | Safari      | 26+            | Enabled by default; Safari 18–25 available via Feature Flags     |
 
-The engine displays an error message if the browser doesn’t support WebGPU.
+When WebGPU is unavailable the engine automatically falls back to the Canvas 2D software renderer — no error page, no
+hard stop. A dismissible in-canvas "SOFTWARE RENDERER" banner appears at the top of the canvas to confirm the fallback
+is active; click or tap it to dismiss. Use `BTAPI.getActiveBackend()` (returns `’webgpu’` or `’software’`) to detect
+which backend is running at runtime.
 
 ## Technologies
 

--- a/README.md
+++ b/README.md
@@ -660,8 +660,8 @@ WebGPU support varies by browser:
 
 When WebGPU is unavailable the engine automatically falls back to the Canvas 2D software renderer — no error page, no
 hard stop. A dismissible in-canvas "SOFTWARE RENDERER" banner appears at the top of the canvas to confirm the fallback
-is active; click or tap it to dismiss. Use `BTAPI.getActiveBackend()` (returns `’webgpu’` or `’software’`) to detect
-which backend is running at runtime.
+is active; click or tap it to dismiss. Use `BT.getActiveBackend()` (returns `’webgpu’` or `’software’`) to detect which
+backend is running at runtime.
 
 ## Technologies
 

--- a/docs/software-fallback-smoke-matrix.md
+++ b/docs/software-fallback-smoke-matrix.md
@@ -1,12 +1,15 @@
 # Software Fallback Smoke Matrix
 
-This checklist is for quick manual verification of the software renderer MVP in `VV-490`.
+This checklist is for quick manual verification of the software renderer. Originally written for `VV-490` (MVP); updated
+in `VV-491` to cover auto-fallback and the dismissible ticker banner.
 
 ## Scope
 
-- Backend under test: `software` (`?renderer=software` or `configure().renderer = 'software'`)
+- Backend under test: `software` (auto-fallback when WebGPU unavailable, `?renderer=software`, or
+  `configure().renderer = 'software'`)
 - Resolution target: low-res scenes (for example `320x240`)
-- In scope: clear, clearRect, primitives, sprites, system text, bitmap text, camera offset, frame capture
+- In scope: auto-fallback detection, ticker banner, clear, clearRect, primitives, sprites, system text, bitmap text,
+  camera offset, frame capture
 - Out of scope: fullscreen shader/post-process effects (`effectAdd`, `effectRemove`, `effectClear`) in software mode
 
 ## Environment
@@ -19,14 +22,16 @@ This checklist is for quick manual verification of the software renderer MVP in 
 
 ## Matrix
 
-| Scene                                   | What to verify                                   | Software expected result                          | Notes                                 |
-| --------------------------------------- | ------------------------------------------------ | ------------------------------------------------- | ------------------------------------- |
-| `tests/visual/fixtures/primitives.html` | clear + clearRect + primitive rasterization      | Matches expected primitive layout and colors      | Check pixel edges are crisp           |
-| `tests/visual/fixtures/camera.html`     | camera offset applied to all draw calls          | Geometry is shifted consistently by camera offset | No partial drift between primitives   |
-| `tests/visual/fixtures/sprites.html`    | indexed sprites + palette offsets + transparency | Sprite shapes/colors match expected output        | Transparent pixels stay see-through   |
-| `tests/visual/fixtures/fonts.html`      | system text + bitmap font rendering              | Text positions and glyph colors are correct       | No missing glyph blocks               |
-| `tests/visual/fixtures/mixed.html`      | primitives + sprites + layering order            | Same stacking as WebGPU for this fixture          | Parity covered by Playwright snapshot |
-| Frame capture via `BT.captureFrame()`   | PNG export in software mode                      | Promise resolves with PNG blob                    | Repeat capture across multiple frames |
+| Scene                                   | What to verify                                   | Software expected result                                              | Notes                                 |
+| --------------------------------------- | ------------------------------------------------ | --------------------------------------------------------------------- | ------------------------------------- |
+| Any page without `?renderer=software`   | Auto-fallback when WebGPU is absent              | Demo boots; `BTAPI.getActiveBackend()` = `'software'`; ticker visible | No error page or hard stop            |
+| Any page with software active           | Dismissible ticker banner at top of canvas       | Banner centered, dismisses on click/tap; absent next frame            | Height 15 px; palette indices 1/2     |
+| `tests/visual/fixtures/primitives.html` | clear + clearRect + primitive rasterization      | Matches expected primitive layout and colors                          | Check pixel edges are crisp           |
+| `tests/visual/fixtures/camera.html`     | camera offset applied to all draw calls          | Geometry is shifted consistently by camera offset                     | No partial drift between primitives   |
+| `tests/visual/fixtures/sprites.html`    | indexed sprites + palette offsets + transparency | Sprite shapes/colors match expected output                            | Transparent pixels stay see-through   |
+| `tests/visual/fixtures/fonts.html`      | system text + bitmap font rendering              | Text positions and glyph colors are correct                           | No missing glyph blocks               |
+| `tests/visual/fixtures/mixed.html`      | primitives + sprites + layering order            | Same stacking as WebGPU for this fixture                              | Parity covered by Playwright snapshot |
+| Frame capture via `BT.captureFrame()`   | PNG export in software mode                      | Promise resolves with PNG blob                                        | Repeat capture across multiple frames |
 
 ## Automated regression
 

--- a/src/BlitTech.ts
+++ b/src/BlitTech.ts
@@ -469,6 +469,19 @@ export const BT = {
     },
 
     /**
+     * Returns the renderer backend that is currently active.
+     *
+     * Call this after initialization to check which backend the engine started.
+     * Useful when you want to adjust demo behavior — for example, skipping
+     * post-process effects that only work under WebGPU.
+     *
+     * @returns `'webgpu'` or `'software'` after successful init; `null` before init or on failure.
+     */
+    getActiveBackend: (): RendererBackend | null => {
+        return BTAPI.instance.getActiveBackend();
+    },
+
+    /**
      * Creates a standalone palette instance.
      *
      * @param size - Palette size. Defaults to 256 colors.

--- a/src/core/BTAPI.test.ts
+++ b/src/core/BTAPI.test.ts
@@ -23,7 +23,6 @@ import type { BitmapFont } from '../assets/BitmapFont';
 import { Palette } from '../assets/Palette';
 import type { SpriteSheet } from '../assets/SpriteSheet';
 import type { Effect } from '../render/effects/Effect';
-import { WEBGPU_ADAPTER_MESSAGE } from '../utils/errorMessages';
 import { Rect2i } from '../utils/Rect2i';
 import { Vector2i } from '../utils/Vector2i';
 import { BTAPI } from './BTAPI';
@@ -352,9 +351,11 @@ describe('BTAPI', () => {
             expect(result).toBe(false);
         });
 
-        it('should return false when navigator.gpu is absent', async () => {
+        it('returns false when both WebGPU and software renderer init fail', async () => {
             uninstallMockNavigatorGPU();
 
+            // makeMockCanvas() returns null for getContext('2d'), so the auto-fallback
+            // SoftwareRenderer also fails to initialize.
             const result = await BTAPI.instance.init(makeMockDemo(), makeMockCanvas());
 
             expect(result).toBe(false);
@@ -453,7 +454,7 @@ describe('BTAPI', () => {
             expect(BTAPI.instance.getDevice()).not.toBeNull();
         });
 
-        it('should throw with WEBGPU_ADAPTER_MESSAGE when WebGPU adapter is unavailable', async () => {
+        it('falls back to software (and fails cleanly) when WebGPU adapter is unavailable', async () => {
             Object.defineProperty(globalThis, 'navigator', {
                 value: {
                     gpu: {
@@ -466,7 +467,11 @@ describe('BTAPI', () => {
                 configurable: true,
             });
 
-            await expect(BTAPI.instance.init(makeMockDemo(), makeMockCanvas())).rejects.toThrow(WEBGPU_ADAPTER_MESSAGE);
+            // BTAPI catches the adapter throw and falls back to software.
+            // makeMockCanvas() has no 2D context, so software init also fails -> false.
+            const result = await BTAPI.instance.init(makeMockDemo(), makeMockCanvas());
+
+            expect(result).toBe(false);
         });
 
         it('should return false when renderer initialization fails', async () => {
@@ -689,6 +694,52 @@ describe('BTAPI', () => {
             const blob = await capturePromise;
             expect(blob.type).toBe('image/png');
         });
+
+        it('auto-falls back to software when WebGPU is unavailable and 2D canvas is available', async () => {
+            uninstallMockNavigatorGPU();
+            vi.stubGlobal(
+                'OffscreenCanvas',
+                class MockOffscreenCanvas {
+                    constructor(
+                        public width: number,
+                        public height: number,
+                    ) {}
+                    getContext(contextType?: string): OffscreenCanvas2DMock | null {
+                        return contextType === '2d' ? makeOffscreenCanvas2dContext() : null;
+                    }
+                },
+            );
+            const demo: IBlitTechDemo = {
+                configure: () => ({
+                    displaySize: new Vector2i(320, 240),
+                    targetFPS: 60,
+                    // No renderer field - defaults to 'webgpu', should auto-fallback
+                }),
+                init: vi.fn().mockResolvedValue(true),
+                update: vi.fn(),
+                render: vi.fn(),
+            };
+            const canvas = makeMock2DCanvas();
+
+            const result = await BTAPI.instance.init(demo, canvas);
+
+            expect(result).toBe(true);
+            expect(BTAPI.instance.getDevice()).toBeNull();
+            expect(BTAPI.instance.getContext()).toBeNull();
+            expect(BTAPI.instance.getRenderer()).not.toBeNull();
+            expect(BTAPI.instance.getActiveBackend()).toBe('software');
+        });
+
+        it('reports webgpu as active backend when WebGPU succeeds', async () => {
+            const result = await BTAPI.instance.init(makeMockDemo(), makeMockCanvas());
+
+            expect(result).toBe(true);
+            expect(BTAPI.instance.getActiveBackend()).toBe('webgpu');
+        });
+
+        it('reports null active backend before init', () => {
+            expect(BTAPI.instance.getActiveBackend()).toBeNull();
+        });
     });
 
     // #endregion
@@ -766,6 +817,111 @@ describe('BTAPI', () => {
             BTAPI.instance.effectRemove(effect);
 
             expect(removeSpy).toHaveBeenCalledWith(effect);
+        });
+    });
+
+    // #endregion
+
+    // #region Software ticker
+
+    describe('software ticker', () => {
+        it('renders ticker when software backend is active', async () => {
+            const rafCallbacks: FrameRequestCallback[] = [];
+            vi.stubGlobal(
+                'requestAnimationFrame',
+                vi.fn((cb: FrameRequestCallback) => {
+                    rafCallbacks.push(cb);
+                    return rafCallbacks.length;
+                }),
+            );
+            vi.stubGlobal(
+                'OffscreenCanvas',
+                class MockOffscreenCanvas {
+                    constructor(
+                        public width: number,
+                        public height: number,
+                    ) {}
+                    getContext(contextType?: string): OffscreenCanvas2DMock | null {
+                        return contextType === '2d' ? makeOffscreenCanvas2dContext() : null;
+                    }
+                },
+            );
+            uninstallMockNavigatorGPU();
+
+            const demo: IBlitTechDemo = {
+                configure: () => ({
+                    displaySize: new Vector2i(320, 240),
+                    targetFPS: 60,
+                    renderer: 'software' as const,
+                }),
+                init: vi.fn().mockResolvedValue(true),
+                update: vi.fn(),
+                render: vi.fn(),
+            };
+
+            await BTAPI.instance.init(demo, makeMock2DCanvas());
+            BTAPI.instance.setPalette(new Palette(16));
+
+            const renderer = BTAPI.instance.getRenderer();
+            expect(renderer).not.toBeNull();
+
+            const drawRectFillSpy = vi.spyOn(renderer as NonNullable<typeof renderer>, 'drawRectFill');
+            const drawBitmapTextSpy = vi.spyOn(renderer as NonNullable<typeof renderer>, 'drawBitmapText');
+
+            // Drain rAF queue (double-rAF bootstrap + first tick).
+            const maxIterations = 1000;
+            let iterations = 0;
+            while (rafCallbacks.length > 0) {
+                iterations++;
+                if (iterations > maxIterations) {
+                    throw new Error('rAF drain exceeded max iterations');
+                }
+                const cb = rafCallbacks.shift();
+                cb?.(16);
+                if (drawRectFillSpy.mock.calls.length > 0) break;
+            }
+
+            expect(drawRectFillSpy).toHaveBeenCalled();
+            expect(drawBitmapTextSpy).toHaveBeenCalled();
+
+            // Background rect should start at (0, 0) and span the full display width.
+            const firstRectCall = drawRectFillSpy.mock.calls[0];
+            expect(firstRectCall).toBeDefined();
+            const [bgRect] = firstRectCall ?? [];
+            expect(bgRect.x).toBe(0);
+            expect(bgRect.y).toBe(0);
+            expect(bgRect.width).toBe(320);
+        });
+
+        it('does not render ticker when WebGPU backend is active', async () => {
+            const rafCallbacks: FrameRequestCallback[] = [];
+            vi.stubGlobal(
+                'requestAnimationFrame',
+                vi.fn((cb: FrameRequestCallback) => {
+                    rafCallbacks.push(cb);
+                    return rafCallbacks.length;
+                }),
+            );
+
+            // navigator.gpu is installed by beforeEach; WebGPU succeeds.
+            await BTAPI.instance.init(makeMockDemo(), makeMockCanvas());
+            BTAPI.instance.setPalette(new Palette(16));
+
+            expect(BTAPI.instance.getActiveBackend()).toBe('webgpu');
+
+            const renderer = BTAPI.instance.getRenderer();
+            const drawRectFillSpy = vi.spyOn(renderer as NonNullable<typeof renderer>, 'drawRectFill');
+
+            // Drain a few rAF ticks.
+            let drained = 0;
+            while (rafCallbacks.length > 0 && drained < 10) {
+                drained++;
+                const cb = rafCallbacks.shift();
+                cb?.(16);
+            }
+
+            // The demo's render() is a vi.fn() no-op, so any drawRectFill would be from the ticker.
+            expect(drawRectFillSpy).not.toHaveBeenCalled();
         });
     });
 

--- a/src/core/BTAPI.test.ts
+++ b/src/core/BTAPI.test.ts
@@ -887,10 +887,12 @@ describe('BTAPI', () => {
             // Background rect should start at (0, 0) and span the full display width.
             const firstRectCall = drawRectFillSpy.mock.calls[0];
             expect(firstRectCall).toBeDefined();
-            const [bgRect] = firstRectCall ?? [];
-            expect(bgRect.x).toBe(0);
-            expect(bgRect.y).toBe(0);
-            expect(bgRect.width).toBe(320);
+            if (firstRectCall) {
+                const [bgRect] = firstRectCall;
+                expect(bgRect.x).toBe(0);
+                expect(bgRect.y).toBe(0);
+                expect(bgRect.width).toBe(320);
+            }
         });
 
         it('does not render ticker when WebGPU backend is active', async () => {

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -16,6 +16,7 @@ import { PointerInput } from '../input/PointerInput';
 import type { Effect } from '../render/effects/Effect';
 import type { IRenderer } from '../render/IRenderer';
 import { SoftwareRenderer } from '../render/SoftwareRenderer';
+import { SoftwareTicker } from '../render/SoftwareTicker';
 import { WebGpuRenderer } from '../render/WebGpuRenderer';
 import type { Color32 } from '../utils/Color32';
 import type { EasingFunction } from '../utils/Easing';
@@ -25,7 +26,7 @@ import {
     paletteIndexOutOfRangeError,
     spriteNotIndexizedError,
 } from '../utils/errorMessages';
-import { Rect2i } from '../utils/Rect2i';
+import type { Rect2i } from '../utils/Rect2i';
 import { Vector2i } from '../utils/Vector2i';
 import type { FrameDropCallback, FrameDropEvent } from './GameLoop';
 import { GameLoop } from './GameLoop';
@@ -53,45 +54,6 @@ export class BTAPI {
 
     /** Patch version number. */
     public static readonly VERSION_PATCH = 0;
-
-    // #endregion
-
-    // #region Software Ticker Constants
-
-    /** Height in pixels of the software-mode ticker banner strip. */
-    private static readonly TICKER_HEIGHT = 16;
-
-    /** System font glyph advance in pixels (matches SYSTEM_FONT_GLYPH_WIDTH = 6). */
-    private static readonly TICKER_CHAR_ADVANCE = 6;
-
-    /** Pixels to scroll left per rendered frame. */
-    private static readonly TICKER_SCROLL_SPEED = 1;
-
-    /** Palette index used for the ticker background fill. */
-    private static readonly TICKER_BG_INDEX = 1;
-
-    /**
-     * Palette index used for the ticker text.
-     *
-     * The system font stores foreground pixels as palette index 1; passing
-     * `TICKER_TEXT_INDEX - 1` as `paletteOffset` remaps those pixels to this index.
-     */
-    private static readonly TICKER_TEXT_INDEX = 2;
-
-    /**
-     * Text displayed in the software-mode ticker.
-     *
-     * Drawn using palette indices TICKER_BG_INDEX (background) and TICKER_TEXT_INDEX
-     * (text). The actual colors depend on the active palette.
-     */
-    private static readonly TICKER_TEXT =
-        'SOFTWARE RENDERER - blit-tech v' +
-        BTAPI.VERSION_MAJOR +
-        '.' +
-        BTAPI.VERSION_MINOR +
-        '.' +
-        BTAPI.VERSION_PATCH +
-        '  ';
 
     // #endregion
 
@@ -126,8 +88,8 @@ export class BTAPI {
     /** Backend that was successfully initialized, or null before init. */
     private activeBackend: RendererBackend | null = null;
 
-    /** X scroll position for the software-mode ticker overlay; advances left each frame. */
-    private tickerScrollX = 0;
+    /** Software-mode ticker overlay; non-null only when the software backend is active. */
+    private ticker: SoftwareTicker | null = null;
 
     /** Active engine palette used by palette-first rendering. */
     private palette: Palette | null = null;
@@ -298,8 +260,8 @@ export class BTAPI {
                     }
 
                     // Software ticker renders on top of the demo, after user draw calls.
-                    if (this.activeBackend === 'software') {
-                        this.renderSoftwareTicker();
+                    if (this.ticker && this.systemFont) {
+                        this.ticker.render(this.renderer, this.hwSettings?.displaySize.x ?? 0, this.systemFont);
                     }
 
                     this.renderer.endFrame();
@@ -683,51 +645,6 @@ export class BTAPI {
 
     // #endregion
 
-    // #region Software Ticker
-
-    /**
-     * Renders the software-mode status ticker at the top of the canvas.
-     *
-     * Draws a filled background strip and tiled scrolling text using the system font.
-     * Saves and restores the camera so the banner is always viewport-relative
-     * regardless of the demo's camera position.
-     *
-     * Called each frame from the GameLoop render callback when activeBackend is 'software'.
-     */
-    private renderSoftwareTicker(): void {
-        if (!this.renderer || !this.hwSettings || !this.systemFont) {
-            return;
-        }
-
-        const displayWidth = this.hwSettings.displaySize.x;
-        const textWidth = BTAPI.TICKER_TEXT.length * BTAPI.TICKER_CHAR_ADVANCE;
-
-        // Advance scroll state; wrap with modular arithmetic so tiled copies remain seamless.
-        this.tickerScrollX -= BTAPI.TICKER_SCROLL_SPEED;
-        if (this.tickerScrollX < -textWidth) {
-            this.tickerScrollX += textWidth;
-        }
-
-        // Suppress camera offset for overlay rendering; restore after.
-        const savedCamera = this.renderer.getCameraOffset();
-        this.renderer.resetCamera();
-
-        // Background strip across the full display width.
-        this.renderer.drawRectFill(new Rect2i(0, 0, displayWidth, BTAPI.TICKER_HEIGHT), BTAPI.TICKER_BG_INDEX);
-
-        // Tile text copies so the banner is always full-width.
-        const paletteOffset = BTAPI.TICKER_TEXT_INDEX - 1;
-        let x = this.tickerScrollX;
-        while (x < displayWidth) {
-            this.renderer.drawBitmapText(this.systemFont, new Vector2i(x, 1), BTAPI.TICKER_TEXT, paletteOffset);
-            x += textWidth;
-        }
-
-        this.renderer.setCameraOffset(savedCamera);
-    }
-
-    // #endregion
-
     // #region Camera API
 
     /**
@@ -968,6 +885,7 @@ export class BTAPI {
                 }
 
                 this.activeBackend = 'webgpu';
+                this.ticker = null;
                 console.log('[BT] Renderer initialized');
 
                 return true;
@@ -990,6 +908,7 @@ export class BTAPI {
         }
 
         this.activeBackend = 'software';
+        this.ticker = new SoftwareTicker(`${BTAPI.VERSION_MAJOR}.${BTAPI.VERSION_MINOR}.${BTAPI.VERSION_PATCH}`);
         console.log('[BT] Renderer initialized');
 
         return true;

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -25,7 +25,7 @@ import {
     paletteIndexOutOfRangeError,
     spriteNotIndexizedError,
 } from '../utils/errorMessages';
-import type { Rect2i } from '../utils/Rect2i';
+import { Rect2i } from '../utils/Rect2i';
 import { Vector2i } from '../utils/Vector2i';
 import type { FrameDropCallback, FrameDropEvent } from './GameLoop';
 import { GameLoop } from './GameLoop';
@@ -56,6 +56,45 @@ export class BTAPI {
 
     // #endregion
 
+    // #region Software Ticker Constants
+
+    /** Height in pixels of the software-mode ticker banner strip. */
+    private static readonly TICKER_HEIGHT = 16;
+
+    /** System font glyph advance in pixels (matches SYSTEM_FONT_GLYPH_WIDTH = 6). */
+    private static readonly TICKER_CHAR_ADVANCE = 6;
+
+    /** Pixels to scroll left per rendered frame. */
+    private static readonly TICKER_SCROLL_SPEED = 1;
+
+    /** Palette index used for the ticker background fill. */
+    private static readonly TICKER_BG_INDEX = 1;
+
+    /**
+     * Palette index used for the ticker text.
+     *
+     * The system font stores foreground pixels as palette index 1; passing
+     * `TICKER_TEXT_INDEX - 1` as `paletteOffset` remaps those pixels to this index.
+     */
+    private static readonly TICKER_TEXT_INDEX = 2;
+
+    /**
+     * Text displayed in the software-mode ticker.
+     *
+     * Drawn using palette indices TICKER_BG_INDEX (background) and TICKER_TEXT_INDEX
+     * (text). The actual colors depend on the active palette.
+     */
+    private static readonly TICKER_TEXT =
+        'SOFTWARE RENDERER - blit-tech v' +
+        BTAPI.VERSION_MAJOR +
+        '.' +
+        BTAPI.VERSION_MINOR +
+        '.' +
+        BTAPI.VERSION_PATCH +
+        '  ';
+
+    // #endregion
+
     // #region Module State - Demo Instance
 
     /** Current demo instance implementing IBlitTechDemo. */
@@ -83,6 +122,12 @@ export class BTAPI {
 
     /** Renderer subsystem for all drawing operations. */
     private renderer: IRenderer | null = null;
+
+    /** Backend that was successfully initialized, or null before init. */
+    private activeBackend: RendererBackend | null = null;
+
+    /** X scroll position for the software-mode ticker overlay; advances left each frame. */
+    private tickerScrollX = 0;
 
     /** Active engine palette used by palette-first rendering. */
     private palette: Palette | null = null;
@@ -252,6 +297,11 @@ export class BTAPI {
                         this.paletteEffects.update(this.palette);
                     }
 
+                    // Software ticker renders on top of the demo, after user draw calls.
+                    if (this.activeBackend === 'software') {
+                        this.renderSoftwareTicker();
+                    }
+
                     this.renderer.endFrame();
                 }
 
@@ -358,6 +408,15 @@ export class BTAPI {
      */
     public getRenderer(): IRenderer | null {
         return this.renderer;
+    }
+
+    /**
+     * Returns the renderer backend that was actually initialized.
+     *
+     * @returns `'webgpu'` or `'software'` after successful init; `null` before init or on failure.
+     */
+    public getActiveBackend(): RendererBackend | null {
+        return this.activeBackend;
     }
 
     /**
@@ -624,6 +683,51 @@ export class BTAPI {
 
     // #endregion
 
+    // #region Software Ticker
+
+    /**
+     * Renders the software-mode status ticker at the top of the canvas.
+     *
+     * Draws a filled background strip and tiled scrolling text using the system font.
+     * Saves and restores the camera so the banner is always viewport-relative
+     * regardless of the demo's camera position.
+     *
+     * Called each frame from the GameLoop render callback when activeBackend is 'software'.
+     */
+    private renderSoftwareTicker(): void {
+        if (!this.renderer || !this.hwSettings || !this.systemFont) {
+            return;
+        }
+
+        const displayWidth = this.hwSettings.displaySize.x;
+        const textWidth = BTAPI.TICKER_TEXT.length * BTAPI.TICKER_CHAR_ADVANCE;
+
+        // Advance scroll state; wrap with modular arithmetic so tiled copies remain seamless.
+        this.tickerScrollX -= BTAPI.TICKER_SCROLL_SPEED;
+        if (this.tickerScrollX < -textWidth) {
+            this.tickerScrollX += textWidth;
+        }
+
+        // Suppress camera offset for overlay rendering; restore after.
+        const savedCamera = this.renderer.getCameraOffset();
+        this.renderer.resetCamera();
+
+        // Background strip across the full display width.
+        this.renderer.drawRectFill(new Rect2i(0, 0, displayWidth, BTAPI.TICKER_HEIGHT), BTAPI.TICKER_BG_INDEX);
+
+        // Tile text copies so the banner is always full-width.
+        const paletteOffset = BTAPI.TICKER_TEXT_INDEX - 1;
+        let x = this.tickerScrollX;
+        while (x < displayWidth) {
+            this.renderer.drawBitmapText(this.systemFont, new Vector2i(x, 1), BTAPI.TICKER_TEXT, paletteOffset);
+            x += textWidth;
+        }
+
+        this.renderer.setCameraOffset(savedCamera);
+    }
+
+    // #endregion
+
     // #region Camera API
 
     /**
@@ -830,44 +934,54 @@ export class BTAPI {
      */
     private async initRenderer(canvas: HTMLCanvasElement, hw: HardwareSettings): Promise<boolean> {
         const requestedBackend = hw.renderer ?? 'webgpu';
-        if (requestedBackend === 'software') {
-            this.device = null;
-            this.context = null;
-            console.log('[BT] Initializing renderer (backend: software)');
-            this.renderer = new SoftwareRenderer(canvas, hw.displaySize, hw.canvasDisplaySize);
 
-            if (!(await this.renderer.init())) {
-                console.error('[BT] Failed to initialize renderer');
-
-                return false;
+        if (requestedBackend !== 'software') {
+            // Try WebGPU. initWebGPU returns null when navigator.gpu is absent and
+            // throws when the adapter or device cannot be created. Both cases fall
+            // through to the software renderer below.
+            let webGPUResult: Awaited<ReturnType<typeof initWebGPU>> = null;
+            try {
+                webGPUResult = await initWebGPU(canvas, hw.displaySize, hw.canvasDisplaySize);
+            } catch {
+                // Adapter/device unavailable; fall through to software.
             }
 
-            console.log('[BT] Renderer initialized');
+            if (webGPUResult) {
+                this.device = webGPUResult.device;
+                this.context = webGPUResult.context;
+                console.log('[BT] Initializing renderer (backend: webgpu)');
 
-            return true;
+                this.renderer = new WebGpuRenderer(
+                    webGPUResult.device,
+                    webGPUResult.context,
+                    hw.displaySize,
+                    // Only forward an explicit outputSize when canvasDisplaySize was
+                    // provided; that is the signal that unlocks the display tier.
+                    hw.canvasDisplaySize !== undefined ? webGPUResult.drawingBufferSize : undefined,
+                    hw.outputUpscaleFilter ?? 'nearest',
+                );
+
+                if (!(await this.renderer.init())) {
+                    console.error('[BT] Failed to initialize renderer');
+
+                    return false;
+                }
+
+                this.activeBackend = 'webgpu';
+                console.log('[BT] Renderer initialized');
+
+                return true;
+            }
+
+            console.warn('[BT] WebGPU unavailable, falling back to software renderer');
         }
 
-        const webGPUResult = await initWebGPU(canvas, hw.displaySize, hw.canvasDisplaySize);
-        if (!webGPUResult) {
-            console.error('[BT] Failed to initialize WebGPU');
+        // Software renderer path: explicit selection or automatic fallback.
+        this.device = null;
+        this.context = null;
+        console.log('[BT] Initializing renderer (backend: software)');
 
-            return false;
-        }
-
-        this.device = webGPUResult.device;
-        this.context = webGPUResult.context;
-
-        console.log('[BT] Initializing renderer (backend: webgpu)');
-
-        this.renderer = new WebGpuRenderer(
-            webGPUResult.device,
-            webGPUResult.context,
-            hw.displaySize,
-            // Only forward an explicit outputSize when canvasDisplaySize was
-            // provided; that is the signal that unlocks the display tier.
-            hw.canvasDisplaySize !== undefined ? webGPUResult.drawingBufferSize : undefined,
-            hw.outputUpscaleFilter ?? 'nearest',
-        );
+        this.renderer = new SoftwareRenderer(canvas, hw.displaySize, hw.canvasDisplaySize);
 
         if (!(await this.renderer.init())) {
             console.error('[BT] Failed to initialize renderer');
@@ -875,6 +989,7 @@ export class BTAPI {
             return false;
         }
 
+        this.activeBackend = 'software';
         console.log('[BT] Renderer initialized');
 
         return true;

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -261,7 +261,16 @@ export class BTAPI {
 
                     // Software ticker renders on top of the demo, after user draw calls.
                     if (this.ticker && this.systemFont) {
-                        this.ticker.render(this.renderer, this.hwSettings?.displaySize.x ?? 0, this.systemFont);
+                        this.ticker.render(
+                            this.renderer,
+                            this.hwSettings?.displaySize.x ?? 0,
+                            this.systemFont,
+                            this.pointer,
+                        );
+
+                        if (this.ticker.isDismissed) {
+                            this.ticker = null;
+                        }
                     }
 
                     this.renderer.endFrame();

--- a/src/render/SoftwareTicker.test.ts
+++ b/src/render/SoftwareTicker.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Unit tests for {@link SoftwareTicker}.
+ *
+ * Verifies scroll state, banner dimensions, camera save/restore, and text
+ * tiling — all without running the full BTAPI engine.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { BitmapFont } from '../assets/BitmapFont';
+import { Rect2i } from '../utils/Rect2i';
+import { Vector2i } from '../utils/Vector2i';
+import type { IRenderer } from './IRenderer';
+import { SoftwareTicker } from './SoftwareTicker';
+
+// #region Helpers
+
+function makeMockRenderer(): IRenderer {
+    return {
+        init: vi.fn().mockResolvedValue(true),
+        beginFrame: vi.fn(),
+        endFrame: vi.fn(),
+        setPalette: vi.fn(),
+        getPalette: vi.fn().mockReturnValue(null),
+        setClearColor: vi.fn(),
+        drawRectFill: vi.fn(),
+        drawPixel: vi.fn(),
+        drawLine: vi.fn(),
+        drawRect: vi.fn(),
+        clearRect: vi.fn(),
+        drawSprite: vi.fn(),
+        drawBitmapText: vi.fn(),
+        captureFrame: vi.fn().mockResolvedValue(new Blob()),
+        setCameraOffset: vi.fn(),
+        getCameraOffset: vi.fn().mockReturnValue(new Vector2i(0, 0)),
+        resetCamera: vi.fn(),
+        addEffect: vi.fn(),
+        removeEffect: vi.fn(),
+        clearEffects: vi.fn(),
+    } as unknown as IRenderer;
+}
+
+function makeMockFont(): BitmapFont {
+    return {} as unknown as BitmapFont;
+}
+
+// #endregion
+
+describe('SoftwareTicker', () => {
+    let renderer: IRenderer;
+    let font: BitmapFont;
+
+    beforeEach(() => {
+        renderer = makeMockRenderer();
+        font = makeMockFont();
+    });
+
+    // #region Constructor
+
+    describe('constructor', () => {
+        it('embeds the version string in the ticker text', () => {
+            const ticker = new SoftwareTicker('1.2.3');
+            const drawBitmapText = vi.spyOn(renderer, 'drawBitmapText');
+
+            ticker.render(renderer, 320, font);
+
+            expect(drawBitmapText.mock.calls[0]?.[2]).toContain('1.2.3');
+        });
+
+        it('includes SOFTWARE RENDERER prefix in the ticker text', () => {
+            const ticker = new SoftwareTicker('0.2.0');
+            const drawBitmapText = vi.spyOn(renderer, 'drawBitmapText');
+
+            ticker.render(renderer, 320, font);
+
+            expect(drawBitmapText.mock.calls[0]?.[2]).toContain('SOFTWARE RENDERER');
+        });
+    });
+
+    // #endregion
+
+    // #region Background rect
+
+    describe('background rect', () => {
+        it('draws a rect that starts at (0, 0)', () => {
+            const ticker = new SoftwareTicker('0.2.0');
+            const drawRectFill = vi.spyOn(renderer, 'drawRectFill');
+
+            ticker.render(renderer, 320, font);
+
+            const [rect] = drawRectFill.mock.calls[0] ?? [];
+            expect(rect).toBeInstanceOf(Rect2i);
+            if (rect instanceof Rect2i) {
+                expect(rect.x).toBe(0);
+                expect(rect.y).toBe(0);
+            }
+        });
+
+        it('draws a rect spanning the full display width', () => {
+            const ticker = new SoftwareTicker('0.2.0');
+            const drawRectFill = vi.spyOn(renderer, 'drawRectFill');
+
+            ticker.render(renderer, 480, font);
+
+            const [rect] = drawRectFill.mock.calls[0] ?? [];
+            if (rect instanceof Rect2i) {
+                expect(rect.width).toBe(480);
+            }
+        });
+
+        it('draws the background rect with palette index 1', () => {
+            const ticker = new SoftwareTicker('0.2.0');
+            const drawRectFill = vi.spyOn(renderer, 'drawRectFill');
+
+            ticker.render(renderer, 320, font);
+
+            const [, paletteIndex] = drawRectFill.mock.calls[0] ?? [];
+            expect(paletteIndex).toBe(1);
+        });
+    });
+
+    // #endregion
+
+    // #region Text rendering
+
+    describe('text rendering', () => {
+        it('draws at least one text tile per render call', () => {
+            const ticker = new SoftwareTicker('0.2.0');
+            const drawBitmapText = vi.spyOn(renderer, 'drawBitmapText');
+
+            ticker.render(renderer, 320, font);
+
+            expect(drawBitmapText).toHaveBeenCalled();
+        });
+
+        it('draws text with palette offset 1 (foreground pixel index 1 -> palette index 2)', () => {
+            const ticker = new SoftwareTicker('0.2.0');
+            const drawBitmapText = vi.spyOn(renderer, 'drawBitmapText');
+
+            ticker.render(renderer, 320, font);
+
+            const [, , , paletteOffset] = drawBitmapText.mock.calls[0] ?? [];
+            expect(paletteOffset).toBe(1);
+        });
+
+        it('tiles text to fill a wide display (multiple drawBitmapText calls)', () => {
+            const ticker = new SoftwareTicker('0.2.0');
+            const drawBitmapText = vi.spyOn(renderer, 'drawBitmapText');
+
+            // With a display much wider than the text, multiple tiles are needed.
+            ticker.render(renderer, 9999, font);
+
+            expect(drawBitmapText.mock.calls.length).toBeGreaterThan(1);
+        });
+    });
+
+    // #endregion
+
+    // #region Scroll state
+
+    describe('scroll state', () => {
+        it('advances the scroll position each render call', () => {
+            const ticker = new SoftwareTicker('0.2.0');
+            const drawBitmapText = vi.spyOn(renderer, 'drawBitmapText');
+
+            ticker.render(renderer, 320, font);
+            const xAfterFirstFrame = (drawBitmapText.mock.calls[0]?.[1] as Vector2i | undefined)?.x ?? 0;
+
+            drawBitmapText.mockClear();
+            ticker.render(renderer, 320, font);
+            const xAfterSecondFrame = (drawBitmapText.mock.calls[0]?.[1] as Vector2i | undefined)?.x ?? 0;
+
+            // Ticker scrolls left (x decreases by 1 each frame).
+            expect(xAfterSecondFrame).toBe(xAfterFirstFrame - 1);
+        });
+
+        it('wraps scroll back to within text-width bounds after many frames', () => {
+            const ticker = new SoftwareTicker('X');
+            const drawBitmapText = vi.spyOn(renderer, 'drawBitmapText');
+
+            // Drive many frames to force multiple wraps.
+            for (let i = 0; i < 5000; i++) {
+                ticker.render(renderer, 320, font);
+            }
+
+            // Inspect only the first tile of a fresh frame so we read scrollX directly.
+            drawBitmapText.mockClear();
+            ticker.render(renderer, 320, font);
+
+            const firstX = (drawBitmapText.mock.calls[0]?.[1] as Vector2i | undefined)?.x ?? 0;
+            const textWidth = 'SOFTWARE RENDERER - blit-tech vX  '.length * 6;
+            expect(firstX).toBeGreaterThan(-textWidth);
+            expect(firstX).toBeLessThanOrEqual(0);
+        });
+    });
+
+    // #endregion
+
+    // #region Camera save/restore
+
+    describe('camera save/restore', () => {
+        it('saves camera, resets it, then restores after render', () => {
+            const savedOffset = new Vector2i(50, 30);
+            vi.spyOn(renderer, 'getCameraOffset').mockReturnValue(savedOffset);
+            const resetCamera = vi.spyOn(renderer, 'resetCamera');
+            const setCameraOffset = vi.spyOn(renderer, 'setCameraOffset');
+
+            const ticker = new SoftwareTicker('0.2.0');
+            ticker.render(renderer, 320, font);
+
+            expect(resetCamera).toHaveBeenCalledOnce();
+            expect(setCameraOffset).toHaveBeenCalledWith(savedOffset);
+        });
+    });
+
+    // #endregion
+});

--- a/src/render/SoftwareTicker.test.ts
+++ b/src/render/SoftwareTicker.test.ts
@@ -1,13 +1,15 @@
 /**
  * Unit tests for {@link SoftwareTicker}.
  *
- * Verifies scroll state, banner dimensions, camera save/restore, and text
- * tiling — all without running the full BTAPI engine.
+ * Verifies static banner rendering, camera save/restore, click-to-dismiss
+ * behavior across pointer slots, and no-op behavior after dismissal.
+ * Does not run the full BTAPI engine.
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { BitmapFont } from '../assets/BitmapFont';
+import type { PointerInput } from '../input/PointerInput';
 import { Rect2i } from '../utils/Rect2i';
 import { Vector2i } from '../utils/Vector2i';
 import type { IRenderer } from './IRenderer';
@@ -44,6 +46,21 @@ function makeMockFont(): BitmapFont {
     return {} as unknown as BitmapFont;
 }
 
+/**
+ * Builds a minimal PointerInput stand-in.
+ *
+ * @param pressedSlot - Slot index that has a button-A press this frame, or -1 for no press.
+ * @param pressY - Y coordinate of the press (display pixels).
+ */
+function makeMockPointer(pressedSlot: number, pressY: number): PointerInput {
+    return {
+        isButtonPressed: vi.fn().mockImplementation((button: number, slot: number) => {
+            return button === 20 && slot === pressedSlot;
+        }),
+        getPos: vi.fn().mockReturnValue(new Vector2i(100, pressY)),
+    } as unknown as PointerInput;
+}
+
 // #endregion
 
 describe('SoftwareTicker', () => {
@@ -55,10 +72,10 @@ describe('SoftwareTicker', () => {
         font = makeMockFont();
     });
 
-    // #region Constructor
+    // #region Construction
 
     describe('constructor', () => {
-        it('embeds the version string in the ticker text', () => {
+        it('embeds the version string in the rendered text', () => {
             const ticker = new SoftwareTicker('1.2.3');
             const drawBitmapText = vi.spyOn(renderer, 'drawBitmapText');
 
@@ -67,7 +84,7 @@ describe('SoftwareTicker', () => {
             expect(drawBitmapText.mock.calls[0]?.[2]).toContain('1.2.3');
         });
 
-        it('includes SOFTWARE RENDERER prefix in the ticker text', () => {
+        it('includes SOFTWARE RENDERER prefix in the rendered text', () => {
             const ticker = new SoftwareTicker('0.2.0');
             const drawBitmapText = vi.spyOn(renderer, 'drawBitmapText');
 
@@ -124,13 +141,13 @@ describe('SoftwareTicker', () => {
     // #region Text rendering
 
     describe('text rendering', () => {
-        it('draws at least one text tile per render call', () => {
+        it('draws exactly one text call per render (no tiling)', () => {
             const ticker = new SoftwareTicker('0.2.0');
             const drawBitmapText = vi.spyOn(renderer, 'drawBitmapText');
 
             ticker.render(renderer, 320, font);
 
-            expect(drawBitmapText).toHaveBeenCalled();
+            expect(drawBitmapText).toHaveBeenCalledOnce();
         });
 
         it('draws text with palette offset 1 (foreground pixel index 1 -> palette index 2)', () => {
@@ -143,54 +160,27 @@ describe('SoftwareTicker', () => {
             expect(paletteOffset).toBe(1);
         });
 
-        it('tiles text to fill a wide display (multiple drawBitmapText calls)', () => {
+        it('centers text within the display width', () => {
+            const ticker = new SoftwareTicker('0.2.0');
+            const drawBitmapText = vi.spyOn(renderer, 'drawBitmapText');
+            const text = 'SOFTWARE RENDERER - blit-tech v0.2.0';
+            const textWidth = text.length * 6;
+            const expectedX = Math.floor((320 - textWidth) / 2);
+
+            ticker.render(renderer, 320, font);
+
+            const pos = drawBitmapText.mock.calls[0]?.[1] as Vector2i | undefined;
+            expect(pos?.x).toBe(expectedX);
+        });
+
+        it('clamps text x to 0 when display is narrower than the text', () => {
             const ticker = new SoftwareTicker('0.2.0');
             const drawBitmapText = vi.spyOn(renderer, 'drawBitmapText');
 
-            // With a display much wider than the text, multiple tiles are needed.
-            ticker.render(renderer, 9999, font);
+            ticker.render(renderer, 10, font);
 
-            expect(drawBitmapText.mock.calls.length).toBeGreaterThan(1);
-        });
-    });
-
-    // #endregion
-
-    // #region Scroll state
-
-    describe('scroll state', () => {
-        it('advances the scroll position each render call', () => {
-            const ticker = new SoftwareTicker('0.2.0');
-            const drawBitmapText = vi.spyOn(renderer, 'drawBitmapText');
-
-            ticker.render(renderer, 320, font);
-            const xAfterFirstFrame = (drawBitmapText.mock.calls[0]?.[1] as Vector2i | undefined)?.x ?? 0;
-
-            drawBitmapText.mockClear();
-            ticker.render(renderer, 320, font);
-            const xAfterSecondFrame = (drawBitmapText.mock.calls[0]?.[1] as Vector2i | undefined)?.x ?? 0;
-
-            // Ticker scrolls left (x decreases by 1 each frame).
-            expect(xAfterSecondFrame).toBe(xAfterFirstFrame - 1);
-        });
-
-        it('wraps scroll back to within text-width bounds after many frames', () => {
-            const ticker = new SoftwareTicker('X');
-            const drawBitmapText = vi.spyOn(renderer, 'drawBitmapText');
-
-            // Drive many frames to force multiple wraps.
-            for (let i = 0; i < 5000; i++) {
-                ticker.render(renderer, 320, font);
-            }
-
-            // Inspect only the first tile of a fresh frame so we read scrollX directly.
-            drawBitmapText.mockClear();
-            ticker.render(renderer, 320, font);
-
-            const firstX = (drawBitmapText.mock.calls[0]?.[1] as Vector2i | undefined)?.x ?? 0;
-            const textWidth = 'SOFTWARE RENDERER - blit-tech vX  '.length * 6;
-            expect(firstX).toBeGreaterThan(-textWidth);
-            expect(firstX).toBeLessThanOrEqual(0);
+            const pos = drawBitmapText.mock.calls[0]?.[1] as Vector2i | undefined;
+            expect(pos?.x).toBe(0);
         });
     });
 
@@ -199,7 +189,7 @@ describe('SoftwareTicker', () => {
     // #region Camera save/restore
 
     describe('camera save/restore', () => {
-        it('saves camera, resets it, then restores after render', () => {
+        it('saves the camera, resets it, then restores it after drawing', () => {
             const savedOffset = new Vector2i(50, 30);
             vi.spyOn(renderer, 'getCameraOffset').mockReturnValue(savedOffset);
             const resetCamera = vi.spyOn(renderer, 'resetCamera');
@@ -210,6 +200,79 @@ describe('SoftwareTicker', () => {
 
             expect(resetCamera).toHaveBeenCalledOnce();
             expect(setCameraOffset).toHaveBeenCalledWith(savedOffset);
+        });
+    });
+
+    // #endregion
+
+    // #region Dismiss on click/tap
+
+    describe('dismiss on click/tap', () => {
+        it('is not dismissed before any render', () => {
+            const ticker = new SoftwareTicker('0.2.0');
+            expect(ticker.isDismissed).toBe(false);
+        });
+
+        it('dismisses when primary button pressed within banner area on slot 0 (mouse)', () => {
+            const ticker = new SoftwareTicker('0.2.0');
+            const pointer = makeMockPointer(0, 7); // y=7 < TICKER_HEIGHT=15
+
+            ticker.render(renderer, 320, font, pointer);
+
+            expect(ticker.isDismissed).toBe(true);
+        });
+
+        it('dismisses when primary button pressed within banner area on touch slot 1', () => {
+            const ticker = new SoftwareTicker('0.2.0');
+            const pointer = makeMockPointer(1, 7);
+
+            ticker.render(renderer, 320, font, pointer);
+
+            expect(ticker.isDismissed).toBe(true);
+        });
+
+        it('does not dismiss when press is below the banner area', () => {
+            const ticker = new SoftwareTicker('0.2.0');
+            const pointer = makeMockPointer(0, 50); // y=50 > TICKER_HEIGHT=15
+
+            ticker.render(renderer, 320, font, pointer);
+
+            expect(ticker.isDismissed).toBe(false);
+        });
+
+        it('does not dismiss when no pointer is supplied', () => {
+            const ticker = new SoftwareTicker('0.2.0');
+
+            ticker.render(renderer, 320, font);
+            ticker.render(renderer, 320, font, null);
+
+            expect(ticker.isDismissed).toBe(false);
+        });
+
+        it('skips drawing on the dismissal frame (returns before drawRectFill)', () => {
+            const ticker = new SoftwareTicker('0.2.0');
+            const drawRectFill = vi.spyOn(renderer, 'drawRectFill');
+            const pointer = makeMockPointer(0, 7);
+
+            ticker.render(renderer, 320, font, pointer);
+
+            expect(drawRectFill).not.toHaveBeenCalled();
+        });
+
+        it('does not render at all after being dismissed', () => {
+            const ticker = new SoftwareTicker('0.2.0');
+
+            // Dismiss via a click.
+            ticker.render(renderer, 320, font, makeMockPointer(0, 7));
+            expect(ticker.isDismissed).toBe(true);
+
+            // Subsequent renders should be no-ops.
+            const drawRectFill = vi.spyOn(renderer, 'drawRectFill');
+            const drawBitmapText = vi.spyOn(renderer, 'drawBitmapText');
+            ticker.render(renderer, 320, font);
+
+            expect(drawRectFill).not.toHaveBeenCalled();
+            expect(drawBitmapText).not.toHaveBeenCalled();
         });
     });
 

--- a/src/render/SoftwareTicker.ts
+++ b/src/render/SoftwareTicker.ts
@@ -1,13 +1,15 @@
 /**
  * Software-mode status ticker overlay.
  *
- * Renders a scrolling "SOFTWARE RENDERER - blit-tech vX.Y.Z" banner at
- * the top of the canvas using palette-indexed draw calls. Designed to be
- * instantiated by BTAPI when the software backend starts and called once
- * per render frame.
+ * Renders a static "SOFTWARE RENDERER - blit-tech vX.Y.Z" banner centered at
+ * the top of the canvas using palette-indexed draw calls. Tapping or clicking
+ * the banner dismisses it permanently. Designed to be instantiated by BTAPI
+ * when the software backend starts and called once per render frame.
  */
 
 import type { BitmapFont } from '../assets/BitmapFont';
+import type { PointerInput } from '../input/PointerInput';
+import { POINTER_SLOT_COUNT } from '../input/PointerInput';
 import { Rect2i } from '../utils/Rect2i';
 import { Vector2i } from '../utils/Vector2i';
 import type { IRenderer } from './IRenderer';
@@ -15,13 +17,10 @@ import type { IRenderer } from './IRenderer';
 // #region Constants
 
 /** Height in pixels of the ticker banner strip. */
-const TICKER_HEIGHT = 16;
+const TICKER_HEIGHT = 15;
 
 /** System font glyph advance in pixels (matches SYSTEM_FONT_GLYPH_WIDTH = 6). */
 const TICKER_CHAR_ADVANCE = 6;
-
-/** Pixels to scroll left per rendered frame. */
-const TICKER_SCROLL_SPEED = 1;
 
 /** Palette index for the ticker background fill. */
 const TICKER_BG_INDEX = 1;
@@ -34,23 +33,31 @@ const TICKER_BG_INDEX = 1;
  */
 const TICKER_TEXT_INDEX = 2;
 
+/**
+ * Pointer button code for primary press (mouse left / touch contact).
+ *
+ * Mirrors the private `BTN_POINTER_A = 20` constant in PointerInput.ts and
+ * the `BT.BTN_POINTER_A` bit-flag mapped through `pointerFlagToPointerCode`.
+ */
+const DISMISS_BUTTON_CODE = 20;
+
 // #endregion
 
 // #region SoftwareTicker
 
 /**
- * Scrolling status banner rendered when the software backend is active.
+ * Static status banner rendered when the software backend is active.
  *
- * Holds its own scroll state. Each call to {@link render} advances the
- * animation by one frame. The camera is saved and restored so the banner
- * is always viewport-relative regardless of the demo's camera position.
+ * The banner is centered horizontally. Clicking or tapping anywhere on the
+ * banner permanently hides it; BTAPI checks {@link isDismissed} after each
+ * {@link render} call and nulls out its reference when the banner is gone.
  */
 export class SoftwareTicker {
     /** Scrolling text content built from the engine version string. */
     private readonly text: string;
 
-    /** Current horizontal scroll offset; advances left each frame. */
-    private scrollX = 0;
+    /** True once the user has dismissed the banner by clicking or tapping it. */
+    private dismissed = false;
 
     /**
      * Creates a ticker for the given engine version.
@@ -58,23 +65,45 @@ export class SoftwareTicker {
      * @param version - Engine version string (e.g. `"0.2.0"`), embedded in the banner text.
      */
     constructor(version: string) {
-        this.text = `SOFTWARE RENDERER - blit-tech v${version}  `;
+        this.text = `SOFTWARE RENDERER - blit-tech v${version}`;
+    }
+
+    /**
+     * Whether the banner has been dismissed by the user.
+     *
+     * BTAPI reads this after each {@link render} call and drops its reference
+     * when `true` so subsequent frames skip the ticker entirely.
+     *
+     * @returns `true` once the user has clicked or tapped the banner; `false` until then.
+     */
+    get isDismissed(): boolean {
+        return this.dismissed;
     }
 
     /**
      * Renders one frame of the ticker onto the given renderer.
      *
+     * Returns immediately when the banner has already been dismissed. When a
+     * pointer press is detected within the banner area the banner is marked
+     * dismissed and this call returns without drawing.
+     *
      * @param renderer - Active renderer backend.
      * @param displayWidth - Logical display width in pixels.
-     * @param font - System bitmap font used to draw the scrolling text.
+     * @param font - System bitmap font used to draw the label text.
+     * @param pointer - Optional pointer subsystem; when supplied, click/tap within the banner dismisses it.
      */
-    render(renderer: IRenderer, displayWidth: number, font: BitmapFont): void {
-        const textWidth = this.text.length * TICKER_CHAR_ADVANCE;
+    render(renderer: IRenderer, displayWidth: number, font: BitmapFont, pointer: PointerInput | null = null): void {
+        if (this.dismissed) {
+            return;
+        }
 
-        // Advance scroll; wrap with modular arithmetic so tiled copies remain seamless.
-        this.scrollX -= TICKER_SCROLL_SPEED;
-        if (this.scrollX < -textWidth) {
-            this.scrollX += textWidth;
+        if (pointer) {
+            for (let slot = 0; slot < POINTER_SLOT_COUNT; slot++) {
+                if (pointer.isButtonPressed(DISMISS_BUTTON_CODE, slot) && pointer.getPos(slot).y < TICKER_HEIGHT) {
+                    this.dismissed = true;
+                    return;
+                }
+            }
         }
 
         const savedCamera = renderer.getCameraOffset();
@@ -82,12 +111,9 @@ export class SoftwareTicker {
 
         renderer.drawRectFill(new Rect2i(0, 0, displayWidth, TICKER_HEIGHT), TICKER_BG_INDEX);
 
-        const paletteOffset = TICKER_TEXT_INDEX - 1;
-        let x = this.scrollX;
-        while (x < displayWidth) {
-            renderer.drawBitmapText(font, new Vector2i(x, 1), this.text, paletteOffset);
-            x += textWidth;
-        }
+        const textWidth = this.text.length * TICKER_CHAR_ADVANCE;
+        const x = Math.max(0, Math.floor((displayWidth - textWidth) / 2));
+        renderer.drawBitmapText(font, new Vector2i(x, 1), this.text, TICKER_TEXT_INDEX - 1);
 
         renderer.setCameraOffset(savedCamera);
     }

--- a/src/render/SoftwareTicker.ts
+++ b/src/render/SoftwareTicker.ts
@@ -1,0 +1,96 @@
+/**
+ * Software-mode status ticker overlay.
+ *
+ * Renders a scrolling "SOFTWARE RENDERER - blit-tech vX.Y.Z" banner at
+ * the top of the canvas using palette-indexed draw calls. Designed to be
+ * instantiated by BTAPI when the software backend starts and called once
+ * per render frame.
+ */
+
+import type { BitmapFont } from '../assets/BitmapFont';
+import { Rect2i } from '../utils/Rect2i';
+import { Vector2i } from '../utils/Vector2i';
+import type { IRenderer } from './IRenderer';
+
+// #region Constants
+
+/** Height in pixels of the ticker banner strip. */
+const TICKER_HEIGHT = 16;
+
+/** System font glyph advance in pixels (matches SYSTEM_FONT_GLYPH_WIDTH = 6). */
+const TICKER_CHAR_ADVANCE = 6;
+
+/** Pixels to scroll left per rendered frame. */
+const TICKER_SCROLL_SPEED = 1;
+
+/** Palette index for the ticker background fill. */
+const TICKER_BG_INDEX = 1;
+
+/**
+ * Palette index for the ticker text.
+ *
+ * The system font stores foreground pixels at palette index 1. Passing
+ * `TICKER_TEXT_INDEX - 1` as `paletteOffset` remaps those pixels to this slot.
+ */
+const TICKER_TEXT_INDEX = 2;
+
+// #endregion
+
+// #region SoftwareTicker
+
+/**
+ * Scrolling status banner rendered when the software backend is active.
+ *
+ * Holds its own scroll state. Each call to {@link render} advances the
+ * animation by one frame. The camera is saved and restored so the banner
+ * is always viewport-relative regardless of the demo's camera position.
+ */
+export class SoftwareTicker {
+    /** Scrolling text content built from the engine version string. */
+    private readonly text: string;
+
+    /** Current horizontal scroll offset; advances left each frame. */
+    private scrollX = 0;
+
+    /**
+     * Creates a ticker for the given engine version.
+     *
+     * @param version - Engine version string (e.g. `"0.2.0"`), embedded in the banner text.
+     */
+    constructor(version: string) {
+        this.text = `SOFTWARE RENDERER - blit-tech v${version}  `;
+    }
+
+    /**
+     * Renders one frame of the ticker onto the given renderer.
+     *
+     * @param renderer - Active renderer backend.
+     * @param displayWidth - Logical display width in pixels.
+     * @param font - System bitmap font used to draw the scrolling text.
+     */
+    render(renderer: IRenderer, displayWidth: number, font: BitmapFont): void {
+        const textWidth = this.text.length * TICKER_CHAR_ADVANCE;
+
+        // Advance scroll; wrap with modular arithmetic so tiled copies remain seamless.
+        this.scrollX -= TICKER_SCROLL_SPEED;
+        if (this.scrollX < -textWidth) {
+            this.scrollX += textWidth;
+        }
+
+        const savedCamera = renderer.getCameraOffset();
+        renderer.resetCamera();
+
+        renderer.drawRectFill(new Rect2i(0, 0, displayWidth, TICKER_HEIGHT), TICKER_BG_INDEX);
+
+        const paletteOffset = TICKER_TEXT_INDEX - 1;
+        let x = this.scrollX;
+        while (x < displayWidth) {
+            renderer.drawBitmapText(font, new Vector2i(x, 1), this.text, paletteOffset);
+            x += textWidth;
+        }
+
+        renderer.setCameraOffset(savedCamera);
+    }
+}
+
+// #endregion

--- a/src/utils/Bootstrap.test.ts
+++ b/src/utils/Bootstrap.test.ts
@@ -135,15 +135,16 @@ describe('bootstrap', () => {
     // #region WebGPU validation
 
     describe('WebGPU validation', () => {
-        it('should return false and call onError when WebGPU is not supported', async () => {
+        it('should proceed to engine init when WebGPU is not supported, letting BTAPI handle fallback', async () => {
             setupDOM();
 
-            // No navigator.gpu installed.
+            // No navigator.gpu installed. BTAPI.init is mocked to return true (set in beforeEach).
             const onError = vi.fn();
             const result = await bootstrap(MockDemo, { waitForDOMReady: false, onError });
 
-            expect(result).toBe(false);
-            expect(onError).toHaveBeenCalledOnce();
+            // Bootstrap no longer hard-stops on missing WebGPU; BTAPI handles backend selection.
+            expect(result).toBe(true);
+            expect(onError).not.toHaveBeenCalled();
         });
 
         it('should skip WebGPU validation when ?renderer=software is set', async () => {

--- a/src/utils/Bootstrap.ts
+++ b/src/utils/Bootstrap.ts
@@ -8,15 +8,7 @@
 import { BTAPI } from '../core/BTAPI';
 import type { IBlitTechDemo } from '../core/IBlitTechDemo';
 import type { ErrorContent } from './BootstrapHelpers';
-import {
-    checkWebGPUSupport,
-    DEFAULT_CANVAS_ID,
-    DEFAULT_CONTAINER_ID,
-    detectBrowser,
-    displayError,
-    getCanvas,
-    getWebGPUInstructions,
-} from './BootstrapHelpers';
+import { DEFAULT_CANVAS_ID, DEFAULT_CONTAINER_ID, displayError, getCanvas } from './BootstrapHelpers';
 import { CANVAS_NOT_FOUND_MESSAGE, INIT_FAILED_MESSAGE } from './errorMessages';
 
 // #region Types
@@ -65,40 +57,6 @@ interface BootstrapResult {
 
 // #endregion
 
-// #region Error Messages
-
-/**
- * Builds a browser-specific WebGPU not-supported message.
- * Detects the current browser and returns actionable instructions.
- *
- * @returns Plain-text error message with per-browser guidance.
- */
-function buildWebGPUNotSupportedMessage(): string {
-    return getWebGPUInstructions(detectBrowser());
-}
-
-/**
- * Returns true when URL query requests software renderer override.
- *
- * Recognizes `?renderer=software`.
- *
- * @returns True if `?renderer=software` is present in the current URL.
- */
-function isSoftwareRendererQueryOverrideEnabled(): boolean {
-    if (typeof window === 'undefined' || !window.location?.search) {
-        return false;
-    }
-
-    try {
-        return new URLSearchParams(window.location.search).get('renderer') === 'software';
-    } catch (error) {
-        console.warn('[BT] Failed to parse renderer query in bootstrap:', error);
-        return false;
-    }
-}
-
-// #endregion
-
 // #region Helper Functions
 
 /**
@@ -134,37 +92,6 @@ function handleBootstrapError(
     displayError(title, message, containerId);
     onError?.(error);
     return { success: false, error };
-}
-
-/**
- * Validates WebGPU support and returns the result.
- *
- * @param containerId - Container ID for error display.
- * @param onError - Optional error callback.
- * @returns BootstrapResult with success status.
- */
-function validateWebGPU(containerId: string, onError?: (error: Error) => void): BootstrapResult {
-    let result: BootstrapResult;
-
-    if (checkWebGPUSupport()) {
-        result = { success: true };
-    } else {
-        console.error("[BT] WebGPU isn't supported in this browser.");
-        console.error(
-            '[BT] Browser: ',
-            typeof navigator !== 'undefined' ? navigator.userAgent : 'navigator unavailable',
-        );
-
-        result = handleBootstrapError(
-            'WebGPU Not Supported',
-            buildWebGPUNotSupportedMessage(),
-            new Error("WebGPU isn't supported in this browser"),
-            containerId,
-            onError,
-        );
-    }
-
-    return result;
 }
 
 /**
@@ -315,14 +242,11 @@ export async function bootstrap(DemoClass: DemoConstructor, options: BootstrapOp
     }
 
     try {
-        // Validate WebGPU support unless software backend is explicitly requested
-        // via `?renderer=software`.
-        if (isSoftwareRendererQueryOverrideEnabled()) {
-            success = true;
-        } else {
-            const webGPUResult = validateWebGPU(containerId, onError);
-            success = webGPUResult.success;
-        }
+        // BTAPI handles backend selection and auto-fallback to software when
+        // WebGPU is unavailable. Always proceed to initDemo() here.
+        // validateWebGPU and isSoftwareRendererQueryOverrideEnabled remain for
+        // VV-492 which will delete the now-obsolete helper code.
+        success = true;
 
         // Validate canvas element.
         if (success) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This pull request wires BTAPI backend selection (WebGPU → software fallback), adds an in-canvas SoftwareTicker for the software renderer, and updates bootstrap flow and tests to reflect the new runtime behavior.

Core changes
- BTAPI
  - Tracks which renderer was initialized via a new activeBackend field and exposes public getActiveBackend(): RendererBackend | null.
  - initRenderer now attempts WebGPU first and falls back to the Canvas 2D software renderer on failure. When the software backend is active, a SoftwareTicker instance is created and rendered each frame; no ticker is used for WebGPU.
  - SoftwareTicker is cleared when dismissed.
- SoftwareTicker
  - New exported class that renders a one-line "SOFTWARE RENDERER - blit-tech vX.Y.Z" banner overlay.
  - Uses palette-indexed rect fill and bitmap text, centers/clamps text horizontally, preserves and restores the renderer camera offset, supports dismissal via primary pointer press in the banner area, and exposes an isDismissed getter.
- Bootstrap
  - Removed early WebGPU detection/error messaging and ?renderer handling from bootstrap; bootstrap now proceeds (success = true) and defers backend selection/fallback to BTAPI while retaining canvas validation and demo initialization.

Tests
- src/core/BTAPI.test.ts
  - Stops importing/asserting WEBGPU_ADAPTER_MESSAGE.
  - Expects BTAPI.instance.init(...) to return false when both WebGPU and software renderer initialization fail.
  - Adds coverage for backend selection reporting: null before init, 'webgpu' when WebGPU succeeds, 'software' when WebGPU fails and 2D canvas is available.
  - Adds tests verifying the software ticker renders draw calls when software is active and does not render when WebGPU is active.
- src/render/SoftwareTicker.test.ts
  - New comprehensive tests for banner text/version rendering, background rect geometry and palette index, horizontal centering/clamping, camera save/reset/restore behavior, dismissal semantics (pointer press inside/outside banner, multiple pointer slots, no-op after dismissed), and skip-of-drawing on the dismissal frame. Uses mocks for IRenderer/BitmapFont/PointerInput.
- src/utils/Bootstrap.test.ts
  - Updated WebGPU validation expectations: bootstrap proceeds successfully (true) when navigator.gpu is missing and waitForDOMReady is false, delegating backend choice to BTAPI.

Docs and README
- README and CLAUDE.md updated to document automatic WebGPU→software fallback, forced software selection via HardwareSettings.renderer or ?renderer=software, the dismissible in-canvas software ticker, and runtime detection via BT.getActiveBackend()/BTAPI.getActiveBackend().
- docs/software-fallback-smoke-matrix.md expanded to include auto-fallback and ticker verification scenarios.

Public API changes
- Added BTAPI.getActiveBackend(): RendererBackend | null.
- Added BT.getActiveBackend(): RendererBackend | null (delegates to BTAPI).
- Added export class SoftwareTicker with render(renderer, displayWidth, font, pointer?) and isDismissed getter.

Impact
- Behavior change: bootstrap no longer fails or shows a WebGPU-not-supported page; engine startup always continues and BTAPI chooses/falls back the renderer at init time.
- Tests and documentation updated to reflect new fallback and ticker behavior.

Lines changed: multiple files (introduces SoftwareTicker, refactors BTAPI init/fallback logic, updates bootstrap flow, and extends test coverage).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/132)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->