### PR TITLE
feat(assets): add Palette.applyHUD() preset for common HUD color slots

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ src/
     BitmapFont.ts          # Bitmap font system (.btfont)
     Palette.ts             # 256-entry indexed color palette
     PaletteEffect.ts       # Palette effect system (cycle, fade, flash, swap)
-    palettes/              # Built-in preset palette data (VGA, CGA, C64, etc.)
+    palettes/              # Built-in preset palette data (VGA, CGA, C64, etc.) + HUD UI preset (hudData.ts)
   input/
     PointerInput.ts        # DOM-backed pointer / mouse / touch / pen tracker (4 slots)
     KeyboardInput.ts       # KeyboardEvent.code state, edges, tick repeat, beforeinput text
@@ -116,6 +116,9 @@ Two backends selectable via `HardwareSettings.renderer` (default `'webgpu'`):
   at call sites
 - Prefer fixed-step helpers `BT.deltaSeconds()` / `BT.timeSeconds()` over hardcoded `1 / TARGET_FPS` in update loops
 - Prefer `BT.cameraClamp(...)` (or `clampCameraToWorld(...)` in utility code) over ad-hoc clamp math
+- Prefer `palette.applyHUD(startSlot?)` (default `1`) to fill the six common UI slots (white, bg, label, header, dim,
+  FPS) and register their `hud_*` name aliases, rather than six manual `palette.set()` calls; override individual slots
+  afterward for demo-specific colors
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ blit-tech/
 │   │   ├── Palette.ts          # 256-entry indexed color palette
 │   │   ├── PaletteEffect.ts    # Palette effect system (cycle, fade, flash, swap)
 │   │   ├── SpriteSheet.ts      # GPU texture wrapper with palette indexization
-│   │   └── palettes/           # Built-in preset palette data (VGA, CGA, C64, etc.)
+│   │   └── palettes/           # Built-in preset palette data (VGA, CGA, C64, etc.) + HUD UI preset
 │   ├── core/
 │   │   ├── BTAPI.ts            # Internal API singleton
 │   │   ├── GameLoop.ts         # Fixed-timestep game loop
@@ -345,13 +345,20 @@ BT.paletteGet(); // retrieve the active palette
 palette.setNamed('player', 3);
 palette.getNamed('player'); // returns 3
 
-// Built-in retro presets
+// Built-in retro presets (create a full palette from preset data)
 Palette.vga(); // VGA 256-color
 Palette.cga(); // CGA 16-color
 Palette.c64(); // Commodore 64 16-color
 Palette.gameboy(); // Game Boy 4-shade
 Palette.pico8(); // PICO-8 16-color
 Palette.nes(); // NES 64-color
+
+// Built-in HUD preset (fill 6 common UI slots into an existing palette)
+const palette = new Palette(256);
+palette.applyHUD(1); // fills slots 1-6: white, bg, label, header, dim, code
+// and registers hud_white / hud_bg / hud_label / hud_header / hud_dim / hud_code aliases
+palette.set(2, new Color32(20, 16, 32)); // override bg with your own color
+BT.paletteSet(palette);
 
 // Serialization
 const json = palette.toJSON();

--- a/src/assets/Palette.test.ts
+++ b/src/assets/Palette.test.ts
@@ -394,6 +394,18 @@ describe('applyHUD', () => {
         expect(() => palette.applyHUD(-1)).toThrow('HUD preset slots start from 1');
     });
 
