### PR TITLE
docs(api): reclassify BT.outputSize as derived getter

### DIFF
--- a/.claude/rules/bt-api-getters.md
+++ b/.claude/rules/bt-api-getters.md
@@ -12,18 +12,21 @@ Quick rules when changing `src/BlitTech.ts` or demos:
 
 | Category | Members |
 | - | - |
-| Configure-time (mirror `HardwareSettings` names) | `displaySize`, `canvasDisplaySize`, `targetFPS`, `outputSize` |
+| Configure-time (mirror `HardwareSettings` names) | `displaySize`, `canvasDisplaySize`, `targetFPS` |
+| Derived | `outputSize` (`canvasDisplaySize ?? displaySize`; no `HardwareSettings` field) |
+| Configure-time (backend) | `requestedBackend` (mirrors `HardwareSettings.backend`) |
 | Loop timing | `deltaSeconds`, `timeSeconds`, `ticks` |
 | Runtime state | `activeBackend`, `camera`, `palette` |
 | Per-frame input | `pointerScrollDelta`, `inputString`, `gamepadCount` |
 
-`outputSize` = effective buffer (`canvasDisplaySize ?? displaySize`). `Vector2i` getters return a clone per read.
-`activeBackend` is what actually started after fallback, not `configure().backend`.
+`Vector2i` getters return a clone per read. `activeBackend` is what actually started after fallback, not
+`configure().backend`.
 `palette` is a live reference - mutating slots affects rendering on the next frame.
 
 ## Naming when adding getters
 
 - Match `HardwareSettings` field name exactly for configure values (`targetFPS`, not `fps` or `targetFps`)
+- Use a derived getter when the value is computed from configure fields (`outputSize`); do not add a matching field
 - Use a runtime-descriptive name when no configure field exists (`activeBackend`, not `renderer`)
 
 Cursor: `.cursor/rules/bt-api-getters.mdc` (always applied in this repo).

--- a/.claude/skills/bt-review/SKILL.md
+++ b/.claude/skills/bt-review/SKILL.md
@@ -33,7 +33,8 @@ Review current changes against project rules and quality standards.
    - Consistent naming conventions
    - **BT API shape:** read-only zero-arg snapshots use getters (`BT.displaySize`, `BT.targetFPS`), not `BT.foo()`.
      Actions and parameterized queries stay methods. New configure mirrors use `HardwareSettings` field names
-     (`targetFPS`, not `fps`). See `CLAUDE.md` (**BT API: getters vs methods**).
+     (`targetFPS`, not `fps`). Derived getters (e.g. `outputSize`) have no matching field. See `CLAUDE.md` (**BT API:
+     getters vs methods**).
 
 4. **Summarize findings**
    - List critical issues that must be fixed

--- a/.cursor/rules/bt-api-getters.mdc
+++ b/.cursor/rules/bt-api-getters.mdc
@@ -11,7 +11,8 @@ When editing `src/BlitTech.ts`, demos, or API docs:
 
 Zero-argument **read-only** values on `BT`:
 
-- **Configure-time** (use same names as `HardwareSettings`): `displaySize`, `canvasDisplaySize`, `targetFPS`, `outputSize`
+- **Configure-time** (use same names as `HardwareSettings`): `displaySize`, `canvasDisplaySize`, `targetFPS`
+- **Derived:** `outputSize` (`canvasDisplaySize ?? displaySize`; no `HardwareSettings` field)
 - **Configure-time (backend):** `requestedBackend` mirrors resolved `HardwareSettings.backend` (includes `?backend=software`)
 - **Loop:** `deltaSeconds`, `timeSeconds`, `ticks`
 - **Runtime:** `activeBackend`, `camera`, `palette`
