### PR TITLE
chore: add claude launch config for demos dev server

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "demos",
+      "runtimeExecutable": "sh",
+      "runtimeArgs": ["-c", "cd ../blit-tech-demos && pnpm dev"],
+      "port": 5173
+    }
+  ]
+}

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,11 +1,13 @@
 {
-  "version": "0.0.1",
+  "version": "0.2.0",
   "configurations": [
     {
       "name": "demos",
+      "type": "node",
+      "request": "launch",
       "runtimeExecutable": "sh",
       "runtimeArgs": ["-c", "cd ../blit-tech-demos && pnpm dev"],
-      "port": 5173
+      "console": "integratedTerminal"
     }
   ]
 }


### PR DESCRIPTION
Adds a launch.json entry that runs the sibling blit-tech-demos Vite dev server on port 5173.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
A new VS Code launch configuration file (`.claude/launch.json`) has been added to support launching the sibling `blit-tech-demos` Vite development server.

## Files Changed
- `.claude/launch.json` (+13/-0)

## Configuration Details
The launch configuration specifies:
- Version: `0.2.0`
- A `demos` configuration entry (type: `node`, request: `launch`) that runs `sh -c "cd ../blit-tech-demos && pnpm dev"`
- Uses `integratedTerminal` for console output
- No explicit port setting is included in the configuration

This enables developers to start the demos development server from the IDE or other environments that support VS Code launch configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/160?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->