### PR TITLE
chore(ci): expand ignore rules for local AI tooling and MCP configs

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,25 @@
+{
+  "version": 1,
+  "hooks": {
+    "preToolUse": [
+      {
+        "command": "rtk hook cursor",
+        "matcher": "Shell"
+      }
+    ],
+    "afterFileEdit": [
+      {
+        "command": "sh .cursor/hooks/format-and-check.sh",
+        "matcher": "Write|TabWrite",
+        "timeout": 30
+      }
+    ],
+    "beforeShellExecution": [
+      {
+        "command": "sh .cursor/hooks/shell-safety.sh",
+        "timeout": 10,
+        "failClosed": true
+      }
+    ]
+  }
+}

--- a/.cursor/hooks/format-and-check.sh
+++ b/.cursor/hooks/format-and-check.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+INPUT_JSON="$(cat)"
+
+if command -v rtk >/dev/null 2>&1; then
+    RUNNER='rtk pnpm exec'
+else
+    RUNNER='pnpm exec'
+fi
+
+FILE_PATH="$(printf '%s' "$INPUT_JSON" | python3 -c "
+import json, sys
+
+def walk(node):
+    if isinstance(node, dict):
+        for key in ('file_path', 'path'):
+            value = node.get(key)
+            if isinstance(value, str) and value:
+                return value
+        for value in node.values():
+            found = walk(value)
+            if found:
+                return found
+    elif isinstance(node, list):
+        for value in node:
+            found = walk(value)
+            if found:
+                return found
+    return ''
+
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    print('')
+    raise SystemExit(0)
+
+print(walk(data))
+")"
+
+if [ -z "$FILE_PATH" ]; then
+    exit 0
+fi
+
+case "$FILE_PATH" in
+    /*) TARGET_FILE="$FILE_PATH" ;;
+    *) TARGET_FILE="$REPO_ROOT/$FILE_PATH" ;;
+esac
+
+if [ ! -f "$TARGET_FILE" ]; then
+    exit 0
+fi
+
+case "$TARGET_FILE" in
+    "$REPO_ROOT"/*) ;;
+    *) exit 0 ;;
+esac
+
+case "$TARGET_FILE" in
+    *.ts|*.tsx|*.js|*.cjs|*.mjs|*.json|*.jsonc|*.css)
+        (cd "$REPO_ROOT" && $RUNNER biome check --write "$TARGET_FILE" >/dev/null 2>&1) || true
+        ;;
+esac
+
+case "$TARGET_FILE" in
+    *.md|*.mdx|*.yml|*.yaml)
+        (cd "$REPO_ROOT" && $RUNNER prettier --write "$TARGET_FILE" >/dev/null 2>&1) || true
+        ;;
+esac
+
+case "$TARGET_FILE" in
+    *.ts|*.tsx|*.js|*.cjs|*.mjs|*.md|*.mdx)
+        SPELLCHECK_OUTPUT="$(cd "$REPO_ROOT" && $RUNNER cspell --no-progress "$TARGET_FILE" 2>&1)" || {
+            printf '[SPELLCHECK] %s\n' "$TARGET_FILE" >&2
+            printf '%s\n' "$SPELLCHECK_OUTPUT" >&2
+        }
+        ;;
+esac
+
+exit 0

--- a/.cursor/hooks/format-and-check.sh
+++ b/.cursor/hooks/format-and-check.sh
@@ -49,31 +49,34 @@ case "$FILE_PATH" in
     *) TARGET_FILE="$REPO_ROOT/$FILE_PATH" ;;
 esac
 
-if [ ! -f "$TARGET_FILE" ]; then
+NORMALIZED_TARGET="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$TARGET_FILE" 2>/dev/null)" || exit 0
+CANONICAL_REPO_ROOT="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$REPO_ROOT")"
+
+if [ ! -f "$NORMALIZED_TARGET" ]; then
     exit 0
 fi
 
-case "$TARGET_FILE" in
-    "$REPO_ROOT"/*) ;;
+case "$NORMALIZED_TARGET" in
+    "$CANONICAL_REPO_ROOT"/*) ;;
     *) exit 0 ;;
 esac
 
-case "$TARGET_FILE" in
+case "$NORMALIZED_TARGET" in
     *.ts|*.tsx|*.js|*.cjs|*.mjs|*.json|*.jsonc|*.css)
-        (cd "$REPO_ROOT" && $RUNNER biome check --write "$TARGET_FILE" >/dev/null 2>&1) || true
+        (cd "$REPO_ROOT" && $RUNNER biome check --write "$NORMALIZED_TARGET" >/dev/null 2>&1) || true
         ;;
 esac
 
-case "$TARGET_FILE" in
+case "$NORMALIZED_TARGET" in
     *.md|*.mdx|*.yml|*.yaml)
-        (cd "$REPO_ROOT" && $RUNNER prettier --write "$TARGET_FILE" >/dev/null 2>&1) || true
+        (cd "$REPO_ROOT" && $RUNNER prettier --write "$NORMALIZED_TARGET" >/dev/null 2>&1) || true
         ;;
 esac
 
-case "$TARGET_FILE" in
+case "$NORMALIZED_TARGET" in
     *.ts|*.tsx|*.js|*.cjs|*.mjs|*.md|*.mdx)
-        SPELLCHECK_OUTPUT="$(cd "$REPO_ROOT" && $RUNNER cspell --no-progress "$TARGET_FILE" 2>&1)" || {
-            printf '[SPELLCHECK] %s\n' "$TARGET_FILE" >&2
+        SPELLCHECK_OUTPUT="$(cd "$REPO_ROOT" && $RUNNER cspell --no-progress "$NORMALIZED_TARGET" 2>&1)" || {
+            printf '[SPELLCHECK] %s\n' "$NORMALIZED_TARGET" >&2
             printf '%s\n' "$SPELLCHECK_OUTPUT" >&2
         }
         ;;

--- a/.cursor/hooks/shell-safety.sh
+++ b/.cursor/hooks/shell-safety.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+set -u
+
+INPUT_JSON="$(cat)"
+
+COMMAND_TEXT="$(printf '%s' "$INPUT_JSON" | python3 -c "
+import json, sys
+
+def walk(node):
+    if isinstance(node, dict):
+        for key in ('command', 'raw_command'):
+            value = node.get(key)
+            if isinstance(value, str) and value:
+                return value
+        for value in node.values():
+            found = walk(value)
+            if found:
+                return found
+    elif isinstance(node, list):
+        for value in node:
+            found = walk(value)
+            if found:
+                return found
+    return ''
+
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    print('')
+    raise SystemExit(0)
+
+print(walk(data))
+")"
+
+if [ -z "$COMMAND_TEXT" ]; then
+    printf '{"permission":"allow"}\n'
+    exit 0
+fi
+
+if printf '%s' "$COMMAND_TEXT" | grep -Eq 'git[[:space:]]+reset[[:space:]]+--hard|git[[:space:]]+clean[[:space:]]+-[^[:cntrl:]]*f[^[:cntrl:]]*d|git[[:space:]]+checkout[[:space:]]+--'; then
+    printf '{"permission":"deny","user_message":"Blocked risky destructive git command.","agent_message":"Use safer git operations or ask for explicit approval."}\n'
+    exit 0
+fi
+
+if printf '%s' "$COMMAND_TEXT" | grep -Eq 'git[[:space:]]+push[^[:cntrl:]]*--force|git[[:space:]]+push[^[:cntrl:]]*-f'; then
+    printf '{"permission":"ask","user_message":"Force push detected. Confirm before continuing.","agent_message":"Potential history rewrite command requires confirmation."}\n'
+    exit 0
+fi
+
+printf '{"permission":"allow"}\n'
+exit 0

--- a/.cursor/hooks/shell-safety.sh
+++ b/.cursor/hooks/shell-safety.sh
@@ -38,7 +38,7 @@ if [ -z "$COMMAND_TEXT" ]; then
     exit 0
 fi
 
-if printf '%s' "$COMMAND_TEXT" | grep -Eq 'git[[:space:]]+reset[[:space:]]+--hard|git[[:space:]]+clean[[:space:]]+-[^[:cntrl:]]*f[^[:cntrl:]]*d|git[[:space:]]+checkout[[:space:]]+--'; then
+if printf '%s' "$COMMAND_TEXT" | grep -Eq 'git[[:space:]]+reset[[:space:]]+--hard|git[[:space:]]+clean[[:space:]]+-[^[:cntrl:]]*f|git[[:space:]]+checkout[[:space:]]+--'; then
     printf '{"permission":"deny","user_message":"Blocked risky destructive git command.","agent_message":"Use safer git operations or ask for explicit approval."}\n'
     exit 0
 fi

--- a/.cursor/rules/bt-api-getters.mdc
+++ b/.cursor/rules/bt-api-getters.mdc
@@ -1,0 +1,41 @@
+---
+description: BT namespace uses getters for read-only state; methods for actions and parameterized queries
+alwaysApply: true
+---
+
+# BT API: getters vs methods
+
+When editing `src/BlitTech.ts`, demos, or API docs:
+
+## Prefer getters (no parentheses)
+
+Zero-argument **read-only** values on `BT`:
+
+- **Configure-time** (use same names as `HardwareSettings`): `displaySize`, `canvasDisplaySize`, `targetFPS`, `outputSize`
+- **Loop:** `deltaSeconds`, `timeSeconds`, `ticks`
+- **Runtime:** `activeBackend`, `camera`, `palette`
+- **Per-frame input:** `pointerScrollDelta`, `inputString`, `gamepadCount`
+
+Good: `BT.displaySize.y`, `BT.targetFPS`, `BT.ticks % 180`
+
+Bad: `BT.displaySize()`, `BT.fps()`, `BT.getActiveBackend()` (removed; use property forms)
+
+## Keep as methods
+
+- Mutations and draws: `cameraSet`, `paletteSet`, `drawSprite`, `effectAdd`, …
+- Any **parameter**: `pointerPos(0)`, `buttonDown(BT.BTN_A)`, `cameraClamp(...)`
+- **Async**: `captureFrame`, `downloadFrame`
+
+## Naming
+
+- Match `HardwareSettings` spelling: `targetFPS` (not `fps`, not `targetFps`)
+- `activeBackend` = backend that started; `configure().renderer` = requested backend only (not exposed as `BT.renderer`)
+
+## New API checklist
+
+1. Zero args + read-only snapshot → **getter** on `BT`
+2. Takes args or mutates → **method**
+3. Mirrors configure? → **same field name** as `HardwareSettings`
+4. Update `docs/api-*.md`, `CLAUDE.md`, demos if public
+
+See `CLAUDE.md` section **BT API: getters vs methods** and `docs/api-core.md`.

--- a/.cursor/rules/claude-canonical.mdc
+++ b/.cursor/rules/claude-canonical.mdc
@@ -1,0 +1,12 @@
+---
+description: Use blit-tech CLAUDE.md as canonical engineering rules
+alwaysApply: true
+---
+
+# blit-tech CLAUDE Is Canonical
+
+- Treat `/Users/vancura/Repos/_BLIT_TECH_/blit-tech/CLAUDE.md` as canonical for implementation in this repo.
+- Follow its API conventions (especially BT getters vs methods), architecture map, command set, and docs-update rules.
+- Do not invent alternate conventions when `CLAUDE.md` provides project-specific direction.
+- Public API or behavior changes must include matching docs updates in `docs/` as described in `CLAUDE.md`.
+- Keep performance-first and strict TypeScript standards from `CLAUDE.md` (no `any`, use type-only imports, integer coordinates where required).

--- a/.cursor/rules/docs-sync-required.mdc
+++ b/.cursor/rules/docs-sync-required.mdc
@@ -1,0 +1,14 @@
+---
+description: Require docs updates for API and behavior changes
+globs: {src/**/*.ts,docs/**/*.md,README.md,CLAUDE.md}
+alwaysApply: false
+---
+
+# Docs Sync Required
+
+- Documentation is part of the implementation, not a follow-up task.
+- When public API changes, update relevant `docs/api-*.md` and related examples in the same change.
+- When runtime behavior changes, update affected guides under `docs/`.
+- When architecture or subsystem structure changes, update `CLAUDE.md` architecture sections.
+- Update `README.md` only when quick start, prerequisites, feature list, or compatibility is affected.
+- If no docs update is needed, state why explicitly in the final response.

