### PR TITLE
feat(renderer): add stats overlay palette swatch hover and copy

### DIFF
--- a/docs/api-core.md
+++ b/docs/api-core.md
@@ -250,9 +250,10 @@ Toggle overlay **body** visibility at runtime with **Backquote** (`~`) or a prim
 48x48 px** corner when `statsOverlayToggleEnabled` is `true` (default). Set `statsOverlayToggleHintVisible: false` to
 hide the hint bar while the body stays hidden. Set `statsOverlayToggleEnabled: false` to lock body visibility at
 `statsOverlayVisibleAtStart`. Set `statsOverlayEnabled: false` in `configure()` to disable the overlay subsystem and all
-toggle input (for example release builds). On WebGPU, the stats overlay uses two late batches: {@link
-IRenderer.drawRectFillOnTop} for bar fills above demo sprites, then {@link IRenderer.drawBitmapTextOnTop} for labels
-above those bars.
+toggle input (for example release builds). On WebGPU, the stats overlay uses late draw batches: {@link
+IRenderer.drawRectFillOnTop} for bar fills above demo sprites, {@link IRenderer.drawBitmapTextOnTop} for labels above
+those bars, then {@link IRenderer.drawRectFillForeground} and {@link IRenderer.drawBitmapTextForeground} for palette
+swatch tooltips above custom rows.
 
 Overlay colors follow one path: use `statsOverlayStyle` when set, otherwise defaults `1` (bar) and `2` (text). You can
 override globally in `configure()` with `statsOverlayStyle: { barPaletteIndex, textPaletteIndex }`, or per custom row on

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -1296,14 +1296,20 @@ export class BTAPI {
     }
 
     /**
-     * Applies overlay toggle input and clears per-frame palette usage before demo render.
+     * Applies overlay input (palette swatch copy, then body toggle) and clears per-frame palette usage.
      *
-     * Toggle runs here (not in {@link StatsOverlay.updateAndRender}) so visibility is current
+     * Input runs here (not in {@link StatsOverlay.updateAndRender}) so visibility is current
      * when deciding whether to track palette usage during `demo.render()`.
      */
     private beginRenderFrame(): void {
         if (this.statsOverlay) {
-            this.statsOverlay.handleToggle(this.pointer, this.keyboard, this.loop?.getTicks() ?? 0);
+            this.statsOverlay.handleFrameInput(
+                this.pointer,
+                this.keyboard,
+                this.loop?.getTicks() ?? 0,
+                () => this.demo?.statsOverlayRows?.(),
+                this.palette,
+            );
         }
 
         resetRenderPaletteUsage(this.framePaletteUsageMask);

--- a/src/render/IRenderer.ts
+++ b/src/render/IRenderer.ts
@@ -94,6 +94,18 @@ export interface IRenderer {
     drawRectFillOnTop(rect: Rect2i, paletteIndex: number): void;
 
     /**
+     * Draws a filled rectangle above overlay sprites for this frame.
+     *
+     * On WebGPU, batched after {@link drawBitmapTextOnTop} so HUD popovers (for example
+     * palette swatch tooltips) appear on top of custom stats rows and labels. Software
+     * backends may implement this as {@link drawRectFill} when call order is preserved.
+     *
+     * @param rect - Rectangle bounds in display coordinates.
+     * @param paletteIndex - Palette color index.
+     */
+    drawRectFillForeground(rect: Rect2i, paletteIndex: number): void;
+
+    /**
      * Draws a single pixel.
      *
      * @param pos - Pixel position.
@@ -163,6 +175,20 @@ export interface IRenderer {
      * @param paletteOffset - Palette index offset applied to all glyphs (default 0).
      */
     drawBitmapTextOnTop(font: BitmapFont, pos: Vector2i, text: string, paletteOffset?: number): void;
+
+    /**
+     * Draws bitmap text above overlay sprites and foreground overlay fills for this frame.
+     *
+     * On WebGPU, batched after {@link drawRectFillForeground} so popover labels (for example
+     * palette swatch tooltips) appear on top of custom stats rows. Software backends may
+     * implement this as {@link drawBitmapText} when call order is preserved.
+     *
+     * @param font - Bitmap font with character glyphs (underlying sheet must be indexized).
+     * @param pos - Text position (top-left corner).
+     * @param text - String to render.
+     * @param paletteOffset - Palette index offset applied to all glyphs (default 0).
+     */
+    drawBitmapTextForeground(font: BitmapFont, pos: Vector2i, text: string, paletteOffset?: number): void;
 
     // #endregion
 

--- a/src/render/SoftwareRenderer.ts
+++ b/src/render/SoftwareRenderer.ts
@@ -260,6 +260,16 @@ export class SoftwareRenderer implements IRenderer {
     }
 
     /**
+     * Queues a filled rectangle after prior draw commands (same FIFO queue as {@link drawRectFill}).
+     *
+     * @param rect - Rectangle to fill in logical pixels.
+     * @param paletteIndex - Palette entry index for the fill color.
+     */
+    drawRectFillForeground(rect: Rect2i, paletteIndex: number): void {
+        this.drawRectFill(rect, paletteIndex);
+    }
+
+    /**
      * Queues a single pixel draw command at the given position.
      *
      * @param pos - Pixel position in logical coordinates.
@@ -371,6 +381,18 @@ export class SoftwareRenderer implements IRenderer {
      * @param paletteOffset - Palette index offset applied to all glyphs (default 0).
      */
     drawBitmapTextOnTop(font: BitmapFont, pos: Vector2i, text: string, paletteOffset: number = 0): void {
+        this.drawBitmapText(font, pos, text, paletteOffset);
+    }
+
+    /**
+     * Queues bitmap text after prior draw commands (same FIFO queue as {@link drawBitmapText}).
+     *
+     * @param font - Bitmap font to render.
+     * @param pos - Top-left position of the text in logical coordinates.
+     * @param text - String to render.
+     * @param paletteOffset - Palette index offset applied to all glyphs (default 0).
+     */
+    drawBitmapTextForeground(font: BitmapFont, pos: Vector2i, text: string, paletteOffset: number = 0): void {
         this.drawBitmapText(font, pos, text, paletteOffset);
     }
 

--- a/src/render/WebGpuRenderer.test.ts
+++ b/src/render/WebGpuRenderer.test.ts
@@ -41,6 +41,8 @@ type WebGpuRendererPipelineAccess = {
     overlayPrimitives: PrimitivePipeline;
     sprites: SpritePipeline;
     overlaySprites: SpritePipeline;
+    foregroundOverlayPrimitives: PrimitivePipeline;
+    foregroundOverlaySprites: SpritePipeline;
 };
 
 /**
@@ -477,7 +479,43 @@ describe('with initialized renderer', () => {
         expect(overlayText).toHaveBeenCalledWith(mockFont, new Vector2i(4, 4), '', 0);
     });
 
-    it('encodes scene pass as primitives, sprites, overlayPrimitives, overlaySprites', () => {
+    it('drawRectFillForeground routes fills to foregroundOverlayPrimitives', () => {
+        const pipelines = getRendererPipelines(renderer);
+        const overlayFill = vi.spyOn(pipelines.overlayPrimitives, 'drawRectFill');
+        const foregroundFill = vi.spyOn(pipelines.foregroundOverlayPrimitives, 'drawRectFill');
+        const overlayRect = new Rect2i(1, 2, 8, 8);
+        const foregroundRect = new Rect2i(3, 4, 6, 6);
+
+        renderer.beginFrame();
+        renderer.drawRectFillOnTop(overlayRect, 3);
+        renderer.drawRectFillForeground(foregroundRect, 5);
+        renderer.endFrame();
+
+        expect(overlayFill).toHaveBeenCalledWith(overlayRect, 3);
+        expect(foregroundFill).toHaveBeenCalledOnce();
+        expect(foregroundFill).toHaveBeenCalledWith(foregroundRect, 5);
+    });
+
+    it('drawBitmapTextForeground routes text to foregroundOverlaySprites', () => {
+        const pipelines = getRendererPipelines(renderer);
+        const overlayText = vi.spyOn(pipelines.overlaySprites, 'drawBitmapText');
+        const foregroundText = vi.spyOn(pipelines.foregroundOverlaySprites, 'drawBitmapText');
+        const mockFont = {
+            getSpriteSheet: () => ({}),
+            getGlyphByCode: () => null,
+        } as unknown as BitmapFont;
+
+        renderer.beginFrame();
+        renderer.drawBitmapTextOnTop(mockFont, new Vector2i(4, 4), '');
+        renderer.drawBitmapTextForeground(mockFont, new Vector2i(8, 8), '');
+        renderer.endFrame();
+
+        expect(overlayText).toHaveBeenCalledWith(mockFont, new Vector2i(4, 4), '', 0);
+        expect(foregroundText).toHaveBeenCalledOnce();
+        expect(foregroundText).toHaveBeenCalledWith(mockFont, new Vector2i(8, 8), '', 0);
+    });
+
+    it('encodes scene pass as primitives, sprites, overlay batches, then foreground overlay batches', () => {
         const pipelines = getRendererPipelines(renderer);
         const encodeOrder: string[] = [];
 
@@ -493,6 +531,12 @@ describe('with initialized renderer', () => {
         vi.spyOn(pipelines.overlaySprites, 'encodePass').mockImplementation(() => {
             encodeOrder.push('overlaySprites');
         });
+        vi.spyOn(pipelines.foregroundOverlayPrimitives, 'encodePass').mockImplementation(() => {
+            encodeOrder.push('foregroundOverlayPrimitives');
+        });
+        vi.spyOn(pipelines.foregroundOverlaySprites, 'encodePass').mockImplementation(() => {
+            encodeOrder.push('foregroundOverlaySprites');
+        });
 
         const mockFont = {
             getSpriteSheet: () => ({}),
@@ -504,20 +548,33 @@ describe('with initialized renderer', () => {
         renderer.drawBitmapText(mockFont, new Vector2i(0, 0), '');
         renderer.drawRectFillOnTop(new Rect2i(0, 220, 320, 16), 1);
         renderer.drawBitmapTextOnTop(mockFont, new Vector2i(5, 225), 'HUD');
+        renderer.drawRectFillForeground(new Rect2i(10, 10, 6, 6), 4);
+        renderer.drawBitmapTextForeground(mockFont, new Vector2i(12, 12), '');
         renderer.endFrame();
 
-        expect(encodeOrder).toEqual(['primitives', 'sprites', 'overlayPrimitives', 'overlaySprites']);
+        expect(encodeOrder).toEqual([
+            'primitives',
+            'sprites',
+            'overlayPrimitives',
+            'overlaySprites',
+            'foregroundOverlayPrimitives',
+            'foregroundOverlaySprites',
+        ]);
     });
 
     it('resets overlay batches on beginFrame', () => {
         const pipelines = getRendererPipelines(renderer);
         const overlayPrimitiveReset = vi.spyOn(pipelines.overlayPrimitives, 'reset');
         const overlaySpriteReset = vi.spyOn(pipelines.overlaySprites, 'reset');
+        const foregroundPrimitiveReset = vi.spyOn(pipelines.foregroundOverlayPrimitives, 'reset');
+        const foregroundSpriteReset = vi.spyOn(pipelines.foregroundOverlaySprites, 'reset');
 
         renderer.beginFrame();
 
         expect(overlayPrimitiveReset).toHaveBeenCalledOnce();
         expect(overlaySpriteReset).toHaveBeenCalledOnce();
+        expect(foregroundPrimitiveReset).toHaveBeenCalledOnce();
+        expect(foregroundSpriteReset).toHaveBeenCalledOnce();
 
         renderer.endFrame();
     });

--- a/src/render/WebGpuRenderer.ts
+++ b/src/render/WebGpuRenderer.ts
@@ -127,6 +127,16 @@ export class WebGpuRenderer implements IRenderer {
      */
     private readonly overlaySprites: SpritePipeline;
 
+    /**
+     * Primitives encoded after overlay sprites (palette tooltip fills above custom rows).
+     */
+    private readonly foregroundOverlayPrimitives: PrimitivePipeline;
+
+    /**
+     * Sprites encoded after foreground overlay primitives (palette tooltip labels).
+     */
+    private readonly foregroundOverlaySprites: SpritePipeline;
+
     /** Pixel-tier post-process chain (logical resolution). */
     private pixelChain: PostProcessChain | null = null;
 
@@ -183,6 +193,8 @@ export class WebGpuRenderer implements IRenderer {
         this.overlayPrimitives = new PrimitivePipeline();
         this.sprites = new SpritePipeline();
         this.overlaySprites = new SpritePipeline();
+        this.foregroundOverlayPrimitives = new PrimitivePipeline();
+        this.foregroundOverlaySprites = new SpritePipeline();
     }
 
     // #endregion
@@ -230,6 +242,18 @@ export class WebGpuRenderer implements IRenderer {
             await this.overlayPrimitives.init(this.device, this.displaySize, this.paletteBuffer, LOGICAL_TARGET_FORMAT);
             await this.sprites.init(this.device, this.displaySize, this.paletteBuffer, LOGICAL_TARGET_FORMAT);
             await this.overlaySprites.init(this.device, this.displaySize, this.paletteBuffer, LOGICAL_TARGET_FORMAT);
+            await this.foregroundOverlayPrimitives.init(
+                this.device,
+                this.displaySize,
+                this.paletteBuffer,
+                LOGICAL_TARGET_FORMAT,
+            );
+            await this.foregroundOverlaySprites.init(
+                this.device,
+                this.displaySize,
+                this.paletteBuffer,
+                LOGICAL_TARGET_FORMAT,
+            );
 
             this.swapFormat = navigator.gpu.getPreferredCanvasFormat();
 
@@ -313,6 +337,8 @@ export class WebGpuRenderer implements IRenderer {
         this.overlayPrimitives.reset();
         this.sprites.reset();
         this.overlaySprites.reset();
+        this.foregroundOverlayPrimitives.reset();
+        this.foregroundOverlaySprites.reset();
     }
 
     /**
@@ -379,6 +405,16 @@ export class WebGpuRenderer implements IRenderer {
      */
     drawRectFillOnTop(rect: Rect2i, paletteIndex: number): void {
         this.overlayPrimitives.drawRectFill(rect, paletteIndex);
+    }
+
+    /**
+     * Draws a filled rectangle in the post-overlay-sprite primitive batch.
+     *
+     * @param rect - Rectangle bounds in pixel coordinates.
+     * @param paletteIndex - Palette color index.
+     */
+    drawRectFillForeground(rect: Rect2i, paletteIndex: number): void {
+        this.foregroundOverlayPrimitives.drawRectFill(rect, paletteIndex);
     }
 
     /**
@@ -464,6 +500,18 @@ export class WebGpuRenderer implements IRenderer {
         this.overlaySprites.drawBitmapText(font, pos, text, paletteOffset);
     }
 
+    /**
+     * Draws bitmap text in the post-foreground-overlay primitive batch.
+     *
+     * @param font - Bitmap font with character glyphs.
+     * @param pos - Text position (top-left corner).
+     * @param text - String to render.
+     * @param paletteOffset - Palette index offset applied to all glyphs (default 0).
+     */
+    drawBitmapTextForeground(font: BitmapFont, pos: Vector2i, text: string, paletteOffset: number = 0): void {
+        this.foregroundOverlaySprites.drawBitmapText(font, pos, text, paletteOffset);
+    }
+
     // #endregion
 
     // #region Frame Capture API
@@ -486,8 +534,9 @@ export class WebGpuRenderer implements IRenderer {
     /**
      * Sets the camera offset for scrolling.
      *
-     * The offset is propagated to all four scene pipelines: `primitives`,
-     * `overlayPrimitives`, `sprites`, and `overlaySprites`.
+     * The offset is propagated to all scene pipelines: `primitives`,
+     * `overlayPrimitives`, `sprites`, `overlaySprites`, `foregroundOverlayPrimitives`, and
+     * `foregroundOverlaySprites`.
      *
      * @param offset - Camera position in pixels.
      */
@@ -497,6 +546,8 @@ export class WebGpuRenderer implements IRenderer {
         this.overlayPrimitives.setCameraOffset(this.cameraOffset);
         this.sprites.setCameraOffset(this.cameraOffset);
         this.overlaySprites.setCameraOffset(this.cameraOffset);
+        this.foregroundOverlayPrimitives.setCameraOffset(this.cameraOffset);
+        this.foregroundOverlaySprites.setCameraOffset(this.cameraOffset);
     }
 
     /**
@@ -509,7 +560,7 @@ export class WebGpuRenderer implements IRenderer {
     }
 
     /**
-     * Resets the camera to the origin (0, 0) on all four scene pipelines.
+     * Resets the camera to the origin (0, 0) on all scene pipelines.
      */
     resetCamera(): void {
         this.cameraOffset = Vector2i.zero();
@@ -517,6 +568,8 @@ export class WebGpuRenderer implements IRenderer {
         this.overlayPrimitives.setCameraOffset(this.cameraOffset);
         this.sprites.setCameraOffset(this.cameraOffset);
         this.overlaySprites.setCameraOffset(this.cameraOffset);
+        this.foregroundOverlayPrimitives.setCameraOffset(this.cameraOffset);
+        this.foregroundOverlaySprites.setCameraOffset(this.cameraOffset);
     }
 
     // #endregion
@@ -610,6 +663,8 @@ export class WebGpuRenderer implements IRenderer {
             this.overlayPrimitives.reset();
             this.sprites.reset();
             this.overlaySprites.reset();
+            this.foregroundOverlayPrimitives.reset();
+            this.foregroundOverlaySprites.reset();
             return null;
         }
 
@@ -619,6 +674,8 @@ export class WebGpuRenderer implements IRenderer {
             this.overlayPrimitives.reset();
             this.sprites.reset();
             this.overlaySprites.reset();
+            this.foregroundOverlayPrimitives.reset();
+            this.foregroundOverlaySprites.reset();
             return null;
         }
 
@@ -641,9 +698,10 @@ export class WebGpuRenderer implements IRenderer {
     /**
      * Encodes the scene render pass into the supplied target view.
      *
-     * Draw order: `primitives`, `sprites`, `overlayPrimitives` (for example HUD
-     * bars via {@link drawRectFillOnTop}), then `overlaySprites` (overlay labels
-     * via {@link drawBitmapTextOnTop}).
+     * Draw order: `primitives`, `sprites`, `overlayPrimitives` (HUD bars via
+     * {@link drawRectFillOnTop}), `overlaySprites` (labels via {@link drawBitmapTextOnTop}),
+     * `foregroundOverlayPrimitives` (popover fills via {@link drawRectFillForeground}), then
+     * `foregroundOverlaySprites` (popover labels via {@link drawBitmapTextForeground}).
      *
      * @param encoder - Active command encoder.
      * @param sceneView - Logical scene attachment view to render into.
@@ -671,6 +729,8 @@ export class WebGpuRenderer implements IRenderer {
         this.sprites.encodePass(renderPass);
         this.overlayPrimitives.encodePass(renderPass);
         this.overlaySprites.encodePass(renderPass);
+        this.foregroundOverlayPrimitives.encodePass(renderPass);
+        this.foregroundOverlaySprites.encodePass(renderPass);
         renderPass.end();
     }
 
@@ -735,6 +795,8 @@ export class WebGpuRenderer implements IRenderer {
         this.overlayPrimitives.reset();
         this.sprites.reset();
         this.overlaySprites.reset();
+        this.foregroundOverlayPrimitives.reset();
+        this.foregroundOverlaySprites.reset();
     }
 
     // #endregion

--- a/src/render/stats-overlay/StatsOverlay.test.ts
+++ b/src/render/stats-overlay/StatsOverlay.test.ts
@@ -6,12 +6,13 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { Palette } from '../../assets/Palette';
 import { markRenderPaletteIndexUsed } from '../../core/RenderPaletteUsage';
+import { Rect2i } from '../../utils/Rect2i';
 import { Vector2i } from '../../utils/Vector2i';
 import { STATS_BAR_HEIGHT, STATS_ROW_GAP_PX } from './constants';
 import { createStatsOverlayLayout, statsRightAlignedTextX, statsToggleHintTextX } from './layoutHelpers';
 import { hintBarY, paletteBandY } from './layoutPlan';
 import { StatsOverlay } from './StatsOverlay';
-import { computePaletteGrid } from './StatsOverlayPaletteView';
+import { computePaletteGrid, writePaletteSwatchTopLeft } from './StatsOverlayPaletteView';
 import {
     createMockRenderer,
     customRowBarY,
@@ -95,6 +96,29 @@ describe('StatsOverlay', () => {
         );
 
         expect(overlay.tracksPaletteUsage).toBe(false);
+    });
+
+    it('swatch press in the toggle corner does not toggle overlay body (VV-549)', () => {
+        const layout = createStatsOverlayLayout(320, 240, 14);
+        const overlay = createOverlay(layout, 'Test Demo', { paletteView: true, visibleAtStart: true });
+        const grid = computePaletteGrid(320);
+        const paletteBandTop = paletteBandY(240, grid.totalHeight);
+        const paletteBand = new Rect2i(0, paletteBandTop, 320, grid.totalHeight);
+        const swatch = new Rect2i();
+        const index = grid.cols * (grid.rows - 1);
+
+        writePaletteSwatchTopLeft(swatch, index, paletteBand, grid);
+
+        overlay.handleFrameInput(
+            {
+                isButtonPressed: () => true,
+                getPos: () => new Vector2i(swatch.x + 1, swatch.y + 1),
+            } as never,
+            null,
+            1,
+        );
+
+        expect(overlay.bodyVisible).toBe(true);
     });
 
     it('starts hidden by default and toggles body visibility', () => {

--- a/src/render/stats-overlay/StatsOverlay.ts
+++ b/src/render/stats-overlay/StatsOverlay.ts
@@ -24,6 +24,7 @@ import {
     createStatsOverlayLayoutPlanScratch,
 } from './layoutPlan';
 import { StatsOverlayBars } from './StatsOverlayBars';
+import { StatsOverlayPaletteInteraction } from './StatsOverlayPaletteInteraction';
 import { computePaletteGrid, DEFAULT_PALETTE_GRID, StatsOverlayPaletteView } from './StatsOverlayPaletteView';
 import { StatsOverlayTimingChart } from './StatsOverlayTimingChart';
 import { StatsOverlayToggle } from './StatsOverlayToggle';
@@ -72,6 +73,8 @@ export class StatsOverlay {
     readonly #timingChartStyle: ResolvedStatsOverlayTimingChartStyle;
 
     readonly #paletteView: StatsOverlayPaletteView;
+
+    readonly #paletteInteraction: StatsOverlayPaletteInteraction;
 
     readonly #paletteColumns: number | undefined;
 
@@ -126,6 +129,7 @@ export class StatsOverlay {
         this.#timingChartHeight = statsOverlayTimingChartHeight ?? DEFAULT_TIMING_CHART_HEIGHT;
         this.#timingChart = new StatsOverlayTimingChart(statsOverlayTimingChart);
         this.#paletteView = new StatsOverlayPaletteView(statsOverlayPaletteView);
+        this.#paletteInteraction = new StatsOverlayPaletteInteraction(targetFps);
         this.#paletteColumns = paletteColumns;
         this.#toggle = new StatsOverlayToggle(statsOverlayVisibleAtStart, statsOverlayToggleEnabled);
         this.#toggleHintVisible = statsOverlayToggleHintVisible;
@@ -157,6 +161,47 @@ export class StatsOverlay {
     }
 
     /**
+     * Handles overlay frame input: palette swatch copy first, then body toggle.
+     *
+     * @param pointer - Pointer subsystem, or `null` when unavailable.
+     * @param keyboard - Keyboard subsystem, or `null` when unavailable.
+     * @param currentTick - Current fixed-update tick for keyboard edge detection.
+     * @param getCustomRows - Optional supplier for demo rows (layout plan for palette hits).
+     * @param palette - Active demo palette for slot count, if any.
+     */
+    handleFrameInput(
+        pointer: PointerInput | null,
+        keyboard: KeyboardInput | null,
+        currentTick: number,
+        getCustomRows?: () => readonly StatsOverlayRow[] | undefined,
+        palette?: Palette | null,
+    ): void {
+        let pointerPressConsumed = false;
+
+        if (this.#paletteView.enabled && this.#toggle.bodyVisible) {
+            const customRows = getCustomRows?.();
+            const { layoutConfig, plan } = this.#buildFramePlan(customRows?.length ?? 0, palette);
+            const grid = layoutConfig.paletteGrid;
+            const colorCount = palette?.size ?? 256;
+
+            if (grid !== undefined && plan.paletteBand.height > 0) {
+                pointerPressConsumed = this.#paletteInteraction.handlePress(
+                    pointer,
+                    currentTick,
+                    plan,
+                    grid,
+                    colorCount,
+                    this.#layout.bottomTextY,
+                    this.#layout.displayWidth,
+                    this.#layout.lineHeight,
+                );
+            }
+        }
+
+        this.#toggle.handleToggle(pointer, keyboard, currentTick, this.#layout.toggleRect, pointerPressConsumed);
+    }
+
+    /**
      * Handles toggle input (Backquote and bottom-left corner press).
      *
      * @param pointer - Pointer subsystem, or `null` when unavailable.
@@ -164,7 +209,7 @@ export class StatsOverlay {
      * @param currentTick - Current fixed-update tick for keyboard edge detection.
      */
     handleToggle(pointer: PointerInput | null, keyboard: KeyboardInput | null, currentTick: number): void {
-        this.#toggle.handleToggle(pointer, keyboard, currentTick, this.#layout.toggleRect);
+        this.handleFrameInput(pointer, keyboard, currentTick);
     }
 
     /**
@@ -264,6 +309,8 @@ export class StatsOverlay {
      * @param customRows - Optional demo rows, if any.
      * @param palette - Active demo palette.
      * @param usedPaletteMask - Per-frame palette usage mask from BTAPI.
+     * @param pointer
+     * @param currentTick
      */
     #drawFrame(
         renderer: IRenderer,
@@ -274,6 +321,8 @@ export class StatsOverlay {
         customRows: readonly StatsOverlayRow[] | undefined,
         palette: Palette | null | undefined,
         usedPaletteMask: Uint8Array,
+        pointer: PointerInput | null,
+        currentTick: number,
     ): void {
         this.#barStyle.barIndex = this.#idxBg;
         this.#barStyle.textIndex = this.#idxText;
@@ -292,6 +341,47 @@ export class StatsOverlay {
                 this.#bars.drawCustomRows(renderer, font, plan, customRows, this.#barStyle);
             }
 
+            this.#bars.drawPaletteBandFill(renderer, plan, this.#idxBg);
+
+            const paletteGrid = layoutConfig.paletteGrid ?? DEFAULT_PALETTE_GRID;
+
+            this.#paletteView.draw(
+                renderer,
+                plan.paletteBand,
+                palette ?? null,
+                paletteGrid,
+                this.#layout.bottomTextY,
+                this.#layout.displayWidth,
+                this.#layout.lineHeight,
+                usedPaletteMask,
+                this.#idxText,
+            );
+
+            const colorCount = palette?.size ?? 256;
+
+            this.#paletteInteraction.tickCopyStatus(currentTick);
+
+            this.#paletteInteraction.updateHover(
+                pointer,
+                plan,
+                paletteGrid,
+                colorCount,
+                this.#layout.bottomTextY,
+                this.#layout.displayWidth,
+                this.#layout.lineHeight,
+            );
+
+            this.#paletteInteraction.drawTooltip(
+                renderer,
+                font,
+                plan,
+                paletteGrid,
+                this.#layout.displayWidth,
+                this.#layout.displayHeight,
+                this.#idxBg,
+                this.#idxText,
+            );
+
             this.#bars.drawTopLabels(
                 renderer,
                 font,
@@ -302,23 +392,10 @@ export class StatsOverlay {
                 topMetricsLabel,
                 topTimingLabel,
             );
-
-            this.#bars.drawPaletteBandFill(renderer, plan, this.#idxBg);
-
-            this.#paletteView.draw(
-                renderer,
-                plan.paletteBand,
-                palette ?? null,
-                layoutConfig.paletteGrid ?? DEFAULT_PALETTE_GRID,
-                this.#layout.bottomTextY,
-                this.#layout.displayWidth,
-                this.#layout.lineHeight,
-                usedPaletteMask,
-                this.#idxText,
-            );
         }
 
         this.#bars.drawHintBarFill(renderer, plan, this.#idxBg);
+
         this.#bars.drawHintLabel(renderer, font, plan, this.#idxText, STATS_BOTTOM_HINT_LABEL);
     }
 
