### PR TITLE
test(core): expand render dimension limit coverage

### DIFF
--- a/docs/api-core.md
+++ b/docs/api-core.md
@@ -78,9 +78,11 @@ example no `canvasDisplaySize` means a 1:1 drawing buffer).
 | `detectDroppedFrames`  | `boolean`                | `false`     | Log a console warning on missed vsync         |
 
 `displaySize`, `canvasDisplaySize`, and `maxCanvasDisplaySize` must be positive whole-number pixel dimensions. Each size
-is capped at `8192×8192` per axis and `16,777,216` total pixels. Invalid sizes make initialization fail before the
-engine applies canvas layout or allocates renderer buffers. In WebGPU mode, the requested logical and output sizes must
-also fit the active adapter/device `maxTextureDimension2D` limit.
+is capped at `8192×8192` per axis and `16,777,216` total pixels (`4096×4096`). Invalid sizes make initialization fail
+before the engine applies canvas layout, sets canvas backing dimensions, or allocates renderer buffers. `BT.init()`
+returns `false` and logs a specific `[BT]` message to the browser console (press F12); the on-canvas bootstrap error
+stays a generic init failure message. In WebGPU mode, the requested logical and output sizes must also fit the active
+adapter/device `maxTextureDimension2D` limit. GPU limit failures do not fall back to the software renderer.
 
 **`BT` getters vs `configure()` fields:** `displaySize`, `canvasDisplaySize`, and `targetFPS` on `BT` mirror the same
 names on `HardwareSettings`. `outputSize` is the effective drawing-buffer size (`canvasDisplaySize ?? displaySize`).

--- a/src/core/BTAPI.test.ts
+++ b/src/core/BTAPI.test.ts
@@ -418,6 +418,31 @@ describe('BTAPI', () => {
             expect(getContext).not.toHaveBeenCalled();
         });
 
