### PR TITLE
feat(utils): expose preset Color32 colors as static getters

### DIFF
--- a/docs/api-core.md
+++ b/docs/api-core.md
@@ -184,10 +184,10 @@ r.max; // Vector2i getter (bottom-right)
 ```ts
 const c = new Color32(r, g, b, a);
 
-// Cached color constants
-Color32.white()       Color32.black()       Color32.transparent()
-Color32.red()         Color32.green()       Color32.blue()
-Color32.yellow()      Color32.cyan()        Color32.magenta()
+// Cached color constants (static getters; frozen singletons)
+Color32.white       Color32.black       Color32.transparent
+Color32.red         Color32.green       Color32.blue
+Color32.yellow      Color32.cyan        Color32.magenta
 Color32.gray(value)   // grayscale, value 0–255
 
 // Hex parsing

--- a/docs/api-palette.md
+++ b/docs/api-palette.md
@@ -125,7 +125,7 @@ BT.paletteFadeRange(start, end, targetPalette, durationMs);
 BT.paletteFadeRange(start, end, targetPalette, durationMs, 'ease-out');
 
 // Flash all non-zero slots to a color then restore (lightning, damage)
-BT.paletteFlash(Color32.white(), 200); // 200 ms
+BT.paletteFlash(Color32.white, 200); // 200 ms
 
 // Instant swap of two slots
 BT.paletteSwap(indexA, indexB);

--- a/docs/bitmap-fonts.md
+++ b/docs/bitmap-fonts.md
@@ -42,7 +42,7 @@ import { BitmapFont, BT, Color32, Vector2i } from 'blit-tech';
 const font = await BitmapFont.load('fonts/MyFont.btfont');
 
 // Render text
-BT.printFont(font, new Vector2i(10, 10), 'Hello World!', Color32.white());
+BT.printFont(font, new Vector2i(10, 10), 'Hello World!', Color32.white);
 
 // Measure text width
 const width = font.measureText('Hello');
@@ -278,7 +278,7 @@ const lines = ['Line 1', 'Line 2', 'Line 3'];
 let y = 10;
 
 for (const line of lines) {
-  BT.printFont(font, new Vector2i(10, y), line, Color32.white());
+  BT.printFont(font, new Vector2i(10, y), line, Color32.white);
   y += font.lineHeight;
 }
 ```
@@ -291,7 +291,7 @@ const textWidth = font.measureText(text);
 const screenWidth = BT.displaySize().x;
 const x = Math.floor((screenWidth - textWidth) / 2);
 
-BT.printFont(font, new Vector2i(x, 10), text, Color32.white());
+BT.printFont(font, new Vector2i(x, 10), text, Color32.white);
 ```
 
 ### Rainbow Text Effect

--- a/docs/performance-best-practices.md
+++ b/docs/performance-best-practices.md
@@ -51,8 +51,8 @@ patterns for managing allocations:
 ```ts
 // Clear and readable
 BT.drawPixel(new Vector2i(x, y), color);
-BT.drawRect(new Rect2i(10, 10, 50, 50), Color32.white());
-BT.printFont(font, new Vector2i(10, 20), 'Hello', Color32.white());
+BT.drawRect(new Rect2i(10, 10, 50, 50), Color32.white);
+BT.printFont(font, new Vector2i(10, 20), 'Hello', Color32.white);
 ```
 
 **Pros:**
@@ -156,7 +156,7 @@ Less optimal:
 
 ```ts
 // Both have the same performance
