### PR TITLE
docs(api): unify palette slot, index, and offset terminology

### DIFF
--- a/docs/api-assets.md
+++ b/docs/api-assets.md
@@ -109,8 +109,9 @@ const sheet = SpriteSheet.fromIndexedPixels(width, height, indexedPixels);
 
 ## Palette Offset
 
-Pass a `paletteOffset` to `BT.drawSprite()` to shift the entire sprite's color range by N slots. Useful for team-color
-variations and damage flashes. Full semantics in [API: Rendering](api-rendering.md).
+Pass a **`paletteOffset`** (per-draw shift, not an absolute slot) to `BT.drawSprite()` and `BT.printFont()` to remap
+stored texel indices before palette lookup. Useful for team-color variations and damage flashes. Terminology and
+examples: [Palette addressing](api-palette.md#palette-addressing). Draw semantics: [API: Rendering](api-rendering.md).
 
 ```ts
 BT.drawSprite(sheet, srcRect, pos, 16); // render in "blue team" color range

--- a/docs/api-palette.md
+++ b/docs/api-palette.md
@@ -33,14 +33,16 @@ BT.systemPrint(pos, 3, 'Score'); // glyphs use absolute slot 3
 ### Per-draw offset (`paletteOffset`)
 
 Indexed sprites and bitmap fonts store small indices in the texture (starting at `1`; stored `0` is transparent). At
-draw time the engine computes `effectiveIndex = storedIndex + paletteOffset` and looks up `palette[effectiveIndex]`.
+draw time the WebGPU sprite shader computes `combined = storedIndex + paletteOffset`, then `index = min(combined, 255u)`
+before palette lookup.
 
 ```ts
 BT.drawSprite(sheet, src, pos, 0); // stored 1 → palette[1], stored 2 → palette[2]
 BT.drawSprite(sheet, src, pos, 16); // stored 1 → palette[17], stored 2 → palette[18]
 ```
 
-Use offsets for team colors, tints, and variants without duplicating art. Out-of-range results render as opaque black.
+Use offsets for team colors, tints, and variants without duplicating art. When `combined` exceeds `255`, lookup uses
+palette slot `255` from the clamp, not an inherent error color.
 
 ### Active palette: `BT.paletteSet()` vs `BT.palette`
 

--- a/docs/api-palette.md
+++ b/docs/api-palette.md
@@ -7,6 +7,56 @@ active palette with `BT.paletteSet()` before any draw calls. Valid sizes: `2, 4,
 
 ---
 
+## Palette Addressing
+
+A palette is a fixed-size table of color **slots** (positions `0` through `size - 1`). Docs and APIs use three related
+terms; they are not interchangeable.
+
+| Term                | Role                                                                  | Typical APIs                                            |
+| ------------------- | --------------------------------------------------------------------- | ------------------------------------------------------- |
+| **slot**            | Prose name for a position in the palette table                        | `palette.set()`, `palette.get()`, `applyHUD()`, effects |
+| **`paletteIndex`**  | **Absolute** slot number written to the framebuffer                   | `BT.clear`, primitives, `BT.systemPrint`                |
+| **`paletteOffset`** | **Per-draw shift** added to each **stored** texel index before lookup | `BT.drawSprite`, `BT.printFont`                         |
+
+**Slot** and **`paletteIndex`** mean the same integer: which entry in the active palette a pixel uses. Parameter names
+use `paletteIndex` on draw calls; guides may say "slot" when reserving ranges or editing colors with `palette.set()`.
+
+### Absolute index (`paletteIndex`)
+
+The draw call picks the slot directly. Slot `0` stays transparent (not drawn).
+
+```ts
+BT.drawRectFill(rect, 6); // every pixel uses palette slot 6 (absolute)
+BT.systemPrint(pos, 3, 'Score'); // glyphs use absolute slot 3
+```
+
+### Per-draw offset (`paletteOffset`)
+
+Indexed sprites and bitmap fonts store small indices in the texture (starting at `1`; stored `0` is transparent). At
+draw time the engine computes `effectiveIndex = storedIndex + paletteOffset` and looks up `palette[effectiveIndex]`.
+
+```ts
+BT.drawSprite(sheet, src, pos, 0); // stored 1 → palette[1], stored 2 → palette[2]
+BT.drawSprite(sheet, src, pos, 16); // stored 1 → palette[17], stored 2 → palette[18]
+```
+
+Use offsets for team colors, tints, and variants without duplicating art. Out-of-range results render as opaque black.
+
+### Active palette: `BT.paletteSet()` vs `BT.palette`
+
+| Action                                                         | Use                                                                             |
+| -------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| First activation or swap to a **different** `Palette` instance | `BT.paletteSet(palette)`                                                        |
+| Edit colors on the **current** active palette                  | `BT.palette.set(slot, color)` — live reference, no second `paletteSet()` needed |
+| Read the active palette                                        | `BT.palette` (throws if none set)                                               |
+
+`BT.palette` returns the same object the engine draws with. Mutating slots updates colors on the next frame. Call
+`BT.paletteSet()` again only when replacing the whole palette object (for example a prebuilt day vs night palette), or
+after a **layout swap** when colors moved to different slot numbers (then also call `BT.spritesRefresh()`). See
+[Palette Guide](palette-guide.md) section 6.
+
+---
+
 ## Palette Setup
 
 ```ts
@@ -14,8 +64,8 @@ active palette with `BT.paletteSet()` before any draw calls. Valid sizes: `2, 4,
 const palette = new Palette(256);
 const palette = BT.paletteCreate(256); // equivalent BT-namespace shorthand
 
-// Set and get colors
-palette.set(1, new Color32(255, 0, 0, 255)); // red at slot 1
+// Set and get colors (slot = absolute palette index; see Palette addressing above)
+palette.set(1, new Color32(255, 0, 0, 255)); // red at absolute slot 1
 palette.get(1); // → Color32 (defensive copy)
 palette.getRef(1); // → Color32 (live reference - do not store)
 
@@ -161,11 +211,11 @@ Effects that auto-remove (fade, flash) clean up when their duration elapses. `pa
 
 ## See Also
 
-| Guide                                 | What it covers                             |
-| ------------------------------------- | ------------------------------------------ |
-| [API: Core](api-core.md)              | bootstrap, init, game loop, core types     |
-| [API: Rendering](api-rendering.md)    | primitives, sprites, text, post-process    |
-| [API: Assets](api-assets.md)          | sprite sheets, bitmap fonts, asset loading |
-| [Palette Guide](palette-guide.md)     | end-to-end palette workflow and best usage |
-| [Palette Presets](palette-presets.md) | exact built-in palette and HUD color data  |
-| [Testing](testing.md)                 | test tiers and palette testing patterns    |
+| Guide                                 | What it covers                                   |
+| ------------------------------------- | ------------------------------------------------ |
+| [API: Core](api-core.md)              | bootstrap, init, game loop, core types           |
+| [API: Rendering](api-rendering.md)    | primitives, sprites, text, post-process          |
+| [API: Assets](api-assets.md)          | sprite sheets, bitmap fonts, asset loading       |
+| [Palette Guide](palette-guide.md)     | end-to-end workflow; links to Palette addressing |
+| [Palette Presets](palette-presets.md) | exact built-in palette and HUD color data        |
+| [Testing](testing.md)                 | test tiers and palette testing patterns          |

--- a/docs/api-rendering.md
+++ b/docs/api-rendering.md
@@ -45,8 +45,10 @@ BT.drawSprite(sheet, srcRect, destPos, paletteOffset);
 
 **Palette offset semantics:** Stored sprite indices start at `1` (index `0` is always transparent and discarded). With
 `paletteOffset = N`, a pixel stored at index `1` renders as `palette[1 + N]`, a pixel at index `2` renders as
-`palette[2 + N]`, and so on. Use this for palette-swap effects such as team colors or damage flashes. Out-of-range
-results render as opaque black; negative values wrap to a large unsigned integer and also produce black.
+`palette[2 + N]`, and so on. Use this for palette-swap effects such as team colors or damage flashes. The WebGPU sprite
+shader clamps with `index = min(combined, 255u)` where `combined = storedIndex + paletteOffset`, so oversized sums map
+to palette slot `255`. The `paletteOffset` argument must be a non-negative integer below the active palette size;
+otherwise the draw throws.
 
 ```ts
 BT.drawSprite(sheet, srcRect, new Vector2i(10, 10)); // normal

--- a/docs/api-rendering.md
+++ b/docs/api-rendering.md
@@ -5,6 +5,10 @@ Primitives, sprites, text, post-process effects, and frame capture.
 All draw calls require a palette to be active (`BT.paletteSet(palette)` before the first `BT.drawSprite`,
 `BT.drawRectFill`, etc.). All coordinates are integer pixels - use `Vector2i` and `Rect2i`, never floats.
 
+**Palette addressing:** primitives and `BT.systemPrint` use an absolute **`paletteIndex`**. Sprites and `BT.printFont`
+use an optional **`paletteOffset`** added to stored texel indices. See
+[Palette addressing](api-palette.md#palette-addressing).
+
 ---
 
 ## Primitives

--- a/docs/palette-guide.md
+++ b/docs/palette-guide.md
@@ -6,6 +6,9 @@ Blit-Tech is palette-first: every visible pixel stores a palette slot index, and
 This guide covers the end-to-end workflow: setup, indexed sprites, palette offsets, runtime effects, and when to call
 `BT.spritesRefresh()`.
 
+For terminology (**slot** vs **`paletteIndex`** vs **`paletteOffset`**) and when to call `BT.paletteSet()` vs mutating
+`BT.palette`, see [Palette addressing](api-palette.md#palette-addressing) in the API palette reference.
+
 ---
 
 ## 1) Create and activate a palette
@@ -22,21 +25,24 @@ Key rules:
 
 - Slot `0` is always transparent.
 - Valid sizes are `2, 4, 16, 32, 64, 128, 256`.
-- `BT.paletteSet()` makes one palette active for all drawing.
+- `BT.paletteSet()` activates a palette before the first draw (or when swapping to another `Palette` instance).
+- After activation, edit colors with `BT.palette.set(...)`; you do not need to call `paletteSet()` again for value-only
+  changes (see [Palette addressing](api-palette.md#palette-addressing)).
 
 ---
 
-## 2) Draw using palette indices
+## 2) Draw using absolute palette indices
 
-Draw calls accept numeric palette slots, not direct RGBA values:
+Primitive and clear APIs take an absolute **`paletteIndex`** (the exact slot written to the framebuffer), not direct
+RGBA values. See [Palette addressing](api-palette.md#palette-addressing).
 
 ```ts
-BT.clear(1);
-BT.drawRectFill(rect, 6);
-BT.drawLine(start, end, 12);
+BT.clear(1); // absolute paletteIndex 1
+BT.drawRectFill(rect, 6); // absolute paletteIndex 6
+BT.drawLine(start, end, 12); // absolute paletteIndex 12
 ```
 
-When slot `6` changes in the active palette, every pixel drawn with slot `6` changes automatically.
+When slot `6` changes in the active palette, every pixel drawn with absolute index `6` changes automatically.
 
 ---
 
@@ -74,9 +80,10 @@ BT.paletteSet(palette);
 
 ---
 
-## 4) Palette offsets (zero-cost color variants)
+## 4) Per-draw palette offsets (zero-cost color variants)
 
-`BT.drawSprite(..., paletteOffset)` shifts every stored sprite index before lookup:
+`BT.drawSprite(..., paletteOffset)` adds a shift to each **stored** sprite index before lookup (not an absolute slot).
+See [Palette addressing](api-palette.md#palette-addressing).
 
 ```ts
 BT.drawSprite(heroSheet, heroSrc, leftTeamPos, 0); // base range


### PR DESCRIPTION
Add a Palette addressing section to api-palette.md defining slot (prose), paletteIndex (absolute draw index), and paletteOffset (per-draw shift on stored texels), with minimal examples and BT.paletteSet vs BT.palette guidance. Cross-link from palette-guide, api-rendering, and api-assets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR unifies terminology and clarifies palette addressing semantics across the API documentation. The main changes establish three distinct concepts:

1. **slot** - a prose-level concept for palette positions
2. **paletteIndex** - the absolute framebuffer index used by primitives and `BT.systemPrint`
3. **paletteOffset** - a per-draw shift applied to stored texel indices in `BT.drawSprite()` and `BT.printFont()`

**Core documentation changes:**

In `api-palette.md` (+60/-10), the "Palette Addressing" section is expanded to define each term with behavioral descriptions and examples. The section clarifies how stored indices are translated at draw time and what happens for out-of-range results. The "Palette Setup" description is updated to align terminology with the clarified definitions.

In `palette-guide.md` (+16/-9), the guide now explicitly distinguishes when to call `BT.paletteSet()` versus mutating `BT.palette`. The "Draw" section emphasizes that primitives and clear APIs take absolute `paletteIndex` values, while the palette offset section reframes `BT.drawSprite(..., paletteOffset)` as a per-draw shift of stored indices, introducing a "zero-cost color variants" framing.

In `api-rendering.md` (+4/-0), a new "Palette addressing" note clarifies the difference in palette index usage between primitives (absolute `paletteIndex`) and sprites (optional `paletteOffset` added to stored texel indices), with a cross-link to the detailed section in api-palette.

In `api-assets.md` (+3/-2), the "Palette Offset" documentation is updated to clarify that `paletteOffset` is a per-draw shift applied to both `BT.drawSprite()` and `BT.printFont()`, with examples linking to the new "Palette addressing" section.

All changes are documentation-only with cross-links established between the affected files to support unified terminology.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/179?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->