### PR TITLE
docs(api): distinguish targetFPS from stats overlay render fps

### DIFF
--- a/docs/api-assets.md
+++ b/docs/api-assets.md
@@ -147,8 +147,8 @@ BT.systemPrint(new Vector2i(10, 10), paletteIndex, 'Score: 100');
 BT.systemPrintMeasure('Score: 100'); // → Vector2i (pixel width, height)
 ```
 
-Use `BT.systemPrint()` for demo-specific HUD panels and labels. The engine draws a default stats overlay (FPS, target
-FPS, backend, resolution, demo title) after each `render()` when `statsOverlayEnabled` is true; see
+Use `BT.systemPrint()` for demo-specific HUD panels and labels. The engine draws a default stats overlay (render FPS,
+target FPS, backend, resolution, demo title) after each `render()` when `statsOverlayEnabled` is true; see
 [API: Core - Stats overlay](api-core.md#stats-overlay). For styled variable-width text, use a bitmap font instead.
 
 ---

--- a/docs/api-core.md
+++ b/docs/api-core.md
@@ -53,7 +53,7 @@ const ok = await BT.init(demo, canvas); // low-level init; prefer bootstrap()
 BT.displaySize; // Vector2i - configured logical resolution (clone per read)
 BT.canvasDisplaySize; // Vector2i | null - output buffer when set in configure()
 BT.outputSize; // Vector2i - effective drawing-buffer size (clone per read)
-BT.targetFPS; // number - target updates per second
+BT.targetFPS; // number - fixed update() rate (simulation), not measured render FPS
 BT.activeBackend; // 'webgpu' | 'software' | null
 ```
 
@@ -72,7 +72,7 @@ example no `canvasDisplaySize` means a 1:1 drawing buffer).
 | `displaySize`          | `Vector2i`               | `320×240`   | Logical render resolution                           |
 | `canvasDisplaySize`    | `Vector2i`               | `640×480`   | CSS/output size; enables display-tier effects       |
 | `maxCanvasDisplaySize` | `Vector2i`               | `960×720`   | Maximum on-screen canvas CSS size                   |
-| `targetFPS`            | `number`                 | `60`        | Fixed-update rate                                   |
+| `targetFPS`            | `number`                 | `60`        | Fixed `update()` rate (simulation ticks per second) |
 | `backend`              | `'webgpu' \| 'software'` | `'webgpu'`  | Force rendering backend                             |
 | `outputUpscaleFilter`  | `'nearest' \| 'linear'`  | `'nearest'` | Upscale filter                                      |
 | `detectDroppedFrames`  | `boolean`                | `false`     | Log a console warning on missed vsync               |
@@ -98,7 +98,8 @@ size queries).
 
 - **Top bar (left):** short demo title derived from `document.title` (registry pages titled `Blit-Tech Demo NNN - Topic`
   show as `Topic Demo`); **top bar (right):** active backend and logical resolution (for example `webgpu | 320x240`)
-- **Bottom bar (left):** measured FPS and configured target FPS; **bottom bar (right):** `[HIDE ~]` hint
+- **Bottom bar (left):** measured **render FPS** (`requestAnimationFrame` cadence) and configured **target FPS**
+  (`update()` rate); **bottom bar (right):** `[HIDE ~]` hint
 - **Custom rows (optional):** extra bars from `statsOverlayRows()` stacked above the bottom bar, **1 px** apart, each
   with left text and optional right text (same 16 px bar style as the built-in rows)
 
@@ -129,6 +130,10 @@ Overlay colors follow one path: use `statsOverlayStyle` when set, otherwise defa
 override globally in `configure()` with `statsOverlayStyle: { barPaletteIndex, textPaletteIndex }`, or per custom row on
 `StatsOverlayRow` (`barPaletteIndex`, `textPaletteIndex`).
 
