### PR TITLE
perf(renderer): gate palette usage tracking and reduce grid overhead

### DIFF
--- a/.claude/skills/perf/SKILL.md
+++ b/.claude/skills/perf/SKILL.md
@@ -24,6 +24,8 @@ Examples:
 - rect intersection
 - glyph lookup and text measurement
 - render-pipeline helper methods that do not require a browser
+- stats overlay palette grid draw (`StatsOverlayPaletteView.bench.ts`)
+- sprite or glyph palette usage marking (`SpriteSheet.bench.ts`)
 
 Commands:
 
@@ -47,7 +49,22 @@ CPU benchmark regression checks run in CI with the `perf` label.
 - PRs labeled `perf` run `pnpm run bench:json`
 - CI compares against the latest successful `main` baseline artifact
 - CI posts or updates a PR comment with the comparison table
-- CI fails if any benchmark regresses by more than 10%
+- CI fails if any benchmark regresses by more than **25%** (see `ci.yml` `--threshold 25`)
+
+New `*.bench.ts` files are picked up automatically on the next `main` baseline upload. No allowlist
+change is required. After adding benchmarks for stats overlay work (VV-543), label the PR `perf` if you
+want regression feedback before merge.
+
+### Stats overlay palette grid benchmarks (VV-543)
+
+| Benchmark file | What it measures |
+| --- | --- |
+| `src/assets/SpriteSheet.bench.ts` | `markPaletteIndicesInRect` on 8x8 glyph vs 64x64 sprite rects |
+| `src/render/stats-overlay/StatsOverlayPaletteView.bench.ts` | Full palette grid `draw()` for 16 vs 256 slots |
+
+Use these when changing palette usage gating, swatch draw scratch reuse, or unique-index marking in
+`SpriteSheet`. Compare locally with `pnpm run bench`; use `pnpm run bench:json` before opening a `perf`
+labeled PR.
 
 ## References
 

--- a/docs/api-core.md
+++ b/docs/api-core.md
@@ -194,7 +194,9 @@ bottom-right toggle rect and text baselines from the system font metrics.
 - **Bottom band:** default **13 px** hint bar with the `[~]` toggle label anchored bottom-right. Set
   `statsOverlayPaletteView: true` to replace it with a live palette swatch grid showing every active palette slot; slots
   referenced by demo draw calls this frame are filled with their color, and unused slots render as empty squares with a
-  small centered marker
+  small centered marker. Palette usage tracking (including sprite and bitmap-text pixel scans) runs only while the
+  overlay is enabled, the palette grid is opted in, and the overlay is visible (not hidden with Backquote or the corner
+  toggle); default demos do not pay that cost
 - **Custom rows (optional):** extra bars from `statsOverlayRows()` stacked above the bottom band, **1 px** apart, each
   with left text and optional right text (same 13 px bar style as the built-in rows)
 

--- a/docs/api-core.md
+++ b/docs/api-core.md
@@ -195,8 +195,8 @@ bottom-right toggle rect and text baselines from the system font metrics.
   `statsOverlayPaletteView: true` to replace it with a live palette swatch grid showing every active palette slot; slots
   referenced by demo draw calls this frame are filled with their color, and unused slots render as empty squares with a
   small centered marker. Palette usage tracking (sprite and bitmap-text pixel scans) runs only when the stats overlay is
-  enabled, `statsOverlayPaletteView` is true, and the overlay is visible (Backquote or the corner toggle has not hidden
-  it). Default demos do not pay that scanning cost.
+  enabled and `statsOverlayPaletteView` is true. The overlay must also be visible — not hidden with Backquote or the
+  corner toggle. Default demos do not pay that scanning cost.
 - **Custom rows (optional):** extra bars from `statsOverlayRows()` stacked above the bottom band, **1 px** apart, each
   with left text and optional right text (same 13 px bar style as the built-in rows)
 

--- a/docs/api-core.md
+++ b/docs/api-core.md
@@ -194,9 +194,9 @@ bottom-right toggle rect and text baselines from the system font metrics.
 - **Bottom band:** default **13 px** hint bar with the `[~]` toggle label anchored bottom-right. Set
   `statsOverlayPaletteView: true` to replace it with a live palette swatch grid showing every active palette slot; slots
   referenced by demo draw calls this frame are filled with their color, and unused slots render as empty squares with a
-  small centered marker. Palette usage tracking (including sprite and bitmap-text pixel scans) runs only while the
-  overlay is enabled, the palette grid is opted in, and the overlay is visible (not hidden with Backquote or the corner
-  toggle); default demos do not pay that cost
+  small centered marker. Palette usage tracking (sprite and bitmap-text pixel scans) runs only when the stats overlay is
+  enabled, `statsOverlayPaletteView` is true, and the overlay is visible (Backquote or the corner toggle has not hidden
+  it). Default demos do not pay that scanning cost.
 - **Custom rows (optional):** extra bars from `statsOverlayRows()` stacked above the bottom band, **1 px** apart, each
   with left text and optional right text (same 13 px bar style as the built-in rows)
 

--- a/docs/performance-testing.md
+++ b/docs/performance-testing.md
@@ -47,6 +47,22 @@ Current benchmark files:
 - `src/utils/Rect2i.bench.ts`
 - `src/assets/BitmapFont.bench.ts`
 - `src/assets/PaletteEffect.bench.ts`
+- `src/assets/SpriteSheet.bench.ts`
+- `src/assets/SystemFont.bench.ts`
+- `src/render/stats-overlay/StatsOverlayPaletteView.bench.ts`
+
+### Stats overlay palette grid (VV-543)
+
+These benchmarks guard perf follow-ups for the live palette swatch grid:
+
+| File                               | Cases                                                                         |
+| ---------------------------------- | ----------------------------------------------------------------------------- |
+| `SpriteSheet.bench.ts`             | `markPaletteIndicesInRect` on a typical 8x8 glyph rect vs a 64x64 sprite rect |
+| `StatsOverlayPaletteView.bench.ts` | `StatsOverlayPaletteView.draw()` for 16-slot vs 256-slot palettes             |
+
+They run in the same Vitest bench suite as the rest of the repo and are included in `benchmark-results.json` for CI. No
+separate registration step is required; the next successful `main` push refreshes the baseline artifact with these
+entries.
 
 ### Metrics
 
@@ -211,6 +227,9 @@ If you add a new sprite operation, follow this order:
 3. **Run `pnpm run bench` locally** to compare the new method against the old behavior or an alternative implementation.
 4. **Run `pnpm run bench:json`** if you want to inspect the machine-readable output used by CI.
 5. **Open a PR** and add the `perf` label for CPU benchmark comparison.
+
+For stats overlay palette usage or grid draw changes, include steps 2-5 so `SpriteSheet.bench.ts` and
+`StatsOverlayPaletteView.bench.ts` are compared against `main`.
 
 ### Best Default
 

--- a/docs/performance-testing.md
+++ b/docs/performance-testing.md
@@ -55,10 +55,10 @@ Current benchmark files:
 
 These benchmarks guard perf follow-ups for the live palette swatch grid:
 
