### PR TITLE
test(api): add BT.getActiveBackend() facade tests

### DIFF
--- a/src/BlitTech.test.ts
+++ b/src/BlitTech.test.ts
@@ -1337,3 +1337,34 @@ describe('BT.effectAdd / BT.effectRemove / BT.effectClear', () => {
 });
 
 // #endregion
+
+// #region BT.getActiveBackend
+
+describe('BT.getActiveBackend', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('delegates to BTAPI.instance.getActiveBackend', () => {
+        const spy = vi.spyOn(BTAPI.instance, 'getActiveBackend').mockReturnValue('webgpu');
+
+        const result = BT.getActiveBackend();
+
+        expect(spy).toHaveBeenCalled();
+        expect(result).toBe('webgpu');
+    });
+
+    it('returns null before initialization', () => {
+        vi.spyOn(BTAPI.instance, 'getActiveBackend').mockReturnValue(null);
+
+        expect(BT.getActiveBackend()).toBeNull();
+    });
+
+    it('returns software when BTAPI reports software backend active', () => {
+        vi.spyOn(BTAPI.instance, 'getActiveBackend').mockReturnValue('software');
+
+        expect(BT.getActiveBackend()).toBe('software');
+    });
+});
+
+// #endregion


### PR DESCRIPTION
Cover the three observable states of the public BT.getActiveBackend() accessor: delegation to BTAPI.instance, null before init, and the 'software' value when the software backend is active.

Existing BTAPI.test.ts already validates the full backend-selection logic (auto-fallback, explicit configure(), URL override); this adds the missing public-facade layer coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added test suite for the public `BT.getActiveBackend()` facade method in `src/BlitTech.test.ts` covering three test cases:

1. Verifies the method delegates to `BTAPI.instance.getActiveBackend()` by spying on the underlying method and confirming it returns the expected value
2. Validates that the method returns `null` when called before BTAPI initialization
3. Tests that the method returns `"software"` when the software backend is the active backend

These tests complement existing `BTAPI.test.ts` coverage of backend-selection logic (auto-fallback, explicit configuration, URL overrides) by adding specific coverage for the public-facing API layer.

Changes: +31 lines in test file only

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/134)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->