+The overlay label `Render FPS: N` is **not** the same as `BT.targetFPS`: render FPS reflects how often `render()` runs
+(browser refresh rate); target FPS is how often `update()` runs (fixed timestep). Do not use overlay render FPS for
+simulation timing—use `BT.ticks`, `BT.deltaSeconds`, or `Timer` instead.
+
 Demos should not duplicate FPS or page-title footer text; the overlay provides those. Reserve about **17 px** per custom
 overlay row above the bottom bar (16 px bar + 1 px gap). When drawing custom top or bottom HUD panels, leave about **15
 px** clear at each edge for the built-in overlay bars, or set `statsOverlayEnabled: false` for full-screen layouts (for
@@ -148,6 +153,16 @@ configure() {
 
 ## Game Loop Timing
 
+Blit-Tech runs two independent cadences:
+
+| Concept             | Where                                                      | Meaning                                                        |
+| ------------------- | ---------------------------------------------------------- | -------------------------------------------------------------- |
+| **Simulation rate** | `targetFPS`, `BT.targetFPS`, `BT.deltaSeconds`, `BT.ticks` | Fixed `update()` step; game logic and `Timer` use ticks        |
+| **Render rate**     | Stats overlay `Render FPS: N`                              | Measured `requestAnimationFrame` cadence; `render()` runs here |
+
+`render()` may run more or fewer times per second than `update()` (for example 120 Hz display with `targetFPS: 60`). Use
+tick-based timing for gameplay; use overlay render FPS only to spot GPU or draw-call bottlenecks.
+
 ```ts
 BT.deltaSeconds; // seconds per fixed tick (1 / BT.targetFPS)
 BT.timeSeconds; // elapsed seconds since init (ticks × deltaSeconds)
@@ -157,10 +172,11 @@ BT.ticksReset(); // reset tick counter to 0
 
 ### Timer
 
-`Timer` fires once per fixed interval. Use it for periodic events: particle spawns, score ticks, palette swaps.
+`Timer` counts **fixed update ticks**, not render frames. Intervals are in ticks; convert to seconds with
+`intervalTicks / BT.targetFPS`. Use it in `update()` for periodic events: particle spawns, score ticks, palette swaps.
 
 ```ts
-const spawn = new Timer(180); // fires every 180 ticks (3 s at 60 FPS)
+const spawn = new Timer(180); // every 180 ticks (3 s when BT.targetFPS === 60)
 
 // Inside update():
 if (spawn.tick()) {

--- a/docs/performance-best-practices.md
+++ b/docs/performance-best-practices.md
@@ -29,13 +29,15 @@ meaningful performance gains. Follow this approach:
 
 ### Frame Budget
 
-At 60 FPS, each frame must complete in **16.66ms** (1000ms / 60). This includes:
+Each **render frame** (one `requestAnimationFrame` callback) must finish before the next vsync. On a 60 Hz display that
+is about **16.66 ms** per frame (`1000 / 60`). That budget covers:
 
-- Fixed update logic (~2-4ms)
-- Rendering (~8-12ms)
-- Browser overhead (~2-4ms)
+- Zero or more fixed `update()` steps at `BT.targetFPS` (~2-4 ms total when one step runs)
+- One `render()` pass (~8-12 ms)
+- Browser overhead (~2-4 ms)
 
-If your frame time exceeds this budget, you'll drop frames and see stuttering.
+If work exceeds the display's render cadence, you drop frames and see stuttering. That is independent of `BT.targetFPS`:
+a 60 Hz simulation on a 120 Hz monitor still has a ~8.33 ms render budget per rAF callback.
 
 ---
 
@@ -209,11 +211,12 @@ for (let i = 0; i < 200; i++) {
 
 ### Fixed Timestep
 
-Blit-Tech uses a fixed 60 FPS timestep by default. This provides:
+Blit-Tech uses a fixed **simulation** timestep by default (`targetFPS: 60` → `update()` about 60 times per second).
+`render()` still runs at the browser's refresh rate. This provides:
 
 - **Deterministic behavior:** Same inputs always produce same results
-- **Predictable physics:** No need to multiply by delta time
-- **Simplified logic:** Frame-based counters and timers
+- **Predictable physics:** Use `BT.ticks` and `BT.deltaSeconds` instead of render-frame timing
+- **Simplified logic:** Tick-based counters and `Timer` intervals
 
 ### Using Ticks for Timing
 
@@ -273,7 +276,8 @@ Don't guess what's slow - **measure it**. Use:
 
 - Chrome DevTools Performance tab
 - `console.time()` / `console.timeEnd()`
-- Configured update rate: `BT.targetFPS` (measured render FPS is shown by the engine stats overlay when enabled)
+- Simulation rate: `BT.targetFPS` and `BT.ticks`
+- Render rate: stats overlay `Render FPS: N` when `statsOverlayEnabled` is true (measured rAF cadence, not `targetFPS`)
 
 ### 3. Allocating in Hot Paths
 

--- a/src/core/IBlitTechDemo.ts
+++ b/src/core/IBlitTechDemo.ts
@@ -78,7 +78,12 @@ export interface HardwareSettings {
      */
     outputUpscaleFilter?: OutputUpscaleFilter;
 
-    /** Target fixed-update rate in frames per second. */
+    /**
+     * Target fixed-update rate: how often {@link IBlitTechDemo.update} runs per second.
+     *
+     * Not the measured render rate shown as `Render FPS` on the stats overlay; `render()` follows
+     * `requestAnimationFrame` and may differ (for example 60 Hz updates on a 120 Hz display).
+     */
     targetFPS: number;
 
     /**
@@ -217,7 +222,7 @@ export interface IBlitTechDemo {
      * Issue all draw calls for the current frame here.
      *
      * When {@link HardwareSettings.statsOverlayEnabled} is `true` (default), the engine
-     * draws a screen-space stats HUD after this method returns (FPS, backend, demo
+     * draws a screen-space stats HUD after this method returns (render FPS, target FPS, backend, demo
      * title). Optional {@link statsOverlayRows} adds stacked bars above the footer.
      * Demos do not need to duplicate FPS or page-title text. Reserve the bottom and top
      * ~15 px bands (plus ~17 px per custom overlay row) for overlay bars, or disable

--- a/src/render/StatsOverlay.test.ts
+++ b/src/render/StatsOverlay.test.ts
@@ -3,7 +3,7 @@
  *
  * Layout contract (see {@link StatsOverlay} and docs/api-core.md Stats overlay):
  * - Top left: demo title; top right: `backend | WxH`
- * - Bottom left: `FPS: N | Target: T`; bottom right: `[HIDE ~]`
+ * - Bottom left: `Render FPS: N | Target: T`; bottom right: `[HIDE ~]`
  * - Custom rows: demo-supplied bars stacked above the bottom bar (1 px gaps)
  */
 
@@ -227,7 +227,7 @@ describe('StatsOverlay', () => {
         });
         expect(calls[2]).toMatchObject({
             pos: new Vector2i(STATS_EDGE_MARGIN_PX, layout.bottomTextY),
-            text: expect.stringMatching(/^FPS: \d+ \| Target: 60$/),
+            text: expect.stringMatching(/^Render FPS: \d+ \| Target: 60$/),
             paletteOffset: 1,
         });
         expect(calls[3]).toEqual({

--- a/src/render/StatsOverlay.ts
+++ b/src/render/StatsOverlay.ts
@@ -1,12 +1,12 @@
 /**
- * Engine-managed stats overlay (FPS, target rate, demo text, backend).
+ * Engine-managed stats overlay (render FPS, target rate, demo text, backend).
  *
  * Instantiated by {@link BTAPI} when {@link HardwareSettings.statsOverlayEnabled} is
  * `true` (default). Layout is computed once at init from logical `displaySize` and
  * system font metrics; per-frame work samples render timing and draws two 16 px bars:
  *
  * - **Top:** demo title (left) and `backend | WxH` (right)
- * - **Bottom:** `FPS: N | Target: T` (left) and `[HIDE ~]` hint (right)
+ * - **Bottom:** `Render FPS: N | Target: T` (left) and `[HIDE ~]` hint (right)
  * - **Custom rows (optional):** demo-supplied bars stacked above the bottom bar, 1 px apart
  *
  * Drawn in screen space (camera reset) after demo `render()`, palette effects, and
@@ -493,7 +493,7 @@ export class StatsOverlay {
 
         renderer.resetCamera();
 
-        const bottomLeftLabel = `FPS: ${this.#fps.measuredFps} | Target: ${this.#targetFps}`;
+        const bottomLeftLabel = `Render FPS: ${this.#fps.measuredFps} | Target: ${this.#targetFps}`;
 
         renderer.drawRectFillOnTop(this.#topBarRect, this.#idxBg);
         renderer.drawRectFillOnTop(this.#bottomBarRect, this.#idxBg);

--- a/src/utils/Timer.ts
+++ b/src/utils/Timer.ts
@@ -1,7 +1,11 @@
 import { BTAPI } from '../core/BTAPI';
 
 /**
- * Fixed-tick interval helper for update loops.
+ * Fixed-tick interval helper for {@link IBlitTechDemo.update} loops.
+ *
+ * Counts engine ticks ({@link BT.ticks}), which advance once per fixed update at
+ * {@link HardwareSettings.targetFPS}, not once per {@link IBlitTechDemo.render} frame.
+ * Convert ticks to seconds with `intervalTicks / BT.targetFPS`.
  *
  * Tracks a "last fired" tick and reports when a configured interval has elapsed.
  * Useful for periodic events such as particle spawning, score ticks, or palette swaps.


### PR DESCRIPTION
Clarify simulation rate (targetFPS, ticks, Timer) vs measured render rate (rAF) in api-core, performance-best-practices, and api-assets. Rename stats overlay label from "FPS" to "Render FPS". Extend JSDoc on Timer, HardwareSettings.targetFPS, and IBlitTechDemo.render.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR clarifies the distinction between simulation rate (targetFPS, ticks, Timer) and measured render rate (requestAnimationFrame) across documentation and source files. The main change is renaming the stats overlay label from "FPS" to "Render FPS" to avoid confusion with the configured target simulation tick rate.

## Changes

### Documentation Updates

**docs/api-core.md** (+21/-5)
- Re-described `BT.targetFPS` as the fixed `update()` simulation tick rate (not render FPS)
- Added explicit documentation for `HardwareSettings.targetFPS` field as the fixed `update()` rate
- Rewrote "Game Loop Timing" section to clarify two independent cadences: simulation vs render
- Updated "Timer" section to specify that `Timer` counts fixed update ticks (not render frames) and intervals are in ticks converted using `BT.targetFPS`
- Added explicit warning that the overlay's "Render FPS" is not the same as `BT.targetFPS` for simulation timing

**docs/performance-best-practices.md** (+13/-9)
- Updated "Frame Budget" section to clarify the 60 Hz budget is independent of `BT.targetFPS`
- Revised "Fixed Timestep" to specify default as `targetFPS: 60`
- Updated "Ignoring the Profiler" guidance with new bullet list explaining how to interpret simulation rate (`BT.targetFPS`, `BT.ticks`) vs render rate from stats overlay (`Render FPS`)

**docs/api-assets.md** (+2/-2)
- Updated "System Font" section's stats overlay description to specify "render FPS" instead of generic "FPS"

### Source Code Updates

**src/core/IBlitTechDemo.ts** (+7/-2)
- Updated JSDoc for `HardwareSettings.targetFPS` to clarify it is a fixed update tick rate
- Adjusted `IBlitTechDemo.render()` documentation to explicitly reference "render FPS" in the overlay description

**src/utils/Timer.ts** (+5/-1)
- Updated `Timer` class JSDoc to explicitly document tick-based counting tied to `BT` fixed updates
- Clarified the helper is for `IBlitTechDemo.update` loops rather than render frames
- Explained ticks-to-seconds conversion concept

**src/render/StatsOverlay.ts** (+3/-3)
- Updated in-file documentation to describe top bar (demo title + `backend | WxH`) and bottom bar (`Render FPS: N | Target: T`)
- Changed bottom-left overlay label string from `FPS: N | Target: T` to `Render FPS: N | Target: T`

**src/render/StatsOverlay.test.ts** (+2/-2)
- Updated test expectations to match new "Render FPS" label format
- Changed assertion regex from `^FPS: \d+ \| Target: 60$` to `^Render FPS: \d+ \| Target: 60$`

## Impact

- Documentation is now clearer about the distinction between fixed simulation updates (governed by `targetFPS`) and variable render frames (measured by requestAnimationFrame)
- Stats overlay label change eliminates ambiguity about what "FPS" refers to
- Total changes: +53/-22 across all files
- No breaking changes to exported APIs or type signatures

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/177?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->