@@ -328,9 +405,9 @@ export class StatsOverlay {
      *
      * @param renderer - Active {@link IRenderer} instance.
      * @param font - System bitmap font.
-     * @param _pointer - Reserved; toggle input is handled in BTAPI before render.
+     * @param pointer - Pointer subsystem for palette swatch hover tooltips.
      * @param _keyboard - Reserved; toggle input is handled in BTAPI before render.
-     * @param _currentTick - Reserved; toggle input is handled in BTAPI before render.
+     * @param currentTick - Current fixed-update tick for copy-status expiry.
      * @param getCustomRows - Optional supplier for demo rows; not invoked while the overlay body is hidden.
      * @param timing - Optional timing snapshot from the previous rendered frame.
      * @param palette - Active demo palette for optional palette grid.
@@ -339,9 +416,9 @@ export class StatsOverlay {
     updateAndRender(
         renderer: IRenderer,
         font: BitmapFont,
-        _pointer: PointerInput | null,
+        pointer: PointerInput | null,
         _keyboard: KeyboardInput | null,
-        _currentTick: number,
+        currentTick: number,
         getCustomRows?: () => readonly StatsOverlayRow[] | undefined,
         timing?: StatsOverlayTimingSnapshot,
         palette?: Palette | null,
@@ -364,7 +441,18 @@ export class StatsOverlay {
         const { layoutConfig, plan } = this.#buildFramePlan(customRows?.length ?? 0, palette);
 
         this.#withOverlayCamera(renderer, () => {
-            this.#drawFrame(renderer, font, plan, layoutConfig, bodyVisible, customRows, palette, usedPaletteMask);
+            this.#drawFrame(
+                renderer,
+                font,
+                plan,
+                layoutConfig,
+                bodyVisible,
+                customRows,
+                palette,
+                usedPaletteMask,
+                pointer,
+                currentTick,
+            );
         });
     }
 }

