### PR TITLE
fix(renderer): tighten stats overlay bar layout metrics

### DIFF
--- a/docs/api-assets.md
+++ b/docs/api-assets.md
@@ -148,9 +148,10 @@ BT.systemPrint(new Vector2i(10, 10), paletteIndex, 'Score: 100');
 BT.systemPrintMeasure('Score: 100'); // → Vector2i (pixel width, height)
 ```
 
-Use `BT.systemPrint()` for demo-specific HUD panels and labels. The engine draws a default stats overlay (render FPS,
-target FPS, backend, resolution, demo title) after each `render()` when `statsOverlayEnabled` is true; see
-[API: Core - Stats overlay](api-core.md#stats-overlay). For styled variable-width text, use a bitmap font instead.
+Use `BT.systemPrint()` for demo-specific HUD panels and labels. The engine draws a default stats overlay (present FPS,
+target FPS, draw calls, frame/update()/render() timings, backend, resolution, demo title) after each `render()` when
+`statsOverlayEnabled` is true; see [API: Core - Stats overlay](api-core.md#stats-overlay). For styled variable-width
+text, use a bitmap font instead.
 
 ---
 

--- a/docs/api-core.md
+++ b/docs/api-core.md
@@ -53,7 +53,7 @@ const ok = await BT.init(demo, canvas); // low-level init; prefer bootstrap()
 BT.displaySize; // Vector2i - configured logical resolution (clone per read)
 BT.canvasDisplaySize; // Vector2i | null - output buffer when set in configure()
 BT.outputSize; // Vector2i - effective drawing-buffer size (clone per read)
-BT.targetFPS; // number - fixed update() rate (simulation), not measured render FPS
+BT.targetFPS; // number - fixed update() rate (simulation), not measured present FPS
 BT.requestedBackend; // 'webgpu' | 'software' | null - resolved request (see below)
 BT.activeBackend; // 'webgpu' | 'software' | null - backend that actually started
 ```
@@ -145,12 +145,15 @@ When `statsOverlayEnabled` is `true` (default), the engine draws a screen-space 
 top of all demo content. Layout is computed once at init from `displaySize` and the system font metrics (no per-frame
 size queries).
 
-- **Top bar (left):** short demo title derived from `document.title` (registry pages titled `Blit-Tech Demo NNN - Topic`
-  show as `Topic Demo`); **top bar (right):** active backend and logical resolution (for example `webgpu | 320x240`)
-- **Bottom bar (left):** measured **render FPS** (`requestAnimationFrame` cadence) and configured **target FPS**
-  (`update()` rate); **bottom bar (right):** `[HIDE ~]` hint
+- **Top row 1 (left):** short demo title derived from `document.title` (registry pages titled
+  `Blit-Tech Demo NNN - Topic` show as `Topic Demo`); **top row 1 (right):** active backend and logical resolution (for
+  example `webgpu | 320x240`)
+- **Top row 2 (left):** `Present FPS: N | Target FPS: T | Draw Calls: C`
+- **Top row 3 (left):** `Frame: Xms | update(): Yms | render(): Zms` (shows `xN` on `update()` when multiple fixed
+  updates ran this frame)
+- **Bottom row (right):** `[~]` hint
 - **Custom rows (optional):** extra bars from `statsOverlayRows()` stacked above the bottom bar, **1 px** apart, each
-  with left text and optional right text (same 16 px bar style as the built-in rows)
+  with left text and optional right text (same 13 px bar style as the built-in rows)
 
 Demos may implement optional `statsOverlayRows()` on `IBlitTechDemo`. The engine calls it once per render frame after
 `render()` when the overlay is enabled and visible (not hidden with Backquote or the corner toggle). Return `undefined`
@@ -179,14 +182,15 @@ Overlay colors follow one path: use `statsOverlayStyle` when set, otherwise defa
 override globally in `configure()` with `statsOverlayStyle: { barPaletteIndex, textPaletteIndex }`, or per custom row on
 `StatsOverlayRow` (`barPaletteIndex`, `textPaletteIndex`).
 
-The overlay label `Render FPS: N` is **not** the same as `BT.targetFPS`: render FPS reflects how often `render()` runs
-(browser refresh rate); target FPS is how often `update()` runs (fixed timestep). Do not use overlay render FPS for
-simulation timing—use `BT.ticks`, `BT.deltaSeconds`, or `Timer` instead.
+The overlay label `Present FPS: N` is **not** the same as `BT.targetFPS`: present FPS reflects how often `render()` runs
+(browser refresh rate), while `Target` is the fixed `update()` rate. `Frame`, `update()`, and `render()` timings are
+smoothed CPU wall-time samples from `performance.now()`. `Draw Calls` counts demo-issued draw API calls during the
+rendered frame. Do not use present FPS for simulation timing—use `BT.ticks`, `BT.deltaSeconds`, or `Timer` instead.
 
