### PR TITLE
docs(security): update supported versions policy for 1.x

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,17 +4,21 @@
 
 | Version | Supported |
 | ------- | --------- |
-| 0.x     | Yes       |
+| 1.x     | Yes       |
+| 0.x     | No        |
+
+The **1.x** release line is actively maintained. Security fixes are published as patch releases on **1.x**. Pre-1.0
+(**0.x**) releases reached end-of-life at **1.0.0** and no longer receive security updates.
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability in blit-tech, please report it responsibly.
+If you discover a security vulnerability in a supported **1.x** release, please report it responsibly.
 
 **Do not open a public issue.** Instead, email the maintainers directly or use
 [GitHub's private vulnerability reporting](https://github.com/vancura/blit-tech/security/advisories/new).
 
-We will acknowledge receipt within 48 hours and provide a timeline for a fix. Once resolved, we will credit you in the
-release notes (unless you prefer to remain anonymous).
+We will acknowledge receipt within 48 hours and provide a timeline for a fix. Once resolved, we will publish a fix on
+the supported **1.x** line and credit you in the release notes (unless you prefer to remain anonymous).
 
 ## Scope
 


### PR DESCRIPTION
Reflect post-1.0 maintenance: support the 1.x line with patch releases, end-of-life 0.x at 1.0.0, and clarify reporting targets supported 1.x releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## SECURITY.md

Updates the security policy to reflect post-1.0 release maintenance strategy:

**Supported Versions Section:**
- Explicitly marks only the `1.x` release line as actively maintained with security patches delivered as point releases
- Declares `0.x` releases end-of-life as of version `1.0.0` with no further security updates

**Vulnerability Reporting Section:**
- Narrows reporting scope to supported `1.x` releases only
- Adds service level commitments: acknowledgment within 48 hours and a defined fix timeline
- Clarifies that fixes will be published on the supported `1.x` line with contributor credit in release notes (unless anonymity is requested)

**Lines changed:** +8/-4

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/148?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->