+        it('rejects invalid maxCanvasDisplaySize before layout or renderer setup', async () => {
+            const demo: IBlitTechDemo = {
+                configure: vi.fn().mockReturnValue({
+                    displaySize: new Vector2i(320, 240),
+                    maxCanvasDisplaySize: { x: Number.NaN, y: 720 } as Vector2i,
+                    targetFPS: 60,
+                }),
+                init: vi.fn().mockResolvedValue(true),
+                update: vi.fn(),
+                render: vi.fn(),
+            };
+            const canvas = makeMockCanvas();
+            const getContext = vi.fn(canvas.getContext.bind(canvas));
+            (canvas as unknown as { getContext: typeof getContext }).getContext = getContext;
+
+            const result = await BTAPI.instance.init(demo, canvas);
+
+            expect(result).toBe(false);
+            expect(canvas.width).toBe(0);
+            expect(canvas.height).toBe(0);
+            expect(canvas.style.setProperty).not.toHaveBeenCalled();
+            expect(getContext).not.toHaveBeenCalled();
+            expect(demo.init).not.toHaveBeenCalled();
+        });
+
         it('rejects WebGPU dimensions above adapter texture limits before canvas allocation', async () => {
             const requestDevice = vi.fn(async () => createMockGPUDevice());
             Object.defineProperty(globalThis, 'navigator', {
@@ -453,6 +478,91 @@ describe('BTAPI', () => {
             expect(canvas.width).toBe(0);
             expect(canvas.height).toBe(0);
             expect(requestDevice).not.toHaveBeenCalled();
+            expect(demo.init).not.toHaveBeenCalled();
+        });
+
+        it('rejects WebGPU canvasDisplaySize above adapter texture limits before canvas allocation', async () => {
+            const requestDevice = vi.fn(async () => createMockGPUDevice());
+            Object.defineProperty(globalThis, 'navigator', {
+                value: {
+                    gpu: {
+                        requestAdapter: async () => ({
+                            requestDevice,
+                            features: new Set(),
+                            limits: { maxTextureDimension2D: 1024 } as GPUSupportedLimits,
+                        }),
+                        getPreferredCanvasFormat: () => 'bgra8unorm' as GPUTextureFormat,
+                    },
+                    userAgent: 'test',
+                },
+                writable: true,
+                configurable: true,
+            });
+            const demo: IBlitTechDemo = {
+                configure: vi.fn().mockReturnValue({
+                    displaySize: new Vector2i(320, 240),
+                    canvasDisplaySize: new Vector2i(2048, 1024),
+                    targetFPS: 60,
+                    renderer: 'webgpu',
+                }),
+                init: vi.fn().mockResolvedValue(true),
+                update: vi.fn(),
+                render: vi.fn(),
+            };
+            const canvas = makeMockCanvas();
+
+            const result = await BTAPI.instance.init(demo, canvas);
+
+            expect(result).toBe(false);
+            expect(canvas.width).toBe(0);
+            expect(canvas.height).toBe(0);
+            expect(requestDevice).not.toHaveBeenCalled();
+            expect(demo.init).not.toHaveBeenCalled();
+        });
+
+        it('rejects WebGPU dimensions above device texture limits without software fallback', async () => {
+            const requestDevice = vi.fn(async () => ({
+                ...createMockGPUDevice(),
+                limits: { maxTextureDimension2D: 512 } as GPUSupportedLimits,
+            }));
+            Object.defineProperty(globalThis, 'navigator', {
+                value: {
+                    gpu: {
+                        requestAdapter: async () => ({
+                            requestDevice,
+                            features: new Set(),
+                            limits: { maxTextureDimension2D: 2048 } as GPUSupportedLimits,
+                        }),
+                        getPreferredCanvasFormat: () => 'bgra8unorm' as GPUTextureFormat,
+                    },
+                    userAgent: 'test',
+                },
+                writable: true,
+                configurable: true,
+            });
+            const demo: IBlitTechDemo = {
+                configure: vi.fn().mockReturnValue({
+                    displaySize: new Vector2i(320, 240),
+                    canvasDisplaySize: new Vector2i(1024, 768),
+                    targetFPS: 60,
+                    renderer: 'webgpu',
+                }),
+                init: vi.fn().mockResolvedValue(true),
+                update: vi.fn(),
+                render: vi.fn(),
+            };
+            const canvas = makeMock2DCanvas();
+            const getContext = vi.fn(canvas.getContext.bind(canvas));
+            (canvas as unknown as { getContext: typeof getContext }).getContext = getContext;
+
+            const result = await BTAPI.instance.init(demo, canvas);
+
+            expect(result).toBe(false);
+            expect(canvas.width).toBe(0);
+            expect(canvas.height).toBe(0);
+            expect(requestDevice).toHaveBeenCalled();
+            expect(getContext).not.toHaveBeenCalledWith('2d');
+            expect(BTAPI.instance.getActiveBackend()).toBeNull();
             expect(demo.init).not.toHaveBeenCalled();
         });
 

--- a/src/core/WebGPUContext.test.ts
+++ b/src/core/WebGPUContext.test.ts
@@ -11,14 +11,16 @@
  * the suite can validate setup logic deterministically.
  */
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
     createMockGPUCanvasContext,
+    createMockGPUDevice,
     installMockNavigatorGPU,
     uninstallMockNavigatorGPU,
 } from '../__test__/webgpu-mock';
 import { WEBGPU_ADAPTER_MESSAGE, WEBGPU_DEVICE_MESSAGE } from '../utils/errorMessages';
+import { RenderDimensionLimitError } from '../utils/RenderLimits';
 import { Vector2i } from '../utils/Vector2i';
 import { initWebGPU } from './WebGPUContext';
 
@@ -114,6 +116,95 @@ describe('initWebGPU', () => {
         const result = await initWebGPU(canvas, displaySize);
 
         expect(result).toBeNull();
+    });
+
+    // #endregion
+
+    // #region Dimension limits
+
+    it('throws RenderDimensionLimitError when displaySize exceeds adapter texture limit', async () => {
+        const requestDevice = vi.fn(async () => createMockGPUDevice());
+        Object.defineProperty(globalThis, 'navigator', {
+            value: {
+                gpu: {
+                    requestAdapter: async () => ({
+                        requestDevice,
+                        features: new Set(),
+                        limits: { maxTextureDimension2D: 1024 } as GPUSupportedLimits,
+                    }),
+                    getPreferredCanvasFormat: () => 'bgra8unorm' as GPUTextureFormat,
+                },
+                userAgent: 'test',
+            },
+            writable: true,
+            configurable: true,
+        });
+
+        const canvas = createMockCanvas();
+
+        await expect(initWebGPU(canvas, new Vector2i(2048, 1024))).rejects.toBeInstanceOf(RenderDimensionLimitError);
+        expect(requestDevice).not.toHaveBeenCalled();
+        expect(canvas.width).toBe(0);
+        expect(canvas.height).toBe(0);
+    });
+
+    it('throws RenderDimensionLimitError when canvasDisplaySize exceeds device texture limit', async () => {
+        const requestDevice = vi.fn(async () => ({
+            ...createMockGPUDevice(),
+            limits: { maxTextureDimension2D: 512 } as GPUSupportedLimits,
+        }));
+        Object.defineProperty(globalThis, 'navigator', {
+            value: {
+                gpu: {
+                    requestAdapter: async () => ({
+                        requestDevice,
+                        features: new Set(),
+                        limits: { maxTextureDimension2D: 2048 } as GPUSupportedLimits,
+                    }),
+                    getPreferredCanvasFormat: () => 'bgra8unorm' as GPUTextureFormat,
+                },
+                userAgent: 'test',
+            },
+            writable: true,
+            configurable: true,
+        });
+
+        const canvas = createMockCanvas();
+        const displaySize = new Vector2i(320, 240);
+        const canvasDisplaySize = new Vector2i(1024, 768);
+
+        await expect(initWebGPU(canvas, displaySize, canvasDisplaySize)).rejects.toBeInstanceOf(
+            RenderDimensionLimitError,
+        );
+        expect(canvas.width).toBe(0);
+        expect(canvas.height).toBe(0);
+    });
+
+    it('succeeds when dimensions are exactly at the adapter texture limit', async () => {
+        Object.defineProperty(globalThis, 'navigator', {
+            value: {
+                gpu: {
+                    requestAdapter: async () => ({
+                        requestDevice: async () => createMockGPUDevice(),
+                        features: new Set(),
+                        limits: { maxTextureDimension2D: 1024 } as GPUSupportedLimits,
+                    }),
+                    getPreferredCanvasFormat: () => 'bgra8unorm' as GPUTextureFormat,
+                },
+                userAgent: 'test',
+            },
+            writable: true,
+            configurable: true,
+        });
+
+        const canvas = createMockCanvas();
+        const size = new Vector2i(1024, 1024);
+
+        const result = await initWebGPU(canvas, size);
+
+        expect(result).not.toBeNull();
+        expect(canvas.width).toBe(1024);
+        expect(canvas.height).toBe(1024);
     });
 
     // #endregion

--- a/src/utils/RenderLimits.test.ts
+++ b/src/utils/RenderLimits.test.ts
@@ -4,7 +4,9 @@ import {
     MAX_RENDER_DIMENSION,
     MAX_RENDER_PIXELS,
     type RenderDimensionField,
+    RenderDimensionLimitError,
     type RenderDimensionSettings,
+    validateRenderDimension,
     validateRenderDimensions,
     validateWebGPUTextureDimension,
 } from './RenderLimits';
@@ -90,6 +92,61 @@ describe('RenderLimits', () => {
 
             expect(error).toContain(MAX_RENDER_PIXELS.toLocaleString('en-US'));
         });
+
+        it('rejects 8192x8192 when per-axis limits pass but total area exceeds cap', () => {
+            const error = validateRenderDimensions({
+                displaySize: rawSize(MAX_RENDER_DIMENSION, MAX_RENDER_DIMENSION),
+            });
+
+            expect(error).toContain('displaySize');
+            expect(error).toContain(MAX_RENDER_PIXELS.toLocaleString('en-US'));
+        });
+
+        it('accepts dimensions at the per-axis maximum with area within cap', () => {
+            expect(
+                validateRenderDimensions({
+                    displaySize: rawSize(MAX_RENDER_DIMENSION, 2048),
+                }),
+            ).toBeNull();
+        });
+
+        it('accepts dimensions at the total pixel area maximum', () => {
+            expect(
+                validateRenderDimensions({
+                    displaySize: rawSize(4096, 4096),
+                }),
+            ).toBeNull();
+        });
+
+        it('accepts dimensions at the per-axis maximum on a single axis', () => {
+            expect(
+                validateRenderDimensions({
+                    displaySize: rawSize(MAX_RENDER_DIMENSION, 1),
+                }),
+            ).toBeNull();
+        });
+    });
+
+    describe('validateRenderDimension', () => {
+        it('returns null for a valid size at engine limits', () => {
+            expect(validateRenderDimension('displaySize', new Vector2i(4096, 4096))).toBeNull();
+        });
+
+        it('returns a field-specific message for invalid sizes', () => {
+            const error = validateRenderDimension('canvasDisplaySize', rawSize(0, 480));
+
+            expect(error).toContain('canvasDisplaySize');
+        });
+    });
+
+    describe('RenderDimensionLimitError', () => {
+        it('uses the expected error name', () => {
+            const error = new RenderDimensionLimitError('test message');
+
+            expect(error.name).toBe('RenderDimensionLimitError');
+            expect(error).toBeInstanceOf(Error);
+            expect(error).toBeInstanceOf(RenderDimensionLimitError);
+        });
     });
 
     describe('validateWebGPUTextureDimension', () => {
@@ -99,8 +156,27 @@ describe('RenderLimits', () => {
             expect(error).toContain('graphics card');
         });
 
+        it('rejects when height alone exceeds the WebGPU texture limit', () => {
+            const error = validateWebGPUTextureDimension('displaySize', new Vector2i(512, 2048), 1024);
+
+            expect(error).toContain('displaySize');
+            expect(error).toContain('graphics card');
+        });
+
+        it('accepts dimensions exactly at the WebGPU texture limit', () => {
+            expect(validateWebGPUTextureDimension('displaySize', new Vector2i(1024, 1024), 1024)).toBeNull();
+        });
+
         it('ignores missing WebGPU texture limits', () => {
             expect(validateWebGPUTextureDimension('displaySize', new Vector2i(2048, 1024), undefined)).toBeNull();
+        });
+
+        it('ignores non-finite WebGPU texture limits', () => {
+            expect(validateWebGPUTextureDimension('displaySize', new Vector2i(2048, 1024), Number.NaN)).toBeNull();
+        });
+
+        it('ignores non-positive WebGPU texture limits', () => {
+            expect(validateWebGPUTextureDimension('displaySize', new Vector2i(2048, 1024), 0)).toBeNull();
         });
     });
 });

