### PR TITLE
feat(core): track per-frame palette usage for stats overlay grid

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ src/
       StatsOverlay.ts      # Orchestrator: sample, toggle, layout plan, delegate draws
       layoutPlan.ts        # Dynamic Y-band planner (chart + palette grid scaffold)
       StatsOverlayTimingChart.ts  # Timing chart band (stub; default off)
-      StatsOverlayPaletteView.ts  # Palette swatch grid (stub; default off)
+      StatsOverlayPaletteView.ts  # Palette swatch grid (default on via statsOverlayPaletteView)
       StatsOverlayBars.ts  # Fixed and custom row bars + labels
       StatsOverlayToggle.ts # Backquote and corner toggle input
     PrimitivePipeline.ts   # Batched geometry writing palette indices (pixels, lines, rects)

--- a/docs/api-core.md
+++ b/docs/api-core.md
@@ -104,17 +104,19 @@ See [Post-Process Effects](post-process-effects.md) for tier routing and presets
 output buffer. Include `displaySize` when you want a custom logical size; optional fields you omit then stay unset (for
 example no `canvasDisplaySize` means a 1:1 drawing buffer).
 
-| Field                  | Type                     | Default     | Description                                                        |
-| ---------------------- | ------------------------ | ----------- | ------------------------------------------------------------------ |
-| `displaySize`          | `Vector2i`               | `320×240`   | **Logical** render resolution                                      |
-| `canvasDisplaySize`    | `Vector2i`               | `640×480`   | **Drawing buffer** size; enables **display-tier** effects when set |
-| `maxCanvasDisplaySize` | `Vector2i`               | `960×720`   | **CSS cap** — maximum on-screen canvas size                        |
-| `targetFPS`            | `number`                 | `60`        | Fixed `update()` rate (simulation ticks per second)                |
-| `backend`              | `'webgpu' \| 'software'` | `'webgpu'`  | Force rendering backend                                            |
-| `outputUpscaleFilter`  | `'nearest' \| 'linear'`  | `'nearest'` | Upscale filter                                                     |
-| `detectDroppedFrames`  | `boolean`                | `false`     | Log a console warning on missed vsync                              |
-| `statsOverlayEnabled`  | `boolean`                | `true`      | Engine stats HUD after each `render()`                             |
-| `statsOverlayStyle`    | `StatsOverlayStyle`      | _unset_     | Optional bar/text palette indices for stats overlay                |
+| Field                        | Type                     | Default     | Description                                                        |
+| ---------------------------- | ------------------------ | ----------- | ------------------------------------------------------------------ |
+| `displaySize`                | `Vector2i`               | `320×240`   | **Logical** render resolution                                      |
+| `canvasDisplaySize`          | `Vector2i`               | `640×480`   | **Drawing buffer** size; enables **display-tier** effects when set |
+| `maxCanvasDisplaySize`       | `Vector2i`               | `960×720`   | **CSS cap** — maximum on-screen canvas size                        |
+| `targetFPS`                  | `number`                 | `60`        | Fixed `update()` rate (simulation ticks per second)                |
+| `backend`                    | `'webgpu' \| 'software'` | `'webgpu'`  | Force rendering backend                                            |
+| `outputUpscaleFilter`        | `'nearest' \| 'linear'`  | `'nearest'` | Upscale filter                                                     |
+| `detectDroppedFrames`        | `boolean`                | `false`     | Log a console warning on missed vsync                              |
+| `statsOverlayEnabled`        | `boolean`                | `true`      | Engine stats HUD after each `render()`                             |
+| `statsOverlayPaletteView`    | `boolean`                | `true`      | Live palette swatch grid in the stats overlay bottom band          |
+| `statsOverlayPaletteColumns` | `number`                 | _unset_     | Max palette swatches per grid row (default: widest fit)            |
+| `statsOverlayStyle`          | `StatsOverlayStyle`      | _unset_     | Optional bar/text palette indices for stats overlay                |
 
 `displaySize`, `canvasDisplaySize`, and `maxCanvasDisplaySize` must be positive whole-number pixel dimensions. Each size
 is capped at `8192×8192` per axis and `16,777,216` total pixels (`4096×4096`). Invalid sizes make initialization fail
