### PR TITLE
feat(renderer): hide stats overlay body by default and split footer bands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ src/
       StatsOverlayTimingChart.ts  # Scrolling update/render timing chart band (opt-in via statsOverlayTimingChart)
       StatsOverlayPaletteView.ts  # Palette swatch grid (opt-in via statsOverlayPaletteView)
       StatsOverlayBars.ts  # Fixed and custom row bars + labels
-      StatsOverlayToggle.ts # Backquote and corner toggle input
+      StatsOverlayToggle.ts # Backquote and bottom-left corner toggle input
     PrimitivePipeline.ts   # Batched geometry writing palette indices (pixels, lines, rects)
     SpritePipeline.ts      # Batched textured quads (sprites, bitmap text)
     PostProcessChain.ts    # Tier-aware fullscreen effect chain

--- a/docs/api-core.md
+++ b/docs/api-core.md
@@ -114,6 +114,9 @@ example no `drawingBufferSize` means a 1:1 drawing buffer).
 | `outputUpscaleFilter`           | `'nearest' \| 'linear'`        | `'nearest'` | Upscale filter                                                       |
 | `detectDroppedFrames`           | `boolean`                      | `false`     | Log a console warning on missed vsync                                |
 | `statsOverlayEnabled`           | `boolean`                      | `true`      | Engine stats HUD after each `render()`                               |
+| `statsOverlayVisibleAtStart`    | `boolean`                      | `false`     | Show overlay body (metrics/palette/custom rows) on first frame       |
+| `statsOverlayToggleHintVisible` | `boolean`                      | `true`      | Draw `[~]` hint bar while overlay body is hidden                     |
+| `statsOverlayToggleEnabled`     | `boolean`                      | `true`      | Enable Backquote and bottom-left corner toggle input                 |
 | `statsOverlayPaletteView`       | `boolean`                      | `false`     | Live palette swatch grid in the stats overlay bottom band (opt-in)   |
 | `statsOverlayPaletteColumns`    | `number`                       | _unset_     | Max palette swatches per grid row (default: widest fit)              |
 | `statsOverlayStyle`             | `StatsOverlayStyle`            | _unset_     | Optional bar/text palette indices for stats overlay                  |
