### PR TITLE
feat(api): export fullscreen effect bases for npm consumers

### DIFF
--- a/docs/post-process-effects.md
+++ b/docs/post-process-effects.md
@@ -309,8 +309,7 @@ Extend `FullscreenEffect` when sampling RGBA at output resolution. Subclasses pr
 `sampler`), declare `tier = 'display'`, set `uniformBytes`, and implement `writeUniforms`.
 
 ```ts
-import type { Vector2i } from 'blit-tech';
-import { FullscreenEffect } from 'blit-tech/render/effects/FullscreenEffect';
+import { FullscreenEffect, type Vector2i } from 'blit-tech';
 
 export class GammaEffect extends FullscreenEffect {
   public readonly tier = 'display' as const;

--- a/src/BlitTech.ts
+++ b/src/BlitTech.ts
@@ -37,6 +37,8 @@ import { RollLine } from './render/effects/display/RollLine';
 import { Scanlines } from './render/effects/display/Scanlines';
 import { Vignette } from './render/effects/display/Vignette';
 import type { Effect, EffectTier } from './render/effects/Effect';
+import { FullscreenEffect } from './render/effects/FullscreenEffect';
+import { FullscreenPixelEffect } from './render/effects/FullscreenPixelEffect';
 import { PixelGlitch } from './render/effects/pixel/PixelGlitch';
 import { PixelMosaic } from './render/effects/pixel/PixelMosaic';
 import { amber, crtPipBoy, green } from './render/effects/presets';
@@ -1472,6 +1474,8 @@ export {
     defaultConfig,
     displayError,
     Flicker,
+    FullscreenEffect,
+    FullscreenPixelEffect,
     getCanvas,
     green,
     Interference,

--- a/src/docs/consumer-doc-imports.test.ts
+++ b/src/docs/consumer-doc-imports.test.ts
@@ -16,6 +16,9 @@ const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '../..');
 /** Imports that bypass the published package entry point. */
 const FORBIDDEN_SOURCE_IMPORT = /from\s+['"]\.\.\/src\/BlitTech['"]/;
 
+/** Deep package subpath imports not exposed in package.json exports. */
+const FORBIDDEN_DEEP_PACKAGE_IMPORT = /from\s+['"]blit-tech\/render\//;
+
 /**
  * Recursively collects markdown file paths under a directory.
  *
@@ -48,6 +51,13 @@ describe('consumer documentation imports', () => {
             const match = FORBIDDEN_SOURCE_IMPORT.exec(content);
 
             expect(match, `found forbidden source import in ${relativePath}: ${match?.[0] ?? ''}`).toBeNull();
+        });
+
+        it(`${relativePath} must not deep-import blit-tech/render/...`, () => {
+            const content = readFileSync(join(REPO_ROOT, relativePath), 'utf8');
+            const match = FORBIDDEN_DEEP_PACKAGE_IMPORT.exec(content);
+
+            expect(match, `found forbidden deep package import in ${relativePath}: ${match?.[0] ?? ''}`).toBeNull();
         });
     }
 });


### PR DESCRIPTION
Expose FullscreenEffect and FullscreenPixelEffect from the main package entry so custom-effect docs can import from 'blit-tech'. Update the post-process guide snippet and extend consumer-doc import tests to reject deep blit-tech/render paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR exposes `FullscreenEffect` and `FullscreenPixelEffect` from the main package entry point (`blit-tech`), allowing npm consumers and documentation to import these effect base classes directly rather than from deeper package paths.

## Changes

**src/BlitTech.ts**
- Added named exports for `FullscreenEffect` and `FullscreenPixelEffect` to the package's public exports, making them available to consumers via `import { FullscreenEffect } from 'blit-tech'`

**docs/post-process-effects.md**
- Updated the `GammaEffect` example in the "Writing a custom effect" section to import `FullscreenEffect` and `Vector2i` together from the main `blit-tech` package, rather than importing `FullscreenEffect` from the deeper `blit-tech/render/effects/FullscreenEffect` path

**src/docs/consumer-doc-imports.test.ts**
- Enhanced consumer-doc import regression tests to forbid deep subpath imports from `blit-tech/render/...`
- Added a new regex constant and assertion to verify that documentation files do not use deep package imports

These changes standardize the public API surface and ensure that effect base classes are properly exposed for reuse in custom implementations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->