-| File                               | Cases                                                                         |
-| ---------------------------------- | ----------------------------------------------------------------------------- |
-| `SpriteSheet.bench.ts`             | `markPaletteIndicesInRect` on a typical 8x8 glyph rect vs a 64x64 sprite rect |
-| `StatsOverlayPaletteView.bench.ts` | `StatsOverlayPaletteView.draw()` for 16-slot vs 256-slot palettes             |
+| File                               | Cases                                                         |
+| ---------------------------------- | ------------------------------------------------------------- |
+| `SpriteSheet.bench.ts`             | `markPaletteIndicesInRect` on 8x8 glyph vs 64x64 sprite rects |
+| `StatsOverlayPaletteView.bench.ts` | Palette grid `draw()` for 16 vs 256 slots                     |
 
 They run in the same Vitest bench suite as the rest of the repo and are included in `benchmark-results.json` for CI. No
 separate registration step is required; the next successful `main` push refreshes the baseline artifact with these

--- a/src/assets/SpriteSheet.bench.ts
+++ b/src/assets/SpriteSheet.bench.ts
@@ -1,0 +1,72 @@
+// #region Imports
+
+import { bench, describe } from 'vitest';
+
+import { resetRenderPaletteUsage } from '../core/RenderPaletteUsage';
+import { Rect2i } from '../utils/Rect2i';
+import { SpriteSheet } from './SpriteSheet';
+
+// #endregion
+
+// #region Constants
+
+const BENCH_OPTIONS = {
+    iterations: 200,
+    time: 100,
+    warmupTime: 25,
+    warmupIterations: 25,
+};
+
+/** 8x8 glyph-sized rect (typical bitmap font glyph). */
+const GLYPH_RECT = new Rect2i(0, 0, 8, 8);
+
+/** 64x64 sprite rect. */
+const SPRITE_RECT = new Rect2i(0, 0, 64, 64);
+
+// #endregion
+
+// #region Fixtures
+
+/**
+ * Builds an indexized sheet filled with cycling non-zero palette indices.
+ *
+ * @param width - Sheet width in pixels.
+ * @param height - Sheet height in pixels.
+ * @returns Sprite sheet for benchmark fixtures.
+ */
+function makeBenchSheet(width: number, height: number): SpriteSheet {
+    const pixels = new Uint8Array(width * height) as Uint8Array<ArrayBuffer>;
+
+    for (let i = 0; i < pixels.length; i++) {
+        // eslint-disable-next-line security/detect-object-injection -- loop index bounded by buffer length
+        pixels[i] = (i % 7) + 1;
+    }
+
+    return SpriteSheet.fromIndexedPixels(width, height, pixels);
+}
+
+const glyphSheet = makeBenchSheet(8, 8);
+const spriteSheet = makeBenchSheet(64, 64);
+const usageMask = new Uint8Array(256);
+
+// #endregion
+
+describe('SpriteSheet.markPaletteIndicesInRect', () => {
+    bench(
+        'glyph rect (8x8)',
+        () => {
+            resetRenderPaletteUsage(usageMask);
+            glyphSheet.markPaletteIndicesInRect(GLYPH_RECT, 0, usageMask);
+        },
+        BENCH_OPTIONS,
+    );
+
+    bench(
+        'sprite rect (64x64)',
+        () => {
+            resetRenderPaletteUsage(usageMask);
+            spriteSheet.markPaletteIndicesInRect(SPRITE_RECT, 0, usageMask);
+        },
+        BENCH_OPTIONS,
+    );
+});

--- a/src/assets/SpriteSheet.test.ts
+++ b/src/assets/SpriteSheet.test.ts
@@ -17,6 +17,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { createMockGPUDevice } from '../__test__/webgpu-mock';
+import { collectUsedRenderPaletteIndices, resetRenderPaletteUsage } from '../core/RenderPaletteUsage';
 import { AssetLimitError, MAX_ASSET_DIMENSION, MAX_ASSET_PIXELS } from '../utils/AssetLimits';
 import { Color32 } from '../utils/Color32';
 import { Rect2i } from '../utils/Rect2i';
@@ -701,6 +702,73 @@ describe('SpriteSheet', () => {
             expect(() => sheet.getIndexedPixels()).toThrow(
                 "This sprite sheet hasn't been converted to palette indices yet. Call sheet.indexize(palette) first.",
             );
+        });
+    });
+
+    // #endregion
+
+    // #region Palette usage marking
+
+    describe('markPaletteIndicesInRect', () => {
+        it('marks resolved palette slots for unique non-zero sheet indices in the rect', () => {
+            const pixels = new Uint8Array([
+                0,
+                1,
+                1,
+                0, //
+                2,
+                2,
+                2,
+                2, //
+                0,
+                3,
+                3,
+                0, //
+                1,
+                0,
+                0,
+                3, //
+            ]) as Uint8Array<ArrayBuffer>;
+            const sheet = SpriteSheet.fromIndexedPixels(4, 4, pixels);
+            const mask = new Uint8Array(16);
+            const scratch: number[] = [];
+
+            sheet.markPaletteIndicesInRect(new Rect2i(0, 0, 4, 4), 0, mask);
+
+            expect(collectUsedRenderPaletteIndices(mask, 16, scratch)).toEqual([1, 2, 3]);
+        });
+
+        it('applies palette offset when marking resolved slots', () => {
+            const pixels = new Uint8Array([1, 2, 0, 0]) as Uint8Array<ArrayBuffer>;
+            const sheet = SpriteSheet.fromIndexedPixels(2, 2, pixels);
+            const mask = new Uint8Array(16);
+            const scratch: number[] = [];
+
+            sheet.markPaletteIndicesInRect(new Rect2i(0, 0, 2, 2), 4, mask);
+
+            expect(collectUsedRenderPaletteIndices(mask, 16, scratch)).toEqual([5, 6]);
+        });
+
+        it('ignores transparent sheet pixels and leaves the mask unchanged when none are used', () => {
+            const pixels = new Uint8Array([0, 0, 0, 0]) as Uint8Array<ArrayBuffer>;
+            const sheet = SpriteSheet.fromIndexedPixels(2, 2, pixels);
+            const mask = new Uint8Array(16);
+            const scratch: number[] = [];
+
+            sheet.markPaletteIndicesInRect(new Rect2i(0, 0, 2, 2), 0, mask);
+
+            expect(collectUsedRenderPaletteIndices(mask, 16, scratch)).toEqual([]);
+        });
+
+        it('is a no-op when the sheet is not indexized', () => {
+            const sheet = new SpriteSheet(mockImage);
+            const mask = new Uint8Array(16);
+            const scratch: number[] = [];
+
+            resetRenderPaletteUsage(mask);
+            sheet.markPaletteIndicesInRect(new Rect2i(0, 0, 16, 16), 0, mask);
+
+            expect(collectUsedRenderPaletteIndices(mask, 16, scratch)).toEqual([]);
         });
     });
 

