### PR TITLE
feat(renderer): add live palette swatch grid to stats overlay

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,23 +19,24 @@ and sprites resolve through a shared indexed palette.
 
 Before writing new code, reviewing existing code, or preflighting, check here first:
 
-| Question                                      | Where to look                                                                                                                                                                                           |
-| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| What does `BT.X` do (getter vs method)?       | `src/BlitTech.ts` JSDoc, `docs/api-core.md`, **BT API: getters vs methods** below                                                                                                                       |
-| How does a subsystem work internally?         | The relevant `src/core/` or `src/render/` file                                                                                                                                                          |
-| What does a demo implement?                   | `src/core/IBlitTechDemo.ts` (interface + HardwareSettings)                                                                                                                                              |
-| How does the stats overlay work?              | `src/render/stats-overlay/` (orchestrator + `layoutPlan.ts`), `src/render/StatsOverlay.ts` barrel, `docs/api-core.md` (Stats overlay), `HardwareSettings.statsOverlayEnabled`                           |
-| What palette/sprite setup pattern is correct? | `docs/palette-guide.md`, then `docs/api-assets.md`                                                                                                                                                      |
-| What are the render/asset dimension limits?   | `src/utils/RenderLimits.ts` (constants), `src/utils/AssetLimits.ts` (asset + glyph limits), `docs/api-assets.md` (asset size limits table), `docs/api-core.md` (HardwareSettings dimension constraints) |
-| Which preset has which exact color values?    | `docs/palette-presets.md`                                                                                                                                                                               |
-| How do post-process effects work?             | `docs/post-process-effects.md`                                                                                                                                                                          |
-| What does the CI do on this file?             | `.github/workflows/ci.yml`                                                                                                                                                                              |
-| Dependency security policy / CI audit gate?   | `docs/security/dependency-policy.md`, `docs/security/audit-exceptions.md`                                                                                                                               |
-| What is the benchmark threshold?              | `ci.yml` benchmark job (`--threshold 25` flag), not docs                                                                                                                                                |
-| What error message style should I use?        | `docs/voice.md`, then `src/utils/errorMessages.ts`                                                                                                                                                      |
-| Is this API exported publicly?                | `src/BlitTech.ts` export block (lines 1460-1501)                                                                                                                                                        |
-| What test mock do I need for GPU code?        | `src/__test__/webgpu-mock.ts`                                                                                                                                                                           |
-| Declaration tooling / TS version alignment?   | `docs/tooling.md`, `docs/developer-experience-guide.md`, `scripts/check-declaration-tooling.mjs`                                                                                                        |
+| Question                                                   | Where to look                                                                                                                                                                                           |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| What does `BT.X` do (getter vs method)?                    | `src/BlitTech.ts` JSDoc, `docs/api-core.md`, **BT API: getters vs methods** below                                                                                                                       |
+| How does a subsystem work internally?                      | The relevant `src/core/` or `src/render/` file                                                                                                                                                          |
+| What does a demo implement?                                | `src/core/IBlitTechDemo.ts` (interface + HardwareSettings)                                                                                                                                              |
+| How does palette usage tracking work for the overlay grid? | `src/core/RenderPaletteUsage.ts`, `src/render/stats-overlay/StatsOverlayPaletteView.ts`                                                                                                                 |
+| How does the stats overlay work?                           | `src/render/stats-overlay/` (orchestrator + `layoutPlan.ts`), `src/render/StatsOverlay.ts` barrel, `docs/api-core.md` (Stats overlay), `HardwareSettings.statsOverlayEnabled`                           |
+| What palette/sprite setup pattern is correct?              | `docs/palette-guide.md`, then `docs/api-assets.md`                                                                                                                                                      |
+| What are the render/asset dimension limits?                | `src/utils/RenderLimits.ts` (constants), `src/utils/AssetLimits.ts` (asset + glyph limits), `docs/api-assets.md` (asset size limits table), `docs/api-core.md` (HardwareSettings dimension constraints) |
+| Which preset has which exact color values?                 | `docs/palette-presets.md`                                                                                                                                                                               |
+| How do post-process effects work?                          | `docs/post-process-effects.md`                                                                                                                                                                          |
+| What does the CI do on this file?                          | `.github/workflows/ci.yml`                                                                                                                                                                              |
+| Dependency security policy / CI audit gate?                | `docs/security/dependency-policy.md`, `docs/security/audit-exceptions.md`                                                                                                                               |
+| What is the benchmark threshold?                           | `ci.yml` benchmark job (`--threshold 25` flag), not docs                                                                                                                                                |
+| What error message style should I use?                     | `docs/voice.md`, then `src/utils/errorMessages.ts`                                                                                                                                                      |
+| Is this API exported publicly?                             | `src/BlitTech.ts` export block (lines 1460-1501)                                                                                                                                                        |
+| What test mock do I need for GPU code?                     | `src/__test__/webgpu-mock.ts`                                                                                                                                                                           |
+| Declaration tooling / TS version alignment?                | `docs/tooling.md`, `docs/developer-experience-guide.md`, `scripts/check-declaration-tooling.mjs`                                                                                                        |
 
 ## Architecture
 
@@ -51,6 +52,7 @@ src/
     IBlitTechDemo.ts       # Demo interface + HardwareSettings
     GameLoop.ts            # Fixed-timestep game loop
     WebGPUContext.ts       # WebGPU adapter/device/context setup
+    RenderPaletteUsage.ts  # Per-frame palette index usage mask for stats overlay grid
   render/
     IRenderer.ts           # Backend-agnostic renderer contract (interface)
     WebGpuRenderer.ts      # WebGPU concrete renderer implementing IRenderer
@@ -58,8 +60,8 @@ src/
     StatsOverlay.ts        # Barrel re-export for BTAPI (implementation under stats-overlay/)
     stats-overlay/
       StatsOverlay.ts      # Orchestrator: sample, toggle, layout plan, delegate draws
-      layoutPlan.ts        # Dynamic Y-band planner (chart + palette grid scaffold)
-      StatsOverlayTimingChart.ts  # Timing chart band (stub; default off)
+      layoutPlan.ts        # Dynamic Y-band planner (timing chart VV-539 + palette grid)
+      StatsOverlayTimingChart.ts  # Timing chart band (VV-539 scaffold; default off)
       StatsOverlayPaletteView.ts  # Palette swatch grid (opt-in via statsOverlayPaletteView)
       StatsOverlayBars.ts  # Fixed and custom row bars + labels
       StatsOverlayToggle.ts # Backquote and corner toggle input

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ src/
       StatsOverlay.ts      # Orchestrator: sample, toggle, layout plan, delegate draws
       layoutPlan.ts        # Dynamic Y-band planner (chart + palette grid scaffold)
       StatsOverlayTimingChart.ts  # Timing chart band (stub; default off)
-      StatsOverlayPaletteView.ts  # Palette swatch grid (stub; default off)
+      StatsOverlayPaletteView.ts  # Palette swatch grid (default on via statsOverlayPaletteView)
       StatsOverlayBars.ts  # Fixed and custom row bars + labels
       StatsOverlayToggle.ts # Backquote and corner toggle input
     PrimitivePipeline.ts   # Batched geometry writing palette indices (pixels, lines, rects)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ src/
       StatsOverlay.ts      # Orchestrator: sample, toggle, layout plan, delegate draws
       layoutPlan.ts        # Dynamic Y-band planner (chart + palette grid scaffold)
       StatsOverlayTimingChart.ts  # Timing chart band (stub; default off)
-      StatsOverlayPaletteView.ts  # Palette swatch grid (default on via statsOverlayPaletteView)
+      StatsOverlayPaletteView.ts  # Palette swatch grid (opt-in via statsOverlayPaletteView)
       StatsOverlayBars.ts  # Fixed and custom row bars + labels
       StatsOverlayToggle.ts # Backquote and corner toggle input
     PrimitivePipeline.ts   # Batched geometry writing palette indices (pixels, lines, rects)

--- a/docs/api-core.md
+++ b/docs/api-core.md
@@ -191,10 +191,10 @@ bottom-right toggle rect and text baselines from the system font metrics.
 - **Top row 2 (left):** `Present: N FPS | Target: T FPS | Draw Calls: C`
 - **Top row 3 (left):** `Frame: Xms | update(): Yms | render(): Zms` (shows `xN` on `update()` when multiple fixed
   updates ran this frame)
-- **Bottom band:** legacy **13 px** hint bar with the `[~]` toggle label anchored bottom-right (default). Set
+- **Bottom band:** default **13 px** hint bar with the `[~]` toggle label anchored bottom-right. Set
   `statsOverlayPaletteView: true` to replace it with a live palette swatch grid showing every active palette slot; slots
   referenced by demo draw calls this frame are filled with their color, and unused slots render as empty squares with a
-  small X mark
+  small centered marker
 - **Custom rows (optional):** extra bars from `statsOverlayRows()` stacked above the bottom band, **1 px** apart, each
   with left text and optional right text (same 13 px bar style as the built-in rows)
 
@@ -232,20 +232,21 @@ rendered frame. Do not use present FPS for simulation timing—use `BT.ticks`, `
 
 Demos should not duplicate engine stats text; the overlay provides it. Reserve about **14 px** per custom overlay row
 above the bottom band (13 px bar + 1 px gap). When drawing custom top or bottom HUD panels, leave about **42 px** clear
-at the top (three built-in text rows + gaps; add about **22 px** when the timing chart feature ships). Leave about **13
-px** clear at the bottom by default (legacy hint bar). When `statsOverlayPaletteView: true`, reserve additional space
-for the palette grid—for example about **69 px** on the default `320×240` layout with a 256-slot palette (32 columns × 8
-rows of 7 px swatches with 1 px gaps). The bottom band height is:
+at the top (three built-in text rows + gaps; add about **22 px** when `statsOverlayTimingChart` is enabled per VV-539).
+Leave about **13 px** clear at the bottom by default (hint bar). When `statsOverlayPaletteView: true`, reserve
+additional space for the palette grid—for example about **69 px** on the default `320×240` layout with a 256-slot
+palette (32 columns × 8 rows of 7 px swatches with 1 px gaps). Column count is chosen by halving from `palette.size`
+until the row fits `displayWidth - 2 * edgeMargin`. The bottom band height is:
 
 ```text
+cols = pickPaletteGridColumnCount(displayWidth, swatchSize, gap, palette.size, maxColumns?)
 rows = ceil(palette.size / cols)