--- a/.cursor/rules/rtk-and-pnpm.mdc
+++ b/.cursor/rules/rtk-and-pnpm.mdc
@@ -1,0 +1,12 @@
+---
+description: RTK shell rewrite and pnpm run convention for agents
+alwaysApply: true
+---
+
+# RTK and pnpm
+
+- Package scripts: **`pnpm run <script>`** only (e.g. `pnpm run preflight`). Bare `pnpm preflight` skips RTK rewrite.
+- Built-ins without `run`: `pnpm install`, `pnpm audit`, `pnpm exec`, `pnpm add`, `pnpm --filter …`.
+- Cursor: `preToolUse` → `rtk hook cursor` on Shell (see `.cursor/hooks.json`).
+- Prefer shell + RTK (`rtk read`, `rtk grep`, `git`, `pnpm run …`) over native Read/Grep for exploration.
+- Full policy: `~/.claude/RTK.md`.

--- a/.gitignore
+++ b/.gitignore
@@ -31,8 +31,22 @@ test-results/
 .vitest/
 benchmark-results.json
 
-# Claude Code local settings
+# Claude Code (skills, rules, settings.json are tracked)
 .claude/settings.local.json
+.claude/memory/
+.claude/worktrees/
+
+# MCP configs (local secrets; project MCP also lives under ~/.cursor/projects/)
+.mcp.json
+mcp.json
+
+# Other AI assistants (local only)
+.codex/
+.aider*
+.continue/
+.windsurf/
+ai-rules/
+.rules
 
 # IDE and editor files
 .vscode/launch.json