@@ -180,8 +182,8 @@ configure() {
 When `statsOverlayEnabled` is `true` (default), the engine draws a screen-space HUD after each demo `render()` call, on
 top of all demo content. Bar bands and text anchors are computed each frame by the internal layout planner in
 `src/render/stats-overlay/layoutPlan.ts` from `displaySize`, custom row count, and optional feature flags (timing chart
-and palette grid default off). Init still caches stable values such as the bottom-right toggle rect and text baselines
-from the system font metrics.
+default off; palette grid on by default via `statsOverlayPaletteView`). Init still caches stable values such as the
+bottom-right toggle rect and text baselines from the system font metrics.
 
 - **Top row 1 (left):** short demo title derived from `document.title` (registry pages titled
   `Blit-Tech Demo NNN - Topic` show as `Topic Demo`); **top row 1 (right):** active backend and logical resolution (for
@@ -189,8 +191,11 @@ from the system font metrics.
 - **Top row 2 (left):** `Present: N FPS | Target: T FPS | Draw Calls: C`
 - **Top row 3 (left):** `Frame: Xms | update(): Yms | render(): Zms` (shows `xN` on `update()` when multiple fixed
   updates ran this frame)
-- **Bottom row (right):** `[~]` hint
-- **Custom rows (optional):** extra bars from `statsOverlayRows()` stacked above the bottom bar, **1 px** apart, each
+- **Bottom band:** live palette swatch grid (default) showing every active palette slot; slots referenced by demo draw
+  calls this frame are filled with their color, and unused slots render as empty rounded squares with a small X mark.
+  The `[~]` hint stays anchored bottom-right; set `statsOverlayPaletteView: false` to restore the legacy 13 px hint bar
+  only
+- **Custom rows (optional):** extra bars from `statsOverlayRows()` stacked above the bottom band, **1 px** apart, each
   with left text and optional right text (same 13 px bar style as the built-in rows)
 
 Demos may implement optional `statsOverlayRows()` on `IBlitTechDemo`. The engine calls it once per render frame after
@@ -226,17 +231,28 @@ smoothed CPU wall-time samples from `performance.now()`. `Draw Calls` counts dem
 rendered frame. Do not use present FPS for simulation timing—use `BT.ticks`, `BT.deltaSeconds`, or `Timer` instead.
 
 Demos should not duplicate engine stats text; the overlay provides it. Reserve about **14 px** per custom overlay row
-above the bottom bar (13 px bar + 1 px gap). When drawing custom top or bottom HUD panels, leave about **42 px** clear
-at the top (three built-in text rows + gaps; add about **22 px** when the timing chart feature ships). Leave about **13
-px** clear at the bottom for the legacy hint bar today; the bottom band becomes **variable height** when the palette
-swatch grid ships (depends on display width and swatch size). Or set `statsOverlayEnabled: false` for full-screen
-layouts (for example terminal-style demos).
+above the bottom band (13 px bar + 1 px gap). When drawing custom top or bottom HUD panels, leave about **42 px** clear
+at the top (three built-in text rows + gaps; add about **22 px** when the timing chart feature ships). Leave about **39
+px** clear at the bottom on the default `320×240` layout with a 256-slot palette (32 columns × 8 rows of 4 px swatches
+with 1 px gaps). The bottom band height is:
+
+```text
+rows = ceil(palette.size / cols)
+cols = widest halving of palette.size that fits:
+       floor((displayWidth - 2 * 3) / (swatchSize + gap)) >= candidate
+bottomReserve = rows * swatchSize + max(0, rows - 1) * gap
+```
+
+Default swatch size is **4 px** with **1 px** gaps; swatches use transparent corner pixels so the bar background shows
+through. Set `statsOverlayPaletteView: false` for the legacy **13 px** hint bar, or `statsOverlayEnabled: false` for
+full-screen layouts (for example terminal-style demos).
 
 ```ts
 configure() {
   return {
     displaySize: new Vector2i(320, 240),
     statsOverlayEnabled: false, // release build or custom full-screen HUD
+    statsOverlayPaletteView: false, // legacy 13 px hint bar without palette grid
     statsOverlayStyle: { barPaletteIndex: 2, textPaletteIndex: 3 }, // optional palette indices
   };
 }

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -40,7 +40,8 @@ and `vi` for browser API stubs. Tests that need a full DOM (Bootstrap, Bootstrap
   `BT.requestedBackend` vs `BT.activeBackend` after WebGPU fallback, `captureFrame()` in software mode, and stats
   overlay render path (Node + GPU mocks + 2D canvas mocks)
 - **StatsOverlay** - colocated tests under `src/render/stats-overlay/*.test.ts`: label parsing, layout helpers,
-  `layoutPlan` golden Y positions for 320x240 (including custom rows and scaffold cases), toggle hit-testing, and
+  `layoutPlan` golden Y positions for 320x240 (including custom rows, palette grid variable bottom band, and timing
+  chart scaffold cases), `StatsOverlayPaletteView.computePaletteGrid` width/size matrix, toggle hit-testing, and
   `updateAndRender` integration (Node)
 - **FrameCapture** - GPU readback, PNG conversion (Node + GPU mocks + browser stubs)
 

--- a/src/assets/SpriteSheet.ts
+++ b/src/assets/SpriteSheet.ts
@@ -493,6 +493,49 @@ export class SpriteSheet {
         return this.indexedPixels.slice() as Uint8Array<ArrayBuffer>;
     }
 
+    /**
+     * Marks palette indices referenced by non-zero pixels in a source rectangle.
+     *
+     * Used by the engine to build the stats overlay palette grid from demo draw
+     * calls. Does not allocate; writes into the supplied usage mask.
+     *
+     * @param srcRect - Region to scan in sheet coordinates.
+     * @param paletteOffset - Palette offset applied at draw time.
+     * @param usedMask - Mutable usage mask indexed by resolved palette slot.
+     */
+    markPaletteIndicesInRect(srcRect: Rect2i, paletteOffset: number, usedMask: Uint8Array): void {
+        if (this.indexedPixels === null) {
+            return;
+        }
+
+        const sheetWidth = this.size.x;
+        const pixels = this.indexedPixels;
+        const startX = Math.max(0, srcRect.x);
+        const startY = Math.max(0, srcRect.y);
+        const endX = Math.min(this.size.x, srcRect.x + srcRect.width);
+        const endY = Math.min(this.size.y, srcRect.y + srcRect.height);
+
+        for (let y = startY; y < endY; y++) {
+            const rowOffset = y * sheetWidth;
+
+            for (let x = startX; x < endX; x++) {
+                 
+                const sheetIndex = pixels[rowOffset + x] ?? 0;
+
+                if (sheetIndex === 0) {
+                    continue;
+                }
+
+                const resolved = sheetIndex + paletteOffset;
+
+                if (resolved > 0 && resolved < usedMask.length) {
+                    // eslint-disable-next-line security/detect-object-injection -- resolved bounds checked above
+                    usedMask[resolved] = 1;
+                }
+            }
+        }
+    }
+
     // #endregion
 
     // #region Accessors

--- a/src/assets/SpriteSheet.ts
+++ b/src/assets/SpriteSheet.ts
@@ -519,7 +519,6 @@ export class SpriteSheet {
             const rowOffset = y * sheetWidth;
 
             for (let x = startX; x < endX; x++) {
-                 
                 const sheetIndex = pixels[rowOffset + x] ?? 0;
 
                 if (sheetIndex === 0) {

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -35,6 +35,11 @@ import type { FrameDropCallback, FrameDropEvent } from './GameLoop';
 import { GameLoop } from './GameLoop';
 import type { Backend, HardwareSettings, IBlitTechDemo } from './IBlitTechDemo';
 import { defaultConfig, mergeHardwareSettings } from './IBlitTechDemo';
+import {
+    collectUsedRenderPaletteIndices,
+    markRenderPaletteIndexUsed,
+    resetRenderPaletteUsage,
+} from './RenderPaletteUsage';
 import { initWebGPU } from './WebGPUContext';
 
 /**
@@ -124,6 +129,12 @@ export class BTAPI {
 
     /** Number of demo draw API calls issued since the last rendered frame. */
     private pendingDrawCalls = 0;
+
+    /** Bitmask of palette indices referenced by demo draw calls this frame. */
+    private readonly framePaletteUsageMask = new Uint8Array(256);
+
+    /** Reusable sorted list of used palette indices for the stats overlay grid. */
+    private readonly framePaletteUsageScratch: number[] = [];
 
     /** Reused timing snapshot passed into the stats overlay each frame. */
     private readonly statsOverlayTiming: {
@@ -269,9 +280,14 @@ export class BTAPI {
                 let renderMs = 0;
 
                 if (this.renderer) {
+                    resetRenderPaletteUsage(this.framePaletteUsageMask);
+
                     this.renderer.beginFrame();
+
                     const renderStartMs = performance.now();
+
                     this.demo?.render();
+
                     renderMs = Math.max(0, performance.now() - renderStartMs);
 
                     // Palette effects run after demo render (so user's explicit palette
@@ -280,6 +296,14 @@ export class BTAPI {
                     if (this.palette && this.paletteEffects.activeCount > 0) {
                         this.paletteEffects.update(this.palette);
                     }
+
+                    const usedPaletteIndices = this.palette
+                        ? collectUsedRenderPaletteIndices(
+                              this.framePaletteUsageMask,
+                              this.palette.size,
+                              this.framePaletteUsageScratch,
+                          )
+                        : this.framePaletteUsageScratch;
 
                     // Stats overlay: screen-space HUD after demo content (top/bottom bars).
                     if (this.statsOverlay && this.systemFont) {
@@ -292,6 +316,7 @@ export class BTAPI {
                             () => this.demo?.statsOverlayRows?.(),
                             this.statsOverlayTiming,
                             this.palette,
+                            usedPaletteIndices,
                         );
                     }
 
@@ -608,6 +633,8 @@ export class BTAPI {
      */
     public setClearColor(paletteIndex: number): void {
         this.assertPaletteIndex(paletteIndex);
+        this.trackPaletteIndexUsed(paletteIndex);
+
         this.renderer?.setClearColor(paletteIndex);
     }
 
@@ -619,7 +646,10 @@ export class BTAPI {
      */
     public clearRect(rect: Rect2i, paletteIndex: number): void {
         this.assertPaletteIndex(paletteIndex);
+        this.trackPaletteIndexUsed(paletteIndex);
+
         this.markDrawCall();
+
         this.renderer?.clearRect(rect, paletteIndex);
     }
 
@@ -631,7 +661,10 @@ export class BTAPI {
      */
     public drawPixel(pos: Vector2i, paletteIndex: number): void {
         this.assertPaletteIndex(paletteIndex);
+        this.trackPaletteIndexUsed(paletteIndex);
+
         this.markDrawCall();
+
         this.renderer?.drawPixel(pos, paletteIndex);
     }
 
@@ -645,7 +678,10 @@ export class BTAPI {
      */
     public drawLine(p0: Vector2i, p1: Vector2i, paletteIndex: number): void {
         this.assertPaletteIndex(paletteIndex);
+        this.trackPaletteIndexUsed(paletteIndex);
+
         this.markDrawCall();
+
         this.renderer?.drawLine(p0, p1, paletteIndex);
     }
 
@@ -661,7 +697,10 @@ export class BTAPI {
      */
     public drawRect(rect: Rect2i, paletteIndex: number): void {
         this.assertPaletteIndex(paletteIndex);
+        this.trackPaletteIndexUsed(paletteIndex);
+
         this.markDrawCall();
+
         this.renderer?.drawRect(rect, paletteIndex);
     }
 
@@ -673,7 +712,10 @@ export class BTAPI {
      */
     public drawRectFill(rect: Rect2i, paletteIndex: number): void {
         this.assertPaletteIndex(paletteIndex);
+        this.trackPaletteIndexUsed(paletteIndex);
+
         this.markDrawCall();
+
         this.renderer?.drawRectFill(rect, paletteIndex);
     }
 
@@ -697,7 +739,9 @@ export class BTAPI {
         }
 
         if (this.systemFont) {
+            this.trackPaletteIndexUsed(paletteIndex);
             this.markDrawCall();
+
             // Offset math: font stores foreground as index 1.
             // Shader computes 1 + (paletteIndex - 1) = paletteIndex.
             this.renderer?.drawBitmapText(this.systemFont, pos, text, paletteIndex - 1);
@@ -726,7 +770,13 @@ export class BTAPI {
     public drawSprite(spriteSheet: SpriteSheet, srcRect: Rect2i, destPos: Vector2i, paletteOffset: number = 0): void {
         this.assertPaletteIndex(paletteOffset);
         this.requireIndexizedSheet(spriteSheet);
+
+        if (this.renderer) {
+            spriteSheet.markPaletteIndicesInRect(srcRect, paletteOffset, this.framePaletteUsageMask);
+        }
+
         this.markDrawCall();
+
         this.renderer?.drawSprite(spriteSheet, srcRect, destPos, paletteOffset);
     }
 
@@ -743,7 +793,13 @@ export class BTAPI {
     public drawBitmapText(font: BitmapFont, pos: Vector2i, text: string, paletteOffset: number = 0): void {
         this.assertPaletteIndex(paletteOffset);
         this.requireIndexizedSheet(font.getSpriteSheet());
+
+        if (this.renderer) {
+            this.markBitmapTextPaletteUsage(font, text, paletteOffset);
+        }
+
         this.markDrawCall();
+
         this.renderer?.drawBitmapText(font, pos, text, paletteOffset);
     }
 
@@ -1025,6 +1081,7 @@ export class BTAPI {
             // throws when the adapter or device cannot be created. Both cases fall
             // through to the software renderer below.
             let webGPUResult: Awaited<ReturnType<typeof initWebGPU>> = null;
+
             try {
                 webGPUResult = await initWebGPU(canvas, hw.displaySize, hw.canvasDisplaySize);
             } catch (error) {
@@ -1038,12 +1095,14 @@ export class BTAPI {
             if (webGPUResult) {
                 this.device = webGPUResult.device;
                 this.context = webGPUResult.context;
+
                 console.log('[BT] Initializing renderer (backend: webgpu)');
 
                 this.renderer = new WebGpuRenderer(
                     webGPUResult.device,
                     webGPUResult.context,
                     hw.displaySize,
+
                     // Only forward an explicit outputSize when canvasDisplaySize was
                     // provided; that is the signal that unlocks the display tier.
                     hw.canvasDisplaySize !== undefined ? webGPUResult.drawingBufferSize : undefined,
@@ -1068,6 +1127,7 @@ export class BTAPI {
         // Software renderer path: explicit selection or automatic fallback.
         this.device = null;
         this.context = null;
+
         console.log('[BT] Initializing renderer (backend: software)');
 
         this.renderer = new SoftwareRenderer(canvas, hw.displaySize, hw.canvasDisplaySize);
@@ -1098,11 +1158,13 @@ export class BTAPI {
         }
 
         const override = BTAPI.getBackendQueryOverride();
+
         if (!override) {
             return;
         }
 
         this.hwSettings.backend = override;
+
         console.info(`[BT] URL override selected backend: ${override}`);
     }
 
@@ -1125,6 +1187,7 @@ export class BTAPI {
 
         try {
             const backend = new URLSearchParams(search).get('backend');
+
             if (backend === 'software') {
                 return 'software';
             }
@@ -1144,8 +1207,10 @@ export class BTAPI {
     private clearInputSubsystems(): void {
         this.pointer?.detach();
         this.pointer = null;
+
         this.keyboard?.detach();
         this.keyboard = null;
+
         this.gamepad?.detach();
         this.gamepad = null;
     }
@@ -1164,6 +1229,7 @@ export class BTAPI {
 
             if (!ok) {
                 console.error('[BT] Demo initialization failed');
+
                 this.clearInputSubsystems();
 
                 return false;
@@ -1172,6 +1238,7 @@ export class BTAPI {
             return true;
         } catch (err) {
             console.error('[BT] Demo initialization threw', err);
+
             this.clearInputSubsystems();
 
             return false;
@@ -1231,6 +1298,36 @@ export class BTAPI {
      */
     private markDrawCall(): void {
         this.pendingDrawCalls++;
+    }
+
+    /**
+     * Marks a palette index as used for the current frame.
+     *
+     * @param index - Palette index to track.
+     */
+    private trackPaletteIndexUsed(index: number): void {
+        if (this.renderer) {
+            markRenderPaletteIndexUsed(this.framePaletteUsageMask, index);
+        }
+    }
+
+    /**
+     * Marks palette indices referenced by bitmap text glyphs in a string.
+     *
+     * @param font - Bitmap font whose glyph atlas is scanned.
+     * @param text - Text about to be drawn.
+     * @param paletteOffset - Palette offset applied at draw time.
+     */
+    private markBitmapTextPaletteUsage(font: BitmapFont, text: string, paletteOffset: number): void {
+        const sheet = font.getSpriteSheet();
+
+        for (const char of text) {
+            const glyph = font.getGlyph(char);
+
+            if (glyph !== null) {
+                sheet.markPaletteIndicesInRect(glyph.rect, paletteOffset, this.framePaletteUsageMask);
+            }
+        }
     }
 
     /**

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -38,6 +38,7 @@ import { defaultConfig, mergeHardwareSettings } from './IBlitTechDemo';
 import {
     collectUsedRenderPaletteIndices,
     markRenderPaletteIndexUsed,
+    RENDER_PALETTE_USAGE_CAPACITY,
     resetRenderPaletteUsage,
 } from './RenderPaletteUsage';
 import { initWebGPU } from './WebGPUContext';
@@ -131,7 +132,10 @@ export class BTAPI {
     private pendingDrawCalls = 0;
 
     /** Bitmask of palette indices referenced by demo draw calls this frame. */
-    private readonly framePaletteUsageMask = new Uint8Array(256);
+    private readonly framePaletteUsageMask = new Uint8Array(RENDER_PALETTE_USAGE_CAPACITY);
+
+    /** Last palette index from {@link setClearColor}; reapplied after each frame reset. */
+    private activeClearPaletteIndex = 0;
 
     /** Reusable sorted list of used palette indices for the stats overlay grid. */
     private readonly framePaletteUsageScratch: number[] = [];
@@ -280,7 +284,7 @@ export class BTAPI {
                 let renderMs = 0;
 
                 if (this.renderer) {
-                    resetRenderPaletteUsage(this.framePaletteUsageMask);
+                    this.resetFramePaletteUsageForRender();
 
                     this.renderer.beginFrame();
 
@@ -633,6 +637,7 @@ export class BTAPI {
      */
     public setClearColor(paletteIndex: number): void {
         this.assertPaletteIndex(paletteIndex);
+        this.activeClearPaletteIndex = paletteIndex;
         this.trackPaletteIndexUsed(paletteIndex);
 
         this.renderer?.setClearColor(paletteIndex);
@@ -1298,6 +1303,20 @@ export class BTAPI {
      */
     private markDrawCall(): void {
         this.pendingDrawCalls++;
+    }
+
+    /**
+     * Clears per-frame palette usage and re-applies the active clear color index.
+     *
+     * The renderer still clears every frame from {@link setClearColor} even when
+     * the demo does not call `BT.clear()` again; the stats overlay should show that slot.
+     */
+    private resetFramePaletteUsageForRender(): void {
+        resetRenderPaletteUsage(this.framePaletteUsageMask);
+
+        if (this.activeClearPaletteIndex > 0) {
+            markRenderPaletteIndexUsed(this.framePaletteUsageMask, this.activeClearPaletteIndex);
+        }
     }
 
     /**

--- a/src/core/RenderPaletteUsage.test.ts
+++ b/src/core/RenderPaletteUsage.test.ts
@@ -32,4 +32,27 @@ describe('RenderPaletteUsage', () => {
 
         expect(collectUsedRenderPaletteIndices(mask, 16, scratch)).toEqual([]);
     });
+
+    it('ignores invalid and out-of-range indices', () => {
+        const mask = new Uint8Array(256);
+        const scratch: number[] = [];
+
+        markRenderPaletteIndexUsed(mask, -1);
+        markRenderPaletteIndexUsed(mask, 256);
+        markRenderPaletteIndexUsed(mask, 300);
+        markRenderPaletteIndexUsed(mask, 1.5);
+
+        expect(collectUsedRenderPaletteIndices(mask, 16, scratch)).toEqual([]);
+    });
+
+    it('collects only valid indices when mixed with invalid values', () => {
+        const mask = new Uint8Array(256);
+        const scratch: number[] = [];
+
+        markRenderPaletteIndexUsed(mask, -1);
+        markRenderPaletteIndexUsed(mask, 5);
+        markRenderPaletteIndexUsed(mask, 256);
+
+        expect(collectUsedRenderPaletteIndices(mask, 16, scratch)).toEqual([5]);
+    });
 });

--- a/src/core/RenderPaletteUsage.test.ts
+++ b/src/core/RenderPaletteUsage.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Unit tests for per-frame palette usage tracking helpers.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+    collectUsedRenderPaletteIndices,
+    markRenderPaletteIndexUsed,
+    resetRenderPaletteUsage,
+} from './RenderPaletteUsage';
+
+describe('RenderPaletteUsage', () => {
+    it('collects sorted used indices and skips transparent slot 0', () => {
+        const mask = new Uint8Array(256);
+        const scratch: number[] = [];
+
+        markRenderPaletteIndexUsed(mask, 0);
+        markRenderPaletteIndexUsed(mask, 3);
+        markRenderPaletteIndexUsed(mask, 1);
+        markRenderPaletteIndexUsed(mask, 7);
+
+        expect(collectUsedRenderPaletteIndices(mask, 16, scratch)).toEqual([1, 3, 7]);
+    });
+
+    it('reset clears prior marks', () => {
+        const mask = new Uint8Array(256);
+        const scratch: number[] = [];
+
+        markRenderPaletteIndexUsed(mask, 2);
+        resetRenderPaletteUsage(mask);
+
+        expect(collectUsedRenderPaletteIndices(mask, 16, scratch)).toEqual([]);
+    });
+});

--- a/src/core/RenderPaletteUsage.ts
+++ b/src/core/RenderPaletteUsage.ts
@@ -1,0 +1,62 @@
+/**
+ * Per-frame palette index usage tracking for debug overlays.
+ *
+ * BTAPI marks indices referenced by demo draw calls during {@link IBlitTechDemo.render}
+ * and exposes a sorted snapshot to the stats overlay palette grid.
+ */
+
+/** Maximum palette slots tracked by the usage mask. */
+export const RENDER_PALETTE_USAGE_CAPACITY = 256;
+
+/**
+ * Clears a palette usage bitmask.
+ *
+ * @param usedMask - Mutable usage mask cleared in place.
+ */
+export function resetRenderPaletteUsage(usedMask: Uint8Array): void {
+    usedMask.fill(0);
+}
+
+/**
+ * Marks one palette index as used this frame.
+ *
+ * Index `0` (transparent) is ignored.
+ *
+ * @param usedMask - Mutable usage mask.
+ * @param index - Palette index referenced by a draw call.
+ */
+export function markRenderPaletteIndexUsed(usedMask: Uint8Array, index: number): void {
+    if (!Number.isInteger(index) || index <= 0 || index >= usedMask.length) {
+        return;
+    }
+
+    // eslint-disable-next-line security/detect-object-injection -- index bounds checked above
+    usedMask[index] = 1;
+}
+
+/**
+ * Collects sorted used palette indices into a reusable scratch array.
+ *
+ * @param usedMask - Usage mask populated during the current frame.
+ * @param paletteSize - Active palette size upper bound.
+ * @param scratch - Reusable output buffer mutated in place.
+ * @returns The same scratch array containing sorted used indices.
+ */
+export function collectUsedRenderPaletteIndices(
+    usedMask: Uint8Array,
+    paletteSize: number,
+    scratch: number[],
+): readonly number[] {
+    scratch.length = 0;
+
+    const limit = Math.min(paletteSize, usedMask.length);
+
+    for (let index = 1; index < limit; index++) {
+        // eslint-disable-next-line security/detect-object-injection -- index bounded by palette size
+        if (usedMask[index] === 1) {
+            scratch.push(index);
+        }
+    }
+
+    return scratch;
+}

--- a/src/render/stats-overlay/StatsOverlay.ts
+++ b/src/render/stats-overlay/StatsOverlay.ts
@@ -118,6 +118,7 @@ export class StatsOverlay {
      * @param getCustomRows - Optional supplier for demo rows; not invoked while the overlay is hidden.
      * @param timing - Optional timing snapshot from the previous rendered frame.
      * @param palette - Active demo palette for optional palette grid (stub when disabled).
+     * @param usedPaletteIndices - Palette slots referenced by demo draw calls this frame.
      */
     updateAndRender(
         renderer: IRenderer,
@@ -128,6 +129,7 @@ export class StatsOverlay {
         getCustomRows?: () => readonly StatsOverlayRow[] | undefined,
         timing?: StatsOverlayTimingSnapshot,
         palette?: Palette | null,
+        usedPaletteIndices: readonly number[] = [],
     ): void {
         this.#fps.sample();
 
@@ -185,7 +187,7 @@ export class StatsOverlay {
                     ? computePaletteGrid(layoutConfig.displayWidth)
                     : DEFAULT_PALETTE_GRID);
 
-            this.#paletteView.draw(renderer, plan.bottomArea, palette ?? null, paletteGrid);
+            this.#paletteView.draw(renderer, plan.bottomArea, palette ?? null, paletteGrid, usedPaletteIndices);
 
             this.#bars.drawFixedBars(renderer, plan, this.#idxBg);
 

--- a/src/render/stats-overlay/StatsOverlayPaletteView.ts
+++ b/src/render/stats-overlay/StatsOverlayPaletteView.ts
@@ -108,8 +108,15 @@ export class StatsOverlayPaletteView {
      * @param _bottomArea - Bottom band rect from layout plan.
      * @param _palette - Active demo palette.
      * @param _grid - Precomputed grid layout.
+     * @param _usedPaletteIndices - Palette slots referenced by demo draw calls this frame.
      */
-    draw(_renderer: IRenderer, _bottomArea: Rect2i, _palette: Palette | null, _grid: PaletteGridLayout): void {
+    draw(
+        _renderer: IRenderer,
+        _bottomArea: Rect2i,
+        _palette: Palette | null,
+        _grid: PaletteGridLayout,
+        _usedPaletteIndices: readonly number[] = [],
+    ): void {
         if (!this.#enabled) {
             return;
         }


### PR DESCRIPTION
Record palette indices referenced by demo draw, clear, and sprite calls each frame and pass the sorted snapshot into the stats overlay. Add SpriteSheet.markPaletteIndicesInRect for indexed sprite draws.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes

### New Module: RenderPaletteUsage.ts
Adds per-frame palette index usage tracking for debug overlays. Exports:
- `RENDER_PALETTE_USAGE_CAPACITY` (256)
- `resetRenderPaletteUsage(usedMask: Uint8Array): void`
- `markRenderPaletteIndexUsed(usedMask: Uint8Array, index: number): void` (ignores index 0; bounds/validity checks)
- `collectUsedRenderPaletteIndices(usedMask: Uint8Array, paletteSize: number, scratch: number[]): readonly number[]` (returns sorted indices)

### Enhanced SpriteSheet.ts
Added `markPaletteIndicesInRect(srcRect: Rect2i, paletteOffset: number, usedMask: Uint8Array): void` which scans an indexed pixel region, skips transparent index 0, resolves sheetIndex + paletteOffset, clamps to sheet bounds, and sets flags in the provided mask for valid palette slots.

### Updated BTAPI.ts
Wires per-frame palette-usage bookkeeping into the render cycle and demo draw paths:
- Resets frame palette usage at render start and collects used indices into a sorted list.
- Tracks palette indices when setting clear color and during palette-indexed draw calls (clearRect, drawPixel, drawLine, drawRect, drawRectFill, drawSystemText).
- Marks indices referenced by sprite-sheet regions (via SpriteSheet.markPaletteIndicesInRect) and bitmap-text glyph rectangles.
- Forwards the collected sorted indices into `StatsOverlay.updateAndRender`.
- New private helpers: `resetFramePaletteUsageForRender`, `trackPaletteIndexUsed`, `markBitmapTextPaletteUsage`.

### Stats Overlay API changes
- `StatsOverlay.updateAndRender(..., usedPaletteIndices: readonly number[] = [])` — new parameter to accept per-frame palette usage.
- `StatsOverlayPaletteView.draw(_renderer, _bottomArea, _palette, _grid, _usedPaletteIndices: readonly number[] = [])` — now accepts the used indices to drive the palette grid view.

### Tests
- `RenderPaletteUsage.test.ts` (Vitest): verifies marking, reset behavior, sorted collection, skipping slot 0, and ignoring invalid/out-of-range indices.

### Documentation & Metadata
- docs/api-core.md: documents new HardwareSettings fields `statsOverlayPaletteView` (default on) and `statsOverlayPaletteColumns`, updates overlay layout guidance and sample configuration.
- docs/testing.md: expands StatsOverlay integration-test descriptions and compute/layout scenarios.
- CLAUDE.md: updated architecture note for `StatsOverlayPaletteView` to reflect default-on behavior.

## Impact
Enables the stats overlay palette grid to show which palette slots are actually referenced each frame, improving visibility for debugging and palette-use optimization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/184?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->