--- a/src/utils/errorMessages.test.ts
+++ b/src/utils/errorMessages.test.ts
@@ -6,6 +6,10 @@ import {
     noActivePaletteError,
     paletteIndexNegativeError,
     paletteIndexOutOfRangeError,
+    renderDimensionAreaTooLargeError,
+    renderDimensionGpuLimitError,
+    renderDimensionInvalidError,
+    renderDimensionTooLargeError,
     spriteColorNotInPaletteError,
     spriteNotIndexizedError,
     WEBGPU_ADAPTER_MESSAGE,
@@ -57,6 +61,54 @@ describe('errorMessages', () => {
 
         it('should suggest closing other tabs or restarting', () => {
             expect(WEBGPU_DEVICE_MESSAGE).toContain('closing other tabs');
+        });
+    });
+
+    describe('renderDimensionInvalidError', () => {
+        it('includes the field name and invalid size', () => {
+            const message = renderDimensionInvalidError('displaySize', '0x240');
+
+            expect(message).toContain('displaySize');
+            expect(message).toContain('0x240');
+        });
+
+        it('directs the author to update configure()', () => {
+            expect(renderDimensionInvalidError('canvasDisplaySize', '320.5x240')).toContain('configure()');
+        });
+    });
+
+    describe('renderDimensionTooLargeError', () => {
+        it('includes the field name, size, and axis limits', () => {
+            const message = renderDimensionTooLargeError('maxCanvasDisplaySize', '9000x720', 8192, 8192);
+
+            expect(message).toContain('maxCanvasDisplaySize');
+            expect(message).toContain('9000x720');
+            expect(message).toContain('8192x8192');
+        });
+
+        it('directs the author to use a smaller configure() size', () => {
+            expect(renderDimensionTooLargeError('displaySize', '9000x240', 8192, 8192)).toContain('configure()');
+        });
+    });
+
+    describe('renderDimensionAreaTooLargeError', () => {
+        it('includes the field name, size, and formatted pixel cap', () => {
+            const message = renderDimensionAreaTooLargeError('displaySize', '4096x4097', 16_777_216);
+
+            expect(message).toContain('displaySize');
+            expect(message).toContain('4096x4097');
+            expect(message).toContain('16,777,216');
+        });
+    });
+
+    describe('renderDimensionGpuLimitError', () => {
+        it('includes the field name, size, and graphics-card limit', () => {
+            const message = renderDimensionGpuLimitError('canvasDisplaySize', '2048x1024', 1024);
+
+            expect(message).toContain('canvasDisplaySize');
+            expect(message).toContain('2048x1024');
+            expect(message).toContain('graphics card');
+            expect(message).toContain('1024');
         });
     });
 });


