### PR TITLE
chore(ci): add pnpm 10 supply-chain hardening

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,6 @@
 shared-workspace-lockfile=false
+
+# Supply-chain hardening for pnpm 10.
+minimum-release-age=10080
+block-exotic-subdeps=true
+strict-dep-builds=true

--- a/package.json
+++ b/package.json
@@ -85,9 +85,9 @@
       "vite-node": "^5.2.0",
       "esbuild": "^0.25.0"
     },
-    "ignoredBuiltDependencies": [
-      "esbuild"
-    ]
+    "allowBuilds": {
+      "esbuild": true
+    }
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.15",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,10 @@
     "overrides": {
       "vite-node": "^5.2.0",
       "esbuild": "^0.25.0"
-    }
+    },
+    "ignoredBuiltDependencies": [
+      "esbuild"
+    ]
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.15",


### PR DESCRIPTION
Set minimum-release-age to 10080 minutes (7 days) so newly published packages cannot be installed before they age out of common exploit windows. Enable block-exotic-subdeps and strict-dep-builds for additional supply-chain protection. Silence esbuild's post-install build script via ignoredBuiltDependencies to keep the lockfile clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes

Updated pnpm configuration to implement supply-chain hardening measures for pnpm 10:

**`.npmrc`**
- `shared-workspace-lockfile=false` (unchanged)
- Added supply-chain hardening settings:
  - `minimum-release-age=10080` (7 days) to avoid installing very recently published packages
  - `block-exotic-subdeps=true` to block exotic transitive dependencies
  - `strict-dep-builds=true` to enforce stricter dependency build behavior

**`package.json`**
- Replaced the older ignored-built-dependencies approach with pnpm 10's package-keyed whitelist:
  - Added `pnpm.allowBuilds` with `"esbuild": true` to explicitly allow esbuild's build script while keeping lockfile behavior compatible with pnpm 10
  - `pnpm.overrides` remains configured for `vite-node` and `esbuild`

## Rationale

These changes enable pnpm 10 supply-chain hardening: enforcing a minimum release age to reduce exposure to newly published malicious packages, blocking unusual sub-dependency structures, tightening build-script execution rules, and explicitly whitelisting esbuild's build step instead of silencing it via ignoredBuiltDependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->