### PR TITLE
feat(renderer): add opt-in stats overlay timing chart band

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ src/
     stats-overlay/
       StatsOverlay.ts      # Orchestrator: sample, toggle, layout plan, delegate draws
       layoutPlan.ts        # Dynamic Y-band planner (timing chart VV-539 + palette grid)
-      StatsOverlayTimingChart.ts  # Timing chart band (VV-539 scaffold; default off)
+      StatsOverlayTimingChart.ts  # Scrolling update/render timing chart band (opt-in via statsOverlayTimingChart)
       StatsOverlayPaletteView.ts  # Palette swatch grid (opt-in via statsOverlayPaletteView)
       StatsOverlayBars.ts  # Fixed and custom row bars + labels
       StatsOverlayToggle.ts # Backquote and corner toggle input

--- a/docs/api-core.md
+++ b/docs/api-core.md
@@ -267,14 +267,23 @@ Default swatch size is **7 px** with **1 px** gaps and **3 px** padding above an
 terminal-style demos).
 
 ```ts
+// Overlay off (release build or custom full-screen HUD).
 configure() {
   return {
     displaySize: new Vector2i(320, 240),
-    statsOverlayEnabled: false, // release build or custom full-screen HUD
-    statsOverlayPaletteView: true, // opt in to live palette swatch grid
-    statsOverlayTimingChart: true, // opt in to update/render timing chart band
+    statsOverlayEnabled: false,
+  };
+}
+
+// Overlay on with palette grid and timing chart.
+configure() {
+  return {
+    displaySize: new Vector2i(320, 240),
+    statsOverlayEnabled: true,
+    statsOverlayPaletteView: true,
+    statsOverlayTimingChart: true,
     statsOverlayTimingChartHeight: 32, // optional; default 22
-    statsOverlayStyle: { barPaletteIndex: 2, textPaletteIndex: 3 }, // optional palette indices
+    statsOverlayStyle: { barPaletteIndex: 2, textPaletteIndex: 3 },
     statsOverlayTimingChartStyle: {
       updateBarPaletteIndex: 2, // defaults to barPaletteIndex when omitted
       renderBarPaletteIndex: 3, // defaults to textPaletteIndex when omitted

--- a/docs/api-core.md
+++ b/docs/api-core.md
@@ -104,19 +104,22 @@ See [Post-Process Effects](post-process-effects.md) for tier routing and presets
 output buffer. Include `displaySize` when you want a custom logical size; optional fields you omit then stay unset (for
 example no `canvasDisplaySize` means a 1:1 drawing buffer).
 
-| Field                        | Type                     | Default     | Description                                                        |
-| ---------------------------- | ------------------------ | ----------- | ------------------------------------------------------------------ |
-| `displaySize`                | `Vector2i`               | `320×240`   | **Logical** render resolution                                      |
-| `canvasDisplaySize`          | `Vector2i`               | `640×480`   | **Drawing buffer** size; enables **display-tier** effects when set |
-| `maxCanvasDisplaySize`       | `Vector2i`               | `960×720`   | **CSS cap** — maximum on-screen canvas size                        |
-| `targetFPS`                  | `number`                 | `60`        | Fixed `update()` rate (simulation ticks per second)                |
-| `backend`                    | `'webgpu' \| 'software'` | `'webgpu'`  | Force rendering backend                                            |
-| `outputUpscaleFilter`        | `'nearest' \| 'linear'`  | `'nearest'` | Upscale filter                                                     |
-| `detectDroppedFrames`        | `boolean`                | `false`     | Log a console warning on missed vsync                              |
-| `statsOverlayEnabled`        | `boolean`                | `true`      | Engine stats HUD after each `render()`                             |
-| `statsOverlayPaletteView`    | `boolean`                | `false`     | Live palette swatch grid in the stats overlay bottom band (opt-in) |
-| `statsOverlayPaletteColumns` | `number`                 | _unset_     | Max palette swatches per grid row (default: widest fit)            |
-| `statsOverlayStyle`          | `StatsOverlayStyle`      | _unset_     | Optional bar/text palette indices for stats overlay                |
+| Field                           | Type                           | Default     | Description                                                          |
+| ------------------------------- | ------------------------------ | ----------- | -------------------------------------------------------------------- |
+| `displaySize`                   | `Vector2i`                     | `320×240`   | **Logical** render resolution                                        |
+| `canvasDisplaySize`             | `Vector2i`                     | `640×480`   | **Drawing buffer** size; enables **display-tier** effects when set   |
+| `maxCanvasDisplaySize`          | `Vector2i`                     | `960×720`   | **CSS cap** — maximum on-screen canvas size                          |
+| `targetFPS`                     | `number`                       | `60`        | Fixed `update()` rate (simulation ticks per second)                  |
+| `backend`                       | `'webgpu' \| 'software'`       | `'webgpu'`  | Force rendering backend                                              |
+| `outputUpscaleFilter`           | `'nearest' \| 'linear'`        | `'nearest'` | Upscale filter                                                       |
+| `detectDroppedFrames`           | `boolean`                      | `false`     | Log a console warning on missed vsync                                |
+| `statsOverlayEnabled`           | `boolean`                      | `true`      | Engine stats HUD after each `render()`                               |
+| `statsOverlayPaletteView`       | `boolean`                      | `false`     | Live palette swatch grid in the stats overlay bottom band (opt-in)   |
+| `statsOverlayPaletteColumns`    | `number`                       | _unset_     | Max palette swatches per grid row (default: widest fit)              |
+| `statsOverlayStyle`             | `StatsOverlayStyle`            | _unset_     | Optional bar/text palette indices for stats overlay                  |
+| `statsOverlayTimingChart`       | `boolean`                      | `false`     | Scrolling update/render timing chart between title and metrics rows  |
+| `statsOverlayTimingChartHeight` | `number`                       | `22`        | Timing chart band height in pixels when the chart is enabled         |
+| `statsOverlayTimingChartStyle`  | `StatsOverlayTimingChartStyle` | _unset_     | Optional timing chart palette indices (defaults to overlay bar/text) |
 
 `displaySize`, `canvasDisplaySize`, and `maxCanvasDisplaySize` must be positive whole-number pixel dimensions. Each size
 is capped at `8192×8192` per axis and `16,777,216` total pixels (`4096×4096`). Invalid sizes make initialization fail
@@ -188,15 +191,24 @@ bottom-right toggle rect and text baselines from the system font metrics.
 - **Top row 1 (left):** short demo title derived from `document.title` (registry pages titled
   `Blit-Tech Demo NNN - Topic` show as `Topic Demo`); **top row 1 (right):** active backend and logical resolution (for
   example `webgpu | 320x240`)
+- **Timing chart (optional):** when `statsOverlayTimingChart: true`, a scrolling band of **one-pixel dots** shows raw
+  per-frame `update()` vs `render()` CPU time (one column per present frame, not per fixed `update()` tick). Band height
+  defaults to **22 px**; override with `statsOverlayTimingChartHeight`. Dot height scales linearly so about **16 ms**
+  fills the band; any non-zero sample draws at least one pixel (sub-millisecond work shows as a baseline dot). The band
+  background uses `statsOverlayStyle.barPaletteIndex`; dot colors default to `statsOverlayStyle.barPaletteIndex` /
+  `textPaletteIndex`; override with `statsOverlayTimingChartStyle`. Additional warning/error/event palette slots are
+  reserved for future chart overlays.
 - **Top row 2 (left):** `Present: N FPS | Target: T FPS | Draw Calls: C`
 - **Top row 3 (left):** `Frame: Xms | update(): Yms | render(): Zms` (shows `xN` on `update()` when multiple fixed
   updates ran this frame)
 - **Bottom band:** default **13 px** hint bar with the `[~]` toggle label anchored bottom-right. Set
   `statsOverlayPaletteView: true` to replace it with a live palette swatch grid showing every active palette slot; slots
   referenced by demo draw calls this frame are filled with their color, and unused slots render as empty squares with a
-  small centered marker. Palette usage tracking (sprite and bitmap-text pixel scans) runs only when the stats overlay is
-  enabled and `statsOverlayPaletteView` is true. The overlay must also be visible — not hidden with Backquote or the
-  corner toggle. Default demos do not pay that scanning cost.
+  small centered marker. The timing chart and palette grid bands use the same `statsOverlayStyle.barPaletteIndex` fill
+  as the other overlay rows (bars draw first; chart dots and swatches render on top). Palette usage tracking (sprite and
+  bitmap-text pixel scans) runs only when the stats overlay is enabled, `statsOverlayPaletteView` is true, **and** the
+  overlay body is visible (not hidden with Backquote or the corner toggle). Default demos do not pay that scanning cost
+  while the overlay is hidden.
 - **Custom rows (optional):** extra bars from `statsOverlayRows()` stacked above the bottom band, **1 px** apart, each
   with left text and optional right text (same 13 px bar style as the built-in rows)
 
@@ -228,17 +240,21 @@ override globally in `configure()` with `statsOverlayStyle: { barPaletteIndex, t
 `StatsOverlayRow` (`barPaletteIndex`, `textPaletteIndex`).
 
 The overlay label `Present: N FPS` is **not** the same as `BT.targetFPS`: present FPS reflects how often `render()` runs
-(browser refresh rate), while `Target` is the fixed `update()` rate. `Frame`, `update()`, and `render()` timings are
-smoothed CPU wall-time samples from `performance.now()`. `Draw Calls` counts demo-issued draw API calls during the
-rendered frame. Do not use present FPS for simulation timing—use `BT.ticks`, `BT.deltaSeconds`, or `Timer` instead.
+(browser refresh rate), while `Target` is the fixed `update()` rate. Present FPS is sampled only while the overlay body
+is visible. `Frame`, `update()`, and `render()` timings are smoothed CPU wall-time samples from `performance.now()`
+shown in the text row; the optional timing chart uses **raw** per-frame `updateMs` / `renderMs` from the prior frame.
+Those demo-only timings **exclude** stats overlay draw (overlay runs after `render()` is timed); `Frame` includes the
+full present frame including overlay and GPU present. When the overlay is hidden, chart history still records demo
+`update()` / `render()` samples and palette usage tracking is off. `Draw Calls` counts demo-issued draw API calls during
+the rendered frame. Do not use present FPS for simulation timing—use `BT.ticks`, `BT.deltaSeconds`, or `Timer` instead.
 
 Demos should not duplicate engine stats text; the overlay provides it. Reserve about **14 px** per custom overlay row
 above the bottom band (13 px bar + 1 px gap). When drawing custom top or bottom HUD panels, leave about **42 px** clear
-at the top (three built-in text rows + gaps; add about **22 px** when `statsOverlayTimingChart` is enabled per VV-539).
-Leave about **13 px** clear at the bottom by default (hint bar). When `statsOverlayPaletteView: true`, reserve
-additional space for the palette grid—for example about **69 px** on the default `320×240` layout with a 256-slot
-palette (32 columns × 8 rows of 7 px swatches with 1 px gaps). Column count is chosen by halving from `palette.size`
-until the row fits `displayWidth - 2 * edgeMargin`. The bottom band height is:
+at the top (three built-in text rows + gaps; add `statsOverlayTimingChartHeight` or **22 px** when
+`statsOverlayTimingChart: true`). Leave about **13 px** clear at the bottom by default (hint bar). When
+`statsOverlayPaletteView: true`, reserve additional space for the palette grid—for example about **69 px** on the
+default `320×240` layout with a 256-slot palette (32 columns × 8 rows of 7 px swatches with 1 px gaps). Column count is
+chosen by halving from `palette.size` until the row fits `displayWidth - 2 * edgeMargin`. The bottom band height is:
 
 ```text
 cols = pickPaletteGridColumnCount(displayWidth, swatchSize, gap, palette.size, maxColumns?)
@@ -256,7 +272,13 @@ configure() {
     displaySize: new Vector2i(320, 240),
     statsOverlayEnabled: false, // release build or custom full-screen HUD
     statsOverlayPaletteView: true, // opt in to live palette swatch grid
+    statsOverlayTimingChart: true, // opt in to update/render timing chart band
+    statsOverlayTimingChartHeight: 32, // optional; default 22
     statsOverlayStyle: { barPaletteIndex: 2, textPaletteIndex: 3 }, // optional palette indices
+    statsOverlayTimingChartStyle: {
+      updateBarPaletteIndex: 2, // defaults to barPaletteIndex when omitted
+      renderBarPaletteIndex: 3, // defaults to textPaletteIndex when omitted
+    },
   };
 }
 ```

--- a/src/BlitTech.test.ts
+++ b/src/BlitTech.test.ts
@@ -163,7 +163,12 @@ describe('BT.canvasDisplaySize', () => {
         });
 
         const first = BT.canvasDisplaySize;
-        first!.x = 999;
+        expect(first).toBeDefined();
+        if (!first) {
+            return;
+        }
+
+        first.x = 999;
 
         expect(BT.canvasDisplaySize?.x).toBe(640);
     });