--- a/src/assets/SpriteSheet.ts
+++ b/src/assets/SpriteSheet.ts
@@ -7,6 +7,9 @@ import { Vector2i } from '../utils/Vector2i';
 import { AssetLoader } from './AssetLoader';
 import type { Palette } from './Palette';
 
+/** Reused per-call bitmask of sheet indices seen while scanning a source rect (VV-543). */
+const markPaletteIndicesInRectScratch = new Uint8Array(256);
+
 /**
  * Result object returned by {@link SpriteSheet.loadIndexed}.
  */
@@ -498,7 +501,8 @@ export class SpriteSheet {
      * Marks palette indices referenced by non-zero pixels in a source rectangle.
      *
      * Used by the engine to build the stats overlay palette grid from demo draw
-     * calls. Does not allocate; writes into the supplied usage mask.
+     * calls. Does not allocate; writes into the supplied usage mask. Each unique
+     * sheet index in the rect is resolved once (VV-543).
      *
      * @param srcRect - Region to scan in sheet coordinates.
      * @param paletteOffset - Palette offset applied at draw time.
@@ -515,6 +519,9 @@ export class SpriteSheet {
         const startY = Math.max(0, srcRect.y);
         const endX = Math.min(this.size.x, srcRect.x + srcRect.width);
         const endY = Math.min(this.size.y, srcRect.y + srcRect.height);
+        const seenSheetIndices = markPaletteIndicesInRectScratch;
+
+        seenSheetIndices.fill(0);
 
         for (let y = startY; y < endY; y++) {
             const rowOffset = y * sheetWidth;
@@ -526,9 +533,15 @@ export class SpriteSheet {
                     continue;
                 }
 
-                const resolved = sheetIndex + paletteOffset;
+                // eslint-disable-next-line security/detect-object-injection -- sheet indices are 0-255
+                if (seenSheetIndices[sheetIndex] === 1) {
+                    continue;
+                }
 
-                markRenderPaletteIndexUsed(usedMask, resolved);
+                // eslint-disable-next-line security/detect-object-injection -- sheet indices are 0-255
+                seenSheetIndices[sheetIndex] = 1;
+
+                markRenderPaletteIndexUsed(usedMask, sheetIndex + paletteOffset);
             }
         }
     }

--- a/src/core/BTAPI.test.ts
+++ b/src/core/BTAPI.test.ts
@@ -1411,6 +1411,63 @@ describe('BTAPI', () => {
 
             expect(markSpy).toHaveBeenCalledTimes(2);
         });
+
+        it('clears stale palette usage after overlay hide and re-show', async () => {
+            const overlaySpy = vi.spyOn(StatsOverlay.prototype, 'updateAndRender');
+            const rafCallbacks: FrameRequestCallback[] = [];
+
+            vi.stubGlobal(
+                'requestAnimationFrame',
+                vi.fn((callback: FrameRequestCallback) => {
+                    rafCallbacks.push(callback);
+                    return rafCallbacks.length;
+                }),
+            );
+
+            const demo: IBlitTechDemo = {
+                configure: () => ({
+                    displaySize: new Vector2i(320, 240),
+                    targetFPS: 60,
+                    statsOverlayPaletteView: true,
+                }),
+                init: vi.fn().mockResolvedValue(true),
+                update: vi.fn(),
+                render: vi.fn(() => {
+                    BTAPI.instance.drawPixel(new Vector2i(0, 0), 9);
+                }),
+            };
+
+            await BTAPI.instance.init(demo, makeMockCanvas());
+            BTAPI.instance.setPalette(new Palette(16));
+
+            const overlay = getStatsOverlay();
+            expect(overlay).not.toBeNull();
+
+            const drainOneFrame = (): void => {
+                const cb = rafCallbacks.shift();
+
+                if (cb) {
+                    cb(16);
+                }
+            };
+
+            drainOneFrame();
+            overlay?.handleToggle(null, { isKeyPressed: (key: string) => key === 'Backquote' } as never, 1);
+            expect(overlay?.tracksPaletteUsage).toBe(false);
+
+            drainOneFrame();
+
+            overlay?.handleToggle(null, { isKeyPressed: (key: string) => key === 'Backquote' } as never, 2);
+            expect(overlay?.tracksPaletteUsage).toBe(true);
+
+            overlaySpy.mockClear();
+            drainOneFrame();
+
+            const usedMask = overlaySpy.mock.calls.at(-1)?.[8] as Uint8Array | undefined;
+            const scratch: number[] = [];
+
+            expect(collectUsedRenderPaletteIndices(usedMask as Uint8Array, 16, scratch)).toEqual([9]);
+        });
     });
 
     // #endregion