-Demos should not duplicate FPS or page-title footer text; the overlay provides those. Reserve about **17 px** per custom
-overlay row above the bottom bar (16 px bar + 1 px gap). When drawing custom top or bottom HUD panels, leave about **15
-px** clear at each edge for the built-in overlay bars, or set `statsOverlayEnabled: false` for full-screen layouts (for
-example terminal-style demos).
+Demos should not duplicate engine stats text; the overlay provides it. Reserve about **14 px** per custom overlay row
+above the bottom bar (13 px bar + 1 px gap). When drawing custom top or bottom HUD panels, leave about **42 px** clear
+at the top (three built-in rows + gaps) and about **13 px** clear at the bottom for the built-in overlay bars, or set
+`statsOverlayEnabled: false` for full-screen layouts (for example terminal-style demos).
 
 ```ts
 configure() {
@@ -207,10 +211,10 @@ Blit-Tech runs two independent cadences:
 | Concept             | Where                                                      | Meaning                                                        |
 | ------------------- | ---------------------------------------------------------- | -------------------------------------------------------------- |
 | **Simulation rate** | `targetFPS`, `BT.targetFPS`, `BT.deltaSeconds`, `BT.ticks` | Fixed `update()` step; game logic and `Timer` use ticks        |
-| **Render rate**     | Stats overlay `Render FPS: N`                              | Measured `requestAnimationFrame` cadence; `render()` runs here |
+| **Render rate**     | Stats overlay `Present FPS: N`                             | Measured `requestAnimationFrame` cadence; `render()` runs here |
 
 `render()` may run more or fewer times per second than `update()` (for example 120 Hz display with `targetFPS: 60`). Use
-tick-based timing for gameplay; use overlay render FPS only to spot GPU or draw-call bottlenecks.
+tick-based timing for gameplay; use overlay present FPS only to spot GPU or draw-call bottlenecks.
 
 ```ts
 BT.deltaSeconds; // seconds per fixed tick (1 / BT.targetFPS)

--- a/docs/performance-best-practices.md
+++ b/docs/performance-best-practices.md
@@ -277,7 +277,7 @@ Don't guess what's slow - **measure it**. Use:
 - Chrome DevTools Performance tab
 - `console.time()` / `console.timeEnd()`
 - Simulation rate: `BT.targetFPS` and `BT.ticks`
-- Render rate: stats overlay `Render FPS: N` when `statsOverlayEnabled` is true (measured rAF cadence, not `targetFPS`)
+- Render rate: stats overlay `Present FPS: N` when `statsOverlayEnabled` is true (measured rAF cadence, not `targetFPS`)
 
 ### 3. Allocating in Hot Paths
 

