### PR TITLE
feat(assets): tighten btfont embedded texture policy and pre-decode validation

### DIFF
--- a/docs/api-assets.md
+++ b/docs/api-assets.md
@@ -10,21 +10,23 @@ Sprite sheets, font atlases, and raw indexed buffers share the same decoded-size
 pixels per side, `16,777,216` total pixels). Limits are enforced before canvas readback, CPU buffer retention, GPU
 texture creation, and software sprite loops.
 
-| Limit                   | Default                      | Applies to                                                       |
-| ----------------------- | ---------------------------- | ---------------------------------------------------------------- |
-| Max width / height      | `8192`                       | Decoded PNGs, font atlas textures, `fromIndexedPixels()`         |
-| Max total pixels        | `16,777,216` (`4096 × 4096`) | Same sources                                                     |
-| Max `.btfont` JSON size | `1,048,576` bytes (`1 MiB`)  | `BitmapFont.load()` before `JSON.parse()`                        |
-| Max glyph count         | `8192`                       | Glyph map entries in a `.btfont` file                            |
-| Max software blit area  | `16,777,216` pixels          | Software renderer source rectangles (clipped to the sheet first) |
+| Limit                        | Default                      | Applies to                                                       |
+| ---------------------------- | ---------------------------- | ---------------------------------------------------------------- |
+| Max width / height           | `8192`                       | Decoded PNGs, font atlas textures, `fromIndexedPixels()`         |
+| Max total pixels             | `16,777,216` (`4096 × 4096`) | Same sources                                                     |
+| Max `.btfont` JSON size      | `1,048,576` bytes (`1 MiB`)  | `BitmapFont.load()` before `JSON.parse()`                        |
+| Max embedded texture payload | `524,288` bytes (`512 KiB`)  | Base64 data in `texture` when using `data:image/png;base64,...`  |
+| Max glyph count              | `8192`                       | Glyph map entries in a `.btfont` file                            |
+| Max software blit area       | `16,777,216` pixels          | Software renderer source rectangles (clipped to the sheet first) |
 
 When a limit is exceeded, loading throws an `AssetLimitError` with a beginner-friendly message. The software renderer
 skips sprite blits whose source rectangle is empty, non-integer, fully outside the sheet, or still too large after
 clipping.
 
-`.btfont` files may reference either a relative PNG path or an embedded `data:` image URI. Embedded textures use the
-same decoded dimension limits as external PNGs. Prefer separate PNG files for large atlases so the JSON payload stays
-under the JSON size limit.
+`.btfont` files may reference either a relative PNG path or an embedded PNG data URI. Embedded textures must use
+`data:image/png;base64,...` and stay within the embedded payload cap above. Other `data:` schemes (for example JPEG) are
+rejected before image decode. Decoded atlas dimensions use the same width, height, and pixel-area limits as sprite
+sheets. Prefer separate PNG files for large atlases so the JSON payload stays under the JSON size limit.
 
 ---
 

