### PR TITLE
docs: add security limits utils to CLAUDE.md architecture map

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,20 +19,21 @@ and sprites resolve through a shared indexed palette.
 
 Before writing new code, reviewing existing code, or preflighting, check here first:
 
-| Question                                      | Where to look                                                                                    |
-| --------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| What does `BT.X` do (getter vs method)?       | `src/BlitTech.ts` JSDoc, `docs/api-core.md`, **BT API: getters vs methods** below                |
-| How does a subsystem work internally?         | The relevant `src/core/` or `src/render/` file                                                   |
-| What does a demo implement?                   | `src/core/IBlitTechDemo.ts` (interface + HardwareSettings)                                       |
-| What palette/sprite setup pattern is correct? | `docs/palette-guide.md`, then `docs/api-assets.md`                                               |
-| Which preset has which exact color values?    | `docs/palette-presets.md`                                                                        |
-| How do post-process effects work?             | `docs/post-process-effects.md`                                                                   |
-| What does the CI do on this file?             | `.github/workflows/ci.yml`                                                                       |
-| What is the benchmark threshold?              | `ci.yml` benchmark job (`--threshold 25` flag), not docs                                         |
-| What error message style should I use?        | `docs/voice.md`, then `src/utils/errorMessages.ts`                                               |
-| Is this API exported publicly?                | `src/BlitTech.ts` export block (lines 1460-1501)                                                 |
-| What test mock do I need for GPU code?        | `src/__test__/webgpu-mock.ts`                                                                    |
-| Declaration tooling / TS version alignment?   | `docs/tooling.md`, `docs/developer-experience-guide.md`, `scripts/check-declaration-tooling.mjs` |
+| Question                                      | Where to look                                                                                                                                                                                           |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| What does `BT.X` do (getter vs method)?       | `src/BlitTech.ts` JSDoc, `docs/api-core.md`, **BT API: getters vs methods** below                                                                                                                       |
+| How does a subsystem work internally?         | The relevant `src/core/` or `src/render/` file                                                                                                                                                          |
+| What does a demo implement?                   | `src/core/IBlitTechDemo.ts` (interface + HardwareSettings)                                                                                                                                              |
+| What palette/sprite setup pattern is correct? | `docs/palette-guide.md`, then `docs/api-assets.md`                                                                                                                                                      |
+| What are the render/asset dimension limits?   | `src/utils/RenderLimits.ts` (constants), `src/utils/AssetLimits.ts` (asset + glyph limits), `docs/api-assets.md` (asset size limits table), `docs/api-core.md` (HardwareSettings dimension constraints) |
+| Which preset has which exact color values?    | `docs/palette-presets.md`                                                                                                                                                                               |
+| How do post-process effects work?             | `docs/post-process-effects.md`                                                                                                                                                                          |
+| What does the CI do on this file?             | `.github/workflows/ci.yml`                                                                                                                                                                              |
+| What is the benchmark threshold?              | `ci.yml` benchmark job (`--threshold 25` flag), not docs                                                                                                                                                |
+| What error message style should I use?        | `docs/voice.md`, then `src/utils/errorMessages.ts`                                                                                                                                                      |
+| Is this API exported publicly?                | `src/BlitTech.ts` export block (lines 1460-1501)                                                                                                                                                        |
+| What test mock do I need for GPU code?        | `src/__test__/webgpu-mock.ts`                                                                                                                                                                           |
+| Declaration tooling / TS version alignment?   | `docs/tooling.md`, `docs/developer-experience-guide.md`, `scripts/check-declaration-tooling.mjs`                                                                                                        |
 
 ## Architecture
 
@@ -81,6 +82,9 @@ src/
     Bootstrap.ts           # Demo bootstrap utilities
     BootstrapHelpers.ts    # Canvas lookup and error display utilities
     CameraUtils.ts         # Camera clamp helper (world/view bounds)
+    CanvasLayoutStyles.ts  # Canvas layout CSS custom properties helper
+    RenderLimits.ts        # Render dimension validation and max-size constants (8192px / 16M px)
+    AssetLimits.ts         # Asset dimension validation, btfont/glyph limits, sprite-blit clipping
     Vector2i.ts            # Integer 2D vector
     Rect2i.ts              # Integer rectangle
     Color32.ts             # 32-bit RGBA color


### PR DESCRIPTION
Register CanvasLayoutStyles.ts, RenderLimits.ts, and AssetLimits.ts in the utils/ architecture section, and add a "What are the render/asset dimension limits?" row to the Where to Find Information table pointing to both source files and the updated api-*.md docs (VV-512 follow-up).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This documentation-only change updates `CLAUDE.md` to enhance discoverability of render and asset dimension limit utilities.

**Changes made:**

Added a new entry to the "Where to Find Information" reference table: "What are the render/asset dimension limits?" with links to `RenderLimits.ts`, `AssetLimits.ts`, and corresponding API documentation sections covering dimension constraints and limits.

Expanded the architecture file index under `src/utils/` to include three utility modules:
- `CanvasLayoutStyles.ts` - Canvas layout CSS custom properties helper
- `RenderLimits.ts` - Render dimension validation and max-size constants (8192px / 16M px)
- `AssetLimits.ts` - Asset dimension validation, btfont/glyph limits, sprite-blit clipping

These changes provide centralized navigation for developers working with dimension constraints and follow up on VV-512 security audit remediation work by documenting the resource limit utilities in the project's architecture guide.

**Impact:** Documentation only; no public API or implementation changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/158?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->