### PR TITLE
docs(security): document solo-maintainer incident triage (VV-517)

### DIFF
--- a/docs/security/dependency-policy.md
+++ b/docs/security/dependency-policy.md
@@ -56,5 +56,6 @@ See [audit-exceptions.md](./audit-exceptions.md) for the full playbook.
 
 ## Related docs
 
-- [security-runbook.md](./security-runbook.md) — MCP preflight, fallback matrix, report template
+- [security-runbook.md](./security-runbook.md) — MCP preflight, fallback matrix, maintainers / incident triage, report
+  template
 - [developer-experience-guide.md](../developer-experience-guide.md) — script reference

--- a/docs/security/security-runbook.md
+++ b/docs/security/security-runbook.md
@@ -12,13 +12,17 @@ the `/security-run` skill and `pnpm security:mcp-preflight`.
 
 **Incident triage (solo maintainer):**
 
-1. Open or triage a [GitHub issue](https://github.com/vancura/blit-tech/issues) with label `security` when available.
+1. Open or triage a [GitHub issue](https://github.com/vancura/blit-tech/issues): apply label `security` if that label
+   exists in the repository and you have permission; if it does not exist, create the issue and add the label when you
+   can edit repository labels. If you cannot create or label issues, contact [@vancura](https://github.com/vancura)
+   (primary security owner) and record the incident in Linear.
 2. Run [Repo-native commands](#repo-native-commands) for the affected repo (`pnpm security:audit`, `pnpm preflight`).
 3. Follow [dependency-policy.md](./dependency-policy.md) for CI failures or temporary risk acceptance.
 4. Record findings using the [Report template](#report-template) (Linear comment or issue body).
 
 Bus-factor evidence (optional): run the `security-ownership-map` skill and attach `summary.json` to hardening reviews.
-VV-522 (backup-owner process) was canceled; this section is the documented fallback instead of a fictional backup owner.
+VV-522 (backup-owner process) was canceled; the **Maintainers** section above (including incident triage) is the
+documented fallback instead of a fictional backup owner.
 
 ## When to run
 

--- a/docs/security/security-runbook.md
+++ b/docs/security/security-runbook.md
@@ -3,6 +3,23 @@
 Deterministic security workflow for Blit-Tech repos when MCP scanners are healthy, degraded, or unavailable. Use with
 the `/security-run` skill and `pnpm security:mcp-preflight`.
 
+## Maintainers
+
+| Role                | Contact / owner                                       | Notes                                                                  |
+| ------------------- | ----------------------------------------------------- | ---------------------------------------------------------------------- |
+| Primary security    | [@vancura](https://github.com/vancura) (`CODEOWNERS`) | Sole maintainer for `blit-tech` and `blit-tech-demos` (May 2026).      |
+| Backup / escalation | _None_ (solo project)                                 | No secondary on-call; treat delayed response as accepted project risk. |
+
+**Incident triage (solo maintainer):**
+
+1. Open or triage a [GitHub issue](https://github.com/vancura/blit-tech/issues) with label `security` when available.
+2. Run [Repo-native commands](#repo-native-commands) for the affected repo (`pnpm security:audit`, `pnpm preflight`).
+3. Follow [dependency-policy.md](./dependency-policy.md) for CI failures or temporary risk acceptance.
+4. Record findings using the [Report template](#report-template) (Linear comment or issue body).
+
+Bus-factor evidence (optional): run the `security-ownership-map` skill and attach `summary.json` to hardening reviews.
+VV-522 (backup-owner process) was canceled; this section is the documented fallback instead of a fictional backup owner.
+
 ## When to run
 
 - Before a comprehensive security assessment or hardening pass.
@@ -75,7 +92,7 @@ When Opsera `compliance-audit` MCP is unavailable, gather evidence manually:
 | Secrets in repo              | `.gitignore`, hooks blocking `.env`; `rg` for hardcoded tokens (no secret values in reports)           |
 | CI integrity                 | `.github/workflows/*.yml` — pinned actions, least privilege                                            |
 | Deploy headers (demos)       | `blit-tech-demos/public/_headers`, `curl -I` on deployed URLs                                          |
-| Ownership / bus factor       | `security-ownership-map` skill output (`summary.json`)                                                 |
+| Ownership / bus factor       | [Maintainers](#maintainers) (solo); optional `security-ownership-map` skill output (`summary.json`)    |
 | MCP governance               | `pnpm security:mcp-preflight --governance-only`                                                        |
 
 ## Repo-native commands


### PR DESCRIPTION
Add Maintainers section to the security runbook with primary owner, explicit no-backup stance, and triage steps. VV-522 was canceled; this satisfies ownership fallback documentation for the hardening program.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR documents solo-maintainer incident triage in the security runbook to satisfy ownership fallback requirements for the hardening program.

## Changes

**docs/security/security-runbook.md**
- Added a "Maintainers" section establishing a named primary owner and an explicit no-backup/no-escalation stance; names this section as the documented substitute for the canceled VV-522 backup-owner process
- Clarified triage wording by replacing ambiguous "when available" with explicit steps: apply the security label, escalate permissions if required, and use a documented no-access fallback; instructs agents to create or triage a GitHub issue (labeling as needed), run repo-native security commands, follow dependency-policy guidance for CI failures or accepted risk, and record outcomes via the report template/Linear
- Added an optional bus-factor evidence step (`security-ownership-map` / summary.json) and updated the "Ownership / bus factor" compliance checklist to reference the Maintainers section as the solo evidence source and make the map output optional rather than required
- Corrected runbook text to point the canceled backup-owner outcome to the new Maintainers section

**docs/security/dependency-policy.md**
- Minor reformatting of the "Related docs" reference to `security-runbook.md` (descriptive text split across two lines)

Commits include co-authorship and sign-off by the author.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/166?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->