--- a/docs/bitmap-fonts.md
+++ b/docs/bitmap-fonts.md
@@ -119,8 +119,22 @@ the PNG without regenerating the JSON.
 }
 ```
 
-The entire texture is embedded as a base64-encoded data URI. This creates a single self-contained file, ideal for
-distribution.
+The entire texture is embedded as a base64-encoded PNG data URI (`data:image/png;base64,...`). This creates a single
+self-contained file, ideal for distribution. Other embedded formats (for example `data:image/jpeg`) are rejected.
+
+## Loading limits
+
+`BitmapFont.load()` enforces the same resource limits as sprite sheets. See [API: Assets](api-assets.md) for the full
+table. In short:
+
+- `.btfont` JSON must be `1 MiB` or smaller; glyph maps are capped at `8192` entries.
+- Embedded PNG payloads must stay within `512 KiB` of base64 data (after the `data:image/png;base64,` prefix).
+- Font atlas textures obey the `8192` per-side and `16,777,216` total-pixel decoded limits.
+- Invalid glyph metrics (non-integer values, negative sizes, rectangles outside the atlas) throw `AssetLimitError`
+  before rendering.
+
+When validation fails, loading throws `AssetLimitError` with a beginner-friendly message. Prefer a separate PNG texture
+for large atlases instead of embedding multi-megabyte base64 in the JSON file.
 
 ## Converting from BMFont Format
 

--- a/src/assets/BitmapFont.test.ts
+++ b/src/assets/BitmapFont.test.ts
@@ -14,7 +14,13 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { AssetLimitError, MAX_ASSET_DIMENSION, MAX_BTFONT_JSON_BYTES, MAX_GLYPH_COUNT } from '../utils/AssetLimits';
+import {
+    AssetLimitError,
+    MAX_ASSET_DIMENSION,
+    MAX_BTFONT_EMBEDDED_TEXTURE_BYTES,
+    MAX_BTFONT_JSON_BYTES,
+    MAX_GLYPH_COUNT,
+} from '../utils/AssetLimits';
 import { Rect2i } from '../utils/Rect2i';
 import { BitmapFont } from './BitmapFont';
 import { SpriteSheet } from './SpriteSheet';
@@ -402,6 +408,80 @@ describe('BitmapFont', () => {
             vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockFontFetchResponse(MOCK_FONT_DATA)));
 
             await expect(BitmapFont.load('huge-texture.btfont')).rejects.toBeInstanceOf(AssetLimitError);
+        });
+
+        it('should reject non-PNG embedded textures before image decode', async () => {
+            vi.stubGlobal(
+                'fetch',
+                vi.fn().mockResolvedValue(
+                    mockFontFetchResponse({
+                        ...MOCK_FONT_DATA,
+                        texture: 'data:image/jpeg;base64,aGVsbG8=',
+                    }),
+                ),
+            );
+
+            await expect(BitmapFont.load('jpeg-texture.btfont')).rejects.toBeInstanceOf(AssetLimitError);
+            await expect(BitmapFont.load('jpeg-texture.btfont')).rejects.toThrow('PNG data URI');
+        });
+
+        it('should reject oversized embedded texture payloads before image decode', async () => {
+            const oversizedTexture = `data:image/png;base64,${'A'.repeat(MAX_BTFONT_EMBEDDED_TEXTURE_BYTES + 1)}`;
+
+            vi.stubGlobal(
+                'fetch',
+                vi.fn().mockResolvedValue(
+                    mockFontFetchResponse({
+                        ...MOCK_FONT_DATA,
+                        texture: oversizedTexture,
+                    }),
+                ),
+            );
+
+            await expect(BitmapFont.load('huge-embedded.btfont')).rejects.toBeInstanceOf(AssetLimitError);
+            await expect(BitmapFont.load('huge-embedded.btfont')).rejects.toThrow(
+                MAX_BTFONT_EMBEDDED_TEXTURE_BYTES.toLocaleString('en-US'),
+            );
+        });
+
+        it('should reject invalid glyph entries before loading the texture', async () => {
+            const loadImageSpy = vi.fn();
+
+            vi.stubGlobal('Image', createStubImage({ onSrcSet: loadImageSpy }));
+            vi.stubGlobal(
+                'fetch',
+                vi.fn().mockResolvedValue(
+                    mockFontFetchResponse({
+                        ...MOCK_FONT_DATA,
+                        glyphs: {
+                            A: null,
+                        },
+                    }),
+                ),
+            );
+
+            await expect(BitmapFont.load('bad-entry.btfont')).rejects.toBeInstanceOf(AssetLimitError);
+            expect(loadImageSpy).not.toHaveBeenCalled();
+        });
+
+        it('should reject negative glyph metrics before loading the texture', async () => {
+            const loadImageSpy = vi.fn();
+
+            vi.stubGlobal('Image', createStubImage({ onSrcSet: loadImageSpy }));
+            vi.stubGlobal(
+                'fetch',
+                vi.fn().mockResolvedValue(
+                    mockFontFetchResponse({
+                        ...MOCK_FONT_DATA,
+                        glyphs: {
+                            A: { x: -1, y: 0, w: 8, h: 12, ox: 0, oy: 0, adv: 9 },
+                        },
+                    }),
+                ),
+            );
+
+            await expect(BitmapFont.load('negative-glyph.btfont')).rejects.toBeInstanceOf(AssetLimitError);
+            expect(loadImageSpy).not.toHaveBeenCalled();
         });
 
         it('should suggest absolute and relative paths when font URL omits / or ./', async () => {

--- a/src/assets/BitmapFont.ts
+++ b/src/assets/BitmapFont.ts
@@ -1,7 +1,10 @@
 import {
     assertImageElementWithinLimits,
     AssetLimitError,
-    validateBtfontGlyphData,
+    BTFONT_EMBEDDED_TEXTURE_PREFIX,
+    validateBtfontEmbeddedTextureUri,
+    validateBtfontGlyphAtlasBounds,
+    validateBtfontGlyphDataPreAtlas,
     validateBtfontJsonByteSize,
     validateGlyphCount,
 } from '../utils/AssetLimits';
@@ -248,8 +251,8 @@ export class BitmapFont {
     /**
      * Loads a bitmap font from a `.btfont` JSON file.
      *
-     * The font descriptor can reference either an embedded data URI or a
-     * texture file path relative to the font JSON file.
+     * The font descriptor can reference either an embedded PNG data URI
+     * (`data:image/png;base64,...`) or a texture file path relative to the font JSON file.
      *
      * @param url - Path to the .btfont file.
      * @returns Loaded bitmap font instance.
@@ -264,7 +267,9 @@ export class BitmapFont {
 
         const { data, glyphEntries } = BitmapFont.parseBtfontFile(url, await response.text());
 
-        // Load texture - embedded `data:` URIs and relative PNG paths are both allowed.
+        BitmapFont.validateGlyphEntriesPreAtlas(glyphEntries);
+
+        // Load texture - embedded PNG data URIs and relative PNG paths are both allowed.
         const image = await BitmapFont.loadTexture(data.texture, url);
         const spriteSheet = new SpriteSheet(image);
         const atlasWidth = spriteSheet.width;
@@ -346,7 +351,32 @@ export class BitmapFont {
             throw new AssetLimitError(glyphCountError);
         }
 
+        const embeddedTextureError = validateBtfontEmbeddedTextureUri(data.texture);
+
+        if (embeddedTextureError) {
+            throw new AssetLimitError(embeddedTextureError);
+        }
+
         return { data, glyphEntries };
+    }
+
+    /**
+     * Validates glyph entries before the font atlas image is decoded.
+     *
+     * @param glyphEntries - Glyph map entries from the parsed font file.
+     */
+    private static validateGlyphEntriesPreAtlas(glyphEntries: Array<[string, GlyphData]>): void {
+        for (const [char, glyphData] of glyphEntries) {
+            if (glyphData === null || typeof glyphData !== 'object' || Array.isArray(glyphData)) {
+                throw new AssetLimitError(btfontGlyphEntryNotObjectError(BitmapFont.formatGlyphCharLabel(char)));
+            }
+
+            const glyphError = validateBtfontGlyphDataPreAtlas(glyphData, BitmapFont.formatGlyphCharLabel(char));
+
+            if (glyphError) {
+                throw new AssetLimitError(glyphError);
+            }
+        }
     }
 
     /**
@@ -366,11 +396,7 @@ export class BitmapFont {
         const asciiGlyphs: (Glyph | null)[] = new Array<Glyph | null>(ASCII_CACHE_SIZE).fill(null);
 
         for (const [char, glyphData] of glyphEntries) {
-            if (glyphData === null || typeof glyphData !== 'object' || Array.isArray(glyphData)) {
-                throw new AssetLimitError(btfontGlyphEntryNotObjectError(BitmapFont.formatGlyphCharLabel(char)));
-            }
-
-            const glyphError = validateBtfontGlyphData(
+            const glyphError = validateBtfontGlyphAtlasBounds(
                 glyphData,
                 atlasWidth,
                 atlasHeight,
@@ -411,8 +437,8 @@ export class BitmapFont {
      * @returns Loaded texture image for the font atlas.
      */
     private static loadTexture(texture: string, fontUrl: string): Promise<HTMLImageElement> {
-        // Check if it's a data URI (embedded base64).
-        if (texture.startsWith('data:')) {
+        // Embedded PNG data URIs are validated in parseBtfontFile before decode.
+        if (texture.startsWith(BTFONT_EMBEDDED_TEXTURE_PREFIX)) {
             return BitmapFont.loadImage(texture);
         }
 

--- a/src/assets/BitmapFont.ts
+++ b/src/assets/BitmapFont.ts
@@ -438,7 +438,7 @@ export class BitmapFont {
      */
     private static loadTexture(texture: string, fontUrl: string): Promise<HTMLImageElement> {
         // Embedded PNG data URIs are validated in parseBtfontFile before decode.
-        if (texture.startsWith(BTFONT_EMBEDDED_TEXTURE_PREFIX)) {
+        if (texture.toLowerCase().startsWith(BTFONT_EMBEDDED_TEXTURE_PREFIX)) {
             return BitmapFont.loadImage(texture);
         }
 

--- a/src/assets/SpriteSheet.test.ts
+++ b/src/assets/SpriteSheet.test.ts
@@ -17,7 +17,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { createMockGPUDevice } from '../__test__/webgpu-mock';
-import { AssetLimitError, MAX_ASSET_DIMENSION } from '../utils/AssetLimits';
+import { AssetLimitError, MAX_ASSET_DIMENSION, MAX_ASSET_PIXELS } from '../utils/AssetLimits';
 import { Color32 } from '../utils/Color32';
 import { Rect2i } from '../utils/Rect2i';
 import { AssetLoader } from './AssetLoader';
@@ -355,6 +355,16 @@ describe('SpriteSheet', () => {
             await expect(SpriteSheet.load('huge.png')).rejects.toBeInstanceOf(AssetLimitError);
         });
 
+        it('rejects images whose total pixel area exceeds engine limits', async () => {
+            vi.spyOn(AssetLoader, 'loadImage').mockResolvedValue({
+                width: 4096,
+                height: 4097,
+            } as HTMLImageElement);
+
+            await expect(SpriteSheet.load('huge-area.png')).rejects.toBeInstanceOf(AssetLimitError);
+            await expect(SpriteSheet.load('huge-area.png')).rejects.toThrow(MAX_ASSET_PIXELS.toLocaleString('en-US'));
+        });
+
         it('should close imageBitmap on destroy when getTexture was never called', async () => {
             const closeSpy = vi.fn();
             vi.stubGlobal(
@@ -521,6 +531,38 @@ describe('SpriteSheet', () => {
             await expect(SpriteSheet.loadColorsIntoPalette('missing.png', palette, 1)).rejects.toThrow(
                 /Failed to load image/,
             );
+        });
+
+        it('rejects oversized images before canvas readback', async () => {
+            const getImageData = vi.fn(() => ({ data: new Uint8ClampedArray(0) }));
+
+            vi.stubGlobal(
+                'OffscreenCanvas',
+                class {
+                    constructor(
+                        public width: number,
+                        public height: number,
+                    ) {}
+
+                    getContext() {
+                        return {
+                            drawImage: vi.fn(),
+                            imageSmoothingEnabled: false,
+                            getImageData,
+                        };
+                    }
+                },
+            );
+            vi.spyOn(AssetLoader, 'loadImage').mockResolvedValue({
+                width: MAX_ASSET_DIMENSION + 1,
+                height: 16,
+            } as HTMLImageElement);
+
+            const palette = new Palette(16);
+            await expect(SpriteSheet.loadColorsIntoPalette('huge.png', palette, 1)).rejects.toBeInstanceOf(
+                AssetLimitError,
+            );
+            expect(getImageData).not.toHaveBeenCalled();
         });
 
         it('rejects atomically when startSlot + discovered colors exceed palette size', async () => {

--- a/src/render/SoftwareRenderer.test.ts
+++ b/src/render/SoftwareRenderer.test.ts
@@ -182,6 +182,53 @@ describe('SoftwareRenderer', () => {
         expect(getPixel(frame as ImageData, 4, 1, 0)).toEqual([255, 255, 0, 255]);
     });
 
+    it('skips non-integer sprite source rectangles in software rendering', async () => {
+        const canvas = {
+            width: 0,
+            height: 0,
+            style: { width: '', height: '' },
+            getContext: canvasGet2d(context),
+            toBlob: (_cb: (blob: Blob | null) => void) => {},
+        } as unknown as HTMLCanvasElement;
+        const renderer = new SoftwareRenderer(canvas, new Vector2i(4, 4));
+        await renderer.init();
+        renderer.setPalette(makePalette());
+
+        const sheet = SpriteSheet.fromIndexedPixels(2, 2, new Uint8Array([1, 2, 3, 4]));
+        const srcRect = new Rect2i(0, 0, 2, 2);
+        srcRect.x = 0.5;
+
+        renderer.beginFrame();
+        renderer.drawSprite(sheet, srcRect, new Vector2i(0, 0), 0);
+        renderer.endFrame();
+
+        const frame = logicalContext.lastImageData;
+        expect(frame).not.toBeNull();
+        expect(getPixel(frame as ImageData, 4, 0, 0)).toEqual([0, 0, 0, 0]);
+    });
+
+    it('skips sprite source rectangles fully outside the sheet', async () => {
+        const canvas = {
+            width: 0,
+            height: 0,
+            style: { width: '', height: '' },
+            getContext: canvasGet2d(context),
+            toBlob: (_cb: (blob: Blob | null) => void) => {},
+        } as unknown as HTMLCanvasElement;
+        const renderer = new SoftwareRenderer(canvas, new Vector2i(4, 4));
+        await renderer.init();
+        renderer.setPalette(makePalette());
+
+        const sheet = SpriteSheet.fromIndexedPixels(2, 2, new Uint8Array([1, 2, 3, 4]));
+        renderer.beginFrame();
+        renderer.drawSprite(sheet, new Rect2i(10, 10, 2, 2), new Vector2i(0, 0), 0);
+        renderer.endFrame();
+
+        const frame = logicalContext.lastImageData;
+        expect(frame).not.toBeNull();
+        expect(getPixel(frame as ImageData, 4, 0, 0)).toEqual([0, 0, 0, 0]);
+    });
+
     it('skips invalid sprite source rectangles in software rendering', async () => {
         const canvas = {
             width: 0,

--- a/src/utils/AssetLimits.test.ts
+++ b/src/utils/AssetLimits.test.ts
@@ -6,10 +6,13 @@ import {
     computeSafePixelArea,
     MAX_ASSET_DIMENSION,
     MAX_ASSET_PIXELS,
+    MAX_BTFONT_EMBEDDED_TEXTURE_BYTES,
     MAX_BTFONT_JSON_BYTES,
     MAX_GLYPH_COUNT,
     validateAssetDimensions,
+    validateBtfontEmbeddedTextureUri,
     validateBtfontGlyphData,
+    validateBtfontGlyphDataPreAtlas,
     validateBtfontJsonByteSize,
     validateGlyphCount,
     validateIndexedPixelInput,
@@ -87,6 +90,38 @@ describe('AssetLimits', () => {
         });
     });
 
+    describe('validateBtfontEmbeddedTextureUri', () => {
+        it('accepts relative texture paths', () => {
+            expect(validateBtfontEmbeddedTextureUri('MyFont.png')).toBeNull();
+        });
+
+        it('accepts PNG data URIs within the payload cap', () => {
+            expect(validateBtfontEmbeddedTextureUri('data:image/png;base64,aGVsbG8=')).toBeNull();
+        });
+
+        it('rejects non-PNG data URIs', () => {
+            expect(validateBtfontEmbeddedTextureUri('data:image/jpeg;base64,abc')).toContain('PNG data URI');
+        });
+
+        it('rejects oversized embedded texture payloads', () => {
+            const oversized = `data:image/png;base64,${'A'.repeat(MAX_BTFONT_EMBEDDED_TEXTURE_BYTES + 1)}`;
+            const error = validateBtfontEmbeddedTextureUri(oversized);
+
+            expect(error).toContain(MAX_BTFONT_EMBEDDED_TEXTURE_BYTES.toLocaleString('en-US'));
+        });
+    });
+
+    describe('validateBtfontGlyphDataPreAtlas', () => {
+        it('rejects glyph areas that are too large to render safely', () => {
+            const error = validateBtfontGlyphDataPreAtlas(
+                { x: 0, y: 0, w: 4096, h: 4097, ox: 0, oy: 0, adv: 4096 },
+                'A',
+            );
+
+            expect(error).toContain('covers too many pixels');
+        });
+    });
+
     describe('validateBtfontGlyphData', () => {
         it('rejects glyph rectangles outside the atlas', () => {
             const error = validateBtfontGlyphData({ x: 60, y: 0, w: 8, h: 12, ox: 0, oy: 0, adv: 8 }, 64, 16, 'A');
@@ -124,6 +159,17 @@ describe('AssetLimits', () => {
 
         it('returns null for rectangles with non-positive size', () => {
             expect(clipSpriteSourceRect(new Rect2i(0, 0, 0, 2), 4, 4)).toBeNull();
+        });
+
+        it('returns null for non-integer source rectangles', () => {
+            const srcRect = new Rect2i(0, 0, 2, 2);
+            srcRect.x = 0.5;
+
+            expect(clipSpriteSourceRect(srcRect, 4, 4)).toBeNull();
+        });
+
+        it('returns null for rectangles fully outside the sheet', () => {
+            expect(clipSpriteSourceRect(new Rect2i(10, 10, 2, 2), 4, 4)).toBeNull();
         });
     });
 });

--- a/src/utils/AssetLimits.test.ts
+++ b/src/utils/AssetLimits.test.ts
@@ -103,6 +103,14 @@ describe('AssetLimits', () => {
             expect(validateBtfontEmbeddedTextureUri('data:image/jpeg;base64,abc')).toContain('PNG data URI');
         });
 
+        it('rejects case-variant non-PNG data URIs', () => {
+            expect(validateBtfontEmbeddedTextureUri('DATA:image/jpeg;base64,abc')).toContain('PNG data URI');
+        });
+
+        it('accepts case-variant PNG data URIs within the payload cap', () => {
+            expect(validateBtfontEmbeddedTextureUri('DATA:image/png;base64,aGVsbG8=')).toBeNull();
+        });
+
         it('rejects oversized embedded texture payloads', () => {
             const oversized = `data:image/png;base64,${'A'.repeat(MAX_BTFONT_EMBEDDED_TEXTURE_BYTES + 1)}`;
             const error = validateBtfontEmbeddedTextureUri(oversized);

--- a/src/utils/AssetLimits.ts
+++ b/src/utils/AssetLimits.ts
@@ -4,6 +4,8 @@ import {
     assetDimensionTooLargeError,
     assetIndexedPixelLengthError,
     assetIndexedPixelOverflowError,
+    btfontEmbeddedTextureFormatError,
+    btfontEmbeddedTextureTooLargeError,
     btfontGlyphAreaTooLargeError,
     btfontGlyphCountTooLargeError,
     btfontGlyphMetricNotIntegerError,
@@ -34,6 +36,12 @@ export const ASSET_DIMENSION_LIMITS = {
 
 /** Maximum `.btfont` JSON payload size in bytes before parsing. */
 export const MAX_BTFONT_JSON_BYTES = 1_048_576;
+
+/** Required prefix for embedded `.btfont` texture data URIs. */
+export const BTFONT_EMBEDDED_TEXTURE_PREFIX = 'data:image/png;base64,';
+
+/** Maximum base64 payload size for an embedded `.btfont` texture (characters after the data-URI prefix). */
+export const MAX_BTFONT_EMBEDDED_TEXTURE_BYTES = 524_288;
 
 /** Maximum number of glyph entries accepted from a `.btfont` file. */
 export const MAX_GLYPH_COUNT = 8192;
@@ -283,6 +291,33 @@ export function validateGlyphCount(count: number): string | null {
 }
 
 /**
+ * Validates an embedded `.btfont` texture URI before image decode.
+ *
+ * Relative PNG paths are accepted without additional checks. Embedded textures must
+ * use {@link BTFONT_EMBEDDED_TEXTURE_PREFIX} and stay within {@link MAX_BTFONT_EMBEDDED_TEXTURE_BYTES}.
+ *
+ * @param texture - Texture field from a `.btfont` file.
+ * @returns A user-facing error message when invalid, otherwise `null`.
+ */
+export function validateBtfontEmbeddedTextureUri(texture: string): string | null {
+    if (!texture.startsWith('data:')) {
+        return null;
+    }
+
+    if (!texture.startsWith(BTFONT_EMBEDDED_TEXTURE_PREFIX)) {
+        return btfontEmbeddedTextureFormatError();
+    }
+
+    const payloadLength = texture.length - BTFONT_EMBEDDED_TEXTURE_PREFIX.length;
+
+    if (payloadLength > MAX_BTFONT_EMBEDDED_TEXTURE_BYTES) {
+        return btfontEmbeddedTextureTooLargeError(payloadLength, MAX_BTFONT_EMBEDDED_TEXTURE_BYTES);
+    }
+
+    return null;
+}
+
+/**
  * Validates numeric glyph metrics before atlas bounds are checked.
  *
  * @param glyph - Glyph metrics from the `.btfont` file.
@@ -322,20 +357,13 @@ function validateBtfontGlyphMetrics(glyph: BtfontGlyphData, charLabel: string): 
 }
 
 /**
- * Validates one serialized glyph entry against atlas bounds and metric rules.
+ * Validates glyph metrics and per-glyph size limits before the font atlas image is decoded.
  *
  * @param glyph - Glyph metrics from the `.btfont` file.
- * @param atlasWidth - Font texture atlas width in pixels.
- * @param atlasHeight - Font texture atlas height in pixels.
  * @param charLabel - Character label used in error text.
  * @returns A user-facing error message when invalid, otherwise `null`.
  */
-export function validateBtfontGlyphData(
-    glyph: BtfontGlyphData,
-    atlasWidth: number,
-    atlasHeight: number,
-    charLabel: string,
-): string | null {
+export function validateBtfontGlyphDataPreAtlas(glyph: BtfontGlyphData, charLabel: string): string | null {
     const metricError = validateBtfontGlyphMetrics(glyph, charLabel);
 
     if (metricError) {
@@ -352,10 +380,6 @@ export function validateBtfontGlyphData(
         );
     }
 
-    if (glyph.x + glyph.w > atlasWidth || glyph.y + glyph.h > atlasHeight) {
-        return btfontGlyphOutsideAtlasError(charLabel, glyph.x, glyph.y, glyph.w, glyph.h, atlasWidth, atlasHeight);
-    }
-
     const glyphArea = glyph.w * glyph.h;
 
     if (glyph.w > 0 && glyph.h > 0 && (!Number.isSafeInteger(glyphArea) || glyphArea > MAX_SPRITE_BLIT_PIXELS)) {
@@ -363,6 +387,52 @@ export function validateBtfontGlyphData(
     }
 
     return null;
+}
+
+/**
+ * Validates that a glyph rectangle fits inside the decoded font atlas.
+ *
+ * @param glyph - Glyph metrics from the `.btfont` file.
+ * @param atlasWidth - Font texture atlas width in pixels.
+ * @param atlasHeight - Font texture atlas height in pixels.
+ * @param charLabel - Character label used in error text.
+ * @returns A user-facing error message when invalid, otherwise `null`.
+ */
+export function validateBtfontGlyphAtlasBounds(
+    glyph: BtfontGlyphData,
+    atlasWidth: number,
+    atlasHeight: number,
+    charLabel: string,
+): string | null {
+    if (glyph.x + glyph.w > atlasWidth || glyph.y + glyph.h > atlasHeight) {
+        return btfontGlyphOutsideAtlasError(charLabel, glyph.x, glyph.y, glyph.w, glyph.h, atlasWidth, atlasHeight);
+    }
+
+    return null;
+}
+
+/**
+ * Validates one serialized glyph entry against atlas bounds and metric rules.
+ *
+ * @param glyph - Glyph metrics from the `.btfont` file.
+ * @param atlasWidth - Font texture atlas width in pixels.
+ * @param atlasHeight - Font texture atlas height in pixels.
+ * @param charLabel - Character label used in error text.
+ * @returns A user-facing error message when invalid, otherwise `null`.
+ */
+export function validateBtfontGlyphData(
+    glyph: BtfontGlyphData,
+    atlasWidth: number,
+    atlasHeight: number,
+    charLabel: string,
+): string | null {
+    const preAtlasError = validateBtfontGlyphDataPreAtlas(glyph, charLabel);
+
+    if (preAtlasError) {
+        return preAtlasError;
+    }
+
+    return validateBtfontGlyphAtlasBounds(glyph, atlasWidth, atlasHeight, charLabel);
 }
 
 /**

--- a/src/utils/AssetLimits.ts
+++ b/src/utils/AssetLimits.ts
@@ -300,11 +300,13 @@ export function validateGlyphCount(count: number): string | null {
  * @returns A user-facing error message when invalid, otherwise `null`.
  */
 export function validateBtfontEmbeddedTextureUri(texture: string): string | null {
-    if (!texture.startsWith('data:')) {
+    const lowerTexture = texture.toLowerCase();
+
+    if (!lowerTexture.startsWith('data:')) {
         return null;
     }
 
-    if (!texture.startsWith(BTFONT_EMBEDDED_TEXTURE_PREFIX)) {
+    if (!lowerTexture.startsWith(BTFONT_EMBEDDED_TEXTURE_PREFIX)) {
         return btfontEmbeddedTextureFormatError();
     }
 

--- a/src/utils/errorMessages.test.ts
+++ b/src/utils/errorMessages.test.ts
@@ -1,6 +1,20 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+    MAX_ASSET_PIXELS,
+    MAX_BTFONT_EMBEDDED_TEXTURE_BYTES,
+    MAX_BTFONT_JSON_BYTES,
+    MAX_GLYPH_COUNT,
+} from './AssetLimits';
+import {
+    assetDimensionAreaTooLargeError,
+    assetDimensionInvalidError,
+    assetDimensionTooLargeError,
+    assetIndexedPixelLengthError,
+    btfontEmbeddedTextureFormatError,
+    btfontEmbeddedTextureTooLargeError,
+    btfontGlyphCountTooLargeError,
+    btfontJsonTooLargeError,
     CANVAS_NOT_FOUND_MESSAGE,
     INIT_FAILED_MESSAGE,
     noActivePaletteError,
@@ -58,6 +72,50 @@ describe('errorMessages', () => {
         it('should suggest closing other tabs or restarting', () => {
             expect(WEBGPU_DEVICE_MESSAGE).toContain('closing other tabs');
         });
+    });
+});
+
+describe('asset limit error message helpers', () => {
+    it('assetDimensionInvalidError mentions whole-number dimensions', () => {
+        expect(assetDimensionInvalidError('sprite sheet', '0x16')).toContain('whole-number');
+    });
+
+    it('assetDimensionTooLargeError includes per-axis limits', () => {
+        expect(assetDimensionTooLargeError('sprite sheet', '9000x16', 8192, 8192)).toContain('8192x8192');
+    });
+
+    it('assetDimensionAreaTooLargeError formats the pixel cap', () => {
+        expect(assetDimensionAreaTooLargeError('sprite sheet', '4096x4097', MAX_ASSET_PIXELS)).toContain(
+            MAX_ASSET_PIXELS.toLocaleString('en-US'),
+        );
+    });
+
+    it('assetIndexedPixelLengthError compares actual and expected lengths', () => {
+        expect(assetIndexedPixelLengthError(10, 4, 4, 16)).toContain('10 values');
+        expect(assetIndexedPixelLengthError(10, 4, 4, 16)).toContain('16');
+    });
+
+    it('btfontJsonTooLargeError suggests moving textures to a PNG file', () => {
+        expect(btfontJsonTooLargeError(MAX_BTFONT_JSON_BYTES + 1, MAX_BTFONT_JSON_BYTES)).toContain('separate PNG');
+    });
+
+    it('btfontGlyphCountTooLargeError includes the glyph cap', () => {
+        expect(btfontGlyphCountTooLargeError(MAX_GLYPH_COUNT + 1, MAX_GLYPH_COUNT)).toContain(
+            MAX_GLYPH_COUNT.toLocaleString('en-US'),
+        );
+    });
+
+    it('btfontEmbeddedTextureFormatError requires a PNG data URI', () => {
+        expect(btfontEmbeddedTextureFormatError()).toContain('data:image/png;base64');
+    });
+
+    it('btfontEmbeddedTextureTooLargeError includes the payload cap', () => {
+        expect(
+            btfontEmbeddedTextureTooLargeError(
+                MAX_BTFONT_EMBEDDED_TEXTURE_BYTES + 1,
+                MAX_BTFONT_EMBEDDED_TEXTURE_BYTES,
+            ),
+        ).toContain(MAX_BTFONT_EMBEDDED_TEXTURE_BYTES.toLocaleString('en-US'));
     });
 });
 

--- a/src/utils/errorMessages.ts
+++ b/src/utils/errorMessages.ts
@@ -203,6 +203,33 @@ export function btfontJsonTooLargeError(byteLength: number, maxBytes: number): s
 }
 
 /**
+ * Returns the error message when an embedded `.btfont` texture URI is not a PNG data URI.
+ *
+ * @returns User-facing error string.
+ */
+export function btfontEmbeddedTextureFormatError(): string {
+    return (
+        'Embedded font textures must use a PNG data URI (data:image/png;base64,...). ' +
+        'Use a relative PNG path in the texture field, or re-export the font with --embed'
+    );
+}
+
+/**
+ * Returns the error message when an embedded `.btfont` texture payload exceeds the size cap.
+ *
+ * @param payloadLength - Base64 payload length in characters (after the data-URI prefix).
+ * @param maxPayloadBytes - Maximum accepted embedded texture payload size.
+ * @returns User-facing error string.
+ */
+export function btfontEmbeddedTextureTooLargeError(payloadLength: number, maxPayloadBytes: number): string {
+    return (
+        `The embedded font texture is too large (${payloadLength.toLocaleString('en-US')} characters of base64 data). ` +
+        `Keep embedded textures under ${maxPayloadBytes.toLocaleString('en-US')} bytes, ` +
+        'or save the atlas as a separate PNG file and reference it by path'
+    );
+}
+
+/**
  * Returns the error message when a `.btfont` file defines too many glyphs.
  *
  * @param count - Number of glyph entries found.


### PR DESCRIPTION
Require embedded font textures to use data:image/png;base64 with a 512 KiB payload cap. Validate glyph metrics before atlas decode; check atlas bounds after. Add AssetLimits helpers, tests, and docs for VV-514.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->