--- a/src/core/BTAPI.test.ts
+++ b/src/core/BTAPI.test.ts
@@ -1110,6 +1110,120 @@ describe('BTAPI', () => {
 
     // #endregion
 
+    // #region Palette usage tracking (VV-543)
+
+    describe('palette usage tracking', () => {
+        function getStatsOverlay(): StatsOverlay | null {
+            return (BTAPI.instance as unknown as { statsOverlay: StatsOverlay | null }).statsOverlay;
+        }
+
+        function makeIndexizedSpriteSheet(markSpy: ReturnType<typeof vi.fn>): SpriteSheet {
+            return {
+                isIndexized: () => true,
+                markPaletteIndicesInRect: markSpy,
+            } as unknown as SpriteSheet;
+        }
+
+        function stubRendererDrawCalls(): void {
+            const renderer = BTAPI.instance.getRenderer();
+
+            expect(renderer).not.toBeNull();
+
+            vi.spyOn(renderer as NonNullable<typeof renderer>, 'drawSprite').mockImplementation(() => {});
+            vi.spyOn(renderer as NonNullable<typeof renderer>, 'drawBitmapText').mockImplementation(() => {});
+        }
+
+        it('skips sprite and bitmap-text palette scans when statsOverlayPaletteView is false', async () => {
+            const markSpy = vi.fn();
+            const mockSheet = makeIndexizedSpriteSheet(markSpy);
+            const mockFont = { getSpriteSheet: () => mockSheet } as unknown as BitmapFont;
+            const demo: IBlitTechDemo = {
+                configure: () => ({
+                    displaySize: new Vector2i(320, 240),
+                    targetFPS: 60,
+                    statsOverlayPaletteView: false,
+                }),
+                init: vi.fn().mockResolvedValue(true),
+                update: vi.fn(),
+                render: vi.fn(),
+            };
+
+            await BTAPI.instance.init(demo, makeMockCanvas());
+            BTAPI.instance.setPalette(new Palette(16));
+            stubRendererDrawCalls();
+
+            BTAPI.instance.drawSprite(mockSheet, new Rect2i(0, 0, 16, 16), new Vector2i(0, 0));
+            BTAPI.instance.drawBitmapText(mockFont, new Vector2i(0, 0), 'ab');
+
+            expect(markSpy).not.toHaveBeenCalled();
+        });
+
+        it('scans sprite and bitmap-text palette usage when statsOverlayPaletteView is true and overlay is visible', async () => {
+            const markSpy = vi.fn();
+            const mockSheet = makeIndexizedSpriteSheet(markSpy);
+            const mockFont = {
+                getSpriteSheet: () => mockSheet,
+                getGlyph: () => ({ rect: new Rect2i(0, 0, 8, 8) }),
+            } as unknown as BitmapFont;
+            const demo: IBlitTechDemo = {
+                configure: () => ({
+                    displaySize: new Vector2i(320, 240),
+                    targetFPS: 60,
+                    statsOverlayPaletteView: true,
+                }),
+                init: vi.fn().mockResolvedValue(true),
+                update: vi.fn(),
+                render: vi.fn(),
+            };
+
+            await BTAPI.instance.init(demo, makeMockCanvas());
+            BTAPI.instance.setPalette(new Palette(16));
+            stubRendererDrawCalls();
+
+            BTAPI.instance.drawSprite(mockSheet, new Rect2i(0, 0, 16, 16), new Vector2i(0, 0));
+            BTAPI.instance.drawBitmapText(mockFont, new Vector2i(0, 0), 'a');
+
+            expect(markSpy).toHaveBeenCalledTimes(2);
+        });
+
+        it('skips palette scans when the palette grid is enabled but the overlay is hidden', async () => {
+            const markSpy = vi.fn();
+            const mockSheet = makeIndexizedSpriteSheet(markSpy);
+            const demo: IBlitTechDemo = {
+                configure: () => ({
+                    displaySize: new Vector2i(320, 240),
+                    targetFPS: 60,
+                    statsOverlayPaletteView: true,
+                }),
+                init: vi.fn().mockResolvedValue(true),
+                update: vi.fn(),
+                render: vi.fn(),
+            };
+
+            await BTAPI.instance.init(demo, makeMockCanvas());
+            BTAPI.instance.setPalette(new Palette(16));
+            stubRendererDrawCalls();
+
+            const overlay = getStatsOverlay();
+            expect(overlay).not.toBeNull();
+
+            overlay?.handleToggle(
+                null,
+                {
+                    isKeyPressed: (key: string) => key === 'Backquote',
+                } as never,
+                1,
+            );
+            expect(overlay?.tracksPaletteUsage).toBe(false);
+
+            BTAPI.instance.drawSprite(mockSheet, new Rect2i(0, 0, 16, 16), new Vector2i(0, 0));
+
+            expect(markSpy).not.toHaveBeenCalled();
+        });
+    });
+
+    // #endregion
+
     // #region assertPaletteIndex
 
     describe('assertPaletteIndex', () => {

--- a/src/core/BTAPI.test.ts
+++ b/src/core/BTAPI.test.ts
@@ -1349,6 +1349,68 @@ describe('BTAPI', () => {
                 ),
             ).toBe(false);
         });
+
+        it('drawSystemText marks only the text palette index and does not scan glyph rects', async () => {
+            const glyphScanSpy = vi.fn();
+            const demo: IBlitTechDemo = {
+                configure: () => ({
+                    displaySize: new Vector2i(320, 240),
+                    targetFPS: 60,
+                    statsOverlayPaletteView: true,
+                }),
+                init: vi.fn().mockResolvedValue(true),
+                update: vi.fn(),
+                render: vi.fn(),
+            };
+
+            await BTAPI.instance.init(demo, makeMockCanvas());
+            BTAPI.instance.setPalette(new Palette(16));
+            stubRendererDrawCalls();
+
+            const systemFont = BTAPI.instance.getSystemFont();
+            expect(systemFont).not.toBeNull();
+
+            vi.spyOn(systemFont!.getSpriteSheet(), 'markPaletteIndicesInRect').mockImplementation(glyphScanSpy);
+
+            const textPaletteIndex = 8;
+
+            BTAPI.instance.drawSystemText(new Vector2i(0, 0), textPaletteIndex, 'hello');
+
+            expect(glyphScanSpy).not.toHaveBeenCalled();
+
+            const usageMask = (BTAPI.instance as unknown as { framePaletteUsageMask: Uint8Array })
+                .framePaletteUsageMask;
+            const scratch: number[] = [];
+
+            expect(collectUsedRenderPaletteIndices(usageMask, 16, scratch)).toEqual([textPaletteIndex]);
+        });
+
+        it('drawBitmapText scans glyph rects when palette tracking is enabled', async () => {
+            const markSpy = vi.fn();
+            const mockSheet = makeIndexizedSpriteSheet(markSpy);
+            const mockFont = {
+                getSpriteSheet: () => mockSheet,
+                getGlyph: (char: string) => ({ rect: new Rect2i(0, 0, 8, 8), char }),
+            } as unknown as BitmapFont;
+            const demo: IBlitTechDemo = {
+                configure: () => ({
+                    displaySize: new Vector2i(320, 240),
+                    targetFPS: 60,
+                    statsOverlayPaletteView: true,
+                }),
+                init: vi.fn().mockResolvedValue(true),
+                update: vi.fn(),
+                render: vi.fn(),
+            };
+
+            await BTAPI.instance.init(demo, makeMockCanvas());
+            BTAPI.instance.setPalette(new Palette(16));
+            stubRendererDrawCalls();
+
+            BTAPI.instance.drawBitmapText(mockFont, new Vector2i(0, 0), 'ab');
+
+            expect(markSpy).toHaveBeenCalledTimes(2);
+        });
     });
 
     // #endregion

--- a/src/core/BTAPI.test.ts
+++ b/src/core/BTAPI.test.ts
@@ -29,11 +29,19 @@ import { Palette } from '../assets/Palette';
 import type { SpriteSheet } from '../assets/SpriteSheet';
 import { BT } from '../BlitTech';
 import type { Effect } from '../render/effects/Effect';
+import { DEFAULT_IDX_TEXT, STATS_EDGE_MARGIN_PX } from '../render/stats-overlay/constants';
+import {
+    computePaletteGrid,
+    DEFAULT_PALETTE_SWATCH_SIZE,
+    PALETTE_GRID_PADDING_PX,
+    PALETTE_SWATCH_GAP_PX,
+} from '../render/stats-overlay/StatsOverlayPaletteView';
 import { StatsOverlay } from '../render/StatsOverlay';
 import { Rect2i } from '../utils/Rect2i';
 import { Vector2i } from '../utils/Vector2i';
 import { BTAPI } from './BTAPI';
 import type { IBlitTechDemo, StatsOverlayRow } from './IBlitTechDemo';
+import { collectUsedRenderPaletteIndices } from './RenderPaletteUsage';
 
 // #region Helpers
 