@@ -42,7 +56,12 @@ benchmark-results.json
 .idea/
 *.iml
 .zed/
-.cursor/
+.cursor/*
+!.cursor/hooks.json
+!.cursor/hooks/
+!.cursor/hooks/**
+!.cursor/rules/
+!.cursor/rules/**
 *.swp
 *.swo
 *~

--- a/.npmignore
+++ b/.npmignore
@@ -14,6 +14,12 @@ ai-rules/
 .rules
 CLAUDE.md
 .claude/
+.mcp.json
+mcp.json
+.codex/
+.aider*
+.continue/
+.windsurf/
 
 *.config.js
 *.config.ts
@@ -32,6 +38,11 @@ vite.config.*.timestamp-*
 
 # Documentation (keep README.md and LICENSE)
 docs/
+
+# Tests, scripts, and local security reports
+tests/
+scripts/
+security-reports/
 
 # Build artifacts
 node_modules/


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR expands repository ignore rules and adds Cursor IDE automation hooks, formatting/safety scripts, and coding-rule documents to standardize AI-assisted workflows and project conventions.

## Cursor IDE Integration

- .cursor/hooks.json
  - Adds Cursor hooks:
    - preToolUse: runs `rtk hook cursor` for Shell tool usage.
    - afterFileEdit: runs `sh .cursor/hooks/format-and-check.sh` on Write/TabWrite events (30s timeout).
    - beforeShellExecution: runs `sh .cursor/hooks/shell-safety.sh` (10s timeout, `failClosed: true`).

- .cursor/hooks/format-and-check.sh
  - Reads JSON stdin to locate a target file path, resolves it to an in-repo absolute path, and exits harmlessly if not applicable.
  - Chooses runner: `rtk pnpm exec` if `rtk` is present, otherwise `pnpm exec`.
  - Best-effort formatting/checks:
    - Runs Biome check/format for .ts/.tsx/.js/.cjs/.mjs/.json/.jsonc/.css.
    - Runs Prettier for .md/.mdx/.yml/.yaml.
    - Runs cspell for selected text/code files and prints spellcheck output on stderr; tool failures are suppressed so the script exits 0.

- .cursor/hooks/shell-safety.sh
  - Extracts a command string from JSON stdin via embedded Python walker.
  - Default: allows commands by printing JSON permission {"permission":"allow"}.
  - Denies destructive git commands (matches `git reset --hard`, `git clean ... -f`, `git checkout --`) and returns a JSON deny with user/agent messages.
  - Marks force pushes (`git push ... --force` or `-f`) as `{"permission":"ask", ...}` to require confirmation.
  - Always returns a single JSON permission line and exits.

## Cursor Coding Rules

- .cursor/rules/bt-api-getters.mdc
  - Enforces BT API conventions: zero-argument read-only snapshot values should be exposed as getters (properties) while mutations, parameterized calls, and async ops remain methods.
  - Lists preferred property names (e.g., targetFPS, activeBackend) and a checklist for new API additions and docs updates.

- .cursor/rules/claude-canonical.mdc
  - Declares CLAUDE.md as the canonical engineering rules source for the repo and requires adherence to its API, architecture, and TypeScript standards (no `any`, type-only imports, integer coordinates where required).
  - Requires docs updates for public API/behavior changes per CLAUDE.md.

- .cursor/rules/docs-sync-required.mdc
  - Adds documentation-sync rules: when APIs, behavior, or architecture change, require updates to designated docs (globs include src/**/*.ts, docs/**/*.md, README.md, CLAUDE.md). Rule is conditional (`alwaysApply: false`) and requires justification if docs are not updated.