--- a/src/render/stats-overlay/StatsOverlay.ts
+++ b/src/render/stats-overlay/StatsOverlay.ts
@@ -371,17 +371,6 @@ export class StatsOverlay {
                 this.#layout.lineHeight,
             );
 
-            this.#paletteInteraction.drawTooltip(
-                renderer,
-                font,
-                plan,
-                paletteGrid,
-                this.#layout.displayWidth,
-                this.#layout.displayHeight,
-                this.#idxBg,
-                this.#idxText,
-            );
-
             this.#bars.drawTopLabels(
                 renderer,
                 font,
@@ -397,6 +386,21 @@ export class StatsOverlay {
         this.#bars.drawHintBarFill(renderer, plan, this.#idxBg);
 
         this.#bars.drawHintLabel(renderer, font, plan, this.#idxText, STATS_BOTTOM_HINT_LABEL);
+
+        if (bodyVisible) {
+            const paletteGrid = layoutConfig.paletteGrid ?? DEFAULT_PALETTE_GRID;
+
+            this.#paletteInteraction.drawTooltip(
+                renderer,
+                font,
+                plan,
+                paletteGrid,
+                this.#layout.displayWidth,
+                this.#layout.displayHeight,
+                this.#idxText,
+                this.#idxBg,
+            );
+        }
     }
 
     /**

--- a/src/render/stats-overlay/StatsOverlayPaletteInteraction.test.ts
+++ b/src/render/stats-overlay/StatsOverlayPaletteInteraction.test.ts
@@ -1,0 +1,419 @@
+/**
+ * Unit tests for palette swatch hit testing, tooltip layout, and clipboard copy (VV-549).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Rect2i } from '../../utils/Rect2i';
+import { Vector2i } from '../../utils/Vector2i';
+import { DEFAULT_IDX_BG, DEFAULT_IDX_TEXT } from './constants';
+import { createStatsOverlayLayout } from './layoutHelpers';
+import { paletteBandY } from './layoutPlan';
+import {
+    hitTestPaletteSwatch,
+    layoutPaletteTooltip,
+    PALETTE_COPY_STATUS_SECONDS,
+    StatsOverlayPaletteInteraction,
+    writePaletteIndexToClipboard,
+} from './StatsOverlayPaletteInteraction';
+import {
+    computePaletteGrid,
+    DEFAULT_PALETTE_SWATCH_SIZE,
+    PALETTE_SWATCH_GAP_PX,
+    resolvePaletteHintExclusionRect,
+    writePaletteSwatchTopLeft,
+} from './StatsOverlayPaletteView';
+import { mockFont } from './testFixtures';
+import type { StatsOverlayLayoutPlan } from './types';
+
+/** Minimal layout plan with only the palette band populated. */
+function paletteOnlyPlan(paletteBand: Rect2i): StatsOverlayLayoutPlan {
+    return { paletteBand } as StatsOverlayLayoutPlan;
+}
+
+/** Builds hint exclusion for the golden 320x240 layout. */
+function goldenHintExclusion(): Rect2i {
+    const layout = createStatsOverlayLayout(320, 240, 14);
+
+    return resolvePaletteHintExclusionRect(layout.bottomTextY, layout.displayWidth, layout.lineHeight);
+}
+
+describe('hitTestPaletteSwatch', () => {
+    const layout = createStatsOverlayLayout(320, 240, 14);
+    const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 256, PALETTE_SWATCH_GAP_PX);
+    const paletteBandTop = paletteBandY(240, grid.totalHeight);
+    const paletteBand = new Rect2i(0, paletteBandTop, 320, grid.totalHeight);
+    const hintExclusion = goldenHintExclusion();
+
+    it('maps pointer inside a swatch to its palette index', () => {
+        const index = 42;
+        const swatch = new Rect2i();
+
+        writePaletteSwatchTopLeft(swatch, index, paletteBand, grid);
+
+        const hit = hitTestPaletteSwatch(
+            swatch.x + 1,
+            swatch.y + 1,
+            paletteBand,
+            grid,
+            256,
+            hintExclusion,
+            layout.displayWidth,
+        );
+
+        expect(hit).toBe(index);
+    });
+
+    it('returns null in horizontal and vertical gaps between swatches', () => {
+        const swatch = new Rect2i();
+
+        writePaletteSwatchTopLeft(swatch, 0, paletteBand, grid);
+        const gapX = swatch.x + grid.swatchSize;
+
+        expect(
+            hitTestPaletteSwatch(gapX, swatch.y + 1, paletteBand, grid, 256, hintExclusion, layout.displayWidth),
+        ).toBeNull();
+
+        const gapY = swatch.y + grid.swatchSize;
+
+        expect(
+            hitTestPaletteSwatch(swatch.x + 1, gapY, paletteBand, grid, 256, hintExclusion, layout.displayWidth),
+        ).toBeNull();
+    });
+
+    it('returns null over the hint exclusion band', () => {
+        const hit = hitTestPaletteSwatch(
+            hintExclusion.x + 1,
+            hintExclusion.y + 1,
+            paletteBand,
+            grid,
+            256,
+            hintExclusion,
+            layout.displayWidth,
+        );
+
+        expect(hit).toBeNull();
+    });
+
+    it('excludes the right scrollbar track from hits', () => {
+        const trackWidth = 8;
+        const swatch = new Rect2i();
+
+        writePaletteSwatchTopLeft(swatch, 31, paletteBand, grid);
+
+        expect(
+            hitTestPaletteSwatch(
+                layout.displayWidth - 1,
+                swatch.y + 1,
+                paletteBand,
+                grid,
+                256,
+                hintExclusion,
+                layout.displayWidth,
+                0,
+                trackWidth,
+            ),
+        ).toBeNull();
+    });
+
+    it('applies scroll row offset to visible row mapping', () => {
+        const scrollRowOffset = 2;
+        const index = scrollRowOffset * grid.cols + 5;
+        const swatch = new Rect2i();
+
+        writePaletteSwatchTopLeft(swatch, index, paletteBand, grid, scrollRowOffset);
+
+        expect(
+            hitTestPaletteSwatch(
+                swatch.x + 1,
+                swatch.y + 1,
+                paletteBand,
+                grid,
+                256,
+                hintExclusion,
+                layout.displayWidth,
+                scrollRowOffset,
+            ),
+        ).toBe(index);
+    });
+
+    it('still hits swatches inside the bottom-left toggle corner overlap', () => {
+        const index = grid.cols * (grid.rows - 1);
+        const swatch = new Rect2i();
+
+        writePaletteSwatchTopLeft(swatch, index, paletteBand, grid);
+
+        expect(
+            hitTestPaletteSwatch(
+                swatch.x + 1,
+                swatch.y + 1,
+                paletteBand,
+                grid,
+                256,
+                hintExclusion,
+                layout.displayWidth,
+            ),
+        ).toBe(index);
+        expect(layout.toggleRect.contains(new Vector2i(swatch.x + 1, swatch.y + 1))).toBe(true);
+    });
+});
+
+describe('layoutPaletteTooltip', () => {
+    const layoutScratch = {
+        body: new Rect2i(),
+        swatch: new Rect2i(),
+        caretLeft: new Vector2i(),
+        caretTip: new Vector2i(),
+        caretRight: new Vector2i(),
+        textPos: new Vector2i(),
+    };
+
+    it('clamps tooltip body inside the display on the right edge', () => {
+        const swatch = new Rect2i(300, 180, 7, 7);
+        const label = '255';
+
+        layoutPaletteTooltip(layoutScratch, swatch, label, 320, 240);
+
+        expect(layoutScratch.body.x + layoutScratch.body.width).toBeLessThanOrEqual(320);
+        expect(layoutScratch.body.x).toBeGreaterThanOrEqual(0);
+    });
+
+    it('clamps tooltip body inside the display on the left edge', () => {
+        const swatch = new Rect2i(0, 180, 7, 7);
+        const label = '255';
+
+        layoutPaletteTooltip(layoutScratch, swatch, label, 320, 240);
+
+        expect(layoutScratch.body.x).toBeGreaterThanOrEqual(0);
+    });
+
+    it('keeps caret tip near swatch center when body is clamped', () => {
+        const swatch = new Rect2i(0, 180, 7, 7);
+        const swatchCenterX = swatch.x + Math.floor(swatch.width / 2);
+
+        layoutPaletteTooltip(layoutScratch, swatch, '12', 320, 240);
+
+        expect(Math.abs(layoutScratch.caretTip.x - swatchCenterX)).toBeLessThanOrEqual(3);
+        expect(layoutScratch.caretTip.y).toBe(swatch.y);
+    });
+});
+
+describe('StatsOverlayPaletteInteraction clipboard', () => {
+    beforeEach(() => {
+        vi.stubGlobal('navigator', {
+            clipboard: {
+                writeText: vi.fn().mockResolvedValue(undefined),
+            },
+        });
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('writes plain index strings to the clipboard', async () => {
+        await writePaletteIndexToClipboard(42);
+
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith('42');
+    });
+
+    it('shows Copied N after successful press', async () => {
+        const interaction = new StatsOverlayPaletteInteraction(60);
+        const layout = createStatsOverlayLayout(320, 240, 14);
+        const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 256, PALETTE_SWATCH_GAP_PX);
+        const paletteBandTop = paletteBandY(240, grid.totalHeight);
+        const plan = paletteOnlyPlan(new Rect2i(0, paletteBandTop, 320, grid.totalHeight));
+        const swatch = new Rect2i();
+
+        writePaletteSwatchTopLeft(swatch, 7, plan.paletteBand, grid);
+
+        const consumed = interaction.handlePress(
+            {
+                isButtonPressed: () => true,
+                getPos: () => new Vector2i(swatch.x + 1, swatch.y + 1),
+            } as never,
+            10,
+            plan,
+            grid,
+            256,
+            layout.bottomTextY,
+            layout.displayWidth,
+            layout.lineHeight,
+        );
+
+        expect(consumed).toBe(true);
+
+        await vi.waitFor(async () => {
+            await Promise.resolve();
+            const probe = {
+                drawRectFillOnTop: vi.fn(),
+                drawRect: vi.fn(),
+                drawBitmapTextOnTop: vi.fn(),
+                drawPixel: vi.fn(),
+            };
+
+            interaction.drawTooltip(
+                probe as never,
+                mockFont,
+                plan,
+                grid,
+                layout.displayWidth,
+                layout.displayHeight,
+                DEFAULT_IDX_BG,
+                DEFAULT_IDX_TEXT,
+            );
+
+            expect(probe.drawBitmapTextOnTop).toHaveBeenCalled();
+        });
+
+        const renderer = {
+            drawRectFillOnTop: vi.fn(),
+            drawRect: vi.fn(),
+            drawBitmapTextOnTop: vi.fn(),
+            drawPixel: vi.fn(),
+        };
+
+        interaction.drawTooltip(
+            renderer as never,
+            mockFont,
+            plan,
+            grid,
+            layout.displayWidth,
+            layout.displayHeight,
+            DEFAULT_IDX_BG,
+            DEFAULT_IDX_TEXT,
+        );
+
+        expect(renderer.drawBitmapTextOnTop).toHaveBeenCalledWith(
+            mockFont,
+            expect.any(Vector2i),
+            'Copied 7',
+            expect.any(Number),
+        );
+    });
+
+    it('shows Copy failed when clipboard write is denied', async () => {
+        vi.mocked(navigator.clipboard.writeText).mockRejectedValueOnce(new Error('denied'));
+
+        const interaction = new StatsOverlayPaletteInteraction(60);
+        const layout = createStatsOverlayLayout(320, 240, 14);
+        const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 256, PALETTE_SWATCH_GAP_PX);
+        const paletteBandTop = paletteBandY(240, grid.totalHeight);
+        const plan = paletteOnlyPlan(new Rect2i(0, paletteBandTop, 320, grid.totalHeight));
+        const swatch = new Rect2i();
+
+        writePaletteSwatchTopLeft(swatch, 3, plan.paletteBand, grid);
+
+        interaction.handlePress(
+            {
+                isButtonPressed: () => true,
+                getPos: () => new Vector2i(swatch.x + 1, swatch.y + 1),
+            } as never,
+            5,
+            plan,
+            grid,
+            256,
+            layout.bottomTextY,
+            layout.displayWidth,
+            layout.lineHeight,
+        );
+
+        await vi.waitFor(() => {
+            const renderer = {
+                drawRectFillOnTop: vi.fn(),
+                drawRect: vi.fn(),
+                drawBitmapTextOnTop: vi.fn(),
+                drawPixel: vi.fn(),
+            };
+
+            interaction.drawTooltip(
+                renderer as never,
+                mockFont,
+                plan,
+                grid,
+                layout.displayWidth,
+                layout.displayHeight,
+                DEFAULT_IDX_BG,
+                DEFAULT_IDX_TEXT,
+            );
+
+            expect(renderer.drawBitmapTextOnTop).toHaveBeenCalledWith(
+                mockFont,
+                expect.any(Vector2i),
+                'Copy failed',
+                expect.any(Number),
+            );
+        });
+    });
+
+    it('clears copy status after the configured duration', async () => {
+        const interaction = new StatsOverlayPaletteInteraction(60);
+        const layout = createStatsOverlayLayout(320, 240, 14);
+        const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 256, PALETTE_SWATCH_GAP_PX);
+        const paletteBandTop = paletteBandY(240, grid.totalHeight);
+        const plan = paletteOnlyPlan(new Rect2i(0, paletteBandTop, 320, grid.totalHeight));
+        const swatch = new Rect2i();
+
+        writePaletteSwatchTopLeft(swatch, 9, plan.paletteBand, grid);
+
+        interaction.handlePress(
+            {
+                isButtonPressed: () => true,
+                getPos: () => new Vector2i(swatch.x + 1, swatch.y + 1),
+            } as never,
+            10,
+            plan,
+            grid,
+            256,
+            layout.bottomTextY,
+            layout.displayWidth,
+            layout.lineHeight,
+        );
+
+        await vi.waitFor(async () => {
+            await Promise.resolve();
+        });
+
+        const expiryTick = 10 + Math.ceil(PALETTE_COPY_STATUS_SECONDS * 60);
+
+        interaction.tickCopyStatus(expiryTick);
+
+        const renderer = {
+            drawRectFillOnTop: vi.fn(),
+            drawRect: vi.fn(),
+            drawBitmapTextOnTop: vi.fn(),
+            drawPixel: vi.fn(),
+        };
+
+        interaction.updateHover(
+            {
+                isValid: () => true,
+                getPos: () => new Vector2i(swatch.x + 1, swatch.y + 1),
+            } as never,
+            plan,
+            grid,
+            256,
+            layout.bottomTextY,
+            layout.displayWidth,
+            layout.lineHeight,
+        );
+
+        interaction.drawTooltip(
+            renderer as never,
+            mockFont,
+            plan,
+            grid,
+            layout.displayWidth,
+            layout.displayHeight,
+            DEFAULT_IDX_BG,
+            DEFAULT_IDX_TEXT,
+        );
+
+        expect(renderer.drawBitmapTextOnTop).toHaveBeenCalledWith(
+            mockFont,
+            expect.any(Vector2i),
+            '9',
+            expect.any(Number),
+        );
+    });
+});

