### PR TITLE
ci(ci): pin third-party actions to commit SHAs and explicit permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,18 +14,20 @@ jobs:
     if:
       github.event_name != 'pull_request' || !contains(fromJSON('["labeled","unlabeled"]'), github.event.action) ||
       (github.event.action == 'labeled' && contains(fromJSON('["perf"]'), github.event.label.name))
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
           version: 10.26.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: '22.18.0'
           cache: 'pnpm'
@@ -50,18 +52,20 @@ jobs:
     runs-on: ubuntu-latest
     needs: quality
     if: github.event_name != 'pull_request' || !contains(fromJSON('["labeled","unlabeled"]'), github.event.action)
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
           version: 10.26.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: '22.18.0'
           cache: 'pnpm'
@@ -78,7 +82,7 @@ jobs:
         run: node scripts/check-declaration-tooling.mjs build.log
 
       - name: Upload library artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: library-dist
           path: dist/
@@ -99,15 +103,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
           version: 10.26.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: '22.18.0'
           cache: 'pnpm'
@@ -119,7 +123,7 @@ jobs:
         run: pnpm bench:json
 
       - name: Upload current benchmark results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: benchmark-results-current
           path: benchmark-results.json
@@ -128,7 +132,7 @@ jobs:
 
       - name: Upload main benchmark baseline
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: benchmark-baseline
           path: benchmark-results.json
@@ -138,7 +142,7 @@ jobs:
       - name: Find latest main benchmark baseline
         id: find-baseline
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const workflowId = 'ci.yml';
@@ -203,7 +207,7 @@ jobs:
 
       - name: Upload benchmark comparison artifacts
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: benchmark-comparison
           path: |
@@ -217,7 +221,7 @@ jobs:
         if:
           github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && github.actor !=
           'dependabot[bot]'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           BENCHMARK_COMMENT_PATH: benchmark-comment.md
         with:
@@ -280,18 +284,20 @@ jobs:
     runs-on: ubuntu-latest
     needs: quality
     if: github.event_name != 'pull_request' || !contains(fromJSON('["labeled","unlabeled"]'), github.event.action)
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
           version: 10.26.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: '22.18.0'
           cache: 'pnpm'
@@ -303,7 +309,7 @@ jobs:
         run: pnpm test:unit:coverage
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         if: always()
         with:
           files: ./coverage/coverage-final.json


### PR DESCRIPTION
Pin all mutable `@vN` action tags in ci.yml to 40-character commit SHAs, matching the pattern already used in pr-checks.yml. Actions pinned: actions/checkout, pnpm/action-setup, actions/setup-node, actions/upload-artifact, actions/github-script, codecov/codecov-action.

Add explicit `permissions: contents: read` to the quality, build-library, and test jobs, which previously had no permissions block. The benchmark job already had correct minimal explicit permissions.

Publish provenance is not added: the release script is local-only and npm provenance requires an OIDC-backed GitHub Actions environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updates the CI workflow to pin all third-party GitHub Actions to specific 40-character commit SHAs instead of mutable version tags, matching the pattern already established in pr-checks.yml. The following actions are pinned across the quality, build-library, benchmark, and test jobs:
- actions/checkout (v6)
- pnpm/action-setup (v4)
- actions/setup-node (v6)
- actions/upload-artifact (v7)
- actions/github-script (v8)
- codecov/codecov-action (v5)

Additionally adds explicit `permissions: contents: read` blocks to the quality, build-library, and test jobs, which previously lacked explicit permission declarations. The benchmark job already had appropriate minimal explicit permissions (actions: read, contents: read, pull-requests: write).

No job logic or workflow logic is modified; changes are limited to action pinning and permission declarations as part of supply chain security hardening. Publish provenance is not implemented as the release script is local-only and npm provenance requires an OIDC-backed GitHub Actions environment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/157?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->