### PR TITLE
feat(renderer): add overlay compositing layers on webgpu

### DIFF
--- a/src/render/IRenderer.ts
+++ b/src/render/IRenderer.ts
@@ -82,6 +82,18 @@ export interface IRenderer {
     drawRectFill(rect: Rect2i, paletteIndex: number): void;
 
     /**
+     * Draws a filled rectangle above sprite content for this frame.
+     *
+     * On WebGPU, batched after the sprite pass so HUD bars (for example the stats
+     * overlay) appear on top of {@link drawSprite} calls. Software backends may
+     * implement this as a normal {@link drawRectFill} when call order is preserved.
+     *
+     * @param rect - Rectangle bounds in display coordinates.
+     * @param paletteIndex - Palette color index.
+     */
+    drawRectFillOnTop(rect: Rect2i, paletteIndex: number): void;
+
+    /**
      * Draws a single pixel.
      *
      * @param pos - Pixel position.
@@ -137,6 +149,20 @@ export interface IRenderer {
      * @param paletteOffset - Palette index offset applied to all glyphs (default 0).
      */
     drawBitmapText(font: BitmapFont, pos: Vector2i, text: string, paletteOffset?: number): void;
+
+    /**
+     * Draws bitmap text above overlay bar fills for this frame.
+     *
+     * On WebGPU, batched after the post-sprite primitive pass so labels (for example
+     * stats overlay text) appear on top of {@link drawRectFillOnTop} bars. Software
+     * backends may implement this as {@link drawBitmapText} when call order is preserved.
+     *
+     * @param font - Bitmap font with character glyphs (underlying sheet must be indexized).
+     * @param pos - Text position (top-left corner).
+     * @param text - String to render.
+     * @param paletteOffset - Palette index offset applied to all glyphs (default 0).
+     */
+    drawBitmapTextOnTop(font: BitmapFont, pos: Vector2i, text: string, paletteOffset?: number): void;
 
     // #endregion
 

--- a/src/render/SoftwareRenderer.ts
+++ b/src/render/SoftwareRenderer.ts
@@ -250,6 +250,16 @@ export class SoftwareRenderer implements IRenderer {
     }
 
     /**
+     * Queues a filled rectangle after prior commands (same FIFO queue as {@link drawRectFill}).
+     *
+     * @param rect - Rectangle to fill in logical pixels.
+     * @param paletteIndex - Palette entry index for the fill color.
+     */
+    drawRectFillOnTop(rect: Rect2i, paletteIndex: number): void {
+        this.drawRectFill(rect, paletteIndex);
+    }
+
+    /**
      * Queues a single pixel draw command at the given position.
      *
      * @param pos - Pixel position in logical coordinates.
@@ -350,6 +360,18 @@ export class SoftwareRenderer implements IRenderer {
             cameraX: this.cameraOffset.x,
             cameraY: this.cameraOffset.y,
         });
+    }
+
+    /**
+     * Queues bitmap text after prior commands (same FIFO queue as {@link drawBitmapText}).
+     *
+     * @param font - Bitmap font with character glyphs.
+     * @param pos - Text origin in logical pixels.
+     * @param text - String to render.
+     * @param paletteOffset - Palette index offset applied to all glyphs (default 0).
+     */
+    drawBitmapTextOnTop(font: BitmapFont, pos: Vector2i, text: string, paletteOffset: number = 0): void {
+        this.drawBitmapText(font, pos, text, paletteOffset);
     }
 
     // #endregion

--- a/src/render/WebGpuRenderer.test.ts
+++ b/src/render/WebGpuRenderer.test.ts
@@ -29,9 +29,29 @@ import { Color32 } from '../utils/Color32';
 import { Rect2i } from '../utils/Rect2i';
 import { Vector2i } from '../utils/Vector2i';
 import type { Effect } from './effects/Effect';
+import type { PrimitivePipeline } from './PrimitivePipeline';
+import type { SpritePipeline } from './SpritePipeline';
 import { WebGpuRenderer } from './WebGpuRenderer';
 
 // #region Test Helpers
+
+/** Internal pipeline batches on {@link WebGpuRenderer} (compile-time private, runtime-accessible). */
+type WebGpuRendererPipelineAccess = {
+    primitives: PrimitivePipeline;
+    overlayPrimitives: PrimitivePipeline;
+    sprites: SpritePipeline;
+    overlaySprites: SpritePipeline;
+};
+
+/**
+ * Returns the four scene-pass pipeline batches for encode-order and routing tests.
+ *
+ * @param renderer - Initialized {@link WebGpuRenderer}.
+ * @returns Primitive and sprite pipeline instances.
+ */
+function getRendererPipelines(renderer: WebGpuRenderer): WebGpuRendererPipelineAccess {
+    return renderer as unknown as WebGpuRendererPipelineAccess;
+}
 
 /** Creates a small 16-color test palette with known color assignments. */
 function createTestPalette(): Palette {
@@ -416,6 +436,88 @@ describe('with initialized renderer', () => {
         expect(() => {
             renderer.drawBitmapText(mockFont, new Vector2i(0, 0), '');
         }).not.toThrow();
+
+        renderer.endFrame();
+    });
+
+    it('drawRectFillOnTop routes fills to overlayPrimitives, not primitives', () => {
+        const pipelines = getRendererPipelines(renderer);
+        const sceneFill = vi.spyOn(pipelines.primitives, 'drawRectFill');
+        const overlayFill = vi.spyOn(pipelines.overlayPrimitives, 'drawRectFill');
+        const rect = new Rect2i(1, 2, 8, 8);
+
+        renderer.beginFrame();
+        renderer.drawRectFill(rect, 2);
+        renderer.drawRectFillOnTop(rect, 5);
+        renderer.endFrame();
+
+        expect(sceneFill).toHaveBeenCalledOnce();
+        expect(sceneFill).toHaveBeenCalledWith(rect, 2);
+        expect(overlayFill).toHaveBeenCalledOnce();
+        expect(overlayFill).toHaveBeenCalledWith(rect, 5);
+    });
+
+    it('drawBitmapTextOnTop routes text to overlaySprites, not sprites', () => {
+        const pipelines = getRendererPipelines(renderer);
+        const sceneText = vi.spyOn(pipelines.sprites, 'drawBitmapText');
+        const overlayText = vi.spyOn(pipelines.overlaySprites, 'drawBitmapText');
+        const mockFont = {
+            getSpriteSheet: () => ({}),
+            getGlyphByCode: () => null,
+        } as unknown as BitmapFont;
+
+        renderer.beginFrame();
+        renderer.drawBitmapText(mockFont, new Vector2i(0, 0), '');
+        renderer.drawBitmapTextOnTop(mockFont, new Vector2i(4, 4), '');
+        renderer.endFrame();
+
+        expect(sceneText).toHaveBeenCalledOnce();
+        expect(sceneText).toHaveBeenCalledWith(mockFont, new Vector2i(0, 0), '', 0);
+        expect(overlayText).toHaveBeenCalledOnce();
+        expect(overlayText).toHaveBeenCalledWith(mockFont, new Vector2i(4, 4), '', 0);
+    });
+
+    it('encodes scene pass as primitives, sprites, overlayPrimitives, overlaySprites', () => {
+        const pipelines = getRendererPipelines(renderer);
+        const encodeOrder: string[] = [];
+
+        vi.spyOn(pipelines.primitives, 'encodePass').mockImplementation(() => {
+            encodeOrder.push('primitives');
+        });
+        vi.spyOn(pipelines.sprites, 'encodePass').mockImplementation(() => {
+            encodeOrder.push('sprites');
+        });
+        vi.spyOn(pipelines.overlayPrimitives, 'encodePass').mockImplementation(() => {
+            encodeOrder.push('overlayPrimitives');
+        });
+        vi.spyOn(pipelines.overlaySprites, 'encodePass').mockImplementation(() => {
+            encodeOrder.push('overlaySprites');
+        });
+
+        const mockFont = {
+            getSpriteSheet: () => ({}),
+            getGlyphByCode: () => null,
+        } as unknown as BitmapFont;
+
+        renderer.beginFrame();
+        renderer.drawRectFill(new Rect2i(0, 0, 4, 4), 2);
+        renderer.drawBitmapText(mockFont, new Vector2i(0, 0), '');
+        renderer.drawRectFillOnTop(new Rect2i(0, 220, 320, 16), 1);
+        renderer.drawBitmapTextOnTop(mockFont, new Vector2i(5, 225), 'HUD');
+        renderer.endFrame();
+
+        expect(encodeOrder).toEqual(['primitives', 'sprites', 'overlayPrimitives', 'overlaySprites']);
+    });
+
+    it('resets overlay batches on beginFrame', () => {
+        const pipelines = getRendererPipelines(renderer);
+        const overlayPrimitiveReset = vi.spyOn(pipelines.overlayPrimitives, 'reset');
+        const overlaySpriteReset = vi.spyOn(pipelines.overlaySprites, 'reset');
+
+        renderer.beginFrame();
+
+        expect(overlayPrimitiveReset).toHaveBeenCalledOnce();
+        expect(overlaySpriteReset).toHaveBeenCalledOnce();
 
         renderer.endFrame();
     });

--- a/src/render/WebGpuRenderer.ts
+++ b/src/render/WebGpuRenderer.ts
@@ -485,7 +485,9 @@ export class WebGpuRenderer implements IRenderer {
 
     /**
      * Sets the camera offset for scrolling.
-     * The offset is propagated to both internal pipelines.
+     *
+     * The offset is propagated to all four scene pipelines: `primitives`,
+     * `overlayPrimitives`, `sprites`, and `overlaySprites`.
      *
      * @param offset - Camera position in pixels.
      */
@@ -507,7 +509,7 @@ export class WebGpuRenderer implements IRenderer {
     }
 
     /**
-     * Resets the camera to the origin (0, 0).
+     * Resets the camera to the origin (0, 0) on all four scene pipelines.
      */
     resetCamera(): void {
         this.cameraOffset = Vector2i.zero();
@@ -637,10 +639,14 @@ export class WebGpuRenderer implements IRenderer {
     }
 
     /**
-     * Encodes the primitive + sprite scene render pass into the supplied target view.
+     * Encodes the scene render pass into the supplied target view.
+     *
+     * Draw order: `primitives`, `sprites`, `overlayPrimitives` (for example HUD
+     * bars via {@link drawRectFillOnTop}), then `overlaySprites` (overlay labels
+     * via {@link drawBitmapTextOnTop}).
      *
      * @param encoder - Active command encoder.
-     * @param sceneView - View to render the scene into.
+     * @param sceneView - Logical scene attachment view to render into.
      */
     private encodeScenePass(encoder: GPUCommandEncoder, sceneView: GPUTextureView): void {
         const clearPaletteIndex = this.resolveClearPaletteIndex();

--- a/src/render/WebGpuRenderer.ts
+++ b/src/render/WebGpuRenderer.ts
@@ -114,8 +114,18 @@ export class WebGpuRenderer implements IRenderer {
     /** Pipeline for palette-indexed geometry (pixels, lines, rectangles). */
     private readonly primitives: PrimitivePipeline;
 
+    /**
+     * Primitives encoded after the sprite pass (stats overlay bars, etc.).
+     */
+    private readonly overlayPrimitives: PrimitivePipeline;
+
     /** Pipeline for textured quads (sprites, bitmap text). */
     private readonly sprites: SpritePipeline;
+
+    /**
+     * Sprites encoded after overlay bar primitives (stats overlay labels, etc.).
+     */
+    private readonly overlaySprites: SpritePipeline;
 
     /** Pixel-tier post-process chain (logical resolution). */
     private pixelChain: PostProcessChain | null = null;
@@ -170,7 +180,9 @@ export class WebGpuRenderer implements IRenderer {
         this.outputSize = (outputSize ?? displaySize).clone();
         this.upscaleFilterMode = upscaleFilter;
         this.primitives = new PrimitivePipeline();
+        this.overlayPrimitives = new PrimitivePipeline();
         this.sprites = new SpritePipeline();
+        this.overlaySprites = new SpritePipeline();
     }
 
     // #endregion
@@ -215,7 +227,9 @@ export class WebGpuRenderer implements IRenderer {
             // viewport is automatic since each pass binds a target view; only
             // the camera scaling here cares about logical size.
             await this.primitives.init(this.device, this.displaySize, this.paletteBuffer, LOGICAL_TARGET_FORMAT);
+            await this.overlayPrimitives.init(this.device, this.displaySize, this.paletteBuffer, LOGICAL_TARGET_FORMAT);
             await this.sprites.init(this.device, this.displaySize, this.paletteBuffer, LOGICAL_TARGET_FORMAT);
+            await this.overlaySprites.init(this.device, this.displaySize, this.paletteBuffer, LOGICAL_TARGET_FORMAT);
 
             this.swapFormat = navigator.gpu.getPreferredCanvasFormat();
 
@@ -296,7 +310,9 @@ export class WebGpuRenderer implements IRenderer {
         }
 
         this.primitives.reset();
+        this.overlayPrimitives.reset();
         this.sprites.reset();
+        this.overlaySprites.reset();
     }
 
     /**
@@ -353,6 +369,16 @@ export class WebGpuRenderer implements IRenderer {
      */
     drawRectFill(rect: Rect2i, paletteIndex: number): void {
         this.primitives.drawRectFill(rect, paletteIndex);
+    }
+
+    /**
+     * Draws a filled rectangle in the post-sprite primitive batch.
+     *
+     * @param rect - Rectangle bounds in pixel coordinates.
+     * @param paletteIndex - Palette color index.
+     */
+    drawRectFillOnTop(rect: Rect2i, paletteIndex: number): void {
+        this.overlayPrimitives.drawRectFill(rect, paletteIndex);
     }
 
     /**
@@ -426,6 +452,18 @@ export class WebGpuRenderer implements IRenderer {
         this.sprites.drawBitmapText(font, pos, text, paletteOffset);
     }
 
+    /**
+     * Draws bitmap text in the post-overlay-bar sprite batch.
+     *
+     * @param font - Bitmap font with character glyphs.
+     * @param pos - Text position (top-left corner).
+     * @param text - String to render.
+     * @param paletteOffset - Palette index offset applied to all glyphs (default 0).
+     */
+    drawBitmapTextOnTop(font: BitmapFont, pos: Vector2i, text: string, paletteOffset: number = 0): void {
+        this.overlaySprites.drawBitmapText(font, pos, text, paletteOffset);
+    }
+
     // #endregion
 
     // #region Frame Capture API
@@ -454,7 +492,9 @@ export class WebGpuRenderer implements IRenderer {
     setCameraOffset(offset: Vector2i): void {
         this.cameraOffset = offset.clone();
         this.primitives.setCameraOffset(this.cameraOffset);
+        this.overlayPrimitives.setCameraOffset(this.cameraOffset);
         this.sprites.setCameraOffset(this.cameraOffset);
+        this.overlaySprites.setCameraOffset(this.cameraOffset);
     }
 
     /**
@@ -472,7 +512,9 @@ export class WebGpuRenderer implements IRenderer {
     resetCamera(): void {
         this.cameraOffset = Vector2i.zero();
         this.primitives.setCameraOffset(this.cameraOffset);
+        this.overlayPrimitives.setCameraOffset(this.cameraOffset);
         this.sprites.setCameraOffset(this.cameraOffset);
+        this.overlaySprites.setCameraOffset(this.cameraOffset);
     }
 
     // #endregion
@@ -563,14 +605,18 @@ export class WebGpuRenderer implements IRenderer {
         } catch (error) {
             console.error('[WebGpuRenderer] Failed to get current texture:', error);
             this.primitives.reset();
+            this.overlayPrimitives.reset();
             this.sprites.reset();
+            this.overlaySprites.reset();
             return null;
         }
 
         if (swapTexture.width === 0 || swapTexture.height === 0) {
             console.warn('[WebGpuRenderer] Texture has zero dimensions, skipping frame');
             this.primitives.reset();
+            this.overlayPrimitives.reset();
             this.sprites.reset();
+            this.overlaySprites.reset();
             return null;
         }
 
@@ -617,6 +663,8 @@ export class WebGpuRenderer implements IRenderer {
 
         this.primitives.encodePass(renderPass);
         this.sprites.encodePass(renderPass);
+        this.overlayPrimitives.encodePass(renderPass);
+        this.overlaySprites.encodePass(renderPass);
         renderPass.end();
     }
 
@@ -678,7 +726,9 @@ export class WebGpuRenderer implements IRenderer {
         // called next. beginFrame() also resets; this prevents stale data from
         // persisting across frames.
         this.primitives.reset();
+        this.overlayPrimitives.reset();
         this.sprites.reset();
+        this.overlaySprites.reset();
     }
 
     // #endregion


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

Adds overlay compositing layers so HUD/overlay content can be rendered on top of sprites and primitive fills in WebGPU. Exposes two new "on top" drawing methods across the renderer API and implements overlay batching and encode-order guarantees in the WebGPU backend. Software renderer preserves existing FIFO behaviour by delegating the new methods to the base commands. Tests validate routing, encode order and batch lifecycle.

## Changes

### Interface Changes (src/render/IRenderer.ts)

- Added:
  - drawRectFillOnTop(rect: Rect2i, paletteIndex: number): void
  - drawBitmapTextOnTop(font: BitmapFont, pos: Vector2i, text: string, paletteOffset?: number): void
- Documentation clarifies intended semantics: on WebGPU these calls are batched after the sprite/primitive passes so overlay HUD content appears above standard draws; software backends may treat them as normal draws when call order is preserved.

### Software Renderer (src/render/SoftwareRenderer.ts)

- Implements drawRectFillOnTop and drawBitmapTextOnTop by delegating to drawRectFill and drawBitmapText respectively, preserving existing FIFO command queue behavior.

### WebGPU Renderer (src/render/WebGpuRenderer.ts)

- Introduces overlay compositing tier with two new internal pipelines:
  - overlayPrimitives (palette-indexed primitives encoded after sprites)
  - overlaySprites (textured sprites encoded after overlay primitives)
- Pipelines are created in init(), cleared/reset at beginFrame(), receive camera offset updates in setCameraOffset() and resetCamera(), and are defensively reset when endFrame() is skipped (e.g. texture acquisition errors or zero-sized textures).
- Ensures encode order during scene pass: primitives → sprites → overlayPrimitives → overlaySprites.
- Public API additions route to overlay batches:
  - drawRectFillOnTop(...)
  - drawBitmapTextOnTop(...)

- Additional defensive behavior: per-frame pipeline state is reset after frame submission.

### Tests (src/render/WebGpuRenderer.test.ts)

- Adds test helpers to expose the renderer's internal pipeline instances at runtime.
- Verifies:
  - drawRectFillOnTop routes to overlayPrimitives while drawRectFill routes to primitives.
  - drawBitmapTextOnTop routes to overlaySprites while drawBitmapText routes to sprites.
  - Scene-pass encode order is primitives, sprites, overlayPrimitives, overlaySprites.
  - beginFrame resets overlay batches (reset() called once on both overlayPrimitives and overlaySprites).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/175?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->