-BT.drawSprite(sheet, sprite, pos, Color32.white());
+BT.drawSprite(sheet, sprite, pos, Color32.white);
 BT.drawSprite(sheet, sprite, pos, new Color32(255, 100, 100, 200));
 ```
 

--- a/src/assets/Palette.test.ts
+++ b/src/assets/Palette.test.ts
@@ -32,19 +32,19 @@ describe('Palette', () => {
     it('keeps index 0 transparent and rejects opaque writes there', () => {
         const palette = new Palette(16);
 
-        expect(palette.get(0).equals(Color32.transparent())).toBe(true);
-        expect(() => palette.set(0, Color32.red())).toThrow(
+        expect(palette.get(0).equals(Color32.transparent)).toBe(true);
+        expect(() => palette.set(0, Color32.red)).toThrow(
             'Slot 0 is always see-through (transparent). Put solid colors in slot 1 or higher.',
         );
 
         palette.set(0, new Color32(12, 34, 56, 0));
 
-        expect(palette.get(0).equals(Color32.transparent())).toBe(true);
+        expect(palette.get(0).equals(Color32.transparent)).toBe(true);
 
         // get() returns a clone, so mutating the result must not change the stored entry.
         const copy = palette.get(0);
         copy.r = 99;
-        expect(palette.get(0).equals(Color32.transparent())).toBe(true);
+        expect(palette.get(0).equals(Color32.transparent)).toBe(true);
     });
 
     it('sets and gets entries within range and throws out of range', () => {
@@ -93,7 +93,7 @@ describe('Palette', () => {
         palette.set(7, color);
 
         expect(palette.findColor(color)).toBe(7);
-        expect(palette.findColor(Color32.blue())).toBe(-1);
+        expect(palette.findColor(Color32.blue)).toBe(-1);
     });
 
     it('clones palettes without sharing mutable entries', () => {
@@ -138,7 +138,7 @@ describe('Palette', () => {
         expect(restored.size).toBe(16);
         expect(restored.get(1).equals(new Color32(11, 22, 33, 255))).toBe(true);
         expect(restored.getNamed('primary')).toBe(1);
-        expect(restored.get(0).equals(Color32.transparent())).toBe(true);
+        expect(restored.get(0).equals(Color32.transparent)).toBe(true);
     });
 
     it('rejects invalid JSON payloads', () => {
@@ -176,7 +176,7 @@ describe('Palette', () => {
         expect(restored.size).toBe(16);
         expect(restored.get(1).equals(new Color32(1, 2, 3, 255))).toBe(true);
         expect(restored.get(15).equals(new Color32(250, 251, 252, 255))).toBe(true);
-        expect(restored.get(0).equals(Color32.transparent())).toBe(true);
+        expect(restored.get(0).equals(Color32.transparent)).toBe(true);
     });
 
     it('rejects invalid raw RGB byte payloads', () => {
@@ -206,7 +206,7 @@ describe('Palette', () => {
 
         expect(target.get(1).equals(new Color32(10, 20, 30, 255))).toBe(true);
         expect(target.get(15).equals(new Color32(200, 210, 220, 255))).toBe(true);
-        expect(target.get(16).equals(Color32.transparent())).toBe(true);
+        expect(target.get(16).equals(Color32.transparent)).toBe(true);
         expect(target.getNamed('last')).toBe(15);
 
         expect(smallTarget.get(1).equals(new Color32(10, 20, 30, 255))).toBe(true);
@@ -247,7 +247,7 @@ describe('Palette', () => {
         expect(Palette.pico8().size).toBe(16);
         expect(Palette.nes().size).toBe(64);
         expect(Palette.c64().findColor(Color32.fromHex('#813338'))).toBe(2);
-        expect(Palette.vga().get(0).equals(Color32.transparent())).toBe(true);
+        expect(Palette.vga().get(0).equals(Color32.transparent)).toBe(true);
         expect(Palette.gameboy().get(1).equals(Color32.fromHex('#306230'))).toBe(true);
         expect(Palette.nes().get(1).equals(Color32.fromHex('#0000fc'))).toBe(true);
         expect(Palette.pico8().get(12).equals(Color32.fromHex('#29adff'))).toBe(true);
@@ -347,8 +347,8 @@ describe('applyHUD', () => {
 
         expect(palette.get(10).equals(Color32.fromHex('#ffffff'))).toBe(true);
         expect(palette.get(15).equals(Color32.fromHex('#6496c8'))).toBe(true);
-        expect(palette.get(9).equals(Color32.black())).toBe(true);
-        expect(palette.get(16).equals(Color32.black())).toBe(true);
+        expect(palette.get(9).equals(Color32.black)).toBe(true);
+        expect(palette.get(16).equals(Color32.black)).toBe(true);
     });
 
     it('registers named aliases at the correct indices', () => {

--- a/src/assets/Palette.ts
+++ b/src/assets/Palette.ts
@@ -122,7 +122,7 @@ function createPreset(hexColors: readonly string[], size: number): Palette {
  * Mutable palette of indexed {@link Color32} entries.
  *
  * The palette is the central color authority for all rendering:
- * - **Index 0 is always transparent.** It is initialized with `Color32.transparent()`
+ * - **Index 0 is always transparent.** It is initialized with `Color32.transparent`
  *   and cannot be set to an opaque color. The primitive and sprite shaders discard
  *   any fragment whose palette index resolves to alpha 0.
  * - **Variable sizes:** valid sizes are `2, 4, 16, 32, 64, 128, 256`. The active size
@@ -164,11 +164,11 @@ export class Palette {
 
         this.size = size;
         this.colors = new Array<Color32>(size);
-        this.colors[0] = Color32.transparent();
+        this.colors[0] = Color32.transparent;
 
         for (let i = 1; i < size; i++) {
             // eslint-disable-next-line security/detect-object-injection -- Constructor initializes all indices from 1 to size - 1
-            this.colors[i] = Color32.black().clone();
+            this.colors[i] = Color32.black.clone();
         }
     }
 
@@ -358,7 +358,7 @@ export class Palette {
                 throw new Error('Slot 0 is always see-through (transparent). Put solid colors in slot 1 or higher.');
             }
 
-            this.colors[0] = Color32.transparent();
+            this.colors[0] = Color32.transparent;
 
             return;
         }
@@ -479,7 +479,7 @@ export class Palette {
     public copyFrom(other: Palette): void {
         const copyCount = Math.min(this.size, other.size);
 
-        this.colors[0] = Color32.transparent();
+        this.colors[0] = Color32.transparent;
 
         for (let i = 1; i < copyCount; i++) {
             // eslint-disable-next-line security/detect-object-injection -- Loop bounds restrict i to valid initialized source and destination indices
@@ -488,7 +488,7 @@ export class Palette {
 
         for (let i = copyCount; i < this.size; i++) {
             // eslint-disable-next-line security/detect-object-injection -- Loop bounds restrict i to valid destination indices
-            this.colors[i] = Color32.transparent().clone();
+            this.colors[i] = Color32.transparent.clone();
         }
 
         this.namedIndices.clear();

--- a/src/render/SoftwareRenderer.ts
+++ b/src/render/SoftwareRenderer.ts
@@ -743,32 +743,32 @@ export class SoftwareRenderer implements IRenderer {
 
     /**
      * Resolves a palette index to a `Color32` for sprite drawing.
-     * Returns `Color32.black()` for out-of-range indices instead of skipping.
+     * Returns `Color32.black` for out-of-range indices instead of skipping.
      *
      * @param paletteIndex - Palette entry index to look up.
      * @returns Resolved color.
      */
     private resolveSpriteColor(paletteIndex: number): Color32 {
         if (!this.palette || paletteIndex >= this.palette.size) {
-            return Color32.black();
+            return Color32.black;
         }
         return this.palette.get(paletteIndex);
     }
 
     /**
-     * Returns the clear color from the palette. Falls back to `Color32.black()`
+     * Returns the clear color from the palette. Falls back to `Color32.black`
      * when no palette is set or the index is out of range.
      *
      * @returns Clear color for the current frame.
      */
     private resolveClearColor(): Color32 {
         if (!this.palette) {
-            return Color32.black();
+            return Color32.black;
         }
         try {
             return this.palette.get(this.clearPaletteIndex);
         } catch {
-            return Color32.black();
+            return Color32.black;
         }
     }
 

--- a/src/render/WebGpuRenderer.test.ts
+++ b/src/render/WebGpuRenderer.test.ts
@@ -37,14 +37,14 @@ import { WebGpuRenderer } from './WebGpuRenderer';
 function createTestPalette(): Palette {
     const palette = new Palette(16);
 
-    palette.set(1, Color32.black());
-    palette.set(2, Color32.red());
-    palette.set(3, Color32.green());
-    palette.set(4, Color32.blue());
-    palette.set(5, Color32.yellow());
-    palette.set(6, Color32.cyan());
-    palette.set(7, Color32.magenta());
-    palette.set(8, Color32.white());
+    palette.set(1, Color32.black);
+    palette.set(2, Color32.red);
+    palette.set(3, Color32.green);
+    palette.set(4, Color32.blue);
+    palette.set(5, Color32.yellow);
+    palette.set(6, Color32.cyan);
+    palette.set(7, Color32.magenta);
+    palette.set(8, Color32.white);
 
     return palette;
 }

--- a/src/utils/Color32.test.ts
+++ b/src/utils/Color32.test.ts
@@ -75,7 +75,7 @@ describe('Color32 constructor', () => {
 
 describe('static color getters', () => {
     it('white() returns (255, 255, 255, 255)', () => {
-        const w = Color32.white();
+        const w = Color32.white;
 
         expect(w.r).toBe(255);
         expect(w.g).toBe(255);
@@ -84,7 +84,7 @@ describe('static color getters', () => {
     });
 
     it('black() returns (0, 0, 0, 255)', () => {
-        const b = Color32.black();
+        const b = Color32.black;
 
         expect(b.r).toBe(0);
         expect(b.g).toBe(0);
@@ -93,7 +93,7 @@ describe('static color getters', () => {
     });
 
     it('transparent() returns (0, 0, 0, 0)', () => {
-        const t = Color32.transparent();
+        const t = Color32.transparent;
 
         expect(t.r).toBe(0);
         expect(t.g).toBe(0);
@@ -102,7 +102,7 @@ describe('static color getters', () => {
     });
 
     it('red() returns (255, 0, 0, 255)', () => {
-        const c = Color32.red();
+        const c = Color32.red;
 
         expect(c.r).toBe(255);
         expect(c.g).toBe(0);
@@ -111,7 +111,7 @@ describe('static color getters', () => {
     });
 
     it('green() returns (0, 255, 0, 255)', () => {
-        const c = Color32.green();
+        const c = Color32.green;
 
         expect(c.r).toBe(0);
         expect(c.g).toBe(255);
@@ -120,7 +120,7 @@ describe('static color getters', () => {
     });
 
     it('blue() returns (0, 0, 255, 255)', () => {
-        const c = Color32.blue();
+        const c = Color32.blue;
 
         expect(c.r).toBe(0);
         expect(c.g).toBe(0);
@@ -129,7 +129,7 @@ describe('static color getters', () => {
     });
 
     it('yellow() returns (255, 255, 0, 255)', () => {
-        const c = Color32.yellow();
+        const c = Color32.yellow;
 
         expect(c.r).toBe(255);
         expect(c.g).toBe(255);
@@ -138,7 +138,7 @@ describe('static color getters', () => {
     });
 
     it('cyan() returns (0, 255, 255, 255)', () => {
-        const c = Color32.cyan();
+        const c = Color32.cyan;
 
         expect(c.r).toBe(0);
         expect(c.g).toBe(255);
@@ -147,7 +147,7 @@ describe('static color getters', () => {
     });
 
     it('magenta() returns (255, 0, 255, 255)', () => {
-        const c = Color32.magenta();
+        const c = Color32.magenta;
 
         expect(c.r).toBe(255);
         expect(c.g).toBe(0);
@@ -156,27 +156,27 @@ describe('static color getters', () => {
     });
 
     it('all color singletons are frozen', () => {
-        expect(Object.isFrozen(Color32.white())).toBe(true);
-        expect(Object.isFrozen(Color32.black())).toBe(true);
-        expect(Object.isFrozen(Color32.transparent())).toBe(true);
-        expect(Object.isFrozen(Color32.red())).toBe(true);
-        expect(Object.isFrozen(Color32.green())).toBe(true);
-        expect(Object.isFrozen(Color32.blue())).toBe(true);
-        expect(Object.isFrozen(Color32.yellow())).toBe(true);
-        expect(Object.isFrozen(Color32.cyan())).toBe(true);
-        expect(Object.isFrozen(Color32.magenta())).toBe(true);
+        expect(Object.isFrozen(Color32.white)).toBe(true);
+        expect(Object.isFrozen(Color32.black)).toBe(true);
+        expect(Object.isFrozen(Color32.transparent)).toBe(true);
+        expect(Object.isFrozen(Color32.red)).toBe(true);
+        expect(Object.isFrozen(Color32.green)).toBe(true);
+        expect(Object.isFrozen(Color32.blue)).toBe(true);
+        expect(Object.isFrozen(Color32.yellow)).toBe(true);
+        expect(Object.isFrozen(Color32.cyan)).toBe(true);
+        expect(Object.isFrozen(Color32.magenta)).toBe(true);
     });
 
     it('returns the same instance on repeated calls', () => {
-        expect(Color32.white()).toBe(Color32.white());
-        expect(Color32.black()).toBe(Color32.black());
-        expect(Color32.transparent()).toBe(Color32.transparent());
-        expect(Color32.red()).toBe(Color32.red());
-        expect(Color32.green()).toBe(Color32.green());
-        expect(Color32.blue()).toBe(Color32.blue());
-        expect(Color32.yellow()).toBe(Color32.yellow());
-        expect(Color32.cyan()).toBe(Color32.cyan());
-        expect(Color32.magenta()).toBe(Color32.magenta());
+        expect(Color32.white).toBe(Color32.white);
+        expect(Color32.black).toBe(Color32.black);
+        expect(Color32.transparent).toBe(Color32.transparent);
+        expect(Color32.red).toBe(Color32.red);
+        expect(Color32.green).toBe(Color32.green);
+        expect(Color32.blue).toBe(Color32.blue);
+        expect(Color32.yellow).toBe(Color32.yellow);
+        expect(Color32.cyan).toBe(Color32.cyan);
+        expect(Color32.magenta).toBe(Color32.magenta);
     });
 
     it('gray(128) returns (128, 128, 128, 255)', () => {
@@ -200,14 +200,14 @@ describe('static color getters', () => {
 
 describe('named color registry', () => {
     it('resolves required CSS level 1 names', () => {
-        expect(Color32.resolveNamedColor('black')?.equals(Color32.black())).toBe(true);
-        expect(Color32.resolveNamedColor('white')?.equals(Color32.white())).toBe(true);
-        expect(Color32.resolveNamedColor('red')?.equals(Color32.red())).toBe(true);
-        expect(Color32.resolveNamedColor('green')?.equals(Color32.green())).toBe(true);
-        expect(Color32.resolveNamedColor('blue')?.equals(Color32.blue())).toBe(true);
-        expect(Color32.resolveNamedColor('yellow')?.equals(Color32.yellow())).toBe(true);
-        expect(Color32.resolveNamedColor('cyan')?.equals(Color32.cyan())).toBe(true);
-        expect(Color32.resolveNamedColor('magenta')?.equals(Color32.magenta())).toBe(true);
+        expect(Color32.resolveNamedColor('black')?.equals(Color32.black)).toBe(true);
+        expect(Color32.resolveNamedColor('white')?.equals(Color32.white)).toBe(true);
+        expect(Color32.resolveNamedColor('red')?.equals(Color32.red)).toBe(true);
+        expect(Color32.resolveNamedColor('green')?.equals(Color32.green)).toBe(true);
+        expect(Color32.resolveNamedColor('blue')?.equals(Color32.blue)).toBe(true);
+        expect(Color32.resolveNamedColor('yellow')?.equals(Color32.yellow)).toBe(true);
+        expect(Color32.resolveNamedColor('cyan')?.equals(Color32.cyan)).toBe(true);
+        expect(Color32.resolveNamedColor('magenta')?.equals(Color32.magenta)).toBe(true);
     });
 
     it('resolves gray and grey to the same singleton', () => {

--- a/src/utils/Color32.test.ts
+++ b/src/utils/Color32.test.ts
@@ -74,7 +74,7 @@ describe('Color32 constructor', () => {
 // #region Static Color Getters
 
 describe('static color getters', () => {
-    it('white() returns (255, 255, 255, 255)', () => {
+    it('white returns (255, 255, 255, 255)', () => {
         const w = Color32.white;
 
         expect(w.r).toBe(255);
@@ -83,7 +83,7 @@ describe('static color getters', () => {
         expect(w.a).toBe(255);
     });
 
-    it('black() returns (0, 0, 0, 255)', () => {
+    it('black returns (0, 0, 0, 255)', () => {
         const b = Color32.black;
 
         expect(b.r).toBe(0);
@@ -92,7 +92,7 @@ describe('static color getters', () => {
         expect(b.a).toBe(255);
     });
 
-    it('transparent() returns (0, 0, 0, 0)', () => {
+    it('transparent returns (0, 0, 0, 0)', () => {
         const t = Color32.transparent;
 
         expect(t.r).toBe(0);
@@ -101,7 +101,7 @@ describe('static color getters', () => {
         expect(t.a).toBe(0);
     });
 
-    it('red() returns (255, 0, 0, 255)', () => {
+    it('red returns (255, 0, 0, 255)', () => {
         const c = Color32.red;
 
         expect(c.r).toBe(255);
@@ -110,7 +110,7 @@ describe('static color getters', () => {
         expect(c.a).toBe(255);
     });
 
-    it('green() returns (0, 255, 0, 255)', () => {
+    it('green returns (0, 255, 0, 255)', () => {
         const c = Color32.green;
 
         expect(c.r).toBe(0);
@@ -119,7 +119,7 @@ describe('static color getters', () => {
         expect(c.a).toBe(255);
     });
 
-    it('blue() returns (0, 0, 255, 255)', () => {
+    it('blue returns (0, 0, 255, 255)', () => {
         const c = Color32.blue;
 
         expect(c.r).toBe(0);
@@ -128,7 +128,7 @@ describe('static color getters', () => {
         expect(c.a).toBe(255);
     });
 
-    it('yellow() returns (255, 255, 0, 255)', () => {
+    it('yellow returns (255, 255, 0, 255)', () => {
         const c = Color32.yellow;
 
         expect(c.r).toBe(255);
@@ -137,7 +137,7 @@ describe('static color getters', () => {
         expect(c.a).toBe(255);
     });
 
-    it('cyan() returns (0, 255, 255, 255)', () => {
+    it('cyan returns (0, 255, 255, 255)', () => {
         const c = Color32.cyan;
 
         expect(c.r).toBe(0);
@@ -146,7 +146,7 @@ describe('static color getters', () => {
         expect(c.a).toBe(255);
     });
 
-    it('magenta() returns (255, 0, 255, 255)', () => {
+    it('magenta returns (255, 0, 255, 255)', () => {
         const c = Color32.magenta;
 
         expect(c.r).toBe(255);
@@ -167,7 +167,7 @@ describe('static color getters', () => {
         expect(Object.isFrozen(Color32.magenta)).toBe(true);
     });
 
-    it('returns the same instance on repeated calls', () => {
+    it('each preset getter yields the same singleton on repeated reads', () => {
         expect(Color32.white).toBe(Color32.white);
         expect(Color32.black).toBe(Color32.black);
         expect(Color32.transparent).toBe(Color32.transparent);

--- a/src/utils/Color32.ts
+++ b/src/utils/Color32.ts
@@ -100,92 +100,83 @@ export class Color32 {
     // #region Static Color Getters
 
     /**
-     * Returns pure white color (255, 255, 255, 255).
-     * Returns a cached frozen singleton - do not modify.
-     *
-     * @returns Opaque white color (cached).
+     * Pure white color (255, 255, 255, 255).
+     * Cached frozen singleton — do not modify.
+     * @returns The shared white Color32 instance.
      */
-    static white(): Color32 {
+    static get white(): Color32 {
         return Color32._white;
     }
 
     /**
-     * Returns pure black color (0, 0, 0, 255).
-     * Returns a cached frozen singleton - do not modify.
-     *
-     * @returns Opaque black color (cached).
+     * Pure black color (0, 0, 0, 255).
+     * Cached frozen singleton — do not modify.
+     * @returns The shared black Color32 instance.
      */
-    static black(): Color32 {
+    static get black(): Color32 {
         return Color32._black;
     }
 
     /**
-     * Returns fully transparent color (0, 0, 0, 0).
-     * Returns a cached frozen singleton - do not modify.
-     *
-     * @returns Transparent black color (cached).
+     * Fully transparent color (0, 0, 0, 0).
+     * Cached frozen singleton — do not modify.
+     * @returns The shared transparent Color32 instance.
      */
-    static transparent(): Color32 {
+    static get transparent(): Color32 {
         return Color32._transparent;
     }
 
     /**
-     * Returns pure red color (255, 0, 0, 255).
-     * Returns a cached frozen singleton - do not modify.
-     *
-     * @returns Opaque red color (cached).
+     * Pure red color (255, 0, 0, 255).
+     * Cached frozen singleton — do not modify.
+     * @returns The shared red Color32 instance.
      */
-    static red(): Color32 {
+    static get red(): Color32 {
         return Color32._red;
     }
 
     /**
-     * Returns pure green color (0, 255, 0, 255).
-     * Returns a cached frozen singleton - do not modify.
-     *
-     * @returns Opaque green color (cached).
+     * Pure green color (0, 255, 0, 255).
+     * Cached frozen singleton — do not modify.
+     * @returns The shared green Color32 instance.
      */
-    static green(): Color32 {
+    static get green(): Color32 {
         return Color32._green;
     }
 
     /**
-     * Returns pure blue color (0, 0, 255, 255).
-     * Returns a cached frozen singleton - do not modify.
-     *
-     * @returns Opaque blue color (cached).
+     * Pure blue color (0, 0, 255, 255).
+     * Cached frozen singleton — do not modify.
+     * @returns The shared blue Color32 instance.
      */
-    static blue(): Color32 {
+    static get blue(): Color32 {
         return Color32._blue;
     }
 
     /**
-     * Returns yellow color (255, 255, 0, 255).
-     * Returns a cached frozen singleton - do not modify.
-     *
-     * @returns Opaque yellow color (cached).
+     * Yellow color (255, 255, 0, 255).
+     * Cached frozen singleton — do not modify.
+     * @returns The shared yellow Color32 instance.
      */
-    static yellow(): Color32 {
+    static get yellow(): Color32 {
         return Color32._yellow;
     }
 
     /**
-     * Returns cyan color (0, 255, 255, 255).
-     * Returns a cached frozen singleton - do not modify.
-     *
-     * @returns Opaque cyan color (cached).
+     * Cyan color (0, 255, 255, 255).
+     * Cached frozen singleton — do not modify.
+     * @returns The shared cyan Color32 instance.
      */
-    static cyan(): Color32 {
+    static get cyan(): Color32 {
         return Color32._cyan;
     }
 
     /**
-     * Returns magenta color (255, 0, 255, 255).
-     * Returns a cached frozen singleton - do not modify.
-     *
-     * @returns Opaque magenta color (cached).
+     * Magenta color (255, 0, 255, 255).
+     * Cached frozen singleton — do not modify.
+     * @returns The shared magenta Color32 instance.
      */
-    static magenta(): Color32 {
+    static get magenta(): Color32 {
         return Color32._magenta;
     }
 

--- a/tests/visual/fixtures/camera.html
+++ b/tests/visual/fixtures/camera.html
@@ -40,13 +40,13 @@
 
             async init() {
                 const palette = new Palette(16);
-                palette.set(BLACK, Color32.black());
-                palette.set(RED, Color32.red());
-                palette.set(GREEN, Color32.green());
-                palette.set(BLUE, Color32.blue());
-                palette.set(YELLOW, Color32.yellow());
-                palette.set(CYAN, Color32.cyan());
-                palette.set(8, Color32.white());
+                palette.set(BLACK, Color32.black);
+                palette.set(RED, Color32.red);
+                palette.set(GREEN, Color32.green);
+                palette.set(BLUE, Color32.blue);
+                palette.set(YELLOW, Color32.yellow);
+                palette.set(CYAN, Color32.cyan);
+                palette.set(8, Color32.white);
                 BT.paletteSet(palette);
 
                 return true;

--- a/tests/visual/fixtures/fonts.html
+++ b/tests/visual/fixtures/fonts.html
@@ -39,14 +39,14 @@
 
             async init() {
                 const palette = new Palette(16);
-                palette.set(BLACK, Color32.black());
-                palette.set(RED, Color32.red());
-                palette.set(GREEN, Color32.green());
-                palette.set(4, Color32.blue());
-                palette.set(YELLOW, Color32.yellow());
-                palette.set(CYAN, Color32.cyan());
-                palette.set(7, Color32.magenta());
-                palette.set(WHITE, Color32.white());
+                palette.set(BLACK, Color32.black);
+                palette.set(RED, Color32.red);
+                palette.set(GREEN, Color32.green);
+                palette.set(4, Color32.blue);
+                palette.set(YELLOW, Color32.yellow);
+                palette.set(CYAN, Color32.cyan);
+                palette.set(7, Color32.magenta);
+                palette.set(WHITE, Color32.white);
                 BT.paletteSet(palette);
 
                 return true;

--- a/tests/visual/fixtures/post-process.html
+++ b/tests/visual/fixtures/post-process.html
@@ -81,14 +81,14 @@
 
             async init() {
                 const palette = new Palette(16);
-                palette.set(BLACK, Color32.black());
-                palette.set(RED, Color32.red());
-                palette.set(GREEN, Color32.green());
-                palette.set(BLUE, Color32.blue());
-                palette.set(YELLOW, Color32.yellow());
-                palette.set(CYAN, Color32.cyan());
-                palette.set(MAGENTA, Color32.magenta());
-                palette.set(WHITE, Color32.white());
+                palette.set(BLACK, Color32.black);
+                palette.set(RED, Color32.red);
+                palette.set(GREEN, Color32.green);
+                palette.set(BLUE, Color32.blue);
+                palette.set(YELLOW, Color32.yellow);
+                palette.set(CYAN, Color32.cyan);
+                palette.set(MAGENTA, Color32.magenta);
+                palette.set(WHITE, Color32.white);
                 BT.paletteSet(palette);
 
                 switch (mode) {

--- a/tests/visual/fixtures/primitives.html
+++ b/tests/visual/fixtures/primitives.html
@@ -42,13 +42,13 @@
             async init() {
                 // Create and activate a test palette.
                 const palette = new Palette(16);
-                palette.set(BLACK, Color32.black());
-                palette.set(RED, Color32.red());
-                palette.set(GREEN, Color32.green());
-                palette.set(BLUE, Color32.blue());
-                palette.set(YELLOW, Color32.yellow());
-                palette.set(CYAN, Color32.cyan());
-                palette.set(8, Color32.white());
+                palette.set(BLACK, Color32.black);
+                palette.set(RED, Color32.red);
+                palette.set(GREEN, Color32.green);
+                palette.set(BLUE, Color32.blue);
+                palette.set(YELLOW, Color32.yellow);
+                palette.set(CYAN, Color32.cyan);
+                palette.set(8, Color32.white);
                 BT.paletteSet(palette);
 
                 return true;


### PR DESCRIPTION
Replace zero-arg static methods (white, black, transparent, primaries) with static getters returning the same frozen singletons. Call sites must drop parentheses (e.g. Color32.white). Color32.gray(value) is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This pull request converts Color32's preset color accessors from zero-argument static methods to static getter properties, making them accessible without parentheses. The change affects nine predefined colors: white, black, transparent, red, green, blue, yellow, cyan, and magenta. The factory method Color32.gray(value) remains unchanged.

## Changes

### Core Implementation
- src/utils/Color32.ts
  - Converted nine static method accessors to getter properties:
    - `static white(): Color32` → `static get white(): Color32`
    - `static black(): Color32` → `static get black(): Color32`
    - `static transparent(): Color32` → `static get transparent(): Color32`
    - `static red()`, `green()`, `blue()`, `yellow()`, `cyan()`, `magenta()` similarly converted
  - All getters return the same frozen singleton instances; only the access pattern changed.

### Internal Usage Updates
- src/assets/Palette.ts
  - Updated palette initialization and reset logic to use property syntax (e.g., `Color32.transparent`, `Color32.black.clone()`).
- src/render/SoftwareRenderer.ts
  - Updated fallback behavior in `resolveSpriteColor` and `resolveClearColor` to use `Color32.black` property.
- src/render/WebGpuRenderer.test.ts
  - Updated test helper `createTestPalette()` to assign colors using the new property form.

### Test Updates
- src/utils/Color32.test.ts
  - Updated tests to access presets as properties and added assertions for immutability (`Object.isFrozen`) and singleton identity.
- src/assets/Palette.test.ts
  - Updated assertions to use property syntax (e.g., `Color32.transparent`, `Color32.black`).

### Documentation Updates
- docs/api-core.md
  - Updated documentation to reflect property-based access for cached Color32 constants.
- docs/api-palette.md
  - Updated `BT.paletteFlash` example to use `Color32.white` (property).
- docs/bitmap-fonts.md
  - Updated `BT.printFont(...)` examples to use `Color32.white`.
- docs/performance-best-practices.md
  - Updated examples in "Inline Allocation" and "Tinting Performance" to use property syntax.

### Visual Test Fixtures
Updated palette initialization in visual fixtures to use property syntax:
- tests/visual/fixtures/camera.html
- tests/visual/fixtures/fonts.html
- tests/visual/fixtures/post-process.html
- tests/visual/fixtures/primitives.html

## Breaking Changes

Call sites must drop parentheses when accessing preset colors:
- `Color32.white()` → `Color32.white`
- `Color32.black()` → `Color32.black`
- Same change for `transparent`, `red`, `green`, `blue`, `yellow`, `cyan`, and `magenta`.

All presets remain frozen singletons and the factory method `Color32.gray(value)` is unchanged.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/139)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->