+    it('throws when startSlot is fractional', () => {
+        const palette = new Palette(16);
+
+        expect(() => palette.applyHUD(1.5)).toThrow('HUD preset slots start from 1');
+    });
+
+    it('throws when startSlot is NaN', () => {
+        const palette = new Palette(16);
+
+        expect(() => palette.applyHUD(NaN)).toThrow('HUD preset slots start from 1');
+    });
+
     it('throws when the six slots exceed the palette size', () => {
         const palette = new Palette(256);
 

--- a/src/assets/Palette.test.ts
+++ b/src/assets/Palette.test.ts
@@ -323,3 +323,107 @@ describe('Palette dirty flag', () => {
 });
 
 // #endregion
+
+// #region applyHUD
+
+describe('applyHUD', () => {
+    it('fills slots 1-6 with canonical HUD colors at default startSlot', () => {
+        const palette = new Palette(16);
+
+        palette.applyHUD();
+
+        expect(palette.get(1).equals(Color32.fromHex('#ffffff'))).toBe(true);
+        expect(palette.get(2).equals(Color32.fromHex('#1e1428'))).toBe(true);
+        expect(palette.get(3).equals(Color32.fromHex('#c8c8c8'))).toBe(true);
+        expect(palette.get(4).equals(Color32.fromHex('#ffdc64'))).toBe(true);
+        expect(palette.get(5).equals(Color32.fromHex('#646464'))).toBe(true);
+        expect(palette.get(6).equals(Color32.fromHex('#6496c8'))).toBe(true);
+    });
+
+    it('fills slots at an explicit non-default startSlot', () => {
+        const palette = new Palette(64);
+
+        palette.applyHUD(10);
+
+        expect(palette.get(10).equals(Color32.fromHex('#ffffff'))).toBe(true);
+        expect(palette.get(15).equals(Color32.fromHex('#6496c8'))).toBe(true);
+        expect(palette.get(9).equals(Color32.black())).toBe(true);
+        expect(palette.get(16).equals(Color32.black())).toBe(true);
+    });
+
+    it('registers named aliases at the correct indices', () => {
+        const palette = new Palette(16);
+
+        palette.applyHUD(1);
+
+        expect(palette.getNamed('hud_white')).toBe(1);
+        expect(palette.getNamed('hud_bg')).toBe(2);
+        expect(palette.getNamed('hud_label')).toBe(3);
+        expect(palette.getNamed('hud_header')).toBe(4);
+        expect(palette.getNamed('hud_dim')).toBe(5);
+        expect(palette.getNamed('hud_code')).toBe(6);
+    });
+
+    it('offsets named aliases correctly when startSlot is not 1', () => {
+        const palette = new Palette(64);
+
+        palette.applyHUD(10);
+
+        expect(palette.getNamed('hud_white')).toBe(10);
+        expect(palette.getNamed('hud_code')).toBe(15);
+    });
+
+    it('does not touch slots outside the HUD range', () => {
+        const palette = new Palette(16);
+
+        palette.set(7, new Color32(1, 2, 3, 255));
+        palette.applyHUD(1);
+
+        expect(palette.get(7).equals(new Color32(1, 2, 3, 255))).toBe(true);
+    });
+
+    it('throws when startSlot is 0', () => {
+        const palette = new Palette(16);
+
+        expect(() => palette.applyHUD(0)).toThrow('HUD preset slots start from 1');
+    });
+
+    it('throws when startSlot is negative', () => {
+        const palette = new Palette(16);
+
+        expect(() => palette.applyHUD(-1)).toThrow('HUD preset slots start from 1');
+    });
+
+    it('throws when the six slots exceed the palette size', () => {
+        const palette = new Palette(256);
+
+        expect(() => palette.applyHUD(251)).toThrow('HUD preset needs 6 slots starting at 251');
+    });
+
+    it('throws immediately on a palette too small to fit the preset', () => {
+        const palette = new Palette(4);
+
+        expect(() => palette.applyHUD(1)).toThrow('HUD preset needs 6 slots');
+    });
+
+    it('re-registers aliases when called a second time at a different startSlot', () => {
+        const palette = new Palette(64);
+
+        palette.applyHUD(1);
+        palette.applyHUD(20);
+
+        expect(palette.getNamed('hud_white')).toBe(20);
+        expect(palette.getNamed('hud_code')).toBe(25);
+    });
+
+    it('marks the palette dirty after applying', () => {
+        const palette = new Palette(16);
+
+        palette.clearDirty();
+        palette.applyHUD(1);
+
+        expect(palette.dirty).toBe(true);
+    });
+});
+
+// #endregion

--- a/src/assets/Palette.ts
+++ b/src/assets/Palette.ts
@@ -7,7 +7,13 @@
  */
 
 import { Color32 } from '../utils/Color32';
-import { paletteIndexNegativeError, paletteIndexOutOfRangeError } from '../utils/errorMessages';
+import {
+    hudRangeError,
+    hudStartSlotError,
+    paletteIndexNegativeError,
+    paletteIndexOutOfRangeError,
+} from '../utils/errorMessages';
+import { HUD_SLOTS } from './palettes/hudData';
 import { C64_HEX, CGA_HEX, GAMEBOY_HEX, NES_HEX, PICO8_HEX, VGA_HEX } from './palettes/presetData';
 
 /** Supported palette sizes exposed by the public API. */
@@ -294,6 +300,47 @@ export class Palette {
      */
     public static nes(): Palette {
         return createPreset(NES_HEX, 64);
+    }
+
+    /**
+     * Writes the six built-in HUD colors into this palette and registers their
+     * named aliases (`hud_white`, `hud_bg`, `hud_label`, `hud_header`, `hud_dim`,
+     * `hud_code`).
+     *
+     * The six slots are written contiguously starting at `startSlot`. After calling
+     * this, use `palette.getNamed('hud_white')` etc. to obtain the assigned indices
+     * without hardcoding numbers.
+     *
+     * Default colors (matching common demo usage):
+     * - `hud_white`  — `#ffffff` pure white
+     * - `hud_bg`     — `#1e1428` dark purple background
+     * - `hud_label`  — `#c8c8c8` medium gray labels
+     * - `hud_header` — `#ffdc64` golden header text
+     * - `hud_dim`    — `#646464` dim gray (FPS, secondary info)
+     * - `hud_code`   — `#6496c8` slate blue code snippets
+     *
+     * @param startSlot - First palette index to write. Must be >= 1 and leave room
+     *   for all six entries within the palette size. Defaults to `1`.
+     * @throws Error if `startSlot` is less than 1.
+     * @throws Error if the six entries would exceed the palette size.
+     */
+    public applyHUD(startSlot: number = 1): void {
+        if (startSlot < 1) {
+            throw new Error(hudStartSlotError(startSlot));
+        }
+
+        if (startSlot + HUD_SLOTS.length > this.size) {
+            throw new Error(hudRangeError(startSlot, HUD_SLOTS.length, this.size));
+        }
+
+        let offset = 0;
+
+        for (const { hex, name } of HUD_SLOTS) {
+            const slot = startSlot + offset++;
+
+            this.set(slot, Color32.fromHex(hex));
+            this.setNamed(name, slot);
+        }
     }
 
     /**

--- a/src/assets/Palette.ts
+++ b/src/assets/Palette.ts
@@ -319,13 +319,13 @@ export class Palette {
      * - `hud_dim`    — `#646464` dim gray (FPS, secondary info)
      * - `hud_code`   — `#6496c8` slate blue code snippets
      *
-     * @param startSlot - First palette index to write. Must be >= 1 and leave room
-     *   for all six entries within the palette size. Defaults to `1`.
-     * @throws Error if `startSlot` is less than 1.
+     * @param startSlot - First palette index to write. Must be a positive integer >= 1
+     *   and leave room for all six entries within the palette size. Defaults to `1`.
+     * @throws Error if `startSlot` is not an integer, is NaN, or is less than 1.
      * @throws Error if the six entries would exceed the palette size.
      */
     public applyHUD(startSlot: number = 1): void {
-        if (startSlot < 1) {
+        if (!Number.isInteger(startSlot) || startSlot < 1) {
             throw new Error(hudStartSlotError(startSlot));
         }
 

--- a/src/assets/palettes/hudData.ts
+++ b/src/assets/palettes/hudData.ts
@@ -7,9 +7,6 @@
  * and a slate blue for code snippets.
  */
 
-/** One HUD palette slot: a canonical color paired with its registered name alias. */
-export type HudSlot = { readonly hex: string; readonly name: string };
-
 // cspell:disable
 
 /**
@@ -20,13 +17,16 @@ export type HudSlot = { readonly hex: string; readonly name: string };
  * The `name` is the alias registered by `palette.setNamed()` so callers can
  * resolve the slot index later via `palette.getNamed('hud_white')` etc.
  */
-export const HUD_SLOTS: readonly HudSlot[] = [
+export const HUD_SLOTS = [
     { hex: 'ffffff', name: 'hud_white' },
     { hex: '1e1428', name: 'hud_bg' },
     { hex: 'c8c8c8', name: 'hud_label' },
     { hex: 'ffdc64', name: 'hud_header' },
     { hex: '646464', name: 'hud_dim' },
     { hex: '6496c8', name: 'hud_code' },
-];
+] as const;
+
+/** One HUD palette slot: a canonical color paired with its registered name alias. */
+export type HudSlot = (typeof HUD_SLOTS)[number];
 
 // cspell:enable

--- a/src/assets/palettes/hudData.ts
+++ b/src/assets/palettes/hudData.ts
@@ -1,0 +1,32 @@
+/**
+ * Built-in HUD palette preset data used by {@link Palette.applyHUD}.
+ *
+ * Six named UI color slots applied contiguously starting at a caller-supplied
+ * start index. Values match the most common pattern seen across blit-tech demos:
+ * white text, a dark background, label gray, golden header, dim gray for FPS,
+ * and a slate blue for code snippets.
+ */
+
+/** One HUD palette slot: a canonical color paired with its registered name alias. */
+export type HudSlot = { readonly hex: string; readonly name: string };
+
+// cspell:disable
+
+/**
+ * The six built-in HUD UI color slots in application order.
+ *
+ * Each entry is a `{ hex, name }` pair. The `hex` value is an `RRGGBB` string
+ * without a leading `#`, matching the format used by {@link Color32.fromHex}.
+ * The `name` is the alias registered by `palette.setNamed()` so callers can
+ * resolve the slot index later via `palette.getNamed('hud_white')` etc.
+ */
+export const HUD_SLOTS: readonly HudSlot[] = [
+    { hex: 'ffffff', name: 'hud_white' },
+    { hex: '1e1428', name: 'hud_bg' },
+    { hex: 'c8c8c8', name: 'hud_label' },
+    { hex: 'ffdc64', name: 'hud_header' },
+    { hex: '646464', name: 'hud_dim' },
+    { hex: '6496c8', name: 'hud_code' },
+];
+
+// cspell:enable

--- a/src/assets/palettes/hudData.ts
+++ b/src/assets/palettes/hudData.ts
@@ -26,7 +26,4 @@ export const HUD_SLOTS = [
     { hex: '6496c8', name: 'hud_code' },
 ] as const;
 
-/** One HUD palette slot: a canonical color paired with its registered name alias. */
-export type HudSlot = (typeof HUD_SLOTS)[number];
-
 // cspell:enable

--- a/src/utils/errorMessages.ts
+++ b/src/utils/errorMessages.ts
@@ -78,6 +78,31 @@ export function paletteIndexOutOfRangeError(index: number, size: number): string
     return `The color number ${index} is too big for this palette. The palette has ${size} colors, so use a number from 0 to ${size - 1}.`;
 }
 
+/**
+ * Returns the error message when `applyHUD` is called with `startSlot` less than 1.
+ *
+ * @param startSlot - The invalid start slot value that was supplied.
+ * @returns User-facing error string.
+ */
+export function hudStartSlotError(startSlot: number): string {
+    return `HUD preset slots start from 1 (slot 0 is always transparent). Got ${startSlot}.`;
+}
+
+/**
+ * Returns the error message when the HUD preset slots would exceed the palette size.
+ *
+ * @param startSlot - The requested start slot.
+ * @param count - Number of HUD slots needed.
+ * @param size - The palette size.
+ * @returns User-facing error string.
+ */
+export function hudRangeError(startSlot: number, count: number, size: number): string {
+    return (
+        `HUD preset needs ${count} slots starting at ${startSlot}, ` +
+        `but this palette only has ${size} entries (max slot: ${size - 1}).`
+    );
+}
+
 // #endregion
 
 // #region Runtime — Sprites


### PR DESCRIPTION
Introduces a convenience method for loading the six built-in HUD UI colors into any palette in one call:

- New hudData.ts defines HUD_SLOTS (white, bg, label, header, dim, code) as a typed readonly array shared across callers
- Palette.applyHUD(startSlot?) writes the six entries contiguously and registers hud_white / hud_bg / hud_label / hud_header / hud_dim / hud_code as named aliases for index-free lookup
- hudStartSlotError() and hudRangeError() centralized in errorMessages.ts for consistent user-facing wording
- Full test coverage: slot filling, named-alias offsets, slot isolation, startSlot 0 / negative / overflow errors, and dirty flag behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes Overview

Adds Palette.applyHUD(startSlot?) convenience to populate six common HUD UI color slots, plus supporting HUD data, validation messages, and tests.

## New Modules

**src/assets/palettes/hudData.ts**
- Exports HUD_SLOTS as a readonly `as const` tuple of six `{ hex: string; name: string }` entries in application order: `hud_white`, `hud_bg`, `hud_label`, `hud_header`, `hud_dim`, `hud_code`.
- (No separate exported HudSlot type; HUD_SLOTS is declared `as const`.)

## Core Changes

**src/assets/Palette.ts**
- Added method: `public applyHUD(startSlot: number = 1): void`
  - Writes the six HUD colors from HUD_SLOTS into consecutive palette indices beginning at `startSlot` (default 1) using existing set APIs.
  - Registers named aliases (`hud_white`, `hud_bg`, `hud_label`, `hud_header`, `hud_dim`, `hud_code`) via setNamed so callers can resolve them index-free.
  - Validates `startSlot` with Number.isInteger and enforces `startSlot >= 1`; validates that the six-slot range fits within the palette size and throws HUD-specific errors on invalid inputs.
  - Marks the palette dirty after applying.
  - Repeated calls update alias mappings to the new indices.

**src/utils/errorMessages.ts**
- Added `hudStartSlotError(startSlot)` and `hudRangeError(startSlot, count, size)` to centralize user-facing HUD validation messages.

## Tests

**src/assets/Palette.test.ts**
- New `applyHUD` suite covering:
  - Canonical HUD color placement for default and explicit startSlot.
  - Named-alias registration and correct offsetting when startSlot shifts.
  - Isolation: slots outside the HUD range remain unchanged.
  - Validation/error cases: startSlot 0, negative, fractional, NaN, insufficient palette capacity (overflow / too-small palettes).
  - Repeated applyHUD calls update alias mappings.
  - Applying the preset marks the palette dirty.

## Documentation

- README.md and CLAUDE.md updated to document the HUD preset location and recommend using `palette.applyHUD()` over manual `palette.set()` for the six HUD slots.

## Other Notes

- A small cleanup removed an unused exported HudSlot (it became dead code after HUD_SLOTS was declared `as const`).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/135)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->