--- a/src/core/BTAPI.test.ts
+++ b/src/core/BTAPI.test.ts
@@ -870,8 +870,17 @@ describe('BTAPI', () => {
             expect(overlaySpy).toHaveBeenCalled();
             const lastCall = overlaySpy.mock.calls.at(-1);
             const getCustomRows = lastCall?.[5] as (() => typeof customRows) | undefined;
+            const timing = lastCall?.[6] as
+                | { frameMs: number; updateMs: number; renderMs: number; updateSteps: number; drawCalls: number }
+                | undefined;
 
             expect(getCustomRows?.()).toBe(customRows);
+            expect(timing).toBeDefined();
+            expect(timing?.frameMs).toBeGreaterThanOrEqual(0);
+            expect(timing?.updateMs).toBeGreaterThanOrEqual(0);
+            expect(timing?.renderMs).toBeGreaterThanOrEqual(0);
+            expect(timing?.updateSteps).toBeGreaterThanOrEqual(0);
+            expect(timing?.drawCalls).toBeGreaterThanOrEqual(0);
         });
 
         it('calls gamepad.endFrame during render-phase input flush', async () => {

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -116,6 +116,30 @@ export class BTAPI {
     /** Built-in 6x14 system font for BT.systemPrint(). */
     private systemFont: BitmapFont | null = null;
 
+    /** Accumulated fixed-step update time for the frame currently being rendered. */
+    private pendingUpdateMs = 0;
+
+    /** Number of fixed-step updates accumulated for the current render frame. */
+    private pendingUpdateSteps = 0;
+
+    /** Number of demo draw API calls issued since the last rendered frame. */
+    private pendingDrawCalls = 0;
+
+    /** Reused timing snapshot passed into the stats overlay each frame. */
+    private readonly statsOverlayTiming: {
+        frameMs: number;
+        updateMs: number;
+        renderMs: number;
+        updateSteps: number;
+        drawCalls: number;
+    } = {
+        frameMs: 0,
+        updateMs: 0,
+        renderMs: 0,
+        updateSteps: 0,
+        drawCalls: 0,
+    };
+
     /** Pointer / mouse / touch input subsystem. Created during {@link init}. */
     private pointer: PointerInput | null = null;
 
@@ -223,13 +247,32 @@ export class BTAPI {
         const onFrameDrop: FrameDropCallback | undefined =
             hwSettings.detectDroppedFrames === true ? (event) => this.handleFrameDrop(event) : undefined;
 
+        this.pendingUpdateMs = 0;
+        this.pendingUpdateSteps = 0;
+        this.pendingDrawCalls = 0;
+        this.statsOverlayTiming.frameMs = 0;
+        this.statsOverlayTiming.updateMs = 0;
+        this.statsOverlayTiming.renderMs = 0;
+        this.statsOverlayTiming.updateSteps = 0;
+        this.statsOverlayTiming.drawCalls = 0;
+
         this.loop = new GameLoop(
             updateInterval,
-            () => this.demo?.update(),
             () => {
+                const updateStartMs = performance.now();
+                this.demo?.update();
+                this.pendingUpdateMs += Math.max(0, performance.now() - updateStartMs);
+                this.pendingUpdateSteps++;
+            },
+            () => {
+                const frameStartMs = performance.now();
+                let renderMs = 0;
+
                 if (this.renderer) {
                     this.renderer.beginFrame();
+                    const renderStartMs = performance.now();
                     this.demo?.render();
+                    renderMs = Math.max(0, performance.now() - renderStartMs);
 
                     // Palette effects run after demo render (so user's explicit palette
                     // changes in render() are respected) but before endFrame (so effects
@@ -247,6 +290,7 @@ export class BTAPI {
                             this.keyboard,
                             this.loop?.getTicks() ?? 0,
                             () => this.demo?.statsOverlayRows?.(),
+                            this.statsOverlayTiming,
                         );
                     }
 
@@ -263,6 +307,16 @@ export class BTAPI {
 
                 this.keyboard?.endFrame(tick);
                 this.gamepad?.endFrame(tick);
+
+                this.statsOverlayTiming.frameMs = Math.max(0, performance.now() - frameStartMs);
+                this.statsOverlayTiming.updateMs = this.pendingUpdateMs;
+                this.statsOverlayTiming.renderMs = renderMs;
+                this.statsOverlayTiming.updateSteps = this.pendingUpdateSteps;
+                this.statsOverlayTiming.drawCalls = this.pendingDrawCalls;
+
+                this.pendingUpdateMs = 0;
+                this.pendingUpdateSteps = 0;
+                this.pendingDrawCalls = 0;
             },
             onFrameDrop,
         );
@@ -564,6 +618,7 @@ export class BTAPI {
      */
     public clearRect(rect: Rect2i, paletteIndex: number): void {
         this.assertPaletteIndex(paletteIndex);
+        this.markDrawCall();
         this.renderer?.clearRect(rect, paletteIndex);
     }
 
@@ -575,6 +630,7 @@ export class BTAPI {
      */
     public drawPixel(pos: Vector2i, paletteIndex: number): void {
         this.assertPaletteIndex(paletteIndex);
+        this.markDrawCall();
         this.renderer?.drawPixel(pos, paletteIndex);
     }
 
@@ -588,6 +644,7 @@ export class BTAPI {
      */
     public drawLine(p0: Vector2i, p1: Vector2i, paletteIndex: number): void {
         this.assertPaletteIndex(paletteIndex);
+        this.markDrawCall();
         this.renderer?.drawLine(p0, p1, paletteIndex);
     }
 
@@ -603,6 +660,7 @@ export class BTAPI {
      */
     public drawRect(rect: Rect2i, paletteIndex: number): void {
         this.assertPaletteIndex(paletteIndex);
+        this.markDrawCall();
         this.renderer?.drawRect(rect, paletteIndex);
     }
 
@@ -614,6 +672,7 @@ export class BTAPI {
      */
     public drawRectFill(rect: Rect2i, paletteIndex: number): void {
         this.assertPaletteIndex(paletteIndex);
+        this.markDrawCall();
         this.renderer?.drawRectFill(rect, paletteIndex);
     }
 
@@ -637,6 +696,7 @@ export class BTAPI {
         }
 
         if (this.systemFont) {
+            this.markDrawCall();
             // Offset math: font stores foreground as index 1.
             // Shader computes 1 + (paletteIndex - 1) = paletteIndex.
             this.renderer?.drawBitmapText(this.systemFont, pos, text, paletteIndex - 1);
@@ -665,6 +725,7 @@ export class BTAPI {
     public drawSprite(spriteSheet: SpriteSheet, srcRect: Rect2i, destPos: Vector2i, paletteOffset: number = 0): void {
         this.assertPaletteIndex(paletteOffset);
         this.requireIndexizedSheet(spriteSheet);
+        this.markDrawCall();
         this.renderer?.drawSprite(spriteSheet, srcRect, destPos, paletteOffset);
     }
 
@@ -681,6 +742,7 @@ export class BTAPI {
     public drawBitmapText(font: BitmapFont, pos: Vector2i, text: string, paletteOffset: number = 0): void {
         this.assertPaletteIndex(paletteOffset);
         this.requireIndexizedSheet(font.getSpriteSheet());
+        this.markDrawCall();
         this.renderer?.drawBitmapText(font, pos, text, paletteOffset);
     }
 
@@ -1161,6 +1223,13 @@ export class BTAPI {
         if (!Number.isFinite(durationMs) || durationMs < 0) {
             throw new Error(`${method}: the time should be a non-negative number of milliseconds (got ${durationMs}).`);
         }
+    }
+
+    /**
+     * Tracks one demo-issued draw API call for the current frame snapshot.
+     */
+    private markDrawCall(): void {
+        this.pendingDrawCalls++;
     }
 
     /**

--- a/src/core/IBlitTechDemo.ts
+++ b/src/core/IBlitTechDemo.ts
@@ -81,7 +81,7 @@ export interface HardwareSettings {
     /**
      * Target fixed-update rate: how often {@link IBlitTechDemo.update} runs per second.
      *
-     * Not the measured render rate shown as `Render FPS` on the stats overlay; `render()` follows
+     * Not the measured render rate shown as `Present` on the stats overlay; `render()` follows
      * `requestAnimationFrame` and may differ (for example 60 Hz updates on a 120 Hz display).
      */
     targetFPS: number;
@@ -143,7 +143,7 @@ export interface StatsOverlayStyle {
 /**
  * One optional stats-overlay row supplied by a demo (left label, optional right label).
  *
- * Rendered as a 16 px bar stacked above the bottom FPS bar with 1 px gaps. Reuse the same
+ * Rendered as a 13 px bar stacked above the bottom `[~]` bar with 1 px gaps. Reuse the same
  * array instance from {@link IBlitTechDemo.statsOverlayRows} when possible to avoid
  * per-frame allocations.
  */
@@ -222,10 +222,11 @@ export interface IBlitTechDemo {
      * Issue all draw calls for the current frame here.
      *
      * When {@link HardwareSettings.statsOverlayEnabled} is `true` (default), the engine
-     * draws a screen-space stats HUD after this method returns (render FPS, target FPS, backend, demo
-     * title). Optional {@link statsOverlayRows} adds stacked bars above the footer.
-     * Demos do not need to duplicate FPS or page-title text. Reserve the bottom and top
-     * ~15 px bands (plus ~17 px per custom overlay row) for overlay bars, or disable
+     * draws a screen-space stats HUD after this method returns (present FPS, target FPS, draw calls,
+     * frame/update()/render() timings, backend, demo title). Optional {@link statsOverlayRows} adds stacked bars above
+     * the footer.
+     * Demos do not need to duplicate engine stats text. Reserve about ~42 px at the top and ~13 px at the bottom
+     * (plus ~14 px per custom overlay row) for overlay bars, or disable
      * the overlay in `configure()` when using custom full-screen HUD layouts.
      *
      * This is a hot path. Batch draws by texture to reduce GPU state changes
@@ -240,7 +241,7 @@ export interface IBlitTechDemo {
      *
      * Called once per render frame after `render()` when {@link HardwareSettings.statsOverlayEnabled}
      * is `true` and the overlay is visible (not hidden via Backquote or corner toggle). Rows stack
-     * upward from just above the bottom FPS bar (1 px gap between bars). Omit this hook or return
+     * upward from just above the bottom `[~]` bar (1 px gap between bars). Omit this hook or return
      * an empty array when no custom rows are needed.
      *
      * Hot path: reuse the same array and row objects when content is unchanged; avoid

--- a/src/core/IBlitTechDemo.ts
+++ b/src/core/IBlitTechDemo.ts
@@ -81,7 +81,7 @@ export interface HardwareSettings {
     /**
      * Target fixed-update rate: how often {@link IBlitTechDemo.update} runs per second.
      *
-     * Not the measured render rate shown as `Present` on the stats overlay; `render()` follows
+     * Not the measured render rate shown as `Present FPS` on the stats overlay; `render()` follows
      * `requestAnimationFrame` and may differ (for example 60 Hz updates on a 120 Hz display).
      */
     targetFPS: number;

--- a/src/render/StatsOverlay.test.ts
+++ b/src/render/StatsOverlay.test.ts
@@ -2,8 +2,10 @@
  * Unit tests for {@link StatsOverlay} layout helpers, label parsing, and draw layout.
  *
  * Layout contract (see {@link StatsOverlay} and docs/api-core.md Stats overlay):
- * - Top left: demo title; top right: `backend | WxH`
- * - Bottom left: `Render FPS: N | Target: T`; bottom right: `[HIDE ~]`
+ * - Top row 1: demo title (left), `backend | WxH` (right)
+ * - Top row 2: `Present FPS | Target FPS | Draw Calls`
+ * - Top row 3: `Frame | update() | render()`
+ * - Bottom row: `[~]` hint (right)
  * - Custom rows: demo-supplied bars stacked above the bottom bar (1 px gaps)
  */
 
@@ -23,9 +25,9 @@ import {
 
 // #region Test Helpers
 
-const STATS_EDGE_MARGIN_PX = 5;
-const STATS_TOP_TEXT_Y = 1;
-const STATS_BAR_HEIGHT = 16;
+const STATS_EDGE_MARGIN_PX = 3;
+const STATS_TOP_TEXT_Y = 0;
+const STATS_BAR_HEIGHT = 13;
 const STATS_ROW_GAP_PX = 1;
 const SYSTEM_CHAR_ADVANCE = 6;
 
@@ -84,7 +86,7 @@ function getRectFillCalls(renderer: ReturnType<typeof createMockRenderer>): Rect
     return renderer.drawRectFillOnTop.mock.calls.map((call) => call[0] as Rect2i);
 }
 
-/** Y of custom row bar top stacked above the bottom FPS bar. */
+/** Y of custom row bar top stacked above the bottom `[~]` bar. */
 function customBarY(displayHeight: number, rowIndex: number): number {
     const bottomBarY = displayHeight - STATS_BAR_HEIGHT;
 
@@ -118,12 +120,12 @@ describe('resolveStatsTopLeftLabel', () => {
 // #region createStatsOverlayLayout
 
 describe('createStatsOverlayLayout', () => {
-    it('places bottom text one line above the display bottom', () => {
+    it('places bottom text at the configured bottom gap offset', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
 
         expect(layout.displayWidth).toBe(320);
         expect(layout.displayHeight).toBe(240);
-        expect(layout.bottomTextY).toBe(240 - 14 - 1);
+        expect(layout.bottomTextY).toBe(240 - 14 + 1);
         expect(layout.topTextY).toBe(STATS_TOP_TEXT_Y);
         expect(layout.toggleRect.x).toBe(320 - 48);
         expect(layout.toggleRect.y).toBe(240 - 48);
@@ -200,7 +202,7 @@ describe('StatsOverlay', () => {
         expect(overlay.visible).toBe(true);
     });
 
-    it('draws top-left, top-right, bottom-left, and bottom-right labels', () => {
+    it('draws top and bottom overlay labels', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
         const topLeftLabel = 'Patterns Demo';
         const overlay = new StatsOverlay(layout, topLeftLabel, 60, 'webgpu');
@@ -211,10 +213,10 @@ describe('StatsOverlay', () => {
         const calls = getBitmapTextCalls(renderer);
         const topRightLabel = 'webgpu | 320x240';
         const topRightX = statsRightAlignedTextX(topRightLabel, 320);
-        const bottomRightLabel = '[HIDE ~]';
+        const bottomRightLabel = '[~]';
         const bottomRightX = statsRightAlignedTextX(bottomRightLabel, 320);
 
-        expect(calls).toHaveLength(4);
+        expect(calls).toHaveLength(5);
         expect(calls[0]).toEqual({
             pos: new Vector2i(STATS_EDGE_MARGIN_PX, STATS_TOP_TEXT_Y),
             text: topLeftLabel,
@@ -226,11 +228,19 @@ describe('StatsOverlay', () => {
             paletteOffset: 1,
         });
         expect(calls[2]).toMatchObject({
-            pos: new Vector2i(STATS_EDGE_MARGIN_PX, layout.bottomTextY),
-            text: expect.stringMatching(/^Render FPS: \d+ \| Target: 60$/),
+            pos: new Vector2i(STATS_EDGE_MARGIN_PX, STATS_BAR_HEIGHT + STATS_ROW_GAP_PX + STATS_TOP_TEXT_Y),
+            text: expect.stringMatching(/^Present FPS: \d+ \| Target FPS: 60 \| Draw Calls: \d+$/),
             paletteOffset: 1,
         });
-        expect(calls[3]).toEqual({
+        expect(calls[3]).toMatchObject({
+            pos: new Vector2i(STATS_EDGE_MARGIN_PX, (STATS_BAR_HEIGHT + STATS_ROW_GAP_PX) * 2 + STATS_TOP_TEXT_Y),
+            text: expect.any(String),
+            paletteOffset: 1,
+        });
+        expect(calls[3]?.text).toContain('Frame: ');
+        expect(calls[3]?.text).toContain(' | update(): ');
+        expect(calls[3]?.text).toContain(' | render(): ');
+        expect(calls[4]).toEqual({
             pos: new Vector2i(bottomRightX, layout.bottomTextY),
             text: bottomRightLabel,
             paletteOffset: 1,
@@ -246,6 +256,26 @@ describe('StatsOverlay', () => {
 
         const topRightCall = getBitmapTextCalls(renderer)[1];
         expect(topRightCall?.text).toBe('software | 320x240');
+    });
+
+    it('uses provided frame timings and shows update-step suffix when multiple updates ran', () => {
+        const layout = createStatsOverlayLayout(320, 240, 14);
+        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu');
+        const renderer = createMockRenderer();
+
+        overlay.updateAndRender(renderer, mockFont, null, null, 0, undefined, {
+            frameMs: 8.25,
+            updateMs: 1.5,
+            renderMs: 3.75,
+            updateSteps: 3,
+            drawCalls: 42,
+        });
+
+        const calls = getBitmapTextCalls(renderer);
+        expect(calls[2]?.text).toContain('Draw Calls: 42');
+        expect(calls[3]?.text).toContain('Frame: 8.3ms');
+        expect(calls[3]?.text).toContain('update(): 1.5msx3');
+        expect(calls[3]?.text).toContain('render(): 3.8ms');
     });
 
     it('skips draw calls when hidden', () => {
@@ -308,7 +338,7 @@ describe('StatsOverlay', () => {
 
         const fills = getRectFillCalls(renderer);
 
-        expect(renderer.drawRectFillOnTop).toHaveBeenCalledWith(fills[2], 5);
+        expect(renderer.drawRectFillOnTop).toHaveBeenCalledWith(fills[4], 5);
 
         const calls = getBitmapTextCalls(renderer);
 
@@ -327,15 +357,15 @@ describe('StatsOverlay', () => {
         const row0BarY = customBarY(240, 0);
         const row1BarY = customBarY(240, 1);
 
-        expect(fills).toHaveLength(4);
-        expect(fills[2]).toMatchObject({ y: row0BarY, width: 320, height: STATS_BAR_HEIGHT });
-        expect(fills[3]).toMatchObject({ y: row1BarY, width: 320, height: STATS_BAR_HEIGHT });
+        expect(fills).toHaveLength(6);
+        expect(fills[4]).toMatchObject({ y: row0BarY, width: 320, height: STATS_BAR_HEIGHT });
+        expect(fills[5]).toMatchObject({ y: row1BarY, width: 320, height: STATS_BAR_HEIGHT });
         expect(row0BarY - row1BarY).toBe(STATS_BAR_HEIGHT + STATS_ROW_GAP_PX);
 
         const calls = getBitmapTextCalls(renderer);
         const rightX = statsRightAlignedTextX('ok', 320);
 
-        expect(calls).toHaveLength(7);
+        expect(calls).toHaveLength(8);
         expect(calls[0]).toEqual({
             pos: new Vector2i(STATS_EDGE_MARGIN_PX, row0BarY + STATS_TOP_TEXT_Y),
             text: 'Position: 10, 20',
@@ -360,8 +390,8 @@ describe('StatsOverlay', () => {
 
         overlay.updateAndRender(renderer, mockFont, null, null, 0, () => []);
 
-        expect(getRectFillCalls(renderer)).toHaveLength(2);
-        expect(getBitmapTextCalls(renderer)).toHaveLength(4);
+        expect(getRectFillCalls(renderer)).toHaveLength(4);
+        expect(getBitmapTextCalls(renderer)).toHaveLength(5);
     });
 
     it('does not invoke getCustomRows while the overlay is hidden', () => {

--- a/src/render/StatsOverlay.ts
+++ b/src/render/StatsOverlay.ts
@@ -30,16 +30,16 @@ import type { IRenderer } from './IRenderer';
 // #region Constants
 
 /** Height of each stats bar strip in pixels. */
-const STATS_BAR_HEIGHT = 16;
+const STATS_BAR_HEIGHT = 13;
 
 /** Horizontal inset from screen edges for stats text. */
-const STATS_EDGE_MARGIN_PX = 5;
+const STATS_EDGE_MARGIN_PX = 3;
 
 /** Gap between the bottom text baseline and the display bottom edge. */
-const STATS_BOTTOM_TEXT_GAP_PX = 1;
+const STATS_BOTTOM_TEXT_GAP_PX = -1;
 
 /** Vertical offset for top-row text inside the top bar. */
-const STATS_TOP_TEXT_Y = 1;
+const STATS_TOP_TEXT_Y = 0;
 
 /** Gap between stacked stats bars (custom rows and bottom bar). */
 const STATS_ROW_GAP_PX = 1;

--- a/src/render/StatsOverlay.ts
+++ b/src/render/StatsOverlay.ts
@@ -1,12 +1,14 @@
 /**
- * Engine-managed stats overlay (render FPS, target rate, demo text, backend).
+ * Engine-managed stats overlay (present FPS, timing metrics, demo text, backend).
  *
  * Instantiated by {@link BTAPI} when {@link HardwareSettings.statsOverlayEnabled} is
  * `true` (default). Layout is computed once at init from logical `displaySize` and
- * system font metrics; per-frame work samples render timing and draws two 16 px bars:
+ * system font metrics; per-frame work samples cadence/timing and draws four 13 px bars:
  *
- * - **Top:** demo title (left) and `backend | WxH` (right)
- * - **Bottom:** `Render FPS: N | Target: T` (left) and `[HIDE ~]` hint (right)
+ * - **Top row 1:** demo title (left) and `backend | WxH` (right)
+ * - **Top row 2:** `Present FPS`, `Target FPS`, and draw-call counter
+ * - **Top row 3:** `Frame`, `update()`, and `render()` timings
+ * - **Bottom:** `[~]` hint (right)
  * - **Custom rows (optional):** demo-supplied bars stacked above the bottom bar, 1 px apart
  *
  * Drawn in screen space (camera reset) after demo `render()`, palette effects, and
@@ -92,6 +94,29 @@ export interface StatsOverlayLayout {
 
     /** Bottom-right 48x48 px region that toggles overlay visibility on primary press. */
     readonly toggleRect: Rect2i;
+}
+
+/**
+ * Per-frame timing snapshot fed into {@link StatsOverlay.updateAndRender}.
+ *
+ * Values are wall-clock CPU timings from `performance.now()` measured by
+ * {@link BTAPI} and smoothed inside the overlay before display.
+ */
+export interface StatsOverlayTimingSnapshot {
+    /** Total frame CPU time in milliseconds (update + render callback work). */
+    readonly frameMs: number;
+
+    /** Sum of all fixed `update()` calls that ran for this frame, in milliseconds. */
+    readonly updateMs: number;
+
+    /** Demo `render()` wall time for this frame, in milliseconds. */
+    readonly renderMs: number;
+
+    /** Number of fixed update steps processed for this frame (0..8). */
+    readonly updateSteps: number;
+
+    /** Number of draw API calls issued by the demo for this frame. */
+    readonly drawCalls: number;
 }
 
 // #endregion
@@ -247,6 +272,97 @@ class FpsSampler {
 
 // #endregion
 
+// #region TimingSampler
+
+/**
+ * Exponentially smoothed overlay timings sourced from {@link StatsOverlayTimingSnapshot}.
+ */
+class TimingSampler {
+    #hasSample = false;
+
+    #smoothedFrameMs = 0;
+
+    #smoothedUpdateMs = 0;
+
+    #smoothedRenderMs = 0;
+
+    #updateSteps = 0;
+
+    #drawCalls = 0;
+
+    /**
+     * Ingests one frame-timing snapshot.
+     *
+     * @param sample - Current-frame timing values from BTAPI.
+     */
+    sample(sample: StatsOverlayTimingSnapshot): void {
+        const frameMs = Math.max(0, sample.frameMs);
+        const updateMs = Math.max(0, sample.updateMs);
+        const renderMs = Math.max(0, sample.renderMs);
+
+        if (!this.#hasSample) {
+            this.#smoothedFrameMs = frameMs;
+            this.#smoothedUpdateMs = updateMs;
+            this.#smoothedRenderMs = renderMs;
+            this.#hasSample = true;
+        } else {
+            this.#smoothedFrameMs += (frameMs - this.#smoothedFrameMs) * FPS_SMOOTHING;
+            this.#smoothedUpdateMs += (updateMs - this.#smoothedUpdateMs) * FPS_SMOOTHING;
+            this.#smoothedRenderMs += (renderMs - this.#smoothedRenderMs) * FPS_SMOOTHING;
+        }
+
+        this.#updateSteps = Math.max(0, Math.floor(sample.updateSteps));
+        this.#drawCalls = Math.max(0, Math.floor(sample.drawCalls));
+    }
+
+    /**
+     * Smoothed full-frame CPU time in milliseconds.
+     *
+     * @returns Smoothed frame time.
+     */
+    get frameMs(): number {
+        return this.#smoothedFrameMs;
+    }
+
+    /**
+     * Smoothed update-loop CPU time in milliseconds.
+     *
+     * @returns Smoothed update time.
+     */
+    get updateMs(): number {
+        return this.#smoothedUpdateMs;
+    }
+
+    /**
+     * Smoothed demo render CPU time in milliseconds.
+     *
+     * @returns Smoothed demo render time.
+     */
+    get renderMs(): number {
+        return this.#smoothedRenderMs;
+    }
+
+    /**
+     * Most recent fixed-step count for the frame.
+     *
+     * @returns Fixed update-step count.
+     */
+    get updateSteps(): number {
+        return this.#updateSteps;
+    }
+
+    /**
+     * Most recent draw-call count for the frame.
+     *
+     * @returns Draw-call count from demo draw APIs.
+     */
+    get drawCalls(): number {
+        return this.#drawCalls;
+    }
+}
+
+// #endregion
+
 // #region StatsOverlay
 
 /**
@@ -266,6 +382,8 @@ export class StatsOverlay {
 
     readonly #fps: FpsSampler;
 
+    readonly #timing: TimingSampler = new TimingSampler();
+
     #visible = true;
 
     #idxBg = DEFAULT_IDX_BG;
@@ -276,13 +394,19 @@ export class StatsOverlay {
 
     readonly #topBarRect = new Rect2i(0, 0, 0, STATS_BAR_HEIGHT);
 
+    readonly #topMetricsBarRect = new Rect2i(0, 0, 0, STATS_BAR_HEIGHT);
+
+    readonly #topTimingBarRect = new Rect2i(0, 0, 0, STATS_BAR_HEIGHT);
+
     readonly #bottomBarRect = new Rect2i(0, 0, 0, STATS_BAR_HEIGHT);
 
     readonly #topLeftPos = new Vector2i(STATS_EDGE_MARGIN_PX, 0);
 
     readonly #topRightPos = new Vector2i(0, 0);
 
-    readonly #bottomLeftPos = new Vector2i(STATS_EDGE_MARGIN_PX, 0);
+    readonly #topMetricsPos = new Vector2i(STATS_EDGE_MARGIN_PX, 0);
+
+    readonly #topTimingPos = new Vector2i(STATS_EDGE_MARGIN_PX, 0);
 
     readonly #bottomRightPos = new Vector2i(0, 0);
 
@@ -313,7 +437,7 @@ export class StatsOverlay {
     ) {
         this.#layout = layout;
         this.#topLeftLabel = topLeftLabel;
-        this.#bottomRightLabel = '[HIDE ~]';
+        this.#bottomRightLabel = '[~]';
         this.#targetFps = targetFps;
         this.#fps = new FpsSampler(this.#targetFps);
         this.#idxBg = style?.barPaletteIndex ?? DEFAULT_IDX_BG;
@@ -322,11 +446,16 @@ export class StatsOverlay {
         const { displayWidth, displayHeight, bottomTextY, topTextY } = layout;
 
         this.#topBarRect.width = displayWidth;
+        this.#topMetricsBarRect.y = STATS_BAR_HEIGHT + STATS_ROW_GAP_PX;
+        this.#topMetricsBarRect.width = displayWidth;
+        this.#topTimingBarRect.y = (STATS_BAR_HEIGHT + STATS_ROW_GAP_PX) * 2;
+        this.#topTimingBarRect.width = displayWidth;
         this.#bottomBarRect.y = displayHeight - STATS_BAR_HEIGHT;
         this.#bottomBarRect.width = displayWidth;
         this.#topLeftPos.y = topTextY;
         this.#topRightPos.y = topTextY;
-        this.#bottomLeftPos.y = bottomTextY;
+        this.#topMetricsPos.y = this.#topMetricsBarRect.y + STATS_TOP_TEXT_Y;
+        this.#topTimingPos.y = this.#topTimingBarRect.y + STATS_TOP_TEXT_Y;
         this.#bottomRightPos.y = bottomTextY;
         this.#bottomRightPos.x = statsRightAlignedTextX(this.#bottomRightLabel, displayWidth);
         this.#topRightLabel = `${activeBackend} | ${displayWidth}x${displayHeight}`;
@@ -404,7 +533,7 @@ export class StatsOverlay {
     /**
      * Y coordinate of the top edge of a custom row bar stacked above the bottom bar.
      *
-     * @param rowIndex - `0` is directly above the bottom FPS bar.
+     * @param rowIndex - `0` is directly above the bottom `[~]` bar.
      * @returns Bar top Y in display pixels.
      */
     #customBarY(rowIndex: number): number {
@@ -472,6 +601,7 @@ export class StatsOverlay {
      * @param keyboard - Keyboard subsystem for Backquote toggle.
      * @param currentTick - Current fixed-update tick for keyboard edge detection.
      * @param getCustomRows - Optional supplier for demo rows; not invoked while the overlay is hidden.
+     * @param timing - Optional timing snapshot from the previous rendered frame.
      */
     updateAndRender(
         renderer: IRenderer,
@@ -480,8 +610,14 @@ export class StatsOverlay {
         keyboard: KeyboardInput | null,
         currentTick: number,
         getCustomRows?: () => readonly StatsOverlayRow[] | undefined,
+        timing?: StatsOverlayTimingSnapshot,
     ): void {
         this.#fps.sample();
+
+        if (timing) {
+            this.#timing.sample(timing);
+        }
+
         this.handleToggle(pointer, keyboard, currentTick);
 
         if (!this.#visible) {
@@ -493,9 +629,15 @@ export class StatsOverlay {
 
         renderer.resetCamera();
 
-        const bottomLeftLabel = `Render FPS: ${this.#fps.measuredFps} | Target: ${this.#targetFps}`;
+        const updateStepSuffix = this.#timing.updateSteps > 1 ? `x${this.#timing.updateSteps}` : '';
+        const topMetricsLabel = `Present FPS: ${this.#fps.measuredFps} | Target FPS: ${this.#targetFps} | Draw Calls: ${this.#timing.drawCalls}`;
+        const topTimingLabel =
+            `Frame: ${this.#timing.frameMs.toFixed(1)}ms | update(): ${this.#timing.updateMs.toFixed(1)}ms${updateStepSuffix} | ` +
+            `render(): ${this.#timing.renderMs.toFixed(1)}ms`;
 
         renderer.drawRectFillOnTop(this.#topBarRect, this.#idxBg);
+        renderer.drawRectFillOnTop(this.#topMetricsBarRect, this.#idxBg);
+        renderer.drawRectFillOnTop(this.#topTimingBarRect, this.#idxBg);
         renderer.drawRectFillOnTop(this.#bottomBarRect, this.#idxBg);
 
         if (customRows !== undefined && customRows.length > 0) {
@@ -506,7 +648,8 @@ export class StatsOverlay {
 
         renderer.drawBitmapTextOnTop(font, this.#topLeftPos, this.#topLeftLabel, textPaletteOffset);
         renderer.drawBitmapTextOnTop(font, this.#topRightPos, this.#topRightLabel, textPaletteOffset);
-        renderer.drawBitmapTextOnTop(font, this.#bottomLeftPos, bottomLeftLabel, textPaletteOffset);
+        renderer.drawBitmapTextOnTop(font, this.#topMetricsPos, topMetricsLabel, textPaletteOffset);
+        renderer.drawBitmapTextOnTop(font, this.#topTimingPos, topTimingLabel, textPaletteOffset);
         renderer.drawBitmapTextOnTop(font, this.#bottomRightPos, this.#bottomRightLabel, textPaletteOffset);
 
         renderer.setCameraOffset(savedCamera);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This pull request refines the stats overlay bar layout and metrics tracking in the renderer, introducing per-frame timing measurements and updating the visual layout and labels.

## Changes Overview

The PR updates the stats overlay from a 2-bar layout to a 3-bar layout, adding detailed per-frame timing metrics including frame time, update time, render time, number of update steps, and draw call counts. The overlay label changes from "Render FPS" to "Present FPS" to more accurately reflect the measured render cadence via requestAnimationFrame.

## Implementation Changes

**BTAPI.ts** now tracks per-frame rendering statistics:
- Accumulates fixed-update time and steps (`pendingUpdateMs`, `pendingUpdateSteps`)
- Counts demo draw API calls via a new private `markDrawCall()` helper
- Maintains a reusable `statsOverlayTiming` snapshot that is reset each frame
- Rendering API methods (`clearRect`, `drawPixel`, `drawLine`, `drawRect`, `drawRectFill`, `drawSystemText`, `drawSprite`, `drawBitmapText`) now invoke `markDrawCall()` to increment call counts
- Measures render duration and passes timing object to `statsOverlay.updateAndRender`

**StatsOverlay.ts** restructures the overlay layout and adds timing support:
- Introduces a new exported `StatsOverlayTimingSnapshot` interface
- Implements internal `TimingSampler` for exponentially smoothing timing metrics
- Updates `updateAndRender()` method signature with optional `timing` parameter
- Restructures bar positioning and text baseline calculations for the new 3-bar layout
- Changes bottom-right label from "[HIDE ~]" to "[~]"
- New layout includes: demo title/backend resolution (top), metrics bar for "Present FPS / Target FPS / Draw Calls", and timing bar for "Frame / update() / render()" with update-steps suffix when applicable
- Bar heights and margins are adjusted for tighter layout

## API Changes

- **Added** exported interface `StatsOverlayTimingSnapshot` in `src/render/StatsOverlay.ts`
- **Updated** method signature: `StatsOverlay.updateAndRender()` now accepts optional `timing?: StatsOverlayTimingSnapshot` parameter

## Documentation Updates

**docs/api-core.md** clarifies engine timing terminology:
- Documents `targetFPS` as the fixed `update()` simulation rate
- Describes the updated stats overlay layout with top-row positioning
- Changes "Render FPS" references to "Present FPS"
- Clarifies the distinction between simulation timing (`targetFPS`) and bottleneck detection (Present FPS)

**docs/api-assets.md** updates `BT.systemPrint()` documentation to describe the expanded default stats overlay showing Present FPS, draw calls, frame/update/render timings, backend, and resolution.

**docs/performance-best-practices.md** and **src/core/IBlitTechDemo.ts** update related guidance to reflect the new "Present FPS" label and revised custom stats overlay row height (13px instead of 16px).

## Test Updates

**BTAPI.test.ts** validates that the stats overlay receives timing objects with numeric fields (`frameMs`, `updateMs`, `renderMs`, `updateSteps`, `drawCalls`) all >= 0.

**StatsOverlay.test.ts** updates expectations to match the new 3-bar layout:
- Adjusts edge margins, text positions, and bar heights
- Verifies the new "[~]" bottom-right label
- Tests the new metrics and timing label rendering with provided timing snapshots
- Validates proper update-steps suffix display
- Checks custom row stacking behavior above the bottom bar

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/182?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->