### PR TITLE
feat(api): add BT.requestedBackend and clarify active backend docs

### DIFF
--- a/.cursor/rules/bt-api-getters.mdc
+++ b/.cursor/rules/bt-api-getters.mdc
@@ -12,6 +12,7 @@ When editing `src/BlitTech.ts`, demos, or API docs:
 Zero-argument **read-only** values on `BT`:
 
 - **Configure-time** (use same names as `HardwareSettings`): `displaySize`, `canvasDisplaySize`, `targetFPS`, `outputSize`
+- **Configure-time (backend):** `requestedBackend` mirrors resolved `HardwareSettings.backend` (includes `?backend=software`)
 - **Loop:** `deltaSeconds`, `timeSeconds`, `ticks`
 - **Runtime:** `activeBackend`, `camera`, `palette`
 - **Per-frame input:** `pointerScrollDelta`, `inputString`, `gamepadCount`
@@ -29,7 +30,8 @@ Bad: `BT.displaySize()`, `BT.fps()`, `BT.getActiveBackend()` (removed; use prope
 ## Naming
 
 - Match `HardwareSettings` spelling: `targetFPS` (not `fps`, not `targetFps`)
-- `activeBackend` = backend that started; `configure().backend` = requested backend only (not exposed on `BT`)
+- `requestedBackend` = resolved request (`configure()` merge + URL override); `activeBackend` = backend that started (after fallback)
+- Runtime feature gates (post-process, etc.) use `activeBackend`, not `requestedBackend`
 
 ## New API checklist
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,12 +151,13 @@ and async work. Do not add new zero-argument `BT.foo()` functions when a getter 
 
 ### Use getters (property access, no `()`)
 
-| Category                                                         | Members                                                       | Notes                                                                                                                |
-| ---------------------------------------------------------------- | ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| **Configure-time** (mirror {@link HardwareSettings} field names) | `displaySize`, `canvasDisplaySize`, `targetFPS`, `outputSize` | `outputSize` = effective buffer (`canvasDisplaySize ?? displaySize`). Clone per read for `Vector2i` getters.         |
-| **Loop timing**                                                  | `deltaSeconds`, `timeSeconds`, `ticks`                        | `targetFPS` is configured rate, not measured FPS.                                                                    |
-| **Runtime state**                                                | `activeBackend`, `camera`, `palette`                          | `activeBackend` is what actually started (after fallback), not `configure().backend`. `palette` is a live reference. |
-| **Per-frame input**                                              | `pointerScrollDelta`, `inputString`, `gamepadCount`           | Read once per frame when needed.                                                                                     |
+| Category                                                         | Members                                                       | Notes                                                                                                        |
+| ---------------------------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Configure-time** (mirror {@link HardwareSettings} field names) | `displaySize`, `canvasDisplaySize`, `targetFPS`, `outputSize` | `outputSize` = effective buffer (`canvasDisplaySize ?? displaySize`). Clone per read for `Vector2i` getters. |
+| **Loop timing**                                                  | `deltaSeconds`, `timeSeconds`, `ticks`                        | `targetFPS` is configured rate, not measured FPS.                                                            |
+| **Configure-time (backend)**                                     | `requestedBackend`                                            | Resolved `HardwareSettings.backend` after merge and `?backend=software`; defaults to `'webgpu'`.             |
+| **Runtime state**                                                | `activeBackend`, `camera`, `palette`                          | `activeBackend` is what actually started (after fallback). `palette` is a live reference.                    |
+| **Per-frame input**                                              | `pointerScrollDelta`, `inputString`, `gamepadCount`           | Read once per frame when needed.                                                                             |
 
 Examples: `BT.displaySize.y`, `BT.targetFPS`, `BT.ticks % 60`, `if (BT.activeBackend === 'software')`.
 
@@ -173,7 +174,8 @@ Examples: `BT.displaySize.y`, `BT.targetFPS`, `BT.ticks % 60`, `if (BT.activeBac
 
 - **Same name as `HardwareSettings`** when exposing configure values (`targetFPS`, not `fps` or `targetFps`).
 - **Descriptive runtime names** when there is no configure field (`activeBackend`, not `renderer`).
-- **Do not** expose `configure().backend` on `BT` as a getter without documenting that it differs from `activeBackend`.
+- **`requestedBackend` vs `activeBackend`:** use `requestedBackend` for the resolved init request; use `activeBackend`
+  for runtime gates (post-process, capture). They differ when WebGPU was requested but fell back to software.
 
 Full tables: `docs/api-core.md`. Style guide: `docs/developer-experience-guide.md` (Naming conventions).
 

--- a/docs/api-core.md
+++ b/docs/api-core.md
@@ -115,14 +115,18 @@ warning and starts the software renderer. Then `activeBackend === 'software'` wh
 **Runtime checks (post-process, capture, etc.):** use `activeBackend`, not `requestedBackend`:
 
 ```ts
-// Correct: skip effects when the running backend cannot host them
+// Correct: gate on the backend that actually started; BT.effectAdd takes one effect
 if (BT.activeBackend === 'webgpu') {
-  BT.effectAdd(crtPipBoy());
+  for (const fx of BT.preset.crtPipBoy()) {
+    BT.effectAdd(fx);
+  }
 }
 
 // Misleading after fallback: requestedBackend may still be 'webgpu'
 if (BT.requestedBackend === 'webgpu') {
-  BT.effectAdd(crtPipBoy()); // throws on software
+  for (const fx of BT.preset.crtPipBoy()) {
+    BT.effectAdd(fx); // throws once activeBackend is software
+  }
 }
 ```
 

--- a/docs/api-core.md
+++ b/docs/api-core.md
@@ -54,7 +54,8 @@ BT.displaySize; // Vector2i - configured logical resolution (clone per read)
 BT.canvasDisplaySize; // Vector2i | null - output buffer when set in configure()
 BT.outputSize; // Vector2i - effective drawing-buffer size (clone per read)
 BT.targetFPS; // number - fixed update() rate (simulation), not measured render FPS
-BT.activeBackend; // 'webgpu' | 'software' | null
+BT.requestedBackend; // 'webgpu' | 'software' | null - resolved request (see below)
+BT.activeBackend; // 'webgpu' | 'software' | null - backend that actually started
 ```
 
 `BT.init()` selects WebGPU or falls back to the Canvas 2D software renderer automatically. When not using `bootstrap()`,
@@ -88,7 +89,51 @@ adapter/device `maxTextureDimension2D` limit. GPU limit failures do not fall bac
 
 **`BT` getters vs `configure()` fields:** `displaySize`, `canvasDisplaySize`, and `targetFPS` on `BT` mirror the same
 names on `HardwareSettings`. `outputSize` is the effective drawing-buffer size (`canvasDisplaySize ?? displaySize`).
-`activeBackend` is the backend that actually started (after fallback), not the `backend` value from `configure()`.
+`requestedBackend` mirrors resolved `HardwareSettings.backend` (including URL overrides). `activeBackend` is the backend
+that actually started and may differ after WebGPU fallback.
+
+### Requested vs active backend
+
+Two getters disambiguate **what you asked for** from **what is running**:
+
+| Getter                | When set                                                                                         | Meaning                                                                        |
+| --------------------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| `BT.requestedBackend` | After hardware settings load (`configure()` merge + URL override), before or after renderer init | Backend the engine will try / tried to start (`'webgpu'` default when omitted) |
+| `BT.activeBackend`    | After successful renderer init only                                                              | Backend that actually started (`null` before init or on init failure)          |
+
+**`configure().backend`** and **`BT.requestedBackend`** both describe the request, but only the getter reflects
+post-merge resolution:
+
+- `demo.configure()` may return a partial object; the engine merges it with `defaultConfig()`.
+- `?backend=software` mutates the resolved `HardwareSettings.backend` **before** `initRenderer()` runs (during
+  `loadHardwareSettings()`). A page opened as `/demos/023-crt-pipboy.html?backend=software` therefore reports
+  `BT.requestedBackend === 'software'` even when `configure()` asked for WebGPU.
+
+**Fallback:** When `requestedBackend` is `'webgpu'` (explicit or default) and WebGPU init fails, the engine logs a
+warning and starts the software renderer. Then `activeBackend === 'software'` while `requestedBackend` stays `'webgpu'`.
+
+**Runtime checks (post-process, capture, etc.):** use `activeBackend`, not `requestedBackend`:
+
+```ts
+// Correct: skip effects when the running backend cannot host them
+if (BT.activeBackend === 'webgpu') {
+  BT.effectAdd(crtPipBoy());
+}
+
+// Misleading after fallback: requestedBackend may still be 'webgpu'
+if (BT.requestedBackend === 'webgpu') {
+  BT.effectAdd(crtPipBoy()); // throws on software
+}
+```
+
+Forcing software up front avoids the fallback path entirely:
+
+```ts
+configure() {
+  return { backend: 'software', /* ... */ };
+}
+// requestedBackend === activeBackend === 'software' after init
+```
 
 ### Stats overlay
 

--- a/docs/developer-experience-guide.md
+++ b/docs/developer-experience-guide.md
@@ -136,7 +136,9 @@ AI-assisted commits add a trailer: `Co-Authored-By: Claude <noreply@anthropic.co
   [CLAUDE.md](../CLAUDE.md) (**BT API: getters vs methods**).
 - **`BT` getter names** that surface `configure()` / `HardwareSettings` use the **same field names** (`displaySize`,
   `targetFPS`, `canvasDisplaySize`, …). Keep acronym spelling consistent (`targetFPS`, not `targetFps`). Runtime-only
-  reads use descriptive names (`activeBackend`, `ticks`, `deltaSeconds`).
+  reads use descriptive names (`activeBackend`, `requestedBackend`, `ticks`, `deltaSeconds`). Use `activeBackend` for
+  runtime capability checks; `requestedBackend` mirrors resolved `HardwareSettings.backend` (including
+  `?backend=software`).
 
 ---
 

--- a/docs/post-process-effects.md
+++ b/docs/post-process-effects.md
@@ -90,7 +90,9 @@ Invariants:
 Appends an effect to the chain matching its declared `tier`. Effects can be added at any time; the first add allocates
 the chain's offscreen render targets, the second add allocates a second target for ping-pong. Throws if the engine has
 not been initialized, if a `tier='display'` effect is added without `canvasDisplaySize`, or if the active backend is
-`'software'` (Canvas 2D does not support post-process effects).
+`'software'` (Canvas 2D does not support post-process effects). At runtime, gate registration with
+`BT.activeBackend === 'webgpu'` (not `BT.requestedBackend` - WebGPU may have been requested but fallen back). See
+[api-core.md](api-core.md#requested-vs-active-backend).
 
 ### `BT.effectRemove(effect: Effect): void`
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -36,8 +36,9 @@ and `vi` for browser API stubs. Tests that need a full DOM (Bootstrap, Bootstrap
 - **PrimitivePipeline** - vertex buffer math, line algorithm (Node + GPU mocks)
 - **SpritePipeline** - texture batching, UV coordinates (Node + GPU mocks)
 - **WebGPUContext** - initialization with mock adapter/device (Node + GPU mocks)
-- **BTAPI** - singleton coordinator; includes software-mode init, `?backend=software` URL override, `captureFrame()` in
-  software mode, and stats overlay render path (Node + GPU mocks + 2D canvas mocks)
+- **BTAPI** - singleton coordinator; includes software-mode init, `?backend=software` URL override,
+  `BT.requestedBackend` vs `BT.activeBackend` after WebGPU fallback, `captureFrame()` in software mode, and stats
+  overlay render path (Node + GPU mocks + 2D canvas mocks)
 - **StatsOverlay** - layout helpers, demo label parsing, right-aligned text X, toggle hit-testing, `updateAndRender` bar
   layout (Node)
 - **FrameCapture** - GPU readback, PNG conversion (Node + GPU mocks + browser stubs)
@@ -66,8 +67,8 @@ documented in [Performance Testing](performance-testing.md).
 Public types are rolled up during `pnpm run build` via `vite-plugin-dts` and API Extractor. The workspace pins
 TypeScript to the same version API Extractor bundles (see `docs/developer-experience-guide.md`).
 
-- **`pnpm run test:declarations`** - Node test runner for `scripts/check-declaration-tooling.mjs` (drift patterns and
-  alignment log parsing). Included in `pnpm run preflight`.
+- **`pnpm run test:declarations`** - Node test runner for `scripts/check-declaration-tooling.mjs` (drift patterns,
+  required `BT` getters in rolled-up `.d.ts`, and alignment log parsing). Included in `pnpm run preflight`.
 - **CI** - after `pnpm run build`, `node scripts/check-declaration-tooling.mjs build.log` runs in both
   `.github/workflows/ci.yml` (build-library job) and `.github/workflows/pr-checks.yml` (bundle-size job) to fail on
   drift warnings and version mismatch.

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -10,7 +10,8 @@ by `vite-plugin-dts` when `rollupTypes: true`). This avoids TS/API Extractor dri
 keeps rolled-up `dist/blit-tech.d.ts` deterministic.
 
 When bumping `typescript` or `vite-plugin-dts`, confirm the build log reports the same bundled version and that
-`node scripts/check-declaration-tooling.mjs build.log` passes. See
+`node scripts/check-declaration-tooling.mjs build.log` passes (log alignment plus required `BT` getters in
+`dist/blit-tech.d.ts`, including `requestedBackend` and `activeBackend`). See
 [Declaration tooling](developer-experience-guide.md#declaration-tooling-typescript--api-extractor) in the DX guide for
 CI details.
 

--- a/scripts/check-declaration-tooling.mjs
+++ b/scripts/check-declaration-tooling.mjs
@@ -85,6 +85,51 @@ export function findAlignmentFailures(logText, expectedVersion) {
     return failures;
 }
 
+/** Opening forms for the rolled-up `BT` object type in `dist/blit-tech.d.ts`. */
+const BT_DECLARATION_OPENERS = [
+    /(?:export\s+)?declare\s+const\s+BT\s*:\s*\{/,
+    /(?:export\s+)?declare\s+namespace\s+BT\s*\{/,
+    /(?:export\s+)?declare\s+interface\s+BT\s*\{/,
+    /(?:export\s+)?type\s+BT\s*=\s*\{/,
+    /\binterface\s+BT\s*\{/,
+];
+
+/**
+ * Extracts the `{ ... }` body of the public `BT` declaration from rolled-up `.d.ts` text.
+ *
+ * @param {string} dtsText Contents of `dist/blit-tech.d.ts`.
+ * @returns {string | null} Balanced brace block for `BT`, or null when not found.
+ */
+export function extractBtDeclarationBlock(dtsText) {
+    for (const opener of BT_DECLARATION_OPENERS) {
+        const match = opener.exec(dtsText);
+        if (!match) {
+            continue;
+        }
+
+        const openBrace = dtsText.indexOf('{', match.index);
+        if (openBrace < 0) {
+            continue;
+        }
+
+        const body = dtsText.slice(openBrace);
+        let depth = 0;
+        for (let i = 0; i < body.length; i++) {
+            const char = body.charAt(i);
+            if (char === '{') {
+                depth++;
+            } else if (char === '}') {
+                depth--;
+                if (depth === 0) {
+                    return body.slice(0, i + 1);
+                }
+            }
+        }
+    }
+
+    return null;
+}
+
 /**
  * Verifies rolled-up declarations export required `BT` facade members.
  *
@@ -93,11 +138,18 @@ export function findAlignmentFailures(logText, expectedVersion) {
  * @returns {string[]} Human-readable failure messages (empty when all members are found).
  */
 export function findMissingBtDeclarationMembers(dtsText, requiredMembers = REQUIRED_BT_DECLARATION_MEMBERS) {
+    const btBlock = extractBtDeclarationBlock(dtsText);
+    if (!btBlock) {
+        return requiredMembers.map(
+            (member) => `dist/blit-tech.d.ts is missing BT declaration block (cannot verify getter: ${member})`,
+        );
+    }
+
     const failures = [];
 
     for (const member of requiredMembers) {
         const pattern = new RegExp(`\\breadonly\\s+${member}\\s*:`, 'm');
-        if (!pattern.test(dtsText)) {
+        if (!pattern.test(btBlock)) {
             failures.push(`dist/blit-tech.d.ts is missing BT getter: ${member}`);
         }
     }

--- a/scripts/check-declaration-tooling.mjs
+++ b/scripts/check-declaration-tooling.mjs
@@ -6,6 +6,12 @@ const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..
 const PACKAGE_JSON_PATH = path.join(REPO_ROOT, 'package.json');
 const DECLARATION_OUTPUT = path.join(REPO_ROOT, 'dist', 'blit-tech.d.ts');
 
+/**
+ * Public `BT` getters that must appear in rolled-up `dist/blit-tech.d.ts`.
+ * Add entries here when shipping new configure/runtime getters on the facade.
+ */
+export const REQUIRED_BT_DECLARATION_MEMBERS = ['requestedBackend', 'activeBackend'];
+
 /** Substrings that indicate TS/API Extractor compiler drift during declaration rollup. */
 export const DRIFT_WARNING_PATTERNS = [
     /incompatible versions/i,
@@ -80,6 +86,26 @@ export function findAlignmentFailures(logText, expectedVersion) {
 }
 
 /**
+ * Verifies rolled-up declarations export required `BT` facade members.
+ *
+ * @param {string} dtsText Contents of `dist/blit-tech.d.ts`.
+ * @param {readonly string[]} [requiredMembers] Getter names that must be present.
+ * @returns {string[]} Human-readable failure messages (empty when all members are found).
+ */
+export function findMissingBtDeclarationMembers(dtsText, requiredMembers = REQUIRED_BT_DECLARATION_MEMBERS) {
+    const failures = [];
+
+    for (const member of requiredMembers) {
+        const pattern = new RegExp(`\\breadonly\\s+${member}\\s*:`, 'm');
+        if (!pattern.test(dtsText)) {
+            failures.push(`dist/blit-tech.d.ts is missing BT getter: ${member}`);
+        }
+    }
+
+    return failures;
+}
+
+/**
  * Validates declaration build output and log alignment.
  *
  * @param {string} logText Full stdout/stderr from `pnpm build`.
@@ -93,6 +119,9 @@ export function validateDeclarationTooling(logText, options = {}) {
 
     if (requireOutputFile && !fs.existsSync(DECLARATION_OUTPUT)) {
         failures.push(`Missing rolled-up declaration output: ${path.relative(REPO_ROOT, DECLARATION_OUTPUT)}`);
+    } else if (requireOutputFile) {
+        const dtsText = fs.readFileSync(DECLARATION_OUTPUT, 'utf8');
+        failures.push(...findMissingBtDeclarationMembers(dtsText));
     }
 
     return failures;

--- a/scripts/check-declaration-tooling.test.mjs
+++ b/scripts/check-declaration-tooling.test.mjs
@@ -3,9 +3,11 @@ import { describe, it } from 'node:test';
 
 import {
     DRIFT_WARNING_PATTERNS,
+    extractBtDeclarationBlock,
     findAlignmentFailures,
     findDriftWarnings,
     findMissingBtDeclarationMembers,
+    REQUIRED_BT_DECLARATION_MEMBERS,
     validateDeclarationTooling,
 } from './check-declaration-tooling.mjs';
 
@@ -61,5 +63,20 @@ describe('check-declaration-tooling', () => {
             '}',
         ].join('\n');
         assert.deepEqual(findMissingBtDeclarationMembers(dts), []);
+    });
+
+    it('findMissingBtDeclarationMembers ignores similarly named members outside BT', () => {
+        const dts = [
+            'interface Other { readonly requestedBackend: string; readonly activeBackend: string; }',
+            'export declare const BT: { readonly ticks: number; };',
+        ].join('\n');
+        const failures = findMissingBtDeclarationMembers(dts);
+        assert.equal(failures.length, REQUIRED_BT_DECLARATION_MEMBERS.length);
+        assert.ok(failures.every((message) => message.includes('missing BT getter')));
+    });
+
+    it('extractBtDeclarationBlock reads export declare const BT object type', () => {
+        const dts = 'export declare const BT: { readonly ticks: number; };';
+        assert.equal(extractBtDeclarationBlock(dts), '{ readonly ticks: number; }');
     });
 });

--- a/scripts/check-declaration-tooling.test.mjs
+++ b/scripts/check-declaration-tooling.test.mjs
@@ -5,6 +5,7 @@ import {
     DRIFT_WARNING_PATTERNS,
     findAlignmentFailures,
     findDriftWarnings,
+    findMissingBtDeclarationMembers,
     validateDeclarationTooling,
 } from './check-declaration-tooling.mjs';
 
@@ -43,5 +44,22 @@ describe('check-declaration-tooling', () => {
         const log = 'Analysis will use the bundled TypeScript version 5.9.3';
         const failures = validateDeclarationTooling(log, { requireOutputFile: false });
         assert.deepEqual(failures, []);
+    });
+
+    it('findMissingBtDeclarationMembers fails when requestedBackend is absent', () => {
+        const dts = 'declare namespace BT { readonly activeBackend: Backend | null; }';
+        const failures = findMissingBtDeclarationMembers(dts);
+        assert.equal(failures.length, 1);
+        assert.match(failures[0], /requestedBackend/);
+    });
+
+    it('findMissingBtDeclarationMembers passes when required getters are present', () => {
+        const dts = [
+            'declare namespace BT {',
+            '  readonly requestedBackend: Backend | null;',
+            '  readonly activeBackend: Backend | null;',
+            '}',
+        ].join('\n');
+        assert.deepEqual(findMissingBtDeclarationMembers(dts), []);
     });
 });

--- a/src/BlitTech.test.ts
+++ b/src/BlitTech.test.ts
@@ -9,7 +9,7 @@
  * suppression behavior used by facade helpers.
  */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
 
 import type { BitmapFont, HardwareSettings } from './BlitTech';
 import { BT, Palette, Rect2i, SpriteSheet, Vector2i } from './BlitTech';
@@ -1434,6 +1434,41 @@ describe('BT.effectAdd / BT.effectRemove / BT.effectClear', () => {
             const text = document.getElementById(DEFAULT_CONTAINER_ID)?.textContent ?? '';
             expect(text).toContain("doesn't support fullscreen effects");
         });
+    });
+});
+
+// #endregion
+
+// #region BT.requestedBackend
+
+describe('BT.requestedBackend', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('is typed as Backend | null on the public facade', () => {
+        expectTypeOf(BT.requestedBackend).toEqualTypeOf<'webgpu' | 'software' | null>();
+    });
+
+    it('delegates to BTAPI.instance.getRequestedBackend', () => {
+        const spy = vi.spyOn(BTAPI.instance, 'getRequestedBackend').mockReturnValue('software');
+
+        const result = BT.requestedBackend;
+
+        expect(spy).toHaveBeenCalled();
+        expect(result).toBe('software');
+    });
+
+    it('returns null before initialization', () => {
+        vi.spyOn(BTAPI.instance, 'getRequestedBackend').mockReturnValue(null);
+
+        expect(BT.requestedBackend).toBeNull();
+    });
+
+    it('returns webgpu when BTAPI reports webgpu requested', () => {
+        vi.spyOn(BTAPI.instance, 'getRequestedBackend').mockReturnValue('webgpu');
+
+        expect(BT.requestedBackend).toBe('webgpu');
     });
 });
 

--- a/src/BlitTech.ts
+++ b/src/BlitTech.ts
@@ -466,6 +466,19 @@ export const BT = {
     },
 
     /**
+     * Backend requested for initialization (`configure().backend` after merge).
+     *
+     * Includes `?backend=software` URL overrides applied before the renderer starts.
+     * Defaults to `'webgpu'` when `backend` is omitted. Does **not** change when WebGPU
+     * falls back to software; use {@link BT.activeBackend} for the backend that actually started.
+     *
+     * @returns `'webgpu'` or `'software'` once hardware settings are loaded; `null` before `BT.init()`.
+     */
+    get requestedBackend(): Backend | null {
+        return BTAPI.instance.getRequestedBackend();
+    },
+
+    /**
      * Fixed-step seconds per update tick.
      *
      * Equivalent to `1 / BT.targetFPS` when `BT.targetFPS` is finite and positive.
@@ -511,8 +524,15 @@ export const BT = {
      * Rendering backend that is currently active.
      *
      * `'webgpu'` or `'software'` after successful init; `null` before init or on failure.
-     * Useful when adjusting demo behavior - for example, skipping post-process effects
-     * that only work under WebGPU.
+     * May differ from {@link BT.requestedBackend} when WebGPU was requested but unavailable
+     * (automatic software fallback). Use this getter for runtime behavior - for example,
+     * skipping post-process effects that only work under WebGPU:
+     *
+     * ```ts
+     * if (BT.activeBackend === 'webgpu') {
+     *   BT.effectAdd(crtStack);
+     * }
+     * ```
      *
      * @returns `'webgpu'` or `'software'` after successful init; `null` before init or on failure.
      */

--- a/src/BlitTech.ts
+++ b/src/BlitTech.ts
@@ -530,7 +530,9 @@ export const BT = {
      *
      * ```ts
      * if (BT.activeBackend === 'webgpu') {
-     *   BT.effectAdd(crtStack);
+     *   for (const fx of BT.preset.crtPipBoy()) {
+     *     BT.effectAdd(fx);
+     *   }
      * }
      * ```
      *

--- a/src/core/BTAPI.test.ts
+++ b/src/core/BTAPI.test.ts
@@ -27,6 +27,7 @@ import {
 import type { BitmapFont } from '../assets/BitmapFont';
 import { Palette } from '../assets/Palette';
 import type { SpriteSheet } from '../assets/SpriteSheet';
+import { BT } from '../BlitTech';
 import type { Effect } from '../render/effects/Effect';
 import { StatsOverlay } from '../render/StatsOverlay';
 import { Rect2i } from '../utils/Rect2i';
@@ -646,6 +647,8 @@ describe('BTAPI', () => {
 
             expect(result).toBe(true);
             expect(BTAPI.instance.getHardwareSettings()?.backend).toBe('software');
+            expect(BTAPI.instance.getRequestedBackend()).toBe('software');
+            expect(BTAPI.instance.getActiveBackend()).toBe('software');
             expect(BTAPI.instance.getDevice()).toBeNull();
         });
 
@@ -667,6 +670,7 @@ describe('BTAPI', () => {
 
             expect(result).toBe(true);
             expect(BTAPI.instance.getHardwareSettings()?.backend).toBe('webgpu');
+            expect(BTAPI.instance.getRequestedBackend()).toBe('webgpu');
             expect(BTAPI.instance.getDevice()).not.toBeNull();
         });
 
@@ -1011,6 +1015,7 @@ describe('BTAPI', () => {
             expect(BTAPI.instance.getDevice()).toBeNull();
             expect(BTAPI.instance.getContext()).toBeNull();
             expect(BTAPI.instance.getRenderer()).not.toBeNull();
+            expect(BTAPI.instance.getRequestedBackend()).toBe('webgpu');
             expect(BTAPI.instance.getActiveBackend()).toBe('software');
         });
 
@@ -1018,11 +1023,79 @@ describe('BTAPI', () => {
             const result = await BTAPI.instance.init(makeMockDemo(), makeMockCanvas());
 
             expect(result).toBe(true);
+            expect(BTAPI.instance.getRequestedBackend()).toBe('webgpu');
             expect(BTAPI.instance.getActiveBackend()).toBe('webgpu');
         });
 
-        it('reports null active backend before init', () => {
+        it('reports null requested and active backends before init', () => {
+            expect(BTAPI.instance.getRequestedBackend()).toBeNull();
             expect(BTAPI.instance.getActiveBackend()).toBeNull();
+        });
+
+        it('exposes requested and active backends on BT after URL override', async () => {
+            vi.stubGlobal('location', { search: '?backend=software' });
+            vi.stubGlobal(
+                'OffscreenCanvas',
+                class MockOffscreenCanvas {
+                    constructor(
+                        public width: number,
+                        public height: number,
+                    ) {}
+                    getContext(contextType?: string): OffscreenCanvas2DMock | null {
+                        return contextType === '2d' ? makeOffscreenCanvas2dContext() : null;
+                    }
+                },
+            );
+            uninstallMockNavigatorGPU();
+
+            const demo: IBlitTechDemo = {
+                configure: () => ({
+                    displaySize: new Vector2i(320, 240),
+                    targetFPS: 60,
+                    backend: 'webgpu',
+                }),
+                init: vi.fn().mockResolvedValue(true),
+                update: vi.fn(),
+                render: vi.fn(),
+            };
+
+            const result = await BT.init(demo, makeMock2DCanvas());
+
+            expect(result).toBe(true);
+            expect(BT.requestedBackend).toBe('software');
+            expect(BT.activeBackend).toBe('software');
+        });
+
+        it('keeps BT.requestedBackend webgpu when BT.activeBackend is software after fallback', async () => {
+            uninstallMockNavigatorGPU();
+            vi.stubGlobal(
+                'OffscreenCanvas',
+                class MockOffscreenCanvas {
+                    constructor(
+                        public width: number,
+                        public height: number,
+                    ) {}
+                    getContext(contextType?: string): OffscreenCanvas2DMock | null {
+                        return contextType === '2d' ? makeOffscreenCanvas2dContext() : null;
+                    }
+                },
+            );
+
+            const demo: IBlitTechDemo = {
+                configure: () => ({
+                    displaySize: new Vector2i(320, 240),
+                    targetFPS: 60,
+                }),
+                init: vi.fn().mockResolvedValue(true),
+                update: vi.fn(),
+                render: vi.fn(),
+            };
+
+            const result = await BT.init(demo, makeMock2DCanvas());
+
+            expect(result).toBe(true);
+            expect(BT.requestedBackend).toBe('webgpu');
+            expect(BT.activeBackend).toBe('software');
         });
     });
 

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -453,6 +453,23 @@ export class BTAPI {
     }
 
     /**
+     * Returns the rendering backend requested for initialization.
+     *
+     * Mirrors resolved {@link HardwareSettings.backend} after `configure()` merge and
+     * any `?backend=software` URL override. Defaults to `'webgpu'` when omitted.
+     * Does not reflect WebGPU-to-software fallback; use {@link getActiveBackend} for that.
+     *
+     * @returns `'webgpu'` or `'software'` once hardware settings are loaded; `null` before that.
+     */
+    public getRequestedBackend(): Backend | null {
+        if (!this.hwSettings) {
+            return null;
+        }
+
+        return this.hwSettings.backend ?? 'webgpu';
+    }
+
+    /**
      * Returns the rendering backend that was actually initialized.
      *
      * @returns `'webgpu'` or `'software'` after successful init; `null` before init or on failure.


### PR DESCRIPTION
Expose resolved init backend on BT (configure merge plus ?backend=software) alongside activeBackend after fallback. Document requested-vs-active patterns for post-process gating and extend declaration tooling to require both getters in dist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes Summary

This pull request adds a new BT.requestedBackend getter to expose the resolved initialization backend (after configure() merge and URL overrides) and clarifies the distinction between the requested init backend and the active runtime backend (which may differ after fallback).

## API Changes

- New getter: BT.requestedBackend: Backend | null — returns the backend requested during initialization (reflects configure() merge and ?backend=software). Returns null before initialization and does not change if runtime fallback (e.g. WebGPU→software) occurs.
- New BTAPI.getRequestedBackend(): Backend | null — implementation backing the facade getter.
- Updated JSDoc for BT.activeBackend to emphasize it reflects the backend that actually started (post-fallback) and to contrast its semantics with requestedBackend.

## Documentation Updates

- docs/api-core.md: added BT.requestedBackend to initialization getters; new "Requested vs active backend" section with examples showing configure()/URL overrides, WebGPU→software fallback behavior, and guidance recommending activeBackend for runtime feature gating.
- docs/developer-experience-guide.md: added requestedBackend to naming guidance and clarified activeBackend for runtime checks.
- docs/post-process-effects.md: clarified BT.effectAdd should guard on BT.activeBackend === 'webgpu' (not requestedBackend).
- docs/testing.md: expanded Tier 2 integration testing guidance to include software-mode initialization, ?backend=software behavior, and requested-vs-active backend cases; updated declaration-tooling test coverage notes.
- docs/tooling.md and .cursor/rules/bt-api-getters.mdc / CLAUDE.md: updated rules and wording to reflect the new getter and semantics.

## Tests

- src/BlitTech.test.ts: added tests for BT.requestedBackend (facade type, delegation to BTAPI, null before init, 'webgpu' when requested).
- src/core/BTAPI.test.ts: extended tests to assert requested vs active backend reporting across success, fallback, null-before-init, and URL-override scenarios.

## Tooling

- scripts/check-declaration-tooling.mjs:
  - Added REQUIRED_BT_DECLARATION_MEMBERS including requestedBackend and activeBackend.
  - Added extractBtDeclarationBlock and findMissingBtDeclarationMembers to extract the BT declaration block from the rolled-up d.ts and verify required readonly members exist.
  - validateDeclarationTooling now reads dist/blit-tech.d.ts (when present) and reports missing BT-member failures alongside existing checks.
- scripts/check-declaration-tooling.test.mjs: unit tests added to cover extraction and missing-member detection, ensuring similarly named members outside the BT block do not satisfy the checks.

## Code Changes

- src/BlitTech.ts: added requestedBackend getter (Backend | null) and updated activeBackend JSDoc/examples. No runtime behavior changes beyond the new accessor.
- src/core/BTAPI.ts: added getRequestedBackend() method.

## Other

- Minor docs/examples corrections (effectAdd examples) and tightening of declaration-checking scope so only the BT block is validated.

Estimated review effort: Medium (docs, tests, tooling, and small API additions).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/178?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->