@@ -37,7 +38,7 @@ Bad: `BT.displaySize()`, `BT.fps()`, `BT.getActiveBackend()` (removed; use prope
 
 1. Zero args + read-only snapshot → **getter** on `BT`
 2. Takes args or mutates → **method**
-3. Mirrors configure? → **same field name** as `HardwareSettings`
+3. Mirrors configure? → **same field name** as `HardwareSettings` (exception: derived getters like `outputSize` have no field)
 4. Update `docs/api-*.md`, `CLAUDE.md`, demos if public
 
 See `CLAUDE.md` section **BT API: getters vs methods** and `docs/api-core.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,13 +160,14 @@ and async work. Do not add new zero-argument `BT.foo()` functions when a getter 
 
 ### Use getters (property access, no `()`)
 
-| Category                                                         | Members                                                       | Notes                                                                                                        |
-| ---------------------------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| **Configure-time** (mirror {@link HardwareSettings} field names) | `displaySize`, `canvasDisplaySize`, `targetFPS`, `outputSize` | `outputSize` = effective buffer (`canvasDisplaySize ?? displaySize`). Clone per read for `Vector2i` getters. |
-| **Loop timing**                                                  | `deltaSeconds`, `timeSeconds`, `ticks`                        | `targetFPS` is configured rate, not measured FPS.                                                            |
-| **Configure-time (backend)**                                     | `requestedBackend`                                            | Resolved `HardwareSettings.backend` after merge and `?backend=software`; defaults to `'webgpu'`.             |
-| **Runtime state**                                                | `activeBackend`, `camera`, `palette`                          | `activeBackend` is what actually started (after fallback). `palette` is a live reference.                    |
-| **Per-frame input**                                              | `pointerScrollDelta`, `inputString`, `gamepadCount`           | Read once per frame when needed.                                                                             |
+| Category                                                         | Members                                             | Notes                                                                                                       |
+| ---------------------------------------------------------------- | --------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| **Configure-time** (mirror {@link HardwareSettings} field names) | `displaySize`, `canvasDisplaySize`, `targetFPS`     | Clone per read for `Vector2i` getters.                                                                      |
+| **Derived**                                                      | `outputSize`                                        | Effective drawing buffer (`canvasDisplaySize ?? displaySize`). No `HardwareSettings` field; clone per read. |
+| **Loop timing**                                                  | `deltaSeconds`, `timeSeconds`, `ticks`              | `targetFPS` is configured rate, not measured FPS.                                                           |
+| **Configure-time (backend)**                                     | `requestedBackend`                                  | Mirrors resolved `HardwareSettings.backend` after merge and `?backend=software`; defaults to `'webgpu'`.    |
+| **Runtime state**                                                | `activeBackend`, `camera`, `palette`                | `activeBackend` is what actually started (after fallback). `palette` is a live reference.                   |
+| **Per-frame input**                                              | `pointerScrollDelta`, `inputString`, `gamepadCount` | Read once per frame when needed.                                                                            |
 
 Examples: `BT.displaySize.y`, `BT.targetFPS`, `BT.ticks % 60`, `if (BT.activeBackend === 'software')`.
 
@@ -182,6 +183,8 @@ Examples: `BT.displaySize.y`, `BT.targetFPS`, `BT.ticks % 60`, `if (BT.activeBac
 ### Naming when adding getters
 
 - **Same name as `HardwareSettings`** when exposing configure values (`targetFPS`, not `fps` or `targetFps`).
+- **Derived getters** when the value is computed from configure fields (`outputSize` from
+  `canvasDisplaySize ?? displaySize`); do not add a matching `HardwareSettings` field.
 - **Descriptive runtime names** when there is no configure field (`activeBackend`, not `renderer`).
 - **`requestedBackend` vs `activeBackend`:** use `requestedBackend` for the resolved init request; use `activeBackend`
   for runtime gates (post-process, capture). They differ when WebGPU was requested but fell back to software.

--- a/docs/api-core.md
+++ b/docs/api-core.md
@@ -128,10 +128,16 @@ returns `false` and logs a specific `[BT]` message to the browser console (press
 stays a generic init failure message. In WebGPU mode, the requested logical and output sizes must also fit the active
 adapter/device `maxTextureDimension2D` limit. GPU limit failures do not fall back to the software renderer.
 
-**`BT` getters vs `configure()` fields:** `displaySize`, `canvasDisplaySize`, and `targetFPS` on `BT` mirror the same
-names on `HardwareSettings`. `outputSize` is the derived drawing-buffer size — see
-[Resolution model](#resolution-model). `requestedBackend` mirrors resolved `HardwareSettings.backend` (including URL
-overrides). `activeBackend` is the backend that actually started and may differ after WebGPU fallback.
+**`BT` getters vs `configure()` fields:**
+
+| Kind        | `BT` getter                                       | `HardwareSettings` field |
+| ----------- | ------------------------------------------------- | ------------------------ |
+| **Mirror**  | `displaySize`, `canvasDisplaySize`, `targetFPS`   | same names               |
+| **Mirror**  | `requestedBackend`                                | `backend`                |
+| **Derived** | `outputSize` (`canvasDisplaySize ?? displaySize`) | _(none)_                 |
+
+`activeBackend` is runtime state (what actually started; may differ from `requestedBackend` after WebGPU fallback). See
+[Resolution model](#resolution-model) for drawing-buffer vocabulary.
 
 ### Requested vs active backend
 

--- a/docs/developer-experience-guide.md
+++ b/docs/developer-experience-guide.md
@@ -135,10 +135,10 @@ AI-assisted commits add a trailer: `Co-Authored-By: Claude <noreply@anthropic.co
   parameterized queries, and async work are methods (`BT.cameraSet`, `BT.pointerPos(0)`). Full rules:
   [CLAUDE.md](../CLAUDE.md) (**BT API: getters vs methods**).
 - **`BT` getter names** that surface `configure()` / `HardwareSettings` use the **same field names** (`displaySize`,
-  `targetFPS`, `canvasDisplaySize`, …). Keep acronym spelling consistent (`targetFPS`, not `targetFps`). Runtime-only
-  reads use descriptive names (`activeBackend`, `requestedBackend`, `ticks`, `deltaSeconds`). Use `activeBackend` for
-  runtime capability checks; `requestedBackend` mirrors resolved `HardwareSettings.backend` (including
-  `?backend=software`).
+  `targetFPS`, `canvasDisplaySize`, …). `BT.outputSize` is **derived** (`canvasDisplaySize ?? displaySize`), not a
+  configure field. Keep acronym spelling consistent (`targetFPS`, not `targetFps`). Runtime-only reads use descriptive
+  names (`activeBackend`, `requestedBackend`, `ticks`, `deltaSeconds`). Use `activeBackend` for runtime capability
+  checks; `requestedBackend` mirrors resolved `HardwareSettings.backend` (including `?backend=software`).
 
 ---
 


### PR DESCRIPTION
Document BT.outputSize as canvasDisplaySize ?? displaySize with no HardwareSettings field. Update CLAUDE.md, Cursor/Claude getter rules, api-core.md mirror/derived table, DX guide, and bt-review skill so configure mirrors stay displaySize, canvasDisplaySize, targetFPS, and backend (requestedBackend).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

Documentation-only change reclassifying `BT.outputSize` as a derived getter computed from `canvasDisplaySize ?? displaySize`, removing its prior association with `HardwareSettings` fields. Updates multiple documentation and guidance files to reflect this distinction and clarify the relationship between BT getters and their corresponding configure-time fields.

## Changes

**`.claude/rules/bt-api-getters.md`**  
Restructured the "Getter list" section to distinguish configure-time fields (including `requestedBackend`), derived getters (`outputSize`), loop timing, runtime state, and per-frame input. Reiterates that Vector2i getters clone-per-read, `activeBackend` reflects post-fallback state, and `palette` is a live reference.

**`CLAUDE.md`**  
Updated the BT getters table to categorize `outputSize` as derived (computed from `canvasDisplaySize ?? displaySize`). Added naming guideline clarifying that derived getters use descriptive names and do not mirror `HardwareSettings` fields.

**`docs/api-core.md`**  
Replaced prior paragraph description with a structured table mapping BT getters (`displaySize`, `canvasDisplaySize`, `targetFPS`, `requestedBackend`, `outputSize`) to their corresponding `HardwareSettings` fields. Added clarification that `activeBackend` is runtime state potentially differing after WebGPU fallback.

**`.cursor/rules/bt-api-getters.mdc`**  
Refined BT getter guidance to treat `outputSize` as derived rather than configure-time. Updated the "New API checklist" to note that derived getters (like `outputSize`) have no matching `HardwareSettings` field.

**`.claude/skills/bt-review/SKILL.md`**  
Clarified that `targetFPS` uses the `HardwareSettings` field name (not `fps`). Noted that derived getters lack matching fields and referenced `CLAUDE.md` for detailed guidance.

**`docs/developer-experience-guide.md`**  
Reflowed explanatory text covering `targetFPS`/`canvasDisplaySize` field naming, acronym spelling, and `activeBackend`/`requestedBackend` distinction. No substantive content changes.

## Summary

- **Lines changed:** +35/-21 across six documentation files
- **Review effort:** Low to Medium
- **Impact:** Clarifies getter classification and maintains configure mirrors: `displaySize`, `canvasDisplaySize`, `targetFPS`, `requestedBackend`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/188?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->