### PR TITLE
refactor(api)!: rename rendering mode API from renderer to backend

### DIFF
--- a/.claude/rules/bt-api-getters.md
+++ b/.claude/rules/bt-api-getters.md
@@ -18,7 +18,7 @@ Quick rules when changing `src/BlitTech.ts` or demos:
 | Per-frame input | `pointerScrollDelta`, `inputString`, `gamepadCount` |
 
 `outputSize` = effective buffer (`canvasDisplaySize ?? displaySize`). `Vector2i` getters return a clone per read.
-`activeBackend` is what actually started after fallback, not `configure().renderer`.
+`activeBackend` is what actually started after fallback, not `configure().backend`.
 `palette` is a live reference - mutating slots affects rendering on the next frame.
 
 ## Naming when adding getters

--- a/.cursor/rules/bt-api-getters.mdc
+++ b/.cursor/rules/bt-api-getters.mdc
@@ -29,7 +29,7 @@ Bad: `BT.displaySize()`, `BT.fps()`, `BT.getActiveBackend()` (removed; use prope
 ## Naming
 
 - Match `HardwareSettings` spelling: `targetFPS` (not `fps`, not `targetFps`)
-- `activeBackend` = backend that started; `configure().renderer` = requested backend only (not exposed as `BT.renderer`)
+- `activeBackend` = backend that started; `configure().backend` = requested backend only (not exposed on `BT`)
 
 ## New API checklist
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ src/
 
 ### Palette-First Rendering
 
-Two backends selectable via `HardwareSettings.renderer` (default `'webgpu'`):
+Two backends selectable via `HardwareSettings.backend` (default `'webgpu'`):
 
 - **WebGPU** (`'webgpu'`): indexed, palette-first hardware renderer.
   1. **Primitives pipeline** - batched geometry writing **palette indices** (pixels, lines, rects). Max 50k
@@ -112,8 +112,8 @@ Two backends selectable via `HardwareSettings.renderer` (default `'webgpu'`):
      effects run on that RGBA before present (see `docs/post-process-effects.md`).
 - **Software** (`'software'`): Canvas 2D fallback. Supports palette rendering, rects, Bresenham lines, indexed sprite
   blits, and bitmap text. Post-process/fullscreen effects throw a clear error directing users to the WebGPU backend.
-  Activates automatically when WebGPU init fails; force explicitly via `HardwareSettings.renderer: 'software'` or the
-  `?renderer=software` URL query parameter. Use `BT.activeBackend` to query which backend started
+  Activates automatically when WebGPU init fails; force explicitly via `HardwareSettings.backend: 'software'` or the
+  `?backend=software` URL query parameter. Use `BT.activeBackend` to query which backend started
   (`'webgpu' | 'software' | null`). The engine stats overlay shows the active backend on the top bar when enabled.
 
 ### Core Types
@@ -151,12 +151,12 @@ and async work. Do not add new zero-argument `BT.foo()` functions when a getter 
 
 ### Use getters (property access, no `()`)
 
-| Category                                                         | Members                                                       | Notes                                                                                                                 |
-| ---------------------------------------------------------------- | ------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| **Configure-time** (mirror {@link HardwareSettings} field names) | `displaySize`, `canvasDisplaySize`, `targetFPS`, `outputSize` | `outputSize` = effective buffer (`canvasDisplaySize ?? displaySize`). Clone per read for `Vector2i` getters.          |
-| **Loop timing**                                                  | `deltaSeconds`, `timeSeconds`, `ticks`                        | `targetFPS` is configured rate, not measured FPS.                                                                     |
-| **Runtime state**                                                | `activeBackend`, `camera`, `palette`                          | `activeBackend` is what actually started (after fallback), not `configure().renderer`. `palette` is a live reference. |
-| **Per-frame input**                                              | `pointerScrollDelta`, `inputString`, `gamepadCount`           | Read once per frame when needed.                                                                                      |
+| Category                                                         | Members                                                       | Notes                                                                                                                |
+| ---------------------------------------------------------------- | ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| **Configure-time** (mirror {@link HardwareSettings} field names) | `displaySize`, `canvasDisplaySize`, `targetFPS`, `outputSize` | `outputSize` = effective buffer (`canvasDisplaySize ?? displaySize`). Clone per read for `Vector2i` getters.         |
+| **Loop timing**                                                  | `deltaSeconds`, `timeSeconds`, `ticks`                        | `targetFPS` is configured rate, not measured FPS.                                                                    |
+| **Runtime state**                                                | `activeBackend`, `camera`, `palette`                          | `activeBackend` is what actually started (after fallback), not `configure().backend`. `palette` is a live reference. |
+| **Per-frame input**                                              | `pointerScrollDelta`, `inputString`, `gamepadCount`           | Read once per frame when needed.                                                                                     |
 
 Examples: `BT.displaySize.y`, `BT.targetFPS`, `BT.ticks % 60`, `if (BT.activeBackend === 'software')`.
 
@@ -173,8 +173,7 @@ Examples: `BT.displaySize.y`, `BT.targetFPS`, `BT.ticks % 60`, `if (BT.activeBac
 
 - **Same name as `HardwareSettings`** when exposing configure values (`targetFPS`, not `fps` or `targetFps`).
 - **Descriptive runtime names** when there is no configure field (`activeBackend`, not `renderer`).
-- **Do not** expose `configure().renderer` on `BT` as `renderer` without documenting that it differs from
-  `activeBackend`.
+- **Do not** expose `configure().backend` on `BT` as a getter without documenting that it differs from `activeBackend`.
 
 Full tables: `docs/api-core.md`. Style guide: `docs/developer-experience-guide.md` (Naming conventions).
 

--- a/cspell.json
+++ b/cspell.json
@@ -9,6 +9,7 @@
     "antialiasing",
     "astimezone",
     "bgra",
+    "backend",
     "bindgroup",
     "bindgroups",
     "biomejs",

--- a/docs/api-assets.md
+++ b/docs/api-assets.md
@@ -148,7 +148,7 @@ BT.systemPrintMeasure('Score: 100'); // → Vector2i (pixel width, height)
 ```
 
 Use `BT.systemPrint()` for demo-specific HUD panels and labels. The engine draws a default stats overlay (FPS, target
-FPS, renderer, resolution, demo title) after each `render()` when `statsOverlayEnabled` is true; see
+FPS, backend, resolution, demo title) after each `render()` when `statsOverlayEnabled` is true; see
 [API: Core - Stats overlay](api-core.md#stats-overlay). For styled variable-width text, use a bitmap font instead.
 
 ---

--- a/docs/api-core.md
+++ b/docs/api-core.md
@@ -73,7 +73,7 @@ example no `canvasDisplaySize` means a 1:1 drawing buffer).
 | `canvasDisplaySize`    | `Vector2i`               | `640×480`   | CSS/output size; enables display-tier effects       |
 | `maxCanvasDisplaySize` | `Vector2i`               | `960×720`   | Maximum on-screen canvas CSS size                   |
 | `targetFPS`            | `number`                 | `60`        | Fixed-update rate                                   |
-| `renderer`             | `'webgpu' \| 'software'` | `'webgpu'`  | Force backend                                       |
+| `backend`              | `'webgpu' \| 'software'` | `'webgpu'`  | Force rendering backend                             |
 | `outputUpscaleFilter`  | `'nearest' \| 'linear'`  | `'nearest'` | Upscale filter                                      |
 | `detectDroppedFrames`  | `boolean`                | `false`     | Log a console warning on missed vsync               |
 | `statsOverlayEnabled`  | `boolean`                | `true`      | Engine stats HUD after each `render()`              |
