### PR TITLE
chore(release): align version constants to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blit-tech",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "type": "module",
   "description": "A lightweight WebGPU retro engine for TypeScript, inspired by RetroBlit.",
   "author": "Václav Vančura",

--- a/src/core/BTAPI.test.ts
+++ b/src/core/BTAPI.test.ts
@@ -12,6 +12,10 @@
  * stubbed animation-frame scheduling, and per-test singleton reset helpers.
  */
 
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
@@ -138,6 +142,14 @@ describe('BTAPI', () => {
 
         it('should expose VERSION_PATCH as a number', () => {
             expect(typeof BTAPI.VERSION_PATCH).toBe('number');
+        });
+
+        it('should match package.json version', () => {
+            const packageJsonPath = join(dirname(fileURLToPath(import.meta.url)), '../../package.json');
+            const { version } = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as { version: string };
+            const btapiVersion = `${BTAPI.VERSION_MAJOR}.${BTAPI.VERSION_MINOR}.${BTAPI.VERSION_PATCH}`;
+
+            expect(btapiVersion).toBe(version);
         });
     });
 

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -47,10 +47,10 @@ export class BTAPI {
     /**
      * Major semantic-version component.
      */
-    public static readonly VERSION_MAJOR = 0;
+    public static readonly VERSION_MAJOR = 1;
 
     /** Minor version number. */
-    public static readonly VERSION_MINOR = 2;
+    public static readonly VERSION_MINOR = 0;
 
     /** Patch version number. */
     public static readonly VERSION_PATCH = 0;

--- a/src/render/SoftwareTicker.ts
+++ b/src/render/SoftwareTicker.ts
@@ -62,7 +62,7 @@ export class SoftwareTicker {
     /**
      * Creates a ticker for the given engine version.
      *
-     * @param version - Engine version string (e.g. `"0.2.0"`), embedded in the banner text.
+     * @param version - Engine version string (e.g. `"1.0.0"`), embedded in the banner text.
      */
     constructor(version: string) {
         this.text = `SOFTWARE RENDERER - blit-tech v${version}`;


### PR DESCRIPTION
Bump package.json and BTAPI VERSION_* to 1.0.0. Add a unit test that asserts package.json matches BTAPI version fields. Update SoftwareTicker JSDoc example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This release aligns version constants across the codebase to 1.0.0, updating both the package manifest and internal version fields, along with corresponding documentation examples.

## Changes

### Version Bump
- **package.json**: Updated `version` from `0.2.0` to `1.0.0`
- **src/core/BTAPI.ts**: Updated static version constants:
  - `VERSION_MAJOR`: `0` → `1`
  - `VERSION_MINOR`: `2` → `0`
  - `VERSION_PATCH`: remains `0`

### Test Coverage
- **src/core/BTAPI.test.ts**: Added unit test to assert that `BTAPI.VERSION_MAJOR/MINOR/PATCH` constants match the corresponding version fields parsed from `package.json`, ensuring version consistency across the codebase

### Documentation
- **src/render/SoftwareTicker.ts**: Updated JSDoc example in the constructor to reflect the new version format (`0.2.0` → `1.0.0`)

## Impact

This change establishes version 1.0.0 as the canonical version across package metadata, runtime constants, and documentation examples. The new test prevents future version misalignment between `package.json` and the `BTAPI` version constants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/140)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->