### PR TITLE
docs(readme): use blit-tech package in install and quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,16 @@ complex frameworks, just sprites, primitives, and fonts.
 
 ## Installation
 
-**Note:** Blit-Tech is currently in development and not yet published to npm. Clone the repository to use it:
+Install [blit-tech](https://www.npmjs.com/package/blit-tech) from npm:
 
 ```bash
-git clone https://github.com/vancura/blit-tech.git
-cd blit-tech
-pnpm install
+pnpm add blit-tech
+```
+
+Or with npm:
+
+```bash
+npm install blit-tech
 ```
 
 ## Examples & Demos
@@ -62,7 +66,7 @@ For interactive examples and demos, visit the [Blit-Tech Demos repository](https
 ## Quick Start
 
 ```ts
-import { bootstrap, BT, Color32, Palette, Rect2i, Vector2i, type IBlitTechDemo } from '../src/BlitTech';
+import { bootstrap, BT, Color32, Palette, Rect2i, Vector2i, type IBlitTechDemo } from 'blit-tech';
 
 const BG = 1;
 const RED = 2;

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ complex frameworks, just sprites, primitives, and fonts.
 
 ## Installation
 
-Install [blit-tech](https://www.npmjs.com/package/blit-tech) from npm:
+Install **blit-tech** from npm:
 
 ```bash
 pnpm add blit-tech

--- a/src/docs/consumer-doc-imports.test.ts
+++ b/src/docs/consumer-doc-imports.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Regression tests for package-consumer documentation imports.
+ *
+ * README and docs guides must import from the published `blit-tech` package,
+ * not from repository source paths such as `../src/BlitTech`.
+ */
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '../..');
+
+/** Imports that bypass the published package entry point. */
+const FORBIDDEN_SOURCE_IMPORT = /from\s+['"]\.\.\/src\/BlitTech['"]/;
+
+/**
+ * Recursively collects markdown file paths under a directory.
+ *
+ * @param dir Absolute directory to scan.
+ * @returns Relative paths from {@link REPO_ROOT}.
+ */
+const collectMarkdownFiles = (dir: string): string[] => {
+    const entries = readdirSync(dir, { withFileTypes: true });
+    const files: string[] = [];
+
+    for (const entry of entries) {
+        const absolutePath = join(dir, entry.name);
+
+        if (entry.isDirectory()) {
+            files.push(...collectMarkdownFiles(absolutePath));
+        } else if (entry.isFile() && entry.name.endsWith('.md')) {
+            files.push(relative(REPO_ROOT, absolutePath));
+        }
+    }
+
+    return files;
+};
+
+const CONSUMER_DOC_FILES = ['README.md', ...collectMarkdownFiles(join(REPO_ROOT, 'docs'))];
+
+describe('consumer documentation imports', () => {
+    for (const relativePath of CONSUMER_DOC_FILES) {
+        it(`${relativePath} must not import from ../src/BlitTech`, () => {
+            const content = readFileSync(join(REPO_ROOT, relativePath), 'utf8');
+            const match = FORBIDDEN_SOURCE_IMPORT.exec(content);
+
+            expect(match, `found forbidden source import in ${relativePath}: ${match?.[0] ?? ''}`).toBeNull();
+        });
+    }
+});


### PR DESCRIPTION
Update Installation for npm consumers (pnpm/npm add) and change Quick Start import from ../src/BlitTech to blit-tech. Add regression test that rejects source-path imports in README and docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR updates consumer-facing documentation to use the published npm package instead of repository source paths.

**Changes:**

1. README.md
- Installation now instructs installing the published package (pnpm add blit-tech / npm install blit-tech).
- Quick Start example imports from 'blit-tech' (package entry) rather than '../src/BlitTech'.
- Removed an external markdown link to npmjs.com (was removed because the external checker returned 403); retained published-install wording without the URL.

2. src/docs/consumer-doc-imports.test.ts
- Added a Vitest regression test that enforces consumer documentation (README.md and all markdown files under docs/) must not import from the repository’s internal source path (`../src/BlitTech`). The test recursively collects markdown files, scans each for the forbidden import pattern, and fails with the offending snippet if found.

Lines changed: +62/-5
Estimated review effort: Medium

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->