--- a/src/render/stats-overlay/StatsOverlayPaletteInteraction.test.ts
+++ b/src/render/stats-overlay/StatsOverlayPaletteInteraction.test.ts
@@ -192,6 +192,15 @@ describe('layoutPaletteTooltip', () => {
 
         expect(layoutScratch.body.y + layoutScratch.body.height).toBe(swatch.y - 1);
     });
+
+    it('keeps tooltip body fully inside the display on the bottom edge', () => {
+        const swatch = new Rect2i(0, 235, 7, 7);
+
+        layoutPaletteTooltip(layoutScratch, swatch, '12', 320, 240);
+
+        expect(layoutScratch.body.y + layoutScratch.body.height).toBeLessThanOrEqual(240);
+        expect(layoutScratch.body.y).toBeGreaterThanOrEqual(0);
+    });
 });
 
 describe('drawPaletteTooltip', () => {

--- a/src/render/stats-overlay/StatsOverlayPaletteInteraction.test.ts
+++ b/src/render/stats-overlay/StatsOverlayPaletteInteraction.test.ts
@@ -455,4 +455,132 @@ describe('StatsOverlayPaletteInteraction clipboard', () => {
             expect.any(Number),
         );
     });
+
+    it('starts copy-status expiry from clipboard completion tick', async () => {
+        let resolveWrite!: () => void;
+
+        vi.mocked(navigator.clipboard.writeText).mockImplementation(
+            () =>
+                new Promise<void>((resolve) => {
+                    resolveWrite = resolve;
+                }),
+        );
+
+        const interaction = new StatsOverlayPaletteInteraction(60);
+        const layout = createStatsOverlayLayout(320, 240, 14);
+        const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 256, PALETTE_SWATCH_GAP_PX);
+        const paletteBandTop = paletteBandY(240, grid.totalHeight);
+        const plan = paletteOnlyPlan(new Rect2i(0, paletteBandTop, 320, grid.totalHeight));
+        const swatch = new Rect2i();
+
+        writePaletteSwatchTopLeft(swatch, 9, plan.paletteBand, grid);
+
+        interaction.handlePress(
+            {
+                isButtonPressed: () => true,
+                getPos: () => new Vector2i(swatch.x + 1, swatch.y + 1),
+            } as never,
+            10,
+            plan,
+            grid,
+            256,
+            layout.bottomTextY,
+            layout.displayWidth,
+            layout.lineHeight,
+        );
+
+        for (let tick = 11; tick <= 25; tick++) {
+            interaction.tickCopyStatus(tick);
+        }
+
+        resolveWrite();
+        await vi.waitFor(async () => {
+            await Promise.resolve();
+
+            const probe = {
+                drawRectFillForeground: vi.fn(),
+                drawBitmapTextForeground: vi.fn(),
+            };
+
+            interaction.drawTooltip(
+                probe as never,
+                mockFont,
+                plan,
+                grid,
+                layout.displayWidth,
+                layout.displayHeight,
+                DEFAULT_IDX_BG,
+                DEFAULT_IDX_TEXT,
+            );
+
+            expect(probe.drawBitmapTextForeground).toHaveBeenCalledWith(
+                mockFont,
+                expect.any(Vector2i),
+                'Copied 9',
+                expect.any(Number),
+            );
+        });
+
+        const completionExpiryTick = 25 + Math.ceil(PALETTE_COPY_STATUS_SECONDS * 60);
+        const pressExpiryTick = 10 + Math.ceil(PALETTE_COPY_STATUS_SECONDS * 60);
+
+        const renderer = {
+            drawRectFillForeground: vi.fn(),
+            drawRectFillOnTop: vi.fn(),
+            drawRect: vi.fn(),
+            drawBitmapTextForeground: vi.fn(),
+            drawBitmapTextOnTop: vi.fn(),
+            drawPixel: vi.fn(),
+        };
+
+        interaction.tickCopyStatus(pressExpiryTick);
+        interaction.drawTooltip(
+            renderer as never,
+            mockFont,
+            plan,
+            grid,
+            layout.displayWidth,
+            layout.displayHeight,
+            DEFAULT_IDX_BG,
+            DEFAULT_IDX_TEXT,
+        );
+
+        expect(renderer.drawBitmapTextForeground).toHaveBeenCalledWith(
+            mockFont,
+            expect.any(Vector2i),
+            'Copied 9',
+            expect.any(Number),
+        );
+
+        interaction.tickCopyStatus(completionExpiryTick);
+        interaction.updateHover(
+            {
+                isValid: () => true,
+                getPos: () => new Vector2i(swatch.x + 1, swatch.y + 1),
+            } as never,
+            plan,
+            grid,
+            256,
+            layout.bottomTextY,
+            layout.displayWidth,
+            layout.lineHeight,
+        );
+        interaction.drawTooltip(
+            renderer as never,
+            mockFont,
+            plan,
+            grid,
+            layout.displayWidth,
+            layout.displayHeight,
+            DEFAULT_IDX_BG,
+            DEFAULT_IDX_TEXT,
+        );
+
+        expect(renderer.drawBitmapTextForeground).toHaveBeenLastCalledWith(
+            mockFont,
+            expect.any(Vector2i),
+            '9',
+            expect.any(Number),
+        );
+    });
 });