@@ -189,10 +192,17 @@ configure() {
 ### Stats overlay
 
 When `statsOverlayEnabled` is `true` (default), the engine draws a screen-space HUD after each demo `render()` call, on
-top of all demo content. Bar bands and text anchors are computed each frame by the internal layout planner in
-`src/render/stats-overlay/layoutPlan.ts` from `displaySize`, custom row count, and optional feature flags (timing chart
-default off; palette grid opt-in via `statsOverlayPaletteView`). Init still caches stable values such as the
-bottom-right toggle rect and text baselines from the system font metrics.
+top of all demo content. The **overlay body** (title, metrics, timing chart, palette grid, custom rows) starts
+**hidden** unless `statsOverlayVisibleAtStart: true`. While the body is hidden, the engine may still draw the **toggle
+hint** (13 px `[~]` bar) when `statsOverlayToggleHintVisible` is `true` (default). Bar bands and text anchors for the
+full body are computed each frame by the internal layout planner in `src/render/stats-overlay/layoutPlan.ts` from
+`displaySize`, custom row count, and optional feature flags (timing chart default off; palette grid opt-in via
+`statsOverlayPaletteView`). Init still caches stable values such as the bottom-left toggle rect and text baselines from
+the system font metrics.
+
+**Migration note:** Upgrading demos now starts with the overlay body hidden. Teaching demos that relied on
+always-visible metrics should opt back in with `statsOverlayVisibleAtStart: true` in `configure()` until authors choose
+otherwise.
 
 - **Top row 1 (left):** short demo title derived from `document.title` (registry pages titled
   `Blit-Tech Demo NNN - Topic` show as `Topic Demo`); **top row 1 (right):** active backend and logical resolution (for
@@ -207,21 +217,21 @@ bottom-right toggle rect and text baselines from the system font metrics.
 - **Top row 2 (left):** `Present: N FPS | Target: T FPS | Draw Calls: C`
 - **Top row 3 (left):** `Frame: Xms | update(): Yms | render(): Zms` (shows `xN` on `update()` when multiple fixed
   updates ran this frame)
-- **Bottom band:** default **13 px** hint bar with the `[~]` toggle label anchored bottom-right. Set
-  `statsOverlayPaletteView: true` to replace it with a live palette swatch grid showing every active palette slot; slots
-  referenced by demo draw calls this frame are filled with their color, and unused slots render as empty squares with a
-  small centered marker. The timing chart and palette grid bands use the same `statsOverlayStyle.barPaletteIndex` fill
-  as the other overlay rows (bars draw first; chart dots and swatches render on top). Palette usage tracking (sprite and
-  bitmap-text pixel scans) runs only when the stats overlay is enabled, `statsOverlayPaletteView` is true, **and** the
-  overlay body is visible (not hidden with Backquote or the corner toggle). Default demos do not pay that scanning cost
-  while the overlay is hidden.
+- **Bottom band:** default **13 px** hint bar with the `[~]` toggle label anchored bottom-left (over the toggle hit
+  region). Set `statsOverlayPaletteView: true` to stack a live palette swatch grid **above** a **1 px** gap and that
+  hint bar; slots referenced by demo draw calls this frame are filled with their color, and unused slots render as empty
+  squares with a small centered marker. The timing chart and palette grid bands use the same
+  `statsOverlayStyle.barPaletteIndex` fill as the other overlay rows (bars draw first; chart dots and swatches render on
+  top). Palette usage tracking (sprite and bitmap-text pixel scans) runs only when the stats overlay is enabled,
+  `statsOverlayPaletteView` is true, **and** the overlay body is visible (not hidden with Backquote or the corner
+  toggle). Default demos do not pay that scanning cost while the overlay is hidden.
 - **Custom rows (optional):** extra bars from `statsOverlayRows()` stacked above the bottom band, **1 px** apart, each
   with left text and optional right text (same 13 px bar style as the built-in rows)
 
 Demos may implement optional `statsOverlayRows()` on `IBlitTechDemo`. The engine calls it once per render frame after
-`render()` when the overlay is enabled and visible (not hidden with Backquote or the corner toggle). Return `undefined`
-or an empty array when no custom rows are needed. Reuse the same array and row objects when possible; update `leftText`
-/ `rightText` in place to avoid per-frame allocations.
+`render()` when the overlay is enabled and the **body** is visible (not hidden with Backquote or the corner toggle).
+Return `undefined` or an empty array when no custom rows are needed. Reuse the same array and row objects when possible;
+update `leftText` / `rightText` in place to avoid per-frame allocations.
 
 ```ts
 /** @implements {IBlitTechDemo} */
@@ -236,10 +246,13 @@ class Demo {
 }
 ```
 
-Toggle visibility at runtime with **Backquote** (`~`) or a primary pointer press in the **bottom-right 48x48 px**
-corner. Set `statsOverlayEnabled: false` in `configure()` to disable the overlay and all toggle input (for example
-release builds). On WebGPU, the stats overlay uses two late batches: {@link IRenderer.drawRectFillOnTop} for bar fills
-above demo sprites, then {@link IRenderer.drawBitmapTextOnTop} for labels above those bars.
+Toggle overlay **body** visibility at runtime with **Backquote** (`~`) or a primary pointer press in the **bottom-left
+48x48 px** corner when `statsOverlayToggleEnabled` is `true` (default). Set `statsOverlayToggleHintVisible: false` to
+hide the hint bar while the body stays hidden. Set `statsOverlayToggleEnabled: false` to lock body visibility at
+`statsOverlayVisibleAtStart`. Set `statsOverlayEnabled: false` in `configure()` to disable the overlay subsystem and all
+toggle input (for example release builds). On WebGPU, the stats overlay uses two late batches: {@link
+IRenderer.drawRectFillOnTop} for bar fills above demo sprites, then {@link IRenderer.drawBitmapTextOnTop} for labels
+above those bars.
 
 Overlay colors follow one path: use `statsOverlayStyle` when set, otherwise defaults `1` (bar) and `2` (text). You can
 override globally in `configure()` with `statsOverlayStyle: { barPaletteIndex, textPaletteIndex }`, or per custom row on
@@ -250,22 +263,26 @@ The overlay label `Present: N FPS` is **not** the same as `BT.targetFPS`: presen
 is visible. `Frame`, `update()`, and `render()` timings are smoothed CPU wall-time samples from `performance.now()`
 shown in the text row; the optional timing chart uses **raw** per-frame `updateMs` / `renderMs` from the prior frame.
 Those demo-only timings **exclude** stats overlay draw (overlay runs after `render()` is timed); `Frame` includes the
-full present frame including overlay and GPU present. When the overlay is hidden, chart history still records demo
-`update()` / `render()` samples and palette usage tracking is off. `Draw Calls` counts demo-issued draw API calls during
-the rendered frame. Do not use present FPS for simulation timing—use `BT.ticks`, `BT.deltaSeconds`, or `Timer` instead.
+full present frame including overlay and GPU present. When the overlay body is hidden, chart history still records demo
+`update()` / `render()` samples, the toggle hint may still draw, and palette usage tracking is off. `Draw Calls` counts
+demo-issued draw API calls during the rendered frame. Do not use present FPS for simulation timing—use `BT.ticks`,
+`BT.deltaSeconds`, or `Timer` instead.
 
 Demos should not duplicate engine stats text; the overlay provides it. Reserve about **14 px** per custom overlay row
 above the bottom band (13 px bar + 1 px gap). When drawing custom top or bottom HUD panels, leave about **42 px** clear
 at the top (three built-in text rows + gaps; add `statsOverlayTimingChartHeight` or **22 px** when
 `statsOverlayTimingChart: true`). Leave about **13 px** clear at the bottom by default (hint bar). When
-`statsOverlayPaletteView: true`, reserve additional space for the palette grid—for example about **69 px** on the
-default `320×240` layout with a 256-slot palette (32 columns × 8 rows of 7 px swatches with 1 px gaps). Column count is
-chosen by halving from `palette.size` until the row fits `displayWidth - 2 * edgeMargin`. The bottom band height is:
+`statsOverlayPaletteView: true`, reserve additional space for the palette grid, the **1 px** row gap, and the **13 px**
+hint bar—for example about **83 px** on the default `320×240` layout with a 256-slot palette (32 columns × 8 rows of 7
+px swatches with 1 px gaps, plus the gap and hint bar). Column count is chosen by halving from `palette.size` until the
+row fits `displayWidth - 2 * edgeMargin`. The footer band height matches `resolveStatsOverlayFooterHeight()` in
+`layoutPlan.ts`:
 
 ```text
 cols = pickPaletteGridColumnCount(displayWidth, swatchSize, gap, palette.size, maxColumns?)
 rows = ceil(palette.size / cols)
-bottomReserve = rows * swatchSize + max(0, rows - 1) * gap + 2 * paletteGridPadding
+paletteGridHeight = rows * swatchSize + max(0, rows - 1) * gap + 2 * paletteGridPadding
+bottomReserve = paletteGridHeight + 1 + 13
 ```
 
 Default swatch size is **7 px** with **1 px** gaps and **3 px** padding above and below the grid. Set

--- a/src/core/BTAPI.test.ts
+++ b/src/core/BTAPI.test.ts
@@ -30,6 +30,7 @@ import type { SpriteSheet } from '../assets/SpriteSheet';
 import { BT } from '../BlitTech';
 import type { Effect } from '../render/effects/Effect';
 import { DEFAULT_IDX_TEXT, STATS_EDGE_MARGIN_PX } from '../render/stats-overlay/constants';
+import { paletteBandY } from '../render/stats-overlay/layoutPlan';
 import {
     computePaletteGrid,
     DEFAULT_PALETTE_SWATCH_SIZE,
@@ -838,6 +839,12 @@ describe('BTAPI', () => {
             const customRows: StatsOverlayRow[] = [{ leftText: 'Position: 1, 2' }];
             const demo: IBlitTechDemo = {
                 ...makeMockDemo(),
+                configure: vi.fn().mockReturnValue({
+                    displaySize: new Vector2i(320, 240),
+                    drawingBufferSize: new Vector2i(640, 480),
+                    targetFPS: 60,
+                    statsOverlayVisibleAtStart: true,
+                }),
                 statsOverlayRows: vi.fn().mockReturnValue(customRows),
             };
             const overlaySpy = vi.spyOn(StatsOverlay.prototype, 'updateAndRender');
@@ -1166,7 +1173,7 @@ describe('BTAPI', () => {
             expect(markSpy).not.toHaveBeenCalled();
         });
 
-        it('scans sprite and bitmap-text palette usage when statsOverlayPaletteView is true and overlay is visible', async () => {
+        it('scans sprite and bitmap-text palette usage when statsOverlayPaletteView is true and overlay body is visible', async () => {
             const markSpy = vi.fn();
             const mockSheet = makeIndexizedSpriteSheet(markSpy);
             const mockFont = {
@@ -1178,6 +1185,7 @@ describe('BTAPI', () => {
                     displaySize: new Vector2i(320, 240),
                     targetFPS: 60,
                     statsOverlayPaletteView: true,
+                    statsOverlayVisibleAtStart: true,
                 }),
                 init: vi.fn().mockResolvedValue(true),
                 update: vi.fn(),
@@ -1194,7 +1202,7 @@ describe('BTAPI', () => {
             expect(markSpy).toHaveBeenCalledTimes(2);
         });
 
-        it('skips palette scans when the palette grid is enabled but the overlay is hidden', async () => {
+        it('skips palette scans when the palette grid is enabled but the overlay body is hidden', async () => {
             const markSpy = vi.fn();
             const mockSheet = makeIndexizedSpriteSheet(markSpy);
             const demo: IBlitTechDemo = {
@@ -1214,14 +1222,36 @@ describe('BTAPI', () => {
 
             const overlay = getStatsOverlay();
             expect(overlay).not.toBeNull();
+            expect(overlay?.bodyVisible).toBe(false);
+            expect(overlay?.tracksPaletteUsage).toBe(false);
 
-            overlay?.handleToggle(
-                null,
-                {
-                    isKeyPressed: (key: string) => key === 'Backquote',
-                } as never,
-                1,
-            );
+            BTAPI.instance.drawSprite(mockSheet, new Rect2i(0, 0, 16, 16), new Vector2i(0, 0));
+
+            expect(markSpy).not.toHaveBeenCalled();
+        });
+
+        it('skips palette scans when the overlay body is hidden even if the toggle hint is visible', async () => {
+            const markSpy = vi.fn();
+            const mockSheet = makeIndexizedSpriteSheet(markSpy);
+            const demo: IBlitTechDemo = {
+                configure: () => ({
+                    displaySize: new Vector2i(320, 240),
+                    targetFPS: 60,
+                    statsOverlayPaletteView: true,
+                    statsOverlayToggleHintVisible: true,
+                }),
+                init: vi.fn().mockResolvedValue(true),
+                update: vi.fn(),
+                render: vi.fn(),
+            };
+
+            await BTAPI.instance.init(demo, makeMockCanvas());
+            BTAPI.instance.setPalette(new Palette(16));
+            stubRendererDrawCalls();
+
+            const overlay = getStatsOverlay();
+            expect(overlay).not.toBeNull();
+            expect(overlay?.bodyVisible).toBe(false);
             expect(overlay?.tracksPaletteUsage).toBe(false);
 
             BTAPI.instance.drawSprite(mockSheet, new Rect2i(0, 0, 16, 16), new Vector2i(0, 0));
@@ -1242,12 +1272,13 @@ describe('BTAPI', () => {
             );
 
             const palette = Palette.cga();
-            const usedSlots = [1, 2] as const;
+            const usedSlots = [5, 6] as const;
             const demo: IBlitTechDemo = {
                 configure: () => ({
                     displaySize: new Vector2i(320, 240),
                     targetFPS: 60,
                     statsOverlayPaletteView: true,
+                    statsOverlayVisibleAtStart: true,
                 }),
                 init: vi.fn().mockResolvedValue(true),
                 update: vi.fn(),
@@ -1299,17 +1330,17 @@ describe('BTAPI', () => {
             const maskScratch: number[] = [];
 
             expect(usedMask).toBeDefined();
-            expect(collectUsedRenderPaletteIndices(usedMask as Uint8Array, palette.size, maskScratch)).toEqual([1, 2]);
+            expect(collectUsedRenderPaletteIndices(usedMask as Uint8Array, palette.size, maskScratch)).toEqual([5, 6]);
 
             const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, palette.size, PALETTE_SWATCH_GAP_PX);
-            const bottomAreaY = 240 - grid.totalHeight;
+            const paletteBandTop = paletteBandY(240, grid.totalHeight);
             const { cols, swatchSize, gap } = grid;
 
             for (const slot of usedSlots) {
                 const col = slot % cols;
                 const row = Math.floor(slot / cols);
                 const x = STATS_EDGE_MARGIN_PX + col * (swatchSize + gap);
-                const y = bottomAreaY + PALETTE_GRID_PADDING_PX + row * (swatchSize + gap);
+                const y = paletteBandTop + PALETTE_GRID_PADDING_PX + row * (swatchSize + gap);
 
                 expect(
                     swatchFills.some(
@@ -1327,7 +1358,7 @@ describe('BTAPI', () => {
             const unusedCol = unusedSlot % cols;
             const unusedRow = Math.floor(unusedSlot / cols);
             const unusedX = STATS_EDGE_MARGIN_PX + unusedCol * (swatchSize + gap);
-            const unusedY = bottomAreaY + PALETTE_GRID_PADDING_PX + unusedRow * (swatchSize + gap);
+            const unusedY = paletteBandTop + PALETTE_GRID_PADDING_PX + unusedRow * (swatchSize + gap);
 
             expect(
                 swatchFills.some(
@@ -1357,6 +1388,7 @@ describe('BTAPI', () => {
                     displaySize: new Vector2i(320, 240),
                     targetFPS: 60,
                     statsOverlayPaletteView: true,
+                    statsOverlayVisibleAtStart: true,
                 }),
                 init: vi.fn().mockResolvedValue(true),
                 update: vi.fn(),
@@ -1400,6 +1432,7 @@ describe('BTAPI', () => {
                     displaySize: new Vector2i(320, 240),
                     targetFPS: 60,
                     statsOverlayPaletteView: true,
+                    statsOverlayVisibleAtStart: true,
                 }),
                 init: vi.fn().mockResolvedValue(true),
                 update: vi.fn(),
@@ -1461,6 +1494,7 @@ describe('BTAPI', () => {
                     displaySize: new Vector2i(320, 240),
                     targetFPS: 60,
                     statsOverlayPaletteView: true,
+                    statsOverlayVisibleAtStart: true,
                 }),
                 init: vi.fn().mockResolvedValue(true),
                 update: vi.fn(),
@@ -1472,6 +1506,7 @@ describe('BTAPI', () => {
 
             const overlay = getStatsOverlay();
             expect(overlay).not.toBeNull();
+            expect(overlay?.bodyVisible).toBe(true);
 
             drainRafUntilRenderCount(1);
 

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -412,6 +412,9 @@ export class BTAPI {
             hw.statsOverlayTimingChart === true,
             hw.statsOverlayTimingChartStyle,
             hw.statsOverlayTimingChartHeight,
+            hw.statsOverlayVisibleAtStart === true,
+            hw.statsOverlayToggleHintVisible !== false,
+            hw.statsOverlayToggleEnabled !== false,
         );
     }
 

--- a/src/core/IBlitTechDemo.test.ts
+++ b/src/core/IBlitTechDemo.test.ts
@@ -65,6 +65,24 @@ describe('defaultConfig', () => {
         expect(settings.statsOverlayPaletteView).toBe(false);
     });
 
+    it('should hide stats overlay body by default', () => {
+        const settings = defaultConfig();
+
+        expect(settings.statsOverlayVisibleAtStart).toBe(false);
+    });
+
+    it('should show stats overlay toggle hint by default', () => {
+        const settings = defaultConfig();
+
+        expect(settings.statsOverlayToggleHintVisible).toBe(true);
+    });
+
+    it('should enable stats overlay toggle input by default', () => {
+        const settings = defaultConfig();
+
+        expect(settings.statsOverlayToggleEnabled).toBe(true);
+    });
+
     it('should disable stats overlay timing chart by default', () => {
         const settings = defaultConfig();
 
@@ -140,6 +158,18 @@ describe('mergeHardwareSettings', () => {
 
         expect(settings.statsOverlayStyle?.barPaletteIndex).toBe(2);
         expect(settings.statsOverlayStyle?.textPaletteIndex).toBe(3);
+    });
+
+    it('merges stats overlay visibility and toggle flags from configure()', () => {
+        const settings = mergeHardwareSettings({
+            statsOverlayVisibleAtStart: true,
+            statsOverlayToggleHintVisible: false,
+            statsOverlayToggleEnabled: false,
+        });
+
+        expect(settings.statsOverlayVisibleAtStart).toBe(true);
+        expect(settings.statsOverlayToggleHintVisible).toBe(false);
+        expect(settings.statsOverlayToggleEnabled).toBe(false);
     });
 
     it('merges statsOverlayTimingChart flags from configure()', () => {

--- a/src/core/IBlitTechDemo.ts
+++ b/src/core/IBlitTechDemo.ts
@@ -114,17 +114,39 @@ export interface HardwareSettings {
     /**
      * When `true` (default), the engine draws a screen-space stats overlay after
      * each demo `render()` call (FPS, target rate, resolution, backend, demo title).
-     * Users can hide or show it with Backquote or a primary press in the
-     * bottom-right 48x48 px corner. Set to `false` to disable the overlay and all
-     * toggle input (for release builds that must not expose debug HUD).
+     * The overlay body starts hidden unless {@link statsOverlayVisibleAtStart} is
+     * `true`. Users can show or hide the body with Backquote or a primary press in
+     * the bottom-left 48x48 px corner when {@link statsOverlayToggleEnabled} is
+     * `true`. Set to `false` to disable the overlay subsystem and all toggle input
+     * (for release builds that must not expose debug HUD).
      */
     statsOverlayEnabled?: boolean;
 
     /**
+     * When `true`, the overlay body (metrics bars, palette grid, custom rows) is
+     * visible on the first frame. Defaults to `false` in {@link defaultConfig}; the
+     * toggle hint may still draw when {@link statsOverlayToggleHintVisible} is `true`.
+     */
+    statsOverlayVisibleAtStart?: boolean;
+
+    /**
+     * When `true` (default), the engine draws the `[~]` toggle hint while the overlay
+     * body is hidden. Set to `false` for expert/minimal demos that want no on-screen
+     * overlay affordance until the body is shown.
+     */
+    statsOverlayToggleHintVisible?: boolean;
+
+    /**
+     * When `true` (default), Backquote and the bottom-left corner pointer press toggle
+     * overlay body visibility. Set to `false` to lock body visibility at
+     * {@link statsOverlayVisibleAtStart}.
+     */
+    statsOverlayToggleEnabled?: boolean;
+
+    /**
      * When `true`, the engine draws a live palette swatch grid in the stats overlay
-     * bottom band showing the active indexed palette. Defaults to `false` in
-     * {@link defaultConfig}; set to `true` to opt in. When `false`, the legacy 13 px
-     * hint bar is shown instead.
+     * footer stacked above the hint bar. Defaults to `false` in {@link defaultConfig};
+     * set to `true` to opt in.
      */
     statsOverlayPaletteView?: boolean;
 
@@ -198,9 +220,9 @@ export interface StatsOverlayTimingChartStyle {
 /**
  * One optional stats-overlay row supplied by a demo (left label, optional right label).
  *
- * Rendered as a 13 px bar stacked above the bottom palette grid (or legacy hint bar when
- * {@link HardwareSettings.statsOverlayPaletteView} is `false`) with 1 px gaps. Reuse the same
- * array instance from {@link IBlitTechDemo.statsOverlayRows} when possible to avoid
+ * Rendered as a 13 px bar stacked above the footer (palette grid + hint bar when
+ * {@link HardwareSettings.statsOverlayPaletteView} is `true`, or the hint bar alone) with 1 px gaps.
+ * Reuse the same array instance from {@link IBlitTechDemo.statsOverlayRows} when possible to avoid
  * per-frame allocations.
  */
 export interface StatsOverlayRow {
@@ -297,7 +319,7 @@ export interface IBlitTechDemo {
      * Optional hook returning extra stats-overlay rows for the current frame.
      *
      * Called once per render frame after `render()` when {@link HardwareSettings.statsOverlayEnabled}
-     * is `true` and the overlay is visible (not hidden via Backquote or corner toggle). Rows stack
+     * is `true` and the overlay body is visible (not hidden via Backquote or corner toggle). Rows stack
      * upward from just above the bottom `[~]` bar (1 px gap between bars). Omit this hook or return
      * an empty array when no custom rows are needed.
      *
@@ -331,6 +353,9 @@ export function defaultConfig(): HardwareSettings {
         outputUpscaleFilter: 'nearest',
         backend: 'webgpu',
         statsOverlayEnabled: true,
+        statsOverlayVisibleAtStart: false,
+        statsOverlayToggleHintVisible: true,
+        statsOverlayToggleEnabled: true,
         statsOverlayPaletteView: false,
         statsOverlayTimingChart: false,
     };
@@ -411,6 +436,50 @@ function resolveExplicitOptionalVector(
 }
 
 /**
+ * Copies a defined scalar or object field from `partial` into `picked`.
+ *
+ * @param picked - Output partial settings.
+ * @param partial - Values returned by the demo's `configure()` hook.
+ * @param key - Hardware settings field to copy when defined.
+ */
+function pickIfDefinedPartial<K extends keyof HardwareSettings>(
+    picked: Partial<HardwareSettings>,
+    partial: Partial<HardwareSettings>,
+    key: K,
+): void {
+    /* eslint-disable security/detect-object-injection -- key is keyof HardwareSettings */
+    if (partial[key] !== undefined) {
+        picked[key] = partial[key];
+    }
+    /* eslint-enable security/detect-object-injection */
+}
+
+/**
+ * Copies defined stats overlay fields from `partial` into `picked`.
+ *
+ * @param picked - Output partial settings.
+ * @param partial - Values returned by the demo's `configure()` hook.
+ */
+function pickDefinedStatsOverlaySettings(picked: Partial<HardwareSettings>, partial: Partial<HardwareSettings>): void {
+    pickIfDefinedPartial(picked, partial, 'statsOverlayEnabled');
+    pickIfDefinedPartial(picked, partial, 'statsOverlayVisibleAtStart');
+    pickIfDefinedPartial(picked, partial, 'statsOverlayToggleHintVisible');
+    pickIfDefinedPartial(picked, partial, 'statsOverlayToggleEnabled');
+    pickIfDefinedPartial(picked, partial, 'statsOverlayPaletteView');
+    pickIfDefinedPartial(picked, partial, 'statsOverlayPaletteColumns');
+    pickIfDefinedPartial(picked, partial, 'statsOverlayTimingChart');
+    pickIfDefinedPartial(picked, partial, 'statsOverlayTimingChartHeight');
+
+    if (partial.statsOverlayStyle !== undefined) {
+        picked.statsOverlayStyle = { ...partial.statsOverlayStyle };
+    }
+
+    if (partial.statsOverlayTimingChartStyle !== undefined) {
+        picked.statsOverlayTimingChartStyle = { ...partial.statsOverlayTimingChartStyle };
+    }
+}
+
+/**
  * Copies only defined fields from a partial configure() return value.
  *
  * @param partial - Values returned by the demo's `configure()` hook.
@@ -434,49 +503,11 @@ function pickDefinedHardwareSettings(partial: Partial<HardwareSettings>): Partia
         picked.maxCanvasSize = pickedMaxCanvasSize;
     }
 
-    if (partial.targetFPS !== undefined) {
-        picked.targetFPS = partial.targetFPS;
-    }
-
-    if (partial.outputUpscaleFilter !== undefined) {
-        picked.outputUpscaleFilter = partial.outputUpscaleFilter;
-    }
-
-    if (partial.detectDroppedFrames !== undefined) {
-        picked.detectDroppedFrames = partial.detectDroppedFrames;
-    }
-
-    if (partial.backend !== undefined) {
-        picked.backend = partial.backend;
-    }
-
-    if (partial.statsOverlayEnabled !== undefined) {
-        picked.statsOverlayEnabled = partial.statsOverlayEnabled;
-    }
-
-    if (partial.statsOverlayPaletteView !== undefined) {
-        picked.statsOverlayPaletteView = partial.statsOverlayPaletteView;
-    }
-
-    if (partial.statsOverlayPaletteColumns !== undefined) {
-        picked.statsOverlayPaletteColumns = partial.statsOverlayPaletteColumns;
-    }
-
-    if (partial.statsOverlayStyle !== undefined) {
-        picked.statsOverlayStyle = { ...partial.statsOverlayStyle };
-    }
-
-    if (partial.statsOverlayTimingChart !== undefined) {
-        picked.statsOverlayTimingChart = partial.statsOverlayTimingChart;
-    }
-
-    if (partial.statsOverlayTimingChartHeight !== undefined) {
-        picked.statsOverlayTimingChartHeight = partial.statsOverlayTimingChartHeight;
-    }
-
-    if (partial.statsOverlayTimingChartStyle !== undefined) {
-        picked.statsOverlayTimingChartStyle = { ...partial.statsOverlayTimingChartStyle };
-    }
+    pickIfDefinedPartial(picked, partial, 'targetFPS');
+    pickIfDefinedPartial(picked, partial, 'outputUpscaleFilter');
+    pickIfDefinedPartial(picked, partial, 'detectDroppedFrames');
+    pickIfDefinedPartial(picked, partial, 'backend');
+    pickDefinedStatsOverlaySettings(picked, partial);
 
     return picked;
 }
@@ -584,9 +615,28 @@ function assignFullDefaultMergeScalars(
 
     assignIfDefined(
         optionals,
+        'statsOverlayVisibleAtStart',
+        picked.statsOverlayVisibleAtStart ?? defaults.statsOverlayVisibleAtStart,
+    );
+
+    assignIfDefined(
+        optionals,
+        'statsOverlayToggleHintVisible',
+        picked.statsOverlayToggleHintVisible ?? defaults.statsOverlayToggleHintVisible,
+    );
+
+    assignIfDefined(
+        optionals,
+        'statsOverlayToggleEnabled',
+        picked.statsOverlayToggleEnabled ?? defaults.statsOverlayToggleEnabled,
+    );
+
+    assignIfDefined(
+        optionals,
         'statsOverlayPaletteView',
         picked.statsOverlayPaletteView ?? defaults.statsOverlayPaletteView,
     );
+
     assignIfDefined(optionals, 'statsOverlayPaletteColumns', picked.statsOverlayPaletteColumns);
 
     assignIfDefined(
@@ -681,6 +731,10 @@ function mergePartialWithFullDefaults(
         displaySize: cloneVector2i(defaults.displaySize),
         targetFPS: picked.targetFPS ?? defaults.targetFPS,
         statsOverlayEnabled: picked.statsOverlayEnabled ?? defaults.statsOverlayEnabled ?? true,
+        statsOverlayVisibleAtStart: picked.statsOverlayVisibleAtStart ?? defaults.statsOverlayVisibleAtStart ?? false,
+        statsOverlayToggleHintVisible:
+            picked.statsOverlayToggleHintVisible ?? defaults.statsOverlayToggleHintVisible ?? true,
+        statsOverlayToggleEnabled: picked.statsOverlayToggleEnabled ?? defaults.statsOverlayToggleEnabled ?? true,
         statsOverlayPaletteView: picked.statsOverlayPaletteView ?? defaults.statsOverlayPaletteView ?? false,
         ...buildFullDefaultMergeOptionals(partial, picked, defaults),
     };
@@ -704,6 +758,10 @@ function mergeExplicitDisplayProfile(
         displaySize: resolveExplicitDisplaySize(partial.displaySize, picked.displaySize, defaults.displaySize),
         targetFPS: picked.targetFPS ?? defaults.targetFPS,
         statsOverlayEnabled: picked.statsOverlayEnabled ?? defaults.statsOverlayEnabled ?? true,
+        statsOverlayVisibleAtStart: picked.statsOverlayVisibleAtStart ?? defaults.statsOverlayVisibleAtStart ?? false,
+        statsOverlayToggleHintVisible:
+            picked.statsOverlayToggleHintVisible ?? defaults.statsOverlayToggleHintVisible ?? true,
+        statsOverlayToggleEnabled: picked.statsOverlayToggleEnabled ?? defaults.statsOverlayToggleEnabled ?? true,
         statsOverlayPaletteView: picked.statsOverlayPaletteView ?? defaults.statsOverlayPaletteView ?? false,
         backend: picked.backend ?? defaults.backend ?? 'webgpu',
         ...buildExplicitDisplayOptionals(partial, picked),

--- a/src/render/stats-overlay/StatsOverlay.test.ts
+++ b/src/render/stats-overlay/StatsOverlay.test.ts
@@ -8,7 +8,8 @@ import { Palette } from '../../assets/Palette';
 import { markRenderPaletteIndexUsed } from '../../core/RenderPaletteUsage';
 import { Vector2i } from '../../utils/Vector2i';
 import { STATS_BAR_HEIGHT, STATS_ROW_GAP_PX } from './constants';
-import { createStatsOverlayLayout, statsRightAlignedTextX } from './layoutHelpers';
+import { createStatsOverlayLayout, statsRightAlignedTextX, statsToggleHintTextX } from './layoutHelpers';
+import { hintBarY, paletteBandY } from './layoutPlan';
 import { StatsOverlay } from './StatsOverlay';
 import { computePaletteGrid } from './StatsOverlayPaletteView';
 import {
@@ -24,6 +25,42 @@ import {
 /** Default overlay tests use the 13 px hint bar (palette grid opt-in off). */
 const STATS_OVERLAY_PALETTE_VIEW_OFF = false;
 
+interface StatsOverlayTestOptions {
+    style?: { barPaletteIndex?: number; textPaletteIndex?: number };
+    paletteView?: boolean;
+    paletteColumns?: number;
+    timingChart?: boolean;
+    timingChartStyle?: { updateBarPaletteIndex?: number; renderBarPaletteIndex?: number };
+    timingChartHeight?: number;
+    visibleAtStart?: boolean;
+    toggleHintVisible?: boolean;
+    toggleEnabled?: boolean;
+    backend?: 'webgpu' | 'software';
+}
+
+/** Builds a {@link StatsOverlay} with explicit VV-546 visibility defaults for tests. */
+function createOverlay(
+    layout: ReturnType<typeof createStatsOverlayLayout>,
+    label: string,
+    options: StatsOverlayTestOptions = {},
+): StatsOverlay {
+    return new StatsOverlay(
+        layout,
+        label,
+        60,
+        options.backend ?? 'webgpu',
+        options.style,
+        options.paletteView ?? STATS_OVERLAY_PALETTE_VIEW_OFF,
+        options.paletteColumns,
+        options.timingChart ?? false,
+        options.timingChartStyle,
+        options.timingChartHeight,
+        options.visibleAtStart ?? false,
+        options.toggleHintVisible ?? true,
+        options.toggleEnabled ?? true,
+    );
+}
+
 /** Builds a usage mask from palette slot indices for tests. */
 function buildUsageMask(indices: readonly number[], size = 256): Uint8Array {
     const mask = new Uint8Array(size);
@@ -38,14 +75,14 @@ function buildUsageMask(indices: readonly number[], size = 256): Uint8Array {
 describe('StatsOverlay', () => {
     it('tracksPaletteUsage is false when palette grid is disabled', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(layout, 'Test Demo', 60, 'webgpu', undefined, STATS_OVERLAY_PALETTE_VIEW_OFF);
+        const overlay = createOverlay(layout, 'Test Demo');
 
         expect(overlay.tracksPaletteUsage).toBe(false);
     });
 
     it('tracksPaletteUsage follows palette grid opt-in and visibility toggle', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(layout, 'Test Demo', 60, 'webgpu', undefined, true);
+        const overlay = createOverlay(layout, 'Test Demo', { paletteView: true, visibleAtStart: true });
 
         expect(overlay.tracksPaletteUsage).toBe(true);
 
@@ -60,11 +97,11 @@ describe('StatsOverlay', () => {
         expect(overlay.tracksPaletteUsage).toBe(false);
     });
 
-    it('starts visible and toggles visibility', () => {
+    it('starts hidden by default and toggles body visibility', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(layout, 'Test Demo', 60, 'webgpu', undefined, STATS_OVERLAY_PALETTE_VIEW_OFF);
+        const overlay = createOverlay(layout, 'Test Demo');
 
-        expect(overlay.visible).toBe(true);
+        expect(overlay.bodyVisible).toBe(false);
 
         overlay.handleToggle(
             null,
@@ -74,7 +111,7 @@ describe('StatsOverlay', () => {
             1,
         );
 
-        expect(overlay.visible).toBe(false);
+        expect(overlay.bodyVisible).toBe(true);
 
         overlay.handleToggle(
             null,
@@ -84,13 +121,13 @@ describe('StatsOverlay', () => {
             2,
         );
 
-        expect(overlay.visible).toBe(true);
+        expect(overlay.bodyVisible).toBe(false);
     });
 
-    it('draws top and bottom overlay labels', () => {
+    it('draws top and bottom overlay labels when body is visible', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
         const topLeftLabel = 'Patterns Demo';
-        const overlay = new StatsOverlay(layout, topLeftLabel, 60, 'webgpu', undefined, STATS_OVERLAY_PALETTE_VIEW_OFF);
+        const overlay = createOverlay(layout, topLeftLabel, { visibleAtStart: true });
         const renderer = createMockRenderer();
 
         overlay.updateAndRender(renderer, mockFont, null, null, 0);
@@ -98,8 +135,8 @@ describe('StatsOverlay', () => {
         const calls = getBitmapTextCalls(renderer);
         const topRightLabel = 'webgpu | 320x240';
         const topRightX = statsRightAlignedTextX(topRightLabel, 320);
-        const bottomRightLabel = '[~]';
-        const bottomRightX = statsRightAlignedTextX(bottomRightLabel, 320);
+        const bottomHintLabel = '[~]';
+        const bottomHintX = statsToggleHintTextX();
 
         expect(calls).toHaveLength(5);
         expect(calls[0]).toEqual({
@@ -126,15 +163,15 @@ describe('StatsOverlay', () => {
         expect(calls[3]?.text).toContain(' | update(): ');
         expect(calls[3]?.text).toContain(' | render(): ');
         expect(calls[4]).toEqual({
-            pos: new Vector2i(bottomRightX, layout.bottomTextY),
-            text: bottomRightLabel,
+            pos: new Vector2i(bottomHintX, layout.bottomTextY),
+            text: bottomHintLabel,
             paletteOffset: 1,
         });
     });
 
     it('uses activeBackend for the top-right label', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(layout, 'Demo', 60, 'software', undefined, STATS_OVERLAY_PALETTE_VIEW_OFF);
+        const overlay = createOverlay(layout, 'Demo', { backend: 'software', visibleAtStart: true });
         const renderer = createMockRenderer();
 
         overlay.updateAndRender(renderer, mockFont, null, null, 0);
@@ -145,7 +182,7 @@ describe('StatsOverlay', () => {
 
     it('uses provided frame timings and shows update-step suffix when multiple updates ran', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu', undefined, STATS_OVERLAY_PALETTE_VIEW_OFF);
+        const overlay = createOverlay(layout, 'Demo', { visibleAtStart: true });
         const renderer = createMockRenderer();
 
         overlay.updateAndRender(renderer, mockFont, null, null, 0, undefined, {
@@ -163,21 +200,55 @@ describe('StatsOverlay', () => {
         expect(calls[3]?.text).toContain('render(): 3.8ms');
     });
 
-    it('skips draw calls when hidden', () => {
+    it('skips draw calls when body is hidden and the toggle hint is disabled', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu', undefined, STATS_OVERLAY_PALETTE_VIEW_OFF);
+        const overlay = createOverlay(layout, 'Demo', { toggleHintVisible: false });
         const renderer = createMockRenderer();
 
-        overlay.handleToggle(null, { isKeyPressed: (key: string) => key === 'Backquote' } as never, 1);
-        overlay.updateAndRender(renderer, mockFont, null, null, 2);
+        overlay.updateAndRender(renderer, mockFont, null, null, 0);
 
         expect(renderer.drawRectFillOnTop).not.toHaveBeenCalled();
         expect(renderer.drawBitmapTextOnTop).not.toHaveBeenCalled();
     });
 
+    it('draws hint-only path while body is hidden and toggle hint is visible', () => {
+        const layout = createStatsOverlayLayout(320, 240, 14);
+        const overlay = createOverlay(layout, 'Demo');
+        const renderer = createMockRenderer();
+        const bottomHintLabel = '[~]';
+        const bottomHintX = statsToggleHintTextX();
+
+        overlay.updateAndRender(renderer, mockFont, null, null, 0);
+
+        expect(getRectFillCalls(renderer)).toHaveLength(1);
+        expect(getRectFillCalls(renderer)[0]).toMatchObject({ y: hintBarY(240), height: STATS_BAR_HEIGHT, width: 320 });
+        expect(getBitmapTextCalls(renderer)).toEqual([
+            {
+                pos: new Vector2i(bottomHintX, layout.bottomTextY),
+                text: bottomHintLabel,
+                paletteOffset: 1,
+            },
+        ]);
+    });
+
+    it('does not draw the palette band while body is hidden even when palette view is enabled', () => {
+        const layout = createStatsOverlayLayout(320, 240, 14);
+        const overlay = createOverlay(layout, 'Demo', { paletteView: true });
+        const renderer = createMockRenderer();
+        const grid = computePaletteGrid(320, undefined, 256);
+
+        overlay.updateAndRender(renderer, mockFont, null, null, 0, undefined, undefined, Palette.vga());
+
+        const fills = getRectFillCalls(renderer);
+
+        expect(fills).toHaveLength(1);
+        expect(fills[0]).toMatchObject({ y: hintBarY(240), height: STATS_BAR_HEIGHT, width: 320 });
+        expect(fills.some((rect) => rect.y === paletteBandY(240, grid.totalHeight))).toBe(false);
+    });
+
     it('resets camera for overlay draws then restores the saved offset', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu', undefined, STATS_OVERLAY_PALETTE_VIEW_OFF);
+        const overlay = createOverlay(layout, 'Demo', { visibleAtStart: true });
         const renderer = createMockRenderer();
         const saved = new Vector2i(12, 34);
 
@@ -190,7 +261,7 @@ describe('StatsOverlay', () => {
 
     it('uses default overlay palette indices when style is omitted', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu', undefined, STATS_OVERLAY_PALETTE_VIEW_OFF);
+        const overlay = createOverlay(layout, 'Demo', { visibleAtStart: true });
         const renderer = createMockRenderer();
         overlay.updateAndRender(renderer, mockFont, null, null, 0);
 
@@ -202,14 +273,10 @@ describe('StatsOverlay', () => {
 
     it('uses statsOverlayStyle palette indices when provided', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(
-            layout,
-            'Demo',
-            60,
-            'webgpu',
-            { barPaletteIndex: 8, textPaletteIndex: 9 },
-            STATS_OVERLAY_PALETTE_VIEW_OFF,
-        );
+        const overlay = createOverlay(layout, 'Demo', {
+            style: { barPaletteIndex: 8, textPaletteIndex: 9 },
+            visibleAtStart: true,
+        });
         const renderer = createMockRenderer();
         overlay.updateAndRender(renderer, mockFont, null, null, 0);
 
@@ -222,14 +289,10 @@ describe('StatsOverlay', () => {
 
     it('draws custom rows with per-row palette indices', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(
-            layout,
-            'Demo',
-            60,
-            'webgpu',
-            { barPaletteIndex: 2, textPaletteIndex: 3 },
-            STATS_OVERLAY_PALETTE_VIEW_OFF,
-        );
+        const overlay = createOverlay(layout, 'Demo', {
+            style: { barPaletteIndex: 2, textPaletteIndex: 3 },
+            visibleAtStart: true,
+        });
         const renderer = createMockRenderer();
         const customRows = [{ leftText: 'Left', barPaletteIndex: 5, textPaletteIndex: 6 }];
 
@@ -237,7 +300,7 @@ describe('StatsOverlay', () => {
 
         const fills = getRectFillCalls(renderer);
 
-        expect(renderer.drawRectFillOnTop).toHaveBeenCalledWith(fills[4], 5);
+        expect(renderer.drawRectFillOnTop).toHaveBeenCalledWith(fills[3], 5);
 
         const calls = getBitmapTextCalls(renderer);
 
@@ -246,7 +309,7 @@ describe('StatsOverlay', () => {
 
     it('draws custom rows stacked above the bottom bar with 1px gaps', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu', undefined, STATS_OVERLAY_PALETTE_VIEW_OFF);
+        const overlay = createOverlay(layout, 'Demo', { visibleAtStart: true });
         const renderer = createMockRenderer();
         const customRows = [{ leftText: 'Position: 10, 20' }, { leftText: 'Bounces: 3', rightText: 'ok' }];
 
@@ -257,8 +320,9 @@ describe('StatsOverlay', () => {
         const row1BarY = customRowBarY(240, 1);
 
         expect(fills).toHaveLength(6);
-        expect(fills[4]).toMatchObject({ y: row0BarY, width: 320, height: STATS_BAR_HEIGHT });
-        expect(fills[5]).toMatchObject({ y: row1BarY, width: 320, height: STATS_BAR_HEIGHT });
+        expect(fills[3]).toMatchObject({ y: row0BarY, width: 320, height: STATS_BAR_HEIGHT });
+        expect(fills[4]).toMatchObject({ y: row1BarY, width: 320, height: STATS_BAR_HEIGHT });
+        expect(fills[5]).toMatchObject({ y: hintBarY(240), width: 320, height: STATS_BAR_HEIGHT });
         expect(row0BarY - row1BarY).toBe(STATS_BAR_HEIGHT + STATS_ROW_GAP_PX);
 
         const calls = getBitmapTextCalls(renderer);
@@ -284,7 +348,7 @@ describe('StatsOverlay', () => {
 
     it('skips extra custom row draws when customRows is empty', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu', undefined, STATS_OVERLAY_PALETTE_VIEW_OFF);
+        const overlay = createOverlay(layout, 'Demo', { visibleAtStart: true });
         const renderer = createMockRenderer();
 
         overlay.updateAndRender(renderer, mockFont, null, null, 0, () => []);
@@ -295,11 +359,10 @@ describe('StatsOverlay', () => {
 
     it('does not invoke getCustomRows while the overlay is hidden', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu', undefined, STATS_OVERLAY_PALETTE_VIEW_OFF);
+        const overlay = createOverlay(layout, 'Demo');
         const renderer = createMockRenderer();
         const getCustomRows = vi.fn(() => [{ leftText: 'Hidden row' }] as const);
 
-        overlay.handleToggle(null, { isKeyPressed: (key: string) => key === 'Backquote' } as never, 1);
         overlay.updateAndRender(renderer, mockFont, null, null, 0, getCustomRows);
 
         expect(getCustomRows).not.toHaveBeenCalled();
@@ -307,7 +370,7 @@ describe('StatsOverlay', () => {
 
     it('renders palette grid when statsOverlayPaletteView is enabled', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu', undefined, true);
+        const overlay = createOverlay(layout, 'Demo', { paletteView: true, visibleAtStart: true });
         const renderer = createMockRenderer();
         const palette = Palette.vga();
         const usedMask = buildUsageMask([1, 2, 3, 4, 5, 6, 7, 8]);
@@ -316,24 +379,30 @@ describe('StatsOverlay', () => {
         overlay.updateAndRender(renderer, mockFont, null, null, 0, undefined, undefined, palette, usedMask);
 
         const fills = getRectFillCalls(renderer);
-        const bottomBarFill = fills.find(
-            (rect) => rect.y === 240 - grid.totalHeight && rect.height === grid.totalHeight && rect.width === 320,
+        const paletteBandFill = fills.find(
+            (rect) =>
+                rect.y === paletteBandY(240, grid.totalHeight) &&
+                rect.height === grid.totalHeight &&
+                rect.width === 320,
         );
 
-        expect(bottomBarFill).toBeDefined();
+        expect(paletteBandFill).toBeDefined();
+        expect(
+            fills.some((rect) => rect.y === hintBarY(240) && rect.height === STATS_BAR_HEIGHT && rect.width === 320),
+        ).toBe(true);
         expect(renderer.drawRectFillOnTop.mock.calls.length).toBeGreaterThan(4);
     });
 
     it('preserves default hint bar height when palette view is disabled', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu', undefined, false);
+        const overlay = createOverlay(layout, 'Demo', { visibleAtStart: true });
         const renderer = createMockRenderer();
         const palette = Palette.vga();
 
         overlay.updateAndRender(renderer, mockFont, null, null, 0, undefined, undefined, palette);
 
         const fills = getRectFillCalls(renderer);
-        expect(fills[3]).toMatchObject({ y: 227, height: STATS_BAR_HEIGHT, width: 320 });
+        expect(fills[3]).toMatchObject({ y: hintBarY(240), height: STATS_BAR_HEIGHT, width: 320 });
         const swatchCalls = renderer.drawRectFillOnTop.mock.calls.filter(
             (call) => (call[0] as { width: number }).width === 1,
         );
@@ -342,7 +411,7 @@ describe('StatsOverlay', () => {
 
     it('stacks custom rows above the palette grid bottom band', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(layout, 'Demo', 60, 'webgpu', undefined, true);
+        const overlay = createOverlay(layout, 'Demo', { paletteView: true, visibleAtStart: true });
         const renderer = createMockRenderer();
         const palette = Palette.vga();
         const usedMask = buildUsageMask([1, 2, 3, 4, 5, 6, 7, 8]);
@@ -352,7 +421,7 @@ describe('StatsOverlay', () => {
         overlay.updateAndRender(renderer, mockFont, null, null, 0, () => customRows, undefined, palette, usedMask);
 
         const fills = getRectFillCalls(renderer);
-        const row0BarY = customRowBarY(240, 0, grid.totalHeight);
+        const row0BarY = customRowBarY(240, 0, grid.totalHeight + STATS_ROW_GAP_PX + STATS_BAR_HEIGHT);
         const customRowFill = fills.find((rect) => rect.height === STATS_BAR_HEIGHT && rect.y === row0BarY);
 
         expect(customRowFill).toMatchObject({ y: row0BarY, width: 320, height: STATS_BAR_HEIGHT });
@@ -360,18 +429,13 @@ describe('StatsOverlay', () => {
 
     it('draws timing chart dots when statsOverlayTimingChart is enabled', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(
-            layout,
-            'Demo',
-            60,
-            'webgpu',
-            { barPaletteIndex: 8, textPaletteIndex: 9 },
-            STATS_OVERLAY_PALETTE_VIEW_OFF,
-            undefined,
-            true,
-            { updateBarPaletteIndex: 10, renderBarPaletteIndex: 11 },
-            36,
-        );
+        const overlay = createOverlay(layout, 'Demo', {
+            style: { barPaletteIndex: 8, textPaletteIndex: 9 },
+            timingChart: true,
+            timingChartStyle: { updateBarPaletteIndex: 10, renderBarPaletteIndex: 11 },
+            timingChartHeight: 36,
+            visibleAtStart: true,
+        });
         const renderer = createMockRenderer();
 
         overlay.updateAndRender(renderer, mockFont, null, null, 0, undefined, {
@@ -393,17 +457,12 @@ describe('StatsOverlay', () => {
 
     it('does not draw overlay while hidden but keeps timing chart samples for re-show', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(
-            layout,
-            'Demo',
-            60,
-            'webgpu',
-            undefined,
-            STATS_OVERLAY_PALETTE_VIEW_OFF,
-            undefined,
-            true,
-            { updateBarPaletteIndex: 10, renderBarPaletteIndex: 11 },
-        );
+        const overlay = createOverlay(layout, 'Demo', {
+            timingChart: true,
+            timingChartStyle: { updateBarPaletteIndex: 10, renderBarPaletteIndex: 11 },
+            visibleAtStart: true,
+            toggleHintVisible: false,
+        });
         const renderer = createMockRenderer();
 
         overlay.handleToggle(null, { isKeyPressed: (key: string) => key === 'Backquote' } as never, 1);
@@ -431,16 +490,7 @@ describe('StatsOverlay', () => {
 
     it('does not draw timing chart dots when statsOverlayTimingChart is disabled', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
-        const overlay = new StatsOverlay(
-            layout,
-            'Demo',
-            60,
-            'webgpu',
-            undefined,
-            STATS_OVERLAY_PALETTE_VIEW_OFF,
-            undefined,
-            false,
-        );
+        const overlay = createOverlay(layout, 'Demo', { visibleAtStart: true });
         const renderer = createMockRenderer();
 
         overlay.updateAndRender(renderer, mockFont, null, null, 0, undefined, {
@@ -452,5 +502,35 @@ describe('StatsOverlay', () => {
         });
 
         expect(renderer.drawRectFillOnTop.mock.calls.some((call) => call[1] === 10)).toBe(false);
+    });
+
+    it('ignores toggle input when statsOverlayToggleEnabled is false', () => {
+        const layout = createStatsOverlayLayout(320, 240, 14);
+        const overlay = createOverlay(layout, 'Demo', { toggleEnabled: false });
+
+        expect(overlay.bodyVisible).toBe(false);
+
+        overlay.handleToggle(
+            null,
+            {
+                isKeyPressed: () => true,
+            } as never,
+            1,
+        );
+
+        expect(overlay.bodyVisible).toBe(false);
+    });
+
+    it('resets camera for hint-only draws then restores the saved offset', () => {
+        const layout = createStatsOverlayLayout(320, 240, 14);
+        const overlay = createOverlay(layout, 'Demo');
+        const renderer = createMockRenderer();
+        const saved = new Vector2i(12, 34);
+
+        renderer.getCameraOffset = vi.fn(() => saved);
+        overlay.updateAndRender(renderer, mockFont, null, null, 0);
+
+        expect(renderer.resetCamera).toHaveBeenCalledOnce();
+        expect(renderer.setCameraOffset).toHaveBeenCalledWith(saved);
     });
 });

--- a/src/render/stats-overlay/StatsOverlay.ts
+++ b/src/render/stats-overlay/StatsOverlay.ts
@@ -59,7 +59,9 @@ export class StatsOverlay {
 
     readonly #timing: TimingSampler = new TimingSampler();
 
-    readonly #toggle: StatsOverlayToggle = new StatsOverlayToggle();
+    readonly #toggle: StatsOverlayToggle;
+
+    readonly #toggleHintVisible: boolean;
 
     readonly #bars: StatsOverlayBars = new StatsOverlayBars();
 
@@ -94,6 +96,9 @@ export class StatsOverlay {
      * @param statsOverlayTimingChart - When true, draws the update/render timing chart band.
      * @param statsOverlayTimingChartStyle - Optional timing chart palette overrides.
      * @param statsOverlayTimingChartHeight - Chart band height in pixels (default 22).
+     * @param statsOverlayVisibleAtStart - Initial overlay body visibility (default false).
+     * @param statsOverlayToggleHintVisible - Draw toggle hint while body hidden (default true).
+     * @param statsOverlayToggleEnabled - Enable Backquote and corner toggle input (default true).
      */
     constructor(
         layout: StatsOverlayLayout,
@@ -106,6 +111,9 @@ export class StatsOverlay {
         statsOverlayTimingChart = false,
         statsOverlayTimingChartStyle?: StatsOverlayTimingChartStyle,
         statsOverlayTimingChartHeight?: number,
+        statsOverlayVisibleAtStart = false,
+        statsOverlayToggleHintVisible = true,
+        statsOverlayToggleEnabled = true,
     ) {
         this.#layout = layout;
         this.#topLeftLabel = topLeftLabel;
@@ -119,6 +127,8 @@ export class StatsOverlay {
         this.#timingChart = new StatsOverlayTimingChart(statsOverlayTimingChart);
         this.#paletteView = new StatsOverlayPaletteView(statsOverlayPaletteView);
         this.#paletteColumns = paletteColumns;
+        this.#toggle = new StatsOverlayToggle(statsOverlayVisibleAtStart, statsOverlayToggleEnabled);
+        this.#toggleHintVisible = statsOverlayToggleHintVisible;
 
         if (statsOverlayTimingChart) {
             this.#timingChart.reset(layout.displayWidth);
@@ -126,28 +136,28 @@ export class StatsOverlay {
     }
 
     /**
-     * Whether the overlay is currently drawn (runtime toggle).
+     * Whether the overlay body is currently drawn (runtime toggle).
      *
-     * @returns `true` while top and bottom bars are rendered.
+     * @returns `true` while metrics bars and palette grid are rendered.
      */
-    get visible(): boolean {
-        return this.#toggle.visible;
+    get bodyVisible(): boolean {
+        return this.#toggle.bodyVisible;
     }
 
     /**
      * Whether demo draw calls should populate the per-frame palette usage mask.
      *
-     * True when the palette swatch grid is configured and the overlay is visible.
+     * True when the palette swatch grid is configured and the overlay body is visible.
      * BTAPI gates per-frame palette usage tracking on this flag.
      *
      * @returns `true` when sprite/text palette usage scanning is needed.
      */
     get tracksPaletteUsage(): boolean {
-        return this.#paletteView.enabled && this.#toggle.visible;
+        return this.#paletteView.enabled && this.#toggle.bodyVisible;
     }
 
     /**
-     * Handles toggle input (Backquote and bottom-right corner press).
+     * Handles toggle input (Backquote and bottom-left corner press).
      *
      * @param pointer - Pointer subsystem, or `null` when unavailable.
      * @param keyboard - Keyboard subsystem, or `null` when unavailable.
@@ -200,65 +210,116 @@ export class StatsOverlay {
     }
 
     /**
-     * Draws overlay bars, palette grid, and labels for one visible frame.
+     * Builds the per-frame layout plan shared by body and hint-only draws.
+     *
+     * @param customRowCount - Demo custom row count for this frame.
+     * @param palette - Active demo palette, if any.
+     * @returns Layout config and computed plan.
+     */
+    #buildFramePlan(
+        customRowCount: number,
+        palette: Palette | null | undefined,
+    ): { layoutConfig: StatsOverlayLayoutConfig; plan: StatsOverlayLayoutPlan } {
+        const layoutConfig = this.#createLayoutConfig(customRowCount, palette);
+        const plan = buildStatsOverlayLayoutPlan(
+            layoutConfig,
+            this.#layoutScratch,
+            this.#topRightLabel,
+            this.#layout.bottomTextY,
+            this.#layout.toggleRect,
+        );
+
+        return { layoutConfig, plan };
+    }
+
+    /**
+     * Resets camera for screen-space overlay drawing.
+     *
+     * @param renderer - Active renderer.
+     * @param draw - Callback that issues overlay draws.
+     */
+    #withOverlayCamera(renderer: IRenderer, draw: () => void): void {
+        const savedCamera = renderer.getCameraOffset();
+
+        renderer.resetCamera();
+
+        try {
+            draw();
+        } finally {
+            renderer.setCameraOffset(savedCamera);
+        }
+    }
+
+    /**
+     * Draws overlay content for one frame.
+     *
+     * Body panels draw only when {@link bodyVisible} is true. The footer hint bar
+     * and `[~]` label always draw when this method runs.
      *
      * @param renderer - Active renderer.
      * @param font - System bitmap font.
      * @param plan - Computed layout plan for this frame.
      * @param layoutConfig - Layout config used to build the plan.
+     * @param bodyVisible - Whether metrics bars and palette grid should draw.
      * @param customRows - Optional demo rows, if any.
      * @param palette - Active demo palette.
      * @param usedPaletteMask - Per-frame palette usage mask from BTAPI.
      */
-    #renderVisible(
+    #drawFrame(
         renderer: IRenderer,
         font: BitmapFont,
         plan: StatsOverlayLayoutPlan,
         layoutConfig: StatsOverlayLayoutConfig,
+        bodyVisible: boolean,
         customRows: readonly StatsOverlayRow[] | undefined,
         palette: Palette | null | undefined,
         usedPaletteMask: Uint8Array,
     ): void {
-        const updateStepSuffix = this.#timing.updateSteps > 1 ? `x${this.#timing.updateSteps}` : '';
-        const topMetricsLabel = `Present: ${this.#fps.measuredFps} FPS | Target: ${this.#targetFps} FPS | Draw Calls: ${this.#timing.drawCalls}`;
-        const topTimingLabel =
-            `Frame: ${this.#timing.frameMs.toFixed(1)}ms | update(): ${this.#timing.updateMs.toFixed(1)}ms${updateStepSuffix} | ` +
-            `render(): ${this.#timing.renderMs.toFixed(1)}ms`;
-
         this.#barStyle.barIndex = this.#idxBg;
         this.#barStyle.textIndex = this.#idxText;
 
-        this.#bars.drawFixedBars(renderer, plan, this.#idxBg);
+        if (bodyVisible) {
+            const updateStepSuffix = this.#timing.updateSteps > 1 ? `x${this.#timing.updateSteps}` : '';
+            const topMetricsLabel = `Present: ${this.#fps.measuredFps} FPS | Target: ${this.#targetFps} FPS | Draw Calls: ${this.#timing.drawCalls}`;
+            const topTimingLabel =
+                `Frame: ${this.#timing.frameMs.toFixed(1)}ms | update(): ${this.#timing.updateMs.toFixed(1)}ms${updateStepSuffix} | ` +
+                `render(): ${this.#timing.renderMs.toFixed(1)}ms`;
 
-        this.#timingChart.draw(renderer, plan.timingChart, this.#timingChartStyle);
+            this.#bars.drawTopBars(renderer, plan, this.#idxBg);
+            this.#timingChart.draw(renderer, plan.timingChart, this.#timingChartStyle);
 
-        this.#paletteView.draw(
-            renderer,
-            plan.bottomArea,
-            palette ?? null,
-            layoutConfig.paletteGrid ?? DEFAULT_PALETTE_GRID,
-            this.#layout.bottomTextY,
-            this.#layout.displayWidth,
-            this.#layout.lineHeight,
-            usedPaletteMask,
-            this.#idxText,
-        );
+            if (customRows !== undefined && customRows.length > 0) {
+                this.#bars.drawCustomRows(renderer, font, plan, customRows, this.#barStyle);
+            }
 
-        if (customRows !== undefined && customRows.length > 0) {
-            this.#bars.drawCustomRows(renderer, font, plan, customRows, this.#barStyle);
+            this.#bars.drawTopLabels(
+                renderer,
+                font,
+                plan,
+                this.#barStyle,
+                this.#topLeftLabel,
+                this.#topRightLabel,
+                topMetricsLabel,
+                topTimingLabel,
+            );
+
+            this.#bars.drawPaletteBandFill(renderer, plan, this.#idxBg);
+
+            this.#paletteView.draw(
+                renderer,
+                plan.paletteBand,
+                palette ?? null,
+                layoutConfig.paletteGrid ?? DEFAULT_PALETTE_GRID,
+                this.#layout.bottomTextY,
+                this.#layout.displayWidth,
+                this.#layout.lineHeight,
+                usedPaletteMask,
+                this.#idxText,
+            );
         }
 
-        this.#bars.drawFixedLabels(
-            renderer,
-            font,
-            plan,
-            this.#barStyle,
-            this.#topLeftLabel,
-            this.#topRightLabel,
-            topMetricsLabel,
-            topTimingLabel,
-            STATS_BOTTOM_HINT_LABEL,
-        );
+        this.#bars.drawHintBarFill(renderer, plan, this.#idxBg);
+        this.#bars.drawHintLabel(renderer, font, plan, this.#idxText, STATS_BOTTOM_HINT_LABEL);
     }
 
     /**
@@ -270,7 +331,7 @@ export class StatsOverlay {
      * @param _pointer - Reserved; toggle input is handled in BTAPI before render.
      * @param _keyboard - Reserved; toggle input is handled in BTAPI before render.
      * @param _currentTick - Reserved; toggle input is handled in BTAPI before render.
-     * @param getCustomRows - Optional supplier for demo rows; not invoked while the overlay is hidden.
+     * @param getCustomRows - Optional supplier for demo rows; not invoked while the overlay body is hidden.
      * @param timing - Optional timing snapshot from the previous rendered frame.
      * @param palette - Active demo palette for optional palette grid.
      * @param usedPaletteMask - Per-frame palette usage mask populated during demo render.
@@ -286,35 +347,24 @@ export class StatsOverlay {
         palette?: Palette | null,
         usedPaletteMask: Uint8Array = EMPTY_PALETTE_USAGE_MASK,
     ): void {
-        // Chart history keeps advancing while hidden so re-show reflects demo-only timing
-        // (overlay draw is skipped below; palette usage tracking is also off when hidden).
+        // Chart history keeps advancing while hidden so re-show reflects demo-only timing.
         this.#sampleTiming(timing);
 
-        if (!this.#toggle.visible) {
+        const bodyVisible = this.#toggle.bodyVisible;
+
+        if (!bodyVisible && !this.#toggleHintVisible) {
             return;
         }
 
-        this.#fps.sample();
-
-        const customRows = getCustomRows?.();
-        const layoutConfig = this.#createLayoutConfig(customRows?.length ?? 0, palette);
-        const plan = buildStatsOverlayLayoutPlan(
-            layoutConfig,
-            this.#layoutScratch,
-            STATS_BOTTOM_HINT_LABEL,
-            this.#topRightLabel,
-            this.#layout.bottomTextY,
-            this.#layout.toggleRect,
-        );
-
-        const savedCamera = renderer.getCameraOffset();
-
-        renderer.resetCamera();
-
-        try {
-            this.#renderVisible(renderer, font, plan, layoutConfig, customRows, palette, usedPaletteMask);
-        } finally {
-            renderer.setCameraOffset(savedCamera);
+        if (bodyVisible) {
+            this.#fps.sample();
         }
+
+        const customRows = bodyVisible ? getCustomRows?.() : undefined;
+        const { layoutConfig, plan } = this.#buildFramePlan(customRows?.length ?? 0, palette);
+
+        this.#withOverlayCamera(renderer, () => {
+            this.#drawFrame(renderer, font, plan, layoutConfig, bodyVisible, customRows, palette, usedPaletteMask);
+        });
     }
 }

--- a/src/render/stats-overlay/StatsOverlayBars.ts
+++ b/src/render/stats-overlay/StatsOverlayBars.ts
@@ -33,13 +33,13 @@ export class StatsOverlayBars {
     }
 
     /**
-     * Draws built-in top/chart/metrics/timing/bottom bar fills.
+     * Draws title, timing chart, metrics, and timing text bar fills.
      *
      * @param renderer - Active renderer.
      * @param plan - Computed layout plan.
      * @param barIndex - Palette index for bar fills.
      */
-    drawFixedBars(renderer: IRenderer, plan: StatsOverlayLayoutPlan, barIndex: number): void {
+    drawTopBars(renderer: IRenderer, plan: StatsOverlayLayoutPlan, barIndex: number): void {
         renderer.drawRectFillOnTop(plan.titleBar, barIndex);
 
         if (plan.timingChart.height > 0) {
@@ -48,11 +48,55 @@ export class StatsOverlayBars {
 
         renderer.drawRectFillOnTop(plan.metricsBar, barIndex);
         renderer.drawRectFillOnTop(plan.timingTextBar, barIndex);
-        renderer.drawRectFillOnTop(plan.bottomArea, barIndex);
     }
 
     /**
-     * Draws built-in overlay text labels.
+     * Draws the palette band background fill when the overlay body is visible.
+     *
+     * @param renderer - Active renderer.
+     * @param plan - Computed layout plan.
+     * @param barIndex - Palette index for bar fills.
+     */
+    drawPaletteBandFill(renderer: IRenderer, plan: StatsOverlayLayoutPlan, barIndex: number): void {
+        if (plan.paletteBand.height > 0) {
+            renderer.drawRectFillOnTop(plan.paletteBand, barIndex);
+        }
+    }
+
+    /**
+     * Draws the bottom hint bar background fill.
+     *
+     * @param renderer - Active renderer.
+     * @param plan - Computed layout plan.
+     * @param barIndex - Palette index for bar fills.
+     */
+    drawHintBarFill(renderer: IRenderer, plan: StatsOverlayLayoutPlan, barIndex: number): void {
+        renderer.drawRectFillOnTop(plan.hintBar, barIndex);
+    }
+
+    /**
+     * Draws the bottom-left `[~]` toggle hint label.
+     *
+     * @param renderer - Active renderer.
+     * @param font - System bitmap font.
+     * @param plan - Computed layout plan.
+     * @param textIndex - Palette index for the hint label.
+     * @param hintLabel - Toggle hint text (typically `[~]`).
+     */
+    drawHintLabel(
+        renderer: IRenderer,
+        font: BitmapFont,
+        plan: StatsOverlayLayoutPlan,
+        textIndex: number,
+        hintLabel: string,
+    ): void {
+        const textPaletteOffset = statsBitmapTextPaletteOffset(textIndex);
+
+        renderer.drawBitmapTextOnTop(font, plan.hintLabelPos, hintLabel, textPaletteOffset);
+    }
+
+    /**
+     * Draws built-in top overlay text labels (excluding the footer hint).
      *
      * @param renderer - Active renderer.
      * @param font - System bitmap font.
@@ -62,9 +106,8 @@ export class StatsOverlayBars {
      * @param topRightLabel - Backend and resolution (right).
      * @param topMetricsLabel - Present FPS / target / draw calls line.
      * @param topTimingLabel - Frame / update / render ms line.
-     * @param bottomRightLabel - Bottom hint text.
      */
-    drawFixedLabels(
+    drawTopLabels(
         renderer: IRenderer,
         font: BitmapFont,
         plan: StatsOverlayLayoutPlan,
@@ -73,7 +116,6 @@ export class StatsOverlayBars {
         topRightLabel: string,
         topMetricsLabel: string,
         topTimingLabel: string,
-        bottomRightLabel: string,
     ): void {
         const textPaletteOffset = statsBitmapTextPaletteOffset(style.textIndex);
 
@@ -81,7 +123,6 @@ export class StatsOverlayBars {
         renderer.drawBitmapTextOnTop(font, plan.topRightPos, topRightLabel, textPaletteOffset);
         renderer.drawBitmapTextOnTop(font, plan.topMetricsPos, topMetricsLabel, textPaletteOffset);
         renderer.drawBitmapTextOnTop(font, plan.topTimingPos, topTimingLabel, textPaletteOffset);
-        renderer.drawBitmapTextOnTop(font, plan.bottomRightPos, bottomRightLabel, textPaletteOffset);
     }
 
     /**

--- a/src/render/stats-overlay/StatsOverlayPaletteView.alloc.test.ts
+++ b/src/render/stats-overlay/StatsOverlayPaletteView.alloc.test.ts
@@ -9,6 +9,7 @@ import { markRenderPaletteIndexUsed } from '../../core/RenderPaletteUsage';
 import type * as Rect2iModule from '../../utils/Rect2i';
 import { Rect2i } from '../../utils/Rect2i';
 import { createStatsOverlayLayout } from './layoutHelpers';
+import { paletteBandY } from './layoutPlan';
 import { computePaletteGrid, DEFAULT_PALETTE_SWATCH_SIZE, StatsOverlayPaletteView } from './StatsOverlayPaletteView';
 
 const { rect2iAllocStats } = vi.hoisted(() => ({ rect2iAllocStats: { count: 0 } }));
@@ -47,14 +48,14 @@ describe('StatsOverlayPaletteView allocation', () => {
         const palette = Palette.cga();
         const usedMask = buildUsageMask([1, 2, 3]);
         const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, palette.size);
-        const bottomArea = new Rect2i(0, 240 - grid.totalHeight, 320, grid.totalHeight);
+        const paletteBand = new Rect2i(0, paletteBandY(240, grid.totalHeight), 320, grid.totalHeight);
         const view = new StatsOverlayPaletteView(true);
         const renderer = { drawRectFillOnTop: vi.fn() } as never;
 
         for (let i = 0; i < 8; i++) {
             view.draw(
                 renderer,
-                bottomArea,
+                paletteBand,
                 palette,
                 grid,
                 layout.bottomTextY,
@@ -70,7 +71,7 @@ describe('StatsOverlayPaletteView allocation', () => {
         for (let i = 0; i < 64; i++) {
             view.draw(
                 renderer,
-                bottomArea,
+                paletteBand,
                 palette,
                 grid,
                 layout.bottomTextY,
@@ -89,14 +90,14 @@ describe('StatsOverlayPaletteView allocation', () => {
         const palette = Palette.vga();
         const usedMask = buildUsageMask([1, 2, 3, 4, 5]);
         const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, palette.size);
-        const bottomArea = new Rect2i(0, 240 - grid.totalHeight, 320, grid.totalHeight);
+        const paletteBand = new Rect2i(0, paletteBandY(240, grid.totalHeight), 320, grid.totalHeight);
         const view = new StatsOverlayPaletteView(true);
         const renderer = { drawRectFillOnTop: vi.fn() } as never;
 
         for (let i = 0; i < 4; i++) {
             view.draw(
                 renderer,
-                bottomArea,
+                paletteBand,
                 palette,
                 grid,
                 layout.bottomTextY,
@@ -112,7 +113,7 @@ describe('StatsOverlayPaletteView allocation', () => {
         for (let i = 0; i < 32; i++) {
             view.draw(
                 renderer,
-                bottomArea,
+                paletteBand,
                 palette,
                 grid,
                 layout.bottomTextY,

--- a/src/render/stats-overlay/StatsOverlayPaletteView.bench.ts
+++ b/src/render/stats-overlay/StatsOverlayPaletteView.bench.ts
@@ -28,13 +28,13 @@ const layout16 = createStatsOverlayLayout(320, 240, 14);
 const grid16 = computePaletteGrid(320, undefined, 16);
 const palette16 = new Palette(16);
 const usedMask16 = new Uint8Array(256);
-const bottomArea16 = new Rect2i(0, 200, 320, 40);
+const paletteBand16 = new Rect2i(0, 200, 320, 40);
 
 const layout256 = createStatsOverlayLayout(320, 240, 14);
 const grid256 = computePaletteGrid(320, undefined, 256);
 const palette256 = new Palette(256);
 const usedMask256 = new Uint8Array(256);
-const bottomArea256 = new Rect2i(0, 120, 320, 120);
+const paletteBand256 = new Rect2i(0, 120, 320, 120);
 
 const paletteView = new StatsOverlayPaletteView(true);
 
@@ -53,7 +53,7 @@ describe('StatsOverlayPaletteView.draw', () => {
             resetRenderPaletteUsage(usedMask16);
             paletteView.draw(
                 noopRenderer as never,
-                bottomArea16,
+                paletteBand16,
                 palette16,
                 grid16,
                 layout16.bottomTextY,
@@ -72,7 +72,7 @@ describe('StatsOverlayPaletteView.draw', () => {
             resetRenderPaletteUsage(usedMask256);
             paletteView.draw(
                 noopRenderer as never,
-                bottomArea256,
+                paletteBand256,
                 palette256,
                 grid256,
                 layout256.bottomTextY,

--- a/src/render/stats-overlay/StatsOverlayPaletteView.test.ts
+++ b/src/render/stats-overlay/StatsOverlayPaletteView.test.ts
@@ -7,9 +7,9 @@ import { describe, expect, it, vi } from 'vitest';
 import { Palette } from '../../assets/Palette';
 import { markRenderPaletteIndexUsed } from '../../core/RenderPaletteUsage';
 import { Rect2i } from '../../utils/Rect2i';
-import { Vector2i } from '../../utils/Vector2i';
-import { DEFAULT_IDX_TEXT, STATS_EDGE_MARGIN_PX } from './constants';
+import { DEFAULT_IDX_TEXT, STATS_EDGE_MARGIN_PX, STATS_ROW_GAP_PX } from './constants';
 import { createStatsOverlayLayout } from './layoutHelpers';
+import { hintBarY, paletteBandY } from './layoutPlan';
 import {
     computePaletteGrid,
     computeUnusedSwatchMarkerRect,
@@ -53,7 +53,7 @@ function createRectFillMock(): {
 function swatchTopLeft(
     index: number,
     cols: number,
-    bottomAreaY: number,
+    paletteBandTopY: number,
     swatchSize: number,
     gap: number,
 ): { x: number; y: number } {
@@ -62,7 +62,7 @@ function swatchTopLeft(
 
     return {
         x: STATS_EDGE_MARGIN_PX + col * (swatchSize + gap),
-        y: bottomAreaY + PALETTE_GRID_PADDING_PX + row * (swatchSize + gap),
+        y: paletteBandTopY + PALETTE_GRID_PADDING_PX + row * (swatchSize + gap),
     };
 }
 
@@ -146,10 +146,10 @@ describe('StatsOverlayPaletteView.draw', () => {
     it('draws filled swatches for used indices and empty X marks for unused slots', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
         const palette = Palette.cga();
-        const usedMask = buildUsageMask([1, 2]);
+        const usedMask = buildUsageMask([5]);
         const swatchSize = DEFAULT_PALETTE_SWATCH_SIZE;
         const grid = computePaletteGrid(320, swatchSize, palette.size, 1);
-        const bottomAreaY = 240 - grid.totalHeight;
+        const paletteBandTop = paletteBandY(240, grid.totalHeight);
         const view = new StatsOverlayPaletteView(true);
         const { drawRectFillOnTop, calls } = createRectFillMock();
         const renderer = {
@@ -158,7 +158,7 @@ describe('StatsOverlayPaletteView.draw', () => {
 
         view.draw(
             renderer,
-            new Rect2i(0, bottomAreaY, 320, grid.totalHeight),
+            new Rect2i(0, paletteBandTop, 320, grid.totalHeight),
             palette,
             grid,
             layout.bottomTextY,
@@ -170,18 +170,18 @@ describe('StatsOverlayPaletteView.draw', () => {
 
         expect(drawRectFillOnTop).toHaveBeenCalled();
 
-        const usedPos = swatchTopLeft(1, grid.cols, bottomAreaY, swatchSize, grid.gap);
+        const usedPos = swatchTopLeft(5, grid.cols, paletteBandTop, swatchSize, grid.gap);
         const usedSwatch = calls.find(
             (call) =>
                 call.rect.x === usedPos.x &&
                 call.rect.y === usedPos.y &&
                 call.rect.width === swatchSize &&
                 call.rect.height === swatchSize &&
-                call.index === 1,
+                call.index === 5,
         );
         expect(usedSwatch).toBeDefined();
 
-        const unusedPos = swatchTopLeft(3, grid.cols, bottomAreaY, swatchSize, grid.gap);
+        const unusedPos = swatchTopLeft(6, grid.cols, paletteBandTop, swatchSize, grid.gap);
         const unusedSwatchMarker = calls.find(
             (call) =>
                 call.rect.x === unusedPos.x + 2 &&
@@ -197,7 +197,7 @@ describe('StatsOverlayPaletteView.draw', () => {
                 call.rect.x === unusedPos.x &&
                 call.rect.y === unusedPos.y &&
                 call.rect.width === swatchSize &&
-                call.index === 3,
+                call.index === 6,
         );
         expect(unusedSwatchFill).toBeUndefined();
     });
@@ -208,13 +208,13 @@ describe('StatsOverlayPaletteView.draw', () => {
         expect(mask).toEqual(new Uint8Array([0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]));
     });
 
-    it('draws swatches with gaps and skips the bottom-right hint region', () => {
+    it('draws swatches with gaps between cells', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
         const palette = Palette.cga();
         const usedMask = buildUsageMask([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
         const swatchSize = DEFAULT_PALETTE_SWATCH_SIZE;
         const grid = computePaletteGrid(320, swatchSize, palette.size, 1);
-        const bottomAreaY = 240 - grid.totalHeight;
+        const paletteBandTop = paletteBandY(240, grid.totalHeight);
         const view = new StatsOverlayPaletteView(true);
         const { drawRectFillOnTop, calls } = createRectFillMock();
         const renderer = {
@@ -223,7 +223,7 @@ describe('StatsOverlayPaletteView.draw', () => {
 
         view.draw(
             renderer,
-            new Rect2i(0, bottomAreaY, 320, grid.totalHeight),
+            new Rect2i(0, paletteBandTop, 320, grid.totalHeight),
             palette,
             grid,
             layout.bottomTextY,
@@ -235,59 +235,50 @@ describe('StatsOverlayPaletteView.draw', () => {
 
         expect(drawRectFillOnTop).toHaveBeenCalled();
 
-        const swatch0 = swatchTopLeft(0, grid.cols, bottomAreaY, swatchSize, grid.gap);
-        const swatch1 = swatchTopLeft(1, grid.cols, bottomAreaY, swatchSize, grid.gap);
-        const gapX = swatch0.x + swatchSize;
+        const swatch1 = swatchTopLeft(1, grid.cols, paletteBandTop, swatchSize, grid.gap);
+        const swatch3 = swatchTopLeft(3, grid.cols, paletteBandTop, swatchSize, grid.gap);
+        const gapX = swatch1.x + swatchSize;
 
-        expect(calls.some((call) => call.rect.x === swatch0.x && call.rect.y === swatch0.y && call.index === 0)).toBe(
-            false,
+        expect(calls.some((call) => call.rect.x === swatch1.x && call.rect.y === swatch1.y && call.index === 1)).toBe(
+            true,
         );
-
-        const gapPixel = calls.find((call) => call.rect.x === gapX && call.rect.y === swatch0.y);
-        expect(gapPixel).toBeUndefined();
-
-        const nextSwatchPixel = calls.find(
-            (call) =>
-                call.rect.x === swatch1.x &&
-                call.rect.y === swatch1.y &&
-                call.rect.width === swatchSize &&
-                call.index === 1,
-        );
-        expect(nextSwatchPixel).toBeDefined();
+        expect(calls.find((call) => call.rect.x === gapX && call.rect.y === swatch1.y)).toBeUndefined();
+        expect(
+            calls.find(
+                (call) =>
+                    call.rect.x === swatch3.x &&
+                    call.rect.y === swatch3.y &&
+                    call.rect.width === swatchSize &&
+                    call.index === 3,
+            ),
+        ).toBeDefined();
     });
 
-    it('draws full column width on rows inside the toggle hit region', () => {
+    it('keeps palette swatches above the dedicated hint bar', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
         const palette = new Palette(256);
         const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, palette.size, 1, 36);
-        const bottomAreaY = 240 - grid.totalHeight;
-        const swatchOriginY = bottomAreaY + 3;
+        const paletteBandTop = paletteBandY(240, grid.totalHeight);
+        const swatchOriginY = paletteBandTop + PALETTE_GRID_PADDING_PX;
         const view = new StatsOverlayPaletteView(true);
         const drawRectFillOnTop = vi.fn();
         const renderer = { drawRectFillOnTop } as never;
-        const row = 5;
-        const col = 35;
-        const index = row * grid.cols + col;
-        const expectedX = 3 + col * (grid.swatchSize + grid.gap);
-        const expectedY = swatchOriginY + row * (grid.swatchSize + grid.gap);
 
         view.draw(
             renderer,
-            new Rect2i(0, bottomAreaY, 320, grid.totalHeight),
+            new Rect2i(0, paletteBandTop, 320, grid.totalHeight),
             palette,
             grid,
             layout.bottomTextY,
             layout.displayWidth,
             layout.lineHeight,
-            buildUsageMask([index]),
+            buildUsageMask([0]),
             DEFAULT_IDX_TEXT,
         );
 
-        const lastColSwatch = drawRectFillOnTop.mock.calls.find(
-            (call) => (call[0] as Rect2i).x === expectedX && (call[0] as Rect2i).y === expectedY,
-        );
-        expect(lastColSwatch).toBeDefined();
-        expect(layout.toggleRect.contains(new Vector2i(expectedX, expectedY))).toBe(true);
+        const bottomRowY = swatchOriginY + (grid.rows - 1) * (grid.swatchSize + grid.gap);
+
+        expect(bottomRowY + grid.swatchSize).toBeLessThanOrEqual(hintBarY(240) - STATS_ROW_GAP_PX);
     });
 
     it('is a no-op when disabled', () => {

--- a/src/render/stats-overlay/StatsOverlayPaletteView.ts
+++ b/src/render/stats-overlay/StatsOverlayPaletteView.ts
@@ -10,7 +10,7 @@ import type { Palette } from '../../assets/Palette';
 import { Rect2i } from '../../utils/Rect2i';
 import type { IRenderer } from '../IRenderer';
 import { STATS_BOTTOM_HINT_LABEL, STATS_EDGE_MARGIN_PX } from './constants';
-import { statsRightAlignedTextX } from './layoutHelpers';
+import { statsToggleHintTextWidth, statsToggleHintTextX } from './layoutHelpers';
 import type { PaletteGridLayout } from './types';
 
 /** Default swatch size in pixels. */
@@ -174,7 +174,7 @@ const hintExclusionCache = {
 };
 
 /**
- * Returns the screen-space rect reserved for the bottom-right `[~]` hint label.
+ * Returns the screen-space rect reserved for the bottom-left `[~]` hint label.
  *
  * Reuses {@link hintExclusionCache.rect} when `bottomTextY`, `displayWidth`, and
  * `lineHeight` match the previous call.
@@ -193,17 +193,13 @@ function resolveHintExclusionRect(bottomTextY: number, displayWidth: number, lin
         return hintExclusionCache.rect;
     }
 
-    const hintLeft = statsRightAlignedTextX(STATS_BOTTOM_HINT_LABEL, displayWidth);
+    const hintLeft = statsToggleHintTextX();
 
     hintExclusionCache.bottomTextY = bottomTextY;
     hintExclusionCache.displayWidth = displayWidth;
     hintExclusionCache.lineHeight = lineHeight;
-    hintExclusionCache.rect.set(
-        hintLeft,
-        bottomTextY,
-        Math.max(0, displayWidth - STATS_EDGE_MARGIN_PX - hintLeft),
-        lineHeight,
-    );
+
+    hintExclusionCache.rect.set(hintLeft, bottomTextY, statsToggleHintTextWidth(STATS_BOTTOM_HINT_LABEL), lineHeight);
 
     return hintExclusionCache.rect;
 }
@@ -333,7 +329,7 @@ function drawPaletteSwatch(
  * Draws the full palette swatch grid inside the bottom band.
  *
  * @param renderer - Active renderer.
- * @param bottomArea - Bottom band rect from layout plan.
+ * @param paletteBand - Palette band rect from layout plan.
  * @param colorCount - Active palette slot count.
  * @param grid - Precomputed grid layout.
  * @param hintExclusion - Region to skip for the `[~]` hint label.
@@ -342,7 +338,7 @@ function drawPaletteSwatch(
  */
 function drawPaletteSwatchGrid(
     renderer: IRenderer,
-    bottomArea: Rect2i,
+    paletteBand: Rect2i,
     colorCount: number,
     grid: PaletteGridLayout,
     hintExclusion: Rect2i,
@@ -350,8 +346,8 @@ function drawPaletteSwatchGrid(
     unusedMarkIndex: number,
 ): void {
     const { cols, swatchSize, gap } = grid;
-    const originX = bottomArea.x + STATS_EDGE_MARGIN_PX;
-    const originY = bottomArea.y + PALETTE_GRID_PADDING_PX;
+    const originX = paletteBand.x + STATS_EDGE_MARGIN_PX;
+    const originY = paletteBand.y + PALETTE_GRID_PADDING_PX;
     const swatchScratch = paletteGridDrawScratch.swatch;
     const markerScratch = paletteGridDrawScratch.marker;
 
@@ -399,10 +395,10 @@ export class StatsOverlayPaletteView {
      * Draws palette swatches in the bottom band.
      *
      * @param renderer - Active renderer.
-     * @param bottomArea - Bottom band rect from layout plan.
+     * @param paletteBand - Palette band rect from layout plan.
      * @param palette - Active demo palette.
      * @param grid - Precomputed grid layout.
-     * @param bottomTextY - Baseline Y for the bottom-right `[~]` hint.
+     * @param bottomTextY - Baseline Y for the bottom-left `[~]` hint.
      * @param displayWidth - Logical display width for hint exclusion.
      * @param lineHeight - System font line height for hint exclusion.
      * @param usedMask - Per-frame usage mask populated during demo render.
@@ -410,7 +406,7 @@ export class StatsOverlayPaletteView {
      */
     draw(
         renderer: IRenderer,
-        bottomArea: Rect2i,
+        paletteBand: Rect2i,
         palette: Palette | null,
         grid: PaletteGridLayout,
         bottomTextY: number,
@@ -425,6 +421,6 @@ export class StatsOverlayPaletteView {
 
         const hintExclusion = resolveHintExclusionRect(bottomTextY, displayWidth, lineHeight);
 
-        drawPaletteSwatchGrid(renderer, bottomArea, palette.size, grid, hintExclusion, usedMask, unusedMarkIndex);
+        drawPaletteSwatchGrid(renderer, paletteBand, palette.size, grid, hintExclusion, usedMask, unusedMarkIndex);
     }
 }

--- a/src/render/stats-overlay/StatsOverlayToggle.ts
+++ b/src/render/stats-overlay/StatsOverlayToggle.ts
@@ -6,27 +6,40 @@ import { POINTER_PRIMARY_BUTTON, STATS_TOGGLE_KEY_CODE } from './constants';
 import { isPointerInStatsToggleCorner } from './layoutHelpers';
 
 /**
- * Handles stats overlay visibility toggle input (Backquote and corner pointer).
+ * Handles stats overlay body visibility toggle input (Backquote and corner pointer).
  */
 export class StatsOverlayToggle {
-    #visible = true;
+    #bodyVisible: boolean;
+
+    readonly #toggleEnabled: boolean;
 
     /**
-     * Whether the overlay is currently drawn (runtime toggle).
+     * Creates toggle state from configure-time visibility and input flags.
      *
-     * @returns `true` while bars are rendered.
+     * @param visibleAtStart - Initial overlay body visibility from configure.
+     * @param toggleEnabled - When false, toggle input is ignored.
      */
-    get visible(): boolean {
-        return this.#visible;
+    constructor(visibleAtStart = false, toggleEnabled = true) {
+        this.#bodyVisible = visibleAtStart;
+        this.#toggleEnabled = toggleEnabled;
     }
 
     /**
-     * Handles toggle input (Backquote and bottom-right corner press).
+     * Whether the overlay body is currently drawn (runtime toggle).
+     *
+     * @returns `true` while metrics bars and palette grid are rendered.
+     */
+    get bodyVisible(): boolean {
+        return this.#bodyVisible;
+    }
+
+    /**
+     * Handles toggle input (Backquote and bottom-left corner press).
      *
      * @param pointer - Pointer subsystem, or `null` when unavailable.
      * @param keyboard - Keyboard subsystem, or `null` when unavailable.
      * @param currentTick - Current fixed-update tick for keyboard edge detection.
-     * @param toggleRect - Bottom-right toggle hit region.
+     * @param toggleRect - Bottom-left toggle hit region.
      */
     handleToggle(
         pointer: PointerInput | null,
@@ -34,8 +47,13 @@ export class StatsOverlayToggle {
         currentTick: number,
         toggleRect: Rect2i,
     ): void {
+        if (!this.#toggleEnabled) {
+            return;
+        }
+
         if (keyboard?.isKeyPressed(STATS_TOGGLE_KEY_CODE, undefined, currentTick)) {
-            this.#visible = !this.#visible;
+            this.#bodyVisible = !this.#bodyVisible;
+
             return;
         }
 
@@ -51,7 +69,8 @@ export class StatsOverlayToggle {
             const pos = pointer.getPos(slot);
 
             if (isPointerInStatsToggleCorner(pos, toggleRect)) {
-                this.#visible = !this.#visible;
+                this.#bodyVisible = !this.#bodyVisible;
+
                 return;
             }
         }

--- a/src/render/stats-overlay/constants.ts
+++ b/src/render/stats-overlay/constants.ts
@@ -13,7 +13,7 @@ export const STATS_TOP_TEXT_Y = 0;
 /** Gap between stacked stats bars (custom rows and bottom bar). */
 export const STATS_ROW_GAP_PX = 1;
 
-/** Side length of the bottom-right corner region that toggles overlay visibility. */
+/** Side length of the bottom-left corner region that toggles overlay body visibility. */
 export const STATS_TOGGLE_CORNER_SIZE = 48;
 
 /** `KeyboardEvent.code` for the tilde / backquote toggle key. */
@@ -52,5 +52,5 @@ export const TIMING_CHART_DEFAULT_ERROR_IDX = 4;
 /** Default event/tag palette index for timing chart semantic overlays. */
 export const TIMING_CHART_DEFAULT_EVENT_IDX = 5;
 
-/** Bottom-right hint label when palette grid is disabled. */
+/** Bottom-left hint label when palette grid is disabled. */
 export const STATS_BOTTOM_HINT_LABEL = '[~]';

--- a/src/render/stats-overlay/index.ts
+++ b/src/render/stats-overlay/index.ts
@@ -10,12 +10,16 @@ export {
     isPointerInStatsToggleCorner,
     statsBitmapTextPaletteOffset,
     statsRightAlignedTextX,
+    statsToggleHintTextX,
 } from './layoutHelpers';
 export type { StatsOverlayLayoutPlanScratch } from './layoutPlan';
 export {
     buildStatsOverlayLayoutPlan,
     createDefaultLayoutConfig,
     createStatsOverlayLayoutPlanScratch,
+    hintBarY,
+    paletteBandY,
+    resolveStatsOverlayFooterHeight,
 } from './layoutPlan';
 export { StatsOverlay } from './StatsOverlay';
 export { StatsOverlayBars } from './StatsOverlayBars';

--- a/src/render/stats-overlay/layoutHelpers.test.ts
+++ b/src/render/stats-overlay/layoutHelpers.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it } from 'vitest';
 
 import { Vector2i } from '../../utils/Vector2i';
 import { STATS_EDGE_MARGIN_PX, STATS_TOP_TEXT_Y, SYSTEM_CHAR_ADVANCE } from './constants';
-import { createStatsOverlayLayout, isPointerInStatsToggleCorner, statsRightAlignedTextX } from './layoutHelpers';
+import {
+    createStatsOverlayLayout,
+    isPointerInStatsToggleCorner,
+    statsRightAlignedTextX,
+    statsToggleHintTextX,
+} from './layoutHelpers';
 
 describe('createStatsOverlayLayout', () => {
     it('places bottom text at the configured bottom gap offset', () => {
@@ -12,7 +17,7 @@ describe('createStatsOverlayLayout', () => {
         expect(layout.displayHeight).toBe(240);
         expect(layout.bottomTextY).toBe(240 - 14 + 1);
         expect(layout.topTextY).toBe(STATS_TOP_TEXT_Y);
-        expect(layout.toggleRect.x).toBe(320 - 48);
+        expect(layout.toggleRect.x).toBe(0);
         expect(layout.toggleRect.y).toBe(240 - 48);
         expect(layout.toggleRect.width).toBe(48);
         expect(layout.toggleRect.height).toBe(48);
@@ -31,18 +36,24 @@ describe('statsRightAlignedTextX', () => {
     });
 });
 
+describe('statsToggleHintTextX', () => {
+    it('anchors the toggle hint at the left edge margin', () => {
+        expect(statsToggleHintTextX()).toBe(STATS_EDGE_MARGIN_PX);
+    });
+});
+
 describe('isPointerInStatsToggleCorner', () => {
-    it('returns true inside the bottom-right 48x48 region', () => {
+    it('returns true inside the bottom-left 48x48 region', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
 
-        expect(isPointerInStatsToggleCorner(new Vector2i(300, 220), layout.toggleRect)).toBe(true);
-        expect(isPointerInStatsToggleCorner(new Vector2i(272, 192), layout.toggleRect)).toBe(true);
+        expect(isPointerInStatsToggleCorner(new Vector2i(20, 220), layout.toggleRect)).toBe(true);
+        expect(isPointerInStatsToggleCorner(new Vector2i(0, 192), layout.toggleRect)).toBe(true);
     });
 
     it('returns false outside the toggle region', () => {
         const layout = createStatsOverlayLayout(320, 240, 14);
 
-        expect(isPointerInStatsToggleCorner(new Vector2i(0, 0), layout.toggleRect)).toBe(false);
-        expect(isPointerInStatsToggleCorner(new Vector2i(271, 191), layout.toggleRect)).toBe(false);
+        expect(isPointerInStatsToggleCorner(new Vector2i(300, 220), layout.toggleRect)).toBe(false);
+        expect(isPointerInStatsToggleCorner(new Vector2i(48, 191), layout.toggleRect)).toBe(false);
     });
 });

--- a/src/render/stats-overlay/layoutHelpers.ts
+++ b/src/render/stats-overlay/layoutHelpers.ts
@@ -26,7 +26,7 @@ export function createStatsOverlayLayout(
 ): StatsOverlayLayout {
     const bottomTextY = displayHeight - lineHeight - STATS_BOTTOM_TEXT_GAP_PX;
     const toggleRect = new Rect2i(
-        displayWidth - STATS_TOGGLE_CORNER_SIZE,
+        0,
         displayHeight - STATS_TOGGLE_CORNER_SIZE,
         STATS_TOGGLE_CORNER_SIZE,
         STATS_TOGGLE_CORNER_SIZE,
@@ -46,7 +46,7 @@ export function createStatsOverlayLayout(
  * Returns whether a pointer position lies inside the toggle corner rect.
  *
  * @param pos - Pointer position in display coordinates.
- * @param toggleRect - Bottom-right toggle region.
+ * @param toggleRect - Bottom-left toggle region.
  * @returns `true` when the point is inside the rect (`Rect2i.contains` half-open bounds).
  */
 export function isPointerInStatsToggleCorner(pos: Vector2i, toggleRect: Rect2i): boolean {
@@ -67,6 +67,27 @@ export function statsRightAlignedTextX(text: string, displayWidth: number): numb
 }
 
 /**
+ * X position for the bottom-left `[~]` toggle hint label.
+ *
+ * Aligns with the bottom-left toggle hit region ({@link STATS_TOGGLE_CORNER_SIZE}).
+ *
+ * @returns Left edge X for `drawBitmapText`.
+ */
+export function statsToggleHintTextX(): number {
+    return STATS_EDGE_MARGIN_PX;
+}
+
+/**
+ * Width in pixels of the bottom-left toggle hint label.
+ *
+ * @param hintLabel - Toggle hint text (typically `[~]`).
+ * @returns Pixel width from system font advance.
+ */
+export function statsToggleHintTextWidth(hintLabel: string): number {
+    return hintLabel.length * SYSTEM_CHAR_ADVANCE;
+}
+
+/**
  * Palette offset for system-font overlay text (foreground glyphs stored as index 1).
  *
  * @param paletteIndex - Palette color index for overlay text.
@@ -77,15 +98,12 @@ export function statsBitmapTextPaletteOffset(paletteIndex: number): number {
 }
 
 /**
- * Y coordinate of the top edge of a custom row bar stacked above the bottom bar.
+ * Y coordinate of the top edge of a custom row bar stacked above the footer.
  *
- * @param displayHeight - Logical display height in pixels.
- * @param bottomAreaY - Top Y of the bottom band.
- * @param rowIndex - `0` is directly above the bottom band.
+ * @param footerStackTopY - Top Y of the footer stack (palette band or hint bar).
+ * @param rowIndex - `0` is directly above the footer stack.
  * @returns Bar top Y in display pixels.
  */
-export function customBarY(displayHeight: number, bottomAreaY: number, rowIndex: number): number {
-    void displayHeight;
-
-    return bottomAreaY - (rowIndex + 1) * (STATS_BAR_HEIGHT + STATS_ROW_GAP_PX);
+export function customBarY(footerStackTopY: number, rowIndex: number): number {
+    return footerStackTopY - (rowIndex + 1) * (STATS_BAR_HEIGHT + STATS_ROW_GAP_PX);
 }

--- a/src/render/stats-overlay/layoutPlan.test.ts
+++ b/src/render/stats-overlay/layoutPlan.test.ts
@@ -6,6 +6,9 @@ import {
     buildStatsOverlayLayoutPlan,
     createDefaultLayoutConfig,
     createStatsOverlayLayoutPlanScratch,
+    hintBarY,
+    paletteBandY,
+    resolveStatsOverlayFooterHeight,
 } from './layoutPlan';
 import { computePaletteGrid } from './StatsOverlayPaletteView';
 
@@ -18,7 +21,6 @@ describe('buildStatsOverlayLayoutPlan', () => {
         const plan = buildStatsOverlayLayoutPlan(
             config,
             scratch,
-            '[~]',
             'webgpu | 320x240',
             layout.bottomTextY,
             layout.toggleRect,
@@ -27,7 +29,8 @@ describe('buildStatsOverlayLayoutPlan', () => {
         expect(plan.titleBar).toMatchObject({ x: 0, y: 0, width: 320, height: STATS_BAR_HEIGHT });
         expect(plan.metricsBar).toMatchObject({ x: 0, y: 14, width: 320, height: STATS_BAR_HEIGHT });
         expect(plan.timingTextBar).toMatchObject({ x: 0, y: 28, width: 320, height: STATS_BAR_HEIGHT });
-        expect(plan.bottomArea).toMatchObject({ x: 0, y: 227, width: 320, height: STATS_BAR_HEIGHT });
+        expect(plan.paletteBand).toMatchObject({ x: 0, y: hintBarY(240), width: 320, height: 0 });
+        expect(plan.hintBar).toMatchObject({ x: 0, y: hintBarY(240), width: 320, height: STATS_BAR_HEIGHT });
         expect(plan.timingChart.height).toBe(0);
     });
 
@@ -39,7 +42,6 @@ describe('buildStatsOverlayLayoutPlan', () => {
         const plan = buildStatsOverlayLayoutPlan(
             config,
             scratch,
-            '[~]',
             'webgpu | 320x240',
             layout.bottomTextY,
             layout.toggleRect,
@@ -67,7 +69,6 @@ describe('buildStatsOverlayLayoutPlan', () => {
         const plan = buildStatsOverlayLayoutPlan(
             config,
             scratch,
-            '[~]',
             'webgpu | 320x240',
             layout.bottomTextY,
             layout.toggleRect,
@@ -90,15 +91,19 @@ describe('buildStatsOverlayLayoutPlan', () => {
         const plan = buildStatsOverlayLayoutPlan(
             config,
             scratch,
-            '[~]',
             'webgpu | 320x240',
             layout.bottomTextY,
             layout.toggleRect,
         );
 
-        expect(plan.bottomArea).toMatchObject({
-            y: 240 - paletteGrid.totalHeight,
+        expect(plan.paletteBand).toMatchObject({
+            y: paletteBandY(240, paletteGrid.totalHeight),
             height: paletteGrid.totalHeight,
+            width: 320,
+        });
+        expect(plan.hintBar).toMatchObject({
+            y: hintBarY(240),
+            height: STATS_BAR_HEIGHT,
             width: 320,
         });
     });
@@ -116,16 +121,30 @@ describe('buildStatsOverlayLayoutPlan', () => {
         const plan = buildStatsOverlayLayoutPlan(
             config,
             scratch,
-            '[~]',
             'webgpu | 320x240',
             layout.bottomTextY,
             layout.toggleRect,
         );
 
         expect(plan.customBars[0]).toMatchObject({
-            y: plan.bottomArea.y - (STATS_BAR_HEIGHT + STATS_ROW_GAP_PX),
+            y: plan.paletteBand.y - (STATS_BAR_HEIGHT + STATS_ROW_GAP_PX),
             width: 320,
             height: STATS_BAR_HEIGHT,
         });
+    });
+
+    it('resolveStatsOverlayFooterHeight reserves hint bar or palette plus gap plus hint', () => {
+        const paletteGrid = computePaletteGrid(320, 4, 256, 1);
+        const hintOnlyConfig = createDefaultLayoutConfig(320, 240, 14, 0);
+        const paletteConfig = {
+            ...hintOnlyConfig,
+            statsOverlayPaletteView: true,
+            paletteGrid,
+        };
+
+        expect(resolveStatsOverlayFooterHeight(hintOnlyConfig)).toBe(STATS_BAR_HEIGHT);
+        expect(resolveStatsOverlayFooterHeight(paletteConfig)).toBe(
+            paletteGrid.totalHeight + STATS_ROW_GAP_PX + STATS_BAR_HEIGHT,
+        );
     });
 });

--- a/src/render/stats-overlay/layoutPlan.ts
+++ b/src/render/stats-overlay/layoutPlan.ts
@@ -15,7 +15,7 @@ import {
     STATS_ROW_GAP_PX,
     STATS_TOP_TEXT_Y,
 } from './constants';
-import { statsRightAlignedTextX } from './layoutHelpers';
+import { statsRightAlignedTextX, statsToggleHintTextX } from './layoutHelpers';
 import type { StatsOverlayLayoutConfig, StatsOverlayLayoutPlan } from './types';
 
 /** Mutable scratch object reused by {@link buildStatsOverlayLayoutPlan}. */
@@ -25,13 +25,35 @@ export interface StatsOverlayLayoutPlanScratch {
     metricsBar: Rect2i;
     timingTextBar: Rect2i;
     customBars: Rect2i[];
-    bottomArea: Rect2i;
+    paletteBand: Rect2i;
+    hintBar: Rect2i;
     toggleRect: Rect2i;
     topLeftPos: Vector2i;
     topRightPos: Vector2i;
     topMetricsPos: Vector2i;
     topTimingPos: Vector2i;
-    bottomRightPos: Vector2i;
+    hintLabelPos: Vector2i;
+}
+
+/**
+ * Top Y of the bottom hint bar (13 px strip at the display bottom edge).
+ *
+ * @param displayHeight - Logical display height in pixels.
+ * @returns Hint bar top Y.
+ */
+export function hintBarY(displayHeight: number): number {
+    return displayHeight - STATS_BAR_HEIGHT;
+}
+
+/**
+ * Top Y of the palette swatch grid band stacked above the hint bar row gap.
+ *
+ * @param displayHeight - Logical display height in pixels.
+ * @param paletteGridHeight - Total palette grid height from {@link computePaletteGrid}.
+ * @returns Palette band top Y.
+ */
+export function paletteBandY(displayHeight: number, paletteGridHeight: number): number {
+    return hintBarY(displayHeight) - STATS_ROW_GAP_PX - paletteGridHeight;
 }
 
 /**
@@ -46,25 +68,57 @@ export function createStatsOverlayLayoutPlanScratch(): StatsOverlayLayoutPlanScr
         metricsBar: new Rect2i(0, 0, 0, STATS_BAR_HEIGHT),
         timingTextBar: new Rect2i(0, 0, 0, STATS_BAR_HEIGHT),
         customBars: [],
-        bottomArea: new Rect2i(0, 0, 0, STATS_BAR_HEIGHT),
+        paletteBand: new Rect2i(0, 0, 0, 0),
+        hintBar: new Rect2i(0, 0, 0, STATS_BAR_HEIGHT),
         toggleRect: new Rect2i(0, 0, 0, 0),
         topLeftPos: new Vector2i(STATS_EDGE_MARGIN_PX, 0),
         topRightPos: new Vector2i(0, 0),
         topMetricsPos: new Vector2i(STATS_EDGE_MARGIN_PX, 0),
         topTimingPos: new Vector2i(STATS_EDGE_MARGIN_PX, 0),
-        bottomRightPos: new Vector2i(0, 0),
+        hintLabelPos: new Vector2i(0, 0),
     };
 }
 
 /**
- * Computes bottom band height from palette grid config or legacy 13 px bar.
+ * Resolves footer rects: optional palette band above a row gap, then the hint bar at the display bottom.
  *
  * @param config - Layout configuration.
- * @returns Bottom area height in pixels.
+ * @param displayHeight - Logical display height in pixels.
+ * @returns Palette band height, footer stack anchor Y, and hint bar top Y.
  */
-function resolveBottomAreaHeight(config: StatsOverlayLayoutConfig): number {
+function resolveFooterLayout(
+    config: StatsOverlayLayoutConfig,
+    displayHeight: number,
+): { paletteBandHeight: number; footerStackTopY: number; hintBarTopY: number } {
+    const hintBarTopY = hintBarY(displayHeight);
+    const paletteEnabled = config.statsOverlayPaletteView && config.paletteGrid !== undefined;
+
+    if (paletteEnabled) {
+        const paletteBandHeight = config.paletteGrid.totalHeight;
+
+        return {
+            paletteBandHeight,
+            footerStackTopY: paletteBandY(displayHeight, paletteBandHeight),
+            hintBarTopY,
+        };
+    }
+
+    return {
+        paletteBandHeight: 0,
+        footerStackTopY: hintBarTopY,
+        hintBarTopY,
+    };
+}
+
+/**
+ * Total reserved footer height (palette grid + row gap + hint bar, or hint bar alone).
+ *
+ * @param config - Layout configuration.
+ * @returns Footer band height in pixels.
+ */
+export function resolveStatsOverlayFooterHeight(config: StatsOverlayLayoutConfig): number {
     if (config.statsOverlayPaletteView && config.paletteGrid !== undefined) {
-        return config.paletteGrid.totalHeight;
+        return config.paletteGrid.totalHeight + STATS_ROW_GAP_PX + STATS_BAR_HEIGHT;
     }
 
     return STATS_BAR_HEIGHT;
@@ -88,27 +142,30 @@ function ensureCustomBarPool(scratch: StatsOverlayLayoutPlanScratch, count: numb
  *
  * @param config - Feature flags and display dimensions.
  * @param scratch - Reusable scratch object mutated in place.
- * @param bottomRightLabel - Text for bottom-right hint (for X alignment).
  * @param topRightLabel - Text for top-right backend/resolution label.
- * @param bottomTextY - Baseline Y for bottom-right text from init layout.
- * @param toggleRect - Bottom-right toggle hit region from init layout.
+ * @param hintLabelBaselineY - Baseline Y for the hint label from init layout.
+ * @param toggleRect - Bottom-left toggle hit region from init layout.
  * @returns The same scratch object as {@link StatsOverlayLayoutPlan}.
  */
 export function buildStatsOverlayLayoutPlan(
     config: StatsOverlayLayoutConfig,
     scratch: StatsOverlayLayoutPlanScratch,
-    bottomRightLabel: string,
     topRightLabel: string,
-    bottomTextY: number,
+    hintLabelBaselineY: number,
     toggleRect: Rect2i,
 ): StatsOverlayLayoutPlan {
     const { displayWidth, displayHeight } = config;
-    const bottomHeight = resolveBottomAreaHeight(config);
+    const { paletteBandHeight, footerStackTopY, hintBarTopY } = resolveFooterLayout(config, displayHeight);
 
-    scratch.bottomArea.x = 0;
-    scratch.bottomArea.y = displayHeight - bottomHeight;
-    scratch.bottomArea.width = displayWidth;
-    scratch.bottomArea.height = bottomHeight;
+    scratch.hintBar.x = 0;
+    scratch.hintBar.y = hintBarTopY;
+    scratch.hintBar.width = displayWidth;
+    scratch.hintBar.height = STATS_BAR_HEIGHT;
+
+    scratch.paletteBand.x = 0;
+    scratch.paletteBand.y = footerStackTopY;
+    scratch.paletteBand.width = displayWidth;
+    scratch.paletteBand.height = paletteBandHeight;
 
     ensureCustomBarPool(scratch, config.customRowCount, displayWidth);
 
@@ -120,7 +177,7 @@ export function buildStatsOverlayLayoutPlan(
             continue;
         }
 
-        const barY = scratch.bottomArea.y - (rowIndex + 1) * (STATS_BAR_HEIGHT + STATS_ROW_GAP_PX);
+        const barY = footerStackTopY - (rowIndex + 1) * (STATS_BAR_HEIGHT + STATS_ROW_GAP_PX);
 
         bar.x = 0;
         bar.y = barY;
@@ -180,8 +237,8 @@ export function buildStatsOverlayLayoutPlan(
     scratch.topTimingPos.x = STATS_EDGE_MARGIN_PX;
     scratch.topTimingPos.y = scratch.timingTextBar.y + STATS_TOP_TEXT_Y;
 
-    scratch.bottomRightPos.x = statsRightAlignedTextX(bottomRightLabel, displayWidth);
-    scratch.bottomRightPos.y = bottomTextY;
+    scratch.hintLabelPos.x = statsToggleHintTextX();
+    scratch.hintLabelPos.y = hintLabelBaselineY;
 
     return scratch;
 }

--- a/src/render/stats-overlay/testFixtures.ts
+++ b/src/render/stats-overlay/testFixtures.ts
@@ -75,17 +75,17 @@ export function getRectFillCalls(renderer: ReturnType<typeof createMockRenderer>
 }
 
 /**
- * Y of custom row bar top stacked above the bottom band.
+ * Y of custom row bar top stacked above the footer.
  *
  * @param displayHeight - Logical display height.
  * @param rowIndex - Custom row index.
- * @param bottomAreaHeight - Bottom band height (defaults to 13 px hint bar).
+ * @param footerHeight - Reserved footer height from {@link resolveStatsOverlayFooterHeight}.
  * @returns Bar top Y.
  */
-export function customRowBarY(displayHeight: number, rowIndex: number, bottomAreaHeight = STATS_BAR_HEIGHT): number {
-    const bottomAreaY = displayHeight - bottomAreaHeight;
+export function customRowBarY(displayHeight: number, rowIndex: number, footerHeight = STATS_BAR_HEIGHT): number {
+    const footerStackTopY = displayHeight - footerHeight;
 
-    return customBarY(displayHeight, bottomAreaY, rowIndex);
+    return customBarY(footerStackTopY, rowIndex);
 }
 
 export const mockFont = {} as BitmapFont;

--- a/src/render/stats-overlay/types.ts
+++ b/src/render/stats-overlay/types.ts
@@ -12,13 +12,13 @@ export interface StatsOverlayLayout {
     /** System font line height in pixels. */
     readonly lineHeight: number;
 
-    /** Y baseline for bottom-bar text. */
+    /** Y baseline for the bottom hint label. */
     readonly bottomTextY: number;
 
     /** Y baseline for top-bar text. */
     readonly topTextY: number;
 
-    /** Bottom-right 48x48 px region that toggles overlay visibility on primary press. */
+    /** Bottom-left 48x48 px region that toggles overlay body visibility on primary press. */
     readonly toggleRect: Rect2i;
 }
 
@@ -45,7 +45,7 @@ export interface StatsOverlayTimingSnapshot {
     readonly drawCalls: number;
 }
 
-/** Computed palette swatch grid dimensions for the bottom band. */
+/** Computed palette swatch grid dimensions for the palette band. */
 export interface PaletteGridLayout {
     /** Number of columns in the grid. */
     readonly cols: number;
@@ -59,35 +59,58 @@ export interface PaletteGridLayout {
     /** Gap between swatches horizontally and vertically. */
     readonly gap: number;
 
-    /** Total bottom band height including padding. */
+    /** Total palette band height including padding. */
     readonly totalHeight: number;
 }
 
 /** Feature flags and dimensions consumed by the layout planner. */
 export interface StatsOverlayLayoutConfig {
     readonly displayWidth: number;
+
     readonly displayHeight: number;
+
     readonly lineHeight: number;
+
     readonly customRowCount: number;
+
     readonly timingChartEnabled: boolean;
+
     readonly timingChartHeight: number;
+
     /** Mirrors {@link HardwareSettings.statsOverlayPaletteView}. */
     readonly statsOverlayPaletteView: boolean;
+
     readonly paletteGrid?: PaletteGridLayout;
 }
 
 /** Computed screen-space bands and text anchors for one frame. */
 export interface StatsOverlayLayoutPlan {
     readonly titleBar: Rect2i;
+
     readonly timingChart: Rect2i;
+
     readonly metricsBar: Rect2i;
+
     readonly timingTextBar: Rect2i;
+
     readonly customBars: readonly Rect2i[];
-    readonly bottomArea: Rect2i;
+
+    /** Palette swatch grid band when {@link HardwareSettings.statsOverlayPaletteView} is enabled; height 0 otherwise. */
+    readonly paletteBand: Rect2i;
+
+    /** Bottom `[~]` hint bar (13 px); always at the display bottom edge. */
+    readonly hintBar: Rect2i;
+
     readonly toggleRect: Rect2i;
+
     readonly topLeftPos: Vector2i;
+
     readonly topRightPos: Vector2i;
+
     readonly topMetricsPos: Vector2i;
+
     readonly topTimingPos: Vector2i;
-    readonly bottomRightPos: Vector2i;
+
+    /** Bottom-left `[~]` toggle hint label anchor. */
+    readonly hintLabelPos: Vector2i;
 }


### PR DESCRIPTION
Add statsOverlayVisibleAtStart, statsOverlayToggleHintVisible, and statsOverlayToggleEnabled to HardwareSettings. Keep the bottom-left [~] hint bar drawable while the body is hidden; gate palette usage tracking, custom rows, and palette grid draws to body-visible frames. Split footer layout into paletteBand and hintBar with a row gap, unify overlay draw paths, and move the toggle hit region to the bottom-left.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Configuration and Visibility Management

Three new optional boolean flags have been added to `HardwareSettings` to provide fine-grained control over the stats overlay:
- `statsOverlayVisibleAtStart` (default `false`): Controls whether the overlay body is visible on startup
- `statsOverlayToggleHintVisible` (default `true`): Controls whether the toggle hint bar `[~]` renders when the body is hidden
- `statsOverlayToggleEnabled` (default `true`): Controls whether toggle input (Backquote key and corner press) is enabled

The stats overlay body now starts hidden by default, improving initial application cleanliness. The toggle hint remains independently visible and interactive, allowing users to show the overlay when needed.

## Core Visibility API Changes

The `StatsOverlay` and `StatsOverlayToggle` classes have been refactored to use `bodyVisible` instead of `visible`, making the visibility semantics clearer. Palette usage tracking now keys off `bodyVisible`, so tracking is automatically disabled when the overlay body is hidden, reducing overhead.

## Frame Rendering Refactoring

`StatsOverlay.updateAndRender` now splits rendering into distinct phases:
- Timing history sampling occurs regardless of toggle state
- FPS sampling and custom row collection happen only when the body is visible
- When the body is hidden and toggle hint rendering is disabled, rendering exits early
- Drawing is unified into a single `#drawFrame` method that renders body sections (bars, timing chart, custom rows, palette grid, top labels) only when `bodyVisible` is true, while the footer hint bar/label renders whenever the method runs

## Footer Layout Restructuring

The footer area has been split into two explicit bands with a 1px gap between them:
- `paletteBand`: The optional palette grid region (positioned above when palette view is enabled)
- `hintBar`: The 13px toggle hint bar at the bottom

New layout helpers `hintBarY()` and `paletteBandY()` compute these regions, with `resolveStatsOverlayFooterHeight()` calculating total footer height based on configuration. This replaces the previous monolithic "bottom area" approach.

## Hit Region Repositioning

The stats overlay toggle hit region has moved from the bottom-right to the bottom-left corner (48x48 area), aligned with where the toggle hint label `[~]` now appears. New helpers `statsToggleHintTextX()` and `statsToggleHintTextWidth()` compute hint label positioning.

## API and Drawing Method Updates

`StatsOverlayBars` rendering was refactored with renamed and split methods:
- `drawFixedBars` → `drawTopBars`: Renders only the top bar fills
- `drawFixedLabels` → `drawTopLabels`: Renders only top title/metrics/timing text labels
- New methods: `drawPaletteBandFill()`, `drawHintBarFill()`, and `drawHintLabel()` for footer rendering

`StatsOverlayPaletteView.draw()` now accepts `paletteBand: Rect2i` instead of `bottomArea: Rect2i`, and hint exclusion rectangle logic has been updated to use the new bottom-left hint positioning.

## Documentation and Test Updates

- API documentation has been updated to reflect the new configuration options and revised overlay runtime behavior
- Test files have been updated to explicitly set `statsOverlayVisibleAtStart: true` where default overlay visibility is needed
- Layout tests now use the new `paletteBandY` coordinate system instead of the previous `bottomAreaY`
- Custom row positioning tests have been adjusted to compute bar Y relative to `footerStackTopY` rather than bottom-area origins
- Toggle positioning tests have been rewritten to validate bottom-left corner hit detection instead of bottom-right

<!-- end of auto-generated comment: release notes by coderabbit.ai -->