@@ -1219,6 +1227,127 @@ describe('BTAPI', () => {
             BTAPI.instance.drawSprite(mockSheet, new Rect2i(0, 0, 16, 16), new Vector2i(0, 0));
 
             expect(markSpy).not.toHaveBeenCalled();
+        });
+
+        it('wires demo render palette usage through the game loop into overlay grid swatches', async () => {
+            const overlaySpy = vi.spyOn(StatsOverlay.prototype, 'updateAndRender');
+            const rafCallbacks: FrameRequestCallback[] = [];
+
+            vi.stubGlobal(
+                'requestAnimationFrame',
+                vi.fn((callback: FrameRequestCallback) => {
+                    rafCallbacks.push(callback);
+                    return rafCallbacks.length;
+                }),
+            );
+
+            const palette = Palette.cga();
+            const usedSlots = [1, 2] as const;
+            const demo: IBlitTechDemo = {
+                configure: () => ({
+                    displaySize: new Vector2i(320, 240),
+                    targetFPS: 60,
+                    statsOverlayPaletteView: true,
+                }),
+                init: vi.fn().mockResolvedValue(true),
+                update: vi.fn(),
+                render: vi.fn(() => {
+                    BTAPI.instance.drawPixel(new Vector2i(4, 4), usedSlots[0]);
+                    BTAPI.instance.drawPixel(new Vector2i(5, 5), usedSlots[1]);
+                }),
+            };
+
+            await BTAPI.instance.init(demo, makeMockCanvas());
+            BTAPI.instance.setPalette(palette);
+
+            const renderer = BTAPI.instance.getRenderer();
+            expect(renderer).not.toBeNull();
+
+            const swatchFills: { index: number; rect: Rect2i }[] = [];
+
+            vi.spyOn(renderer as NonNullable<typeof renderer>, 'drawRectFillOnTop').mockImplementation(
+                (rect, index) => {
+                    swatchFills.push({ index, rect: new Rect2i(rect.x, rect.y, rect.width, rect.height) });
+                },
+            );
+
+            const maxIterations = 1000;
+            let iterations = 0;
+
+            while (rafCallbacks.length > 0) {
+                iterations++;
+                if (iterations > maxIterations) {
+                    throw new Error('Exceeded max rAF callback drain iterations before overlay render.');
+                }
+
+                const cb = rafCallbacks.shift();
+
+                if (cb) {
+                    cb(16);
+                }
+
+                if (overlaySpy.mock.calls.length > 0) {
+                    break;
+                }
+            }
+
+            expect(demo.render).toHaveBeenCalled();
+            expect(overlaySpy).toHaveBeenCalled();
+
+            const lastCall = overlaySpy.mock.calls.at(-1);
+            const usedMask = lastCall?.[8] as Uint8Array | undefined;
+            const maskScratch: number[] = [];
+
+            expect(usedMask).toBeDefined();
+            expect(collectUsedRenderPaletteIndices(usedMask as Uint8Array, palette.size, maskScratch)).toEqual([1, 2]);
+
+            const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, palette.size, PALETTE_SWATCH_GAP_PX);
+            const bottomAreaY = 240 - grid.totalHeight;
+            const { cols, swatchSize, gap } = grid;
+
+            for (const slot of usedSlots) {
+                const col = slot % cols;
+                const row = Math.floor(slot / cols);
+                const x = STATS_EDGE_MARGIN_PX + col * (swatchSize + gap);
+                const y = bottomAreaY + PALETTE_GRID_PADDING_PX + row * (swatchSize + gap);
+
+                expect(
+                    swatchFills.some(
+                        (fill) =>
+                            fill.index === slot &&
+                            fill.rect.x === x &&
+                            fill.rect.y === y &&
+                            fill.rect.width === swatchSize &&
+                            fill.rect.height === swatchSize,
+                    ),
+                ).toBe(true);
+            }
+
+            const unusedSlot = 3;
+            const unusedCol = unusedSlot % cols;
+            const unusedRow = Math.floor(unusedSlot / cols);
+            const unusedX = STATS_EDGE_MARGIN_PX + unusedCol * (swatchSize + gap);
+            const unusedY = bottomAreaY + PALETTE_GRID_PADDING_PX + unusedRow * (swatchSize + gap);
+
+            expect(
+                swatchFills.some(
+                    (fill) =>
+                        fill.index === DEFAULT_IDX_TEXT &&
+                        fill.rect.x === unusedX + 2 &&
+                        fill.rect.y === unusedY + 2 &&
+                        fill.rect.width === 3 &&
+                        fill.rect.height === 3,
+                ),
+            ).toBe(true);
+            expect(
+                swatchFills.some(
+                    (fill) =>
+                        fill.index === unusedSlot &&
+                        fill.rect.x === unusedX &&
+                        fill.rect.y === unusedY &&
+                        fill.rect.width === swatchSize,
+                ),
+            ).toBe(false);
         });
     });
 

--- a/src/core/BTAPI.test.ts
+++ b/src/core/BTAPI.test.ts
@@ -1424,6 +1424,35 @@ describe('BTAPI', () => {
                 }),
             );
 
