### PR TITLE
docs: align node >=22.18.0 across docs and ci

### DIFF
--- a/.claude/skills/preflight/SKILL.md
+++ b/.claude/skills/preflight/SKILL.md
@@ -12,6 +12,11 @@ Run comprehensive quality checks before committing or pushing code.
 /preflight
 ```
 
+## Prerequisites
+
+- **Node.js** >=22.18.0 (`engines` in `package.json`)
+- **pnpm** 10.26.2+ (`packageManager` in `package.json`)
+
 ## Steps
 
 1. **Run all checks**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '22.18.0'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -63,7 +63,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '22.18.0'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -109,7 +109,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '22.18.0'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -293,7 +293,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '22.18.0'
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: '22'
+          node-version: '22.18.0'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -64,7 +64,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: '22'
+          node-version: '22.18.0'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -92,7 +92,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: '22'
+          node-version: '22.18.0'
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,9 +132,14 @@ All code must follow the project's style guidelines:
 - **Linting** - Code must pass all linting checks
 - **JSDoc** - Required for public APIs
 
+### Development environment
+
+- **Node.js** >=22.18.0 (`engines` in `package.json`)
+- **pnpm** 10.26.2+ (`packageManager` in `package.json`)
+
 ### Pre-commit Checks
 
-Before committing, run the preflight checks:
+Before committing, run the preflight checks (requires the Node.js version above):
 
 ```bash
 pnpm preflight

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ complex frameworks, just sprites, primitives, and fonts.
 
 **App toolchain**
 
-- **Node.js** v22 or higher (LTS)
+- **Node.js** >=22.18.0 (LTS)
 - An **ESM bundler** (Vite, webpack, esbuild, and similar) to load the published package in the browser
 
 ## Installation
@@ -157,7 +157,8 @@ See [API: Core](docs/api-core.md) for `bootstrap()` options and
 The commands below apply when building or contributing to **blit-tech** from a repository checkout (not when consuming
 the npm package). See [CONTRIBUTING.md](CONTRIBUTING.md) for clone setup, DCO sign-off, and pull request workflow.
 
-**Repository prerequisites:** **pnpm** v10.26.2 or higher (see `packageManager` in `package.json`).
+**Repository prerequisites:** **Node.js** >=22.18.0 (see `engines` in `package.json`); **pnpm** v10.26.2 or higher (see
+`packageManager` in `package.json`).
 
 ### Scripts
 

--- a/docs/developer-experience-guide.md
+++ b/docs/developer-experience-guide.md
@@ -10,6 +10,7 @@ Blit-Tech project.
 See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow. Key points:
 
 - Fork the repository and create a feature branch from `main`.
+- Use **Node.js** >=22.18.0 and **pnpm** 10.26.2+ (see `engines` and `packageManager` in `package.json`).
 - Run `pnpm install` and confirm `pnpm preflight` passes before opening a PR.
 - All commits require a DCO sign-off: use `git commit -s`.
 - Follow [Conventional Commits](https://www.conventionalcommits.org/) for commit messages.


### PR DESCRIPTION
Document the package.json engines floor in README, CONTRIBUTING, developer-experience-guide, and the preflight skill. Pin GitHub Actions to Node 22.18.0 so CI matches the enforced runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request aligns Node.js version requirements across documentation and CI to enforce the `package.json` engines floor of **Node.js >=22.18.0**.

## Changes

**Documentation Updates:**
- **README.md**: Updated runtime and repository prerequisites sections to specify Node.js >=22.18.0 (LTS) and pnpm v10.26.2+
- **CONTRIBUTING.md**: Added "Development environment" section documenting required Node.js (>=22.18.0) and pnpm versions
- **docs/developer-experience-guide.md**: Added minimum toolchain requirements (Node.js >=22.18.0 and pnpm 10.26.2+)
- **.claude/skills/preflight/SKILL.md**: Added "Prerequisites" section listing Node.js and pnpm version requirements matching package.json

**CI/Workflow Updates:**
- **.github/workflows/ci.yml**: Pinned Node.js version to 22.18.0 across all four jobs (quality, build-library, benchmark, and test), replacing the generic `22` version
- **.github/workflows/pr-checks.yml**: Updated Node.js version to 22.18.0 across three jobs (quality, commitlint, and bundle-size)

These changes ensure that CI environments enforce the same Node.js floor version specified in package.json, and developers have clear, consistent documentation about required toolchain versions across all relevant guides.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->