### PR DESCRIPTION
Add boundary and WebGPU adapter/device cases in RenderLimits and WebGPUContext tests. Cover BTAPI init rejection for invalid maxCanvasDisplaySize, oversized canvasDisplaySize, and GPU limit failures without software fallback. Assert renderDimension* error helpers and document HardwareSettings validation in api-core.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR expands test coverage for render dimension validation and limits, addressing VV-513. The changes include new unit tests, documentation updates, and error message validation across multiple core modules.

## Changes Overview

**Documentation (api-core.md)**
Updated the `Initialization` documentation to clarify validation behavior for `displaySize`, `canvasDisplaySize`, and `maxCanvasDisplaySize`. Documents that sizes are capped per-axis and by total pixels, invalid sizes cause `BT.init()` to fail early with a specific console `[BT]` message, and in WebGPU mode GPU `maxTextureDimension2D` limit failures do not fall back to the software renderer.

**Core API Tests (BTAPI.test.ts)**
Added three new unit test cases covering invalid hardware settings:
- Rejection when `maxCanvasDisplaySize` contains a `NaN` dimension, ensuring canvas sizing APIs and initialization functions are not called
- Rejection when `canvasDisplaySize` exceeds WebGPU adapter `maxTextureDimension2D` limits before canvas allocation
- Rejection when requested WebGPU dimensions exceed device texture limits without software fallback, confirming the WebGPU path was attempted and active backend remains unset