@@ -88,7 +88,7 @@ adapter/device `maxTextureDimension2D` limit. GPU limit failures do not fall bac
 
 **`BT` getters vs `configure()` fields:** `displaySize`, `canvasDisplaySize`, and `targetFPS` on `BT` mirror the same
 names on `HardwareSettings`. `outputSize` is the effective drawing-buffer size (`canvasDisplaySize ?? displaySize`).
-`activeBackend` is the backend that actually started (after fallback), not the `renderer` value from `configure()`.
+`activeBackend` is the backend that actually started (after fallback), not the `backend` value from `configure()`.
 
 ### Stats overlay
 

--- a/docs/post-process-effects.md
+++ b/docs/post-process-effects.md
@@ -89,8 +89,8 @@ Invariants:
 
 Appends an effect to the chain matching its declared `tier`. Effects can be added at any time; the first add allocates
 the chain's offscreen render targets, the second add allocates a second target for ping-pong. Throws if the engine has
-not been initialized, if a `tier='display'` effect is added without `canvasDisplaySize`, or if the active backend
-backend is `'software'` (Canvas 2D does not support post-process effects).
+not been initialized, if a `tier='display'` effect is added without `canvasDisplaySize`, or if the active backend is
+`'software'` (Canvas 2D does not support post-process effects).
 
 ### `BT.effectRemove(effect: Effect): void`
 

--- a/docs/post-process-effects.md
+++ b/docs/post-process-effects.md
@@ -89,7 +89,7 @@ Invariants:
 
 Appends an effect to the chain matching its declared `tier`. Effects can be added at any time; the first add allocates
 the chain's offscreen render targets, the second add allocates a second target for ping-pong. Throws if the engine has
-not been initialized, if a `tier='display'` effect is added without `canvasDisplaySize`, or if the active renderer
+not been initialized, if a `tier='display'` effect is added without `canvasDisplaySize`, or if the active backend
 backend is `'software'` (Canvas 2D does not support post-process effects).
 
 ### `BT.effectRemove(effect: Effect): void`