+            const render = vi.fn(() => {
+                const renderCall = render.mock.calls.length;
+
+                if (renderCall === 1) {
+                    BTAPI.instance.drawPixel(new Vector2i(0, 0), 9);
+                    return;
+                }
+
+                if (renderCall >= 3) {
+                    BTAPI.instance.drawPixel(new Vector2i(0, 0), 7);
+                }
+            });
+
+            const drainRafUntilRenderCount = (target: number): void => {
+                let guard = 0;
+
+                while (render.mock.calls.length < target) {
+                    if (guard++ > 1000 || rafCallbacks.length === 0) {
+                        throw new Error(`Timed out waiting for render call ${target}`);
+                    }
+
+                    const cb = rafCallbacks.shift();
+
+                    if (cb) {
+                        cb(16);
+                    }
+                }
+            };
+
             const demo: IBlitTechDemo = {
                 configure: () => ({
                     displaySize: new Vector2i(320, 240),
@@ -1432,9 +1461,7 @@ describe('BTAPI', () => {
                 }),
                 init: vi.fn().mockResolvedValue(true),
                 update: vi.fn(),
-                render: vi.fn(() => {
-                    BTAPI.instance.drawPixel(new Vector2i(0, 0), 9);
-                }),
+                render,
             };
 
             await BTAPI.instance.init(demo, makeMockCanvas());
@@ -1443,30 +1470,23 @@ describe('BTAPI', () => {
             const overlay = getStatsOverlay();
             expect(overlay).not.toBeNull();
 
-            const drainOneFrame = (): void => {
-                const cb = rafCallbacks.shift();
+            drainRafUntilRenderCount(1);
 
-                if (cb) {
-                    cb(16);
-                }
-            };
-
-            drainOneFrame();
             overlay?.handleToggle(null, { isKeyPressed: (key: string) => key === 'Backquote' } as never, 1);
             expect(overlay?.tracksPaletteUsage).toBe(false);
 
-            drainOneFrame();
+            drainRafUntilRenderCount(2);
 
             overlay?.handleToggle(null, { isKeyPressed: (key: string) => key === 'Backquote' } as never, 2);
             expect(overlay?.tracksPaletteUsage).toBe(true);
 
             overlaySpy.mockClear();
-            drainOneFrame();
+            drainRafUntilRenderCount(3);
 
             const usedMask = overlaySpy.mock.calls.at(-1)?.[8] as Uint8Array | undefined;
             const scratch: number[] = [];
 
-            expect(collectUsedRenderPaletteIndices(usedMask as Uint8Array, 16, scratch)).toEqual([9]);
+            expect(collectUsedRenderPaletteIndices(usedMask as Uint8Array, 16, scratch)).toEqual([7]);
         });
     });
 

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -277,7 +277,9 @@ export class BTAPI {
                 let renderMs = 0;
 
                 if (this.renderer) {
-                    resetRenderPaletteUsage(this.framePaletteUsageMask);
+                    if (this.shouldTrackFramePaletteUsage()) {
+                        resetRenderPaletteUsage(this.framePaletteUsageMask);
+                    }
 
                     this.renderer.beginFrame();
 
@@ -762,7 +764,7 @@ export class BTAPI {
         this.assertPaletteIndex(paletteOffset);
         this.requireIndexizedSheet(spriteSheet);
 
-        if (this.renderer) {
+        if (this.renderer && this.shouldTrackFramePaletteUsage()) {
             spriteSheet.markPaletteIndicesInRect(srcRect, paletteOffset, this.framePaletteUsageMask);
         }
 
@@ -1292,14 +1294,25 @@ export class BTAPI {
     }
 
     /**
+     * Whether demo draw calls should populate {@link framePaletteUsageMask} this frame.
+     *
+     * @returns `true` when the stats overlay palette grid is active and visible.
+     */
+    private shouldTrackFramePaletteUsage(): boolean {
+        return this.statsOverlay?.tracksPaletteUsage ?? false;
+    }
+
+    /**
      * Marks a palette index as used for the current frame.
      *
      * @param index - Palette index to track.
      */
     private trackPaletteIndexUsed(index: number): void {
-        if (this.renderer) {
-            markRenderPaletteIndexUsed(this.framePaletteUsageMask, index);
+        if (!this.shouldTrackFramePaletteUsage() || !this.renderer) {
+            return;
         }
+
+        markRenderPaletteIndexUsed(this.framePaletteUsageMask, index);
     }
 
     /**
@@ -1310,6 +1323,10 @@ export class BTAPI {
      * @param paletteOffset - Palette offset applied at draw time.
      */
     private markBitmapTextPaletteUsage(font: BitmapFont, text: string, paletteOffset: number): void {
+        if (!this.shouldTrackFramePaletteUsage()) {
+            return;
+        }
+
         const sheet = font.getSpriteSheet();
 
         for (const char of text) {

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -277,9 +277,7 @@ export class BTAPI {
                 let renderMs = 0;
 
                 if (this.renderer) {
-                    if (this.shouldTrackFramePaletteUsage()) {
-                        resetRenderPaletteUsage(this.framePaletteUsageMask);
-                    }
+                    this.beginRenderFrame();
 
                     this.renderer.beginFrame();
 
@@ -1291,6 +1289,20 @@ export class BTAPI {
      */
     private markDrawCall(): void {
         this.pendingDrawCalls++;
+    }
+
+    /**
+     * Applies overlay toggle input and clears per-frame palette usage before demo render.
+     *
+     * Toggle runs here (not in {@link StatsOverlay.updateAndRender}) so visibility is current
+     * when deciding whether to track palette usage during `demo.render()`.
+     */
+    private beginRenderFrame(): void {
+        if (this.statsOverlay) {
+            this.statsOverlay.handleToggle(this.pointer, this.keyboard, this.loop?.getTicks() ?? 0);
+        }
+
+        resetRenderPaletteUsage(this.framePaletteUsageMask);
     }
 
     /**

--- a/src/render/stats-overlay/StatsOverlay.test.ts
+++ b/src/render/stats-overlay/StatsOverlay.test.ts
@@ -36,6 +36,30 @@ function buildUsageMask(indices: readonly number[], size = 256): Uint8Array {
 }
 
 describe('StatsOverlay', () => {
+    it('tracksPaletteUsage is false when palette grid is disabled', () => {
+        const layout = createStatsOverlayLayout(320, 240, 14);
+        const overlay = new StatsOverlay(layout, 'Test Demo', 60, 'webgpu', undefined, STATS_OVERLAY_PALETTE_VIEW_OFF);
+
+        expect(overlay.tracksPaletteUsage).toBe(false);
+    });
+
+    it('tracksPaletteUsage follows palette grid opt-in and visibility toggle', () => {
+        const layout = createStatsOverlayLayout(320, 240, 14);
+        const overlay = new StatsOverlay(layout, 'Test Demo', 60, 'webgpu', undefined, true);
+
+        expect(overlay.tracksPaletteUsage).toBe(true);
+
+        overlay.handleToggle(
+            null,
+            {
+                isKeyPressed: (key: string) => key === 'Backquote',
+            } as never,
+            1,
+        );
+
+        expect(overlay.tracksPaletteUsage).toBe(false);
+    });
+
     it('starts visible and toggles visibility', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
         const overlay = new StatsOverlay(layout, 'Test Demo', 60, 'webgpu', undefined, STATS_OVERLAY_PALETTE_VIEW_OFF);

--- a/src/render/stats-overlay/StatsOverlay.ts
+++ b/src/render/stats-overlay/StatsOverlay.ts
@@ -112,6 +112,18 @@ export class StatsOverlay {
     }
 
     /**
+     * Whether demo draw calls should populate the per-frame palette usage mask.
+     *
+     * True when the palette swatch grid is configured and the overlay is visible.
+     * BTAPI gates per-frame palette usage tracking on this flag.
+     *
+     * @returns `true` when sprite/text palette usage scanning is needed.
+     */
+    get tracksPaletteUsage(): boolean {
+        return this.#paletteView.enabled && this.#toggle.visible;
+    }
+
+    /**
      * Handles toggle input (Backquote and bottom-right corner press).
      *
      * @param pointer - Pointer subsystem, or `null` when unavailable.

--- a/src/render/stats-overlay/StatsOverlay.ts
+++ b/src/render/stats-overlay/StatsOverlay.ts
@@ -240,7 +240,8 @@ export class StatsOverlay {
     }
 
     /**
-     * Processes toggle input then draws the overlay.
+     * Draws the overlay. Toggle input is handled earlier in the frame by BTAPI
+     * ({@link BTAPI.beginRenderFrame}) so palette usage tracking matches visibility.
      *
      * @param renderer - Active {@link IRenderer} instance.
      * @param font - System bitmap font.
@@ -265,7 +266,6 @@ export class StatsOverlay {
     ): void {
         this.#fps.sample();
         this.#sampleTiming(timing);
-        this.handleToggle(pointer, keyboard, currentTick);
 
         if (!this.#toggle.visible) {
             return;

--- a/src/render/stats-overlay/StatsOverlay.ts
+++ b/src/render/stats-overlay/StatsOverlay.ts
@@ -245,9 +245,9 @@ export class StatsOverlay {
      *
      * @param renderer - Active {@link IRenderer} instance.
      * @param font - System bitmap font.
-     * @param pointer - Pointer subsystem for corner toggle.
-     * @param keyboard - Keyboard subsystem for Backquote toggle.
-     * @param currentTick - Current fixed-update tick for keyboard edge detection.
+     * @param _pointer - Reserved; toggle input is handled in BTAPI before render.
+     * @param _keyboard - Reserved; toggle input is handled in BTAPI before render.
+     * @param _currentTick - Reserved; toggle input is handled in BTAPI before render.
      * @param getCustomRows - Optional supplier for demo rows; not invoked while the overlay is hidden.
      * @param timing - Optional timing snapshot from the previous rendered frame.
      * @param palette - Active demo palette for optional palette grid.
@@ -256,9 +256,9 @@ export class StatsOverlay {
     updateAndRender(
         renderer: IRenderer,
         font: BitmapFont,
-        pointer: PointerInput | null,
-        keyboard: KeyboardInput | null,
-        currentTick: number,
+        _pointer: PointerInput | null,
+        _keyboard: KeyboardInput | null,
+        _currentTick: number,
         getCustomRows?: () => readonly StatsOverlayRow[] | undefined,
         timing?: StatsOverlayTimingSnapshot,
         palette?: Palette | null,

--- a/src/render/stats-overlay/StatsOverlayPaletteView.alloc.test.ts
+++ b/src/render/stats-overlay/StatsOverlayPaletteView.alloc.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Allocation regression tests for {@link StatsOverlayPaletteView} draw hot path (VV-543).
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Palette } from '../../assets/Palette';
+import { markRenderPaletteIndexUsed } from '../../core/RenderPaletteUsage';
+import type * as Rect2iModule from '../../utils/Rect2i';
+import { Rect2i } from '../../utils/Rect2i';
+import { createStatsOverlayLayout } from './layoutHelpers';
+import { computePaletteGrid, DEFAULT_PALETTE_SWATCH_SIZE, StatsOverlayPaletteView } from './StatsOverlayPaletteView';
+
+const { rect2iAllocStats } = vi.hoisted(() => ({ rect2iAllocStats: { count: 0 } }));
+
+vi.mock('../../utils/Rect2i', async (importOriginal) => {
+    const mod = await importOriginal<typeof Rect2iModule>();
+
+    class CountingRect2i extends mod.Rect2i {
+        constructor(...args: ConstructorParameters<typeof mod.Rect2i>) {
+            rect2iAllocStats.count++;
+            super(...args);
+        }
+    }
+
+    return { ...mod, Rect2i: CountingRect2i };
+});
+
+/** Builds a usage mask from palette slot indices for tests. */
+function buildUsageMask(indices: readonly number[], size = 256): Uint8Array {
+    const mask = new Uint8Array(size);
+
+    for (const index of indices) {
+        markRenderPaletteIndexUsed(mask, index);
+    }
+
+    return mask;
+}
+
+describe('StatsOverlayPaletteView allocation', () => {
+    beforeEach(() => {
+        rect2iAllocStats.count = 0;
+    });
+
+    it('does not construct Rect2i during repeated 16-slot palette grid draws', () => {
+        const layout = createStatsOverlayLayout(320, 240, 14);
+        const palette = Palette.cga();
+        const usedMask = buildUsageMask([1, 2, 3]);
+        const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, palette.size);
+        const bottomArea = new Rect2i(0, 240 - grid.totalHeight, 320, grid.totalHeight);
+        const view = new StatsOverlayPaletteView(true);
+        const renderer = { drawRectFillOnTop: vi.fn() } as never;
+
+        for (let i = 0; i < 8; i++) {
+            view.draw(
+                renderer,
+                bottomArea,
+                palette,
+                grid,
+                layout.bottomTextY,
+                layout.displayWidth,
+                layout.lineHeight,
+                usedMask,
+                2,
+            );
+        }
+
+        const afterWarmup = rect2iAllocStats.count;
+
+        for (let i = 0; i < 64; i++) {
+            view.draw(
+                renderer,
+                bottomArea,
+                palette,
+                grid,
+                layout.bottomTextY,
+                layout.displayWidth,
+                layout.lineHeight,
+                usedMask,
+                2,
+            );
+        }
+
+        expect(rect2iAllocStats.count).toBe(afterWarmup);
+    });
+
+    it('does not construct Rect2i during repeated 256-slot palette grid draws', () => {
+        const layout = createStatsOverlayLayout(320, 240, 14);
+        const palette = Palette.vga();
+        const usedMask = buildUsageMask([1, 2, 3, 4, 5]);
+        const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, palette.size);
+        const bottomArea = new Rect2i(0, 240 - grid.totalHeight, 320, grid.totalHeight);
+        const view = new StatsOverlayPaletteView(true);
+        const renderer = { drawRectFillOnTop: vi.fn() } as never;
+
+        for (let i = 0; i < 4; i++) {
+            view.draw(
+                renderer,
+                bottomArea,
+                palette,
+                grid,
+                layout.bottomTextY,
+                layout.displayWidth,
+                layout.lineHeight,
+                usedMask,
+                2,
+            );
+        }
+
+        const afterWarmup = rect2iAllocStats.count;
+
+        for (let i = 0; i < 32; i++) {
+            view.draw(
+                renderer,
+                bottomArea,
+                palette,
+                grid,
+                layout.bottomTextY,
+                layout.displayWidth,
+                layout.lineHeight,
+                usedMask,
+                2,
+            );
+        }
+
+        expect(rect2iAllocStats.count).toBe(afterWarmup);
+    });
+});

--- a/src/render/stats-overlay/StatsOverlayPaletteView.bench.ts
+++ b/src/render/stats-overlay/StatsOverlayPaletteView.bench.ts
@@ -1,0 +1,87 @@
+// #region Imports
+
+import { bench, describe } from 'vitest';
+
+import { Palette } from '../../assets/Palette';
+import { resetRenderPaletteUsage } from '../../core/RenderPaletteUsage';
+import { Rect2i } from '../../utils/Rect2i';
+import { Vector2i } from '../../utils/Vector2i';
+import { createStatsOverlayLayout } from './layoutHelpers';
+import { computePaletteGrid, StatsOverlayPaletteView } from './StatsOverlayPaletteView';
+
+// #endregion
+
+// #region Constants
+
+const BENCH_OPTIONS = {
+    iterations: 100,
+    time: 100,
+    warmupTime: 25,
+    warmupIterations: 25,
+};
+
+// #endregion
+
+// #region Fixtures
+
+const layout16 = createStatsOverlayLayout(320, 240, 14);
+const grid16 = computePaletteGrid(320, undefined, 16);
+const palette16 = new Palette(16);
+const usedMask16 = new Uint8Array(256);
+const bottomArea16 = new Rect2i(0, 200, 320, 40);
+
+const layout256 = createStatsOverlayLayout(320, 240, 14);
+const grid256 = computePaletteGrid(320, undefined, 256);
+const palette256 = new Palette(256);
+const usedMask256 = new Uint8Array(256);
+const bottomArea256 = new Rect2i(0, 120, 320, 120);
+
+const paletteView = new StatsOverlayPaletteView(true);
+
+const noopRenderer = {
+    drawRectFillOnTop: () => {},
+    getCameraOffset: () => new Vector2i(0, 0),
+    resetCamera: () => {},
+};
+
+// #endregion
+
+describe('StatsOverlayPaletteView.draw', () => {
+    bench(
+        '16-slot palette grid',
+        () => {
+            resetRenderPaletteUsage(usedMask16);
+            paletteView.draw(
+                noopRenderer as never,
+                bottomArea16,
+                palette16,
+                grid16,
+                layout16.bottomTextY,
+                layout16.displayWidth,
+                layout16.lineHeight,
+                usedMask16,
+                1,
+            );
+        },
+        BENCH_OPTIONS,
+    );
+
+    bench(
+        '256-slot palette grid',
+        () => {
+            resetRenderPaletteUsage(usedMask256);
+            paletteView.draw(
+                noopRenderer as never,
+                bottomArea256,
+                palette256,
+                grid256,
+                layout256.bottomTextY,
+                layout256.displayWidth,
+                layout256.lineHeight,
+                usedMask256,
+                1,
+            );
+        },
+        BENCH_OPTIONS,
+    );
+});

--- a/src/render/stats-overlay/StatsOverlayPaletteView.ts
+++ b/src/render/stats-overlay/StatsOverlayPaletteView.ts
@@ -165,18 +165,47 @@ function swatchIntersectsRect(x: number, y: number, swatchSize: number, exclusio
     return rectsIntersect(x, y, swatchSize, swatchSize, exclusion.x, exclusion.y, exclusion.width, exclusion.height);
 }
 
+/** Cached hint exclusion rect; recomputed only when layout inputs change (VV-543). */
+const hintExclusionCache = {
+    bottomTextY: Number.NaN,
+    displayWidth: Number.NaN,
+    lineHeight: Number.NaN,
+    rect: new Rect2i(),
+};
+
 /**
- * Builds the screen-space rect reserved for the bottom-right `[~]` hint label.
+ * Returns the screen-space rect reserved for the bottom-right `[~]` hint label.
+ *
+ * Reuses {@link hintExclusionCache.rect} when `bottomTextY`, `displayWidth`, and
+ * `lineHeight` match the previous call.
  *
  * @param bottomTextY - Baseline Y for the hint text.
  * @param displayWidth - Logical display width.
  * @param lineHeight - System font line height.
  * @returns Exclusion rect for swatch placement.
  */
-function buildHintExclusionRect(bottomTextY: number, displayWidth: number, lineHeight: number): Rect2i {
+function resolveHintExclusionRect(bottomTextY: number, displayWidth: number, lineHeight: number): Rect2i {
+    if (
+        hintExclusionCache.bottomTextY === bottomTextY &&
+        hintExclusionCache.displayWidth === displayWidth &&
+        hintExclusionCache.lineHeight === lineHeight
+    ) {
+        return hintExclusionCache.rect;
+    }
+
     const hintLeft = statsRightAlignedTextX(STATS_BOTTOM_HINT_LABEL, displayWidth);
 
-    return new Rect2i(hintLeft, bottomTextY, Math.max(0, displayWidth - STATS_EDGE_MARGIN_PX - hintLeft), lineHeight);
+    hintExclusionCache.bottomTextY = bottomTextY;
+    hintExclusionCache.displayWidth = displayWidth;
+    hintExclusionCache.lineHeight = lineHeight;
+    hintExclusionCache.rect.set(
+        hintLeft,
+        bottomTextY,
+        Math.max(0, displayWidth - STATS_EDGE_MARGIN_PX - hintLeft),
+        lineHeight,
+    );
+
+    return hintExclusionCache.rect;
 }
 
 /** Preferred side length for the filled marker drawn inside unused swatches. */
@@ -394,7 +423,7 @@ export class StatsOverlayPaletteView {
             return;
         }
 
-        const hintExclusion = buildHintExclusionRect(bottomTextY, displayWidth, lineHeight);
+        const hintExclusion = resolveHintExclusionRect(bottomTextY, displayWidth, lineHeight);
 
         drawPaletteSwatchGrid(renderer, bottomArea, palette.size, grid, hintExclusion, usedMask, unusedMarkIndex);
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR reduces renderer overhead by gating palette-usage tracking behind overlay visibility, clearing per-frame state, and reducing allocations/work in the stats-overlay palette grid.

## Key Changes

### Render-frame gating & toggle handling
- Reset the per-frame palette usage mask (framePaletteUsageMask) at the start of each render frame.
- Move overlay toggle input handling into BTAPI.beginRenderFrame() so visibility changes are applied before any palette tracking or grid drawing.
- Add a shouldTrackFramePaletteUsage() predicate and gate palette-tracking operations behind it; tracking functions early-return when tracking is disabled or no renderer is present.
- Remove duplicate handleToggle from StatsOverlay.updateAndRender and silence unused parameters by prefixing them with underscores.

### Palette tracking behavior
- Add StatsOverlay.tracksPaletteUsage getter that returns true only when the palette swatch grid is enabled and the overlay is visible.
- Sprite draws and bitmap-text glyph scans mark palette indices only when tracking is active; drawSystemText continues to record only the provided text palette index.

### SpriteSheet optimization
- Refactor SpriteSheet.markPaletteIndicesInRect to use a reusable per-call scratch bitmask (Uint8Array(256)) to deduplicate palette-index marking, so each unique non-zero index is marked once.
- Add tests verifying deduplication, palette-slot offset behavior, transparent-region no-ops, and behavior for non-indexized sheets.

### StatsOverlayPaletteView allocation reduction
- Replace buildHintExclusionRect with resolveHintExclusionRect that caches the bottom-right hint-exclusion Rect2i and recomputes only when bottomTextY, displayWidth, or lineHeight change—avoids per-draw Rect2i allocations.
- Add allocation-regression tests asserting repeated draws (16- and 256-slot grids) do not allocate extra Rect2i instances after warmup.

### Tests, benchmarks, and docs
- Add comprehensive BTAPI tests covering palette-usage tracking for sprites, bitmap-text, and system text; overlay hide/re-show clears stale palette usage; verify palette-grid rendering (swatch coordinates and DEFAULT_IDX_TEXT).
- Add hide/re-show integration test drawing different palette indices before/after hide/show and draining rAF to account for game-loop warmup frames.
- Add StatsOverlayPaletteView.alloc.test.ts and Vitest benchmarks: StatsOverlayPaletteView.bench.ts and SpriteSheet.bench.ts.
- Update docs (api-core.md and performance-testing.md) to document that palette scanning runs only when the overlay + palette grid are enabled and visible, describe the new benchmarks, and raise the CI benchmark regression threshold from 10% to 25%.

## Misc
- Minor documentation/benchmark wording and formatting adjustments; wrap api-core tracking copy for readability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->