--- a/src/BlitTech.ts
+++ b/src/BlitTech.ts
@@ -26,6 +26,7 @@ import {
     mergeHardwareSettings,
     type StatsOverlayRow,
     type StatsOverlayStyle,
+    type StatsOverlayTimingChartStyle,
 } from './core/IBlitTechDemo';
 import {
     createDefaultKeyboardRuntimeMaps,
@@ -1563,6 +1564,7 @@ export type {
     IBlitTechDemo,
     StatsOverlayRow,
     StatsOverlayStyle,
+    StatsOverlayTimingChartStyle,
     TextSize,
 };
 export type { IndexedSpriteLoadResult };

--- a/src/core/BTAPI.test.ts
+++ b/src/core/BTAPI.test.ts
@@ -1369,8 +1369,11 @@ describe('BTAPI', () => {
 
             const systemFont = BTAPI.instance.getSystemFont();
             expect(systemFont).not.toBeNull();
+            if (!systemFont) {
+                return;
+            }
 
-            vi.spyOn(systemFont!.getSpriteSheet(), 'markPaletteIndicesInRect').mockImplementation(glyphScanSpy);
+            vi.spyOn(systemFont.getSpriteSheet(), 'markPaletteIndicesInRect').mockImplementation(glyphScanSpy);
 
             const textPaletteIndex = 8;
 

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -409,6 +409,9 @@ export class BTAPI {
             hw.statsOverlayStyle,
             hw.statsOverlayPaletteView === true,
             hw.statsOverlayPaletteColumns,
+            hw.statsOverlayTimingChart === true,
+            hw.statsOverlayTimingChartStyle,
+            hw.statsOverlayTimingChartHeight,
         );
     }
 

--- a/src/core/IBlitTechDemo.test.ts
+++ b/src/core/IBlitTechDemo.test.ts
@@ -64,6 +64,12 @@ describe('defaultConfig', () => {
         expect(settings.statsOverlayPaletteView).toBe(false);
     });
 
+    it('should disable stats overlay timing chart by default', () => {
+        const settings = defaultConfig();
+
+        expect(settings.statsOverlayTimingChart).toBeUndefined();
+    });
+
     it('should return a fresh object on each call', () => {
         const a = defaultConfig();
         const b = defaultConfig();
@@ -133,5 +139,30 @@ describe('mergeHardwareSettings', () => {
 
         expect(settings.statsOverlayStyle?.barPaletteIndex).toBe(2);
         expect(settings.statsOverlayStyle?.textPaletteIndex).toBe(3);
+    });
+
+    it('merges statsOverlayTimingChart flags from configure()', () => {
+        const settings = mergeHardwareSettings({
+            statsOverlayTimingChart: true,
+            statsOverlayTimingChartStyle: {
+                updateBarPaletteIndex: 20,
+                renderBarPaletteIndex: 21,
+                warningPaletteIndex: 22,
+            },
+        });
+
+        expect(settings.statsOverlayTimingChart).toBe(true);
+        expect(settings.statsOverlayTimingChartStyle?.updateBarPaletteIndex).toBe(20);
+        expect(settings.statsOverlayTimingChartStyle?.renderBarPaletteIndex).toBe(21);
+        expect(settings.statsOverlayTimingChartStyle?.warningPaletteIndex).toBe(22);
+    });
+
+    it('merges statsOverlayTimingChartHeight from configure()', () => {
+        const settings = mergeHardwareSettings({
+            statsOverlayTimingChart: true,
+            statsOverlayTimingChartHeight: 36,
+        });
+
+        expect(settings.statsOverlayTimingChartHeight).toBe(36);
     });
 });

--- a/src/core/IBlitTechDemo.test.ts
+++ b/src/core/IBlitTechDemo.test.ts
@@ -67,7 +67,7 @@ describe('defaultConfig', () => {
     it('should disable stats overlay timing chart by default', () => {
         const settings = defaultConfig();
 
-        expect(settings.statsOverlayTimingChart).toBeUndefined();
+        expect(settings.statsOverlayTimingChart).toBe(false);
     });
 
     it('should return a fresh object on each call', () => {

--- a/src/core/IBlitTechDemo.ts
+++ b/src/core/IBlitTechDemo.ts
@@ -141,6 +141,27 @@ export interface HardwareSettings {
      * When omitted, the overlay uses palette index `1` for bars and `2` for text.
      */
     statsOverlayStyle?: StatsOverlayStyle;
+
+    /**
+     * When `true`, the engine draws a scrolling update/render timing chart band between the
+     * title row and the Present FPS row. Defaults to `false` in {@link defaultConfig}.
+     *
+     * Chart bars use raw per-frame CPU samples from BTAPI (not EMA-smoothed text row values).
+     */
+    statsOverlayTimingChart?: boolean;
+
+    /**
+     * Height in pixels of the timing chart band when {@link statsOverlayTimingChart} is `true`.
+     * Defaults to 22 pixels when omitted.
+     */
+    statsOverlayTimingChartHeight?: number;
+
+    /**
+     * Optional palette indices for the timing chart band. Update/render bar colors default to
+     * {@link StatsOverlayStyle} bar/text indices; warning/error/event slots provision semantic
+     * tints for follow-up chart overlays (VV-545).
+     */
+    statsOverlayTimingChartStyle?: StatsOverlayTimingChartStyle;
 }
 
 /**
@@ -152,6 +173,26 @@ export interface StatsOverlayStyle {
 
     /** Palette index for overlay text (built-in labels and custom rows unless overridden). */
     textPaletteIndex?: number;
+}
+
+/**
+ * Palette indices for the stats overlay timing chart band.
+ */
+export interface StatsOverlayTimingChartStyle {
+    /** Update bar color; defaults to {@link StatsOverlayStyle.barPaletteIndex} or overlay bar index. */
+    updateBarPaletteIndex?: number;
+
+    /** Render bar color; defaults to {@link StatsOverlayStyle.textPaletteIndex} or overlay text index. */
+    renderBarPaletteIndex?: number;
+
+    /** Warning tint for future severity overlays (VV-545). */
+    warningPaletteIndex?: number;
+
+    /** Error tint for future severity overlays (VV-545). */
+    errorPaletteIndex?: number;
+
+    /** Event/tag tint for future chart markers (VV-541). */
+    eventPaletteIndex?: number;
 }
 
 /**
@@ -357,6 +398,18 @@ function pickDefinedHardwareSettings(partial: Partial<HardwareSettings>): Partia
         picked.statsOverlayStyle = { ...partial.statsOverlayStyle };
     }
 
+    if (partial.statsOverlayTimingChart !== undefined) {
+        picked.statsOverlayTimingChart = partial.statsOverlayTimingChart;
+    }
+
+    if (partial.statsOverlayTimingChartHeight !== undefined) {
+        picked.statsOverlayTimingChartHeight = partial.statsOverlayTimingChartHeight;
+    }
+
+    if (partial.statsOverlayTimingChartStyle !== undefined) {
+        picked.statsOverlayTimingChartStyle = { ...partial.statsOverlayTimingChartStyle };
+    }
+
     return picked;
 }
 
@@ -379,6 +432,107 @@ function resolveMergedOptionalVector(
 }
 
 /**
+ * Sets `target[key]` when `value` is defined.
+ *
+ * @param target - Partial settings object being built.
+ * @param key - Hardware settings field to assign.
+ * @param value - Resolved value, or `undefined` to skip.
+ */
+function assignIfDefined<K extends keyof HardwareSettings>(
+    target: Partial<HardwareSettings>,
+    key: K,
+    value: HardwareSettings[K] | undefined,
+): void {
+    if (value !== undefined) {
+        // eslint-disable-next-line security/detect-object-injection -- key is keyof HardwareSettings
+        target[key] = value;
+    }
+}
+
+/**
+ * Shallow-clones an object-shaped optional before assignment.
+ *
+ * @param value - Optional record from configure or defaults.
+ * @returns Cloned record, or `undefined` when input is omitted.
+ */
+function shallowCloneOptional<T extends object>(value: T | undefined): T | undefined {
+    return value === undefined ? undefined : { ...value };
+}
+
+/**
+ * Merged optional vectors for the full-default configure path.
+ *
+ * @param optionals - Partial settings object being built.
+ * @param picked - Defined fields from `configure()`.
+ * @param defaults - Baseline hardware settings.
+ */
+function assignFullDefaultMergeVectors(
+    optionals: Partial<HardwareSettings>,
+    picked: Partial<HardwareSettings>,
+    defaults: HardwareSettings,
+): void {
+    assignIfDefined(
+        optionals,
+        'canvasDisplaySize',
+        resolveMergedOptionalVector(picked.canvasDisplaySize, defaults.canvasDisplaySize),
+    );
+
+    assignIfDefined(
+        optionals,
+        'maxCanvasDisplaySize',
+        resolveMergedOptionalVector(picked.maxCanvasDisplaySize, defaults.maxCanvasDisplaySize),
+    );
+}
+
+/**
+ * Merged optional scalars and overlay records for the full-default configure path.
+ *
+ * @param optionals - Partial settings object being built.
+ * @param picked - Defined fields from `configure()`.
+ * @param defaults - Baseline hardware settings.
+ */
+function assignFullDefaultMergeScalars(
+    optionals: Partial<HardwareSettings>,
+    picked: Partial<HardwareSettings>,
+    defaults: HardwareSettings,
+): void {
+    assignIfDefined(optionals, 'outputUpscaleFilter', picked.outputUpscaleFilter ?? defaults.outputUpscaleFilter);
+    assignIfDefined(optionals, 'detectDroppedFrames', picked.detectDroppedFrames ?? defaults.detectDroppedFrames);
+    assignIfDefined(optionals, 'backend', picked.backend ?? defaults.backend);
+
+    assignIfDefined(
+        optionals,
+        'statsOverlayStyle',
+        shallowCloneOptional(picked.statsOverlayStyle ?? defaults.statsOverlayStyle),
+    );
+
+    assignIfDefined(
+        optionals,
+        'statsOverlayPaletteView',
+        picked.statsOverlayPaletteView ?? defaults.statsOverlayPaletteView,
+    );
+    assignIfDefined(optionals, 'statsOverlayPaletteColumns', picked.statsOverlayPaletteColumns);
+
+    assignIfDefined(
+        optionals,
+        'statsOverlayTimingChart',
+        picked.statsOverlayTimingChart ?? defaults.statsOverlayTimingChart,
+    );
+
+    assignIfDefined(
+        optionals,
+        'statsOverlayTimingChartHeight',
+        picked.statsOverlayTimingChartHeight ?? defaults.statsOverlayTimingChartHeight,
+    );
+
+    assignIfDefined(
+        optionals,
+        'statsOverlayTimingChartStyle',
+        shallowCloneOptional(picked.statsOverlayTimingChartStyle ?? defaults.statsOverlayTimingChartStyle),
+    );
+}
+
+/**
  * Collects optional hardware fields for the full-default merge path.
  *
  * @param picked - Defined fields from `configure()`.
@@ -390,56 +544,32 @@ function buildFullDefaultMergeOptionals(
     defaults: HardwareSettings,
 ): Partial<HardwareSettings> {
     const optionals: Partial<HardwareSettings> = {};
+    assignFullDefaultMergeVectors(optionals, picked, defaults);
+    assignFullDefaultMergeScalars(optionals, picked, defaults);
+    return optionals;
+}
 
-    const canvasDisplaySize = resolveMergedOptionalVector(picked.canvasDisplaySize, defaults.canvasDisplaySize);
-
-    if (canvasDisplaySize !== undefined) {
-        optionals.canvasDisplaySize = canvasDisplaySize;
-    }
-
-    const maxCanvasDisplaySize = resolveMergedOptionalVector(
-        picked.maxCanvasDisplaySize,
-        defaults.maxCanvasDisplaySize,
+/**
+ * Optional fields explicitly set in `configure()` when the demo provided `displaySize`.
+ *
+ * @param picked - Defined fields with vectors cloned.
+ * @returns Partial settings to spread into the resolved profile.
+ */
+function buildExplicitDisplayOptionals(picked: Partial<HardwareSettings>): Partial<HardwareSettings> {
+    const optionals: Partial<HardwareSettings> = {};
+    assignIfDefined(optionals, 'canvasDisplaySize', picked.canvasDisplaySize);
+    assignIfDefined(optionals, 'maxCanvasDisplaySize', picked.maxCanvasDisplaySize);
+    assignIfDefined(optionals, 'outputUpscaleFilter', picked.outputUpscaleFilter);
+    assignIfDefined(optionals, 'detectDroppedFrames', picked.detectDroppedFrames);
+    assignIfDefined(optionals, 'statsOverlayStyle', shallowCloneOptional(picked.statsOverlayStyle));
+    assignIfDefined(optionals, 'statsOverlayPaletteColumns', picked.statsOverlayPaletteColumns);
+    assignIfDefined(optionals, 'statsOverlayTimingChart', picked.statsOverlayTimingChart);
+    assignIfDefined(optionals, 'statsOverlayTimingChartHeight', picked.statsOverlayTimingChartHeight);
+    assignIfDefined(
+        optionals,
+        'statsOverlayTimingChartStyle',
+        shallowCloneOptional(picked.statsOverlayTimingChartStyle),
     );
-
-    if (maxCanvasDisplaySize !== undefined) {
-        optionals.maxCanvasDisplaySize = maxCanvasDisplaySize;
-    }
-
-    const outputUpscaleFilter = picked.outputUpscaleFilter ?? defaults.outputUpscaleFilter;
-
-    if (outputUpscaleFilter !== undefined) {
-        optionals.outputUpscaleFilter = outputUpscaleFilter;
-    }
-
-    const detectDroppedFrames = picked.detectDroppedFrames ?? defaults.detectDroppedFrames;
-
-    if (detectDroppedFrames !== undefined) {
-        optionals.detectDroppedFrames = detectDroppedFrames;
-    }
-
-    const backend = picked.backend ?? defaults.backend;
-
-    if (backend !== undefined) {
-        optionals.backend = backend;
-    }
-
-    const statsOverlayStyle = picked.statsOverlayStyle ?? defaults.statsOverlayStyle;
-
-    if (statsOverlayStyle !== undefined) {
-        optionals.statsOverlayStyle = { ...statsOverlayStyle };
-    }
-
-    const statsOverlayPaletteView = picked.statsOverlayPaletteView ?? defaults.statsOverlayPaletteView;
-
-    if (statsOverlayPaletteView !== undefined) {
-        optionals.statsOverlayPaletteView = statsOverlayPaletteView;
-    }
-
-    if (picked.statsOverlayPaletteColumns !== undefined) {
-        optionals.statsOverlayPaletteColumns = picked.statsOverlayPaletteColumns;
-    }
-
     return optionals;
 }
 
@@ -475,15 +605,8 @@ function mergeExplicitDisplayProfile(picked: Partial<HardwareSettings>, defaults
         targetFPS: picked.targetFPS ?? defaults.targetFPS,
         statsOverlayEnabled: picked.statsOverlayEnabled ?? defaults.statsOverlayEnabled ?? true,
         statsOverlayPaletteView: picked.statsOverlayPaletteView ?? defaults.statsOverlayPaletteView ?? false,
-        ...(picked.canvasDisplaySize !== undefined ? { canvasDisplaySize: picked.canvasDisplaySize } : {}),
-        ...(picked.maxCanvasDisplaySize !== undefined ? { maxCanvasDisplaySize: picked.maxCanvasDisplaySize } : {}),
-        ...(picked.outputUpscaleFilter !== undefined ? { outputUpscaleFilter: picked.outputUpscaleFilter } : {}),
-        ...(picked.detectDroppedFrames !== undefined ? { detectDroppedFrames: picked.detectDroppedFrames } : {}),
         backend: picked.backend ?? defaults.backend ?? 'webgpu',
-        ...(picked.statsOverlayStyle !== undefined ? { statsOverlayStyle: { ...picked.statsOverlayStyle } } : {}),
-        ...(picked.statsOverlayPaletteColumns !== undefined
-            ? { statsOverlayPaletteColumns: picked.statsOverlayPaletteColumns }
-            : {}),
+        ...buildExplicitDisplayOptionals(picked),
     };
 }
 

--- a/src/core/IBlitTechDemo.ts
+++ b/src/core/IBlitTechDemo.ts
@@ -332,6 +332,7 @@ export function defaultConfig(): HardwareSettings {
         backend: 'webgpu',
         statsOverlayEnabled: true,
         statsOverlayPaletteView: false,
+        statsOverlayTimingChart: false,
     };
 }
 

--- a/src/render/stats-overlay/StatsOverlay.test.ts
+++ b/src/render/stats-overlay/StatsOverlay.test.ts
@@ -316,7 +316,11 @@ describe('StatsOverlay', () => {
         overlay.updateAndRender(renderer, mockFont, null, null, 0, undefined, undefined, palette, usedMask);
 
         const fills = getRectFillCalls(renderer);
-        expect(fills[3]).toMatchObject({ y: 240 - grid.totalHeight, height: grid.totalHeight, width: 320 });
+        const bottomBarFill = fills.find(
+            (rect) => rect.y === 240 - grid.totalHeight && rect.height === grid.totalHeight && rect.width === 320,
+        );
+
+        expect(bottomBarFill).toBeDefined();
         expect(renderer.drawRectFillOnTop.mock.calls.length).toBeGreaterThan(4);
     });
 
@@ -352,5 +356,101 @@ describe('StatsOverlay', () => {
         const customRowFill = fills.find((rect) => rect.height === STATS_BAR_HEIGHT && rect.y === row0BarY);
 
         expect(customRowFill).toMatchObject({ y: row0BarY, width: 320, height: STATS_BAR_HEIGHT });
+    });
+
+    it('draws timing chart dots when statsOverlayTimingChart is enabled', () => {
+        const layout = createStatsOverlayLayout(320, 240, 14);
+        const overlay = new StatsOverlay(
+            layout,
+            'Demo',
+            60,
+            'webgpu',
+            { barPaletteIndex: 8, textPaletteIndex: 9 },
+            STATS_OVERLAY_PALETTE_VIEW_OFF,
+            undefined,
+            true,
+            { updateBarPaletteIndex: 10, renderBarPaletteIndex: 11 },
+            36,
+        );
+        const renderer = createMockRenderer();
+
+        overlay.updateAndRender(renderer, mockFont, null, null, 0, undefined, {
+            frameMs: 8,
+            updateMs: 200,
+            renderMs: 100,
+            updateSteps: 1,
+            drawCalls: 4,
+        });
+
+        const dotCalls = renderer.drawRectFillOnTop.mock.calls.filter(
+            (call) => (call[0] as { width: number }).width === 1 && (call[0] as { height: number }).height === 1,
+        );
+        const paletteIndices = dotCalls.map((call) => call[1] as number);
+
+        expect(paletteIndices).toContain(10);
+        expect(paletteIndices).toContain(11);
+    });
+
+    it('does not draw overlay while hidden but keeps timing chart samples for re-show', () => {
+        const layout = createStatsOverlayLayout(320, 240, 14);
+        const overlay = new StatsOverlay(
+            layout,
+            'Demo',
+            60,
+            'webgpu',
+            undefined,
+            STATS_OVERLAY_PALETTE_VIEW_OFF,
+            undefined,
+            true,
+            { updateBarPaletteIndex: 10, renderBarPaletteIndex: 11 },
+        );
+        const renderer = createMockRenderer();
+
+        overlay.handleToggle(null, { isKeyPressed: (key: string) => key === 'Backquote' } as never, 1);
+        overlay.updateAndRender(renderer, mockFont, null, null, 0, undefined, {
+            frameMs: 8,
+            updateMs: 12,
+            renderMs: 8,
+            updateSteps: 1,
+            drawCalls: 4,
+        });
+
+        expect(renderer.drawRectFillOnTop).not.toHaveBeenCalled();
+
+        overlay.handleToggle(null, { isKeyPressed: (key: string) => key === 'Backquote' } as never, 2);
+        overlay.updateAndRender(renderer, mockFont, null, null, 0, undefined, {
+            frameMs: 8,
+            updateMs: 12,
+            renderMs: 8,
+            updateSteps: 1,
+            drawCalls: 4,
+        });
+
+        expect(renderer.drawRectFillOnTop.mock.calls.some((call) => call[1] === 10)).toBe(true);
+    });
+
+    it('does not draw timing chart dots when statsOverlayTimingChart is disabled', () => {
+        const layout = createStatsOverlayLayout(320, 240, 14);
+        const overlay = new StatsOverlay(
+            layout,
+            'Demo',
+            60,
+            'webgpu',
+            undefined,
+            STATS_OVERLAY_PALETTE_VIEW_OFF,
+            undefined,
+            false,
+        );
+        const renderer = createMockRenderer();
+
+        overlay.updateAndRender(renderer, mockFont, null, null, 0, undefined, {
+            frameMs: 8,
+            updateMs: 200,
+            renderMs: 100,
+            updateSteps: 1,
+            drawCalls: 4,
+        });
+
+        expect(renderer.drawRectFillOnTop.mock.calls.some((call) => call[1] === 10)).toBe(false);
     });
 });

--- a/src/render/stats-overlay/StatsOverlay.ts
+++ b/src/render/stats-overlay/StatsOverlay.ts
@@ -7,11 +7,16 @@
 
 import type { BitmapFont } from '../../assets/BitmapFont';
 import type { Palette } from '../../assets/Palette';
-import type { Backend, StatsOverlayRow, StatsOverlayStyle } from '../../core/IBlitTechDemo';
+import type {
+    Backend,
+    StatsOverlayRow,
+    StatsOverlayStyle,
+    StatsOverlayTimingChartStyle,
+} from '../../core/IBlitTechDemo';
 import type { KeyboardInput } from '../../input/KeyboardInput';
 import type { PointerInput } from '../../input/PointerInput';
 import type { IRenderer } from '../IRenderer';
-import { DEFAULT_IDX_BG, DEFAULT_IDX_TEXT, STATS_BOTTOM_HINT_LABEL } from './constants';
+import { DEFAULT_IDX_BG, DEFAULT_IDX_TEXT, DEFAULT_TIMING_CHART_HEIGHT, STATS_BOTTOM_HINT_LABEL } from './constants';
 import { FpsSampler } from './FpsSampler';
 import {
     buildStatsOverlayLayoutPlan,
@@ -22,6 +27,8 @@ import { StatsOverlayBars } from './StatsOverlayBars';
 import { computePaletteGrid, DEFAULT_PALETTE_GRID, StatsOverlayPaletteView } from './StatsOverlayPaletteView';
 import { StatsOverlayTimingChart } from './StatsOverlayTimingChart';
 import { StatsOverlayToggle } from './StatsOverlayToggle';
+import type { ResolvedStatsOverlayTimingChartStyle } from './timingChartStyle';
+import { resolveStatsOverlayTimingChartStyle } from './timingChartStyle';
 import { TimingSampler } from './TimingSampler';
 import type {
     StatsOverlayLayout,
@@ -58,6 +65,10 @@ export class StatsOverlay {
 
     readonly #timingChart: StatsOverlayTimingChart;
 
+    readonly #timingChartHeight: number;
+
+    readonly #timingChartStyle: ResolvedStatsOverlayTimingChartStyle;
+
     readonly #paletteView: StatsOverlayPaletteView;
 
     readonly #paletteColumns: number | undefined;
@@ -80,6 +91,9 @@ export class StatsOverlay {
      * @param style - Optional palette indices from {@link HardwareSettings.statsOverlayStyle}.
      * @param statsOverlayPaletteView - When true, draws the live palette swatch grid.
      * @param paletteColumns - Optional max swatches per row from {@link HardwareSettings.statsOverlayPaletteColumns}.
+     * @param statsOverlayTimingChart - When true, draws the update/render timing chart band.
+     * @param statsOverlayTimingChartStyle - Optional timing chart palette overrides.
+     * @param statsOverlayTimingChartHeight - Chart band height in pixels (default 22).
      */
     constructor(
         layout: StatsOverlayLayout,
@@ -89,6 +103,9 @@ export class StatsOverlay {
         style?: StatsOverlayStyle,
         statsOverlayPaletteView = false,
         paletteColumns?: number,
+        statsOverlayTimingChart = false,
+        statsOverlayTimingChartStyle?: StatsOverlayTimingChartStyle,
+        statsOverlayTimingChartHeight?: number,
     ) {
         this.#layout = layout;
         this.#topLeftLabel = topLeftLabel;
@@ -97,9 +114,15 @@ export class StatsOverlay {
         this.#idxBg = style?.barPaletteIndex ?? DEFAULT_IDX_BG;
         this.#idxText = style?.textPaletteIndex ?? DEFAULT_IDX_TEXT;
         this.#topRightLabel = `${activeBackend} | ${layout.displayWidth}x${layout.displayHeight}`;
-        this.#timingChart = new StatsOverlayTimingChart(false);
+        this.#timingChartStyle = resolveStatsOverlayTimingChartStyle(style, statsOverlayTimingChartStyle);
+        this.#timingChartHeight = statsOverlayTimingChartHeight ?? DEFAULT_TIMING_CHART_HEIGHT;
+        this.#timingChart = new StatsOverlayTimingChart(statsOverlayTimingChart);
         this.#paletteView = new StatsOverlayPaletteView(statsOverlayPaletteView);
         this.#paletteColumns = paletteColumns;
+
+        if (statsOverlayTimingChart) {
+            this.#timingChart.reset(layout.displayWidth);
+        }
     }
 
     /**
@@ -170,6 +193,8 @@ export class StatsOverlay {
                 customRowCount,
             ),
             statsOverlayPaletteView,
+            timingChartEnabled: this.#timingChart.enabled,
+            timingChartHeight: this.#timingChartHeight,
             ...(paletteGrid !== undefined ? { paletteGrid } : {}),
         };
     }
@@ -203,12 +228,9 @@ export class StatsOverlay {
         this.#barStyle.barIndex = this.#idxBg;
         this.#barStyle.textIndex = this.#idxText;
 
-        this.#timingChart.draw(renderer, plan.timingChart, {
-            updateBarIndex: this.#idxBg,
-            renderBarIndex: this.#idxText,
-        });
-
         this.#bars.drawFixedBars(renderer, plan, this.#idxBg);
+
+        this.#timingChart.draw(renderer, plan.timingChart, this.#timingChartStyle);
 
         this.#paletteView.draw(
             renderer,
@@ -264,12 +286,15 @@ export class StatsOverlay {
         palette?: Palette | null,
         usedPaletteMask: Uint8Array = EMPTY_PALETTE_USAGE_MASK,
     ): void {
-        this.#fps.sample();
+        // Chart history keeps advancing while hidden so re-show reflects demo-only timing
+        // (overlay draw is skipped below; palette usage tracking is also off when hidden).
         this.#sampleTiming(timing);
 
         if (!this.#toggle.visible) {
             return;
         }
+
+        this.#fps.sample();
 
         const customRows = getCustomRows?.();
         const layoutConfig = this.#createLayoutConfig(customRows?.length ?? 0, palette);

--- a/src/render/stats-overlay/StatsOverlayBars.ts
+++ b/src/render/stats-overlay/StatsOverlayBars.ts
@@ -33,7 +33,7 @@ export class StatsOverlayBars {
     }
 
     /**
-     * Draws built-in top/metrics/timing/bottom bar fills.
+     * Draws built-in top/chart/metrics/timing/bottom bar fills.
      *
      * @param renderer - Active renderer.
      * @param plan - Computed layout plan.
@@ -41,6 +41,11 @@ export class StatsOverlayBars {
      */
     drawFixedBars(renderer: IRenderer, plan: StatsOverlayLayoutPlan, barIndex: number): void {
         renderer.drawRectFillOnTop(plan.titleBar, barIndex);
+
+        if (plan.timingChart.height > 0) {
+            renderer.drawRectFillOnTop(plan.timingChart, barIndex);
+        }
+
         renderer.drawRectFillOnTop(plan.metricsBar, barIndex);
         renderer.drawRectFillOnTop(plan.timingTextBar, barIndex);
         renderer.drawRectFillOnTop(plan.bottomArea, barIndex);

--- a/src/render/stats-overlay/StatsOverlayTimingChart.test.ts
+++ b/src/render/stats-overlay/StatsOverlayTimingChart.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+
+import { Rect2i } from '../../utils/Rect2i';
+import { TIMING_CHART_FULL_SCALE_MS } from './constants';
+import { StatsOverlayTimingChart } from './StatsOverlayTimingChart';
+import { createMockRenderer, getRectFillCalls } from './testFixtures';
+import { computeTimingChartBarHeight } from './timingChartStyle';
+
+describe('computeTimingChartBarHeight', () => {
+    it('maps ms proportionally to chart height and clamps at band bounds', () => {
+        expect(computeTimingChartBarHeight(0, 22, TIMING_CHART_FULL_SCALE_MS)).toBe(0);
+        expect(computeTimingChartBarHeight(0.1, 22, TIMING_CHART_FULL_SCALE_MS)).toBe(1);
+        expect(computeTimingChartBarHeight(8, 22, TIMING_CHART_FULL_SCALE_MS)).toBe(11);
+        expect(computeTimingChartBarHeight(32, 22, TIMING_CHART_FULL_SCALE_MS)).toBe(22);
+    });
+});
+
+describe('StatsOverlayTimingChart', () => {
+    it('does not draw when disabled', () => {
+        const chart = new StatsOverlayTimingChart(false);
+        const renderer = createMockRenderer();
+
+        chart.reset(4);
+        chart.sample({ frameMs: 1, updateMs: 2, renderMs: 3, updateSteps: 1, drawCalls: 1 });
+        chart.draw(renderer, new Rect2i(0, 14, 4, 22), {
+            updateBarIndex: 1,
+            renderBarIndex: 2,
+            warningBarIndex: 3,
+            errorBarIndex: 4,
+            eventBarIndex: 5,
+        });
+
+        expect(renderer.drawRectFillOnTop).not.toHaveBeenCalled();
+    });
+
+    it('wraps ring buffer and keeps newest samples on the right', () => {
+        const chart = new StatsOverlayTimingChart(true);
+        const renderer = createMockRenderer();
+        const style = {
+            updateBarIndex: 8,
+            renderBarIndex: 9,
+            warningBarIndex: 3,
+            errorBarIndex: 4,
+            eventBarIndex: 5,
+        };
+        const chartRect = new Rect2i(0, 0, 3, 22);
+        const baselineY = chartRect.y + chartRect.height - 1;
+
+        chart.reset(3);
+        chart.sample({ frameMs: 0, updateMs: 4, renderMs: 0, updateSteps: 1, drawCalls: 0 });
+        chart.sample({ frameMs: 0, updateMs: 8, renderMs: 0, updateSteps: 1, drawCalls: 0 });
+        chart.sample({ frameMs: 0, updateMs: 12, renderMs: 0, updateSteps: 1, drawCalls: 0 });
+        chart.sample({ frameMs: 0, updateMs: 16, renderMs: 0, updateSteps: 1, drawCalls: 0 });
+
+        chart.draw(renderer, chartRect, style);
+
+        const updateDotY = (ms: number) =>
+            baselineY - computeTimingChartBarHeight(ms, chartRect.height, TIMING_CHART_FULL_SCALE_MS) + 1;
+
+        const updateDots = getRectFillCalls(renderer).filter(
+            (rect) => rect.width === 1 && rect.height === 1 && rect.y === updateDotY(8),
+        );
+
+        expect(updateDots.some((rect) => rect.x === 0)).toBe(true);
+        expect(
+            getRectFillCalls(renderer).some(
+                (rect) => rect.width === 1 && rect.height === 1 && rect.y === updateDotY(16) && rect.x === 2,
+            ),
+        ).toBe(true);
+    });
+
+    it('draws render dots for sub-millisecond samples', () => {
+        const chart = new StatsOverlayTimingChart(true);
+        const renderer = createMockRenderer();
+        const style = {
+            updateBarIndex: 8,
+            renderBarIndex: 9,
+            warningBarIndex: 3,
+            errorBarIndex: 4,
+            eventBarIndex: 5,
+        };
+
+        chart.reset(4);
+        chart.sample({ frameMs: 0, updateMs: 0, renderMs: 0.1, updateSteps: 1, drawCalls: 1 });
+        chart.draw(renderer, new Rect2i(0, 14, 4, 32), style);
+
+        expect(
+            renderer.drawRectFillOnTop.mock.calls.some(
+                (call) =>
+                    (call[0] as { width: number; height: number }).width === 1 &&
+                    (call[0] as { height: number }).height === 1 &&
+                    call[1] === 9,
+            ),
+        ).toBe(true);
+    });
+
+    it('draws update and render dots with distinct palette indices', () => {
+        const chart = new StatsOverlayTimingChart(true);
+        const renderer = createMockRenderer();
+
+        chart.reset(1);
+        chart.sample({ frameMs: 0, updateMs: 12, renderMs: 8, updateSteps: 1, drawCalls: 0 });
+        chart.draw(renderer, new Rect2i(10, 14, 1, 22), {
+            updateBarIndex: 8,
+            renderBarIndex: 9,
+            warningBarIndex: 3,
+            errorBarIndex: 4,
+            eventBarIndex: 5,
+        });
+
+        const dots = getRectFillCalls(renderer).filter((rect) => rect.width === 1 && rect.height === 1);
+        const paletteIndices = renderer.drawRectFillOnTop.mock.calls
+            .filter(
+                (call) => (call[0] as { width: number }).width === 1 && (call[0] as { height: number }).height === 1,
+            )
+            .map((call) => call[1] as number);
+
+        expect(paletteIndices).toContain(8);
+        expect(paletteIndices).toContain(9);
+        expect(dots).toHaveLength(2);
+    });
+});

--- a/src/render/stats-overlay/StatsOverlayTimingChart.ts
+++ b/src/render/stats-overlay/StatsOverlayTimingChart.ts
@@ -1,25 +1,31 @@
 /**
- * Timing chart band for the stats overlay (VV-539 scaffold).
- *
- * Ring buffer and vertical bar drawing land in a follow-up; this stub wires
- * sample/draw hooks into the layout planner with no visible output when disabled.
+ * Scrolling update/render timing chart band for the stats overlay (VV-539).
  */
 
-import type { Rect2i } from '../../utils/Rect2i';
+import { Rect2i } from '../../utils/Rect2i';
 import type { IRenderer } from '../IRenderer';
+import { TIMING_CHART_FULL_SCALE_MS } from './constants';
+import { computeTimingChartBarHeight, type ResolvedStatsOverlayTimingChartStyle } from './timingChartStyle';
 import type { StatsOverlayTimingSnapshot } from './types';
 
-/** Palette indices for chart drawing (stub defaults). */
-export interface StatsOverlayTimingChartStyle {
-    readonly updateBarIndex: number;
-    readonly renderBarIndex: number;
-}
+/** Palette indices for chart drawing. */
+export type StatsOverlayTimingChartDrawStyle = ResolvedStatsOverlayTimingChartStyle;
 
 /**
- * Scrolling update/render timing chart (stub until VV-539).
+ * Scrolling update/render timing chart with a fixed-capacity ring buffer.
  */
 export class StatsOverlayTimingChart {
     readonly #enabled: boolean;
+
+    #bufferWidth = 0;
+
+    #writeIndex = 0;
+
+    #sampleCount = 0;
+
+    #updateMsBuffer = new Float32Array(0);
+
+    #renderMsBuffer = new Float32Array(0);
 
     /**
      * Creates a timing chart with the given feature flag.
@@ -40,26 +46,115 @@ export class StatsOverlayTimingChart {
     }
 
     /**
-     * Records one frame timing sample (no-op when disabled).
+     * Clears ring-buffer state when the chart width changes.
      *
-     * @param _timing - Per-frame snapshot from BTAPI.
+     * @param width - New chart width in pixels.
      */
-    sample(_timing: StatsOverlayTimingSnapshot): void {
-        if (!this.#enabled) {
+    reset(width: number): void {
+        if (width <= 0) {
+            this.#bufferWidth = 0;
+            this.#writeIndex = 0;
+            this.#sampleCount = 0;
             return;
+        }
+
+        if (width === this.#bufferWidth) {
+            return;
+        }
+
+        this.#bufferWidth = width;
+        this.#writeIndex = 0;
+        this.#sampleCount = 0;
+        this.#updateMsBuffer = new Float32Array(width);
+        this.#renderMsBuffer = new Float32Array(width);
+    }
+
+    /**
+     * Records one frame timing sample into the ring buffer.
+     *
+     * @param timing - Per-frame snapshot from BTAPI.
+     */
+    sample(timing: StatsOverlayTimingSnapshot): void {
+        if (!this.#enabled || this.#bufferWidth <= 0) {
+            return;
+        }
+
+        const index = this.#writeIndex;
+
+        /* eslint-disable security/detect-object-injection -- index is ring-buffer write cursor bounded by bufferWidth */
+        this.#updateMsBuffer[index] = Math.max(0, timing.updateMs);
+        this.#renderMsBuffer[index] = Math.max(0, timing.renderMs);
+        /* eslint-enable security/detect-object-injection */
+
+        this.#writeIndex = (this.#writeIndex + 1) % this.#bufferWidth;
+        this.#sampleCount = Math.min(this.#sampleCount + 1, this.#bufferWidth);
+    }
+
+    /**
+     * Draws one-pixel timing dots for each populated ring-buffer column.
+     *
+     * Uses {@link IRenderer.drawRectFillOnTop} with 1x1 rects so update and render samples stay
+     * visible without alpha blending (palette-indexed engine).
+     *
+     * @param renderer - Active renderer.
+     * @param chartRect - Screen-space chart band from layout plan.
+     * @param style - Resolved chart palette indices.
+     */
+    draw(renderer: IRenderer, chartRect: Rect2i, style: StatsOverlayTimingChartDrawStyle): void {
+        if (!this.#enabled || chartRect.width <= 0 || chartRect.height <= 0) {
+            return;
+        }
+
+        this.reset(chartRect.width);
+
+        if (this.#sampleCount <= 0) {
+            return;
+        }
+
+        const baselineY = chartRect.y + chartRect.height - 1;
+
+        for (let column = 0; column < this.#sampleCount; column++) {
+            const bufferIndex =
+                this.#sampleCount < this.#bufferWidth ? column : (this.#writeIndex + column) % this.#bufferWidth;
+
+            /* eslint-disable security/detect-object-injection -- bufferIndex derived from bounded ring cursor */
+            const updateMs = this.#updateMsBuffer[bufferIndex] ?? 0;
+            const renderMs = this.#renderMsBuffer[bufferIndex] ?? 0;
+
+            /* eslint-enable security/detect-object-injection */
+            const x = chartRect.x + column;
+
+            this.#drawDot(renderer, x, baselineY, renderMs, chartRect, style.renderBarIndex);
+            this.#drawDot(renderer, x, baselineY, updateMs, chartRect, style.updateBarIndex);
         }
     }
 
     /**
-     * Draws the timing chart band (no-op when disabled).
+     * Draws one timing sample as a single pixel above the chart baseline.
      *
-     * @param _renderer - Active renderer.
-     * @param _chartRect - Screen-space chart band from layout plan.
-     * @param _style - Chart palette indices.
+     * @param renderer - Active renderer.
+     * @param x - Column X in screen space.
+     * @param baselineY - Bottom row of the chart band.
+     * @param ms - Timing sample in milliseconds.
+     * @param chartRect - Chart band bounds for clamping.
+     * @param paletteIndex - Palette index for the dot.
      */
-    draw(_renderer: IRenderer, _chartRect: Rect2i, _style: StatsOverlayTimingChartStyle): void {
-        if (!this.#enabled) {
+    #drawDot(
+        renderer: IRenderer,
+        x: number,
+        baselineY: number,
+        ms: number,
+        chartRect: Rect2i,
+        paletteIndex: number,
+    ): void {
+        const offset = computeTimingChartBarHeight(ms, chartRect.height, TIMING_CHART_FULL_SCALE_MS);
+
+        if (offset <= 0) {
             return;
         }
+
+        const y = Math.max(chartRect.y, baselineY - offset + 1);
+
+        renderer.drawRectFillOnTop(new Rect2i(x, y, 1, 1), paletteIndex);
     }
 }

--- a/src/render/stats-overlay/StatsOverlayTimingChart.ts
+++ b/src/render/stats-overlay/StatsOverlayTimingChart.ts
@@ -27,6 +27,8 @@ export class StatsOverlayTimingChart {
 
     #renderMsBuffer = new Float32Array(0);
 
+    readonly #dotScratch = new Rect2i(0, 0, 1, 1);
+
     /**
      * Creates a timing chart with the given feature flag.
      *
@@ -155,6 +157,7 @@ export class StatsOverlayTimingChart {
 
         const y = Math.max(chartRect.y, baselineY - offset + 1);
 
-        renderer.drawRectFillOnTop(new Rect2i(x, y, 1, 1), paletteIndex);
+        this.#dotScratch.set(x, y, 1, 1);
+        renderer.drawRectFillOnTop(this.#dotScratch, paletteIndex);
     }
 }

--- a/src/render/stats-overlay/constants.ts
+++ b/src/render/stats-overlay/constants.ts
@@ -40,5 +40,17 @@ export const SYSTEM_CHAR_ADVANCE = 6;
 /** Default timing chart band height in pixels (RetroBlit uses bottom - 22). */
 export const DEFAULT_TIMING_CHART_HEIGHT = 22;
 
+/** Milliseconds mapped to full chart band height (~one 60 FPS frame budget). */
+export const TIMING_CHART_FULL_SCALE_MS = 16;
+
+/** Default warning palette index for timing chart semantic overlays. */
+export const TIMING_CHART_DEFAULT_WARNING_IDX = 3;
+
+/** Default error palette index for timing chart semantic overlays. */
+export const TIMING_CHART_DEFAULT_ERROR_IDX = 4;
+
+/** Default event/tag palette index for timing chart semantic overlays. */
+export const TIMING_CHART_DEFAULT_EVENT_IDX = 5;
+
 /** Bottom-right hint label when palette grid is disabled. */
 export const STATS_BOTTOM_HINT_LABEL = '[~]';

--- a/src/render/stats-overlay/index.ts
+++ b/src/render/stats-overlay/index.ts
@@ -20,8 +20,11 @@ export {
 export { StatsOverlay } from './StatsOverlay';
 export { StatsOverlayBars } from './StatsOverlayBars';
 export { computePaletteGrid, StatsOverlayPaletteView } from './StatsOverlayPaletteView';
+export type { StatsOverlayTimingChartDrawStyle } from './StatsOverlayTimingChart';
 export { StatsOverlayTimingChart } from './StatsOverlayTimingChart';
 export { StatsOverlayToggle } from './StatsOverlayToggle';
+export type { ResolvedStatsOverlayTimingChartStyle } from './timingChartStyle';
+export { computeTimingChartBarHeight, resolveStatsOverlayTimingChartStyle } from './timingChartStyle';
 export { TimingSampler } from './TimingSampler';
 export type {
     PaletteGridLayout,

--- a/src/render/stats-overlay/layoutPlan.ts
+++ b/src/render/stats-overlay/layoutPlan.ts
@@ -3,7 +3,7 @@
  *
  * Computes bar rects and text anchors each frame from display size, custom row count,
  * and optional timing-chart / palette-grid feature flags (timing chart default off per
- * VV-539; palette grid opt-in via {@link HardwareSettings.statsOverlayPaletteView}).
+ * VV-539 timing chart opt-in via {@link HardwareSettings.statsOverlayTimingChart}).
  */
 
 import { Rect2i } from '../../utils/Rect2i';

--- a/src/render/stats-overlay/testFixtures.ts
+++ b/src/render/stats-overlay/testFixtures.ts
@@ -28,9 +28,13 @@ export function createMockRenderer(): IRenderer & {
     drawBitmapTextOnTop: ReturnType<typeof vi.fn>;
     drawPixel: ReturnType<typeof vi.fn>;
     drawRectFill: ReturnType<typeof vi.fn>;
-    drawRectFillOnTop: ReturnType<typeof vi.fn>;
+    drawRectFillOnTop: ReturnType<typeof vi.fn> & { rectSnapshots: Rect2i[] };
 } {
-    const drawRectFillOnTop = vi.fn();
+    const rectSnapshots: Rect2i[] = [];
+    const drawRectFillOnTop = vi.fn((rect: Rect2i) => {
+        rectSnapshots.push(new Rect2i(rect.x, rect.y, rect.width, rect.height));
+    }) as ReturnType<typeof vi.fn> & { rectSnapshots: Rect2i[] };
+    drawRectFillOnTop.rectSnapshots = rectSnapshots;
     const drawBitmapTextOnTop = vi.fn();
     const drawPixel = vi.fn();
 
@@ -67,15 +71,7 @@ export function getBitmapTextCalls(renderer: ReturnType<typeof createMockRendere
  * @returns Filled rectangles in invocation order.
  */
 export function getRectFillCalls(renderer: ReturnType<typeof createMockRenderer>): Rect2i[] {
-    return renderer.drawRectFillOnTop.mock.calls.map(
-        (call) =>
-            new Rect2i(
-                (call[0] as Rect2i).x,
-                (call[0] as Rect2i).y,
-                (call[0] as Rect2i).width,
-                (call[0] as Rect2i).height,
-            ),
-    );
+    return [...renderer.drawRectFillOnTop.rectSnapshots];
 }
 
 /**

--- a/src/render/stats-overlay/testFixtures.ts
+++ b/src/render/stats-overlay/testFixtures.ts
@@ -5,7 +5,7 @@
 import { vi } from 'vitest';
 
 import type { BitmapFont } from '../../assets/BitmapFont';
-import type { Rect2i } from '../../utils/Rect2i';
+import { Rect2i } from '../../utils/Rect2i';
 import { Vector2i } from '../../utils/Vector2i';
 import type { IRenderer } from '../IRenderer';
 import { STATS_BAR_HEIGHT } from './constants';
@@ -67,7 +67,15 @@ export function getBitmapTextCalls(renderer: ReturnType<typeof createMockRendere
  * @returns Filled rectangles in invocation order.
  */
 export function getRectFillCalls(renderer: ReturnType<typeof createMockRenderer>): Rect2i[] {
-    return renderer.drawRectFillOnTop.mock.calls.map((call) => call[0] as Rect2i);
+    return renderer.drawRectFillOnTop.mock.calls.map(
+        (call) =>
+            new Rect2i(
+                (call[0] as Rect2i).x,
+                (call[0] as Rect2i).y,
+                (call[0] as Rect2i).width,
+                (call[0] as Rect2i).height,
+            ),
+    );
 }
 
 /**

--- a/src/render/stats-overlay/timingChartStyle.test.ts
+++ b/src/render/stats-overlay/timingChartStyle.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    TIMING_CHART_DEFAULT_ERROR_IDX,
+    TIMING_CHART_DEFAULT_EVENT_IDX,
+    TIMING_CHART_DEFAULT_WARNING_IDX,
+} from './constants';
+import { resolveStatsOverlayTimingChartStyle } from './timingChartStyle';
+
+describe('resolveStatsOverlayTimingChartStyle', () => {
+    it('defaults update/render bars to overlay style indices', () => {
+        const resolved = resolveStatsOverlayTimingChartStyle({ barPaletteIndex: 10, textPaletteIndex: 11 }, undefined);
+
+        expect(resolved.updateBarIndex).toBe(10);
+        expect(resolved.renderBarIndex).toBe(11);
+        expect(resolved.warningBarIndex).toBe(TIMING_CHART_DEFAULT_WARNING_IDX);
+        expect(resolved.errorBarIndex).toBe(TIMING_CHART_DEFAULT_ERROR_IDX);
+        expect(resolved.eventBarIndex).toBe(TIMING_CHART_DEFAULT_EVENT_IDX);
+    });
+
+    it('honors timing chart palette overrides', () => {
+        const resolved = resolveStatsOverlayTimingChartStyle(
+            { barPaletteIndex: 1, textPaletteIndex: 2 },
+            {
+                updateBarPaletteIndex: 20,
+                renderBarPaletteIndex: 21,
+                warningPaletteIndex: 22,
+                errorPaletteIndex: 23,
+                eventPaletteIndex: 24,
+            },
+        );
+
+        expect(resolved.updateBarIndex).toBe(20);
+        expect(resolved.renderBarIndex).toBe(21);
+        expect(resolved.warningBarIndex).toBe(22);
+        expect(resolved.errorBarIndex).toBe(23);
+        expect(resolved.eventBarIndex).toBe(24);
+    });
+});

--- a/src/render/stats-overlay/timingChartStyle.test.ts
+++ b/src/render/stats-overlay/timingChartStyle.test.ts
@@ -4,8 +4,25 @@ import {
     TIMING_CHART_DEFAULT_ERROR_IDX,
     TIMING_CHART_DEFAULT_EVENT_IDX,
     TIMING_CHART_DEFAULT_WARNING_IDX,
+    TIMING_CHART_FULL_SCALE_MS,
 } from './constants';
-import { resolveStatsOverlayTimingChartStyle } from './timingChartStyle';
+import { computeTimingChartBarHeight, resolveStatsOverlayTimingChartStyle } from './timingChartStyle';
+
+describe('computeTimingChartBarHeight', () => {
+    const chartHeight = 22;
+
+    it('returns 0 for non-positive samples and invalid scale inputs', () => {
+        expect(computeTimingChartBarHeight(-5, chartHeight, TIMING_CHART_FULL_SCALE_MS)).toBe(0);
+        expect(computeTimingChartBarHeight(0, chartHeight, TIMING_CHART_FULL_SCALE_MS)).toBe(0);
+        expect(computeTimingChartBarHeight(5, 0, TIMING_CHART_FULL_SCALE_MS)).toBe(0);
+        expect(computeTimingChartBarHeight(5, chartHeight, 0)).toBe(0);
+    });
+
+    it('draws at least 1 px for sub-millisecond samples and clamps at band height', () => {
+        expect(computeTimingChartBarHeight(0.1, chartHeight, TIMING_CHART_FULL_SCALE_MS)).toBe(1);
+        expect(computeTimingChartBarHeight(999, chartHeight, TIMING_CHART_FULL_SCALE_MS)).toBe(chartHeight);
+    });
+});
 
 describe('resolveStatsOverlayTimingChartStyle', () => {
     it('defaults update/render bars to overlay style indices', () => {

--- a/src/render/stats-overlay/timingChartStyle.ts
+++ b/src/render/stats-overlay/timingChartStyle.ts
@@ -1,0 +1,61 @@
+import type { StatsOverlayStyle, StatsOverlayTimingChartStyle } from '../../core/IBlitTechDemo';
+import {
+    DEFAULT_IDX_BG,
+    DEFAULT_IDX_TEXT,
+    TIMING_CHART_DEFAULT_ERROR_IDX,
+    TIMING_CHART_DEFAULT_EVENT_IDX,
+    TIMING_CHART_DEFAULT_WARNING_IDX,
+} from './constants';
+
+/** Resolved palette indices used when drawing the timing chart band. */
+export interface ResolvedStatsOverlayTimingChartStyle {
+    readonly updateBarIndex: number;
+    readonly renderBarIndex: number;
+    readonly warningBarIndex: number;
+    readonly errorBarIndex: number;
+    readonly eventBarIndex: number;
+}
+
+/**
+ * Resolves timing chart palette indices from overlay and chart-specific settings.
+ *
+ * @param overlayStyle - Global overlay bar/text indices from hardware settings.
+ * @param chartStyle - Optional timing-chart palette overrides.
+ * @returns Resolved indices for chart draw and future semantic overlays.
+ */
+export function resolveStatsOverlayTimingChartStyle(
+    overlayStyle: StatsOverlayStyle | undefined,
+    chartStyle: StatsOverlayTimingChartStyle | undefined,
+): ResolvedStatsOverlayTimingChartStyle {
+    const barIndex = overlayStyle?.barPaletteIndex ?? DEFAULT_IDX_BG;
+    const textIndex = overlayStyle?.textPaletteIndex ?? DEFAULT_IDX_TEXT;
+
+    return {
+        updateBarIndex: chartStyle?.updateBarPaletteIndex ?? barIndex,
+        renderBarIndex: chartStyle?.renderBarPaletteIndex ?? textIndex,
+        warningBarIndex: chartStyle?.warningPaletteIndex ?? TIMING_CHART_DEFAULT_WARNING_IDX,
+        errorBarIndex: chartStyle?.errorPaletteIndex ?? TIMING_CHART_DEFAULT_ERROR_IDX,
+        eventBarIndex: chartStyle?.eventPaletteIndex ?? TIMING_CHART_DEFAULT_EVENT_IDX,
+    };
+}
+
+/**
+ * Maps a timing sample in milliseconds to a vertical dot offset in pixels above the baseline.
+ *
+ * Scales linearly so {@link fullScaleMs} fills the chart band. Any non-zero sample draws at
+ * least one pixel so lightweight demos (sub-millisecond `update()` / `render()`) stay visible.
+ *
+ * @param ms - Sample value in milliseconds.
+ * @param chartHeight - Chart band height in pixels.
+ * @param fullScaleMs - Milliseconds that map to full band height.
+ * @returns Clamped offset in pixels (0 when sample is zero).
+ */
+export function computeTimingChartBarHeight(ms: number, chartHeight: number, fullScaleMs: number): number {
+    if (chartHeight <= 0 || ms <= 0 || fullScaleMs <= 0) {
+        return 0;
+    }
+
+    const scaled = Math.floor((ms * chartHeight) / fullScaleMs);
+
+    return Math.min(chartHeight, Math.max(1, scaled));
+}

--- a/src/utils/errorMessages.ts
+++ b/src/utils/errorMessages.ts
@@ -328,9 +328,7 @@ export function btfontGlyphNegativePositionError(charLabel: string): string {
  * @returns User-facing error string.
  */
 export function btfontGlyphNegativeSizeError(charLabel: string): string {
-    return (
-        `The '${charLabel}' glyph has a negative width or height. ` + 'Use 0 or greater for w and h in the .btfont file'
-    );
+    return `The '${charLabel}' glyph has a negative width or height. Use 0 or greater for w and h in the .btfont file`;
 }
 
 /**
@@ -340,7 +338,7 @@ export function btfontGlyphNegativeSizeError(charLabel: string): string {
  * @returns User-facing error string.
  */
 export function btfontGlyphNegativeAdvanceError(charLabel: string): string {
-    return `The '${charLabel}' glyph has a negative advance width. ` + 'Use 0 or greater for adv in the .btfont file';
+    return `The '${charLabel}' glyph has a negative advance width. Use 0 or greater for adv in the .btfont file`;
 }
 
 /**


### PR DESCRIPTION
Implement VV-539 scrolling update/render timing dots with ring buffer sampling, configurable band height and palette style slots, bar background fills for chart and palette bands, and sub-millisecond minimum dot visibility. Wire new HardwareSettings through BTAPI, document timing semantics, and add unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR implements VV-539: an opt-in scrolling timing-chart band for the stats overlay. It records per-frame update/render timings into a ring buffer and renders one-pixel timing dots (with sub-millisecond minimum visibility), with configurable band height and palette/style slots.

## Key Changes

### Core configuration & wiring
- Added optional HardwareSettings fields:
  - statsOverlayTimingChart?: boolean (default false)
  - statsOverlayTimingChartHeight?: number (default documented 22)
  - statsOverlayTimingChartStyle?: StatsOverlayTimingChartStyle (per-slot palette index overrides)
- BTAPI.setupStatsOverlay now forwards these timing-chart settings into StatsOverlay.
- mergeHardwareSettings / configure() updated to merge/clone the new timing-chart options consistently via new helpers (assignIfDefined, shallowCloneOptional). configure() examples split into "overlay off" and "overlay on" cases.

### Stats overlay rendering & behavior
- StatsOverlay constructor accepts timing-chart options, resolves style at construction, and stores timingChartHeight for layout.
- Layout planning includes timingChartHeight; fixed bars are drawn before the timing chart.
- Sampling behavior: timing snapshots are recorded before the overlay visibility check so history advances while hidden; Present FPS sampling is skipped when the overlay is hidden.

### Timing-chart implementation
- Replaced scaffold with a working StatsOverlayTimingChart:
  - Maintains circular buffers for updateMs/renderMs; reset(width) clears buffers when chart width changes.
  - sample(timing) records non-negative samples when enabled and initialized.
  - draw(renderer, chartRect, style) gates on feature flag and non-zero height, ensures buffer width, iterates populated columns and draws two one-pixel vertical timing dots per column (render then update), stacking upward from a baseline.
- computeTimingChartBarHeight(ms, chartHeight, fullScaleMs) helper added: maps ms -> vertical pixels, returns 0 for non-positive inputs, ensures at least 1 pixel for sub-ms samples, clamps at chart height.
- Styling resolution added: resolveStatsOverlayTimingChartStyle derives final palette indices (update/render plus warning/error/event) from overlay style and chart overrides with fallback constants.
- Introduced a resolved draw-style type: StatsOverlayTimingChartDrawStyle (distinct from config-time StatsOverlayTimingChartStyle).

### Exports & constants
- New exports from stats-overlay module: StatsOverlayTimingChartDrawStyle, ResolvedStatsOverlayTimingChartStyle, computeTimingChartBarHeight, resolveStatsOverlayTimingChartStyle.
- Added constants:
  - TIMING_CHART_FULL_SCALE_MS
  - TIMING_CHART_DEFAULT_WARNING_IDX
  - TIMING_CHART_DEFAULT_ERROR_IDX
  - TIMING_CHART_DEFAULT_EVENT_IDX
- BlitTech.ts re-exports StatsOverlayTimingChartStyle type.

### Documentation
- docs/api-core.md updated to document the timing-chart configuration (enable flag, height, style), behavior, palette usage conditions, and timing semantics (Present vs BT.targetFPS, smoothed CPU wall-time samples). configure() examples updated to show overlay off/on and timing-chart settings.

## Testing & fixtures
- New unit tests:
  - timingChartStyle.test.ts: computeTimingChartBarHeight edge cases and resolveStatsOverlayTimingChartStyle behavior (defaults and overrides).
  - StatsOverlayTimingChart.test.ts: bar-height mapping, ring-buffer wraparound and x-positioning, sub-millisecond rendering, distinct palette indices for update vs render, and draw-count expectations.
- Integration tests:
  - StatsOverlay.test.ts: palette-band geometry matching, timing-chart drawing when enabled, history retention while overlay hidden, and disabled behavior.
  - IBlitTechDemo.test.ts: defaultConfig asserts statsOverlayTimingChart defaults to false; mergeHardwareSettings tests for preserving/merging timing-chart fields.
- Test fixtures updated: Rect2i value-import and snapshotting in createMockRenderer to stabilize assertions; other tests hardened to avoid non-null assertions.

## Minor changes
- StatsOverlayBars draws timingChart fill only when plan.timingChart.height > 0.
- layoutPlan JSDoc updated to reference timing-chart opt-in.
- src/render/stats-overlay/index.ts adjusted to re-export new timing-chart types/helpers.
- Simplified formatting of two error-message helpers.

## Public API surface changes
- HardwareSettings (src/core/IBlitTechDemo.ts) extended with:
  - statsOverlayTimingChart?: boolean
  - statsOverlayTimingChartHeight?: number
  - statsOverlayTimingChartStyle?: StatsOverlayTimingChartStyle
- New exported interface/type: StatsOverlayTimingChartStyle (config-time) and exported draw/resolved style types from stats-overlay entry.
- StatsOverlay constructor signature updated to accept timing-chart options (statsOverlayTimingChart, statsOverlayTimingChartStyle, statsOverlayTimingChartHeight).
- StatsOverlayTimingChart gains reset(width) and functional sample/draw methods; draw's style parameter uses the resolved draw-style type.

## Notes for reviewers
- Merge/mergeHelpers refactor touches config-merge logic—review assignIfDefined/shallowCloneOptional for correctness.
- Pay attention to the semantics change where timing samples continue while the overlay is hidden but FPS sampling is skipped.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/187?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->