- .cursor/rules/rtk-and-pnpm.mdc
  - Standardizes RTK + pnpm conventions: prefer `pnpm run <script>` to trigger RTK shell rewrite, documents allowed built-in pnpm commands without `run`, and instructs Cursor to invoke `rtk hook cursor` for Shell preToolUse.

## Ignore Rule Updates

- .gitignore
  - Adds local AI tooling and MCP config ignores:
    - Claudi/Claude-related local files: `.claude/settings.local.json`, `.claude/memory/`, `.claude/worktrees/`
    - MCP local config files: `.mcp.json`, `mcp.json`
    - Other local AI assistant dirs: `.codex/`, `.aider*`, `.continue/`, `.windsurf/`, `ai-rules/`, `.rules`
  - Ignores `.cursor/*` while explicitly allowing tracked Cursor configuration files and directories: `!.cursor/hooks.json`, `!.cursor/hooks/`, `!.cursor/hooks/**`, `!.cursor/rules/`, `!.cursor/rules/**`.

- .npmignore
  - Excludes AI-assistant and MCP config files from package publishes: `.claude/`, `.mcp.json`, `mcp.json`, `.codex/`, `.aider*`, `.continue/`, `.windsurf/`, `ai-rules/`, `.rules`, and `.cursor/`.
  - Retains prior exclusions (src/, build artifacts, docs, tests, dev config files, environment files, etc.).

## Notes for reviewers
- Hooks/scripts are defensive and designed to be best-effort (formatters/spellcheck suppressed to avoid failing edits).
- Shell safety hook encodes specific git protections and a force-push confirmation flow; consider extending or adjusting regexes/messages if different policies are desired.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/173?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->