@@ -144,7 +144,7 @@ interface HardwareSettings {
   outputUpscaleFilter?: 'nearest' | 'linear'; // default 'nearest'
   targetFPS: number;
   detectDroppedFrames?: boolean;
-  renderer?: 'webgpu' | 'software'; // default 'webgpu'; 'software' disables all post-process effects
+  backend?: 'webgpu' | 'software'; // default 'webgpu'; 'software' disables all post-process effects
 }
 ```
 

--- a/docs/software-fallback-smoke-matrix.md
+++ b/docs/software-fallback-smoke-matrix.md
@@ -5,8 +5,8 @@ for auto-fallback and the engine stats overlay (backend shown on the top bar whe
 
 ## Scope
 
-- Backend under test: `software` (auto-fallback when WebGPU unavailable, `?renderer=software`, or
-  `configure().renderer = 'software'`)
+- Backend under test: `software` (auto-fallback when WebGPU unavailable, `?backend=software`, or
+  `configure().backend = 'software'`)
 - Resolution target: low-res scenes (for example `320x240`)
 - In scope: auto-fallback detection, stats overlay backend line, clear, clearRect, primitives, sprites, system text,
   bitmap text, camera offset, frame capture
@@ -16,7 +16,7 @@ for auto-fallback and the engine stats overlay (backend shown on the top bar whe
 
 - Browser: latest Chrome or Edge
 - URL override for software mode:
-  - `?renderer=software`
+  - `?backend=software`
 - Optional baseline comparison:
   - same page without override (WebGPU path)
 
@@ -24,7 +24,7 @@ for auto-fallback and the engine stats overlay (backend shown on the top bar whe
 
 | Scene                                   | What to verify                                   | Software expected result                                    | Notes                                     |
 | --------------------------------------- | ------------------------------------------------ | ----------------------------------------------------------- | ----------------------------------------- |
-| Any page without `?renderer=software`   | Auto-fallback when WebGPU is absent              | Demo boots; `BT.activeBackend` = `'software'`               | No error page or hard stop                |
+| Any page without `?backend=software`    | Auto-fallback when WebGPU is absent              | Demo boots; `BT.activeBackend` = `'software'`               | No error page or hard stop                |
 | Any page with software active           | Stats overlay top bar shows `software`           | Top bar reads `software \| WxH` (toggle with `~` or corner) | Disable with `statsOverlayEnabled: false` |
 | `tests/visual/fixtures/primitives.html` | clear + clearRect + primitive rasterization      | Matches expected primitive layout and colors                | Check pixel edges are crisp               |
 | `tests/visual/fixtures/camera.html`     | camera offset applied to all draw calls          | Geometry is shifted consistently by camera offset           | No partial drift between primitives       |
@@ -36,7 +36,7 @@ for auto-fallback and the engine stats overlay (backend shown on the top bar whe
 ## Automated regression
 
 Visual parity for software mode is exercised by Playwright under `tests/visual/` (`primitives`, `camera`, `sprites`,
-`fonts`, `mixed` specs load fixtures with `?renderer=software`). Run `pnpm run test:visual` after renderer changes that
+`fonts`, `mixed` specs load fixtures with `?backend=software`). Run `pnpm run test:visual` after renderer changes that
 affect pixel output.
 
 ## Known exclusions (expected in MVP)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -29,14 +29,14 @@ and `vi` for browser API stubs. Tests that need a full DOM (Bootstrap, Bootstrap
   `getIndexedPixels()` defensive-copy semantics (Node + GPU mocks)
 - **BitmapFont** - glyph lookup, text measurement (Node + vi stubs)
 - **BootstrapHelpers** - WebGPU support detection, canvas lookup (happy-dom)
-- **Bootstrap** - full bootstrap lifecycle, including `?renderer=software` WebGPU-skip path (happy-dom)
+- **Bootstrap** - full bootstrap lifecycle, including `?backend=software` WebGPU-skip path (happy-dom)
 - **WebGpuRenderer** - frame lifecycle, camera, pipeline delegation (Node + GPU mocks)
 - **SoftwareRenderer** - frame lifecycle, palette enforcement, camera offsets, indexed sprite blits, bitmap text,
   `captureFrame()` semantics, and unsupported-effects assertions (Node + 2D canvas mocks)
 - **PrimitivePipeline** - vertex buffer math, line algorithm (Node + GPU mocks)
 - **SpritePipeline** - texture batching, UV coordinates (Node + GPU mocks)
 - **WebGPUContext** - initialization with mock adapter/device (Node + GPU mocks)
-- **BTAPI** - singleton coordinator; includes software-mode init, `?renderer=software` URL override, `captureFrame()` in
+- **BTAPI** - singleton coordinator; includes software-mode init, `?backend=software` URL override, `captureFrame()` in
   software mode, and stats overlay render path (Node + GPU mocks + 2D canvas mocks)
 - **StatsOverlay** - layout helpers, demo label parsing, right-aligned text X, toggle hit-testing, `updateAndRender` bar
   layout (Node)
@@ -46,7 +46,7 @@ and `vi` for browser API stubs. Tests that need a full DOM (Bootstrap, Bootstrap
 
 Actual GPU rendering verified via screenshot comparison. Requires Chrome with WebGPU flags enabled.
 
-Each spec covers both the default WebGPU backend and the `?renderer=software` software backend, producing separate
+Each spec covers both the default WebGPU backend and the `?backend=software` software backend, producing separate
 baseline screenshots for each.
 
 - **Primitives** - pixel, line, and rectangle rendering

--- a/src/BlitTech.test.ts
+++ b/src/BlitTech.test.ts
@@ -1392,7 +1392,7 @@ describe('BT.effectAdd / BT.effectRemove / BT.effectClear', () => {
             vi.spyOn(BTAPI.instance, 'getRenderer').mockReturnValue({} as never);
             vi.spyOn(BTAPI.instance, 'effectAdd').mockImplementation(() => {
                 throw new Error(
-                    "The software renderer doesn't support fullscreen effects. To use post-process effects, set renderer to 'webgpu' in configure().",
+                    "The software renderer doesn't support fullscreen effects. To use post-process effects, set backend to 'webgpu' in configure().",
                 );
             });
 
@@ -1400,7 +1400,7 @@ describe('BT.effectAdd / BT.effectRemove / BT.effectClear', () => {
 
             const text = document.getElementById(DEFAULT_CONTAINER_ID)?.textContent ?? '';
             expect(text).toContain("doesn't support fullscreen effects");
-            expect(text).toContain("set renderer to 'webgpu' in configure()");
+            expect(text).toContain("set backend to 'webgpu' in configure()");
         });
     });
 
@@ -1409,7 +1409,7 @@ describe('BT.effectAdd / BT.effectRemove / BT.effectClear', () => {
             vi.spyOn(BTAPI.instance, 'getRenderer').mockReturnValue({} as never);
             vi.spyOn(BTAPI.instance, 'effectRemove').mockImplementation(() => {
                 throw new Error(
-                    "The software renderer doesn't support fullscreen effects. To use post-process effects, set renderer to 'webgpu' in configure().",
+                    "The software renderer doesn't support fullscreen effects. To use post-process effects, set backend to 'webgpu' in configure().",
                 );
             });
 
@@ -1425,7 +1425,7 @@ describe('BT.effectAdd / BT.effectRemove / BT.effectClear', () => {
             vi.spyOn(BTAPI.instance, 'getRenderer').mockReturnValue({} as never);
             vi.spyOn(BTAPI.instance, 'effectClear').mockImplementation(() => {
                 throw new Error(
-                    "The software renderer doesn't support fullscreen effects. To use post-process effects, set renderer to 'webgpu' in configure().",
+                    "The software renderer doesn't support fullscreen effects. To use post-process effects, set backend to 'webgpu' in configure().",
                 );
             });
 

--- a/src/BlitTech.ts
+++ b/src/BlitTech.ts
@@ -19,11 +19,11 @@ import type { IndexedSpriteLoadResult } from './assets/SpriteSheet';
 import { SpriteSheet } from './assets/SpriteSheet';
 import { BTAPI } from './core/BTAPI';
 import {
+    type Backend,
     defaultConfig,
     type HardwareSettings,
     type IBlitTechDemo,
     mergeHardwareSettings,
-    type RendererBackend,
     type StatsOverlayRow,
     type StatsOverlayStyle,
 } from './core/IBlitTechDemo';
@@ -508,7 +508,7 @@ export const BT = {
     },
 
     /**
-     * Renderer backend that is currently active.
+     * Rendering backend that is currently active.
      *
      * `'webgpu'` or `'software'` after successful init; `null` before init or on failure.
      * Useful when adjusting demo behavior - for example, skipping post-process effects
@@ -516,7 +516,7 @@ export const BT = {
      *
      * @returns `'webgpu'` or `'software'` after successful init; `null` before init or on failure.
      */
-    get activeBackend(): RendererBackend | null {
+    get activeBackend(): Backend | null {
         return BTAPI.instance.getActiveBackend();
     },
 
@@ -1532,13 +1532,13 @@ export {
     Vignette,
 };
 export type {
+    Backend,
     BootstrapOptions,
     EasingFunction,
     Effect,
     EffectTier,
     HardwareSettings,
     IBlitTechDemo,
-    RendererBackend,
     StatsOverlayRow,
     StatsOverlayStyle,
     TextSize,

--- a/src/core/BTAPI.test.ts
+++ b/src/core/BTAPI.test.ts
@@ -401,7 +401,7 @@ describe('BTAPI', () => {
                     displaySize: new Vector2i(320, 240),
                     canvasDisplaySize: { x: 8193, y: 480 } as Vector2i,
                     targetFPS: 60,
-                    renderer: 'software',
+                    backend: 'software',
                 }),
                 init: vi.fn().mockResolvedValue(true),
                 update: vi.fn(),
@@ -465,7 +465,7 @@ describe('BTAPI', () => {
                 configure: vi.fn().mockReturnValue({
                     displaySize: new Vector2i(2048, 1024),
                     targetFPS: 60,
-                    renderer: 'webgpu',
+                    backend: 'webgpu',
                 }),
                 init: vi.fn().mockResolvedValue(true),
                 update: vi.fn(),
@@ -504,7 +504,7 @@ describe('BTAPI', () => {
                     displaySize: new Vector2i(320, 240),
                     canvasDisplaySize: new Vector2i(2048, 1024),
                     targetFPS: 60,
-                    renderer: 'webgpu',
+                    backend: 'webgpu',
                 }),
                 init: vi.fn().mockResolvedValue(true),
                 update: vi.fn(),
@@ -546,7 +546,7 @@ describe('BTAPI', () => {
                     displaySize: new Vector2i(320, 240),
                     canvasDisplaySize: new Vector2i(1024, 768),
                     targetFPS: 60,
-                    renderer: 'webgpu',
+                    backend: 'webgpu',
                 }),
                 init: vi.fn().mockResolvedValue(true),
                 update: vi.fn(),
@@ -596,7 +596,7 @@ describe('BTAPI', () => {
                     displaySize: new Vector2i(320, 240),
                     canvasDisplaySize: new Vector2i(640, 480),
                     targetFPS: 60,
-                    renderer: 'software',
+                    backend: 'software',
                 }),
                 init: vi.fn().mockResolvedValue(true),
                 update: vi.fn(),
@@ -612,8 +612,8 @@ describe('BTAPI', () => {
             expect(BTAPI.instance.getRenderer()).not.toBeNull();
         });
 
-        it('URL override ?renderer=software wins over configure().renderer=webgpu', async () => {
-            vi.stubGlobal('location', { search: '?renderer=software' });
+        it('URL override ?backend=software wins over configure().backend=webgpu', async () => {
+            vi.stubGlobal('location', { search: '?backend=software' });
             vi.stubGlobal(
                 'OffscreenCanvas',
                 class MockOffscreenCanvas {
@@ -633,7 +633,7 @@ describe('BTAPI', () => {
                     displaySize: new Vector2i(320, 240),
                     canvasDisplaySize: new Vector2i(640, 480),
                     targetFPS: 60,
-                    renderer: 'webgpu',
+                    backend: 'webgpu',
                 }),
                 init: vi.fn().mockResolvedValue(true),
                 update: vi.fn(),
@@ -645,19 +645,19 @@ describe('BTAPI', () => {
             const result = await BTAPI.instance.init(demo, canvas);
 
             expect(result).toBe(true);
-            expect(BTAPI.instance.getHardwareSettings()?.renderer).toBe('software');
+            expect(BTAPI.instance.getHardwareSettings()?.backend).toBe('software');
             expect(BTAPI.instance.getDevice()).toBeNull();
         });
 
-        it('ignores unknown renderer query values and keeps configure renderer', async () => {
-            vi.stubGlobal('location', { search: '?renderer=banana' });
+        it('ignores unknown backend query values and keeps configure backend', async () => {
+            vi.stubGlobal('location', { search: '?backend=banana' });
 
             const demo: IBlitTechDemo = {
                 configure: () => ({
                     displaySize: new Vector2i(320, 240),
                     canvasDisplaySize: new Vector2i(640, 480),
                     targetFPS: 60,
-                    renderer: 'webgpu',
+                    backend: 'webgpu',
                 }),
                 init: vi.fn().mockResolvedValue(true),
                 update: vi.fn(),
@@ -666,7 +666,7 @@ describe('BTAPI', () => {
             const result = await BTAPI.instance.init(demo, makeMockCanvas());
 
             expect(result).toBe(true);
-            expect(BTAPI.instance.getHardwareSettings()?.renderer).toBe('webgpu');
+            expect(BTAPI.instance.getHardwareSettings()?.backend).toBe('webgpu');
             expect(BTAPI.instance.getDevice()).not.toBeNull();
         });
 
@@ -936,7 +936,7 @@ describe('BTAPI', () => {
         });
 
         it('captureFrame works in software mode after a rendered frame', async () => {
-            vi.stubGlobal('location', { search: '?renderer=software' });
+            vi.stubGlobal('location', { search: '?backend=software' });
             vi.stubGlobal(
                 'OffscreenCanvas',
                 class MockOffscreenCanvas {
@@ -956,7 +956,7 @@ describe('BTAPI', () => {
                     displaySize: new Vector2i(320, 240),
                     canvasDisplaySize: new Vector2i(640, 480),
                     targetFPS: 60,
-                    renderer: 'software',
+                    backend: 'software',
                 }),
                 init: vi.fn().mockResolvedValue(true),
                 update: vi.fn(),
@@ -997,7 +997,7 @@ describe('BTAPI', () => {
                 configure: () => ({
                     displaySize: new Vector2i(320, 240),
                     targetFPS: 60,
-                    // No renderer field - defaults to 'webgpu', should auto-fallback
+                    // No backend field - defaults to 'webgpu', should auto-fallback
                 }),
                 init: vi.fn().mockResolvedValue(true),
                 update: vi.fn(),

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -16,7 +16,7 @@ import { PointerInput } from '../input/PointerInput';
 import type { Effect } from '../render/effects/Effect';
 import type { IRenderer } from '../render/IRenderer';
 import { SoftwareRenderer } from '../render/SoftwareRenderer';
-import { createStatsOverlayLayout, resolveStatsDemoText, StatsOverlay } from '../render/StatsOverlay';
+import { createStatsOverlayLayout, resolveStatsTopLeftLabel, StatsOverlay } from '../render/StatsOverlay';
 import { WebGpuRenderer } from '../render/WebGpuRenderer';
 import { applyCanvasLayoutStyles, DEFAULT_MAX_CANVAS_DISPLAY_SIZE } from '../utils/CanvasLayoutStyles';
 import type { Color32 } from '../utils/Color32';
@@ -33,7 +33,7 @@ import { RenderDimensionLimitError, validateRenderDimensions } from '../utils/Re
 import { Vector2i } from '../utils/Vector2i';
 import type { FrameDropCallback, FrameDropEvent } from './GameLoop';
 import { GameLoop } from './GameLoop';
-import type { HardwareSettings, IBlitTechDemo, RendererBackend } from './IBlitTechDemo';
+import type { Backend, HardwareSettings, IBlitTechDemo } from './IBlitTechDemo';
 import { defaultConfig, mergeHardwareSettings } from './IBlitTechDemo';
 import { initWebGPU } from './WebGPUContext';
 
@@ -89,7 +89,7 @@ export class BTAPI {
     private renderer: IRenderer | null = null;
 
     /** Backend that was successfully initialized, or null before init. */
-    private activeBackend: RendererBackend | null = null;
+    private activeBackend: Backend | null = null;
 
     /**
      * Engine stats overlay; non-null when {@link HardwareSettings.statsOverlayEnabled}
@@ -291,7 +291,7 @@ export class BTAPI {
             return false;
         }
 
-        this.applyRendererQueryOverride();
+        this.applyBackendQueryOverride();
 
         const renderDimensionError = validateRenderDimensions(this.hwSettings);
 
@@ -334,7 +334,7 @@ export class BTAPI {
 
         this.statsOverlay = new StatsOverlay(
             layout,
-            resolveStatsDemoText(pageTitle),
+            resolveStatsTopLeftLabel(pageTitle),
             hw.targetFPS,
             this.activeBackend,
             hw.statsOverlayStyle,
@@ -453,11 +453,11 @@ export class BTAPI {
     }
 
     /**
-     * Returns the renderer backend that was actually initialized.
+     * Returns the rendering backend that was actually initialized.
      *
      * @returns `'webgpu'` or `'software'` after successful init; `null` before init or on failure.
      */
-    public getActiveBackend(): RendererBackend | null {
+    public getActiveBackend(): Backend | null {
         return this.activeBackend;
     }
 
@@ -922,7 +922,7 @@ export class BTAPI {
     /**
      * Constructs and initializes the renderer for the active hardware settings.
      *
-     * Logs the selected backend name, creates the requested renderer backend,
+     * Logs the selected backend name, constructs the matching {@link IRenderer},
      * calls {@link IRenderer.init}, and reports success or failure.
      *
      * @param canvas - Render target canvas.
@@ -938,7 +938,7 @@ export class BTAPI {
             ...(hw.canvasDisplaySize !== undefined ? { canvasDisplaySize: hw.canvasDisplaySize } : {}),
         });
 
-        const requestedBackend = hw.renderer ?? 'webgpu';
+        const requestedBackend = hw.backend ?? 'webgpu';
 
         if (requestedBackend !== 'software') {
             // Try WebGPU. initWebGPU returns null when navigator.gpu is absent and
@@ -1005,33 +1005,33 @@ export class BTAPI {
     }
 
     /**
-     * Applies URL renderer override from `?renderer=...` when present.
+     * Applies URL backend override from `?backend=...` when present.
      *
      * Supported values:
      * - `software`
      *
      * Unknown values are ignored so accidental query typos do not break startup.
      */
-    private applyRendererQueryOverride(): void {
+    private applyBackendQueryOverride(): void {
         if (!this.hwSettings) {
             return;
         }
 
-        const override = BTAPI.getRendererQueryOverride();
+        const override = BTAPI.getBackendQueryOverride();
         if (!override) {
             return;
         }
 
-        this.hwSettings.renderer = override;
-        console.info(`[BT] URL override selected renderer backend: ${override}`);
+        this.hwSettings.backend = override;
+        console.info(`[BT] URL override selected backend: ${override}`);
     }
 
     /**
-     * Reads renderer override from the current URL query string.
+     * Reads backend override from the current URL query string.
      *
-     * @returns Supported renderer backend override, or null when absent/invalid.
+     * @returns Supported backend override, or null when absent/invalid.
      */
-    private static getRendererQueryOverride(): RendererBackend | null {
+    private static getBackendQueryOverride(): Backend | null {
         const search =
             typeof globalThis.location?.search === 'string'
                 ? globalThis.location.search
@@ -1044,12 +1044,12 @@ export class BTAPI {
         }
 
         try {
-            const renderer = new URLSearchParams(search).get('renderer');
-            if (renderer === 'software') {
+            const backend = new URLSearchParams(search).get('backend');
+            if (backend === 'software') {
                 return 'software';
             }
         } catch (error) {
-            console.warn('[BT] Failed to parse renderer query override:', error);
+            console.warn('[BT] Failed to parse backend query override:', error);
         }
 
         return null;

--- a/src/core/IBlitTechDemo.test.ts
+++ b/src/core/IBlitTechDemo.test.ts
@@ -46,6 +46,12 @@ describe('defaultConfig', () => {
         expect(settings.outputUpscaleFilter).toBe('nearest');
     });
 
+    it("should default backend to 'webgpu'", () => {
+        const settings = defaultConfig();
+
+        expect(settings.backend).toBe('webgpu');
+    });
+
     it('should enable stats overlay by default', () => {
         const settings = defaultConfig();
 
@@ -70,6 +76,7 @@ describe('mergeHardwareSettings', () => {
         expect(settings.displaySize.x).toBe(320);
         expect(settings.canvasDisplaySize?.x).toBe(640);
         expect(settings.targetFPS).toBe(60);
+        expect(settings.backend).toBe('webgpu');
     });
 
     it('merges targetFPS-only partials with full defaults', () => {

--- a/src/core/IBlitTechDemo.test.ts
+++ b/src/core/IBlitTechDemo.test.ts
@@ -96,6 +96,7 @@ describe('mergeHardwareSettings', () => {
         expect(settings.displaySize.x).toBe(320);
         expect(settings.canvasDisplaySize).toBeUndefined();
         expect(settings.targetFPS).toBe(60);
+        expect(settings.backend).toBe('webgpu');
     });
 
     it('applies only provided fields when displaySize is set', () => {

--- a/src/core/IBlitTechDemo.test.ts
+++ b/src/core/IBlitTechDemo.test.ts
@@ -95,11 +95,11 @@ describe('mergeHardwareSettings', () => {
         const settings = mergeHardwareSettings({
             displaySize: new Vector2i(320, 240),
             canvasDisplaySize: new Vector2i(640, 480),
-            renderer: 'software',
+            backend: 'software',
         });
 
         expect(settings.canvasDisplaySize?.x).toBe(640);
-        expect(settings.renderer).toBe('software');
+        expect(settings.backend).toBe('software');
         expect(settings.targetFPS).toBe(60);
         expect(settings.statsOverlayEnabled).toBe(true);
     });

--- a/src/core/IBlitTechDemo.ts
+++ b/src/core/IBlitTechDemo.ts
@@ -266,6 +266,7 @@ export function defaultConfig(): HardwareSettings {
         maxCanvasDisplaySize: new Vector2i(DEFAULT_MAX_CANVAS_DISPLAY_SIZE.x, DEFAULT_MAX_CANVAS_DISPLAY_SIZE.y),
         targetFPS: 60,
         outputUpscaleFilter: 'nearest',
+        backend: 'webgpu',
         statsOverlayEnabled: true,
     };
 }

--- a/src/core/IBlitTechDemo.ts
+++ b/src/core/IBlitTechDemo.ts
@@ -10,16 +10,15 @@ import { Vector2i } from '../utils/Vector2i';
 export type OutputUpscaleFilter = 'nearest' | 'linear';
 
 /**
- * Renderer backend selection for {@link HardwareSettings.renderer}.
+ * Rendering backend selection for {@link HardwareSettings.backend}.
  *
- * - `'webgpu'` - Hardware-accelerated WebGPU renderer (default). Supports all
- *   draw primitives, sprites, palette, camera, and fullscreen post-process
- *   effects.
+ * - `'webgpu'` - Hardware-accelerated WebGPU path (default). Supports all draw
+ *   primitives, sprites, palette, camera, and fullscreen post-process effects.
  * - `'software'` - Canvas 2D software fallback. Supports draw primitives,
  *   sprites, palette, and camera. Fullscreen shader effects are not available
  *   and will throw when added.
  */
-export type RendererBackend = 'webgpu' | 'software';
+export type Backend = 'webgpu' | 'software';
 
 /**
  * Engine-facing hardware configuration returned by `configure()` when a demo
@@ -99,13 +98,13 @@ export interface HardwareSettings {
     detectDroppedFrames?: boolean;
 
     /**
-     * Renderer backend to use. Defaults to `'webgpu'`.
+     * Rendering backend to use. Defaults to `'webgpu'`.
      *
      * Set to `'software'` to opt into the Canvas 2D fallback backend.
-     * You can also force software mode at runtime with `?renderer=software`
+     * You can also force software mode at runtime with `?backend=software`
      * in the page URL.
      */
-    renderer?: RendererBackend;
+    backend?: Backend;
 
     /**
      * When `true` (default), the engine draws a screen-space stats overlay after
@@ -176,7 +175,7 @@ export interface StatsOverlayRow {
 export interface IBlitTechDemo {
     /**
      * Optional hook to declare display size, optional output drawing-buffer size,
-     * upscale filter, target fixed-update rate, renderer backend, and stats overlay.
+     * upscale filter, target fixed-update rate, rendering backend, and stats overlay.
      *
      * When omitted, the engine uses {@link defaultConfig} (`320x240` at
      * `60` FPS).
@@ -193,7 +192,7 @@ export interface IBlitTechDemo {
     configure?(): Partial<HardwareSettings>;
 
     /**
-     * Called once after the selected renderer backend has been initialized.
+     * Called once after the selected rendering backend has been initialized.
      * Load assets and prepare a demo state here.
      *
      * @returns Promise that resolves to true if successful, false to abort.
@@ -314,8 +313,8 @@ function pickDefinedHardwareSettings(partial: Partial<HardwareSettings>): Partia
         picked.detectDroppedFrames = partial.detectDroppedFrames;
     }
 
-    if (partial.renderer !== undefined) {
-        picked.renderer = partial.renderer;
+    if (partial.backend !== undefined) {
+        picked.backend = partial.backend;
     }
 
     if (partial.statsOverlayEnabled !== undefined) {
@@ -387,10 +386,10 @@ function buildFullDefaultMergeOptionals(
         optionals.detectDroppedFrames = detectDroppedFrames;
     }
 
-    const renderer = picked.renderer ?? defaults.renderer;
+    const backend = picked.backend ?? defaults.backend;
 
-    if (renderer !== undefined) {
-        optionals.renderer = renderer;
+    if (backend !== undefined) {
+        optionals.backend = backend;
     }
 
     const statsOverlayStyle = picked.statsOverlayStyle ?? defaults.statsOverlayStyle;
@@ -435,7 +434,7 @@ function mergeExplicitDisplayProfile(picked: Partial<HardwareSettings>, defaults
         ...(picked.maxCanvasDisplaySize !== undefined ? { maxCanvasDisplaySize: picked.maxCanvasDisplaySize } : {}),
         ...(picked.outputUpscaleFilter !== undefined ? { outputUpscaleFilter: picked.outputUpscaleFilter } : {}),
         ...(picked.detectDroppedFrames !== undefined ? { detectDroppedFrames: picked.detectDroppedFrames } : {}),
-        ...(picked.renderer !== undefined ? { renderer: picked.renderer } : {}),
+        ...(picked.backend !== undefined ? { backend: picked.backend } : {}),
         ...(picked.statsOverlayStyle !== undefined ? { statsOverlayStyle: { ...picked.statsOverlayStyle } } : {}),
     };
 }

--- a/src/core/IBlitTechDemo.ts
+++ b/src/core/IBlitTechDemo.ts
@@ -425,6 +425,7 @@ function mergePartialWithFullDefaults(picked: Partial<HardwareSettings>, default
  * @param picked - Defined fields with vectors cloned.
  * @param defaults - Baseline hardware settings for required fallbacks.
  * @returns Resolved settings; omitted optionals such as `canvasDisplaySize` stay unset.
+ * `backend` always inherits from {@link defaultConfig} when omitted from `configure()`.
  */
 function mergeExplicitDisplayProfile(picked: Partial<HardwareSettings>, defaults: HardwareSettings): HardwareSettings {
     return {
@@ -435,7 +436,7 @@ function mergeExplicitDisplayProfile(picked: Partial<HardwareSettings>, defaults
         ...(picked.maxCanvasDisplaySize !== undefined ? { maxCanvasDisplaySize: picked.maxCanvasDisplaySize } : {}),
         ...(picked.outputUpscaleFilter !== undefined ? { outputUpscaleFilter: picked.outputUpscaleFilter } : {}),
         ...(picked.detectDroppedFrames !== undefined ? { detectDroppedFrames: picked.detectDroppedFrames } : {}),
-        ...(picked.backend !== undefined ? { backend: picked.backend } : {}),
+        backend: picked.backend ?? defaults.backend ?? 'webgpu',
         ...(picked.statsOverlayStyle !== undefined ? { statsOverlayStyle: { ...picked.statsOverlayStyle } } : {}),
     };
 }

--- a/src/render/IRenderer.ts
+++ b/src/render/IRenderer.ts
@@ -11,7 +11,7 @@ import type { Effect } from './effects/Effect';
  * Any rendering backend (WebGPU, software Canvas 2D, headless test stub, etc.)
  * must satisfy this interface. {@link BTAPI} holds a reference to `IRenderer`
  * and never depends on the concrete implementation directly, allowing the engine
- * to swap backends at initialization time based on {@link HardwareSettings.renderer}.
+ * to swap backends at initialization time based on {@link HardwareSettings.backend}.
  *
  * Lifecycle:
  * 1. Call {@link init} once after construction.

--- a/src/render/SoftwareRenderer.ts
+++ b/src/render/SoftwareRenderer.ts
@@ -85,7 +85,7 @@ export class SoftwareRenderer implements IRenderer {
     // #region Constants
 
     private static readonly EFFECTS_UNSUPPORTED_MESSAGE =
-        "The software renderer doesn't support fullscreen effects. To use post-process effects, set renderer to 'webgpu' in configure().";
+        "The software renderer doesn't support fullscreen effects. To use post-process effects, set backend to 'webgpu' in configure().";
 
     // #endregion
 

--- a/src/render/StatsOverlay.test.ts
+++ b/src/render/StatsOverlay.test.ts
@@ -16,7 +16,7 @@ import type { IRenderer } from './IRenderer';
 import {
     createStatsOverlayLayout,
     isPointerInStatsToggleCorner,
-    resolveStatsDemoText,
+    resolveStatsTopLeftLabel,
     StatsOverlay,
     statsRightAlignedTextX,
 } from './StatsOverlay';
@@ -95,21 +95,21 @@ const mockFont = {} as BitmapFont;
 
 // #endregion
 
-// #region resolveStatsDemoLabel
+// #region resolveStatsTopLeftLabel
 
-describe('resolveStatsDemoLabel', () => {
+describe('resolveStatsTopLeftLabel', () => {
     it('formats registry-style page titles without a Blit-Tech prefix', () => {
-        expect(resolveStatsDemoText('Blit-Tech Demo 006 - Patterns')).toBe('Patterns Demo');
-        expect(resolveStatsDemoText('Blit-Tech Demo 002 - Primitives')).toBe('Primitives Demo');
+        expect(resolveStatsTopLeftLabel('Blit-Tech Demo 006 - Patterns')).toBe('Patterns Demo');
+        expect(resolveStatsTopLeftLabel('Blit-Tech Demo 002 - Primitives')).toBe('Primitives Demo');
     });
 
     it('falls back when title is empty', () => {
-        expect(resolveStatsDemoText('')).toBe('Demo');
-        expect(resolveStatsDemoText(undefined)).toBe('Demo');
+        expect(resolveStatsTopLeftLabel('')).toBe('Demo');
+        expect(resolveStatsTopLeftLabel(undefined)).toBe('Demo');
     });
 
     it('passes through non-registry titles unchanged', () => {
-        expect(resolveStatsDemoText('Custom Page')).toBe('Custom Page');
+        expect(resolveStatsTopLeftLabel('Custom Page')).toBe('Custom Page');
     });
 });
 
@@ -200,28 +200,29 @@ describe('StatsOverlay', () => {
         expect(overlay.visible).toBe(true);
     });
 
-    it('draws demo title top-left, backend top-right, FPS bottom-left, and hide hint bottom-right', () => {
+    it('draws top-left, top-right, bottom-left, and bottom-right labels', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(layout, 'Patterns Demo', 60, 'webgpu');
+        const topLeftLabel = 'Patterns Demo';
+        const overlay = new StatsOverlay(layout, topLeftLabel, 60, 'webgpu');
         const renderer = createMockRenderer();
 
         overlay.updateAndRender(renderer, mockFont, null, null, 0);
 
         const calls = getBitmapTextCalls(renderer);
-        const backendText = 'webgpu | 320x240';
-        const topRightX = statsRightAlignedTextX(backendText, 320);
-        const hideText = '[HIDE ~]';
-        const hideTextX = statsRightAlignedTextX(hideText, 320);
+        const topRightLabel = 'webgpu | 320x240';
+        const topRightX = statsRightAlignedTextX(topRightLabel, 320);
+        const bottomRightLabel = '[HIDE ~]';
+        const bottomRightX = statsRightAlignedTextX(bottomRightLabel, 320);
 
         expect(calls).toHaveLength(4);
         expect(calls[0]).toEqual({
             pos: new Vector2i(STATS_EDGE_MARGIN_PX, STATS_TOP_TEXT_Y),
-            text: 'Patterns Demo',
+            text: topLeftLabel,
             paletteOffset: 1,
         });
         expect(calls[1]).toEqual({
             pos: new Vector2i(topRightX, STATS_TOP_TEXT_Y),
-            text: backendText,
+            text: topRightLabel,
             paletteOffset: 1,
         });
         expect(calls[2]).toMatchObject({
@@ -230,21 +231,21 @@ describe('StatsOverlay', () => {
             paletteOffset: 1,
         });
         expect(calls[3]).toEqual({
-            pos: new Vector2i(hideTextX, layout.bottomTextY),
-            text: hideText,
+            pos: new Vector2i(bottomRightX, layout.bottomTextY),
+            text: bottomRightLabel,
             paletteOffset: 1,
         });
     });
 
-    it('uses constructor backend label on the top-right line', () => {
+    it('uses activeBackend for the top-right label', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
         const overlay = new StatsOverlay(layout, 'Demo', 60, 'software');
         const renderer = createMockRenderer();
 
         overlay.updateAndRender(renderer, mockFont, null, null, 0);
 
-        const backendCall = getBitmapTextCalls(renderer)[1];
-        expect(backendCall?.text).toBe('software | 320x240');
+        const topRightCall = getBitmapTextCalls(renderer)[1];
+        expect(topRightCall?.text).toBe('software | 320x240');
     });
 
     it('skips draw calls when hidden', () => {

--- a/src/render/StatsOverlay.ts
+++ b/src/render/StatsOverlay.ts
@@ -5,7 +5,7 @@
  * `true` (default). Layout is computed once at init from logical `displaySize` and
  * system font metrics; per-frame work samples render timing and draws two 16 px bars:
  *
- * - **Top:** demo title (left) and `renderer | WxH` (right)
+ * - **Top:** demo title (left) and `backend | WxH` (right)
  * - **Bottom:** `FPS: N | Target: T` (left) and `[HIDE ~]` hint (right)
  * - **Custom rows (optional):** demo-supplied bars stacked above the bottom bar, 1 px apart
  *
@@ -19,7 +19,7 @@
  */
 
 import type { BitmapFont } from '../assets/BitmapFont';
-import type { RendererBackend, StatsOverlayRow, StatsOverlayStyle } from '../core/IBlitTechDemo';
+import type { Backend, StatsOverlayRow, StatsOverlayStyle } from '../core/IBlitTechDemo';
 import type { KeyboardInput } from '../input/KeyboardInput';
 import type { PointerInput } from '../input/PointerInput';
 import { POINTER_SLOT_COUNT } from '../input/PointerInput';
@@ -99,13 +99,13 @@ export interface StatsOverlayLayout {
 // #region Helper Functions
 
 /**
- * Turns the browser page title into a short bottom-bar demo text.
+ * Turns the browser page title into a short top-left overlay label.
  *
  * @param pageTitle - Browser document title when available.
- * @returns Short demo text for the top-left bar (registry titles such as
+ * @returns Short label for the top-left bar (registry titles such as
  *   `Blit-Tech Demo 002 - Primitives` become `Primitives Demo`).
  */
-export function resolveStatsDemoText(pageTitle: string | undefined): string {
+export function resolveStatsTopLeftLabel(pageTitle: string | undefined): string {
     const raw = typeof pageTitle === 'string' ? pageTitle.trim() : '';
 
     if (raw.length === 0) {
@@ -258,9 +258,9 @@ class FpsSampler {
 export class StatsOverlay {
     readonly #layout: StatsOverlayLayout;
 
-    readonly #demoText: string;
+    readonly #topLeftLabel: string;
 
-    readonly #toggleHintText: string;
+    readonly #bottomRightLabel: string;
 
     readonly #targetFps: number;
 
@@ -272,19 +272,19 @@ export class StatsOverlay {
 
     #idxText = DEFAULT_IDX_TEXT;
 
-    readonly #rendererText: string;
+    readonly #topRightLabel: string;
 
     readonly #topBarRect = new Rect2i(0, 0, 0, STATS_BAR_HEIGHT);
 
     readonly #bottomBarRect = new Rect2i(0, 0, 0, STATS_BAR_HEIGHT);
 
-    readonly #demoTopPos = new Vector2i(STATS_EDGE_MARGIN_PX, 0);
+    readonly #topLeftPos = new Vector2i(STATS_EDGE_MARGIN_PX, 0);
 
     readonly #topRightPos = new Vector2i(0, 0);
 
-    readonly #fpsPos = new Vector2i(STATS_EDGE_MARGIN_PX, 0);
+    readonly #bottomLeftPos = new Vector2i(STATS_EDGE_MARGIN_PX, 0);
 
-    readonly #toggleHintPos = new Vector2i(0, 0);
+    readonly #bottomRightPos = new Vector2i(0, 0);
 
     /** Reused bar rects for demo-supplied rows (index 0 = closest to bottom bar). */
     #customBarRects: Rect2i[] = [];
@@ -299,21 +299,21 @@ export class StatsOverlay {
      * Creates an overlay with fixed layout and text strings.
      *
      * @param layout - Cached display layout from {@link createStatsOverlayLayout}.
-     * @param demoText - Short title shown on the top-left.
+     * @param topLeftLabel - Short title shown on the top-left.
      * @param targetFps - Configured fixed-update rate for the target FPS line.
-     * @param activeRenderer - Renderer started by BTAPI (`webgpu` or `software`).
+     * @param activeBackend - Backend started by BTAPI (`webgpu` or `software`).
      * @param style - Optional palette indices from {@link HardwareSettings.statsOverlayStyle}.
      */
     constructor(
         layout: StatsOverlayLayout,
-        demoText: string,
+        topLeftLabel: string,
         targetFps: number,
-        activeRenderer: RendererBackend,
+        activeBackend: Backend,
         style?: StatsOverlayStyle,
     ) {
         this.#layout = layout;
-        this.#demoText = demoText;
-        this.#toggleHintText = '[HIDE ~]';
+        this.#topLeftLabel = topLeftLabel;
+        this.#bottomRightLabel = '[HIDE ~]';
         this.#targetFps = targetFps;
         this.#fps = new FpsSampler(this.#targetFps);
         this.#idxBg = style?.barPaletteIndex ?? DEFAULT_IDX_BG;
@@ -324,13 +324,13 @@ export class StatsOverlay {
         this.#topBarRect.width = displayWidth;
         this.#bottomBarRect.y = displayHeight - STATS_BAR_HEIGHT;
         this.#bottomBarRect.width = displayWidth;
-        this.#demoTopPos.y = topTextY;
+        this.#topLeftPos.y = topTextY;
         this.#topRightPos.y = topTextY;
-        this.#fpsPos.y = bottomTextY;
-        this.#toggleHintPos.y = bottomTextY;
-        this.#toggleHintPos.x = statsRightAlignedTextX(this.#toggleHintText, displayWidth);
-        this.#rendererText = `${activeRenderer} | ${displayWidth}x${displayHeight}`;
-        this.#topRightPos.x = statsRightAlignedTextX(this.#rendererText, displayWidth);
+        this.#bottomLeftPos.y = bottomTextY;
+        this.#bottomRightPos.y = bottomTextY;
+        this.#bottomRightPos.x = statsRightAlignedTextX(this.#bottomRightLabel, displayWidth);
+        this.#topRightLabel = `${activeBackend} | ${displayWidth}x${displayHeight}`;
+        this.#topRightPos.x = statsRightAlignedTextX(this.#topRightLabel, displayWidth);
     }
 
     /**
@@ -466,7 +466,7 @@ export class StatsOverlay {
     /**
      * Processes toggle input then draws the overlay.
      *
-     * @param renderer - Active renderer backend.
+     * @param renderer - Active {@link IRenderer} instance.
      * @param font - System bitmap font.
      * @param pointer - Pointer subsystem for corner toggle.
      * @param keyboard - Keyboard subsystem for Backquote toggle.
@@ -493,7 +493,7 @@ export class StatsOverlay {
 
         renderer.resetCamera();
 
-        const fpsText = `FPS: ${this.#fps.measuredFps} | Target: ${this.#targetFps}`;
+        const bottomLeftLabel = `FPS: ${this.#fps.measuredFps} | Target: ${this.#targetFps}`;
 
         renderer.drawRectFillOnTop(this.#topBarRect, this.#idxBg);
         renderer.drawRectFillOnTop(this.#bottomBarRect, this.#idxBg);
@@ -504,10 +504,10 @@ export class StatsOverlay {
 
         const textPaletteOffset = statsBitmapTextPaletteOffset(this.#idxText);
 
-        renderer.drawBitmapTextOnTop(font, this.#demoTopPos, this.#demoText, textPaletteOffset);
-        renderer.drawBitmapTextOnTop(font, this.#topRightPos, this.#rendererText, textPaletteOffset);
-        renderer.drawBitmapTextOnTop(font, this.#fpsPos, fpsText, textPaletteOffset);
-        renderer.drawBitmapTextOnTop(font, this.#toggleHintPos, this.#toggleHintText, textPaletteOffset);
+        renderer.drawBitmapTextOnTop(font, this.#topLeftPos, this.#topLeftLabel, textPaletteOffset);
+        renderer.drawBitmapTextOnTop(font, this.#topRightPos, this.#topRightLabel, textPaletteOffset);
+        renderer.drawBitmapTextOnTop(font, this.#bottomLeftPos, bottomLeftLabel, textPaletteOffset);
+        renderer.drawBitmapTextOnTop(font, this.#bottomRightPos, this.#bottomRightLabel, textPaletteOffset);
 
         renderer.setCameraOffset(savedCamera);
     }

--- a/src/utils/errorMessages.test.ts
+++ b/src/utils/errorMessages.test.ts
@@ -85,8 +85,8 @@ describe('errorMessages', () => {
             expect(STATS_OVERLAY_NO_BACKEND.length).toBeGreaterThan(0);
         });
 
-        it('should mention renderer readiness', () => {
-            expect(STATS_OVERLAY_NO_BACKEND).toContain("renderer isn't ready");
+        it('should mention backend readiness', () => {
+            expect(STATS_OVERLAY_NO_BACKEND).toContain("backend isn't ready");
         });
     });
 

--- a/src/utils/errorMessages.ts
+++ b/src/utils/errorMessages.ts
@@ -45,12 +45,12 @@ export const WEBGPU_DEVICE_MESSAGE =
     "Couldn't connect to the graphics card. Try closing other tabs or restarting the browser.";
 
 /**
- * Friendly message for the stats-overlay setup path when runtime renderer state is unavailable.
+ * Friendly message for the stats-overlay setup path when the rendering backend is unavailable.
  *
- * Shown when overlay initialization runs before a renderer has been selected.
+ * Shown when overlay initialization runs before a backend has been selected.
  */
 export const STATS_OVERLAY_NO_BACKEND =
-    "Couldn't start the stats overlay because the renderer isn't ready yet. Try initializing the renderer before creating the overlay.";
+    "Couldn't start the stats overlay because the rendering backend isn't ready yet. Try initializing the engine before creating the overlay.";
 
 // #region Runtime - Render configuration
 

--- a/tests/visual/camera.spec.ts
+++ b/tests/visual/camera.spec.ts
@@ -30,7 +30,7 @@ test.describe('Camera Rendering', () => {
     });
 
     test('should render matching camera offsets in software mode', async ({ page }) => {
-        await page.goto('/camera.html?renderer=software');
+        await page.goto('/camera.html?backend=software');
 
         await page.waitForFunction(
             () => {

--- a/tests/visual/fonts.spec.ts
+++ b/tests/visual/fonts.spec.ts
@@ -30,7 +30,7 @@ test.describe('Font Rendering', () => {
     });
 
     test('should render matching text output in software mode', async ({ page }) => {
-        await page.goto('/fonts.html?renderer=software');
+        await page.goto('/fonts.html?backend=software');
 
         await page.waitForFunction(
             () => {

--- a/tests/visual/mixed.spec.ts
+++ b/tests/visual/mixed.spec.ts
@@ -30,7 +30,7 @@ test.describe('Mixed Rendering', () => {
     });
 
     test('should render matching primitives and sprites layering in software mode', async ({ page }) => {
-        await page.goto('/mixed.html?renderer=software');
+        await page.goto('/mixed.html?backend=software');
 
         await page.waitForFunction(
             () => {

--- a/tests/visual/primitives.spec.ts
+++ b/tests/visual/primitives.spec.ts
@@ -35,7 +35,7 @@ test.describe('Primitive Rendering', () => {
     });
 
     test('should render matching primitive patterns in software mode', async ({ page }) => {
-        await page.goto('/primitives.html?renderer=software');
+        await page.goto('/primitives.html?backend=software');
 
         await page.waitForFunction(
             () => {

--- a/tests/visual/sprites.spec.ts
+++ b/tests/visual/sprites.spec.ts
@@ -30,7 +30,7 @@ test.describe('Sprite Rendering', () => {
     });
 
     test('should render matching indexed sprites with offsets in software mode', async ({ page }) => {
-        await page.goto('/sprites.html?renderer=software');
+        await page.goto('/sprites.html?backend=software');
 
         await page.waitForFunction(
             () => {


### PR DESCRIPTION
RendererBackend is now Backend. HardwareSettings.renderer is HardwareSettings.backend. URL override is ?backend=software (not ?renderer=software). BT.activeBackend is unchanged.

Update docs, tests, stats overlay labels, and post-process error copy to match the backend vs IRenderer naming split.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

Refactors public API and implementation to replace "renderer" terminology with "backend" across code, docs, tests and error messages. The change centralizes the concept of selectable rendering backends and materializes the default backend as 'webgpu'.

## Core API Changes

- Exported type renamed: RendererBackend → Backend (type: 'webgpu' | 'software').
- BT.activeBackend getter: return type changed from RendererBackend | null → Backend | null (property name unchanged; semantics clarified: it reflects the backend that actually started, which may differ from configure().backend).
- BTAPI.getActiveBackend(): now returns Backend | null.
- HardwareSettings.renderer → HardwareSettings.backend.
- URL query override parameter: ?renderer=software → ?backend=software.

## Initialization & Defaults

- defaultConfig() explicitly sets backend: 'webgpu'.
- Backend selection and initialization now read hw.backend (defaulted to 'webgpu') rather than hw.renderer.
- mergeExplicitDisplayProfile() now falls back to defaultConfig().backend when configure() sets displaySize but omits backend (matches mergePartialWithFullDefaults() behavior).
- New helpers for query overrides: applyBackendQueryOverride() / getBackendQueryOverride().

## Stats Overlay & Rendering Surface

- StatsOverlay refactor:
  - Constructor args renamed: demoText → topLeftLabel, activeRenderer → activeBackend.
  - Helper renamed: resolveStatsDemoText(...) → resolveStatsTopLeftLabel(...).
  - Overlay renders explicit labels: top-left (page title), top-right (backend | WxH), bottom-left (FPS/target), bottom-right (toggle hint).
- Stats overlay label helper import/usage updated accordingly.

## Documentation, Messages, and Rules

- Documentation updated across docs/*.md and CLAUDE.md to use HardwareSettings.backend and ?backend=software examples.
- Rules (.claude / .cursor) updated to clarify activeBackend vs configure().backend distinction.
- User-facing messages adjusted:
  - Post-process effects guidance and SoftwareRenderer error guidance now reference backend: 'webgpu'.
  - STATS_OVERLAY_NO_BACKEND now references "rendering backend isn't ready yet".
- cspell.json: added "backend" to custom words.

## Tests & Visual Fixtures

- Unit and integration tests updated to backend naming and updated guidance (BlitTech.test.ts, src/core/BTAPI.test.ts, IBlitTechDemo.test.ts, StatsOverlay.test.ts, utils/errorMessages.test.ts).
- Visual Playwright tests updated to load software mode via ?backend=software (camera, fonts, mixed, primitives, sprites).

## Scope & Backwards Compatibility

- Breaking public API rename for configuration/typing (renderer → backend). Runtime accessor BT.activeBackend remains present but its documentation now distinguishes requested vs started backend.
- Most changes are naming/documentation/tests; the explicit defaulting of backend in merges/defaultConfig and the mergeExplicitDisplayProfile fallback are deliberate behavioral alignments to ensure consistent defaults.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->