**WebGPU Context Tests (WebGPUContext.test.ts)**
Expanded WebGPU dimension-limit behavior coverage with tests verifying:
- Initialization rejects with `RenderDimensionLimitError` when display size exceeds adapter/device `maxTextureDimension2D`
- Device request is not called when adapter limits are exceeded
- Canvas width/height remain at `0` on failures
- Success case when dimensions are exactly at the adapter limit

**Render Limits Tests (RenderLimits.test.ts)**
Enhanced `validateRenderDimensions` test suite with new cases for:
- Rejection when total render pixel area exceeds the cap despite per-axis limits passing
- Acceptance cases for per-axis maximums when within area cap and per-axis limits
- New test blocks for `validateRenderDimension` behavior and `RenderDimensionLimitError` instance validation
- Extended `validateWebGPUTextureDimension` tests covering edge cases including partial axis overflows, exact-limit acceptance, and invalid texture limit handling

**Error Message Tests (errorMessages.test.ts)**
Added Vitest coverage for `renderDimension*` error message helpers (`renderDimensionInvalidError`, `renderDimensionTooLargeError`, `renderDimensionAreaTooLargeError`, `renderDimensionGpuLimitError`) verifying they include expected parameter information with formatted pixel caps and graphics-card limits, providing guidance to `configure()`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->