### PR TITLE
feat(utils): add static Color32.lerp helper

### DIFF
--- a/docs/api-core.md
+++ b/docs/api-core.md
@@ -199,6 +199,10 @@ Color32.resolveNamedColor('brand');   // → Color32 | undefined
 Color32.updateColor('brand', newColor);
 Color32.unregisterColor('brand');
 
+// Interpolation
+Color32.lerp(a, b, t);       // blend a→b; t clamped [0,1]; RGBA independent; truncates like instance lerp
+c.lerp(other, t);            // same semantics as static helper
+
 // Conversion
 c.toFloat32Array()            // [r/255, g/255, b/255, a/255]
 c.luminance                   // perceived brightness: 0.299r + 0.587g + 0.114b

--- a/src/utils/Color32.test.ts
+++ b/src/utils/Color32.test.ts
@@ -839,6 +839,58 @@ describe('lerp', () => {
     });
 });
 
+describe('Color32.lerp (static)', () => {
+    it('matches instance lerp for representative inputs', () => {
+        const a = new Color32(12, 34, 56, 78);
+        const b = new Color32(200, 100, 50, 254);
+
+        for (const t of [0, 0.25, 0.5, 0.75, 1, -1, 2]) {
+            expect(Color32.lerp(a, b, t).equals(a.lerp(b, t))).toBe(true);
+        }
+    });
+
+    it('returns a at t=0', () => {
+        const a = new Color32(0, 0, 0, 255);
+        const b = new Color32(255, 255, 255, 255);
+        const result = Color32.lerp(a, b, 0);
+
+        expect(result.r).toBe(0);
+        expect(result.g).toBe(0);
+        expect(result.b).toBe(0);
+        expect(result.a).toBe(255);
+    });
+
+    it('returns b at t=1', () => {
+        const a = new Color32(0, 0, 0, 255);
+        const b = new Color32(255, 255, 255, 255);
+        const result = Color32.lerp(a, b, 1);
+
+        expect(result.r).toBe(255);
+        expect(result.g).toBe(255);
+        expect(result.b).toBe(255);
+        expect(result.a).toBe(255);
+    });
+
+    it('returns midpoint at t=0.5 including alpha', () => {
+        const a = new Color32(0, 0, 0, 0);
+        const b = new Color32(200, 100, 50, 254);
+        const result = Color32.lerp(a, b, 0.5);
+
+        expect(result.r).toBe(100);
+        expect(result.g).toBe(50);
+        expect(result.b).toBe(25);
+        expect(result.a).toBe(127);
+    });
+
+    it('clamps t outside [0, 1]', () => {
+        const a = new Color32(100, 100, 100, 255);
+        const b = new Color32(200, 200, 200, 255);
+
+        expect(Color32.lerp(a, b, -5).r).toBe(100);
+        expect(Color32.lerp(a, b, 10).r).toBe(200);
+    });
+});
+
 describe('lerpInPlace', () => {
     it('modifies self and returns this', () => {
         const a = new Color32(0, 0, 0, 0);

--- a/src/utils/Color32.ts
+++ b/src/utils/Color32.ts
@@ -200,6 +200,19 @@ export class Color32 {
     }
 
     /**
+     * Linearly interpolates between two colors.
+     * Each RGBA channel is interpolated independently. `t` is clamped to [0, 1].
+     *
+     * @param a - Color at t = 0.
+     * @param b - Color at t = 1.
+     * @param t - Interpolation factor (0.0 = `a`, 1.0 = `b`).
+     * @returns New color blended between `a` and `b`.
+     */
+    static lerp(a: Color32, b: Color32, t: number): Color32 {
+        return a.lerp(b, t);
+    }
+
+    /**
      * Registers a named color in the global color registry.
      * Name matching is case-insensitive and trims surrounding whitespace.
      *


### PR DESCRIPTION
Expose Color32.lerp(a, b, t) delegating to instance lerp; document in api-core and cover with unit tests (parity, endpoints, alpha, clamp).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR adds a static helper method `Color32.lerp(a, b, t)` to facilitate linear color interpolation between two Color32 instances.

## Changes

**Implementation** (`src/utils/Color32.ts`):
- Added public static method `Color32.lerp(a: Color32, b: Color32, t: number): Color32` that delegates to the existing instance method `a.lerp(b, t)`
- Performs per-channel interpolation with `t` clamped to `[0, 1]`

**Tests** (`src/utils/Color32.test.ts`):
- Added comprehensive test suite `Color32.lerp (static)` covering:
  - Parity with the instance method across representative `t` values
  - Endpoint behavior at `t = 0` and `t = 1`
  - Midpoint interpolation at `t = 0.5` including alpha channel
  - Clamping behavior for out-of-range `t` values

**Documentation** (`docs/api-core.md`):
- Documented the new static method `Color32.lerp(a, b, t)`
- Documented the instance method `c.lerp(other, t)`
- Noted that `t` is clamped to `[0, 1]` and blending is RGBA-wise independent with consistent truncation semantics

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/138)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->