--- a/src/render/stats-overlay/StatsOverlayPaletteInteraction.test.ts
+++ b/src/render/stats-overlay/StatsOverlayPaletteInteraction.test.ts
@@ -10,6 +10,7 @@ import { DEFAULT_IDX_BG, DEFAULT_IDX_TEXT } from './constants';
 import { createStatsOverlayLayout } from './layoutHelpers';
 import { paletteBandY } from './layoutPlan';
 import {
+    drawPaletteTooltip,
     hitTestPaletteSwatch,
     layoutPaletteTooltip,
     PALETTE_COPY_STATUS_SECONDS,
@@ -162,9 +163,6 @@ describe('layoutPaletteTooltip', () => {
     const layoutScratch = {
         body: new Rect2i(),
         swatch: new Rect2i(),
-        caretLeft: new Vector2i(),
-        caretTip: new Vector2i(),
-        caretRight: new Vector2i(),
         textPos: new Vector2i(),
     };
 
@@ -187,14 +185,38 @@ describe('layoutPaletteTooltip', () => {
         expect(layoutScratch.body.x).toBeGreaterThanOrEqual(0);
     });
 
-    it('keeps caret tip near swatch center when body is clamped', () => {
-        const swatch = new Rect2i(0, 180, 7, 7);
-        const swatchCenterX = swatch.x + Math.floor(swatch.width / 2);
+    it('places tooltip body above the swatch with a one-pixel gap', () => {
+        const swatch = new Rect2i(40, 180, 7, 7);
 
         layoutPaletteTooltip(layoutScratch, swatch, '12', 320, 240);
 
-        expect(Math.abs(layoutScratch.caretTip.x - swatchCenterX)).toBeLessThanOrEqual(3);
-        expect(layoutScratch.caretTip.y).toBe(swatch.y);
+        expect(layoutScratch.body.y + layoutScratch.body.height).toBe(swatch.y - 1);
+    });
+});
+
+describe('drawPaletteTooltip', () => {
+    it('draws via foreground overlay APIs so tooltips stay above custom stats rows', () => {
+        const layoutScratch = {
+            body: new Rect2i(),
+            swatch: new Rect2i(40, 180, 7, 7),
+            textPos: new Vector2i(),
+        };
+        const layout = layoutPaletteTooltip(layoutScratch, layoutScratch.swatch, '42', 320, 240);
+        const renderer = {
+            drawRectFillForeground: vi.fn(),
+            drawRectFillOnTop: vi.fn(),
+            drawRect: vi.fn(),
+            drawBitmapTextForeground: vi.fn(),
+            drawBitmapTextOnTop: vi.fn(),
+        };
+
+        drawPaletteTooltip(renderer as never, mockFont, layout, '42', DEFAULT_IDX_BG, DEFAULT_IDX_TEXT);
+
+        expect(renderer.drawRectFillForeground).toHaveBeenCalled();
+        expect(renderer.drawRectFillOnTop).not.toHaveBeenCalled();
+        expect(renderer.drawRect).not.toHaveBeenCalled();
+        expect(renderer.drawBitmapTextForeground).toHaveBeenCalled();
+        expect(renderer.drawBitmapTextOnTop).not.toHaveBeenCalled();
     });
 });
 
@@ -246,8 +268,10 @@ describe('StatsOverlayPaletteInteraction clipboard', () => {
         await vi.waitFor(async () => {
             await Promise.resolve();
             const probe = {
+                drawRectFillForeground: vi.fn(),
                 drawRectFillOnTop: vi.fn(),
                 drawRect: vi.fn(),
+                drawBitmapTextForeground: vi.fn(),
                 drawBitmapTextOnTop: vi.fn(),
                 drawPixel: vi.fn(),
             };
@@ -263,12 +287,14 @@ describe('StatsOverlayPaletteInteraction clipboard', () => {
                 DEFAULT_IDX_TEXT,
             );
 
-            expect(probe.drawBitmapTextOnTop).toHaveBeenCalled();
+            expect(probe.drawBitmapTextForeground).toHaveBeenCalled();
         });
 
         const renderer = {
+            drawRectFillForeground: vi.fn(),
             drawRectFillOnTop: vi.fn(),
             drawRect: vi.fn(),
+            drawBitmapTextForeground: vi.fn(),
             drawBitmapTextOnTop: vi.fn(),
             drawPixel: vi.fn(),
         };
@@ -284,7 +310,7 @@ describe('StatsOverlayPaletteInteraction clipboard', () => {
             DEFAULT_IDX_TEXT,
         );
 
-        expect(renderer.drawBitmapTextOnTop).toHaveBeenCalledWith(
+        expect(renderer.drawBitmapTextForeground).toHaveBeenCalledWith(
             mockFont,
             expect.any(Vector2i),
             'Copied 7',
@@ -320,8 +346,10 @@ describe('StatsOverlayPaletteInteraction clipboard', () => {
 
         await vi.waitFor(() => {
             const renderer = {
+                drawRectFillForeground: vi.fn(),
                 drawRectFillOnTop: vi.fn(),
                 drawRect: vi.fn(),
+                drawBitmapTextForeground: vi.fn(),
                 drawBitmapTextOnTop: vi.fn(),
                 drawPixel: vi.fn(),
             };
@@ -337,7 +365,7 @@ describe('StatsOverlayPaletteInteraction clipboard', () => {
                 DEFAULT_IDX_TEXT,
             );
 
-            expect(renderer.drawBitmapTextOnTop).toHaveBeenCalledWith(
+            expect(renderer.drawBitmapTextForeground).toHaveBeenCalledWith(
                 mockFont,
                 expect.any(Vector2i),
                 'Copy failed',
@@ -379,8 +407,10 @@ describe('StatsOverlayPaletteInteraction clipboard', () => {
         interaction.tickCopyStatus(expiryTick);
 
         const renderer = {
+            drawRectFillForeground: vi.fn(),
             drawRectFillOnTop: vi.fn(),
             drawRect: vi.fn(),
+            drawBitmapTextForeground: vi.fn(),
             drawBitmapTextOnTop: vi.fn(),
             drawPixel: vi.fn(),
         };
@@ -409,7 +439,7 @@ describe('StatsOverlayPaletteInteraction clipboard', () => {
             DEFAULT_IDX_TEXT,
         );
 
-        expect(renderer.drawBitmapTextOnTop).toHaveBeenCalledWith(
+        expect(renderer.drawBitmapTextForeground).toHaveBeenCalledWith(
             mockFont,
             expect.any(Vector2i),
             '9',

--- a/src/render/stats-overlay/StatsOverlayPaletteInteraction.ts
+++ b/src/render/stats-overlay/StatsOverlayPaletteInteraction.ts
@@ -1,0 +1,638 @@
+/**
+ * Palette swatch hover tooltips and clipboard copy for the stats overlay (VV-549).
+ */
+
+import type { BitmapFont } from '../../assets/BitmapFont';
+import type { PointerInput } from '../../input/PointerInput';
+import { POINTER_SLOT_COUNT } from '../../input/PointerInput';
+import { Rect2i } from '../../utils/Rect2i';
+import { Vector2i } from '../../utils/Vector2i';
+import type { IRenderer } from '../IRenderer';
+import { POINTER_PRIMARY_BUTTON, STATS_EDGE_MARGIN_PX, SYSTEM_CHAR_ADVANCE } from './constants';
+import { statsBitmapTextPaletteOffset } from './layoutHelpers';
+import {
+    PALETTE_GRID_PADDING_PX,
+    resolvePaletteHintExclusionRect,
+    writePaletteSwatchTopLeft,
+} from './StatsOverlayPaletteView';
+import type { PaletteGridLayout, StatsOverlayLayoutPlan } from './types';
+
+/** Reserved width on the right edge of the palette band excluded from swatch hits (VV-550 scrollbar). */
+export const PALETTE_SCROLLBAR_TRACK_WIDTH_PX = 0;
+
+/** Duration for transient copy status tooltips in seconds. */
+export const PALETTE_COPY_STATUS_SECONDS = 0.75;
+
+/** Horizontal padding inside the tooltip label body. */
+const TOOLTIP_PADDING_X_PX = 2;
+
+/** Vertical padding inside the tooltip label body. */
+const TOOLTIP_PADDING_Y_PX = 1;
+
+/** Height of the downward caret below the tooltip body. */
+const TOOLTIP_CARET_HEIGHT_PX = 3;
+
+/** Half-width of the caret in pixels (forms a `\/` shape under the body). */
+const TOOLTIP_CARET_HALF_WIDTH_PX = 2;
+
+/** Clipboard copy feedback state for palette swatch presses. */
+type PaletteCopyStatus = 'idle' | 'copied' | 'failed';
+
+/** Scratch rects and points reused by tooltip layout and draw (one overlay at a time). */
+const tooltipScratch = {
+    body: new Rect2i(),
+    swatch: new Rect2i(),
+    caretLeft: new Vector2i(),
+    caretTip: new Vector2i(),
+    caretRight: new Vector2i(),
+    textPos: new Vector2i(),
+};
+
+/**
+ * Returns whether a palette slot at the given swatch origin overlaps the hint exclusion rect.
+ *
+ * @param swatchX - Swatch left edge in display pixels.
+ * @param swatchY - Swatch top edge in display pixels.
+ * @param swatchSize - Side length of the swatch.
+ * @param hintExclusion - Region reserved for the `[~]` hint label.
+ * @returns `true` when the swatch should not receive hits or draws.
+ */
+function swatchOverlapsHintExclusion(
+    swatchX: number,
+    swatchY: number,
+    swatchSize: number,
+    hintExclusion: Rect2i,
+): boolean {
+    const ex = hintExclusion;
+
+    return !(
+        ex.x >= swatchX + swatchSize ||
+        ex.x + ex.width <= swatchX ||
+        ex.y >= swatchY + swatchSize ||
+        ex.y + ex.height <= swatchY
+    );
+}
+
+/**
+ * Tests whether a pointer lies outside the palette band, including the scrollbar track.
+ *
+ * @param pointerX - Pointer X in display coordinates.
+ * @param pointerY - Pointer Y in display coordinates.
+ * @param paletteBand - Palette band rect from the layout plan.
+ * @param bandRight - Right edge of the hittable band (excludes scrollbar track).
+ * @returns `true` when the pointer lies outside the palette band (including scrollbar track).
+ */
+function isPointerOutsidePaletteBand(
+    pointerX: number,
+    pointerY: number,
+    paletteBand: Rect2i,
+    bandRight: number,
+): boolean {
+    return (
+        pointerX < paletteBand.x ||
+        pointerX >= bandRight ||
+        pointerY < paletteBand.y ||
+        pointerY >= paletteBand.y + paletteBand.height
+    );
+}
+
+/**
+ * Maps band-local coordinates to a palette index, or `null` when not over a swatch cell.
+ *
+ * @param localX - X relative to the grid origin inside the palette band.
+ * @param localY - Y relative to the grid origin inside the palette band.
+ * @param cols - Grid column count.
+ * @param swatchSize - Swatch side length in pixels.
+ * @param gap - Gap between swatches.
+ * @param scrollRowOffset - First visible grid row.
+ * @param colorCount - Active palette slot count.
+ * @returns Palette index, or `null` when the point is in padding or out of range.
+ */
+function resolvePaletteIndexAtBandLocal(
+    localX: number,
+    localY: number,
+    cols: number,
+    swatchSize: number,
+    gap: number,
+    scrollRowOffset: number,
+    colorCount: number,
+): number | null {
+    if (localX < 0 || localY < 0) {
+        return null;
+    }
+
+    const pitch = swatchSize + gap;
+    const col = Math.floor(localX / pitch);
+    const row = Math.floor(localY / pitch);
+
+    if (col >= cols) {
+        return null;
+    }
+
+    const inSwatchX = localX - col * pitch;
+
+    if (inSwatchX >= swatchSize) {
+        return null;
+    }
+
+    const inSwatchY = localY - row * pitch;
+
+    if (inSwatchY >= swatchSize) {
+        return null;
+    }
+
+    const index = (scrollRowOffset + row) * cols + col;
+
+    if (index < 0 || index >= colorCount) {
+        return null;
+    }
+
+    return index;
+}
+
+/**
+ * Maps a pointer position to a palette swatch index, or `null` when no swatch is under the point.
+ *
+ * @param pointerX - Pointer X in display coordinates.
+ * @param pointerY - Pointer Y in display coordinates.
+ * @param paletteBand - Palette band rect from the layout plan.
+ * @param grid - Precomputed grid layout.
+ * @param colorCount - Active palette slot count.
+ * @param hintExclusion - Region to skip for the `[~]` hint label.
+ * @param displayWidth - Logical display width for scrollbar track exclusion.
+ * @param scrollRowOffset - First visible grid row (default `0`; VV-550 scroll).
+ * @param scrollbarTrackWidth - Right-edge track width excluded from hits (default {@link PALETTE_SCROLLBAR_TRACK_WIDTH_PX}).
+ * @returns Palette index, or `null` when the pointer is not over a hittable swatch.
+ */
+export function hitTestPaletteSwatch(
+    pointerX: number,
+    pointerY: number,
+    paletteBand: Rect2i,
+    grid: PaletteGridLayout,
+    colorCount: number,
+    hintExclusion: Rect2i,
+    displayWidth: number,
+    scrollRowOffset = 0,
+    scrollbarTrackWidth = PALETTE_SCROLLBAR_TRACK_WIDTH_PX,
+): number | null {
+    const { cols, swatchSize, gap } = grid;
+
+    if (cols <= 0 || swatchSize <= 0 || colorCount <= 0) {
+        return null;
+    }
+
+    const bandRight = Math.min(paletteBand.x + paletteBand.width, displayWidth) - scrollbarTrackWidth;
+
+    if (isPointerOutsidePaletteBand(pointerX, pointerY, paletteBand, bandRight)) {
+        return null;
+    }
+
+    const localX = pointerX - (paletteBand.x + STATS_EDGE_MARGIN_PX);
+    const localY = pointerY - (paletteBand.y + PALETTE_GRID_PADDING_PX);
+    const index = resolvePaletteIndexAtBandLocal(localX, localY, cols, swatchSize, gap, scrollRowOffset, colorCount);
+
+    if (index === null) {
+        return null;
+    }
+
+    const swatchScratch = tooltipScratch.swatch;
+
+    writePaletteSwatchTopLeft(swatchScratch, index, paletteBand, grid, scrollRowOffset);
+
+    if (swatchOverlapsHintExclusion(swatchScratch.x, swatchScratch.y, swatchSize, hintExclusion)) {
+        return null;
+    }
+
+    return index;
+}
+
+/** Layout output for a docked palette swatch tooltip. */
+export interface PaletteTooltipLayout {
+    /** Tooltip label body in display coordinates. */
+    readonly body: Rect2i;
+
+    /** Bitmap text draw position (top-left of glyphs). */
+    readonly textPos: Vector2i;
+
+    /** Caret left, tip, and right points forming `\/` under the body. */
+    readonly caretLeft: Vector2i;
+
+    readonly caretTip: Vector2i;
+
+    readonly caretRight: Vector2i;
+}
+
+/**
+ * Lays out a docked tooltip above a swatch with clamping inside the display.
+ *
+ * @param target - Reusable layout object written in place.
+ * @param swatchRect - Swatch bounds in display coordinates.
+ * @param label - Tooltip label text.
+ * @param displayWidth - Logical display width.
+ * @param displayHeight - Logical display height.
+ * @returns `target` for chaining.
+ */
+export function layoutPaletteTooltip(
+    target: PaletteTooltipLayout,
+    swatchRect: Rect2i,
+    label: string,
+    displayWidth: number,
+    displayHeight: number,
+): PaletteTooltipLayout {
+    const textWidth = label.length * SYSTEM_CHAR_ADVANCE;
+    const bodyWidth = textWidth + TOOLTIP_PADDING_X_PX * 2;
+    const bodyHeight = SYSTEM_CHAR_ADVANCE + TOOLTIP_PADDING_Y_PX * 2;
+    const swatchCenterX = swatchRect.x + Math.floor(swatchRect.width / 2);
+    const swatchTopY = swatchRect.y;
+
+    let bodyX = swatchCenterX - Math.floor(bodyWidth / 2);
+    let bodyBottom = swatchTopY - TOOLTIP_CARET_HEIGHT_PX - 1;
+    let bodyY = bodyBottom - bodyHeight;
+
+    if (bodyX < 0) {
+        bodyX = 0;
+    }
+
+    if (bodyX + bodyWidth > displayWidth) {
+        bodyX = Math.max(0, displayWidth - bodyWidth);
+    }
+
+    if (bodyY < 0) {
+        bodyY = 0;
+        bodyBottom = bodyY + bodyHeight;
+    }
+
+    if (bodyBottom + TOOLTIP_CARET_HEIGHT_PX > displayHeight) {
+        bodyBottom = displayHeight - TOOLTIP_CARET_HEIGHT_PX - 1;
+        bodyY = bodyBottom - bodyHeight;
+
+        if (bodyY < 0) {
+            bodyY = 0;
+        }
+    }
+
+    target.body.set(bodyX, bodyY, bodyWidth, bodyHeight);
+    target.textPos.set(bodyX + TOOLTIP_PADDING_X_PX, bodyY + TOOLTIP_PADDING_Y_PX);
+
+    let caretTipX = swatchCenterX;
+
+    if (caretTipX < bodyX + TOOLTIP_CARET_HALF_WIDTH_PX) {
+        caretTipX = bodyX + TOOLTIP_CARET_HALF_WIDTH_PX;
+    }
+
+    if (caretTipX > bodyX + bodyWidth - TOOLTIP_CARET_HALF_WIDTH_PX - 1) {
+        caretTipX = bodyX + bodyWidth - TOOLTIP_CARET_HALF_WIDTH_PX - 1;
+    }
+
+    const caretBaseY = bodyBottom;
+    const caretTipY = Math.min(displayHeight - 1, swatchTopY);
+
+    target.caretLeft.set(caretTipX - TOOLTIP_CARET_HALF_WIDTH_PX, caretBaseY);
+    target.caretTip.set(caretTipX, caretTipY);
+    target.caretRight.set(caretTipX + TOOLTIP_CARET_HALF_WIDTH_PX, caretBaseY);
+
+    return target;
+}
+
+/**
+ * Draws a docked palette swatch tooltip (body, outline, text, caret).
+ *
+ * @param renderer - Active renderer.
+ * @param font - System bitmap font.
+ * @param layout - Tooltip layout from {@link layoutPaletteTooltip}.
+ * @param label - Tooltip label text.
+ * @param barIndex - Palette index for tooltip body fill.
+ * @param textIndex - Palette index for outline, text, and caret.
+ */
+export function drawPaletteTooltip(
+    renderer: IRenderer,
+    font: BitmapFont,
+    layout: PaletteTooltipLayout,
+    label: string,
+    barIndex: number,
+    textIndex: number,
+): void {
+    if (label.length === 0) {
+        return;
+    }
+
+    renderer.drawRectFillOnTop(layout.body, barIndex);
+    renderer.drawRect(layout.body, textIndex);
+
+    const textPaletteOffset = statsBitmapTextPaletteOffset(textIndex);
+
+    renderer.drawBitmapTextOnTop(font, layout.textPos, label, textPaletteOffset);
+
+    const caretBaseY = layout.caretLeft.y;
+    const caretTipY = layout.caretTip.y;
+
+    if (caretTipY <= caretBaseY) {
+        renderer.drawPixel(layout.caretTip, textIndex);
+
+        return;
+    }
+
+    for (let y = caretBaseY; y <= caretTipY; y++) {
+        const t = (y - caretBaseY) / (caretTipY - caretBaseY);
+        const leftX = Math.round(layout.caretLeft.x + (layout.caretTip.x - layout.caretLeft.x) * t);
+        const rightX = Math.round(layout.caretRight.x + (layout.caretTip.x - layout.caretRight.x) * t);
+
+        renderer.drawPixel(new Vector2i(leftX, y), textIndex);
+
+        if (rightX !== leftX) {
+            renderer.drawPixel(new Vector2i(rightX, y), textIndex);
+        }
+    }
+}
+
+/**
+ * Writes palette index text to the clipboard when the API is available.
+ *
+ * @param index - Palette slot to copy.
+ * @returns Resolves on success; rejects when clipboard is unavailable or denied.
+ */
+export async function writePaletteIndexToClipboard(index: number): Promise<void> {
+    const clipboard = globalThis.navigator?.clipboard;
+
+    if (!clipboard?.writeText) {
+        throw new Error('Clipboard API unavailable');
+    }
+
+    await clipboard.writeText(String(index));
+}
+
+/**
+ * Handles palette swatch hover, copy-on-press, and tooltip rendering for the stats overlay.
+ */
+export class StatsOverlayPaletteInteraction {
+    readonly #targetFps: number;
+
+    #hoveredIndex: number | null = null;
+
+    #copyStatus: PaletteCopyStatus = 'idle';
+
+    #copyStatusIndex = -1;
+
+    #copyStatusExpiryTick = -1;
+
+    #tooltipLabel = '';
+
+    #tooltipLabelKey = '';
+
+    #scrollRowOffset = 0;
+
+    #scrollbarTrackWidth = PALETTE_SCROLLBAR_TRACK_WIDTH_PX;
+
+    /**
+     * Creates palette interaction state.
+     *
+     * @param targetFps - Configured fixed-update rate for copy-status timing.
+     */
+    constructor(targetFps: number) {
+        this.#targetFps = targetFps;
+    }
+
+    /**
+     * First visible palette grid row for hit testing (VV-550 scroll).
+     *
+     * @param offset - Row offset applied to pointer-to-index mapping.
+     */
+    setScrollRowOffset(offset: number): void {
+        this.#scrollRowOffset = Math.max(0, Math.floor(offset));
+    }
+
+    /**
+     * Right-edge track width excluded from swatch hits (VV-550 scrollbar).
+     *
+     * @param width - Track width in pixels.
+     */
+    setScrollbarTrackWidth(width: number): void {
+        this.#scrollbarTrackWidth = Math.max(0, Math.floor(width));
+    }
+
+    /**
+     * Clears transient copy status when the expiry tick is reached.
+     *
+     * @param currentTick - Current fixed-update tick.
+     */
+    tickCopyStatus(currentTick: number): void {
+        if (this.#copyStatusExpiryTick >= 0 && currentTick >= this.#copyStatusExpiryTick) {
+            this.#copyStatus = 'idle';
+            this.#copyStatusIndex = -1;
+            this.#copyStatusExpiryTick = -1;
+            this.#tooltipLabelKey = '';
+        }
+    }
+
+    /**
+     * Updates hovered swatch index from the current pointer position.
+     *
+     * @param pointer - Pointer subsystem, or `null` when unavailable.
+     * @param plan - Layout plan for this frame.
+     * @param grid - Palette grid layout.
+     * @param colorCount - Active palette slot count.
+     * @param bottomTextY - Baseline Y for the `[~]` hint.
+     * @param displayWidth - Logical display width.
+     * @param lineHeight - System font line height.
+     */
+    updateHover(
+        pointer: PointerInput | null,
+        plan: StatsOverlayLayoutPlan,
+        grid: PaletteGridLayout,
+        colorCount: number,
+        bottomTextY: number,
+        displayWidth: number,
+        lineHeight: number,
+    ): void {
+        if (plan.paletteBand.height <= 0 || grid.cols <= 0) {
+            this.#hoveredIndex = null;
+
+            return;
+        }
+
+        if (!pointer) {
+            this.#hoveredIndex = null;
+
+            return;
+        }
+
+        const hintExclusion = resolvePaletteHintExclusionRect(bottomTextY, displayWidth, lineHeight);
+        let hovered: number | null = null;
+
+        for (let slot = 0; slot < POINTER_SLOT_COUNT; slot++) {
+            if (!pointer.isValid(slot)) {
+                continue;
+            }
+
+            const pos = pointer.getPos(slot);
+            const hit = hitTestPaletteSwatch(
+                pos.x,
+                pos.y,
+                plan.paletteBand,
+                grid,
+                colorCount,
+                hintExclusion,
+                displayWidth,
+                this.#scrollRowOffset,
+                this.#scrollbarTrackWidth,
+            );
+
+            if (hit !== null) {
+                hovered = hit;
+
+                break;
+            }
+        }
+
+        this.#hoveredIndex = hovered;
+    }
+
+    /**
+     * Handles primary press over a swatch and attempts clipboard copy.
+     *
+     * @param pointer - Pointer subsystem, or `null` when unavailable.
+     * @param currentTick - Current fixed-update tick.
+     * @param plan - Layout plan for this frame.
+     * @param grid - Palette grid layout.
+     * @param colorCount - Active palette slot count.
+     * @param bottomTextY - Baseline Y for the `[~]` hint.
+     * @param displayWidth - Logical display width.
+     * @param lineHeight - System font line height.
+     * @returns `true` when a swatch press was handled (toggle should be skipped).
+     */
+    handlePress(
+        pointer: PointerInput | null,
+        currentTick: number,
+        plan: StatsOverlayLayoutPlan,
+        grid: PaletteGridLayout,
+        colorCount: number,
+        bottomTextY: number,
+        displayWidth: number,
+        lineHeight: number,
+    ): boolean {
+        if (plan.paletteBand.height <= 0 || grid.cols <= 0 || !pointer) {
+            return false;
+        }
+
+        const hintExclusion = resolvePaletteHintExclusionRect(bottomTextY, displayWidth, lineHeight);
+
+        for (let slot = 0; slot < POINTER_SLOT_COUNT; slot++) {
+            if (!pointer.isButtonPressed(POINTER_PRIMARY_BUTTON, slot)) {
+                continue;
+            }
+
+            const pos = pointer.getPos(slot);
+            const index = hitTestPaletteSwatch(
+                pos.x,
+                pos.y,
+                plan.paletteBand,
+                grid,
+                colorCount,
+                hintExclusion,
+                displayWidth,
+                this.#scrollRowOffset,
+                this.#scrollbarTrackWidth,
+            );
+
+            if (index === null) {
+                continue;
+            }
+
+            void (async () => {
+                try {
+                    await writePaletteIndexToClipboard(index);
+                    this.#setCopyStatus('copied', index, currentTick);
+                } catch {
+                    this.#setCopyStatus('failed', index, currentTick);
+                }
+            })();
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Draws the hover or copy-status tooltip when applicable.
+     *
+     * @param renderer - Active renderer.
+     * @param font - System bitmap font.
+     * @param plan - Layout plan for this frame.
+     * @param grid - Palette grid layout.
+     * @param displayWidth - Logical display width.
+     * @param displayHeight - Logical display height.
+     * @param barIndex - Tooltip body fill palette index.
+     * @param textIndex - Tooltip stroke/text palette index.
+     */
+    drawTooltip(
+        renderer: IRenderer,
+        font: BitmapFont,
+        plan: StatsOverlayLayoutPlan,
+        grid: PaletteGridLayout,
+        displayWidth: number,
+        displayHeight: number,
+        barIndex: number,
+        textIndex: number,
+    ): void {
+        const label = this.#resolveTooltipLabel();
+
+        if (label.length === 0) {
+            return;
+        }
+
+        const index = this.#copyStatus !== 'idle' ? this.#copyStatusIndex : this.#hoveredIndex;
+
+        if (index === null || index < 0) {
+            return;
+        }
+
+        writePaletteSwatchTopLeft(tooltipScratch.swatch, index, plan.paletteBand, grid, this.#scrollRowOffset);
+
+        const layout = layoutPaletteTooltip(tooltipScratch, tooltipScratch.swatch, label, displayWidth, displayHeight);
+
+        drawPaletteTooltip(renderer, font, layout, label, barIndex, textIndex);
+    }
+
+    /**
+     * Updates transient copy feedback after a clipboard write attempt.
+     *
+     * @param status - New copy status.
+     * @param index - Palette index that was copied.
+     * @param currentTick - Tick when copy was requested.
+     */
+    #setCopyStatus(status: Exclude<PaletteCopyStatus, 'idle'>, index: number, currentTick: number): void {
+        this.#copyStatus = status;
+        this.#copyStatusIndex = index;
+        this.#copyStatusExpiryTick = currentTick + Math.ceil(PALETTE_COPY_STATUS_SECONDS * this.#targetFps);
+        this.#tooltipLabelKey = '';
+    }
+
+    /**
+     * Returns the tooltip label for hover or copy status, caching the last resolved string.
+     *
+     * @returns Tooltip label for the current hover or copy status.
+     */
+    #resolveTooltipLabel(): string {
+        let label: string;
+
+        if (this.#copyStatus === 'copied') {
+            label = `Copied ${this.#copyStatusIndex}`;
+        } else if (this.#copyStatus === 'failed') {
+            label = 'Copy failed';
+        } else if (this.#hoveredIndex !== null) {
+            label = String(this.#hoveredIndex);
+        } else {
+            label = '';
+        }
+
+        const key = `${this.#hoveredIndex}:${this.#copyStatus}:${this.#copyStatusIndex}`;
+
+        if (key !== this.#tooltipLabelKey) {
+            this.#tooltipLabelKey = key;
+            this.#tooltipLabel = label;
+        }
+
+        return this.#tooltipLabel;
+    }
+}

--- a/src/render/stats-overlay/StatsOverlayPaletteInteraction.ts
+++ b/src/render/stats-overlay/StatsOverlayPaletteInteraction.ts
@@ -17,23 +17,13 @@ import {
 } from './StatsOverlayPaletteView';
 import type { PaletteGridLayout, StatsOverlayLayoutPlan } from './types';
 
+// #region Constants and types
+
 /** Reserved width on the right edge of the palette band excluded from swatch hits (VV-550 scrollbar). */
 export const PALETTE_SCROLLBAR_TRACK_WIDTH_PX = 0;
 
 /** Duration for transient copy status tooltips in seconds. */
 export const PALETTE_COPY_STATUS_SECONDS = 0.75;
-
-/** Horizontal padding inside the tooltip label body. */
-const TOOLTIP_PADDING_X_PX = 2;
-
-/** Vertical padding inside the tooltip label body. */
-const TOOLTIP_PADDING_Y_PX = 1;
-
-/** Height of the downward caret below the tooltip body. */
-const TOOLTIP_CARET_HEIGHT_PX = 3;
-
-/** Half-width of the caret in pixels (forms a `\/` shape under the body). */
-const TOOLTIP_CARET_HALF_WIDTH_PX = 2;
 
 /** Clipboard copy feedback state for palette swatch presses. */
 type PaletteCopyStatus = 'idle' | 'copied' | 'failed';
@@ -42,11 +32,13 @@ type PaletteCopyStatus = 'idle' | 'copied' | 'failed';
 const tooltipScratch = {
     body: new Rect2i(),
     swatch: new Rect2i(),
-    caretLeft: new Vector2i(),
-    caretTip: new Vector2i(),
-    caretRight: new Vector2i(),
+    outlineEdge: new Rect2i(),
     textPos: new Vector2i(),
 };
+
+// #endregion
+
+// #region Helpers
 
 /**
  * Returns whether a palette slot at the given swatch origin overlaps the hint exclusion rect.
@@ -206,6 +198,10 @@ export function hitTestPaletteSwatch(
     return index;
 }
 
+// #endregion
+
+// #region Tooltip
+
 /** Layout output for a docked palette swatch tooltip. */
 export interface PaletteTooltipLayout {
     /** Tooltip label body in display coordinates. */
@@ -213,13 +209,6 @@ export interface PaletteTooltipLayout {
 
     /** Bitmap text draw position (top-left of glyphs). */
     readonly textPos: Vector2i;
-
-    /** Caret left, tip, and right points forming `\/` under the body. */
-    readonly caretLeft: Vector2i;
-
-    readonly caretTip: Vector2i;
-
-    readonly caretRight: Vector2i;
 }
 
 /**
@@ -240,14 +229,12 @@ export function layoutPaletteTooltip(
     displayHeight: number,
 ): PaletteTooltipLayout {
     const textWidth = label.length * SYSTEM_CHAR_ADVANCE;
-    const bodyWidth = textWidth + TOOLTIP_PADDING_X_PX * 2;
-    const bodyHeight = SYSTEM_CHAR_ADVANCE + TOOLTIP_PADDING_Y_PX * 2;
+    const bodyWidth = textWidth + 5;
     const swatchCenterX = swatchRect.x + Math.floor(swatchRect.width / 2);
-    const swatchTopY = swatchRect.y;
+    const swatchTopY = swatchRect.y - 14;
 
     let bodyX = swatchCenterX - Math.floor(bodyWidth / 2);
-    let bodyBottom = swatchTopY - TOOLTIP_CARET_HEIGHT_PX - 1;
-    let bodyY = bodyBottom - bodyHeight;
+    let bodyY = swatchTopY;
 
     if (bodyX < 0) {
         bodyX = 0;
@@ -259,50 +246,27 @@ export function layoutPaletteTooltip(
 
     if (bodyY < 0) {
         bodyY = 0;
-        bodyBottom = bodyY + bodyHeight;
     }
 
-    if (bodyBottom + TOOLTIP_CARET_HEIGHT_PX > displayHeight) {
-        bodyBottom = displayHeight - TOOLTIP_CARET_HEIGHT_PX - 1;
-        bodyY = bodyBottom - bodyHeight;
-
-        if (bodyY < 0) {
-            bodyY = 0;
-        }
+    if (bodyY > displayHeight) {
+        bodyY = Math.max(0, displayHeight);
     }
 
-    target.body.set(bodyX, bodyY, bodyWidth, bodyHeight);
-    target.textPos.set(bodyX + TOOLTIP_PADDING_X_PX, bodyY + TOOLTIP_PADDING_Y_PX);
-
-    let caretTipX = swatchCenterX;
-
-    if (caretTipX < bodyX + TOOLTIP_CARET_HALF_WIDTH_PX) {
-        caretTipX = bodyX + TOOLTIP_CARET_HALF_WIDTH_PX;
-    }
-
-    if (caretTipX > bodyX + bodyWidth - TOOLTIP_CARET_HALF_WIDTH_PX - 1) {
-        caretTipX = bodyX + bodyWidth - TOOLTIP_CARET_HALF_WIDTH_PX - 1;
-    }
-
-    const caretBaseY = bodyBottom;
-    const caretTipY = Math.min(displayHeight - 1, swatchTopY);
-
-    target.caretLeft.set(caretTipX - TOOLTIP_CARET_HALF_WIDTH_PX, caretBaseY);
-    target.caretTip.set(caretTipX, caretTipY);
-    target.caretRight.set(caretTipX + TOOLTIP_CARET_HALF_WIDTH_PX, caretBaseY);
+    target.body.set(bodyX, bodyY, bodyWidth, 13);
+    target.textPos.set(bodyX + 3, bodyY);
 
     return target;
 }
 
 /**
- * Draws a docked palette swatch tooltip (body, outline, text, caret).
+ * Draws a docked palette swatch tooltip (filled body, outline stroke, label text).
  *
  * @param renderer - Active renderer.
  * @param font - System bitmap font.
  * @param layout - Tooltip layout from {@link layoutPaletteTooltip}.
  * @param label - Tooltip label text.
- * @param barIndex - Palette index for tooltip body fill.
- * @param textIndex - Palette index for outline, text, and caret.
+ * @param barIndex - Palette index for tooltip body fill (stats overlay background).
+ * @param textIndex - Palette index for outline stroke and label text.
  */
 export function drawPaletteTooltip(
     renderer: IRenderer,
@@ -316,34 +280,16 @@ export function drawPaletteTooltip(
         return;
     }
 
-    renderer.drawRectFillOnTop(layout.body, barIndex);
-    renderer.drawRect(layout.body, textIndex);
+    renderer.drawRectFillForeground(layout.body, barIndex);
 
     const textPaletteOffset = statsBitmapTextPaletteOffset(textIndex);
 
-    renderer.drawBitmapTextOnTop(font, layout.textPos, label, textPaletteOffset);
-
-    const caretBaseY = layout.caretLeft.y;
-    const caretTipY = layout.caretTip.y;
-
-    if (caretTipY <= caretBaseY) {
-        renderer.drawPixel(layout.caretTip, textIndex);
-
-        return;
-    }
-
-    for (let y = caretBaseY; y <= caretTipY; y++) {
-        const t = (y - caretBaseY) / (caretTipY - caretBaseY);
-        const leftX = Math.round(layout.caretLeft.x + (layout.caretTip.x - layout.caretLeft.x) * t);
-        const rightX = Math.round(layout.caretRight.x + (layout.caretTip.x - layout.caretRight.x) * t);
-
-        renderer.drawPixel(new Vector2i(leftX, y), textIndex);
-
-        if (rightX !== leftX) {
-            renderer.drawPixel(new Vector2i(rightX, y), textIndex);
-        }
-    }
+    renderer.drawBitmapTextForeground(font, layout.textPos, label, textPaletteOffset);
 }
+
+// #endregion
+
+// #region Clipboard
 
 /**
  * Writes palette index text to the clipboard when the API is available.
@@ -360,6 +306,10 @@ export async function writePaletteIndexToClipboard(index: number): Promise<void>
 
     await clipboard.writeText(String(index));
 }
+
+// #endregion
+
+// #region Interaction
 
 /**
  * Handles palette swatch hover, copy-on-press, and tooltip rendering for the stats overlay.
@@ -636,3 +586,5 @@ export class StatsOverlayPaletteInteraction {
         return this.#tooltipLabel;
     }
 }
+
+// #endregion

--- a/src/render/stats-overlay/StatsOverlayPaletteInteraction.ts
+++ b/src/render/stats-overlay/StatsOverlayPaletteInteraction.ts
@@ -25,6 +25,9 @@ export const PALETTE_SCROLLBAR_TRACK_WIDTH_PX = 0;
 /** Duration for transient copy status tooltips in seconds. */
 export const PALETTE_COPY_STATUS_SECONDS = 0.75;
 
+/** Gap between the tooltip body bottom edge and the swatch top edge. */
+const TOOLTIP_GAP_ABOVE_SWATCH_PX = 1;
+
 /** Clipboard copy feedback state for palette swatch presses. */
 type PaletteCopyStatus = 'idle' | 'copied' | 'failed';
 
@@ -229,12 +232,12 @@ export function layoutPaletteTooltip(
     displayHeight: number,
 ): PaletteTooltipLayout {
     const textWidth = label.length * SYSTEM_CHAR_ADVANCE;
-    const bodyWidth = textWidth + 5;
+    const bodyWidth = textWidth + 7;
+    const bodyHeight = 13;
     const swatchCenterX = swatchRect.x + Math.floor(swatchRect.width / 2);
-    const swatchTopY = swatchRect.y - 14;
 
     let bodyX = swatchCenterX - Math.floor(bodyWidth / 2);
-    let bodyY = swatchTopY;
+    let bodyY = swatchRect.y - bodyHeight - TOOLTIP_GAP_ABOVE_SWATCH_PX;
 
     if (bodyX < 0) {
         bodyX = 0;
@@ -248,25 +251,25 @@ export function layoutPaletteTooltip(
         bodyY = 0;
     }
 
-    if (bodyY > displayHeight) {
-        bodyY = Math.max(0, displayHeight);
+    if (bodyY + bodyHeight > displayHeight) {
+        bodyY = Math.max(0, displayHeight - bodyHeight);
     }
 
-    target.body.set(bodyX, bodyY, bodyWidth, 13);
-    target.textPos.set(bodyX + 3, bodyY);
+    target.body.set(bodyX, bodyY, bodyWidth, bodyHeight);
+    target.textPos.set(bodyX + 4, bodyY);
 
     return target;
 }
 
 /**
- * Draws a docked palette swatch tooltip (filled body, outline stroke, label text).
+ * Draws a docked palette swatch tooltip (filled body, 1px border, label text).
  *
  * @param renderer - Active renderer.
  * @param font - System bitmap font.
  * @param layout - Tooltip layout from {@link layoutPaletteTooltip}.
  * @param label - Tooltip label text.
  * @param barIndex - Palette index for tooltip body fill (stats overlay background).
- * @param textIndex - Palette index for outline stroke and label text.
+ * @param textIndex - Palette index for the border and label text.
  */
 export function drawPaletteTooltip(
     renderer: IRenderer,
@@ -281,6 +284,20 @@ export function drawPaletteTooltip(
     }
 
     renderer.drawRectFillForeground(layout.body, barIndex);
+
+    const edge = tooltipScratch.outlineEdge;
+    const x0 = layout.body.x;
+    const y0 = layout.body.y;
+    const x1 = layout.body.x + layout.body.width - 1;
+    const y1 = layout.body.y + layout.body.height - 1;
+
+    renderer.drawRectFillForeground(edge.set(x0, y0, x1 - x0 + 1, 1), textIndex);
+    renderer.drawRectFillForeground(edge.set(x0, y1, x1 - x0 + 1, 1), textIndex);
+
+    if (y1 - y0 > 1) {
+        renderer.drawRectFillForeground(edge.set(x0, y0 + 1, 1, y1 - y0 - 1), textIndex);
+        renderer.drawRectFillForeground(edge.set(x1, y0 + 1, 1, y1 - y0 - 1), textIndex);
+    }
 
     const textPaletteOffset = statsBitmapTextPaletteOffset(textIndex);
 
@@ -340,24 +357,6 @@ export class StatsOverlayPaletteInteraction {
      */
     constructor(targetFps: number) {
         this.#targetFps = targetFps;
-    }
-
-    /**
-     * First visible palette grid row for hit testing (VV-550 scroll).
-     *
-     * @param offset - Row offset applied to pointer-to-index mapping.
-     */
-    setScrollRowOffset(offset: number): void {
-        this.#scrollRowOffset = Math.max(0, Math.floor(offset));
-    }
-
-    /**
-     * Right-edge track width excluded from swatch hits (VV-550 scrollbar).
-     *
-     * @param width - Track width in pixels.
-     */
-    setScrollbarTrackWidth(width: number): void {
-        this.#scrollbarTrackWidth = Math.max(0, Math.floor(width));
     }
 
     /**

--- a/src/render/stats-overlay/StatsOverlayPaletteInteraction.ts
+++ b/src/render/stats-overlay/StatsOverlayPaletteInteraction.ts
@@ -350,6 +350,9 @@ export class StatsOverlayPaletteInteraction {
 
     #scrollbarTrackWidth = PALETTE_SCROLLBAR_TRACK_WIDTH_PX;
 
+    /** Latest fixed-update tick observed from {@link tickCopyStatus} or {@link handlePress}. */
+    #lastKnownTick = 0;
+
     /**
      * Creates palette interaction state.
      *
@@ -365,6 +368,8 @@ export class StatsOverlayPaletteInteraction {
      * @param currentTick - Current fixed-update tick.
      */
     tickCopyStatus(currentTick: number): void {
+        this.#lastKnownTick = currentTick;
+
         if (this.#copyStatusExpiryTick >= 0 && currentTick >= this.#copyStatusExpiryTick) {
             this.#copyStatus = 'idle';
             this.#copyStatusIndex = -1;
@@ -463,6 +468,8 @@ export class StatsOverlayPaletteInteraction {
             return false;
         }
 
+        this.#lastKnownTick = currentTick;
+
         const hintExclusion = resolvePaletteHintExclusionRect(bottomTextY, displayWidth, lineHeight);
 
         for (let slot = 0; slot < POINTER_SLOT_COUNT; slot++) {
@@ -490,9 +497,9 @@ export class StatsOverlayPaletteInteraction {
             void (async () => {
                 try {
                     await writePaletteIndexToClipboard(index);
-                    this.#setCopyStatus('copied', index, currentTick);
+                    this.#setCopyStatus('copied', index, this.#lastKnownTick);
                 } catch {
-                    this.#setCopyStatus('failed', index, currentTick);
+                    this.#setCopyStatus('failed', index, this.#lastKnownTick);
                 }
             })();
 
@@ -548,12 +555,12 @@ export class StatsOverlayPaletteInteraction {
      *
      * @param status - New copy status.
      * @param index - Palette index that was copied.
-     * @param currentTick - Tick when copy was requested.
+     * @param completionTick - Fixed-update tick when the clipboard write finished.
      */
-    #setCopyStatus(status: Exclude<PaletteCopyStatus, 'idle'>, index: number, currentTick: number): void {
+    #setCopyStatus(status: Exclude<PaletteCopyStatus, 'idle'>, index: number, completionTick: number): void {
         this.#copyStatus = status;
         this.#copyStatusIndex = index;
-        this.#copyStatusExpiryTick = currentTick + Math.ceil(PALETTE_COPY_STATUS_SECONDS * this.#targetFps);
+        this.#copyStatusExpiryTick = completionTick + Math.ceil(PALETTE_COPY_STATUS_SECONDS * this.#targetFps);
         this.#tooltipLabelKey = '';
     }
 

--- a/src/render/stats-overlay/StatsOverlayPaletteView.ts
+++ b/src/render/stats-overlay/StatsOverlayPaletteView.ts
@@ -184,7 +184,15 @@ const hintExclusionCache = {
  * @param lineHeight - System font line height.
  * @returns Exclusion rect for swatch placement.
  */
-function resolveHintExclusionRect(bottomTextY: number, displayWidth: number, lineHeight: number): Rect2i {
+/**
+ * Returns the screen-space rect reserved for the bottom-left `[~]` hint label.
+ *
+ * @param bottomTextY - Baseline Y for the hint text.
+ * @param displayWidth - Logical display width.
+ * @param lineHeight - System font line height.
+ * @returns Exclusion rect for swatch placement and hit testing.
+ */
+export function resolvePaletteHintExclusionRect(bottomTextY: number, displayWidth: number, lineHeight: number): Rect2i {
     if (
         hintExclusionCache.bottomTextY === bottomTextY &&
         hintExclusionCache.displayWidth === displayWidth &&
@@ -326,6 +334,33 @@ function drawPaletteSwatch(
 }
 
 /**
+ * Writes the top-left corner of a palette swatch into {@link target}.
+ *
+ * @param target - Reusable rect mutated in place.
+ * @param index - Palette slot index.
+ * @param paletteBand - Palette band rect from layout plan.
+ * @param grid - Precomputed grid layout.
+ * @param scrollRowOffset - First visible grid row (default `0`).
+ */
+export function writePaletteSwatchTopLeft(
+    target: Rect2i,
+    index: number,
+    paletteBand: Rect2i,
+    grid: PaletteGridLayout,
+    scrollRowOffset = 0,
+): void {
+    const { cols, swatchSize, gap } = grid;
+    const col = index % cols;
+    const row = Math.floor(index / cols) - scrollRowOffset;
+    const originX = paletteBand.x + STATS_EDGE_MARGIN_PX;
+    const originY = paletteBand.y + PALETTE_GRID_PADDING_PX;
+    const x = originX + col * (swatchSize + gap);
+    const y = originY + row * (swatchSize + gap);
+
+    target.set(x, y, swatchSize, swatchSize);
+}
+
+/**
  * Draws the full palette swatch grid inside the bottom band.
  *
  * @param renderer - Active renderer.
@@ -345,17 +380,14 @@ function drawPaletteSwatchGrid(
     usedMask: Uint8Array,
     unusedMarkIndex: number,
 ): void {
-    const { cols, swatchSize, gap } = grid;
-    const originX = paletteBand.x + STATS_EDGE_MARGIN_PX;
-    const originY = paletteBand.y + PALETTE_GRID_PADDING_PX;
+    const { swatchSize } = grid;
     const swatchScratch = paletteGridDrawScratch.swatch;
     const markerScratch = paletteGridDrawScratch.marker;
 
     for (let index = 0; index < colorCount; index++) {
-        const col = index % cols;
-        const row = Math.floor(index / cols);
-        const x = originX + col * (swatchSize + gap);
-        const y = originY + row * (swatchSize + gap);
+        writePaletteSwatchTopLeft(swatchScratch, index, paletteBand, grid);
+        const x = swatchScratch.x;
+        const y = swatchScratch.y;
 
         // Reserve only the `[~]` text band; do not clip against the 48x48 toggle hit rect
         // (it overlaps many grid rows and would truncate every row below it).
@@ -419,7 +451,7 @@ export class StatsOverlayPaletteView {
             return;
         }
 
-        const hintExclusion = resolveHintExclusionRect(bottomTextY, displayWidth, lineHeight);
+        const hintExclusion = resolvePaletteHintExclusionRect(bottomTextY, displayWidth, lineHeight);
 
         drawPaletteSwatchGrid(renderer, paletteBand, palette.size, grid, hintExclusion, usedMask, unusedMarkIndex);
     }

--- a/src/render/stats-overlay/StatsOverlayToggle.ts
+++ b/src/render/stats-overlay/StatsOverlayToggle.ts
@@ -40,12 +40,14 @@ export class StatsOverlayToggle {
      * @param keyboard - Keyboard subsystem, or `null` when unavailable.
      * @param currentTick - Current fixed-update tick for keyboard edge detection.
      * @param toggleRect - Bottom-left toggle hit region.
+     * @param pointerPressConsumed - When true, skip pointer corner toggle (palette swatch handled the press).
      */
     handleToggle(
         pointer: PointerInput | null,
         keyboard: KeyboardInput | null,
         currentTick: number,
         toggleRect: Rect2i,
+        pointerPressConsumed = false,
     ): void {
         if (!this.#toggleEnabled) {
             return;
@@ -57,7 +59,7 @@ export class StatsOverlayToggle {
             return;
         }
 
-        if (!pointer) {
+        if (!pointer || pointerPressConsumed) {
             return;
         }
 

--- a/src/render/stats-overlay/testFixtures.ts
+++ b/src/render/stats-overlay/testFixtures.ts
@@ -26,9 +26,11 @@ export type BitmapTextCall = {
 export function createMockRenderer(): IRenderer & {
     drawBitmapText: ReturnType<typeof vi.fn>;
     drawBitmapTextOnTop: ReturnType<typeof vi.fn>;
+    drawBitmapTextForeground: ReturnType<typeof vi.fn>;
     drawPixel: ReturnType<typeof vi.fn>;
     drawRectFill: ReturnType<typeof vi.fn>;
     drawRectFillOnTop: ReturnType<typeof vi.fn> & { rectSnapshots: Rect2i[] };
+    drawRectFillForeground: ReturnType<typeof vi.fn>;
 } {
     const rectSnapshots: Rect2i[] = [];
     const drawRectFillOnTop = vi.fn((rect: Rect2i) => {
@@ -45,9 +47,11 @@ export function createMockRenderer(): IRenderer & {
         setCameraOffset: vi.fn(),
         drawRectFill: vi.fn(),
         drawRectFillOnTop,
+        drawRectFillForeground: vi.fn(),
         drawRect,
         drawBitmapText: vi.fn(),
         drawBitmapTextOnTop,
+        drawBitmapTextForeground: vi.fn(),
         drawPixel,
     } as never;
 }

--- a/src/render/stats-overlay/testFixtures.ts
+++ b/src/render/stats-overlay/testFixtures.ts
@@ -37,6 +37,7 @@ export function createMockRenderer(): IRenderer & {
     drawRectFillOnTop.rectSnapshots = rectSnapshots;
     const drawBitmapTextOnTop = vi.fn();
     const drawPixel = vi.fn();
+    const drawRect = vi.fn();
 
     return {
         getCameraOffset: vi.fn(() => Vector2i.zero()),
@@ -44,6 +45,7 @@ export function createMockRenderer(): IRenderer & {
         setCameraOffset: vi.fn(),
         drawRectFill: vi.fn(),
         drawRectFillOnTop,
+        drawRect,
         drawBitmapText: vi.fn(),
         drawBitmapTextOnTop,
         drawPixel,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes

This pull request adds interactive palette swatch features to the stats overlay (hover, tooltips, and copy-to-clipboard), integrates those interactions into per-frame input handling, and introduces a foreground overlay rendering tier so popover tooltips render above overlay content.

### New module: StatsOverlayPaletteInteraction
- Implements swatch hit-testing, tooltip layout/drawing, and clipboard copy:
  - hitTestPaletteSwatch(...) — maps pointer coordinates to palette indices honoring grid layout, optional scroll-row offset, right-edge scrollbar exclusion, and a hint-exclusion rect.
  - layoutPaletteTooltip(...) and drawPaletteTooltip(...) — position and render a tooltip docked above a swatch with edge clamping and border.
  - writePaletteIndexToClipboard(index) — async helper that writes the numeric index string to navigator.clipboard.writeText (throws when unavailable).
  - StatsOverlayPaletteInteraction class — tracks hovered index and transient copy-status with tick-based expiry; public methods:
    - constructor(targetFps: number)
    - tickCopyStatus(currentTick: number)
    - updateHover(pointer, plan, grid, colorCount, bottomTextY, displayWidth, lineHeight)
    - handlePress(pointer, currentTick, plan, grid, colorCount, bottomTextY, displayWidth, lineHeight): boolean
    - drawTooltip(renderer, font, plan, grid, displayWidth, displayHeight, barIndex, textIndex)
  - Constants: PALETTE_SCROLLBAR_TRACK_WIDTH_PX, PALETTE_COPY_STATUS_SECONDS.

### StatsOverlay integration
- Adds StatsOverlay.handleFrameInput(pointer, keyboard, currentTick, getCustomRows?, palette?) which:
  - Runs palette swatch press handling first (when palette view is enabled and body visible) and can return/indicate whether the pointer press was consumed.
  - Forwards body-toggle handling to StatsOverlayToggle while passing a pointerPressConsumed flag so a swatch press won’t also toggle the overlay.
- handleToggle now delegates to handleFrameInput.
- updateAndRender and render path accept a real pointer and currentTick so rendering can update hover state and copy-status expiry per frame.
- During palette band rendering (when bodyVisible), the overlay ticks copy-status, updates hover from pointer + layout geometry, and draws tooltip popovers via the palette interaction helper.

### Renderer / API changes
- IRenderer:
  - Added drawRectFillForeground(rect, paletteIndex) and drawBitmapTextForeground(font, pos, text, paletteOffset?) for a foreground overlay tier used by popovers/tooltips.
- WebGpuRenderer:
  - Adds foregroundOverlayPrimitives and foregroundOverlaySprites pipelines and implements drawRectFillForeground and drawBitmapTextForeground.
  - Ensures encoding order renders foreground fills and sprites after existing overlay batches; resets and manages new pipelines alongside existing batches.
- SoftwareRenderer:
  - Adds drawRectFillForeground and drawBitmapTextForeground which queue/forward the same style of draw commands to preserve layering for software backends.

### BTAPI change
- BTAPI.beginRenderFrame() now calls StatsOverlay.handleFrameInput(...) (passing pointer, keyboard, currentTick, a supplier for demo.statsOverlayRows, and the active palette) instead of calling handleToggle directly. Per-frame palette-usage clearing still occurs before demo.render() palette-usage tracking.

### StatsOverlayPaletteView helpers
- Exports resolvePaletteHintExclusionRect(bottomTextY, displayWidth, lineHeight) for the hint-exclusion band used for swatch placement and hit-testing.
- Exports writePaletteSwatchTopLeft(target, index, paletteBand, grid, scrollRowOffset?) to compute a swatch’s top-left coordinates.

### StatsOverlayToggle
- StatsOverlayToggle.handleToggle(...) gains an optional pointerPressConsumed?: boolean parameter (default false) so the bottom-left corner toggle can be skipped when a press was already handled (e.g., a swatch copy).

### Tests and test fixtures
- Adds comprehensive unit tests for StatsOverlayPaletteInteraction covering hit testing (gaps, hint-exclusion band, scrollbar area, scroll offsets), tooltip layout/clamping and draw routing, clipboard success/failure and copy-status expiry and timing semantics.
- Adds an integration test ensuring pressing a palette swatch in the toggle-corner region does not toggle the overlay body.
- Expands test fixtures/mock renderer to include spies for drawRect and the new foreground draw APIs.
- WebGpuRenderer tests extended to assert routing to foreground overlay pipelines and updated encode-order and reset behavior.

### Docs
- docs/api-core.md updated to describe four late draw batches and explicit handling for palette swatch tooltips via drawRectFillForeground and drawBitmapTextForeground.

### Public API surface changes
- StatsOverlay:
  - Added public handleFrameInput(pointer, keyboard, currentTick, getCustomRows?, palette?)
  - handleToggle delegates to handleFrameInput
  - updateAndRender signature updated to accept pointer and currentTick for per-frame hover/tick logic
- New/changed exports:
  - StatsOverlayPaletteInteraction (class, helpers, constants)
  - resolvePaletteHintExclusionRect, writePaletteSwatchTopLeft (from StatsOverlayPaletteView)
  - IRenderer: drawRectFillForeground, drawBitmapTextForeground added
  - WebGpuRenderer, SoftwareRenderer: implementations of the foreground methods added
  - StatsOverlayToggle.handleToggle signature extended with pointerPressConsumed

All new behaviors are covered by tests and renderer routing/unit tests were added/updated to validate foreground overlay layering and tooltip rendering/copy behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/224?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->