-cols = widest halving of palette.size that fits:
-       floor((displayWidth - 2 * 3) / (swatchSize + gap)) >= candidate
-bottomReserve = rows * swatchSize + max(0, rows - 1) * gap
+bottomReserve = rows * swatchSize + max(0, rows - 1) * gap + 2 * paletteGridPadding
 ```
 
-Default swatch size is **7 px** with **1 px** gaps. Set `statsOverlayPaletteView: true` to enable the grid, or
-`statsOverlayEnabled: false` for full-screen layouts (for example terminal-style demos).
+Default swatch size is **7 px** with **1 px** gaps and **3 px** padding above and below the grid. Set
+`statsOverlayPaletteView: true` to enable the grid, or `statsOverlayEnabled: false` for full-screen layouts (for example
+terminal-style demos).
 
 ```ts
 configure() {

--- a/docs/api-core.md
+++ b/docs/api-core.md
@@ -104,17 +104,19 @@ See [Post-Process Effects](post-process-effects.md) for tier routing and presets
 output buffer. Include `displaySize` when you want a custom logical size; optional fields you omit then stay unset (for
 example no `canvasDisplaySize` means a 1:1 drawing buffer).
 
-| Field                  | Type                     | Default     | Description                                                        |
-| ---------------------- | ------------------------ | ----------- | ------------------------------------------------------------------ |
-| `displaySize`          | `Vector2i`               | `320×240`   | **Logical** render resolution                                      |
-| `canvasDisplaySize`    | `Vector2i`               | `640×480`   | **Drawing buffer** size; enables **display-tier** effects when set |
-| `maxCanvasDisplaySize` | `Vector2i`               | `960×720`   | **CSS cap** — maximum on-screen canvas size                        |
-| `targetFPS`            | `number`                 | `60`        | Fixed `update()` rate (simulation ticks per second)                |
-| `backend`              | `'webgpu' \| 'software'` | `'webgpu'`  | Force rendering backend                                            |
-| `outputUpscaleFilter`  | `'nearest' \| 'linear'`  | `'nearest'` | Upscale filter                                                     |
-| `detectDroppedFrames`  | `boolean`                | `false`     | Log a console warning on missed vsync                              |
-| `statsOverlayEnabled`  | `boolean`                | `true`      | Engine stats HUD after each `render()`                             |
-| `statsOverlayStyle`    | `StatsOverlayStyle`      | _unset_     | Optional bar/text palette indices for stats overlay                |
+| Field                        | Type                     | Default     | Description                                                        |
+| ---------------------------- | ------------------------ | ----------- | ------------------------------------------------------------------ |
+| `displaySize`                | `Vector2i`               | `320×240`   | **Logical** render resolution                                      |
+| `canvasDisplaySize`          | `Vector2i`               | `640×480`   | **Drawing buffer** size; enables **display-tier** effects when set |
+| `maxCanvasDisplaySize`       | `Vector2i`               | `960×720`   | **CSS cap** — maximum on-screen canvas size                        |
+| `targetFPS`                  | `number`                 | `60`        | Fixed `update()` rate (simulation ticks per second)                |
+| `backend`                    | `'webgpu' \| 'software'` | `'webgpu'`  | Force rendering backend                                            |
+| `outputUpscaleFilter`        | `'nearest' \| 'linear'`  | `'nearest'` | Upscale filter                                                     |
+| `detectDroppedFrames`        | `boolean`                | `false`     | Log a console warning on missed vsync                              |
+| `statsOverlayEnabled`        | `boolean`                | `true`      | Engine stats HUD after each `render()`                             |
+| `statsOverlayPaletteView`    | `boolean`                | `true`      | Live palette swatch grid in the stats overlay bottom band          |
+| `statsOverlayPaletteColumns` | `number`                 | _unset_     | Max palette swatches per grid row (default: widest fit)            |
+| `statsOverlayStyle`          | `StatsOverlayStyle`      | _unset_     | Optional bar/text palette indices for stats overlay                |
 
 `displaySize`, `canvasDisplaySize`, and `maxCanvasDisplaySize` must be positive whole-number pixel dimensions. Each size
 is capped at `8192×8192` per axis and `16,777,216` total pixels (`4096×4096`). Invalid sizes make initialization fail
@@ -180,8 +182,8 @@ configure() {
 When `statsOverlayEnabled` is `true` (default), the engine draws a screen-space HUD after each demo `render()` call, on
 top of all demo content. Bar bands and text anchors are computed each frame by the internal layout planner in
 `src/render/stats-overlay/layoutPlan.ts` from `displaySize`, custom row count, and optional feature flags (timing chart
-and palette grid default off). Init still caches stable values such as the bottom-right toggle rect and text baselines
-from the system font metrics.
+default off; palette grid on by default via `statsOverlayPaletteView`). Init still caches stable values such as the
+bottom-right toggle rect and text baselines from the system font metrics.
 
 - **Top row 1 (left):** short demo title derived from `document.title` (registry pages titled
   `Blit-Tech Demo NNN - Topic` show as `Topic Demo`); **top row 1 (right):** active backend and logical resolution (for
@@ -189,8 +191,11 @@ from the system font metrics.
 - **Top row 2 (left):** `Present: N FPS | Target: T FPS | Draw Calls: C`
 - **Top row 3 (left):** `Frame: Xms | update(): Yms | render(): Zms` (shows `xN` on `update()` when multiple fixed
   updates ran this frame)
-- **Bottom row (right):** `[~]` hint
-- **Custom rows (optional):** extra bars from `statsOverlayRows()` stacked above the bottom bar, **1 px** apart, each
+- **Bottom band:** live palette swatch grid (default) showing every active palette slot; slots referenced by demo draw
+  calls this frame are filled with their color, and unused slots render as empty rounded squares with a small X mark.
+  The `[~]` hint stays anchored bottom-right; set `statsOverlayPaletteView: false` to restore the legacy 13 px hint bar
+  only
+- **Custom rows (optional):** extra bars from `statsOverlayRows()` stacked above the bottom band, **1 px** apart, each
   with left text and optional right text (same 13 px bar style as the built-in rows)
 
 Demos may implement optional `statsOverlayRows()` on `IBlitTechDemo`. The engine calls it once per render frame after
@@ -226,17 +231,28 @@ smoothed CPU wall-time samples from `performance.now()`. `Draw Calls` counts dem
 rendered frame. Do not use present FPS for simulation timing—use `BT.ticks`, `BT.deltaSeconds`, or `Timer` instead.
 
 Demos should not duplicate engine stats text; the overlay provides it. Reserve about **14 px** per custom overlay row
-above the bottom bar (13 px bar + 1 px gap). When drawing custom top or bottom HUD panels, leave about **42 px** clear
-at the top (three built-in text rows + gaps; add about **22 px** when the timing chart feature ships). Leave about **13
-px** clear at the bottom for the legacy hint bar today; the bottom band becomes **variable height** when the palette
-swatch grid ships (depends on display width and swatch size). Or set `statsOverlayEnabled: false` for full-screen
-layouts (for example terminal-style demos).
+above the bottom band (13 px bar + 1 px gap). When drawing custom top or bottom HUD panels, leave about **42 px** clear
+at the top (three built-in text rows + gaps; add about **22 px** when the timing chart feature ships). Leave about **39
+px** clear at the bottom on the default `320×240` layout with a 256-slot palette (32 columns × 8 rows of 4 px swatches
+with 1 px gaps). The bottom band height is:
+
+```text
+rows = ceil(palette.size / cols)
+cols = widest halving of palette.size that fits:
+       floor((displayWidth - 2 * 3) / (swatchSize + gap)) >= candidate
+bottomReserve = rows * swatchSize + max(0, rows - 1) * gap
+```
+
+Default swatch size is **4 px** with **1 px** gaps; swatches use transparent corner pixels so the bar background shows
+through. Set `statsOverlayPaletteView: false` for the legacy **13 px** hint bar, or `statsOverlayEnabled: false` for
+full-screen layouts (for example terminal-style demos).
 
 ```ts
 configure() {
   return {
     displaySize: new Vector2i(320, 240),
     statsOverlayEnabled: false, // release build or custom full-screen HUD
+    statsOverlayPaletteView: false, // legacy 13 px hint bar without palette grid
     statsOverlayStyle: { barPaletteIndex: 2, textPaletteIndex: 3 }, // optional palette indices
   };
 }

--- a/docs/api-core.md
+++ b/docs/api-core.md
@@ -114,7 +114,7 @@ example no `canvasDisplaySize` means a 1:1 drawing buffer).
 | `outputUpscaleFilter`        | `'nearest' \| 'linear'`  | `'nearest'` | Upscale filter                                                     |
 | `detectDroppedFrames`        | `boolean`                | `false`     | Log a console warning on missed vsync                              |
 | `statsOverlayEnabled`        | `boolean`                | `true`      | Engine stats HUD after each `render()`                             |
-| `statsOverlayPaletteView`    | `boolean`                | `true`      | Live palette swatch grid in the stats overlay bottom band          |
+| `statsOverlayPaletteView`    | `boolean`                | `false`     | Live palette swatch grid in the stats overlay bottom band (opt-in) |
 | `statsOverlayPaletteColumns` | `number`                 | _unset_     | Max palette swatches per grid row (default: widest fit)            |
 | `statsOverlayStyle`          | `StatsOverlayStyle`      | _unset_     | Optional bar/text palette indices for stats overlay                |
 
@@ -182,7 +182,7 @@ configure() {
 When `statsOverlayEnabled` is `true` (default), the engine draws a screen-space HUD after each demo `render()` call, on
 top of all demo content. Bar bands and text anchors are computed each frame by the internal layout planner in
 `src/render/stats-overlay/layoutPlan.ts` from `displaySize`, custom row count, and optional feature flags (timing chart
-default off; palette grid on by default via `statsOverlayPaletteView`). Init still caches stable values such as the
+default off; palette grid opt-in via `statsOverlayPaletteView`). Init still caches stable values such as the
 bottom-right toggle rect and text baselines from the system font metrics.
 
 - **Top row 1 (left):** short demo title derived from `document.title` (registry pages titled
@@ -191,10 +191,10 @@ bottom-right toggle rect and text baselines from the system font metrics.
 - **Top row 2 (left):** `Present: N FPS | Target: T FPS | Draw Calls: C`
 - **Top row 3 (left):** `Frame: Xms | update(): Yms | render(): Zms` (shows `xN` on `update()` when multiple fixed
   updates ran this frame)
-- **Bottom band:** live palette swatch grid (default) showing every active palette slot; slots referenced by demo draw
-  calls this frame are filled with their color, and unused slots render as empty rounded squares with a small X mark.
-  The `[~]` hint stays anchored bottom-right; set `statsOverlayPaletteView: false` to restore the legacy 13 px hint bar
-  only
+- **Bottom band:** legacy **13 px** hint bar with the `[~]` toggle label anchored bottom-right (default). Set
+  `statsOverlayPaletteView: true` to replace it with a live palette swatch grid showing every active palette slot; slots
+  referenced by demo draw calls this frame are filled with their color, and unused slots render as empty squares with a
+  small X mark
 - **Custom rows (optional):** extra bars from `statsOverlayRows()` stacked above the bottom band, **1 px** apart, each
   with left text and optional right text (same 13 px bar style as the built-in rows)
 
@@ -232,9 +232,10 @@ rendered frame. Do not use present FPS for simulation timing—use `BT.ticks`, `
 
 Demos should not duplicate engine stats text; the overlay provides it. Reserve about **14 px** per custom overlay row
 above the bottom band (13 px bar + 1 px gap). When drawing custom top or bottom HUD panels, leave about **42 px** clear
-at the top (three built-in text rows + gaps; add about **22 px** when the timing chart feature ships). Leave about **39
-px** clear at the bottom on the default `320×240` layout with a 256-slot palette (32 columns × 8 rows of 4 px swatches
-with 1 px gaps). The bottom band height is:
+at the top (three built-in text rows + gaps; add about **22 px** when the timing chart feature ships). Leave about **13
+px** clear at the bottom by default (legacy hint bar). When `statsOverlayPaletteView: true`, reserve additional space
+for the palette grid—for example about **69 px** on the default `320×240` layout with a 256-slot palette (32 columns × 8
+rows of 7 px swatches with 1 px gaps). The bottom band height is:
 
 ```text
 rows = ceil(palette.size / cols)
@@ -243,16 +244,15 @@ cols = widest halving of palette.size that fits:
 bottomReserve = rows * swatchSize + max(0, rows - 1) * gap
 ```
 
-Default swatch size is **4 px** with **1 px** gaps; swatches use transparent corner pixels so the bar background shows
-through. Set `statsOverlayPaletteView: false` for the legacy **13 px** hint bar, or `statsOverlayEnabled: false` for
-full-screen layouts (for example terminal-style demos).
+Default swatch size is **7 px** with **1 px** gaps. Set `statsOverlayPaletteView: true` to enable the grid, or
+`statsOverlayEnabled: false` for full-screen layouts (for example terminal-style demos).
 
 ```ts
 configure() {
   return {
     displaySize: new Vector2i(320, 240),
     statsOverlayEnabled: false, // release build or custom full-screen HUD
-    statsOverlayPaletteView: false, // legacy 13 px hint bar without palette grid
+    statsOverlayPaletteView: true, // opt in to live palette swatch grid
     statsOverlayStyle: { barPaletteIndex: 2, textPaletteIndex: 3 }, // optional palette indices
   };
 }

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -40,7 +40,8 @@ and `vi` for browser API stubs. Tests that need a full DOM (Bootstrap, Bootstrap
   `BT.requestedBackend` vs `BT.activeBackend` after WebGPU fallback, `captureFrame()` in software mode, and stats
   overlay render path (Node + GPU mocks + 2D canvas mocks)
 - **StatsOverlay** - colocated tests under `src/render/stats-overlay/*.test.ts`: label parsing, layout helpers,
-  `layoutPlan` golden Y positions for 320x240 (including custom rows and scaffold cases), toggle hit-testing, and
+  `layoutPlan` golden Y positions for 320x240 (including custom rows, palette grid variable bottom band, and timing
+  chart scaffold cases), `StatsOverlayPaletteView.computePaletteGrid` width/size matrix, toggle hit-testing, and
   `updateAndRender` integration (Node)
 - **FrameCapture** - GPU readback, PNG conversion (Node + GPU mocks + browser stubs)
 

--- a/src/assets/SpriteSheet.ts
+++ b/src/assets/SpriteSheet.ts
@@ -1,3 +1,4 @@
+import { markRenderPaletteIndexUsed } from '../core/RenderPaletteUsage';
 import { assertAssetDimensions, assertImageElementWithinLimits, assertIndexedPixelInput } from '../utils/AssetLimits';
 import { Color32 } from '../utils/Color32';
 import { spriteColorNotInPaletteError } from '../utils/errorMessages';
@@ -527,10 +528,7 @@ export class SpriteSheet {
 
                 const resolved = sheetIndex + paletteOffset;
 
-                if (resolved > 0 && resolved < usedMask.length) {
-                    // eslint-disable-next-line security/detect-object-injection -- resolved bounds checked above
-                    usedMask[resolved] = 1;
-                }
+                markRenderPaletteIndexUsed(usedMask, resolved);
             }
         }
     }

--- a/src/assets/SpriteSheet.ts
+++ b/src/assets/SpriteSheet.ts
@@ -493,6 +493,49 @@ export class SpriteSheet {
         return this.indexedPixels.slice() as Uint8Array<ArrayBuffer>;
     }
 
+    /**
+     * Marks palette indices referenced by non-zero pixels in a source rectangle.
+     *
+     * Used by the engine to build the stats overlay palette grid from demo draw
+     * calls. Does not allocate; writes into the supplied usage mask.
+     *
+     * @param srcRect - Region to scan in sheet coordinates.
+     * @param paletteOffset - Palette offset applied at draw time.
+     * @param usedMask - Mutable usage mask indexed by resolved palette slot.
+     */
+    markPaletteIndicesInRect(srcRect: Rect2i, paletteOffset: number, usedMask: Uint8Array): void {
+        if (this.indexedPixels === null) {
+            return;
+        }
+
+        const sheetWidth = this.size.x;
+        const pixels = this.indexedPixels;
+        const startX = Math.max(0, srcRect.x);
+        const startY = Math.max(0, srcRect.y);
+        const endX = Math.min(this.size.x, srcRect.x + srcRect.width);
+        const endY = Math.min(this.size.y, srcRect.y + srcRect.height);
+
+        for (let y = startY; y < endY; y++) {
+            const rowOffset = y * sheetWidth;
+
+            for (let x = startX; x < endX; x++) {
+                 
+                const sheetIndex = pixels[rowOffset + x] ?? 0;
+
+                if (sheetIndex === 0) {
+                    continue;
+                }
+
+                const resolved = sheetIndex + paletteOffset;
+
+                if (resolved > 0 && resolved < usedMask.length) {
+                    // eslint-disable-next-line security/detect-object-injection -- resolved bounds checked above
+                    usedMask[resolved] = 1;
+                }
+            }
+        }
+    }
+
     // #endregion
 
     // #region Accessors

--- a/src/assets/SpriteSheet.ts
+++ b/src/assets/SpriteSheet.ts
@@ -519,7 +519,6 @@ export class SpriteSheet {
             const rowOffset = y * sheetWidth;
 
             for (let x = startX; x < endX; x++) {
-                 
                 const sheetIndex = pixels[rowOffset + x] ?? 0;
 
                 if (sheetIndex === 0) {

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -35,6 +35,11 @@ import type { FrameDropCallback, FrameDropEvent } from './GameLoop';
 import { GameLoop } from './GameLoop';
 import type { Backend, HardwareSettings, IBlitTechDemo } from './IBlitTechDemo';
 import { defaultConfig, mergeHardwareSettings } from './IBlitTechDemo';
+import {
+    collectUsedRenderPaletteIndices,
+    markRenderPaletteIndexUsed,
+    resetRenderPaletteUsage,
+} from './RenderPaletteUsage';
 import { initWebGPU } from './WebGPUContext';
 
 /**
@@ -124,6 +129,12 @@ export class BTAPI {
 
     /** Number of demo draw API calls issued since the last rendered frame. */
     private pendingDrawCalls = 0;
+
+    /** Bitmask of palette indices referenced by demo draw calls this frame. */
+    private readonly framePaletteUsageMask = new Uint8Array(256);
+
+    /** Reusable sorted list of used palette indices for the stats overlay grid. */
+    private readonly framePaletteUsageScratch: number[] = [];
 
     /** Reused timing snapshot passed into the stats overlay each frame. */
     private readonly statsOverlayTiming: {
@@ -269,9 +280,14 @@ export class BTAPI {
                 let renderMs = 0;
 
                 if (this.renderer) {
+                    resetRenderPaletteUsage(this.framePaletteUsageMask);
+
                     this.renderer.beginFrame();
+
                     const renderStartMs = performance.now();
+
                     this.demo?.render();
+
                     renderMs = Math.max(0, performance.now() - renderStartMs);
 
                     // Palette effects run after demo render (so user's explicit palette
@@ -280,6 +296,14 @@ export class BTAPI {
                     if (this.palette && this.paletteEffects.activeCount > 0) {
                         this.paletteEffects.update(this.palette);
                     }
+
+                    const usedPaletteIndices = this.palette
+                        ? collectUsedRenderPaletteIndices(
+                              this.framePaletteUsageMask,
+                              this.palette.size,
+                              this.framePaletteUsageScratch,
+                          )
+                        : this.framePaletteUsageScratch;
 
                     // Stats overlay: screen-space HUD after demo content (top/bottom bars).
                     if (this.statsOverlay && this.systemFont) {
@@ -292,6 +316,7 @@ export class BTAPI {
                             () => this.demo?.statsOverlayRows?.(),
                             this.statsOverlayTiming,
                             this.palette,
+                            usedPaletteIndices,
                         );
                     }
 
@@ -608,6 +633,8 @@ export class BTAPI {
      */
     public setClearColor(paletteIndex: number): void {
         this.assertPaletteIndex(paletteIndex);
+        this.trackPaletteIndexUsed(paletteIndex);
+
         this.renderer?.setClearColor(paletteIndex);
     }
 
@@ -619,7 +646,10 @@ export class BTAPI {
      */
     public clearRect(rect: Rect2i, paletteIndex: number): void {
         this.assertPaletteIndex(paletteIndex);
+        this.trackPaletteIndexUsed(paletteIndex);
+
         this.markDrawCall();
+
         this.renderer?.clearRect(rect, paletteIndex);
     }
 
@@ -631,7 +661,10 @@ export class BTAPI {
      */
     public drawPixel(pos: Vector2i, paletteIndex: number): void {
         this.assertPaletteIndex(paletteIndex);
+        this.trackPaletteIndexUsed(paletteIndex);
+
         this.markDrawCall();
+
         this.renderer?.drawPixel(pos, paletteIndex);
     }
 
@@ -645,7 +678,10 @@ export class BTAPI {
      */
     public drawLine(p0: Vector2i, p1: Vector2i, paletteIndex: number): void {
         this.assertPaletteIndex(paletteIndex);
+        this.trackPaletteIndexUsed(paletteIndex);
+
         this.markDrawCall();
+
         this.renderer?.drawLine(p0, p1, paletteIndex);
     }
 
@@ -661,7 +697,10 @@ export class BTAPI {
      */
     public drawRect(rect: Rect2i, paletteIndex: number): void {
         this.assertPaletteIndex(paletteIndex);
+        this.trackPaletteIndexUsed(paletteIndex);
+
         this.markDrawCall();
+
         this.renderer?.drawRect(rect, paletteIndex);
     }
 
@@ -673,7 +712,10 @@ export class BTAPI {
      */
     public drawRectFill(rect: Rect2i, paletteIndex: number): void {
         this.assertPaletteIndex(paletteIndex);
+        this.trackPaletteIndexUsed(paletteIndex);
+
         this.markDrawCall();
+
         this.renderer?.drawRectFill(rect, paletteIndex);
     }
 
@@ -697,7 +739,9 @@ export class BTAPI {
         }
 
         if (this.systemFont) {
+            this.trackPaletteIndexUsed(paletteIndex);
             this.markDrawCall();
+
             // Offset math: font stores foreground as index 1.
             // Shader computes 1 + (paletteIndex - 1) = paletteIndex.
             this.renderer?.drawBitmapText(this.systemFont, pos, text, paletteIndex - 1);
@@ -726,7 +770,13 @@ export class BTAPI {
     public drawSprite(spriteSheet: SpriteSheet, srcRect: Rect2i, destPos: Vector2i, paletteOffset: number = 0): void {
         this.assertPaletteIndex(paletteOffset);
         this.requireIndexizedSheet(spriteSheet);
+
+        if (this.renderer) {
+            spriteSheet.markPaletteIndicesInRect(srcRect, paletteOffset, this.framePaletteUsageMask);
+        }
+
         this.markDrawCall();
+
         this.renderer?.drawSprite(spriteSheet, srcRect, destPos, paletteOffset);
     }
 
@@ -743,7 +793,13 @@ export class BTAPI {
     public drawBitmapText(font: BitmapFont, pos: Vector2i, text: string, paletteOffset: number = 0): void {
         this.assertPaletteIndex(paletteOffset);
         this.requireIndexizedSheet(font.getSpriteSheet());
+
+        if (this.renderer) {
+            this.markBitmapTextPaletteUsage(font, text, paletteOffset);
+        }
+
         this.markDrawCall();
+
         this.renderer?.drawBitmapText(font, pos, text, paletteOffset);
     }
 
@@ -1025,6 +1081,7 @@ export class BTAPI {
             // throws when the adapter or device cannot be created. Both cases fall
             // through to the software renderer below.
             let webGPUResult: Awaited<ReturnType<typeof initWebGPU>> = null;
+
             try {
                 webGPUResult = await initWebGPU(canvas, hw.displaySize, hw.canvasDisplaySize);
             } catch (error) {
@@ -1038,12 +1095,14 @@ export class BTAPI {
             if (webGPUResult) {
                 this.device = webGPUResult.device;
                 this.context = webGPUResult.context;
+
                 console.log('[BT] Initializing renderer (backend: webgpu)');
 
                 this.renderer = new WebGpuRenderer(
                     webGPUResult.device,
                     webGPUResult.context,
                     hw.displaySize,
+
                     // Only forward an explicit outputSize when canvasDisplaySize was
                     // provided; that is the signal that unlocks the display tier.
                     hw.canvasDisplaySize !== undefined ? webGPUResult.drawingBufferSize : undefined,
@@ -1068,6 +1127,7 @@ export class BTAPI {
         // Software renderer path: explicit selection or automatic fallback.
         this.device = null;
         this.context = null;
+
         console.log('[BT] Initializing renderer (backend: software)');
 
         this.renderer = new SoftwareRenderer(canvas, hw.displaySize, hw.canvasDisplaySize);
@@ -1098,11 +1158,13 @@ export class BTAPI {
         }
 
         const override = BTAPI.getBackendQueryOverride();
+
         if (!override) {
             return;
         }
 
         this.hwSettings.backend = override;
+
         console.info(`[BT] URL override selected backend: ${override}`);
     }
 
@@ -1125,6 +1187,7 @@ export class BTAPI {
 
         try {
             const backend = new URLSearchParams(search).get('backend');
+
             if (backend === 'software') {
                 return 'software';
             }
@@ -1144,8 +1207,10 @@ export class BTAPI {
     private clearInputSubsystems(): void {
         this.pointer?.detach();
         this.pointer = null;
+
         this.keyboard?.detach();
         this.keyboard = null;
+
         this.gamepad?.detach();
         this.gamepad = null;
     }
@@ -1164,6 +1229,7 @@ export class BTAPI {
 
             if (!ok) {
                 console.error('[BT] Demo initialization failed');
+
                 this.clearInputSubsystems();
 
                 return false;
@@ -1172,6 +1238,7 @@ export class BTAPI {
             return true;
         } catch (err) {
             console.error('[BT] Demo initialization threw', err);
+
             this.clearInputSubsystems();
 
             return false;
@@ -1231,6 +1298,36 @@ export class BTAPI {
      */
     private markDrawCall(): void {
         this.pendingDrawCalls++;
+    }
+
+    /**
+     * Marks a palette index as used for the current frame.
+     *
+     * @param index - Palette index to track.
+     */
+    private trackPaletteIndexUsed(index: number): void {
+        if (this.renderer) {
+            markRenderPaletteIndexUsed(this.framePaletteUsageMask, index);
+        }
+    }
+
+    /**
+     * Marks palette indices referenced by bitmap text glyphs in a string.
+     *
+     * @param font - Bitmap font whose glyph atlas is scanned.
+     * @param text - Text about to be drawn.
+     * @param paletteOffset - Palette offset applied at draw time.
+     */
+    private markBitmapTextPaletteUsage(font: BitmapFont, text: string, paletteOffset: number): void {
+        const sheet = font.getSpriteSheet();
+
+        for (const char of text) {
+            const glyph = font.getGlyph(char);
+
+            if (glyph !== null) {
+                sheet.markPaletteIndicesInRect(glyph.rect, paletteOffset, this.framePaletteUsageMask);
+            }
+        }
     }
 
     /**

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -418,6 +418,8 @@ export class BTAPI {
             hw.targetFPS,
             this.activeBackend,
             hw.statsOverlayStyle,
+            hw.statsOverlayPaletteView !== false,
+            hw.statsOverlayPaletteColumns,
         );
     }
 

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -36,7 +36,6 @@ import { GameLoop } from './GameLoop';
 import type { Backend, HardwareSettings, IBlitTechDemo } from './IBlitTechDemo';
 import { defaultConfig, mergeHardwareSettings } from './IBlitTechDemo';
 import {
-    collectUsedRenderPaletteIndices,
     markRenderPaletteIndexUsed,
     RENDER_PALETTE_USAGE_CAPACITY,
     resetRenderPaletteUsage,
@@ -133,9 +132,6 @@ export class BTAPI {
 
     /** Bitmask of palette indices referenced by demo draw calls this frame. */
     private readonly framePaletteUsageMask = new Uint8Array(RENDER_PALETTE_USAGE_CAPACITY);
-
-    /** Reusable sorted list of used palette indices for the stats overlay grid. */
-    private readonly framePaletteUsageScratch: number[] = [];
 
     /** Reused timing snapshot passed into the stats overlay each frame. */
     private readonly statsOverlayTiming: {
@@ -298,14 +294,6 @@ export class BTAPI {
                         this.paletteEffects.update(this.palette);
                     }
 
-                    const usedPaletteIndices = this.palette
-                        ? collectUsedRenderPaletteIndices(
-                              this.framePaletteUsageMask,
-                              this.palette.size,
-                              this.framePaletteUsageScratch,
-                          )
-                        : this.framePaletteUsageScratch;
-
                     // Stats overlay: screen-space HUD after demo content (top/bottom bars).
                     if (this.statsOverlay && this.systemFont) {
                         this.statsOverlay.updateAndRender(
@@ -317,7 +305,7 @@ export class BTAPI {
                             () => this.demo?.statsOverlayRows?.(),
                             this.statsOverlayTiming,
                             this.palette,
-                            usedPaletteIndices,
+                            this.framePaletteUsageMask,
                         );
                     }
 

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -38,6 +38,7 @@ import { defaultConfig, mergeHardwareSettings } from './IBlitTechDemo';
 import {
     collectUsedRenderPaletteIndices,
     markRenderPaletteIndexUsed,
+    RENDER_PALETTE_USAGE_CAPACITY,
     resetRenderPaletteUsage,
 } from './RenderPaletteUsage';
 import { initWebGPU } from './WebGPUContext';
@@ -131,7 +132,7 @@ export class BTAPI {
     private pendingDrawCalls = 0;
 
     /** Bitmask of palette indices referenced by demo draw calls this frame. */
-    private readonly framePaletteUsageMask = new Uint8Array(256);
+    private readonly framePaletteUsageMask = new Uint8Array(RENDER_PALETTE_USAGE_CAPACITY);
 
     /** Reusable sorted list of used palette indices for the stats overlay grid. */
     private readonly framePaletteUsageScratch: number[] = [];
@@ -418,7 +419,7 @@ export class BTAPI {
             hw.targetFPS,
             this.activeBackend,
             hw.statsOverlayStyle,
-            hw.statsOverlayPaletteView !== false,
+            hw.statsOverlayPaletteView === true,
             hw.statsOverlayPaletteColumns,
         );
     }

--- a/src/core/IBlitTechDemo.test.ts
+++ b/src/core/IBlitTechDemo.test.ts
@@ -91,6 +91,7 @@ describe('mergeHardwareSettings', () => {
         expect(settings.displaySize.x).toBe(320);
         expect(settings.canvasDisplaySize?.x).toBe(640);
         expect(settings.targetFPS).toBe(30);
+        expect(settings.statsOverlayPaletteView).toBe(false);
     });
 
     it('keeps canvasDisplaySize unset when displaySize is provided without output sizing', () => {
@@ -116,6 +117,7 @@ describe('mergeHardwareSettings', () => {
         expect(settings.backend).toBe('software');
         expect(settings.targetFPS).toBe(60);
         expect(settings.statsOverlayEnabled).toBe(true);
+        expect(settings.statsOverlayPaletteView).toBe(false);
     });
 
     it('honors statsOverlayEnabled: false from configure()', () => {

--- a/src/core/IBlitTechDemo.test.ts
+++ b/src/core/IBlitTechDemo.test.ts
@@ -58,10 +58,10 @@ describe('defaultConfig', () => {
         expect(settings.statsOverlayEnabled).toBe(true);
     });
 
-    it('should enable stats overlay palette view by default', () => {
+    it('should disable stats overlay palette view by default', () => {
         const settings = defaultConfig();
 
-        expect(settings.statsOverlayPaletteView).toBe(true);
+        expect(settings.statsOverlayPaletteView).toBe(false);
     });
 
     it('should return a fresh object on each call', () => {

--- a/src/core/IBlitTechDemo.test.ts
+++ b/src/core/IBlitTechDemo.test.ts
@@ -58,6 +58,12 @@ describe('defaultConfig', () => {
         expect(settings.statsOverlayEnabled).toBe(true);
     });
 
+    it('should enable stats overlay palette view by default', () => {
+        const settings = defaultConfig();
+
+        expect(settings.statsOverlayPaletteView).toBe(true);
+    });
+
     it('should return a fresh object on each call', () => {
         const a = defaultConfig();
         const b = defaultConfig();

--- a/src/core/IBlitTechDemo.ts
+++ b/src/core/IBlitTechDemo.ts
@@ -121,9 +121,10 @@ export interface HardwareSettings {
     statsOverlayEnabled?: boolean;
 
     /**
-     * When `true` (default), the engine draws a live palette swatch grid in the stats
-     * overlay bottom band showing the active indexed palette. Set to `false` to restore
-     * the legacy 13 px hint bar only.
+     * When `true`, the engine draws a live palette swatch grid in the stats overlay
+     * bottom band showing the active indexed palette. Defaults to `false` in
+     * {@link defaultConfig}; set to `true` to opt in. When `false`, the legacy 13 px
+     * hint bar is shown instead.
      */
     statsOverlayPaletteView?: boolean;
 
@@ -455,7 +456,7 @@ function mergePartialWithFullDefaults(picked: Partial<HardwareSettings>, default
         displaySize: cloneVector2i(defaults.displaySize),
         targetFPS: picked.targetFPS ?? defaults.targetFPS,
         statsOverlayEnabled: picked.statsOverlayEnabled ?? defaults.statsOverlayEnabled ?? true,
-        statsOverlayPaletteView: picked.statsOverlayPaletteView ?? defaults.statsOverlayPaletteView ?? true,
+        statsOverlayPaletteView: picked.statsOverlayPaletteView ?? defaults.statsOverlayPaletteView ?? false,
         ...buildFullDefaultMergeOptionals(picked, defaults),
     };
 }
@@ -473,7 +474,7 @@ function mergeExplicitDisplayProfile(picked: Partial<HardwareSettings>, defaults
         displaySize: picked.displaySize ?? cloneVector2i(defaults.displaySize),
         targetFPS: picked.targetFPS ?? defaults.targetFPS,
         statsOverlayEnabled: picked.statsOverlayEnabled ?? defaults.statsOverlayEnabled ?? true,
-        statsOverlayPaletteView: picked.statsOverlayPaletteView ?? defaults.statsOverlayPaletteView ?? true,
+        statsOverlayPaletteView: picked.statsOverlayPaletteView ?? defaults.statsOverlayPaletteView ?? false,
         ...(picked.canvasDisplaySize !== undefined ? { canvasDisplaySize: picked.canvasDisplaySize } : {}),
         ...(picked.maxCanvasDisplaySize !== undefined ? { maxCanvasDisplaySize: picked.maxCanvasDisplaySize } : {}),
         ...(picked.outputUpscaleFilter !== undefined ? { outputUpscaleFilter: picked.outputUpscaleFilter } : {}),

--- a/src/core/IBlitTechDemo.ts
+++ b/src/core/IBlitTechDemo.ts
@@ -121,6 +121,19 @@ export interface HardwareSettings {
     statsOverlayEnabled?: boolean;
 
     /**
+     * When `true` (default), the engine draws a live palette swatch grid in the stats
+     * overlay bottom band showing the active indexed palette. Set to `false` to restore
+     * the legacy 13 px hint bar only.
+     */
+    statsOverlayPaletteView?: boolean;
+
+    /**
+     * Maximum palette swatches per row in the stats overlay grid. When unset, the engine
+     * picks the widest column count that fits {@link HardwareSettings.displaySize}.
+     */
+    statsOverlayPaletteColumns?: number;
+
+    /**
      * Palette indices for the built-in stats overlay bars (top and bottom) and as defaults
      * for custom {@link StatsOverlayRow} entries that omit per-row colors.
      *
@@ -143,7 +156,8 @@ export interface StatsOverlayStyle {
 /**
  * One optional stats-overlay row supplied by a demo (left label, optional right label).
  *
- * Rendered as a 13 px bar stacked above the bottom `[~]` bar with 1 px gaps. Reuse the same
+ * Rendered as a 13 px bar stacked above the bottom palette grid (or legacy hint bar when
+ * {@link HardwareSettings.statsOverlayPaletteView} is `false`) with 1 px gaps. Reuse the same
  * array instance from {@link IBlitTechDemo.statsOverlayRows} when possible to avoid
  * per-frame allocations.
  */
@@ -225,9 +239,10 @@ export interface IBlitTechDemo {
      * draws a screen-space stats HUD after this method returns (present FPS, target FPS, draw calls,
      * frame/update()/render() timings, backend, demo title). Optional {@link statsOverlayRows} adds stacked bars above
      * the footer.
-     * Demos do not need to duplicate engine stats text. Reserve about ~42 px at the top and ~13 px at the bottom
-     * (plus ~14 px per custom overlay row) for overlay bars, or disable
-     * the overlay in `configure()` when using custom full-screen HUD layouts.
+     * Demos do not need to duplicate engine stats text. Reserve about ~42 px at the top and space for the bottom palette
+     * grid (or ~13 px when {@link HardwareSettings.statsOverlayPaletteView} is `false`) at the bottom (plus ~14 px per
+     * custom overlay row) for overlay bars, or disable the overlay in `configure()` when using custom full-screen HUD
+     * layouts.
      *
      * This is a hot path. Batch draws by texture to reduce GPU state changes
      * and reuse Color32/Vector2i instances instead of allocating per frame.
@@ -274,6 +289,7 @@ export function defaultConfig(): HardwareSettings {
         outputUpscaleFilter: 'nearest',
         backend: 'webgpu',
         statsOverlayEnabled: true,
+        statsOverlayPaletteView: false,
     };
 }
 
@@ -326,6 +342,14 @@ function pickDefinedHardwareSettings(partial: Partial<HardwareSettings>): Partia
 
     if (partial.statsOverlayEnabled !== undefined) {
         picked.statsOverlayEnabled = partial.statsOverlayEnabled;
+    }
+
+    if (partial.statsOverlayPaletteView !== undefined) {
+        picked.statsOverlayPaletteView = partial.statsOverlayPaletteView;
+    }
+
+    if (partial.statsOverlayPaletteColumns !== undefined) {
+        picked.statsOverlayPaletteColumns = partial.statsOverlayPaletteColumns;
     }
 
     if (partial.statsOverlayStyle !== undefined) {
@@ -405,6 +429,16 @@ function buildFullDefaultMergeOptionals(
         optionals.statsOverlayStyle = { ...statsOverlayStyle };
     }
 
+    const statsOverlayPaletteView = picked.statsOverlayPaletteView ?? defaults.statsOverlayPaletteView;
+
+    if (statsOverlayPaletteView !== undefined) {
+        optionals.statsOverlayPaletteView = statsOverlayPaletteView;
+    }
+
+    if (picked.statsOverlayPaletteColumns !== undefined) {
+        optionals.statsOverlayPaletteColumns = picked.statsOverlayPaletteColumns;
+    }
+
     return optionals;
 }
 
@@ -421,6 +455,7 @@ function mergePartialWithFullDefaults(picked: Partial<HardwareSettings>, default
         displaySize: cloneVector2i(defaults.displaySize),
         targetFPS: picked.targetFPS ?? defaults.targetFPS,
         statsOverlayEnabled: picked.statsOverlayEnabled ?? defaults.statsOverlayEnabled ?? true,
+        statsOverlayPaletteView: picked.statsOverlayPaletteView ?? defaults.statsOverlayPaletteView ?? true,
         ...buildFullDefaultMergeOptionals(picked, defaults),
     };
 }
@@ -438,12 +473,16 @@ function mergeExplicitDisplayProfile(picked: Partial<HardwareSettings>, defaults
         displaySize: picked.displaySize ?? cloneVector2i(defaults.displaySize),
         targetFPS: picked.targetFPS ?? defaults.targetFPS,
         statsOverlayEnabled: picked.statsOverlayEnabled ?? defaults.statsOverlayEnabled ?? true,
+        statsOverlayPaletteView: picked.statsOverlayPaletteView ?? defaults.statsOverlayPaletteView ?? true,
         ...(picked.canvasDisplaySize !== undefined ? { canvasDisplaySize: picked.canvasDisplaySize } : {}),
         ...(picked.maxCanvasDisplaySize !== undefined ? { maxCanvasDisplaySize: picked.maxCanvasDisplaySize } : {}),
         ...(picked.outputUpscaleFilter !== undefined ? { outputUpscaleFilter: picked.outputUpscaleFilter } : {}),
         ...(picked.detectDroppedFrames !== undefined ? { detectDroppedFrames: picked.detectDroppedFrames } : {}),
         backend: picked.backend ?? defaults.backend ?? 'webgpu',
         ...(picked.statsOverlayStyle !== undefined ? { statsOverlayStyle: { ...picked.statsOverlayStyle } } : {}),
+        ...(picked.statsOverlayPaletteColumns !== undefined
+            ? { statsOverlayPaletteColumns: picked.statsOverlayPaletteColumns }
+            : {}),
     };
 }
 

--- a/src/core/RenderPaletteUsage.test.ts
+++ b/src/core/RenderPaletteUsage.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Unit tests for per-frame palette usage tracking helpers.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+    collectUsedRenderPaletteIndices,
+    markRenderPaletteIndexUsed,
+    resetRenderPaletteUsage,
+} from './RenderPaletteUsage';
+
+describe('RenderPaletteUsage', () => {
+    it('collects sorted used indices and skips transparent slot 0', () => {
+        const mask = new Uint8Array(256);
+        const scratch: number[] = [];
+
+        markRenderPaletteIndexUsed(mask, 0);
+        markRenderPaletteIndexUsed(mask, 3);
+        markRenderPaletteIndexUsed(mask, 1);
+        markRenderPaletteIndexUsed(mask, 7);
+
+        expect(collectUsedRenderPaletteIndices(mask, 16, scratch)).toEqual([1, 3, 7]);
+    });
+
+    it('reset clears prior marks', () => {
+        const mask = new Uint8Array(256);
+        const scratch: number[] = [];
+
+        markRenderPaletteIndexUsed(mask, 2);
+        resetRenderPaletteUsage(mask);
+
+        expect(collectUsedRenderPaletteIndices(mask, 16, scratch)).toEqual([]);
+    });
+});

--- a/src/core/RenderPaletteUsage.ts
+++ b/src/core/RenderPaletteUsage.ts
@@ -1,0 +1,62 @@
+/**
+ * Per-frame palette index usage tracking for debug overlays.
+ *
+ * BTAPI marks indices referenced by demo draw calls during {@link IBlitTechDemo.render}
+ * and exposes a sorted snapshot to the stats overlay palette grid.
+ */
+
+/** Maximum palette slots tracked by the usage mask. */
+export const RENDER_PALETTE_USAGE_CAPACITY = 256;
+
+/**
+ * Clears a palette usage bitmask.
+ *
+ * @param usedMask - Mutable usage mask cleared in place.
+ */
+export function resetRenderPaletteUsage(usedMask: Uint8Array): void {
+    usedMask.fill(0);
+}
+
+/**
+ * Marks one palette index as used this frame.
+ *
+ * Index `0` (transparent) is ignored.
+ *
+ * @param usedMask - Mutable usage mask.
+ * @param index - Palette index referenced by a draw call.
+ */
+export function markRenderPaletteIndexUsed(usedMask: Uint8Array, index: number): void {
+    if (!Number.isInteger(index) || index <= 0 || index >= usedMask.length) {
+        return;
+    }
+
+    // eslint-disable-next-line security/detect-object-injection -- index bounds checked above
+    usedMask[index] = 1;
+}
+
+/**
+ * Collects sorted used palette indices into a reusable scratch array.
+ *
+ * @param usedMask - Usage mask populated during the current frame.
+ * @param paletteSize - Active palette size upper bound.
+ * @param scratch - Reusable output buffer mutated in place.
+ * @returns The same scratch array containing sorted used indices.
+ */
+export function collectUsedRenderPaletteIndices(
+    usedMask: Uint8Array,
+    paletteSize: number,
+    scratch: number[],
+): readonly number[] {
+    scratch.length = 0;
+
+    const limit = Math.min(paletteSize, usedMask.length);
+
+    for (let index = 1; index < limit; index++) {
+        // eslint-disable-next-line security/detect-object-injection -- index bounded by palette size
+        if (usedMask[index] === 1) {
+            scratch.push(index);
+        }
+    }
+
+    return scratch;
+}

--- a/src/core/RenderPaletteUsage.ts
+++ b/src/core/RenderPaletteUsage.ts
@@ -2,7 +2,7 @@
  * Per-frame palette index usage tracking for debug overlays.
  *
  * BTAPI marks indices referenced by demo draw calls during {@link IBlitTechDemo.render}
- * and exposes a sorted snapshot to the stats overlay palette grid.
+ * and passes the usage mask directly to the stats overlay palette grid.
  */
 
 /** Maximum palette slots tracked by the usage mask. */

--- a/src/render/stats-overlay/StatsOverlay.test.ts
+++ b/src/render/stats-overlay/StatsOverlay.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { Palette } from '../../assets/Palette';
+import { markRenderPaletteIndexUsed } from '../../core/RenderPaletteUsage';
 import { Vector2i } from '../../utils/Vector2i';
 import { STATS_BAR_HEIGHT, STATS_ROW_GAP_PX } from './constants';
 import { createStatsOverlayLayout, statsRightAlignedTextX } from './layoutHelpers';
@@ -20,12 +21,24 @@ import {
     STATS_TOP_TEXT_Y,
 } from './testFixtures';
 
-const LEGACY_PALETTE_VIEW = false;
+/** Default overlay tests use the 13 px hint bar (palette grid opt-in off). */
+const STATS_OVERLAY_PALETTE_VIEW_OFF = false;
+
+/** Builds a usage mask from palette slot indices for tests. */
+function buildUsageMask(indices: readonly number[], size = 256): Uint8Array {
+    const mask = new Uint8Array(size);
+
+    for (const index of indices) {
+        markRenderPaletteIndexUsed(mask, index);
+    }
+
+    return mask;
+}
 
 describe('StatsOverlay', () => {
     it('starts visible and toggles visibility', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(layout, 'Test Demo', 60, 'webgpu', undefined, LEGACY_PALETTE_VIEW);
+        const overlay = new StatsOverlay(layout, 'Test Demo', 60, 'webgpu', undefined, STATS_OVERLAY_PALETTE_VIEW_OFF);
 
         expect(overlay.visible).toBe(true);
 
@@ -53,7 +66,7 @@ describe('StatsOverlay', () => {
     it('draws top and bottom overlay labels', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
         const topLeftLabel = 'Patterns Demo';
-        const overlay = new StatsOverlay(layout, topLeftLabel, 60, 'webgpu', undefined, LEGACY_PALETTE_VIEW);
+        const overlay = new StatsOverlay(layout, topLeftLabel, 60, 'webgpu', undefined, STATS_OVERLAY_PALETTE_VIEW_OFF);
         const renderer = createMockRenderer();
 
         overlay.updateAndRender(renderer, mockFont, null, null, 0);
@@ -97,7 +110,7 @@ describe('StatsOverlay', () => {
 
     it('uses activeBackend for the top-right label', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(layout, 'Demo', 60, 'software', undefined, LEGACY_PALETTE_VIEW);
+        const overlay = new StatsOverlay(layout, 'Demo', 60, 'software', undefined, STATS_OVERLAY_PALETTE_VIEW_OFF);
         const renderer = createMockRenderer();
 
         overlay.updateAndRender(renderer, mockFont, null, null, 0);
@@ -108,7 +121,7 @@ describe('StatsOverlay', () => {
 
     it('uses provided frame timings and shows update-step suffix when multiple updates ran', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu', undefined, LEGACY_PALETTE_VIEW);
+        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu', undefined, STATS_OVERLAY_PALETTE_VIEW_OFF);
         const renderer = createMockRenderer();
 
         overlay.updateAndRender(renderer, mockFont, null, null, 0, undefined, {
@@ -128,7 +141,7 @@ describe('StatsOverlay', () => {
 
     it('skips draw calls when hidden', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu', undefined, LEGACY_PALETTE_VIEW);
+        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu', undefined, STATS_OVERLAY_PALETTE_VIEW_OFF);
         const renderer = createMockRenderer();
 
         overlay.handleToggle(null, { isKeyPressed: (key: string) => key === 'Backquote' } as never, 1);
@@ -140,7 +153,7 @@ describe('StatsOverlay', () => {
 
     it('resets camera for overlay draws then restores the saved offset', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu', undefined, LEGACY_PALETTE_VIEW);
+        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu', undefined, STATS_OVERLAY_PALETTE_VIEW_OFF);
         const renderer = createMockRenderer();
         const saved = new Vector2i(12, 34);
 
@@ -153,7 +166,7 @@ describe('StatsOverlay', () => {
 
     it('uses default overlay palette indices when style is omitted', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu', undefined, LEGACY_PALETTE_VIEW);
+        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu', undefined, STATS_OVERLAY_PALETTE_VIEW_OFF);
         const renderer = createMockRenderer();
         overlay.updateAndRender(renderer, mockFont, null, null, 0);
 
@@ -171,7 +184,7 @@ describe('StatsOverlay', () => {
             60,
             'webgpu',
             { barPaletteIndex: 8, textPaletteIndex: 9 },
-            LEGACY_PALETTE_VIEW,
+            STATS_OVERLAY_PALETTE_VIEW_OFF,
         );
         const renderer = createMockRenderer();
         overlay.updateAndRender(renderer, mockFont, null, null, 0);
@@ -191,7 +204,7 @@ describe('StatsOverlay', () => {
             60,
             'webgpu',
             { barPaletteIndex: 2, textPaletteIndex: 3 },
-            LEGACY_PALETTE_VIEW,
+            STATS_OVERLAY_PALETTE_VIEW_OFF,
         );
         const renderer = createMockRenderer();
         const customRows = [{ leftText: 'Left', barPaletteIndex: 5, textPaletteIndex: 6 }];
@@ -209,7 +222,7 @@ describe('StatsOverlay', () => {
 
     it('draws custom rows stacked above the bottom bar with 1px gaps', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu', undefined, LEGACY_PALETTE_VIEW);
+        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu', undefined, STATS_OVERLAY_PALETTE_VIEW_OFF);
         const renderer = createMockRenderer();
         const customRows = [{ leftText: 'Position: 10, 20' }, { leftText: 'Bounces: 3', rightText: 'ok' }];
 
@@ -247,7 +260,7 @@ describe('StatsOverlay', () => {
 
     it('skips extra custom row draws when customRows is empty', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu', undefined, LEGACY_PALETTE_VIEW);
+        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu', undefined, STATS_OVERLAY_PALETTE_VIEW_OFF);
         const renderer = createMockRenderer();
 
         overlay.updateAndRender(renderer, mockFont, null, null, 0, () => []);
@@ -258,7 +271,7 @@ describe('StatsOverlay', () => {
 
     it('does not invoke getCustomRows while the overlay is hidden', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu', undefined, LEGACY_PALETTE_VIEW);
+        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu', undefined, STATS_OVERLAY_PALETTE_VIEW_OFF);
         const renderer = createMockRenderer();
         const getCustomRows = vi.fn(() => [{ leftText: 'Hidden row' }] as const);
 
@@ -268,22 +281,22 @@ describe('StatsOverlay', () => {
         expect(getCustomRows).not.toHaveBeenCalled();
     });
 
-    it('renders palette grid by default with a variable bottom band', () => {
+    it('renders palette grid when statsOverlayPaletteView is enabled', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu');
+        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu', undefined, true);
         const renderer = createMockRenderer();
         const palette = Palette.vga();
-        const usedIndices = [1, 2, 3, 4, 5, 6, 7, 8];
+        const usedMask = buildUsageMask([1, 2, 3, 4, 5, 6, 7, 8]);
         const grid = computePaletteGrid(320, undefined, palette.size);
 
-        overlay.updateAndRender(renderer, mockFont, null, null, 0, undefined, undefined, palette, usedIndices);
+        overlay.updateAndRender(renderer, mockFont, null, null, 0, undefined, undefined, palette, usedMask);
 
         const fills = getRectFillCalls(renderer);
         expect(fills[3]).toMatchObject({ y: 240 - grid.totalHeight, height: grid.totalHeight, width: 320 });
         expect(renderer.drawRectFillOnTop.mock.calls.length).toBeGreaterThan(4);
     });
 
-    it('preserves legacy bottom bar height when palette view is disabled', () => {
+    it('preserves default hint bar height when palette view is disabled', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
         const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu', undefined, false);
         const renderer = createMockRenderer();
@@ -301,14 +314,14 @@ describe('StatsOverlay', () => {
 
     it('stacks custom rows above the palette grid bottom band', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu');
+        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu', undefined, true);
         const renderer = createMockRenderer();
         const palette = Palette.vga();
-        const usedIndices = [1, 2, 3, 4, 5, 6, 7, 8];
+        const usedMask = buildUsageMask([1, 2, 3, 4, 5, 6, 7, 8]);
         const grid = computePaletteGrid(320, undefined, palette.size);
         const customRows = [{ leftText: 'Palette row' }];
 
-        overlay.updateAndRender(renderer, mockFont, null, null, 0, () => customRows, undefined, palette, usedIndices);
+        overlay.updateAndRender(renderer, mockFont, null, null, 0, () => customRows, undefined, palette, usedMask);
 
         const fills = getRectFillCalls(renderer);
         const row0BarY = customRowBarY(240, 0, grid.totalHeight);

--- a/src/render/stats-overlay/StatsOverlay.test.ts
+++ b/src/render/stats-overlay/StatsOverlay.test.ts
@@ -4,10 +4,12 @@
 
 import { describe, expect, it, vi } from 'vitest';
 
+import { Palette } from '../../assets/Palette';
 import { Vector2i } from '../../utils/Vector2i';
 import { STATS_BAR_HEIGHT, STATS_ROW_GAP_PX } from './constants';
 import { createStatsOverlayLayout, statsRightAlignedTextX } from './layoutHelpers';
 import { StatsOverlay } from './StatsOverlay';
+import { computePaletteGrid } from './StatsOverlayPaletteView';
 import {
     createMockRenderer,
     customRowBarY,
@@ -18,10 +20,12 @@ import {
     STATS_TOP_TEXT_Y,
 } from './testFixtures';
 
+const LEGACY_PALETTE_VIEW = false;
+
 describe('StatsOverlay', () => {
     it('starts visible and toggles visibility', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(layout, 'Test Demo', 60, 'webgpu');
+        const overlay = new StatsOverlay(layout, 'Test Demo', 60, 'webgpu', undefined, LEGACY_PALETTE_VIEW);
 
         expect(overlay.visible).toBe(true);
 
@@ -49,7 +53,7 @@ describe('StatsOverlay', () => {
     it('draws top and bottom overlay labels', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
         const topLeftLabel = 'Patterns Demo';
-        const overlay = new StatsOverlay(layout, topLeftLabel, 60, 'webgpu');
+        const overlay = new StatsOverlay(layout, topLeftLabel, 60, 'webgpu', undefined, LEGACY_PALETTE_VIEW);
         const renderer = createMockRenderer();
 
         overlay.updateAndRender(renderer, mockFont, null, null, 0);
@@ -93,7 +97,7 @@ describe('StatsOverlay', () => {
 
     it('uses activeBackend for the top-right label', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(layout, 'Demo', 60, 'software');
+        const overlay = new StatsOverlay(layout, 'Demo', 60, 'software', undefined, LEGACY_PALETTE_VIEW);
         const renderer = createMockRenderer();
 
         overlay.updateAndRender(renderer, mockFont, null, null, 0);
@@ -104,7 +108,7 @@ describe('StatsOverlay', () => {
 
     it('uses provided frame timings and shows update-step suffix when multiple updates ran', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu');
+        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu', undefined, LEGACY_PALETTE_VIEW);
         const renderer = createMockRenderer();
 
         overlay.updateAndRender(renderer, mockFont, null, null, 0, undefined, {
@@ -124,7 +128,7 @@ describe('StatsOverlay', () => {
 
     it('skips draw calls when hidden', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu');
+        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu', undefined, LEGACY_PALETTE_VIEW);
         const renderer = createMockRenderer();
 
         overlay.handleToggle(null, { isKeyPressed: (key: string) => key === 'Backquote' } as never, 1);
@@ -136,7 +140,7 @@ describe('StatsOverlay', () => {
 
     it('resets camera for overlay draws then restores the saved offset', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu');
+        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu', undefined, LEGACY_PALETTE_VIEW);
         const renderer = createMockRenderer();
         const saved = new Vector2i(12, 34);
 
@@ -149,7 +153,7 @@ describe('StatsOverlay', () => {
 
     it('uses default overlay palette indices when style is omitted', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu');
+        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu', undefined, LEGACY_PALETTE_VIEW);
         const renderer = createMockRenderer();
         overlay.updateAndRender(renderer, mockFont, null, null, 0);
 
@@ -161,7 +165,14 @@ describe('StatsOverlay', () => {
 
     it('uses statsOverlayStyle palette indices when provided', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu', { barPaletteIndex: 8, textPaletteIndex: 9 });
+        const overlay = new StatsOverlay(
+            layout,
+            'Demo',
+            60,
+            'webgpu',
+            { barPaletteIndex: 8, textPaletteIndex: 9 },
+            LEGACY_PALETTE_VIEW,
+        );
         const renderer = createMockRenderer();
         overlay.updateAndRender(renderer, mockFont, null, null, 0);
 
@@ -174,7 +185,14 @@ describe('StatsOverlay', () => {
 
     it('draws custom rows with per-row palette indices', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu', { barPaletteIndex: 2, textPaletteIndex: 3 });
+        const overlay = new StatsOverlay(
+            layout,
+            'Demo',
+            60,
+            'webgpu',
+            { barPaletteIndex: 2, textPaletteIndex: 3 },
+            LEGACY_PALETTE_VIEW,
+        );
         const renderer = createMockRenderer();
         const customRows = [{ leftText: 'Left', barPaletteIndex: 5, textPaletteIndex: 6 }];
 
@@ -191,7 +209,7 @@ describe('StatsOverlay', () => {
 
     it('draws custom rows stacked above the bottom bar with 1px gaps', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu');
+        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu', undefined, LEGACY_PALETTE_VIEW);
         const renderer = createMockRenderer();
         const customRows = [{ leftText: 'Position: 10, 20' }, { leftText: 'Bounces: 3', rightText: 'ok' }];
 
@@ -229,7 +247,7 @@ describe('StatsOverlay', () => {
 
     it('skips extra custom row draws when customRows is empty', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu');
+        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu', undefined, LEGACY_PALETTE_VIEW);
         const renderer = createMockRenderer();
 
         overlay.updateAndRender(renderer, mockFont, null, null, 0, () => []);
@@ -240,7 +258,7 @@ describe('StatsOverlay', () => {
 
     it('does not invoke getCustomRows while the overlay is hidden', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu');
+        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu', undefined, LEGACY_PALETTE_VIEW);
         const renderer = createMockRenderer();
         const getCustomRows = vi.fn(() => [{ leftText: 'Hidden row' }] as const);
 
@@ -248,5 +266,54 @@ describe('StatsOverlay', () => {
         overlay.updateAndRender(renderer, mockFont, null, null, 0, getCustomRows);
 
         expect(getCustomRows).not.toHaveBeenCalled();
+    });
+
+    it('renders palette grid by default with a variable bottom band', () => {
+        const layout = createStatsOverlayLayout(320, 240, 14);
+        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu');
+        const renderer = createMockRenderer();
+        const palette = Palette.vga();
+        const usedIndices = [1, 2, 3, 4, 5, 6, 7, 8];
+        const grid = computePaletteGrid(320, undefined, palette.size);
+
+        overlay.updateAndRender(renderer, mockFont, null, null, 0, undefined, undefined, palette, usedIndices);
+
+        const fills = getRectFillCalls(renderer);
+        expect(fills[3]).toMatchObject({ y: 240 - grid.totalHeight, height: grid.totalHeight, width: 320 });
+        expect(renderer.drawRectFillOnTop.mock.calls.length).toBeGreaterThan(4);
+    });
+
+    it('preserves legacy bottom bar height when palette view is disabled', () => {
+        const layout = createStatsOverlayLayout(320, 240, 14);
+        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu', undefined, false);
+        const renderer = createMockRenderer();
+        const palette = Palette.vga();
+
+        overlay.updateAndRender(renderer, mockFont, null, null, 0, undefined, undefined, palette);
+
+        const fills = getRectFillCalls(renderer);
+        expect(fills[3]).toMatchObject({ y: 227, height: STATS_BAR_HEIGHT, width: 320 });
+        const swatchCalls = renderer.drawRectFillOnTop.mock.calls.filter(
+            (call) => (call[0] as { width: number }).width === 1,
+        );
+        expect(swatchCalls).toHaveLength(0);
+    });
+
+    it('stacks custom rows above the palette grid bottom band', () => {
+        const layout = createStatsOverlayLayout(320, 240, 14);
+        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu');
+        const renderer = createMockRenderer();
+        const palette = Palette.vga();
+        const usedIndices = [1, 2, 3, 4, 5, 6, 7, 8];
+        const grid = computePaletteGrid(320, undefined, palette.size);
+        const customRows = [{ leftText: 'Palette row' }];
+
+        overlay.updateAndRender(renderer, mockFont, null, null, 0, () => customRows, undefined, palette, usedIndices);
+
+        const fills = getRectFillCalls(renderer);
+        const row0BarY = customRowBarY(240, 0, grid.totalHeight);
+        const customRowFill = fills.find((rect) => rect.height === STATS_BAR_HEIGHT && rect.y === row0BarY);
+
+        expect(customRowFill).toMatchObject({ y: row0BarY, width: 320, height: STATS_BAR_HEIGHT });
     });
 });

--- a/src/render/stats-overlay/StatsOverlay.ts
+++ b/src/render/stats-overlay/StatsOverlay.ts
@@ -23,7 +23,12 @@ import { computePaletteGrid, DEFAULT_PALETTE_GRID, StatsOverlayPaletteView } fro
 import { StatsOverlayTimingChart } from './StatsOverlayTimingChart';
 import { StatsOverlayToggle } from './StatsOverlayToggle';
 import { TimingSampler } from './TimingSampler';
-import type { StatsOverlayLayout, StatsOverlayTimingSnapshot } from './types';
+import type {
+    StatsOverlayLayout,
+    StatsOverlayLayoutConfig,
+    StatsOverlayLayoutPlan,
+    StatsOverlayTimingSnapshot,
+} from './types';
 
 /**
  * Screen-space stats HUD rendered after demo content each frame.
@@ -52,6 +57,8 @@ export class StatsOverlay {
 
     readonly #paletteView: StatsOverlayPaletteView;
 
+    readonly #paletteColumns: number | undefined;
+
     readonly #layoutScratch = createStatsOverlayLayoutPlanScratch();
 
     readonly #barStyle = { barIndex: DEFAULT_IDX_BG, textIndex: DEFAULT_IDX_TEXT };
@@ -68,6 +75,8 @@ export class StatsOverlay {
      * @param targetFps - Configured fixed-update rate for the target FPS line.
      * @param activeBackend - Backend started by BTAPI (`webgpu` or `software`).
      * @param style - Optional palette indices from {@link HardwareSettings.statsOverlayStyle}.
+     * @param paletteViewEnabled - When true (default), draws the live palette swatch grid.
+     * @param paletteColumns - Optional max swatches per row from {@link HardwareSettings.statsOverlayPaletteColumns}.
      */
     constructor(
         layout: StatsOverlayLayout,
@@ -75,6 +84,8 @@ export class StatsOverlay {
         targetFps: number,
         activeBackend: Backend,
         style?: StatsOverlayStyle,
+        paletteViewEnabled = true,
+        paletteColumns?: number,
     ) {
         this.#layout = layout;
         this.#topLeftLabel = topLeftLabel;
@@ -84,7 +95,8 @@ export class StatsOverlay {
         this.#idxText = style?.textPaletteIndex ?? DEFAULT_IDX_TEXT;
         this.#topRightLabel = `${activeBackend} | ${layout.displayWidth}x${layout.displayHeight}`;
         this.#timingChart = new StatsOverlayTimingChart(false);
-        this.#paletteView = new StatsOverlayPaletteView(false);
+        this.#paletteView = new StatsOverlayPaletteView(paletteViewEnabled);
+        this.#paletteColumns = paletteColumns;
     }
 
     /**
@@ -108,6 +120,111 @@ export class StatsOverlay {
     }
 
     /**
+     * Records timing samples when a snapshot is provided.
+     *
+     * @param timing - Optional timing snapshot from the previous rendered frame.
+     */
+    #sampleTiming(timing?: StatsOverlayTimingSnapshot): void {
+        if (!timing) {
+            return;
+        }
+
+        this.#timing.sample(timing);
+        this.#timingChart.sample(timing);
+    }
+
+    /**
+     * Builds per-frame layout config including optional palette grid dimensions.
+     *
+     * @param customRowCount - Demo custom row count for this frame.
+     * @param palette - Active demo palette, if any.
+     * @returns Layout config for {@link buildStatsOverlayLayoutPlan}.
+     */
+    #createLayoutConfig(customRowCount: number, palette: Palette | null | undefined): StatsOverlayLayoutConfig {
+        const paletteViewEnabled = this.#paletteView.enabled;
+        const colorCount = palette?.size ?? 256;
+        const paletteGrid = paletteViewEnabled
+            ? computePaletteGrid(this.#layout.displayWidth, undefined, colorCount, undefined, this.#paletteColumns)
+            : undefined;
+
+        return {
+            ...createDefaultLayoutConfig(
+                this.#layout.displayWidth,
+                this.#layout.displayHeight,
+                this.#layout.lineHeight,
+                customRowCount,
+            ),
+            paletteViewEnabled,
+            ...(paletteGrid !== undefined ? { paletteGrid } : {}),
+        };
+    }
+
+    /**
+     * Draws overlay bars, palette grid, and labels for one visible frame.
+     *
+     * @param renderer - Active renderer.
+     * @param font - System bitmap font.
+     * @param plan - Computed layout plan for this frame.
+     * @param layoutConfig - Layout config used to build the plan.
+     * @param customRows - Optional demo rows, if any.
+     * @param palette - Active demo palette.
+     * @param usedPaletteIndices - Palette slots referenced by demo draw calls this frame.
+     */
+    #renderVisible(
+        renderer: IRenderer,
+        font: BitmapFont,
+        plan: StatsOverlayLayoutPlan,
+        layoutConfig: StatsOverlayLayoutConfig,
+        customRows: readonly StatsOverlayRow[] | undefined,
+        palette: Palette | null | undefined,
+        usedPaletteIndices: readonly number[],
+    ): void {
+        const updateStepSuffix = this.#timing.updateSteps > 1 ? `x${this.#timing.updateSteps}` : '';
+        const topMetricsLabel = `Present: ${this.#fps.measuredFps} FPS | Target: ${this.#targetFps} FPS | Draw Calls: ${this.#timing.drawCalls}`;
+        const topTimingLabel =
+            `Frame: ${this.#timing.frameMs.toFixed(1)}ms | update(): ${this.#timing.updateMs.toFixed(1)}ms${updateStepSuffix} | ` +
+            `render(): ${this.#timing.renderMs.toFixed(1)}ms`;
+
+        this.#barStyle.barIndex = this.#idxBg;
+        this.#barStyle.textIndex = this.#idxText;
+
+        this.#timingChart.draw(renderer, plan.timingChart, {
+            updateBarIndex: this.#idxBg,
+            renderBarIndex: this.#idxText,
+        });
+
+        this.#bars.drawFixedBars(renderer, plan, this.#idxBg);
+
+        this.#paletteView.draw(
+            renderer,
+            plan.bottomArea,
+            palette ?? null,
+            layoutConfig.paletteGrid ?? DEFAULT_PALETTE_GRID,
+            this.#layout.bottomTextY,
+            this.#layout.displayWidth,
+            this.#layout.lineHeight,
+            usedPaletteIndices,
+            this.#idxText,
+        );
+
+        if (customRows !== undefined && customRows.length > 0) {
+            this.#bars.drawCustomRows(renderer, font, plan, customRows, this.#barStyle);
+        }
+
+        this.#bars.drawFixedLabels(
+            renderer,
+            font,
+            plan,
+            this.#barStyle,
+            this.#topLeftLabel,
+            this.#topRightLabel,
+            topMetricsLabel,
+            topTimingLabel,
+            STATS_BOTTOM_HINT_LABEL,
+        );
+    }
+
+    /**
      * Processes toggle input then draws the overlay.
      *
      * @param renderer - Active {@link IRenderer} instance.
@@ -118,6 +235,7 @@ export class StatsOverlay {
      * @param getCustomRows - Optional supplier for demo rows; not invoked while the overlay is hidden.
      * @param timing - Optional timing snapshot from the previous rendered frame.
      * @param palette - Active demo palette for optional palette grid (stub when disabled).
+     * @param usedPaletteIndices - Palette slots referenced by demo draw calls this frame.
      */
     updateAndRender(
         renderer: IRenderer,
@@ -128,14 +246,10 @@ export class StatsOverlay {
         getCustomRows?: () => readonly StatsOverlayRow[] | undefined,
         timing?: StatsOverlayTimingSnapshot,
         palette?: Palette | null,
+        usedPaletteIndices: readonly number[] = [],
     ): void {
         this.#fps.sample();
-
-        if (timing) {
-            this.#timing.sample(timing);
-            this.#timingChart.sample(timing);
-        }
-
+        this.#sampleTiming(timing);
         this.handleToggle(pointer, keyboard, currentTick);
 
         if (!this.#toggle.visible) {
@@ -143,14 +257,7 @@ export class StatsOverlay {
         }
 
         const customRows = getCustomRows?.();
-        const customRowCount = customRows?.length ?? 0;
-        const layoutConfig = createDefaultLayoutConfig(
-            this.#layout.displayWidth,
-            this.#layout.displayHeight,
-            this.#layout.lineHeight,
-            customRowCount,
-        );
-
+        const layoutConfig = this.#createLayoutConfig(customRows?.length ?? 0, palette);
         const plan = buildStatsOverlayLayoutPlan(
             layoutConfig,
             this.#layoutScratch,
@@ -165,45 +272,7 @@ export class StatsOverlay {
         renderer.resetCamera();
 
         try {
-            const updateStepSuffix = this.#timing.updateSteps > 1 ? `x${this.#timing.updateSteps}` : '';
-            const topMetricsLabel = `Present: ${this.#fps.measuredFps} FPS | Target: ${this.#targetFps} FPS | Draw Calls: ${this.#timing.drawCalls}`;
-            const topTimingLabel =
-                `Frame: ${this.#timing.frameMs.toFixed(1)}ms | update(): ${this.#timing.updateMs.toFixed(1)}ms${updateStepSuffix} | ` +
-                `render(): ${this.#timing.renderMs.toFixed(1)}ms`;
-
-            this.#barStyle.barIndex = this.#idxBg;
-            this.#barStyle.textIndex = this.#idxText;
-
-            this.#timingChart.draw(renderer, plan.timingChart, {
-                updateBarIndex: this.#idxBg,
-                renderBarIndex: this.#idxText,
-            });
-
-            const paletteGrid =
-                layoutConfig.paletteGrid ??
-                (layoutConfig.paletteViewEnabled
-                    ? computePaletteGrid(layoutConfig.displayWidth)
-                    : DEFAULT_PALETTE_GRID);
-
-            this.#paletteView.draw(renderer, plan.bottomArea, palette ?? null, paletteGrid);
-
-            this.#bars.drawFixedBars(renderer, plan, this.#idxBg);
-
-            if (customRows !== undefined && customRows.length > 0) {
-                this.#bars.drawCustomRows(renderer, font, plan, customRows, this.#barStyle);
-            }
-
-            this.#bars.drawFixedLabels(
-                renderer,
-                font,
-                plan,
-                this.#barStyle,
-                this.#topLeftLabel,
-                this.#topRightLabel,
-                topMetricsLabel,
-                topTimingLabel,
-                STATS_BOTTOM_HINT_LABEL,
-            );
+            this.#renderVisible(renderer, font, plan, layoutConfig, customRows, palette, usedPaletteIndices);
         } finally {
             renderer.setCameraOffset(savedCamera);
         }

--- a/src/render/stats-overlay/StatsOverlay.ts
+++ b/src/render/stats-overlay/StatsOverlay.ts
@@ -1,8 +1,8 @@
 /**
  * Screen-space stats HUD orchestrator.
  *
- * Delegates layout planning, bar drawing, toggle input, and feature stubs
- * (timing chart, palette grid) to submodules under `stats-overlay/`.
+ * Delegates layout planning, bar drawing, toggle input, timing chart (VV-539),
+ * and palette grid (VV-540) to submodules under `stats-overlay/`.
  */
 
 import type { BitmapFont } from '../../assets/BitmapFont';
@@ -29,6 +29,9 @@ import type {
     StatsOverlayLayoutPlan,
     StatsOverlayTimingSnapshot,
 } from './types';
+
+/** Empty usage mask for overlay draws when palette tracking is inactive. */
+const EMPTY_PALETTE_USAGE_MASK = new Uint8Array(0);
 
 /**
  * Screen-space stats HUD rendered after demo content each frame.
@@ -75,7 +78,7 @@ export class StatsOverlay {
      * @param targetFps - Configured fixed-update rate for the target FPS line.
      * @param activeBackend - Backend started by BTAPI (`webgpu` or `software`).
      * @param style - Optional palette indices from {@link HardwareSettings.statsOverlayStyle}.
-     * @param paletteViewEnabled - When true (default), draws the live palette swatch grid.
+     * @param statsOverlayPaletteView - When true, draws the live palette swatch grid.
      * @param paletteColumns - Optional max swatches per row from {@link HardwareSettings.statsOverlayPaletteColumns}.
      */
     constructor(
@@ -84,7 +87,7 @@ export class StatsOverlay {
         targetFps: number,
         activeBackend: Backend,
         style?: StatsOverlayStyle,
-        paletteViewEnabled = true,
+        statsOverlayPaletteView = false,
         paletteColumns?: number,
     ) {
         this.#layout = layout;
@@ -95,7 +98,7 @@ export class StatsOverlay {
         this.#idxText = style?.textPaletteIndex ?? DEFAULT_IDX_TEXT;
         this.#topRightLabel = `${activeBackend} | ${layout.displayWidth}x${layout.displayHeight}`;
         this.#timingChart = new StatsOverlayTimingChart(false);
-        this.#paletteView = new StatsOverlayPaletteView(paletteViewEnabled);
+        this.#paletteView = new StatsOverlayPaletteView(statsOverlayPaletteView);
         this.#paletteColumns = paletteColumns;
     }
 
@@ -141,9 +144,9 @@ export class StatsOverlay {
      * @returns Layout config for {@link buildStatsOverlayLayoutPlan}.
      */
     #createLayoutConfig(customRowCount: number, palette: Palette | null | undefined): StatsOverlayLayoutConfig {
-        const paletteViewEnabled = this.#paletteView.enabled;
+        const statsOverlayPaletteView = this.#paletteView.enabled;
         const colorCount = palette?.size ?? 256;
-        const paletteGrid = paletteViewEnabled
+        const paletteGrid = statsOverlayPaletteView
             ? computePaletteGrid(this.#layout.displayWidth, undefined, colorCount, undefined, this.#paletteColumns)
             : undefined;
 
@@ -154,7 +157,7 @@ export class StatsOverlay {
                 this.#layout.lineHeight,
                 customRowCount,
             ),
-            paletteViewEnabled,
+            statsOverlayPaletteView,
             ...(paletteGrid !== undefined ? { paletteGrid } : {}),
         };
     }
@@ -168,7 +171,7 @@ export class StatsOverlay {
      * @param layoutConfig - Layout config used to build the plan.
      * @param customRows - Optional demo rows, if any.
      * @param palette - Active demo palette.
-     * @param usedPaletteIndices - Palette slots referenced by demo draw calls this frame.
+     * @param usedPaletteMask - Per-frame palette usage mask from BTAPI.
      */
     #renderVisible(
         renderer: IRenderer,
@@ -177,7 +180,7 @@ export class StatsOverlay {
         layoutConfig: StatsOverlayLayoutConfig,
         customRows: readonly StatsOverlayRow[] | undefined,
         palette: Palette | null | undefined,
-        usedPaletteIndices: readonly number[],
+        usedPaletteMask: Uint8Array,
     ): void {
         const updateStepSuffix = this.#timing.updateSteps > 1 ? `x${this.#timing.updateSteps}` : '';
         const topMetricsLabel = `Present: ${this.#fps.measuredFps} FPS | Target: ${this.#targetFps} FPS | Draw Calls: ${this.#timing.drawCalls}`;
@@ -203,7 +206,7 @@ export class StatsOverlay {
             this.#layout.bottomTextY,
             this.#layout.displayWidth,
             this.#layout.lineHeight,
-            usedPaletteIndices,
+            usedPaletteMask,
             this.#idxText,
         );
 
@@ -234,8 +237,8 @@ export class StatsOverlay {
      * @param currentTick - Current fixed-update tick for keyboard edge detection.
      * @param getCustomRows - Optional supplier for demo rows; not invoked while the overlay is hidden.
      * @param timing - Optional timing snapshot from the previous rendered frame.
-     * @param palette - Active demo palette for optional palette grid (stub when disabled).
-     * @param usedPaletteIndices - Palette slots referenced by demo draw calls this frame.
+     * @param palette - Active demo palette for optional palette grid.
+     * @param usedPaletteMask - Per-frame palette usage mask populated during demo render.
      */
     updateAndRender(
         renderer: IRenderer,
@@ -246,7 +249,7 @@ export class StatsOverlay {
         getCustomRows?: () => readonly StatsOverlayRow[] | undefined,
         timing?: StatsOverlayTimingSnapshot,
         palette?: Palette | null,
-        usedPaletteIndices: readonly number[] = [],
+        usedPaletteMask: Uint8Array = EMPTY_PALETTE_USAGE_MASK,
     ): void {
         this.#fps.sample();
         this.#sampleTiming(timing);
@@ -272,7 +275,7 @@ export class StatsOverlay {
         renderer.resetCamera();
 
         try {
-            this.#renderVisible(renderer, font, plan, layoutConfig, customRows, palette, usedPaletteIndices);
+            this.#renderVisible(renderer, font, plan, layoutConfig, customRows, palette, usedPaletteMask);
         } finally {
             renderer.setCameraOffset(savedCamera);
         }

--- a/src/render/stats-overlay/StatsOverlayPaletteView.test.ts
+++ b/src/render/stats-overlay/StatsOverlayPaletteView.test.ts
@@ -13,12 +13,30 @@ import {
     buildUsedPaletteLookup,
     computePaletteGrid,
     DEFAULT_PALETTE_SWATCH_SIZE,
+    PALETTE_GRID_PADDING_PX,
     PALETTE_SWATCH_GAP_PX,
     paletteGridRowStackHeight,
     paletteGridRowWidth,
     pickPaletteGridColumnCount,
     StatsOverlayPaletteView,
 } from './StatsOverlayPaletteView';
+
+/** Returns the top-left pixel for one palette index in the bottom-band grid. */
+function swatchTopLeft(
+    index: number,
+    cols: number,
+    bottomAreaY: number,
+    swatchSize: number,
+    gap: number,
+): { x: number; y: number } {
+    const col = index % cols;
+    const row = Math.floor(index / cols);
+
+    return {
+        x: STATS_EDGE_MARGIN_PX + col * (swatchSize + gap),
+        y: bottomAreaY + PALETTE_GRID_PADDING_PX + row * (swatchSize + gap),
+    };
+}
 
 describe('computePaletteGrid', () => {
     it('uses 32 columns and 8 rows at 320 px width for a 256-color palette', () => {
@@ -27,9 +45,9 @@ describe('computePaletteGrid', () => {
         expect(grid).toEqual({
             cols: 32,
             rows: 8,
-            swatchSize: 4,
+            swatchSize: DEFAULT_PALETTE_SWATCH_SIZE,
             gap: 1,
-            totalHeight: paletteGridRowStackHeight(8, 4, 1),
+            totalHeight: paletteGridRowStackHeight(8, DEFAULT_PALETTE_SWATCH_SIZE, 1) + PALETTE_GRID_PADDING_PX * 2,
         });
         expect(paletteGridRowWidth(grid.cols, grid.swatchSize, grid.gap)).toBeLessThanOrEqual(320 - 6);
     });
@@ -53,7 +71,7 @@ describe('computePaletteGrid', () => {
 
         expect(grid.cols).toBe(1);
         expect(grid.rows).toBe(256);
-        expect(grid.totalHeight).toBe(paletteGridRowStackHeight(256, 4, 1));
+        expect(grid.totalHeight).toBe(paletteGridRowStackHeight(256, 4, 1) + PALETTE_GRID_PADDING_PX * 2);
     });
 
     it('returns an empty grid when color count is zero', () => {
@@ -84,8 +102,9 @@ describe('StatsOverlayPaletteView.draw', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
         const palette = Palette.cga();
         const usedIndices = [1, 2];
-        const grid = computePaletteGrid(320, 4, palette.size, 1);
-        const originY = 240 - grid.totalHeight;
+        const swatchSize = DEFAULT_PALETTE_SWATCH_SIZE;
+        const grid = computePaletteGrid(320, swatchSize, palette.size, 1);
+        const bottomAreaY = 240 - grid.totalHeight;
         const view = new StatsOverlayPaletteView(true);
         const drawRectFillOnTop = vi.fn();
         const renderer = {
@@ -94,7 +113,7 @@ describe('StatsOverlayPaletteView.draw', () => {
 
         view.draw(
             renderer,
-            new Rect2i(0, originY, 320, grid.totalHeight),
+            new Rect2i(0, bottomAreaY, 320, grid.totalHeight),
             palette,
             grid,
             layout.bottomTextY,
@@ -111,23 +130,32 @@ describe('StatsOverlayPaletteView.draw', () => {
             index: call[1] as number,
         }));
 
-        const usedSwatch = calls.find((call) => call.rect.x === 9 && call.rect.y === originY + 1 && call.index === 1);
+        const usedPos = swatchTopLeft(1, grid.cols, bottomAreaY, swatchSize, grid.gap);
+        const usedSwatch = calls.find(
+            (call) =>
+                call.rect.x === usedPos.x &&
+                call.rect.y === usedPos.y &&
+                call.rect.width === swatchSize &&
+                call.rect.height === swatchSize &&
+                call.index === 1,
+        );
         expect(usedSwatch).toBeDefined();
 
-        const unusedSwatchOutline = calls.find(
-            (call) => call.rect.x === 19 && call.rect.y === originY && call.index === DEFAULT_IDX_TEXT,
-        );
-        expect(unusedSwatchOutline).toBeDefined();
-
+        const unusedPos = swatchTopLeft(3, grid.cols, bottomAreaY, swatchSize, grid.gap);
         const unusedSwatchFill = calls.find(
-            (call) => call.rect.x === 19 && call.rect.y === originY + 1 && call.index === 3,
+            (call) =>
+                call.rect.x === unusedPos.x &&
+                call.rect.y === unusedPos.y &&
+                call.rect.width === swatchSize &&
+                call.index === 3,
         );
         expect(unusedSwatchFill).toBeUndefined();
 
         const unusedX = calls.find(
-            (call) => call.rect.x === 19 && call.rect.y === originY + 1 && call.index === DEFAULT_IDX_TEXT,
+            (call) => call.rect.x === unusedPos.x + 2 && call.rect.y === unusedPos.y + swatchSize - 3,
         );
         expect(unusedX).toBeDefined();
+        expect(unusedX?.index).toBe(DEFAULT_IDX_TEXT);
     });
 
     it('buildUsedPaletteLookup ignores slot 0 and out-of-range indices', () => {
@@ -136,12 +164,13 @@ describe('StatsOverlayPaletteView.draw', () => {
         );
     });
 
-    it('draws rounded swatches with gaps and skips the bottom-right hint region', () => {
+    it('draws swatches with gaps and skips the bottom-right hint region', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
         const palette = Palette.cga();
         const usedIndices = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
-        const grid = computePaletteGrid(320, 4, palette.size, 1);
-        const originY = 240 - grid.totalHeight;
+        const swatchSize = DEFAULT_PALETTE_SWATCH_SIZE;
+        const grid = computePaletteGrid(320, swatchSize, palette.size, 1);
+        const bottomAreaY = 240 - grid.totalHeight;
         const view = new StatsOverlayPaletteView(true);
         const drawRectFillOnTop = vi.fn();
         const renderer = {
@@ -150,7 +179,7 @@ describe('StatsOverlayPaletteView.draw', () => {
 
         view.draw(
             renderer,
-            new Rect2i(0, originY, 320, grid.totalHeight),
+            new Rect2i(0, bottomAreaY, 320, grid.totalHeight),
             palette,
             grid,
             layout.bottomTextY,
@@ -167,22 +196,23 @@ describe('StatsOverlayPaletteView.draw', () => {
             index: call[1] as number,
         }));
 
-        const swatch00 = calls.filter(
-            (call) => call.rect.x >= 3 && call.rect.x <= 6 && call.rect.y >= originY && call.rect.y <= originY + 3,
-        );
-        expect(swatch00.some((call) => call.rect.x === 3 && call.rect.y === originY)).toBe(false);
-        expect(swatch00.some((call) => call.rect.x === 6 && call.rect.y === originY)).toBe(false);
-        expect(swatch00.some((call) => call.rect.x === 3 && call.rect.y === originY + 3)).toBe(false);
-        expect(swatch00.some((call) => call.rect.x === 6 && call.rect.y === originY + 3)).toBe(false);
-        expect(swatch00.some((call) => call.rect.x === 4 && call.rect.y === originY + 1 && call.index === 1)).toBe(
+        const swatch0 = swatchTopLeft(0, grid.cols, bottomAreaY, swatchSize, grid.gap);
+        const swatch1 = swatchTopLeft(1, grid.cols, bottomAreaY, swatchSize, grid.gap);
+        const gapX = swatch0.x + swatchSize;
+
+        expect(calls.some((call) => call.rect.x === swatch0.x && call.rect.y === swatch0.y && call.index === 0)).toBe(
             false,
         );
 
-        const gapPixel = calls.find((call) => call.rect.x === 7 && call.rect.y === originY);
+        const gapPixel = calls.find((call) => call.rect.x === gapX && call.rect.y === swatch0.y);
         expect(gapPixel).toBeUndefined();
 
         const nextSwatchPixel = calls.find(
-            (call) => call.rect.x === 9 && call.rect.y === originY + 1 && call.index === 1,
+            (call) =>
+                call.rect.x === swatch1.x &&
+                call.rect.y === swatch1.y &&
+                call.rect.width === swatchSize &&
+                call.index === 1,
         );
         expect(nextSwatchPixel).toBeDefined();
     });

--- a/src/render/stats-overlay/StatsOverlayPaletteView.test.ts
+++ b/src/render/stats-overlay/StatsOverlayPaletteView.test.ts
@@ -144,10 +144,15 @@ describe('StatsOverlayPaletteView.draw', () => {
         expect(usedSwatch).toBeDefined();
 
         const unusedPos = swatchTopLeft(3, grid.cols, bottomAreaY, swatchSize, grid.gap);
-        const unusedSwatchOutline = calls.find(
-            (call) => call.rect.x === unusedPos.x && call.rect.y === unusedPos.y && call.index === DEFAULT_IDX_TEXT,
+        const unusedSwatchMarker = calls.find(
+            (call) =>
+                call.rect.x === unusedPos.x + 2 &&
+                call.rect.y === unusedPos.y + 2 &&
+                call.rect.width === 3 &&
+                call.rect.height === 3 &&
+                call.index === DEFAULT_IDX_TEXT,
         );
-        expect(unusedSwatchOutline).toBeDefined();
+        expect(unusedSwatchMarker).toBeDefined();
 
         const unusedSwatchFill = calls.find(
             (call) =>
@@ -157,12 +162,6 @@ describe('StatsOverlayPaletteView.draw', () => {
                 call.index === 3,
         );
         expect(unusedSwatchFill).toBeUndefined();
-
-        const unusedX = calls.find(
-            (call) => call.rect.x === unusedPos.x + 2 && call.rect.y === unusedPos.y + swatchSize - 3,
-        );
-        expect(unusedX).toBeDefined();
-        expect(unusedX?.index).toBe(DEFAULT_IDX_TEXT);
     });
 
     it('buildUsedPaletteLookup ignores slot 0 and out-of-range indices', () => {

--- a/src/render/stats-overlay/StatsOverlayPaletteView.test.ts
+++ b/src/render/stats-overlay/StatsOverlayPaletteView.test.ts
@@ -12,6 +12,7 @@ import { createStatsOverlayLayout } from './layoutHelpers';
 import {
     buildUsedPaletteLookup,
     computePaletteGrid,
+    computeUnusedSwatchMarkerRect,
     DEFAULT_PALETTE_SWATCH_SIZE,
     PALETTE_GRID_PADDING_PX,
     PALETTE_SWATCH_GAP_PX,
@@ -144,12 +145,13 @@ describe('StatsOverlayPaletteView.draw', () => {
         expect(usedSwatch).toBeDefined();
 
         const unusedPos = swatchTopLeft(3, grid.cols, bottomAreaY, swatchSize, grid.gap);
+        const expectedMarker = computeUnusedSwatchMarkerRect(unusedPos.x, unusedPos.y, swatchSize);
         const unusedSwatchMarker = calls.find(
             (call) =>
-                call.rect.x === unusedPos.x + 2 &&
-                call.rect.y === unusedPos.y + 2 &&
-                call.rect.width === 3 &&
-                call.rect.height === 3 &&
+                call.rect.x === expectedMarker.x &&
+                call.rect.y === expectedMarker.y &&
+                call.rect.width === expectedMarker.width &&
+                call.rect.height === expectedMarker.height &&
                 call.index === DEFAULT_IDX_TEXT,
         );
         expect(unusedSwatchMarker).toBeDefined();

--- a/src/render/stats-overlay/StatsOverlayPaletteView.test.ts
+++ b/src/render/stats-overlay/StatsOverlayPaletteView.test.ts
@@ -5,12 +5,12 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { Palette } from '../../assets/Palette';
+import { markRenderPaletteIndexUsed } from '../../core/RenderPaletteUsage';
 import { Rect2i } from '../../utils/Rect2i';
 import { Vector2i } from '../../utils/Vector2i';
 import { DEFAULT_IDX_TEXT, STATS_EDGE_MARGIN_PX } from './constants';
 import { createStatsOverlayLayout } from './layoutHelpers';
 import {
-    buildUsedPaletteLookup,
     computePaletteGrid,
     computeUnusedSwatchMarkerRect,
     DEFAULT_PALETTE_SWATCH_SIZE,
@@ -21,6 +21,17 @@ import {
     pickPaletteGridColumnCount,
     StatsOverlayPaletteView,
 } from './StatsOverlayPaletteView';
+
+/** Builds a usage mask from palette slot indices for tests. */
+function buildUsageMask(indices: readonly number[], size = 256): Uint8Array {
+    const mask = new Uint8Array(size);
+
+    for (const index of indices) {
+        markRenderPaletteIndexUsed(mask, index);
+    }
+
+    return mask;
+}
 
 /** Returns the top-left pixel for one palette index in the bottom-band grid. */
 function swatchTopLeft(
@@ -119,7 +130,7 @@ describe('StatsOverlayPaletteView.draw', () => {
     it('draws filled swatches for used indices and empty X marks for unused slots', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
         const palette = Palette.cga();
-        const usedIndices = [1, 2];
+        const usedMask = buildUsageMask([1, 2]);
         const swatchSize = DEFAULT_PALETTE_SWATCH_SIZE;
         const grid = computePaletteGrid(320, swatchSize, palette.size, 1);
         const bottomAreaY = 240 - grid.totalHeight;
@@ -137,7 +148,7 @@ describe('StatsOverlayPaletteView.draw', () => {
             layout.bottomTextY,
             layout.displayWidth,
             layout.lineHeight,
-            usedIndices,
+            usedMask,
             DEFAULT_IDX_TEXT,
         );
 
@@ -180,16 +191,16 @@ describe('StatsOverlayPaletteView.draw', () => {
         expect(unusedSwatchFill).toBeUndefined();
     });
 
-    it('buildUsedPaletteLookup ignores slot 0 and out-of-range indices', () => {
-        expect(buildUsedPaletteLookup([0, 1, 99], 16)).toEqual(
-            new Uint8Array([0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
-        );
+    it('usage mask ignores slot 0 and out-of-range indices', () => {
+        const mask = buildUsageMask([0, 1, 99], 16);
+
+        expect(mask).toEqual(new Uint8Array([0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]));
     });
 
     it('draws swatches with gaps and skips the bottom-right hint region', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
         const palette = Palette.cga();
-        const usedIndices = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+        const usedMask = buildUsageMask([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
         const swatchSize = DEFAULT_PALETTE_SWATCH_SIZE;
         const grid = computePaletteGrid(320, swatchSize, palette.size, 1);
         const bottomAreaY = 240 - grid.totalHeight;
@@ -207,7 +218,7 @@ describe('StatsOverlayPaletteView.draw', () => {
             layout.bottomTextY,
             layout.displayWidth,
             layout.lineHeight,
-            usedIndices,
+            usedMask,
             DEFAULT_IDX_TEXT,
         );
 
@@ -262,7 +273,7 @@ describe('StatsOverlayPaletteView.draw', () => {
             layout.bottomTextY,
             layout.displayWidth,
             layout.lineHeight,
-            [index],
+            buildUsageMask([index]),
             DEFAULT_IDX_TEXT,
         );
 
@@ -286,7 +297,7 @@ describe('StatsOverlayPaletteView.draw', () => {
             227,
             320,
             14,
-            [1, 2, 3],
+            buildUsageMask([1, 2, 3]),
             DEFAULT_IDX_TEXT,
         );
 

--- a/src/render/stats-overlay/StatsOverlayPaletteView.test.ts
+++ b/src/render/stats-overlay/StatsOverlayPaletteView.test.ts
@@ -100,6 +100,21 @@ describe('computePaletteGrid', () => {
     });
 });
 
+describe('computeUnusedSwatchMarkerRect', () => {
+    it('returns a centered 3x3 marker for a 7px swatch', () => {
+        expect(computeUnusedSwatchMarkerRect(10, 20, 7)).toEqual(new Rect2i(12, 22, 3, 3));
+    });
+
+    it('returns a zero-area rect for non-positive swatch sizes', () => {
+        expect(computeUnusedSwatchMarkerRect(10, 20, 0)).toEqual(new Rect2i(10, 20, 0, 0));
+        expect(computeUnusedSwatchMarkerRect(10, 20, -2)).toEqual(new Rect2i(10, 20, 0, 0));
+    });
+
+    it('clamps marker size for small swatches', () => {
+        expect(computeUnusedSwatchMarkerRect(0, 0, 4)).toEqual(new Rect2i(1, 1, 1, 1));
+    });
+});
+
 describe('StatsOverlayPaletteView.draw', () => {
     it('draws filled swatches for used indices and empty X marks for unused slots', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
@@ -145,13 +160,12 @@ describe('StatsOverlayPaletteView.draw', () => {
         expect(usedSwatch).toBeDefined();
 
         const unusedPos = swatchTopLeft(3, grid.cols, bottomAreaY, swatchSize, grid.gap);
-        const expectedMarker = computeUnusedSwatchMarkerRect(unusedPos.x, unusedPos.y, swatchSize);
         const unusedSwatchMarker = calls.find(
             (call) =>
-                call.rect.x === expectedMarker.x &&
-                call.rect.y === expectedMarker.y &&
-                call.rect.width === expectedMarker.width &&
-                call.rect.height === expectedMarker.height &&
+                call.rect.x === unusedPos.x + 2 &&
+                call.rect.y === unusedPos.y + 2 &&
+                call.rect.width === 3 &&
+                call.rect.height === 3 &&
                 call.index === DEFAULT_IDX_TEXT,
         );
         expect(unusedSwatchMarker).toBeDefined();

--- a/src/render/stats-overlay/StatsOverlayPaletteView.test.ts
+++ b/src/render/stats-overlay/StatsOverlayPaletteView.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Unit tests for {@link computePaletteGrid} and palette swatch drawing.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { Palette } from '../../assets/Palette';
+import { Rect2i } from '../../utils/Rect2i';
+import { Vector2i } from '../../utils/Vector2i';
+import { DEFAULT_IDX_TEXT, STATS_EDGE_MARGIN_PX } from './constants';
+import { createStatsOverlayLayout } from './layoutHelpers';
+import {
+    buildUsedPaletteLookup,
+    computePaletteGrid,
+    DEFAULT_PALETTE_SWATCH_SIZE,
+    PALETTE_SWATCH_GAP_PX,
+    paletteGridRowStackHeight,
+    paletteGridRowWidth,
+    pickPaletteGridColumnCount,
+    StatsOverlayPaletteView,
+} from './StatsOverlayPaletteView';
+
+describe('computePaletteGrid', () => {
+    it('uses 32 columns and 8 rows at 320 px width for a 256-color palette', () => {
+        const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 256, PALETTE_SWATCH_GAP_PX);
+
+        expect(grid).toEqual({
+            cols: 32,
+            rows: 8,
+            swatchSize: 4,
+            gap: 1,
+            totalHeight: paletteGridRowStackHeight(8, 4, 1),
+        });
+        expect(paletteGridRowWidth(grid.cols, grid.swatchSize, grid.gap)).toBeLessThanOrEqual(320 - 6);
+    });
+
+    it('keeps small palettes on one row when width allows', () => {
+        expect(computePaletteGrid(320, 4, 2).cols).toBe(2);
+        expect(computePaletteGrid(320, 4, 4).cols).toBe(4);
+        expect(computePaletteGrid(320, 4, 16).cols).toBe(16);
+    });
+
+    it('halves column count when a single row no longer fits', () => {
+        const narrowWidth = paletteGridRowWidth(16, 4, 1) + STATS_EDGE_MARGIN_PX * 2 - 1;
+        const grid = computePaletteGrid(narrowWidth, 4, 16, 1);
+
+        expect(grid.cols).toBe(8);
+        expect(grid.rows).toBe(2);
+    });
+
+    it('falls back to one column when only one swatch fits horizontally', () => {
+        const grid = computePaletteGrid(10, 4, 256, 1);
+
+        expect(grid.cols).toBe(1);
+        expect(grid.rows).toBe(256);
+        expect(grid.totalHeight).toBe(paletteGridRowStackHeight(256, 4, 1));
+    });
+
+    it('returns an empty grid when color count is zero', () => {
+        expect(computePaletteGrid(320, 4, 0, 1)).toEqual({
+            cols: 0,
+            rows: 0,
+            swatchSize: 4,
+            gap: 1,
+            totalHeight: 0,
+        });
+    });
+
+    it('matches pickPaletteGridColumnCount helper cases', () => {
+        expect(pickPaletteGridColumnCount(320, 4, 1, 256)).toBe(32);
+        expect(pickPaletteGridColumnCount(320, 4, 1, 32)).toBe(32);
+        expect(pickPaletteGridColumnCount(120, 4, 1, 32)).toBe(16);
+    });
+
+    it('caps column count when statsOverlayPaletteColumns is set', () => {
+        expect(computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 16, PALETTE_SWATCH_GAP_PX, 8).cols).toBe(8);
+        expect(computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 16, PALETTE_SWATCH_GAP_PX, 8).rows).toBe(2);
+        expect(pickPaletteGridColumnCount(320, DEFAULT_PALETTE_SWATCH_SIZE, PALETTE_SWATCH_GAP_PX, 256, 8)).toBe(8);
+    });
+});
+
+describe('StatsOverlayPaletteView.draw', () => {
+    it('draws filled swatches for used indices and empty X marks for unused slots', () => {
+        const layout = createStatsOverlayLayout(320, 240, 14);
+        const palette = Palette.cga();
+        const usedIndices = [1, 2];
+        const grid = computePaletteGrid(320, 4, palette.size, 1);
+        const originY = 240 - grid.totalHeight;
+        const view = new StatsOverlayPaletteView(true);
+        const drawRectFillOnTop = vi.fn();
+        const renderer = {
+            drawRectFillOnTop,
+        } as never;
+
+        view.draw(
+            renderer,
+            new Rect2i(0, originY, 320, grid.totalHeight),
+            palette,
+            grid,
+            layout.bottomTextY,
+            layout.displayWidth,
+            layout.lineHeight,
+            usedIndices,
+            DEFAULT_IDX_TEXT,
+        );
+
+        expect(drawRectFillOnTop).toHaveBeenCalled();
+
+        const calls = drawRectFillOnTop.mock.calls.map((call) => ({
+            rect: call[0] as Rect2i,
+            index: call[1] as number,
+        }));
+
+        const usedSwatch = calls.find((call) => call.rect.x === 9 && call.rect.y === originY + 1 && call.index === 1);
+        expect(usedSwatch).toBeDefined();
+
+        const unusedSwatchOutline = calls.find(
+            (call) => call.rect.x === 19 && call.rect.y === originY && call.index === DEFAULT_IDX_TEXT,
+        );
+        expect(unusedSwatchOutline).toBeDefined();
+
+        const unusedSwatchFill = calls.find(
+            (call) => call.rect.x === 19 && call.rect.y === originY + 1 && call.index === 3,
+        );
+        expect(unusedSwatchFill).toBeUndefined();
+
+        const unusedX = calls.find(
+            (call) => call.rect.x === 19 && call.rect.y === originY + 1 && call.index === DEFAULT_IDX_TEXT,
+        );
+        expect(unusedX).toBeDefined();
+    });
+
+    it('buildUsedPaletteLookup ignores slot 0 and out-of-range indices', () => {
+        expect(buildUsedPaletteLookup([0, 1, 99], 16)).toEqual(
+            new Uint8Array([0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        );
+    });
+
+    it('draws rounded swatches with gaps and skips the bottom-right hint region', () => {
+        const layout = createStatsOverlayLayout(320, 240, 14);
+        const palette = Palette.cga();
+        const usedIndices = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+        const grid = computePaletteGrid(320, 4, palette.size, 1);
+        const originY = 240 - grid.totalHeight;
+        const view = new StatsOverlayPaletteView(true);
+        const drawRectFillOnTop = vi.fn();
+        const renderer = {
+            drawRectFillOnTop,
+        } as never;
+
+        view.draw(
+            renderer,
+            new Rect2i(0, originY, 320, grid.totalHeight),
+            palette,
+            grid,
+            layout.bottomTextY,
+            layout.displayWidth,
+            layout.lineHeight,
+            usedIndices,
+            DEFAULT_IDX_TEXT,
+        );
+
+        expect(drawRectFillOnTop).toHaveBeenCalled();
+
+        const calls = drawRectFillOnTop.mock.calls.map((call) => ({
+            rect: call[0] as Rect2i,
+            index: call[1] as number,
+        }));
+
+        const swatch00 = calls.filter(
+            (call) => call.rect.x >= 3 && call.rect.x <= 6 && call.rect.y >= originY && call.rect.y <= originY + 3,
+        );
+        expect(swatch00.some((call) => call.rect.x === 3 && call.rect.y === originY)).toBe(false);
+        expect(swatch00.some((call) => call.rect.x === 6 && call.rect.y === originY)).toBe(false);
+        expect(swatch00.some((call) => call.rect.x === 3 && call.rect.y === originY + 3)).toBe(false);
+        expect(swatch00.some((call) => call.rect.x === 6 && call.rect.y === originY + 3)).toBe(false);
+        expect(swatch00.some((call) => call.rect.x === 4 && call.rect.y === originY + 1 && call.index === 1)).toBe(
+            false,
+        );
+
+        const gapPixel = calls.find((call) => call.rect.x === 7 && call.rect.y === originY);
+        expect(gapPixel).toBeUndefined();
+
+        const nextSwatchPixel = calls.find(
+            (call) => call.rect.x === 9 && call.rect.y === originY + 1 && call.index === 1,
+        );
+        expect(nextSwatchPixel).toBeDefined();
+    });
+
+    it('draws full column width on rows inside the toggle hit region', () => {
+        const layout = createStatsOverlayLayout(320, 240, 14);
+        const palette = new Palette(256);
+        const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, palette.size, 1, 36);
+        const bottomAreaY = 240 - grid.totalHeight;
+        const swatchOriginY = bottomAreaY + 3;
+        const view = new StatsOverlayPaletteView(true);
+        const drawRectFillOnTop = vi.fn();
+        const renderer = { drawRectFillOnTop } as never;
+        const row = 5;
+        const col = 35;
+        const index = row * grid.cols + col;
+        const expectedX = 3 + col * (grid.swatchSize + grid.gap);
+        const expectedY = swatchOriginY + row * (grid.swatchSize + grid.gap);
+
+        view.draw(
+            renderer,
+            new Rect2i(0, bottomAreaY, 320, grid.totalHeight),
+            palette,
+            grid,
+            layout.bottomTextY,
+            layout.displayWidth,
+            layout.lineHeight,
+            [index],
+            DEFAULT_IDX_TEXT,
+        );
+
+        const lastColSwatch = drawRectFillOnTop.mock.calls.find(
+            (call) => (call[0] as Rect2i).x === expectedX && (call[0] as Rect2i).y === expectedY,
+        );
+        expect(lastColSwatch).toBeDefined();
+        expect(layout.toggleRect.contains(new Vector2i(expectedX, expectedY))).toBe(true);
+    });
+
+    it('is a no-op when disabled', () => {
+        const view = new StatsOverlayPaletteView(false);
+        const drawRectFillOnTop = vi.fn();
+        const renderer = { drawRectFillOnTop } as never;
+
+        view.draw(
+            renderer,
+            new Rect2i(0, 201, 320, 39),
+            Palette.cga(),
+            computePaletteGrid(320),
+            227,
+            320,
+            14,
+            [1, 2, 3],
+            DEFAULT_IDX_TEXT,
+        );
+
+        expect(drawRectFillOnTop).not.toHaveBeenCalled();
+    });
+});

--- a/src/render/stats-overlay/StatsOverlayPaletteView.test.ts
+++ b/src/render/stats-overlay/StatsOverlayPaletteView.test.ts
@@ -33,6 +33,22 @@ function buildUsageMask(indices: readonly number[], size = 256): Uint8Array {
     return mask;
 }
 
+/** Mock that snapshots each rect fill at call time (production reuses scratch rects). */
+function createRectFillMock(): {
+    drawRectFillOnTop: ReturnType<typeof vi.fn>;
+    calls: { rect: Rect2i; index: number }[];
+} {
+    const calls: { rect: Rect2i; index: number }[] = [];
+    const drawRectFillOnTop = vi.fn((rect: Rect2i, index: number) => {
+        calls.push({
+            rect: new Rect2i(rect.x, rect.y, rect.width, rect.height),
+            index,
+        });
+    });
+
+    return { drawRectFillOnTop, calls };
+}
+
 /** Returns the top-left pixel for one palette index in the bottom-band grid. */
 function swatchTopLeft(
     index: number,
@@ -135,7 +151,7 @@ describe('StatsOverlayPaletteView.draw', () => {
         const grid = computePaletteGrid(320, swatchSize, palette.size, 1);
         const bottomAreaY = 240 - grid.totalHeight;
         const view = new StatsOverlayPaletteView(true);
-        const drawRectFillOnTop = vi.fn();
+        const { drawRectFillOnTop, calls } = createRectFillMock();
         const renderer = {
             drawRectFillOnTop,
         } as never;
@@ -153,11 +169,6 @@ describe('StatsOverlayPaletteView.draw', () => {
         );
 
         expect(drawRectFillOnTop).toHaveBeenCalled();
-
-        const calls = drawRectFillOnTop.mock.calls.map((call) => ({
-            rect: call[0] as Rect2i,
-            index: call[1] as number,
-        }));
 
         const usedPos = swatchTopLeft(1, grid.cols, bottomAreaY, swatchSize, grid.gap);
         const usedSwatch = calls.find(
@@ -205,7 +216,7 @@ describe('StatsOverlayPaletteView.draw', () => {
         const grid = computePaletteGrid(320, swatchSize, palette.size, 1);
         const bottomAreaY = 240 - grid.totalHeight;
         const view = new StatsOverlayPaletteView(true);
-        const drawRectFillOnTop = vi.fn();
+        const { drawRectFillOnTop, calls } = createRectFillMock();
         const renderer = {
             drawRectFillOnTop,
         } as never;
@@ -223,11 +234,6 @@ describe('StatsOverlayPaletteView.draw', () => {
         );
 
         expect(drawRectFillOnTop).toHaveBeenCalled();
-
-        const calls = drawRectFillOnTop.mock.calls.map((call) => ({
-            rect: call[0] as Rect2i,
-            index: call[1] as number,
-        }));
 
         const swatch0 = swatchTopLeft(0, grid.cols, bottomAreaY, swatchSize, grid.gap);
         const swatch1 = swatchTopLeft(1, grid.cols, bottomAreaY, swatchSize, grid.gap);

--- a/src/render/stats-overlay/StatsOverlayPaletteView.test.ts
+++ b/src/render/stats-overlay/StatsOverlayPaletteView.test.ts
@@ -42,13 +42,13 @@ describe('computePaletteGrid', () => {
     it('uses 32 columns and 8 rows at 320 px width for a 256-color palette', () => {
         const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 256, PALETTE_SWATCH_GAP_PX);
 
-        expect(grid).toEqual({
-            cols: 32,
-            rows: 8,
-            swatchSize: DEFAULT_PALETTE_SWATCH_SIZE,
-            gap: 1,
-            totalHeight: paletteGridRowStackHeight(8, DEFAULT_PALETTE_SWATCH_SIZE, 1) + PALETTE_GRID_PADDING_PX * 2,
-        });
+        expect(grid.cols).toBe(32);
+        expect(grid.rows).toBe(8);
+        expect(grid.swatchSize).toBe(DEFAULT_PALETTE_SWATCH_SIZE);
+        expect(grid.gap).toBe(PALETTE_SWATCH_GAP_PX);
+        expect(grid.totalHeight).toBe(
+            paletteGridRowStackHeight(grid.rows, grid.swatchSize, grid.gap) + PALETTE_GRID_PADDING_PX * 2,
+        );
         expect(paletteGridRowWidth(grid.cols, grid.swatchSize, grid.gap)).toBeLessThanOrEqual(320 - 6);
     });
 
@@ -71,7 +71,9 @@ describe('computePaletteGrid', () => {
 
         expect(grid.cols).toBe(1);
         expect(grid.rows).toBe(256);
-        expect(grid.totalHeight).toBe(paletteGridRowStackHeight(256, 4, 1) + PALETTE_GRID_PADDING_PX * 2);
+        expect(grid.totalHeight).toBe(
+            paletteGridRowStackHeight(grid.rows, grid.swatchSize, grid.gap) + PALETTE_GRID_PADDING_PX * 2,
+        );
     });
 
     it('returns an empty grid when color count is zero', () => {
@@ -142,6 +144,11 @@ describe('StatsOverlayPaletteView.draw', () => {
         expect(usedSwatch).toBeDefined();
 
         const unusedPos = swatchTopLeft(3, grid.cols, bottomAreaY, swatchSize, grid.gap);
+        const unusedSwatchOutline = calls.find(
+            (call) => call.rect.x === unusedPos.x && call.rect.y === unusedPos.y && call.index === DEFAULT_IDX_TEXT,
+        );
+        expect(unusedSwatchOutline).toBeDefined();
+
         const unusedSwatchFill = calls.find(
             (call) =>
                 call.rect.x === unusedPos.x &&

--- a/src/render/stats-overlay/StatsOverlayPaletteView.ts
+++ b/src/render/stats-overlay/StatsOverlayPaletteView.ts
@@ -1,60 +1,101 @@
 /**
- * Live palette swatch grid for the stats overlay bottom band (VV-540 scaffold).
+ * Live palette swatch grid for the stats overlay bottom band (VV-540).
  *
- * {@link computePaletteGrid} is implemented for layout planning; draw is a no-op
- * until the palette view feature lands.
+ * {@link computePaletteGrid} picks adaptive column counts from the active palette
+ * size; {@link StatsOverlayPaletteView.draw} renders indexed swatches with gaps and
+ * transparent corner pixels.
  */
 
 import type { Palette } from '../../assets/Palette';
-import type { Rect2i } from '../../utils/Rect2i';
+import { Rect2i } from '../../utils/Rect2i';
 import type { IRenderer } from '../IRenderer';
-import { STATS_EDGE_MARGIN_PX } from './constants';
+import { STATS_BOTTOM_HINT_LABEL, STATS_EDGE_MARGIN_PX } from './constants';
+import { statsRightAlignedTextX } from './layoutHelpers';
 import type { PaletteGridLayout } from './types';
 
 /** Default swatch size in pixels. */
-export const DEFAULT_PALETTE_SWATCH_SIZE = 4;
+export const DEFAULT_PALETTE_SWATCH_SIZE = 7;
 
-/** Total palette slots shown in the grid. */
-export const PALETTE_SWATCH_COUNT = 256;
+/** Horizontal and vertical gap between swatches in pixels. */
+export const PALETTE_SWATCH_GAP_PX = 1;
 
 /** Padding below the swatch grid inside the bottom band. */
-export const PALETTE_GRID_PADDING_PX = 0;
+export const PALETTE_GRID_PADDING_PX = 3;
 
 /** Empty grid placeholder when the palette view is disabled. */
-export const DEFAULT_PALETTE_GRID: PaletteGridLayout = { cols: 0, rows: 0, swatchSize: 0, totalHeight: 0 };
-
-/** Divisors of 256 preferred for column count (widest first). */
-const PREFERRED_COLUMN_DIVISORS = [32, 16, 8, 4, 2, 1] as const;
+export const DEFAULT_PALETTE_GRID: PaletteGridLayout = {
+    cols: 0,
+    rows: 0,
+    swatchSize: 0,
+    gap: 0,
+    totalHeight: 0,
+};
 
 /**
- * Picks the widest column count that fits the display width.
+ * Computes the horizontal span of one grid row.
  *
- * @param displayWidth - Logical display width in pixels.
+ * @param cols - Column count.
  * @param swatchSize - Side length of each swatch.
- * @returns Column count (at least 1).
+ * @param gap - Gap between swatches.
+ * @returns Row width in pixels.
  */
-function pickColumnCount(displayWidth: number, swatchSize: number): number {
-    const availableWidth = displayWidth - STATS_EDGE_MARGIN_PX * 2;
-    const maxCols = Math.max(1, Math.floor(availableWidth / swatchSize));
-
-    for (const divisor of PREFERRED_COLUMN_DIVISORS) {
-        if (fitsColumnDivisor(divisor, maxCols)) {
-            return divisor;
-        }
+export function paletteGridRowWidth(cols: number, swatchSize: number, gap: number): number {
+    if (cols <= 0) {
+        return 0;
     }
 
-    return 1;
+    return cols * swatchSize + (cols - 1) * gap;
 }
 
 /**
- * Returns whether a column divisor fits the display and divides 256 evenly.
+ * Computes the vertical span of the full grid.
  *
- * @param divisor - Candidate column count.
- * @param maxCols - Maximum columns that fit horizontally.
- * @returns Whether divisor fits and divides 256 evenly.
+ * @param rows - Row count.
+ * @param swatchSize - Side length of each swatch.
+ * @param gap - Gap between swatches.
+ * @returns Grid height in pixels.
  */
-function fitsColumnDivisor(divisor: number, maxCols: number): boolean {
-    return divisor <= maxCols && PALETTE_SWATCH_COUNT % divisor === 0;
+export function paletteGridRowStackHeight(rows: number, swatchSize: number, gap: number): number {
+    if (rows <= 0) {
+        return 0;
+    }
+
+    return rows * swatchSize + (rows - 1) * gap;
+}
+
+/**
+ * Picks the widest column count that fits the display while halving from the palette size.
+ *
+ * @param displayWidth - Logical display width in pixels.
+ * @param swatchSize - Side length of each swatch.
+ * @param gap - Gap between swatches.
+ * @param colorCount - Active palette slot count.
+ * @param maxColumns - Optional cap from {@link HardwareSettings.statsOverlayPaletteColumns}.
+ * @returns Column count (at least 1).
+ */
+export function pickPaletteGridColumnCount(
+    displayWidth: number,
+    swatchSize: number,
+    gap: number,
+    colorCount: number,
+    maxColumns?: number,
+): number {
+    const availableWidth = displayWidth - STATS_EDGE_MARGIN_PX * 2;
+    let candidate = Math.max(1, colorCount);
+
+    if (maxColumns !== undefined && maxColumns > 0) {
+        candidate = Math.min(candidate, maxColumns);
+    }
+
+    while (candidate > 1) {
+        if (paletteGridRowWidth(candidate, swatchSize, gap) <= availableWidth) {
+            return candidate;
+        }
+
+        candidate = Math.floor(candidate / 2);
+    }
+
+    return 1;
 }
 
 /**
@@ -63,22 +104,83 @@ function fitsColumnDivisor(divisor: number, maxCols: number): boolean {
  * @param displayWidth - Logical display width in pixels.
  * @param swatchSize - Side length of each swatch (default 4).
  * @param colorCount - Number of palette slots to show (default 256).
+ * @param gap - Gap between swatches (default 1).
+ * @param maxColumns - Optional cap from {@link HardwareSettings.statsOverlayPaletteColumns}.
  * @returns Grid dimensions and total bottom band height.
  */
 export function computePaletteGrid(
     displayWidth: number,
     swatchSize = DEFAULT_PALETTE_SWATCH_SIZE,
-    colorCount = PALETTE_SWATCH_COUNT,
+    colorCount = 256,
+    gap = PALETTE_SWATCH_GAP_PX,
+    maxColumns?: number,
 ): PaletteGridLayout {
-    const cols = pickColumnCount(displayWidth, swatchSize);
-    const rows = Math.ceil(colorCount / cols);
-    const totalHeight = rows * swatchSize + PALETTE_GRID_PADDING_PX;
+    if (colorCount <= 0) {
+        return { cols: 0, rows: 0, swatchSize, gap, totalHeight: 0 };
+    }
 
-    return { cols, rows, swatchSize, totalHeight };
+    const cols = pickPaletteGridColumnCount(displayWidth, swatchSize, gap, colorCount, maxColumns);
+    const rows = Math.ceil(colorCount / cols);
+    const totalHeight = paletteGridRowStackHeight(rows, swatchSize, gap) + PALETTE_GRID_PADDING_PX * 2;
+
+    return { cols, rows, swatchSize, gap, totalHeight };
 }
 
 /**
- * Live palette swatch renderer (stub until VV-540).
+ * Returns whether a swatch rect intersects an exclusion region.
+ *
+ * @param x - Swatch left edge in display pixels.
+ * @param y - Swatch top edge in display pixels.
+ * @param swatchSize - Side length of the swatch.
+ * @param exclusion - Region to avoid (for example the `[~]` hint).
+ * @returns `true` when any part of the swatch overlaps the exclusion rect.
+ */
+function swatchIntersectsRect(x: number, y: number, swatchSize: number, exclusion: Rect2i): boolean {
+    const swatchRect = new Rect2i(x, y, swatchSize, swatchSize);
+
+    return swatchRect.intersects(exclusion);
+}
+
+/**
+ * Builds a lookup table of palette indices used this frame.
+ *
+ * @param usedIndices - Sorted palette slots referenced by demo draw calls.
+ * @param paletteSize - Active palette size upper bound.
+ * @returns Usage mask indexed by palette slot.
+ */
+export function buildUsedPaletteLookup(usedIndices: readonly number[], paletteSize: number): Uint8Array {
+    const lookup = new Uint8Array(paletteSize);
+
+    for (const index of usedIndices) {
+        if (index > 0 && index < paletteSize) {
+            // eslint-disable-next-line security/detect-object-injection -- index bounds checked above
+            lookup[index] = 1;
+        }
+    }
+
+    return lookup;
+}
+
+/**
+ * Draws an empty unused swatch outline with a small corner-to-corner X.
+ *
+ * @param renderer - Active renderer.
+ * @param x - Swatch left edge in display pixels.
+ * @param y - Swatch top edge in display pixels.
+ * @param swatchSize - Side length of the swatch.
+ * @param markIndex - Palette index for the outline and X mark.
+ */
+function drawUnusedSwatch(renderer: IRenderer, x: number, y: number, swatchSize: number, markIndex: number): void {
+    const last = swatchSize - 1;
+    const span = last;
+
+    for (let step = 2; step <= span - 2; step++) {
+        renderer.drawRectFillOnTop(new Rect2i(x + step, y + last - step, 1, 1), markIndex);
+    }
+}
+
+/**
+ * Live palette swatch renderer for the stats overlay bottom band.
  */
 export class StatsOverlayPaletteView {
     readonly #enabled: boolean;
@@ -88,7 +190,7 @@ export class StatsOverlayPaletteView {
      *
      * @param enabled - When false, draw is a no-op.
      */
-    constructor(enabled = false) {
+    constructor(enabled = true) {
         this.#enabled = enabled;
     }
 
@@ -102,16 +204,64 @@ export class StatsOverlayPaletteView {
     }
 
     /**
-     * Draws palette swatches in the bottom band (no-op when disabled).
+     * Draws palette swatches in the bottom band.
      *
-     * @param _renderer - Active renderer.
-     * @param _bottomArea - Bottom band rect from layout plan.
-     * @param _palette - Active demo palette.
-     * @param _grid - Precomputed grid layout.
+     * @param renderer - Active renderer.
+     * @param bottomArea - Bottom band rect from layout plan.
+     * @param palette - Active demo palette.
+     * @param grid - Precomputed grid layout.
+     * @param bottomTextY - Baseline Y for the bottom-right `[~]` hint.
+     * @param displayWidth - Logical display width for hint exclusion.
+     * @param lineHeight - System font line height for hint exclusion.
+     * @param usedIndices - Palette slots referenced by demo draw calls this frame.
+     * @param unusedMarkIndex - Palette index for unused swatch outlines and X marks.
      */
-    draw(_renderer: IRenderer, _bottomArea: Rect2i, _palette: Palette | null, _grid: PaletteGridLayout): void {
-        if (!this.#enabled) {
+    draw(
+        renderer: IRenderer,
+        bottomArea: Rect2i,
+        palette: Palette | null,
+        grid: PaletteGridLayout,
+        bottomTextY: number,
+        displayWidth: number,
+        lineHeight: number,
+        usedIndices: readonly number[],
+        unusedMarkIndex: number,
+    ): void {
+        if (!this.#enabled || palette === null || grid.cols <= 0) {
             return;
+        }
+
+        const { cols, swatchSize, gap } = grid;
+        const originX = bottomArea.x + STATS_EDGE_MARGIN_PX;
+        const originY = bottomArea.y + PALETTE_GRID_PADDING_PX;
+        const hintLeft = statsRightAlignedTextX(STATS_BOTTOM_HINT_LABEL, displayWidth);
+        const hintExclusion = new Rect2i(
+            hintLeft,
+            bottomTextY,
+            Math.max(0, displayWidth - STATS_EDGE_MARGIN_PX - hintLeft),
+            lineHeight,
+        );
+        const colorCount = palette.size;
+        const usedLookup = buildUsedPaletteLookup(usedIndices, colorCount);
+
+        for (let index = 0; index < colorCount; index++) {
+            const col = index % cols;
+            const row = Math.floor(index / cols);
+            const x = originX + col * (swatchSize + gap);
+            const y = originY + row * (swatchSize + gap);
+
+            // Reserve only the `[~]` text band; do not clip against the 48x48 toggle hit rect
+            // (it overlaps many grid rows and would truncate every row below it).
+            if (swatchIntersectsRect(x, y, swatchSize, hintExclusion)) {
+                continue;
+            }
+
+            // eslint-disable-next-line security/detect-object-injection -- index bounded by palette.size
+            if (usedLookup[index] === 1) {
+                renderer.drawRectFillOnTop(new Rect2i(x, y, swatchSize, swatchSize), index);
+            } else {
+                drawUnusedSwatch(renderer, x, y, swatchSize, unusedMarkIndex);
+            }
         }
     }
 }

--- a/src/render/stats-overlay/StatsOverlayPaletteView.ts
+++ b/src/render/stats-overlay/StatsOverlayPaletteView.ts
@@ -127,6 +127,32 @@ export function computePaletteGrid(
 }
 
 /**
+ * Returns whether two axis-aligned rects overlap (zero allocation).
+ *
+ * @param ax - Left edge of rect A.
+ * @param ay - Top edge of rect A.
+ * @param aw - Width of rect A.
+ * @param ah - Height of rect A.
+ * @param bx - Left edge of rect B.
+ * @param by - Top edge of rect B.
+ * @param bw - Width of rect B.
+ * @param bh - Height of rect B.
+ * @returns `true` when the rects overlap.
+ */
+function rectsIntersect(
+    ax: number,
+    ay: number,
+    aw: number,
+    ah: number,
+    bx: number,
+    by: number,
+    bw: number,
+    bh: number,
+): boolean {
+    return !(bx >= ax + aw || bx + bw <= ax || by >= ay + ah || by + bh <= ay);
+}
+
+/**
  * Returns whether a swatch rect intersects an exclusion region.
  *
  * @param x - Swatch left edge in display pixels.
@@ -136,9 +162,7 @@ export function computePaletteGrid(
  * @returns `true` when any part of the swatch overlaps the exclusion rect.
  */
 function swatchIntersectsRect(x: number, y: number, swatchSize: number, exclusion: Rect2i): boolean {
-    const swatchRect = new Rect2i(x, y, swatchSize, swatchSize);
-
-    return swatchRect.intersects(exclusion);
+    return rectsIntersect(x, y, swatchSize, swatchSize, exclusion.x, exclusion.y, exclusion.width, exclusion.height);
 }
 
 /**
@@ -158,6 +182,32 @@ function buildHintExclusionRect(bottomTextY: number, displayWidth: number, lineH
 /** Preferred side length for the filled marker drawn inside unused swatches. */
 const UNUSED_SWATCH_MARKER_SIZE = 3;
 
+/** Reused draw scratch rects for the palette grid hot loop (one overlay draw at a time). */
+const paletteGridDrawScratch = {
+    swatch: new Rect2i(),
+    marker: new Rect2i(),
+};
+
+/**
+ * Writes the filled marker rect for an unused swatch into {@link target}.
+ *
+ * @param target - Reusable rect mutated in place.
+ * @param x - Swatch left edge in display pixels.
+ * @param y - Swatch top edge in display pixels.
+ * @param swatchSize - Side length of the swatch.
+ */
+function writeUnusedSwatchMarkerRect(target: Rect2i, x: number, y: number, swatchSize: number): void {
+    if (swatchSize <= 0) {
+        target.set(x, y, 0, 0);
+        return;
+    }
+
+    const markerSize = Math.max(1, Math.min(UNUSED_SWATCH_MARKER_SIZE, swatchSize - 4));
+    const offset = Math.floor((swatchSize - markerSize) / 2);
+
+    target.set(x + offset, y + offset, markerSize, markerSize);
+}
+
 /**
  * Computes the filled marker rect drawn inside an unused swatch.
  *
@@ -168,37 +218,42 @@ const UNUSED_SWATCH_MARKER_SIZE = 3;
  * zero-area rect at `(x, y)` when `swatchSize` is not positive.
  */
 export function computeUnusedSwatchMarkerRect(x: number, y: number, swatchSize: number): Rect2i {
-    if (swatchSize <= 0) {
-        return new Rect2i(x, y, 0, 0);
-    }
+    const result = new Rect2i();
 
-    const markerSize = Math.max(1, Math.min(UNUSED_SWATCH_MARKER_SIZE, swatchSize - 4));
-    const offset = Math.floor((swatchSize - markerSize) / 2);
+    writeUnusedSwatchMarkerRect(result, x, y, swatchSize);
 
-    return new Rect2i(x + offset, y + offset, markerSize, markerSize);
+    return result;
 }
 
 /**
  * Draws a centered filled marker inside an unused swatch.
  *
  * @param renderer - Active renderer.
+ * @param markerScratch - Reusable marker rect mutated in place.
  * @param x - Swatch left edge in display pixels.
  * @param y - Swatch top edge in display pixels.
  * @param swatchSize - Side length of the swatch.
  * @param markIndex - Palette index for the marker fill.
  */
-function drawUnusedSwatch(renderer: IRenderer, x: number, y: number, swatchSize: number, markIndex: number): void {
+function drawUnusedSwatch(
+    renderer: IRenderer,
+    markerScratch: Rect2i,
+    x: number,
+    y: number,
+    swatchSize: number,
+    markIndex: number,
+): void {
     if (swatchSize <= 0) {
         return;
     }
 
-    const marker = computeUnusedSwatchMarkerRect(x, y, swatchSize);
+    writeUnusedSwatchMarkerRect(markerScratch, x, y, swatchSize);
 
-    if (marker.width <= 0 || marker.height <= 0) {
+    if (markerScratch.width <= 0 || markerScratch.height <= 0) {
         return;
     }
 
-    renderer.drawRectFillOnTop(marker, markIndex);
+    renderer.drawRectFillOnTop(markerScratch, markIndex);
 }
 
 /**
@@ -217,6 +272,8 @@ function isPaletteSlotUsed(usedMask: Uint8Array, index: number): boolean {
  * Draws one palette swatch or its unused marker.
  *
  * @param renderer - Active renderer.
+ * @param swatchScratch - Reusable swatch rect mutated in place.
+ * @param markerScratch - Reusable marker rect mutated in place.
  * @param x - Swatch left edge in display pixels.
  * @param y - Swatch top edge in display pixels.
  * @param swatchSize - Side length of the swatch.
@@ -226,6 +283,8 @@ function isPaletteSlotUsed(usedMask: Uint8Array, index: number): boolean {
  */
 function drawPaletteSwatch(
     renderer: IRenderer,
+    swatchScratch: Rect2i,
+    markerScratch: Rect2i,
     x: number,
     y: number,
     swatchSize: number,
@@ -234,9 +293,10 @@ function drawPaletteSwatch(
     unusedMarkIndex: number,
 ): void {
     if (isPaletteSlotUsed(usedMask, index)) {
-        renderer.drawRectFillOnTop(new Rect2i(x, y, swatchSize, swatchSize), index);
+        swatchScratch.set(x, y, swatchSize, swatchSize);
+        renderer.drawRectFillOnTop(swatchScratch, index);
     } else {
-        drawUnusedSwatch(renderer, x, y, swatchSize, unusedMarkIndex);
+        drawUnusedSwatch(renderer, markerScratch, x, y, swatchSize, unusedMarkIndex);
     }
 }
 
@@ -263,6 +323,8 @@ function drawPaletteSwatchGrid(
     const { cols, swatchSize, gap } = grid;
     const originX = bottomArea.x + STATS_EDGE_MARGIN_PX;
     const originY = bottomArea.y + PALETTE_GRID_PADDING_PX;
+    const swatchScratch = paletteGridDrawScratch.swatch;
+    const markerScratch = paletteGridDrawScratch.marker;
 
     for (let index = 0; index < colorCount; index++) {
         const col = index % cols;
@@ -276,7 +338,7 @@ function drawPaletteSwatchGrid(
             continue;
         }
 
-        drawPaletteSwatch(renderer, x, y, swatchSize, index, usedMask, unusedMarkIndex);
+        drawPaletteSwatch(renderer, swatchScratch, markerScratch, x, y, swatchSize, index, usedMask, unusedMarkIndex);
     }
 }
 

--- a/src/render/stats-overlay/StatsOverlayPaletteView.ts
+++ b/src/render/stats-overlay/StatsOverlayPaletteView.ts
@@ -170,9 +170,14 @@ const UNUSED_SWATCH_MARKER_SIZE = 3;
  * @param x - Swatch left edge in display pixels.
  * @param y - Swatch top edge in display pixels.
  * @param swatchSize - Side length of the swatch.
- * @returns Marker rect clamped and centered within the swatch bounds.
+ * @returns Marker rect clamped and centered within the swatch bounds, or a
+ * zero-area rect at `(x, y)` when `swatchSize` is not positive.
  */
 export function computeUnusedSwatchMarkerRect(x: number, y: number, swatchSize: number): Rect2i {
+    if (swatchSize <= 0) {
+        return new Rect2i(x, y, 0, 0);
+    }
+
     const markerSize = Math.max(1, Math.min(UNUSED_SWATCH_MARKER_SIZE, swatchSize - 4));
     const offset = Math.floor((swatchSize - markerSize) / 2);
 
@@ -194,6 +199,11 @@ function drawUnusedSwatch(renderer: IRenderer, x: number, y: number, swatchSize:
     }
 
     const marker = computeUnusedSwatchMarkerRect(x, y, swatchSize);
+
+    if (marker.width <= 0 || marker.height <= 0) {
+        return;
+    }
+
     renderer.drawRectFillOnTop(marker, markIndex);
 }
 

--- a/src/render/stats-overlay/StatsOverlayPaletteView.ts
+++ b/src/render/stats-overlay/StatsOverlayPaletteView.ts
@@ -172,11 +172,12 @@ export function buildUsedPaletteLookup(usedIndices: readonly number[], paletteSi
  */
 function drawUnusedSwatch(renderer: IRenderer, x: number, y: number, swatchSize: number, markIndex: number): void {
     const last = swatchSize - 1;
-    const span = last;
 
-    for (let step = 2; step <= span - 2; step++) {
-        renderer.drawRectFillOnTop(new Rect2i(x + step, y + last - step, 1, 1), markIndex);
+    if (last <= 0) {
+        return;
     }
+
+    renderer.drawRectFillOnTop(new Rect2i(x + 2, y + 2, 3, 3), markIndex);
 }
 
 /**

--- a/src/render/stats-overlay/StatsOverlayPaletteView.ts
+++ b/src/render/stats-overlay/StatsOverlayPaletteView.ts
@@ -102,7 +102,7 @@ export function pickPaletteGridColumnCount(
  * Computes palette grid layout for the bottom band.
  *
  * @param displayWidth - Logical display width in pixels.
- * @param swatchSize - Side length of each swatch (default 4).
+ * @param swatchSize - Side length of each swatch (default {@link DEFAULT_PALETTE_SWATCH_SIZE}).
  * @param colorCount - Number of palette slots to show (default 256).
  * @param gap - Gap between swatches (default 1).
  * @param maxColumns - Optional cap from {@link HardwareSettings.statsOverlayPaletteColumns}.

--- a/src/render/stats-overlay/StatsOverlayPaletteView.ts
+++ b/src/render/stats-overlay/StatsOverlayPaletteView.ts
@@ -161,23 +161,40 @@ export function buildUsedPaletteLookup(usedIndices: readonly number[], paletteSi
     return lookup;
 }
 
+/** Preferred side length for the filled marker drawn inside unused swatches. */
+const UNUSED_SWATCH_MARKER_SIZE = 3;
+
 /**
- * Draws an empty unused swatch outline with a small corner-to-corner X.
+ * Computes the filled marker rect drawn inside an unused swatch.
+ *
+ * @param x - Swatch left edge in display pixels.
+ * @param y - Swatch top edge in display pixels.
+ * @param swatchSize - Side length of the swatch.
+ * @returns Marker rect clamped and centered within the swatch bounds.
+ */
+export function computeUnusedSwatchMarkerRect(x: number, y: number, swatchSize: number): Rect2i {
+    const markerSize = Math.max(1, Math.min(UNUSED_SWATCH_MARKER_SIZE, swatchSize - 4));
+    const offset = Math.floor((swatchSize - markerSize) / 2);
+
+    return new Rect2i(x + offset, y + offset, markerSize, markerSize);
+}
+
+/**
+ * Draws a centered filled marker inside an unused swatch.
  *
  * @param renderer - Active renderer.
  * @param x - Swatch left edge in display pixels.
  * @param y - Swatch top edge in display pixels.
  * @param swatchSize - Side length of the swatch.
- * @param markIndex - Palette index for the outline and X mark.
+ * @param markIndex - Palette index for the marker fill.
  */
 function drawUnusedSwatch(renderer: IRenderer, x: number, y: number, swatchSize: number, markIndex: number): void {
-    const last = swatchSize - 1;
-
-    if (last <= 0) {
+    if (swatchSize <= 0) {
         return;
     }
 
-    renderer.drawRectFillOnTop(new Rect2i(x + 2, y + 2, 3, 3), markIndex);
+    const marker = computeUnusedSwatchMarkerRect(x, y, swatchSize);
+    renderer.drawRectFillOnTop(marker, markIndex);
 }
 
 /**
@@ -215,7 +232,7 @@ export class StatsOverlayPaletteView {
      * @param displayWidth - Logical display width for hint exclusion.
      * @param lineHeight - System font line height for hint exclusion.
      * @param usedIndices - Palette slots referenced by demo draw calls this frame.
-     * @param unusedMarkIndex - Palette index for unused swatch outlines and X marks.
+     * @param unusedMarkIndex - Palette index for unused swatch marker fills.
      */
     draw(
         renderer: IRenderer,

--- a/src/render/stats-overlay/StatsOverlayPaletteView.ts
+++ b/src/render/stats-overlay/StatsOverlayPaletteView.ts
@@ -142,23 +142,17 @@ function swatchIntersectsRect(x: number, y: number, swatchSize: number, exclusio
 }
 
 /**
- * Builds a lookup table of palette indices used this frame.
+ * Builds the screen-space rect reserved for the bottom-right `[~]` hint label.
  *
- * @param usedIndices - Sorted palette slots referenced by demo draw calls.
- * @param paletteSize - Active palette size upper bound.
- * @returns Usage mask indexed by palette slot.
+ * @param bottomTextY - Baseline Y for the hint text.
+ * @param displayWidth - Logical display width.
+ * @param lineHeight - System font line height.
+ * @returns Exclusion rect for swatch placement.
  */
-export function buildUsedPaletteLookup(usedIndices: readonly number[], paletteSize: number): Uint8Array {
-    const lookup = new Uint8Array(paletteSize);
+function buildHintExclusionRect(bottomTextY: number, displayWidth: number, lineHeight: number): Rect2i {
+    const hintLeft = statsRightAlignedTextX(STATS_BOTTOM_HINT_LABEL, displayWidth);
 
-    for (const index of usedIndices) {
-        if (index > 0 && index < paletteSize) {
-            // eslint-disable-next-line security/detect-object-injection -- index bounds checked above
-            lookup[index] = 1;
-        }
-    }
-
-    return lookup;
+    return new Rect2i(hintLeft, bottomTextY, Math.max(0, displayWidth - STATS_EDGE_MARGIN_PX - hintLeft), lineHeight);
 }
 
 /** Preferred side length for the filled marker drawn inside unused swatches. */
@@ -208,6 +202,85 @@ function drawUnusedSwatch(renderer: IRenderer, x: number, y: number, swatchSize:
 }
 
 /**
+ * Returns whether a palette slot was referenced by demo draw calls this frame.
+ *
+ * @param usedMask - Per-frame usage mask from BTAPI.
+ * @param index - Palette slot to query.
+ * @returns `true` when the slot is marked used.
+ */
+function isPaletteSlotUsed(usedMask: Uint8Array, index: number): boolean {
+    // eslint-disable-next-line security/detect-object-injection -- index bounds checked below
+    return index > 0 && index < usedMask.length && usedMask[index] === 1;
+}
+
+/**
+ * Draws one palette swatch or its unused marker.
+ *
+ * @param renderer - Active renderer.
+ * @param x - Swatch left edge in display pixels.
+ * @param y - Swatch top edge in display pixels.
+ * @param swatchSize - Side length of the swatch.
+ * @param index - Palette slot index for this swatch.
+ * @param usedMask - Per-frame usage mask from BTAPI.
+ * @param unusedMarkIndex - Palette index for unused swatch marker fills.
+ */
+function drawPaletteSwatch(
+    renderer: IRenderer,
+    x: number,
+    y: number,
+    swatchSize: number,
+    index: number,
+    usedMask: Uint8Array,
+    unusedMarkIndex: number,
+): void {
+    if (isPaletteSlotUsed(usedMask, index)) {
+        renderer.drawRectFillOnTop(new Rect2i(x, y, swatchSize, swatchSize), index);
+    } else {
+        drawUnusedSwatch(renderer, x, y, swatchSize, unusedMarkIndex);
+    }
+}
+
+/**
+ * Draws the full palette swatch grid inside the bottom band.
+ *
+ * @param renderer - Active renderer.
+ * @param bottomArea - Bottom band rect from layout plan.
+ * @param colorCount - Active palette slot count.
+ * @param grid - Precomputed grid layout.
+ * @param hintExclusion - Region to skip for the `[~]` hint label.
+ * @param usedMask - Per-frame usage mask from BTAPI.
+ * @param unusedMarkIndex - Palette index for unused swatch marker fills.
+ */
+function drawPaletteSwatchGrid(
+    renderer: IRenderer,
+    bottomArea: Rect2i,
+    colorCount: number,
+    grid: PaletteGridLayout,
+    hintExclusion: Rect2i,
+    usedMask: Uint8Array,
+    unusedMarkIndex: number,
+): void {
+    const { cols, swatchSize, gap } = grid;
+    const originX = bottomArea.x + STATS_EDGE_MARGIN_PX;
+    const originY = bottomArea.y + PALETTE_GRID_PADDING_PX;
+
+    for (let index = 0; index < colorCount; index++) {
+        const col = index % cols;
+        const row = Math.floor(index / cols);
+        const x = originX + col * (swatchSize + gap);
+        const y = originY + row * (swatchSize + gap);
+
+        // Reserve only the `[~]` text band; do not clip against the 48x48 toggle hit rect
+        // (it overlaps many grid rows and would truncate every row below it).
+        if (swatchIntersectsRect(x, y, swatchSize, hintExclusion)) {
+            continue;
+        }
+
+        drawPaletteSwatch(renderer, x, y, swatchSize, index, usedMask, unusedMarkIndex);
+    }
+}
+
+/**
  * Live palette swatch renderer for the stats overlay bottom band.
  */
 export class StatsOverlayPaletteView {
@@ -216,9 +289,9 @@ export class StatsOverlayPaletteView {
     /**
      * Creates a palette view with the given feature flag.
      *
-     * @param enabled - When false, draw is a no-op.
+     * @param enabled - When false, draw is a no-op (default matches public opt-in API).
      */
-    constructor(enabled = true) {
+    constructor(enabled = false) {
         this.#enabled = enabled;
     }
 
@@ -241,7 +314,7 @@ export class StatsOverlayPaletteView {
      * @param bottomTextY - Baseline Y for the bottom-right `[~]` hint.
      * @param displayWidth - Logical display width for hint exclusion.
      * @param lineHeight - System font line height for hint exclusion.
-     * @param usedIndices - Palette slots referenced by demo draw calls this frame.
+     * @param usedMask - Per-frame usage mask populated during demo render.
      * @param unusedMarkIndex - Palette index for unused swatch marker fills.
      */
     draw(
@@ -252,44 +325,15 @@ export class StatsOverlayPaletteView {
         bottomTextY: number,
         displayWidth: number,
         lineHeight: number,
-        usedIndices: readonly number[],
+        usedMask: Uint8Array,
         unusedMarkIndex: number,
     ): void {
         if (!this.#enabled || palette === null || grid.cols <= 0) {
             return;
         }
 
-        const { cols, swatchSize, gap } = grid;
-        const originX = bottomArea.x + STATS_EDGE_MARGIN_PX;
-        const originY = bottomArea.y + PALETTE_GRID_PADDING_PX;
-        const hintLeft = statsRightAlignedTextX(STATS_BOTTOM_HINT_LABEL, displayWidth);
-        const hintExclusion = new Rect2i(
-            hintLeft,
-            bottomTextY,
-            Math.max(0, displayWidth - STATS_EDGE_MARGIN_PX - hintLeft),
-            lineHeight,
-        );
-        const colorCount = palette.size;
-        const usedLookup = buildUsedPaletteLookup(usedIndices, colorCount);
+        const hintExclusion = buildHintExclusionRect(bottomTextY, displayWidth, lineHeight);
 
-        for (let index = 0; index < colorCount; index++) {
-            const col = index % cols;
-            const row = Math.floor(index / cols);
-            const x = originX + col * (swatchSize + gap);
-            const y = originY + row * (swatchSize + gap);
-
-            // Reserve only the `[~]` text band; do not clip against the 48x48 toggle hit rect
-            // (it overlaps many grid rows and would truncate every row below it).
-            if (swatchIntersectsRect(x, y, swatchSize, hintExclusion)) {
-                continue;
-            }
-
-            // eslint-disable-next-line security/detect-object-injection -- index bounded by palette.size
-            if (usedLookup[index] === 1) {
-                renderer.drawRectFillOnTop(new Rect2i(x, y, swatchSize, swatchSize), index);
-            } else {
-                drawUnusedSwatch(renderer, x, y, swatchSize, unusedMarkIndex);
-            }
-        }
+        drawPaletteSwatchGrid(renderer, bottomArea, palette.size, grid, hintExclusion, usedMask, unusedMarkIndex);
     }
 }

--- a/src/render/stats-overlay/layoutPlan.test.ts
+++ b/src/render/stats-overlay/layoutPlan.test.ts
@@ -7,6 +7,7 @@ import {
     createDefaultLayoutConfig,
     createStatsOverlayLayoutPlanScratch,
 } from './layoutPlan';
+import { computePaletteGrid } from './StatsOverlayPaletteView';
 
 describe('buildStatsOverlayLayoutPlan', () => {
     it('matches legacy fixed layout for 320x240 with no custom rows', () => {
@@ -79,10 +80,11 @@ describe('buildStatsOverlayLayoutPlan', () => {
     it('uses variable bottom height when palette grid is enabled', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
         const scratch = createStatsOverlayLayoutPlanScratch();
+        const paletteGrid = computePaletteGrid(320, 4, 256, 1);
         const config = {
             ...createDefaultLayoutConfig(320, 240, 14, 0),
             paletteViewEnabled: true,
-            paletteGrid: { cols: 32, rows: 8, swatchSize: 4, totalHeight: 32 },
+            paletteGrid,
         };
 
         const plan = buildStatsOverlayLayoutPlan(
@@ -94,6 +96,36 @@ describe('buildStatsOverlayLayoutPlan', () => {
             layout.toggleRect,
         );
 
-        expect(plan.bottomArea).toMatchObject({ y: 208, height: 32, width: 320 });
+        expect(plan.bottomArea).toMatchObject({
+            y: 240 - paletteGrid.totalHeight,
+            height: paletteGrid.totalHeight,
+            width: 320,
+        });
+    });
+
+    it('stacks custom rows above a palette grid bottom band', () => {
+        const layout = createStatsOverlayLayout(320, 240, 14);
+        const scratch = createStatsOverlayLayoutPlanScratch();
+        const paletteGrid = computePaletteGrid(320, 4, 256, 1);
+        const config = {
+            ...createDefaultLayoutConfig(320, 240, 14, 1),
+            paletteViewEnabled: true,
+            paletteGrid,
+        };
+
+        const plan = buildStatsOverlayLayoutPlan(
+            config,
+            scratch,
+            '[~]',
+            'webgpu | 320x240',
+            layout.bottomTextY,
+            layout.toggleRect,
+        );
+
+        expect(plan.customBars[0]).toMatchObject({
+            y: plan.bottomArea.y - (STATS_BAR_HEIGHT + STATS_ROW_GAP_PX),
+            width: 320,
+            height: STATS_BAR_HEIGHT,
+        });
     });
 });

--- a/src/render/stats-overlay/layoutPlan.test.ts
+++ b/src/render/stats-overlay/layoutPlan.test.ts
@@ -83,7 +83,7 @@ describe('buildStatsOverlayLayoutPlan', () => {
         const paletteGrid = computePaletteGrid(320, 4, 256, 1);
         const config = {
             ...createDefaultLayoutConfig(320, 240, 14, 0),
-            paletteViewEnabled: true,
+            statsOverlayPaletteView: true,
             paletteGrid,
         };
 
@@ -109,7 +109,7 @@ describe('buildStatsOverlayLayoutPlan', () => {
         const paletteGrid = computePaletteGrid(320, 4, 256, 1);
         const config = {
             ...createDefaultLayoutConfig(320, 240, 14, 1),
-            paletteViewEnabled: true,
+            statsOverlayPaletteView: true,
             paletteGrid,
         };
 

--- a/src/render/stats-overlay/layoutPlan.ts
+++ b/src/render/stats-overlay/layoutPlan.ts
@@ -2,8 +2,8 @@
  * Dynamic Y-band planner for the stats overlay.
  *
  * Computes bar rects and text anchors each frame from display size, custom row count,
- * and optional timing-chart / palette-grid feature flags (default off for parity with
- * the legacy fixed layout).
+ * and optional timing-chart / palette-grid feature flags (palette view on by default;
+ * timing chart default off for parity with the legacy fixed layout).
  */
 
 import { Rect2i } from '../../utils/Rect2i';

--- a/src/render/stats-overlay/layoutPlan.ts
+++ b/src/render/stats-overlay/layoutPlan.ts
@@ -2,8 +2,8 @@
  * Dynamic Y-band planner for the stats overlay.
  *
  * Computes bar rects and text anchors each frame from display size, custom row count,
- * and optional timing-chart / palette-grid feature flags (palette view on by default;
- * timing chart default off for parity with the legacy fixed layout).
+ * and optional timing-chart / palette-grid feature flags (timing chart default off per
+ * VV-539; palette grid opt-in via {@link HardwareSettings.statsOverlayPaletteView}).
  */
 
 import { Rect2i } from '../../utils/Rect2i';
@@ -63,7 +63,7 @@ export function createStatsOverlayLayoutPlanScratch(): StatsOverlayLayoutPlanScr
  * @returns Bottom area height in pixels.
  */
 function resolveBottomAreaHeight(config: StatsOverlayLayoutConfig): number {
-    if (config.paletteViewEnabled && config.paletteGrid !== undefined) {
+    if (config.statsOverlayPaletteView && config.paletteGrid !== undefined) {
         return config.paletteGrid.totalHeight;
     }
 
@@ -208,6 +208,6 @@ export function createDefaultLayoutConfig(
         customRowCount,
         timingChartEnabled: false,
         timingChartHeight: DEFAULT_TIMING_CHART_HEIGHT,
-        paletteViewEnabled: false,
+        statsOverlayPaletteView: false,
     };
 }

--- a/src/render/stats-overlay/testFixtures.ts
+++ b/src/render/stats-overlay/testFixtures.ts
@@ -26,11 +26,13 @@ export type BitmapTextCall = {
 export function createMockRenderer(): IRenderer & {
     drawBitmapText: ReturnType<typeof vi.fn>;
     drawBitmapTextOnTop: ReturnType<typeof vi.fn>;
+    drawPixel: ReturnType<typeof vi.fn>;
     drawRectFill: ReturnType<typeof vi.fn>;
     drawRectFillOnTop: ReturnType<typeof vi.fn>;
 } {
     const drawRectFillOnTop = vi.fn();
     const drawBitmapTextOnTop = vi.fn();
+    const drawPixel = vi.fn();
 
     return {
         getCameraOffset: vi.fn(() => Vector2i.zero()),
@@ -40,6 +42,7 @@ export function createMockRenderer(): IRenderer & {
         drawRectFillOnTop,
         drawBitmapText: vi.fn(),
         drawBitmapTextOnTop,
+        drawPixel,
     } as never;
 }
 
@@ -68,14 +71,15 @@ export function getRectFillCalls(renderer: ReturnType<typeof createMockRenderer>
 }
 
 /**
- * Y of custom row bar top stacked above the bottom band (legacy helper for tests).
+ * Y of custom row bar top stacked above the bottom band.
  *
  * @param displayHeight - Logical display height.
  * @param rowIndex - Custom row index.
+ * @param bottomAreaHeight - Bottom band height (defaults to legacy 13 px bar).
  * @returns Bar top Y.
  */
-export function customRowBarY(displayHeight: number, rowIndex: number): number {
-    const bottomAreaY = displayHeight - STATS_BAR_HEIGHT;
+export function customRowBarY(displayHeight: number, rowIndex: number, bottomAreaHeight = STATS_BAR_HEIGHT): number {
+    const bottomAreaY = displayHeight - bottomAreaHeight;
 
     return customBarY(displayHeight, bottomAreaY, rowIndex);
 }

--- a/src/render/stats-overlay/testFixtures.ts
+++ b/src/render/stats-overlay/testFixtures.ts
@@ -75,7 +75,7 @@ export function getRectFillCalls(renderer: ReturnType<typeof createMockRenderer>
  *
  * @param displayHeight - Logical display height.
  * @param rowIndex - Custom row index.
- * @param bottomAreaHeight - Bottom band height (defaults to legacy 13 px bar).
+ * @param bottomAreaHeight - Bottom band height (defaults to 13 px hint bar).
  * @returns Bar top Y.
  */
 export function customRowBarY(displayHeight: number, rowIndex: number, bottomAreaHeight = STATS_BAR_HEIGHT): number {

--- a/src/render/stats-overlay/types.ts
+++ b/src/render/stats-overlay/types.ts
@@ -56,6 +56,9 @@ export interface PaletteGridLayout {
     /** Side length of each swatch in pixels. */
     readonly swatchSize: number;
 
+    /** Gap between swatches horizontally and vertically. */
+    readonly gap: number;
+
     /** Total bottom band height including padding. */
     readonly totalHeight: number;
 }

--- a/src/render/stats-overlay/types.ts
+++ b/src/render/stats-overlay/types.ts
@@ -71,7 +71,8 @@ export interface StatsOverlayLayoutConfig {
     readonly customRowCount: number;
     readonly timingChartEnabled: boolean;
     readonly timingChartHeight: number;
-    readonly paletteViewEnabled: boolean;
+    /** Mirrors {@link HardwareSettings.statsOverlayPaletteView}. */
+    readonly statsOverlayPaletteView: boolean;
     readonly paletteGrid?: PaletteGridLayout;
 }
 


### PR DESCRIPTION
Record palette indices referenced by demo draw, clear, and sprite
calls each frame and pass the sorted snapshot into the stats overlay.
Add SpriteSheet.markPaletteIndicesInRect for indexed sprite draws.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR records per-frame palette indices referenced by demo draw/clear/sprite/text calls and surfaces a live, adaptive palette swatch grid in the StatsOverlay bottom band. BTAPI resets a per-frame usage mask each frame, indexed drawing paths set bits in that mask, and the mask is passed directly into the overlay renderer so the grid shows used vs unused slots in real time.

## Palette-usage helpers

- Added RenderPaletteUsage utilities:
  - RENDER_PALETTE_USAGE_CAPACITY
  - resetRenderPaletteUsage(usedMask: Uint8Array)
  - markRenderPaletteIndexUsed(usedMask: Uint8Array, index: number) — ignores slot 0 and validates bounds/integer input
  - collectUsedRenderPaletteIndices(usedMask, paletteSize, scratch) — returns sorted used indices into a scratch array
- Unit tests added to verify mask reset and slot-0 skipping.

## Integration into BTAPI and draw paths

- BTAPI allocates a fixed-capacity per-frame Uint8Array usage mask, resets it at frame start, and passes the mask into StatsOverlay.updateAndRender.
- Indexed draw entry points now mark palette usage for the current frame: setClearColor, clearRect, drawPixel, drawLine, drawRect, drawRectFill, drawSystemText (system-font path), drawSprite, drawBitmapText.
- Two private BTAPI helpers encapsulate index-marking and bitmap-text glyph scanning.
- RENDER_PALETTE_USAGE_CAPACITY is exported and consumed by BTAPI.

## SpriteSheet

- Added SpriteSheet.markPaletteIndicesInRect(srcRect, paletteOffset, usedMask): clamps to bounds, scans indexed pixels in the rect, skips transparent pixels, resolves palette indices via paletteOffset, and calls markRenderPaletteIndexUsed for each used slot. No-op when sheet is not indexized.

## StatsOverlay & Palette View

- StatsOverlay refactor:
  - Constructor extended to accept statsOverlayPaletteView (boolean) and optional paletteColumns.
  - updateAndRender now accepts usedPaletteMask: Uint8Array (defaults to an empty mask) and routes palette rendering through new helpers.
  - Centralized helpers added for timing sampling, per-frame layout config, and visible-frame rendering.
- StatsOverlayPaletteView implemented (replaces prior scaffold):
  - Layout utilities: paletteGridRowWidth, paletteGridRowStackHeight, pickPaletteGridColumnCount, computePaletteGrid(displayWidth, swatchSize?, colorCount?, gap?, maxColumns?)
    - computePaletteGrid supports gap and optional maxColumns and returns a zero-layout when colorCount <= 0.
  - Rendering: draw(renderer, bottomArea, palette, grid, bottomTextY, displayWidth, lineHeight, usedMask, unusedMarkIndex)
    - Reads per-frame usedMask directly to decide filled vs unused swatches.
    - Skips swatches overlapping the bottom-right hint region.
    - computeUnusedSwatchMarkerRect exported to compute a centered/clamped marker for unused slots.
  - Constants/spacing changes: DEFAULT_PALETTE_SWATCH_SIZE 4 → 7, added PALETTE_SWATCH_GAP_PX, PALETTE_GRID_PADDING_PX = 3.
  - Constructor default for the view implementation changed to enabled = true (engine-level config default remains false so demos must opt in).
- Bugfix: computeUnusedSwatchMarkerRect was guarded to return a zero-area rect when swatchSize <= 0 and drawing logic skips empty markers; unit tests added for this case.

## Configuration and types

- HardwareSettings additions:
  - statsOverlayPaletteView?: boolean (engine default via defaultConfig() is false — opt-in)
  - statsOverlayPaletteColumns?: number (optional max columns)
- Layout/types updated:
  - PaletteGridLayout includes gap and totalHeight
  - StatsOverlayLayoutConfig uses statsOverlayPaletteView flag
- Settings pick/merge pipeline extended to propagate the new fields and preserve the false default when omitted.

## Tests and docs

- Tests:
  - RenderPaletteUsage unit tests.
  - Extensive StatsOverlayPaletteView unit tests covering computePaletteGrid, computeUnusedSwatchMarkerRect (including zero-area guard), and draw behavior (used swatches, unused marker rendering, gap handling, hint exclusion, disabled behavior).
  - StatsOverlay tests updated to pass palette-view flag explicitly and assert bottom-band Y/height derived from computePaletteGrid.
  - layoutPlan and other overlay tests updated to compute bottomArea from the grid; default-config tests assert statsOverlayPaletteView defaults to false.
- Docs:
  - docs/api-core.md and docs/testing.md updated to document the opt-in palette grid, palette columns option, bottom-band height calculation, and testing expectations.
  - CLAUDE.md updated to list RenderPaletteUsage and the implemented StatsOverlayPaletteView.

## Commits / notes

- Refactor commit simplified data flow by passing the usage mask directly to the stats overlay grid (removed intermediate per-frame conversions).
- No breaking public API changes: signatures were extended with optional parameters/defaults and configuration default remains opt-in so existing demos are unaffected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/185?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->