### PR TITLE
refactor(renderer): move stats overlay draws to StatsOverlayDrawTarget

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,9 +60,11 @@ src/
     StatsOverlay.ts        # Barrel re-export for BTAPI (implementation under stats-overlay/)
     stats-overlay/
       StatsOverlay.ts      # Orchestrator: sample, toggle, layout plan, delegate draws
+      StatsOverlayDrawTarget.ts # Internal draw port (drawBarFill / drawLabel); not on IRenderer or BT
       layoutPlan.ts        # Dynamic Y-band planner (timing chart VV-539 + palette grid)
       StatsOverlayTimingChart.ts  # Scrolling update/render timing chart band (opt-in via statsOverlayTimingChart)
       StatsOverlayPaletteView.ts  # Palette swatch grid (opt-in via statsOverlayPaletteView)
+      StatsOverlayPaletteInteraction.ts # Swatch hover tooltips and clipboard copy
       StatsOverlayBars.ts  # Fixed and custom row bars + labels
       StatsOverlayToggle.ts # Backquote and bottom-left corner toggle input
     PrimitivePipeline.ts   # Batched geometry writing palette indices (pixels, lines, rects)

--- a/docs/api-core.md
+++ b/docs/api-core.md
@@ -250,10 +250,8 @@ Toggle overlay **body** visibility at runtime with **Backquote** (`~`) or a prim
 48x48 px** corner when `statsOverlayToggleEnabled` is `true` (default). Set `statsOverlayToggleHintVisible: false` to
 hide the hint bar while the body stays hidden. Set `statsOverlayToggleEnabled: false` to lock body visibility at
 `statsOverlayVisibleAtStart`. Set `statsOverlayEnabled: false` in `configure()` to disable the overlay subsystem and all
-toggle input (for example release builds). On WebGPU, the stats overlay uses late draw batches: {@link
-IRenderer.drawRectFillOnTop} for bar fills above demo sprites, {@link IRenderer.drawBitmapTextOnTop} for labels above
-those bars, then {@link IRenderer.drawRectFillForeground} and {@link IRenderer.drawBitmapTextForeground} for palette
-swatch tooltips above custom rows.
+toggle input (for example release builds). On WebGPU, the engine draws the stats HUD after your `render()` call,
+composited above demo sprites via internal overlay draw batches (not available on `BT`).
 
 Overlay colors follow one path: use `statsOverlayStyle` when set, otherwise defaults `1` (bar) and `2` (text). You can
 override globally in `configure()` with `statsOverlayStyle: { barPaletteIndex, textPaletteIndex }`, or per custom row on

--- a/src/core/BTAPI.test.ts
+++ b/src/core/BTAPI.test.ts
@@ -31,6 +31,7 @@ import { BT } from '../BlitTech';
 import type { Effect } from '../render/effects/Effect';
 import { DEFAULT_IDX_TEXT, STATS_EDGE_MARGIN_PX } from '../render/stats-overlay/constants';
 import { paletteBandY } from '../render/stats-overlay/layoutPlan';
+import type { StatsOverlayDrawTarget } from '../render/stats-overlay/StatsOverlayDrawTarget';
 import {
     computePaletteGrid,
     DEFAULT_PALETTE_SWATCH_SIZE,
@@ -1296,11 +1297,12 @@ describe('BTAPI', () => {
 
             const swatchFills: { index: number; rect: Rect2i }[] = [];
 
-            vi.spyOn(renderer as NonNullable<typeof renderer>, 'drawRectFillOnTop').mockImplementation(
-                (rect, index) => {
-                    swatchFills.push({ index, rect: new Rect2i(rect.x, rect.y, rect.width, rect.height) });
-                },
-            );
+            vi.spyOn(
+                renderer as NonNullable<typeof renderer> & StatsOverlayDrawTarget,
+                'drawBarFill',
+            ).mockImplementation((rect: Rect2i, index: number) => {
+                swatchFills.push({ index, rect: new Rect2i(rect.x, rect.y, rect.width, rect.height) });
+            });
 
             const maxIterations = 1000;
             let iterations = 0;

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -16,6 +16,7 @@ import { PointerInput } from '../input/PointerInput';
 import type { Effect } from '../render/effects/Effect';
 import type { IRenderer } from '../render/IRenderer';
 import { SoftwareRenderer } from '../render/SoftwareRenderer';
+import type { StatsOverlayDrawTarget } from '../render/stats-overlay/StatsOverlayDrawTarget';
 import { createStatsOverlayLayout, resolveStatsTopLeftLabel, StatsOverlay } from '../render/StatsOverlay';
 import { WebGpuRenderer } from '../render/WebGpuRenderer';
 import { applyCanvasLayoutStyles, DEFAULT_MAX_CANVAS_SIZE } from '../utils/CanvasLayoutStyles';
@@ -91,7 +92,7 @@ export class BTAPI {
     private canvas: HTMLCanvasElement | null = null;
 
     /** Renderer subsystem for all drawing operations. */
-    private renderer: IRenderer | null = null;
+    private renderer: (IRenderer & StatsOverlayDrawTarget) | null = null;
 
     /** Backend that was successfully initialized, or null before init. */
     private activeBackend: Backend | null = null;

--- a/src/render/IRenderer.ts
+++ b/src/render/IRenderer.ts
@@ -82,30 +82,6 @@ export interface IRenderer {
     drawRectFill(rect: Rect2i, paletteIndex: number): void;
 
     /**
-     * Draws a filled rectangle above sprite content for this frame.
-     *
-     * On WebGPU, batched after the sprite pass so HUD bars (for example the stats
-     * overlay) appear on top of {@link drawSprite} calls. Software backends may
-     * implement this as a normal {@link drawRectFill} when call order is preserved.
-     *
-     * @param rect - Rectangle bounds in display coordinates.
-     * @param paletteIndex - Palette color index.
-     */
-    drawRectFillOnTop(rect: Rect2i, paletteIndex: number): void;
-
-    /**
-     * Draws a filled rectangle above overlay sprites for this frame.
-     *
-     * On WebGPU, batched after {@link drawBitmapTextOnTop} so HUD popovers (for example
-     * palette swatch tooltips) appear on top of custom stats rows and labels. Software
-     * backends may implement this as {@link drawRectFill} when call order is preserved.
-     *
-     * @param rect - Rectangle bounds in display coordinates.
-     * @param paletteIndex - Palette color index.
-     */
-    drawRectFillForeground(rect: Rect2i, paletteIndex: number): void;
-
-    /**
      * Draws a single pixel.
      *
      * @param pos - Pixel position.
@@ -161,34 +137,6 @@ export interface IRenderer {
      * @param paletteOffset - Palette index offset applied to all glyphs (default 0).
      */
     drawBitmapText(font: BitmapFont, pos: Vector2i, text: string, paletteOffset?: number): void;
-
-    /**
-     * Draws bitmap text above overlay bar fills for this frame.
-     *
-     * On WebGPU, batched after the post-sprite primitive pass so labels (for example
-     * stats overlay text) appear on top of {@link drawRectFillOnTop} bars. Software
-     * backends may implement this as {@link drawBitmapText} when call order is preserved.
-     *
-     * @param font - Bitmap font with character glyphs (underlying sheet must be indexized).
-     * @param pos - Text position (top-left corner).
-     * @param text - String to render.
-     * @param paletteOffset - Palette index offset applied to all glyphs (default 0).
-     */
-    drawBitmapTextOnTop(font: BitmapFont, pos: Vector2i, text: string, paletteOffset?: number): void;
-
-    /**
-     * Draws bitmap text above overlay sprites and foreground overlay fills for this frame.
-     *
-     * On WebGPU, batched after {@link drawRectFillForeground} so popover labels (for example
-     * palette swatch tooltips) appear on top of custom stats rows. Software backends may
-     * implement this as {@link drawBitmapText} when call order is preserved.
-     *
-     * @param font - Bitmap font with character glyphs (underlying sheet must be indexized).
-     * @param pos - Text position (top-left corner).
-     * @param text - String to render.
-     * @param paletteOffset - Palette index offset applied to all glyphs (default 0).
-     */
-    drawBitmapTextForeground(font: BitmapFont, pos: Vector2i, text: string, paletteOffset?: number): void;
 
     // #endregion
 

--- a/src/render/SoftwareRenderer.ts
+++ b/src/render/SoftwareRenderer.ts
@@ -8,6 +8,7 @@ import { Rect2i } from '../utils/Rect2i';
 import { Vector2i } from '../utils/Vector2i';
 import type { Effect } from './effects/Effect';
 import type { IRenderer } from './IRenderer';
+import type { StatsOverlayDrawTarget } from './stats-overlay/StatsOverlayDrawTarget';
 
 // #region Type Definitions
 
@@ -81,7 +82,7 @@ type Canvas2D = OffscreenCanvasRenderingContext2D | CanvasRenderingContext2D;
  * logical-resolution RGBA buffer every frame, then presenting that buffer to the
  * target canvas with optional nearest-neighbor upscaling.
  */
-export class SoftwareRenderer implements IRenderer {
+export class SoftwareRenderer implements IRenderer, StatsOverlayDrawTarget {
     // #region Constants
 
     private static readonly EFFECTS_UNSUPPORTED_MESSAGE =
@@ -139,16 +140,20 @@ export class SoftwareRenderer implements IRenderer {
         this.canvas.height = this.outputSize.y;
 
         this.outputCtx = this.canvas.getContext('2d') as Canvas2D | null;
+
         if (!this.outputCtx) {
             return false;
         }
+
         this.outputCtx.imageSmoothingEnabled = false;
 
         this.logicalCanvas = this.createLogicalCanvas();
         this.logicalCtx = this.logicalCanvas.getContext('2d') as Canvas2D | null;
+
         if (!this.logicalCtx) {
             return false;
         }
+
         this.logicalCtx.imageSmoothingEnabled = false;
 
         if ('createImageData' in this.logicalCtx) {
@@ -171,6 +176,7 @@ export class SoftwareRenderer implements IRenderer {
      */
     setPalette(palette: Palette): void {
         this.palette = palette;
+
         if (this.clearPaletteIndex >= this.palette.size) {
             this.clearPaletteIndex = 0;
         }
@@ -197,6 +203,7 @@ export class SoftwareRenderer implements IRenderer {
         if (!this.palette) {
             throw new Error(noActivePaletteError());
         }
+
         this.commands.length = 0;
     }
 
@@ -215,6 +222,7 @@ export class SoftwareRenderer implements IRenderer {
      */
     endFrame(): void {
         const clearColor = this.resolveClearColor();
+
         this.fillFrame(clearColor.r, clearColor.g, clearColor.b, clearColor.a);
 
         for (const command of this.commands) {
@@ -250,22 +258,12 @@ export class SoftwareRenderer implements IRenderer {
     }
 
     /**
-     * Queues a filled rectangle after prior commands (same FIFO queue as {@link drawRectFill}).
+     * Queues a stats overlay bar fill (same FIFO queue as {@link drawRectFill}).
      *
      * @param rect - Rectangle to fill in logical pixels.
      * @param paletteIndex - Palette entry index for the fill color.
      */
-    drawRectFillOnTop(rect: Rect2i, paletteIndex: number): void {
-        this.drawRectFill(rect, paletteIndex);
-    }
-
-    /**
-     * Queues a filled rectangle after prior draw commands (same FIFO queue as {@link drawRectFill}).
-     *
-     * @param rect - Rectangle to fill in logical pixels.
-     * @param paletteIndex - Palette entry index for the fill color.
-     */
-    drawRectFillForeground(rect: Rect2i, paletteIndex: number): void {
+    drawBarFill(rect: Rect2i, paletteIndex: number): void {
         this.drawRectFill(rect, paletteIndex);
     }
 
@@ -373,26 +371,14 @@ export class SoftwareRenderer implements IRenderer {
     }
 
     /**
-     * Queues bitmap text after prior commands (same FIFO queue as {@link drawBitmapText}).
+     * Queues a stats overlay label (same FIFO queue as {@link drawBitmapText}).
      *
      * @param font - Bitmap font with character glyphs.
      * @param pos - Text origin in logical pixels.
      * @param text - String to render.
      * @param paletteOffset - Palette index offset applied to all glyphs (default 0).
      */
-    drawBitmapTextOnTop(font: BitmapFont, pos: Vector2i, text: string, paletteOffset: number = 0): void {
-        this.drawBitmapText(font, pos, text, paletteOffset);
-    }
-
-    /**
-     * Queues bitmap text after prior draw commands (same FIFO queue as {@link drawBitmapText}).
-     *
-     * @param font - Bitmap font to render.
-     * @param pos - Top-left position of the text in logical coordinates.
-     * @param text - String to render.
-     * @param paletteOffset - Palette index offset applied to all glyphs (default 0).
-     */
-    drawBitmapTextForeground(font: BitmapFont, pos: Vector2i, text: string, paletteOffset: number = 0): void {
+    drawLabel(font: BitmapFont, pos: Vector2i, text: string, paletteOffset: number = 0): void {
         this.drawBitmapText(font, pos, text, paletteOffset);
     }
 
@@ -489,8 +475,10 @@ export class SoftwareRenderer implements IRenderer {
         }
 
         const canvas = document.createElement('canvas');
+
         canvas.width = this.displaySize.x;
         canvas.height = this.displaySize.y;
+
         return canvas;
     }
 
@@ -530,6 +518,7 @@ export class SoftwareRenderer implements IRenderer {
                     command.cameraY,
                 );
                 return;
+
             case 'rect':
                 this.rasterRect(
                     command.x0,
@@ -541,6 +530,7 @@ export class SoftwareRenderer implements IRenderer {
                     command.cameraY,
                 );
                 return;
+
             case 'line':
                 this.rasterLine(
                     command.x0,
@@ -552,9 +542,11 @@ export class SoftwareRenderer implements IRenderer {
                     command.cameraY,
                 );
                 return;
+
             case 'sprite':
                 this.rasterSprite(command);
                 return;
+
             case 'bitmapText':
                 this.rasterBitmapText(command);
                 return;
@@ -582,6 +574,7 @@ export class SoftwareRenderer implements IRenderer {
         cameraY: number,
     ): void {
         const color = this.resolvePrimitiveColor(paletteIndex);
+
         if (!color || width <= 0 || height <= 0) {
             return;
         }
@@ -624,6 +617,7 @@ export class SoftwareRenderer implements IRenderer {
 
         const x1 = x + width - 1;
         const y1 = y + height - 1;
+
         this.rasterLine(x, y, x1, y, paletteIndex, cameraX, cameraY);
         this.rasterLine(x, y1, x1, y1, paletteIndex, cameraX, cameraY);
         this.rasterLine(x, y + 1, x, y1 - 1, paletteIndex, cameraX, cameraY);
@@ -667,14 +661,18 @@ export class SoftwareRenderer implements IRenderer {
 
         while (true) {
             this.writePixel(cx, cy, color.r, color.g, color.b, 255);
+
             if (cx === tx && cy === ty) {
                 break;
             }
+
             const e2 = err * 2;
+
             if (e2 > -dy) {
                 err -= dy;
                 cx += sx;
             }
+
             if (e2 < dx) {
                 err += dx;
                 cy += sy;
@@ -717,6 +715,7 @@ export class SoftwareRenderer implements IRenderer {
                 const color = this.resolveSpriteColor(finalIndex);
                 const destX = destPos.x + destOffsetX + x - command.cameraX;
                 const destY = destPos.y + destOffsetY + y - command.cameraY;
+
                 this.writePixel(destX, destY, color.r, color.g, color.b, 255);
             }
         }
@@ -729,11 +728,14 @@ export class SoftwareRenderer implements IRenderer {
      */
     private rasterBitmapText(command: BitmapTextCommand): void {
         let cursorX = command.pos.x;
+
         for (const char of command.text) {
             const glyph = command.font.getGlyph(char);
+
             if (!glyph) {
                 continue;
             }
+
             this.rasterSprite({
                 kind: 'sprite',
                 spriteSheet: command.font.getSpriteSheet(),
@@ -743,6 +745,7 @@ export class SoftwareRenderer implements IRenderer {
                 cameraX: command.cameraX,
                 cameraY: command.cameraY,
             });
+
             cursorX += glyph.advance;
         }
     }
@@ -761,7 +764,9 @@ export class SoftwareRenderer implements IRenderer {
         if (x < 0 || y < 0 || x >= this.displaySize.x || y >= this.displaySize.y) {
             return;
         }
+
         const index = (y * this.displaySize.x + x) * 4;
+
         // eslint-disable-next-line security/detect-object-injection
         this.framePixels[index] = r;
         this.framePixels[index + 1] = g;
@@ -780,7 +785,9 @@ export class SoftwareRenderer implements IRenderer {
         if (!this.palette || paletteIndex >= this.palette.size) {
             return null;
         }
+
         const color = this.palette.get(paletteIndex);
+
         return color.a === 0 ? null : color;
     }
 
@@ -795,6 +802,7 @@ export class SoftwareRenderer implements IRenderer {
         if (!this.palette || paletteIndex >= this.palette.size) {
             return Color32.black;
         }
+
         return this.palette.get(paletteIndex);
     }
 
@@ -808,6 +816,7 @@ export class SoftwareRenderer implements IRenderer {
         if (!this.palette) {
             return Color32.black;
         }
+
         try {
             return this.palette.get(this.clearPaletteIndex);
         } catch {
@@ -838,17 +847,21 @@ export class SoftwareRenderer implements IRenderer {
         if (!this.pendingCapture) {
             return;
         }
+
         if (typeof this.canvas.toBlob !== 'function') {
             this.pendingCapture.reject(
                 new Error(
                     "Can't save this frame - your browser doesn't support canvas image export. Try Chrome or Edge.",
                 ),
             );
+
             this.pendingCapture = null;
+
             return;
         }
 
         const request = this.pendingCapture;
+
         this.pendingCapture = null;
         this.canvas.toBlob((blob) => {
             if (!blob) {

--- a/src/render/WebGpuRenderer.test.ts
+++ b/src/render/WebGpuRenderer.test.ts
@@ -41,8 +41,6 @@ type WebGpuRendererPipelineAccess = {
     overlayPrimitives: PrimitivePipeline;
     sprites: SpritePipeline;
     overlaySprites: SpritePipeline;
-    foregroundOverlayPrimitives: PrimitivePipeline;
-    foregroundOverlaySprites: SpritePipeline;
 };
 
 /**
@@ -442,7 +440,7 @@ describe('with initialized renderer', () => {
         renderer.endFrame();
     });
 
-    it('drawRectFillOnTop routes fills to overlayPrimitives, not primitives', () => {
+    it('drawBarFill routes fills to overlayPrimitives, not primitives', () => {
         const pipelines = getRendererPipelines(renderer);
         const sceneFill = vi.spyOn(pipelines.primitives, 'drawRectFill');
         const overlayFill = vi.spyOn(pipelines.overlayPrimitives, 'drawRectFill');
@@ -450,7 +448,7 @@ describe('with initialized renderer', () => {
 
         renderer.beginFrame();
         renderer.drawRectFill(rect, 2);
-        renderer.drawRectFillOnTop(rect, 5);
+        renderer.drawBarFill(rect, 5);
         renderer.endFrame();
 
         expect(sceneFill).toHaveBeenCalledOnce();
@@ -459,7 +457,7 @@ describe('with initialized renderer', () => {
         expect(overlayFill).toHaveBeenCalledWith(rect, 5);
     });
 
-    it('drawBitmapTextOnTop routes text to overlaySprites, not sprites', () => {
+    it('drawLabel routes text to overlaySprites, not sprites', () => {
         const pipelines = getRendererPipelines(renderer);
         const sceneText = vi.spyOn(pipelines.sprites, 'drawBitmapText');
         const overlayText = vi.spyOn(pipelines.overlaySprites, 'drawBitmapText');
@@ -470,7 +468,7 @@ describe('with initialized renderer', () => {
 
         renderer.beginFrame();
         renderer.drawBitmapText(mockFont, new Vector2i(0, 0), '');
-        renderer.drawBitmapTextOnTop(mockFont, new Vector2i(4, 4), '');
+        renderer.drawLabel(mockFont, new Vector2i(4, 4), '');
         renderer.endFrame();
 
         expect(sceneText).toHaveBeenCalledOnce();
@@ -479,43 +477,7 @@ describe('with initialized renderer', () => {
         expect(overlayText).toHaveBeenCalledWith(mockFont, new Vector2i(4, 4), '', 0);
     });
 
-    it('drawRectFillForeground routes fills to foregroundOverlayPrimitives', () => {
-        const pipelines = getRendererPipelines(renderer);
-        const overlayFill = vi.spyOn(pipelines.overlayPrimitives, 'drawRectFill');
-        const foregroundFill = vi.spyOn(pipelines.foregroundOverlayPrimitives, 'drawRectFill');
-        const overlayRect = new Rect2i(1, 2, 8, 8);
-        const foregroundRect = new Rect2i(3, 4, 6, 6);
-
-        renderer.beginFrame();
-        renderer.drawRectFillOnTop(overlayRect, 3);
-        renderer.drawRectFillForeground(foregroundRect, 5);
-        renderer.endFrame();
-
-        expect(overlayFill).toHaveBeenCalledWith(overlayRect, 3);
-        expect(foregroundFill).toHaveBeenCalledOnce();
-        expect(foregroundFill).toHaveBeenCalledWith(foregroundRect, 5);
-    });
-
-    it('drawBitmapTextForeground routes text to foregroundOverlaySprites', () => {
-        const pipelines = getRendererPipelines(renderer);
-        const overlayText = vi.spyOn(pipelines.overlaySprites, 'drawBitmapText');
-        const foregroundText = vi.spyOn(pipelines.foregroundOverlaySprites, 'drawBitmapText');
-        const mockFont = {
-            getSpriteSheet: () => ({}),
-            getGlyphByCode: () => null,
-        } as unknown as BitmapFont;
-
-        renderer.beginFrame();
-        renderer.drawBitmapTextOnTop(mockFont, new Vector2i(4, 4), '');
-        renderer.drawBitmapTextForeground(mockFont, new Vector2i(8, 8), '');
-        renderer.endFrame();
-
-        expect(overlayText).toHaveBeenCalledWith(mockFont, new Vector2i(4, 4), '', 0);
-        expect(foregroundText).toHaveBeenCalledOnce();
-        expect(foregroundText).toHaveBeenCalledWith(mockFont, new Vector2i(8, 8), '', 0);
-    });
-
-    it('encodes scene pass as primitives, sprites, overlay batches, then foreground overlay batches', () => {
+    it('encodes scene pass as primitives, sprites, then overlay batches', () => {
         const pipelines = getRendererPipelines(renderer);
         const encodeOrder: string[] = [];
 
@@ -531,12 +493,6 @@ describe('with initialized renderer', () => {
         vi.spyOn(pipelines.overlaySprites, 'encodePass').mockImplementation(() => {
             encodeOrder.push('overlaySprites');
         });
-        vi.spyOn(pipelines.foregroundOverlayPrimitives, 'encodePass').mockImplementation(() => {
-            encodeOrder.push('foregroundOverlayPrimitives');
-        });
-        vi.spyOn(pipelines.foregroundOverlaySprites, 'encodePass').mockImplementation(() => {
-            encodeOrder.push('foregroundOverlaySprites');
-        });
 
         const mockFont = {
             getSpriteSheet: () => ({}),
@@ -546,35 +502,22 @@ describe('with initialized renderer', () => {
         renderer.beginFrame();
         renderer.drawRectFill(new Rect2i(0, 0, 4, 4), 2);
         renderer.drawBitmapText(mockFont, new Vector2i(0, 0), '');
-        renderer.drawRectFillOnTop(new Rect2i(0, 220, 320, 16), 1);
-        renderer.drawBitmapTextOnTop(mockFont, new Vector2i(5, 225), 'HUD');
-        renderer.drawRectFillForeground(new Rect2i(10, 10, 6, 6), 4);
-        renderer.drawBitmapTextForeground(mockFont, new Vector2i(12, 12), '');
+        renderer.drawBarFill(new Rect2i(0, 220, 320, 16), 1);
+        renderer.drawLabel(mockFont, new Vector2i(5, 225), 'HUD');
         renderer.endFrame();
 
-        expect(encodeOrder).toEqual([
-            'primitives',
-            'sprites',
-            'overlayPrimitives',
-            'overlaySprites',
-            'foregroundOverlayPrimitives',
-            'foregroundOverlaySprites',
-        ]);
+        expect(encodeOrder).toEqual(['primitives', 'sprites', 'overlayPrimitives', 'overlaySprites']);
     });
 
     it('resets overlay batches on beginFrame', () => {
         const pipelines = getRendererPipelines(renderer);
         const overlayPrimitiveReset = vi.spyOn(pipelines.overlayPrimitives, 'reset');
         const overlaySpriteReset = vi.spyOn(pipelines.overlaySprites, 'reset');
-        const foregroundPrimitiveReset = vi.spyOn(pipelines.foregroundOverlayPrimitives, 'reset');
-        const foregroundSpriteReset = vi.spyOn(pipelines.foregroundOverlaySprites, 'reset');
 
         renderer.beginFrame();
 
         expect(overlayPrimitiveReset).toHaveBeenCalledOnce();
         expect(overlaySpriteReset).toHaveBeenCalledOnce();
-        expect(foregroundPrimitiveReset).toHaveBeenCalledOnce();
-        expect(foregroundSpriteReset).toHaveBeenCalledOnce();
 
         renderer.endFrame();
     });

--- a/src/render/WebGpuRenderer.ts
+++ b/src/render/WebGpuRenderer.ts
@@ -11,6 +11,7 @@ import { PaletteResolveUpscalePass } from './PaletteResolveUpscalePass';
 import { PostProcessChain } from './PostProcessChain';
 import { PrimitivePipeline } from './PrimitivePipeline';
 import { SpritePipeline } from './SpritePipeline';
+import type { StatsOverlayDrawTarget } from './stats-overlay/StatsOverlayDrawTarget';
 import type { UpscaleFilter } from './UpscalePass';
 
 // #region Configuration
@@ -53,7 +54,7 @@ const LOGICAL_TARGET_FORMAT: GPUTextureFormat = 'r8uint';
  * exists only after palette resolve/upscale, so display-tier effects remain
  * unchanged while the obsolete logical RGBA path is removed.
  */
-export class WebGpuRenderer implements IRenderer {
+export class WebGpuRenderer implements IRenderer, StatsOverlayDrawTarget {
     // #region State
 
     /** WebGPU device for GPU operations. */
@@ -127,16 +128,6 @@ export class WebGpuRenderer implements IRenderer {
      */
     private readonly overlaySprites: SpritePipeline;
 
-    /**
-     * Primitives encoded after overlay sprites (palette tooltip fills above custom rows).
-     */
-    private readonly foregroundOverlayPrimitives: PrimitivePipeline;
-
-    /**
-     * Sprites encoded after foreground overlay primitives (palette tooltip labels).
-     */
-    private readonly foregroundOverlaySprites: SpritePipeline;
-
     /** Pixel-tier post-process chain (logical resolution). */
     private pixelChain: PostProcessChain | null = null;
 
@@ -148,6 +139,8 @@ export class WebGpuRenderer implements IRenderer {
 
     /** Logical-resolution scene framebuffer; allocated lazily. */
     private sceneTex: GPUTexture | null = null;
+
+    /** Stable view of the scene framebuffer. */
     private sceneTexView: GPUTextureView | null = null;
 
     /** Cached swap-chain format used by lazy texture creation. */
@@ -193,8 +186,6 @@ export class WebGpuRenderer implements IRenderer {
         this.overlayPrimitives = new PrimitivePipeline();
         this.sprites = new SpritePipeline();
         this.overlaySprites = new SpritePipeline();
-        this.foregroundOverlayPrimitives = new PrimitivePipeline();
-        this.foregroundOverlaySprites = new SpritePipeline();
     }
 
     // #endregion
@@ -242,18 +233,6 @@ export class WebGpuRenderer implements IRenderer {
             await this.overlayPrimitives.init(this.device, this.displaySize, this.paletteBuffer, LOGICAL_TARGET_FORMAT);
             await this.sprites.init(this.device, this.displaySize, this.paletteBuffer, LOGICAL_TARGET_FORMAT);
             await this.overlaySprites.init(this.device, this.displaySize, this.paletteBuffer, LOGICAL_TARGET_FORMAT);
-            await this.foregroundOverlayPrimitives.init(
-                this.device,
-                this.displaySize,
-                this.paletteBuffer,
-                LOGICAL_TARGET_FORMAT,
-            );
-            await this.foregroundOverlaySprites.init(
-                this.device,
-                this.displaySize,
-                this.paletteBuffer,
-                LOGICAL_TARGET_FORMAT,
-            );
 
             this.swapFormat = navigator.gpu.getPreferredCanvasFormat();
 
@@ -337,8 +316,6 @@ export class WebGpuRenderer implements IRenderer {
         this.overlayPrimitives.reset();
         this.sprites.reset();
         this.overlaySprites.reset();
-        this.foregroundOverlayPrimitives.reset();
-        this.foregroundOverlaySprites.reset();
     }
 
     /**
@@ -398,23 +375,13 @@ export class WebGpuRenderer implements IRenderer {
     }
 
     /**
-     * Draws a filled rectangle in the post-sprite primitive batch.
+     * Draws a filled rectangle in the stats overlay primitive batch (above demo sprites).
      *
      * @param rect - Rectangle bounds in pixel coordinates.
      * @param paletteIndex - Palette color index.
      */
-    drawRectFillOnTop(rect: Rect2i, paletteIndex: number): void {
+    drawBarFill(rect: Rect2i, paletteIndex: number): void {
         this.overlayPrimitives.drawRectFill(rect, paletteIndex);
-    }
-
-    /**
-     * Draws a filled rectangle in the post-overlay-sprite primitive batch.
-     *
-     * @param rect - Rectangle bounds in pixel coordinates.
-     * @param paletteIndex - Palette color index.
-     */
-    drawRectFillForeground(rect: Rect2i, paletteIndex: number): void {
-        this.foregroundOverlayPrimitives.drawRectFill(rect, paletteIndex);
     }
 
     /**
@@ -489,27 +456,15 @@ export class WebGpuRenderer implements IRenderer {
     }
 
     /**
-     * Draws bitmap text in the post-overlay-bar sprite batch.
+     * Draws bitmap text in the stats overlay sprite batch (above overlay bar fills).
      *
      * @param font - Bitmap font with character glyphs.
      * @param pos - Text position (top-left corner).
      * @param text - String to render.
      * @param paletteOffset - Palette index offset applied to all glyphs (default 0).
      */
-    drawBitmapTextOnTop(font: BitmapFont, pos: Vector2i, text: string, paletteOffset: number = 0): void {
+    drawLabel(font: BitmapFont, pos: Vector2i, text: string, paletteOffset: number = 0): void {
         this.overlaySprites.drawBitmapText(font, pos, text, paletteOffset);
-    }
-
-    /**
-     * Draws bitmap text in the post-foreground-overlay primitive batch.
-     *
-     * @param font - Bitmap font with character glyphs.
-     * @param pos - Text position (top-left corner).
-     * @param text - String to render.
-     * @param paletteOffset - Palette index offset applied to all glyphs (default 0).
-     */
-    drawBitmapTextForeground(font: BitmapFont, pos: Vector2i, text: string, paletteOffset: number = 0): void {
-        this.foregroundOverlaySprites.drawBitmapText(font, pos, text, paletteOffset);
     }
 
     // #endregion
@@ -535,8 +490,7 @@ export class WebGpuRenderer implements IRenderer {
      * Sets the camera offset for scrolling.
      *
      * The offset is propagated to all scene pipelines: `primitives`,
-     * `overlayPrimitives`, `sprites`, `overlaySprites`, `foregroundOverlayPrimitives`, and
-     * `foregroundOverlaySprites`.
+     * `overlayPrimitives`, `sprites`, and `overlaySprites`.
      *
      * @param offset - Camera position in pixels.
      */
@@ -546,8 +500,6 @@ export class WebGpuRenderer implements IRenderer {
         this.overlayPrimitives.setCameraOffset(this.cameraOffset);
         this.sprites.setCameraOffset(this.cameraOffset);
         this.overlaySprites.setCameraOffset(this.cameraOffset);
-        this.foregroundOverlayPrimitives.setCameraOffset(this.cameraOffset);
-        this.foregroundOverlaySprites.setCameraOffset(this.cameraOffset);
     }
 
     /**
@@ -568,8 +520,6 @@ export class WebGpuRenderer implements IRenderer {
         this.overlayPrimitives.setCameraOffset(this.cameraOffset);
         this.sprites.setCameraOffset(this.cameraOffset);
         this.overlaySprites.setCameraOffset(this.cameraOffset);
-        this.foregroundOverlayPrimitives.setCameraOffset(this.cameraOffset);
-        this.foregroundOverlaySprites.setCameraOffset(this.cameraOffset);
     }
 
     // #endregion
@@ -601,6 +551,7 @@ export class WebGpuRenderer implements IRenderer {
         }
 
         const chain = effect.tier === 'pixel' ? this.pixelChain : this.displayChain;
+
         chain.add(effect);
     }
 
@@ -659,23 +610,23 @@ export class WebGpuRenderer implements IRenderer {
             swapTexture = this.context.getCurrentTexture();
         } catch (error) {
             console.error('[WebGpuRenderer] Failed to get current texture:', error);
+
             this.primitives.reset();
             this.overlayPrimitives.reset();
             this.sprites.reset();
             this.overlaySprites.reset();
-            this.foregroundOverlayPrimitives.reset();
-            this.foregroundOverlaySprites.reset();
+
             return null;
         }
 
         if (swapTexture.width === 0 || swapTexture.height === 0) {
             console.warn('[WebGpuRenderer] Texture has zero dimensions, skipping frame');
+
             this.primitives.reset();
             this.overlayPrimitives.reset();
             this.sprites.reset();
             this.overlaySprites.reset();
-            this.foregroundOverlayPrimitives.reset();
-            this.foregroundOverlaySprites.reset();
+
             return null;
         }
 
@@ -698,10 +649,8 @@ export class WebGpuRenderer implements IRenderer {
     /**
      * Encodes the scene render pass into the supplied target view.
      *
-     * Draw order: `primitives`, `sprites`, `overlayPrimitives` (HUD bars via
-     * {@link drawRectFillOnTop}), `overlaySprites` (labels via {@link drawBitmapTextOnTop}),
-     * `foregroundOverlayPrimitives` (popover fills via {@link drawRectFillForeground}), then
-     * `foregroundOverlaySprites` (popover labels via {@link drawBitmapTextForeground}).
+     * Draw order: `primitives`, `sprites`, `overlayPrimitives` (stats bars via
+     * {@link drawBarFill}), then `overlaySprites` (stats labels via {@link drawLabel}).
      *
      * @param encoder - Active command encoder.
      * @param sceneView - Logical scene attachment view to render into.
@@ -729,8 +678,7 @@ export class WebGpuRenderer implements IRenderer {
         this.sprites.encodePass(renderPass);
         this.overlayPrimitives.encodePass(renderPass);
         this.overlaySprites.encodePass(renderPass);
-        this.foregroundOverlayPrimitives.encodePass(renderPass);
-        this.foregroundOverlaySprites.encodePass(renderPass);
+
         renderPass.end();
     }
 
@@ -760,6 +708,7 @@ export class WebGpuRenderer implements IRenderer {
         if (this.resolvePass) {
             const resolveSrc = this.requireSceneTexView();
             const resolveDest = displayActive ? this.requireDisplayChainInput() : swapChainView;
+
             this.resolvePass.encode(encoder, resolveSrc, resolveDest, this.displaySize);
         }
 
@@ -795,8 +744,6 @@ export class WebGpuRenderer implements IRenderer {
         this.overlayPrimitives.reset();
         this.sprites.reset();
         this.overlaySprites.reset();
-        this.foregroundOverlayPrimitives.reset();
-        this.foregroundOverlaySprites.reset();
     }
 
     // #endregion
@@ -842,6 +789,7 @@ export class WebGpuRenderer implements IRenderer {
                 format: LOGICAL_TARGET_FORMAT,
                 usage: SCENE_TARGET_USAGE,
             });
+
             this.sceneTexView = this.sceneTex.createView();
         }
 
@@ -856,9 +804,11 @@ export class WebGpuRenderer implements IRenderer {
      */
     private requireDisplayChainInput(): GPUTextureView {
         const chain = this.displayChain;
+
         if (!chain?.isActive()) {
             throw new Error('WebGpuRenderer.requireDisplayChainInput: display chain inactive.');
         }
+
         return chain.getInputView();
     }
 

--- a/src/render/stats-overlay/StatsOverlay.test.ts
+++ b/src/render/stats-overlay/StatsOverlay.test.ts
@@ -231,8 +231,8 @@ describe('StatsOverlay', () => {
 
         overlay.updateAndRender(renderer, mockFont, null, null, 0);
 
-        expect(renderer.drawRectFillOnTop).not.toHaveBeenCalled();
-        expect(renderer.drawBitmapTextOnTop).not.toHaveBeenCalled();
+        expect(renderer.drawBarFill).not.toHaveBeenCalled();
+        expect(renderer.drawLabel).not.toHaveBeenCalled();
     });
 
     it('draws hint-only path while body is hidden and toggle hint is visible', () => {
@@ -292,7 +292,7 @@ describe('StatsOverlay', () => {
         const calls = getBitmapTextCalls(renderer);
 
         expect(calls.every((call) => call.paletteOffset === 1)).toBe(true);
-        expect(renderer.drawRectFillOnTop).toHaveBeenCalledWith(expect.anything(), 1);
+        expect(renderer.drawBarFill).toHaveBeenCalledWith(expect.anything(), 1);
     });
 
     it('uses statsOverlayStyle palette indices when provided', () => {
@@ -304,7 +304,7 @@ describe('StatsOverlay', () => {
         const renderer = createMockRenderer();
         overlay.updateAndRender(renderer, mockFont, null, null, 0);
 
-        expect(renderer.drawRectFillOnTop).toHaveBeenCalledWith(expect.anything(), 8);
+        expect(renderer.drawBarFill).toHaveBeenCalledWith(expect.anything(), 8);
 
         const calls = getBitmapTextCalls(renderer);
 
@@ -324,7 +324,7 @@ describe('StatsOverlay', () => {
 
         const fills = getRectFillCalls(renderer);
 
-        expect(renderer.drawRectFillOnTop).toHaveBeenCalledWith(fills[3], 5);
+        expect(renderer.drawBarFill).toHaveBeenCalledWith(fills[3], 5);
 
         const calls = getBitmapTextCalls(renderer);
 
@@ -414,7 +414,7 @@ describe('StatsOverlay', () => {
         expect(
             fills.some((rect) => rect.y === hintBarY(240) && rect.height === STATS_BAR_HEIGHT && rect.width === 320),
         ).toBe(true);
-        expect(renderer.drawRectFillOnTop.mock.calls.length).toBeGreaterThan(4);
+        expect(renderer.drawBarFill.mock.calls.length).toBeGreaterThan(4);
     });
 
     it('preserves default hint bar height when palette view is disabled', () => {
@@ -427,7 +427,7 @@ describe('StatsOverlay', () => {
 
         const fills = getRectFillCalls(renderer);
         expect(fills[3]).toMatchObject({ y: hintBarY(240), height: STATS_BAR_HEIGHT, width: 320 });
-        const swatchCalls = renderer.drawRectFillOnTop.mock.calls.filter(
+        const swatchCalls = renderer.drawBarFill.mock.calls.filter(
             (call) => (call[0] as { width: number }).width === 1,
         );
         expect(swatchCalls).toHaveLength(0);
@@ -470,7 +470,7 @@ describe('StatsOverlay', () => {
             drawCalls: 4,
         });
 
-        const dotCalls = renderer.drawRectFillOnTop.mock.calls.filter(
+        const dotCalls = renderer.drawBarFill.mock.calls.filter(
             (call) => (call[0] as { width: number }).width === 1 && (call[0] as { height: number }).height === 1,
         );
         const paletteIndices = dotCalls.map((call) => call[1] as number);
@@ -498,7 +498,7 @@ describe('StatsOverlay', () => {
             drawCalls: 4,
         });
 
-        expect(renderer.drawRectFillOnTop).not.toHaveBeenCalled();
+        expect(renderer.drawBarFill).not.toHaveBeenCalled();
 
         overlay.handleToggle(null, { isKeyPressed: (key: string) => key === 'Backquote' } as never, 2);
         overlay.updateAndRender(renderer, mockFont, null, null, 0, undefined, {
@@ -509,7 +509,7 @@ describe('StatsOverlay', () => {
             drawCalls: 4,
         });
 
-        expect(renderer.drawRectFillOnTop.mock.calls.some((call) => call[1] === 10)).toBe(true);
+        expect(renderer.drawBarFill.mock.calls.some((call) => call[1] === 10)).toBe(true);
     });
 
     it('does not draw timing chart dots when statsOverlayTimingChart is disabled', () => {
@@ -525,7 +525,7 @@ describe('StatsOverlay', () => {
             drawCalls: 4,
         });
 
-        expect(renderer.drawRectFillOnTop.mock.calls.some((call) => call[1] === 10)).toBe(false);
+        expect(renderer.drawBarFill.mock.calls.some((call) => call[1] === 10)).toBe(false);
     });
 
     it('ignores toggle input when statsOverlayToggleEnabled is false', () => {

--- a/src/render/stats-overlay/StatsOverlay.ts
+++ b/src/render/stats-overlay/StatsOverlay.ts
@@ -15,7 +15,6 @@ import type {
 } from '../../core/IBlitTechDemo';
 import type { KeyboardInput } from '../../input/KeyboardInput';
 import type { PointerInput } from '../../input/PointerInput';
-import type { IRenderer } from '../IRenderer';
 import { DEFAULT_IDX_BG, DEFAULT_IDX_TEXT, DEFAULT_TIMING_CHART_HEIGHT, STATS_BOTTOM_HINT_LABEL } from './constants';
 import { FpsSampler } from './FpsSampler';
 import {
@@ -24,6 +23,7 @@ import {
     createStatsOverlayLayoutPlanScratch,
 } from './layoutPlan';
 import { StatsOverlayBars } from './StatsOverlayBars';
+import type { StatsOverlayRenderer } from './StatsOverlayDrawTarget';
 import { StatsOverlayPaletteInteraction } from './StatsOverlayPaletteInteraction';
 import { computePaletteGrid, DEFAULT_PALETTE_GRID, StatsOverlayPaletteView } from './StatsOverlayPaletteView';
 import { StatsOverlayTimingChart } from './StatsOverlayTimingChart';
@@ -213,6 +213,63 @@ export class StatsOverlay {
     }
 
     /**
+     * Draws the overlay. Toggle input is handled earlier in the frame by BTAPI
+     * ({@link BTAPI.beginRenderFrame}) so palette usage tracking matches visibility.
+     *
+     * @param renderer - Active {@link StatsOverlayRenderer} instance.
+     * @param font - System bitmap font.
+     * @param pointer - Pointer subsystem for palette swatch hover tooltips.
+     * @param _keyboard - Reserved; toggle input is handled in BTAPI before render.
+     * @param currentTick - Current fixed-update tick for copy-status expiry.
+     * @param getCustomRows - Optional supplier for demo rows; not invoked while the overlay body is hidden.
+     * @param timing - Optional timing snapshot from the previous rendered frame.
+     * @param palette - Active demo palette for optional palette grid.
+     * @param usedPaletteMask - Per-frame palette usage mask populated during demo render.
+     */
+    updateAndRender(
+        renderer: StatsOverlayRenderer,
+        font: BitmapFont,
+        pointer: PointerInput | null,
+        _keyboard: KeyboardInput | null,
+        currentTick: number,
+        getCustomRows?: () => readonly StatsOverlayRow[] | undefined,
+        timing?: StatsOverlayTimingSnapshot,
+        palette?: Palette | null,
+        usedPaletteMask: Uint8Array = EMPTY_PALETTE_USAGE_MASK,
+    ): void {
+        // Chart history keeps advancing while hidden so re-show reflects demo-only timing.
+        this.#sampleTiming(timing);
+
+        const bodyVisible = this.#toggle.bodyVisible;
+
+        if (!bodyVisible && !this.#toggleHintVisible) {
+            return;
+        }
+
+        if (bodyVisible) {
+            this.#fps.sample();
+        }
+
+        const customRows = bodyVisible ? getCustomRows?.() : undefined;
+        const { layoutConfig, plan } = this.#buildFramePlan(customRows?.length ?? 0, palette);
+
+        this.#withOverlayCamera(renderer, () => {
+            this.#drawFrame(
+                renderer,
+                font,
+                plan,
+                layoutConfig,
+                bodyVisible,
+                customRows,
+                palette,
+                usedPaletteMask,
+                pointer,
+                currentTick,
+            );
+        });
+    }
+
+    /**
      * Records timing samples when a snapshot is provided.
      *
      * @param timing - Optional timing snapshot from the previous rendered frame.
@@ -283,7 +340,7 @@ export class StatsOverlay {
      * @param renderer - Active renderer.
      * @param draw - Callback that issues overlay draws.
      */
-    #withOverlayCamera(renderer: IRenderer, draw: () => void): void {
+    #withOverlayCamera(renderer: StatsOverlayRenderer, draw: () => void): void {
         const savedCamera = renderer.getCameraOffset();
 
         renderer.resetCamera();
@@ -313,7 +370,7 @@ export class StatsOverlay {
      * @param currentTick
      */
     #drawFrame(
-        renderer: IRenderer,
+        renderer: StatsOverlayRenderer,
         font: BitmapFont,
         plan: StatsOverlayLayoutPlan,
         layoutConfig: StatsOverlayLayoutConfig,
@@ -327,10 +384,16 @@ export class StatsOverlay {
         this.#barStyle.barIndex = this.#idxBg;
         this.#barStyle.textIndex = this.#idxText;
 
+        let topMetricsLabel = '';
+        let topTimingLabel = '';
+        const paletteGrid = layoutConfig.paletteGrid ?? DEFAULT_PALETTE_GRID;
+
         if (bodyVisible) {
             const updateStepSuffix = this.#timing.updateSteps > 1 ? `x${this.#timing.updateSteps}` : '';
-            const topMetricsLabel = `Present: ${this.#fps.measuredFps} FPS | Target: ${this.#targetFps} FPS | Draw Calls: ${this.#timing.drawCalls}`;
-            const topTimingLabel =
+
+            topMetricsLabel = `Present: ${this.#fps.measuredFps} FPS | Target: ${this.#targetFps} FPS | Draw Calls: ${this.#timing.drawCalls}`;
+
+            topTimingLabel =
                 `Frame: ${this.#timing.frameMs.toFixed(1)}ms | update(): ${this.#timing.updateMs.toFixed(1)}ms${updateStepSuffix} | ` +
                 `render(): ${this.#timing.renderMs.toFixed(1)}ms`;
 
@@ -338,12 +401,10 @@ export class StatsOverlay {
             this.#timingChart.draw(renderer, plan.timingChart, this.#timingChartStyle);
 
             if (customRows !== undefined && customRows.length > 0) {
-                this.#bars.drawCustomRows(renderer, font, plan, customRows, this.#barStyle);
+                this.#bars.drawCustomRowFills(renderer, plan, customRows, this.#barStyle);
             }
 
             this.#bars.drawPaletteBandFill(renderer, plan, this.#idxBg);
-
-            const paletteGrid = layoutConfig.paletteGrid ?? DEFAULT_PALETTE_GRID;
 
             this.#paletteView.draw(
                 renderer,
@@ -371,6 +432,24 @@ export class StatsOverlay {
                 this.#layout.lineHeight,
             );
 
+            this.#paletteInteraction.drawTooltipChrome(
+                renderer,
+                plan,
+                paletteGrid,
+                this.#layout.displayWidth,
+                this.#layout.displayHeight,
+                this.#idxBg,
+                this.#idxText,
+            );
+        }
+
+        this.#bars.drawHintBarFill(renderer, plan, this.#idxBg);
+
+        if (bodyVisible) {
+            if (customRows !== undefined && customRows.length > 0) {
+                this.#bars.drawCustomRowLabels(renderer, font, plan, customRows, this.#barStyle);
+            }
+
             this.#bars.drawTopLabels(
                 renderer,
                 font,
@@ -381,16 +460,8 @@ export class StatsOverlay {
                 topMetricsLabel,
                 topTimingLabel,
             );
-        }
 
-        this.#bars.drawHintBarFill(renderer, plan, this.#idxBg);
-
-        this.#bars.drawHintLabel(renderer, font, plan, this.#idxText, STATS_BOTTOM_HINT_LABEL);
-
-        if (bodyVisible) {
-            const paletteGrid = layoutConfig.paletteGrid ?? DEFAULT_PALETTE_GRID;
-
-            this.#paletteInteraction.drawTooltip(
+            this.#paletteInteraction.drawTooltipLabel(
                 renderer,
                 font,
                 plan,
@@ -398,65 +469,9 @@ export class StatsOverlay {
                 this.#layout.displayWidth,
                 this.#layout.displayHeight,
                 this.#idxText,
-                this.#idxBg,
             );
         }
-    }
 
-    /**
-     * Draws the overlay. Toggle input is handled earlier in the frame by BTAPI
-     * ({@link BTAPI.beginRenderFrame}) so palette usage tracking matches visibility.
-     *
-     * @param renderer - Active {@link IRenderer} instance.
-     * @param font - System bitmap font.
-     * @param pointer - Pointer subsystem for palette swatch hover tooltips.
-     * @param _keyboard - Reserved; toggle input is handled in BTAPI before render.
-     * @param currentTick - Current fixed-update tick for copy-status expiry.
-     * @param getCustomRows - Optional supplier for demo rows; not invoked while the overlay body is hidden.
-     * @param timing - Optional timing snapshot from the previous rendered frame.
-     * @param palette - Active demo palette for optional palette grid.
-     * @param usedPaletteMask - Per-frame palette usage mask populated during demo render.
-     */
-    updateAndRender(
-        renderer: IRenderer,
-        font: BitmapFont,
-        pointer: PointerInput | null,
-        _keyboard: KeyboardInput | null,
-        currentTick: number,
-        getCustomRows?: () => readonly StatsOverlayRow[] | undefined,
-        timing?: StatsOverlayTimingSnapshot,
-        palette?: Palette | null,
-        usedPaletteMask: Uint8Array = EMPTY_PALETTE_USAGE_MASK,
-    ): void {
-        // Chart history keeps advancing while hidden so re-show reflects demo-only timing.
-        this.#sampleTiming(timing);
-
-        const bodyVisible = this.#toggle.bodyVisible;
-
-        if (!bodyVisible && !this.#toggleHintVisible) {
-            return;
-        }
-
-        if (bodyVisible) {
-            this.#fps.sample();
-        }
-
-        const customRows = bodyVisible ? getCustomRows?.() : undefined;
-        const { layoutConfig, plan } = this.#buildFramePlan(customRows?.length ?? 0, palette);
-
-        this.#withOverlayCamera(renderer, () => {
-            this.#drawFrame(
-                renderer,
-                font,
-                plan,
-                layoutConfig,
-                bodyVisible,
-                customRows,
-                palette,
-                usedPaletteMask,
-                pointer,
-                currentTick,
-            );
-        });
+        this.#bars.drawHintLabel(renderer, font, plan, this.#idxText, STATS_BOTTOM_HINT_LABEL);
     }
 }

--- a/src/render/stats-overlay/StatsOverlay.ts
+++ b/src/render/stats-overlay/StatsOverlay.ts
@@ -366,8 +366,8 @@ export class StatsOverlay {
      * @param customRows - Optional demo rows, if any.
      * @param palette - Active demo palette.
      * @param usedPaletteMask - Per-frame palette usage mask from BTAPI.
-     * @param pointer
-     * @param currentTick
+     * @param pointer - Pointer subsystem for palette swatch hover, or `null` when unavailable.
+     * @param currentTick - Current fixed-update tick for copy-status expiry.
      */
     #drawFrame(
         renderer: StatsOverlayRenderer,

--- a/src/render/stats-overlay/StatsOverlayBars.ts
+++ b/src/render/stats-overlay/StatsOverlayBars.ts
@@ -1,9 +1,9 @@
 import type { BitmapFont } from '../../assets/BitmapFont';
 import type { StatsOverlayRow } from '../../core/IBlitTechDemo';
 import { Vector2i } from '../../utils/Vector2i';
-import type { IRenderer } from '../IRenderer';
 import { STATS_EDGE_MARGIN_PX, STATS_TOP_TEXT_Y } from './constants';
 import { statsBitmapTextPaletteOffset, statsRightAlignedTextX } from './layoutHelpers';
+import type { StatsOverlayDrawTarget } from './StatsOverlayDrawTarget';
 import type { StatsOverlayLayoutPlan } from './types';
 
 /** Default bar and text palette indices for overlay drawing. */
@@ -35,56 +35,56 @@ export class StatsOverlayBars {
     /**
      * Draws title, timing chart, metrics, and timing text bar fills.
      *
-     * @param renderer - Active renderer.
+     * @param target - Stats overlay draw target.
      * @param plan - Computed layout plan.
      * @param barIndex - Palette index for bar fills.
      */
-    drawTopBars(renderer: IRenderer, plan: StatsOverlayLayoutPlan, barIndex: number): void {
-        renderer.drawRectFillOnTop(plan.titleBar, barIndex);
+    drawTopBars(target: StatsOverlayDrawTarget, plan: StatsOverlayLayoutPlan, barIndex: number): void {
+        target.drawBarFill(plan.titleBar, barIndex);
 
         if (plan.timingChart.height > 0) {
-            renderer.drawRectFillOnTop(plan.timingChart, barIndex);
+            target.drawBarFill(plan.timingChart, barIndex);
         }
 
-        renderer.drawRectFillOnTop(plan.metricsBar, barIndex);
-        renderer.drawRectFillOnTop(plan.timingTextBar, barIndex);
+        target.drawBarFill(plan.metricsBar, barIndex);
+        target.drawBarFill(plan.timingTextBar, barIndex);
     }
 
     /**
      * Draws the palette band background fill when the overlay body is visible.
      *
-     * @param renderer - Active renderer.
+     * @param target - Stats overlay draw target.
      * @param plan - Computed layout plan.
      * @param barIndex - Palette index for bar fills.
      */
-    drawPaletteBandFill(renderer: IRenderer, plan: StatsOverlayLayoutPlan, barIndex: number): void {
+    drawPaletteBandFill(target: StatsOverlayDrawTarget, plan: StatsOverlayLayoutPlan, barIndex: number): void {
         if (plan.paletteBand.height > 0) {
-            renderer.drawRectFillOnTop(plan.paletteBand, barIndex);
+            target.drawBarFill(plan.paletteBand, barIndex);
         }
     }
 
     /**
      * Draws the bottom hint bar background fill.
      *
-     * @param renderer - Active renderer.
+     * @param target - Stats overlay draw target.
      * @param plan - Computed layout plan.
      * @param barIndex - Palette index for bar fills.
      */
-    drawHintBarFill(renderer: IRenderer, plan: StatsOverlayLayoutPlan, barIndex: number): void {
-        renderer.drawRectFillOnTop(plan.hintBar, barIndex);
+    drawHintBarFill(target: StatsOverlayDrawTarget, plan: StatsOverlayLayoutPlan, barIndex: number): void {
+        target.drawBarFill(plan.hintBar, barIndex);
     }
 
     /**
      * Draws the bottom-left `[~]` toggle hint label.
      *
-     * @param renderer - Active renderer.
+     * @param target - Stats overlay draw target.
      * @param font - System bitmap font.
      * @param plan - Computed layout plan.
      * @param textIndex - Palette index for the hint label.
      * @param hintLabel - Toggle hint text (typically `[~]`).
      */
     drawHintLabel(
-        renderer: IRenderer,
+        target: StatsOverlayDrawTarget,
         font: BitmapFont,
         plan: StatsOverlayLayoutPlan,
         textIndex: number,
@@ -92,13 +92,13 @@ export class StatsOverlayBars {
     ): void {
         const textPaletteOffset = statsBitmapTextPaletteOffset(textIndex);
 
-        renderer.drawBitmapTextOnTop(font, plan.hintLabelPos, hintLabel, textPaletteOffset);
+        target.drawLabel(font, plan.hintLabelPos, hintLabel, textPaletteOffset);
     }
 
     /**
      * Draws built-in top overlay text labels (excluding the footer hint).
      *
-     * @param renderer - Active renderer.
+     * @param target - Stats overlay draw target.
      * @param font - System bitmap font.
      * @param plan - Computed layout plan.
      * @param style - Default overlay palette indices.
@@ -108,7 +108,7 @@ export class StatsOverlayBars {
      * @param topTimingLabel - Frame / update / render ms line.
      */
     drawTopLabels(
-        renderer: IRenderer,
+        target: StatsOverlayDrawTarget,
         font: BitmapFont,
         plan: StatsOverlayLayoutPlan,
         style: StatsOverlayBarStyle,
@@ -119,23 +119,55 @@ export class StatsOverlayBars {
     ): void {
         const textPaletteOffset = statsBitmapTextPaletteOffset(style.textIndex);
 
-        renderer.drawBitmapTextOnTop(font, plan.topLeftPos, topLeftLabel, textPaletteOffset);
-        renderer.drawBitmapTextOnTop(font, plan.topRightPos, topRightLabel, textPaletteOffset);
-        renderer.drawBitmapTextOnTop(font, plan.topMetricsPos, topMetricsLabel, textPaletteOffset);
-        renderer.drawBitmapTextOnTop(font, plan.topTimingPos, topTimingLabel, textPaletteOffset);
+        target.drawLabel(font, plan.topLeftPos, topLeftLabel, textPaletteOffset);
+        target.drawLabel(font, plan.topRightPos, topRightLabel, textPaletteOffset);
+        target.drawLabel(font, plan.topMetricsPos, topMetricsLabel, textPaletteOffset);
+        target.drawLabel(font, plan.topTimingPos, topTimingLabel, textPaletteOffset);
     }
 
     /**
-     * Draws demo-supplied custom rows from the layout plan.
+     * Draws demo-supplied custom row bar fills from the layout plan.
      *
-     * @param renderer - Active renderer.
+     * @param target - Stats overlay draw target.
+     * @param plan - Computed layout plan with custom bar rects.
+     * @param rows - Custom overlay rows.
+     * @param style - Default overlay palette indices.
+     */
+    drawCustomRowFills(
+        target: StatsOverlayDrawTarget,
+        plan: StatsOverlayLayoutPlan,
+        rows: readonly StatsOverlayRow[],
+        style: StatsOverlayBarStyle,
+    ): void {
+        const rowCount = rows.length;
+
+        /* eslint-disable security/detect-object-injection -- rowIndex bounded by rows.length */
+        for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+            const row = rows[rowIndex];
+            const barRect = plan.customBars[rowIndex];
+
+            if (row === undefined || barRect === undefined) {
+                continue;
+            }
+
+            const barIndex = row.barPaletteIndex ?? style.barIndex;
+
+            target.drawBarFill(barRect, barIndex);
+        }
+        /* eslint-enable security/detect-object-injection */
+    }
+
+    /**
+     * Draws demo-supplied custom row labels from the layout plan.
+     *
+     * @param target - Stats overlay draw target.
      * @param font - System bitmap font.
      * @param plan - Computed layout plan with custom bar rects.
      * @param rows - Custom overlay rows.
      * @param style - Default overlay palette indices.
      */
-    drawCustomRows(
-        renderer: IRenderer,
+    drawCustomRowLabels(
+        target: StatsOverlayDrawTarget,
         font: BitmapFont,
         plan: StatsOverlayLayoutPlan,
         rows: readonly StatsOverlayRow[],
@@ -161,22 +193,20 @@ export class StatsOverlayBars {
                 continue;
             }
 
-            const barIndex = row.barPaletteIndex ?? style.barIndex;
             const textIndex = row.textPaletteIndex ?? style.textIndex;
             const textPaletteOffset = statsBitmapTextPaletteOffset(textIndex);
             const barY = barRect.y;
 
             leftPos.y = barY + STATS_TOP_TEXT_Y;
 
-            renderer.drawRectFillOnTop(barRect, barIndex);
-            renderer.drawBitmapTextOnTop(font, leftPos, row.leftText, textPaletteOffset);
+            target.drawLabel(font, leftPos, row.leftText, textPaletteOffset);
 
             const rightText = row.rightText;
 
             if (rightText !== undefined && rightText.length > 0) {
                 rightPos.y = barY + STATS_TOP_TEXT_Y;
                 rightPos.x = statsRightAlignedTextX(rightText, displayWidth);
-                renderer.drawBitmapTextOnTop(font, rightPos, rightText, textPaletteOffset);
+                target.drawLabel(font, rightPos, rightText, textPaletteOffset);
             }
         }
         /* eslint-enable security/detect-object-injection */

--- a/src/render/stats-overlay/StatsOverlayDrawTarget.ts
+++ b/src/render/stats-overlay/StatsOverlayDrawTarget.ts
@@ -1,0 +1,42 @@
+import type { BitmapFont } from '../../assets/BitmapFont';
+import type { Rect2i } from '../../utils/Rect2i';
+import type { Vector2i } from '../../utils/Vector2i';
+import type { IRenderer } from '../IRenderer';
+
+/**
+ * Internal draw port for the engine stats HUD.
+ *
+ * Not part of the public {@link BT} API. {@link WebGpuRenderer} and
+ * {@link SoftwareRenderer} implement this alongside {@link IRenderer}.
+ */
+export interface StatsOverlayDrawTarget {
+    /**
+     * Filled rectangles composited above demo sprites for the stats overlay.
+     *
+     * On WebGPU, batched in `overlayPrimitives` after the demo sprite pass.
+     *
+     * @param rect - Rectangle bounds in display coordinates.
+     * @param paletteIndex - Palette color index.
+     */
+    drawBarFill(rect: Rect2i, paletteIndex: number): void;
+
+    /**
+     * Bitmap text composited above overlay bar fills for the stats overlay.
+     *
+     * On WebGPU, batched in `overlaySprites` after overlay bar fills.
+     *
+     * @param font - Bitmap font with character glyphs (underlying sheet must be indexized).
+     * @param pos - Text position (top-left corner).
+     * @param text - String to render.
+     * @param paletteOffset - Palette index offset applied to all glyphs (default 0).
+     */
+    drawLabel(font: BitmapFont, pos: Vector2i, text: string, paletteOffset?: number): void;
+}
+
+/**
+ * Renderer surface used by {@link StatsOverlay.updateAndRender}.
+ *
+ * Combines screen-space camera helpers with stats overlay draw batches.
+ */
+export type StatsOverlayRenderer = Pick<IRenderer, 'getCameraOffset' | 'resetCamera' | 'setCameraOffset'> &
+    StatsOverlayDrawTarget;

--- a/src/render/stats-overlay/StatsOverlayPaletteInteraction.test.ts
+++ b/src/render/stats-overlay/StatsOverlayPaletteInteraction.test.ts
@@ -10,7 +10,8 @@ import { DEFAULT_IDX_BG, DEFAULT_IDX_TEXT } from './constants';
 import { createStatsOverlayLayout } from './layoutHelpers';
 import { paletteBandY } from './layoutPlan';
 import {
-    drawPaletteTooltip,
+    drawPaletteTooltipChrome,
+    drawPaletteTooltipLabel,
     hitTestPaletteSwatch,
     layoutPaletteTooltip,
     PALETTE_COPY_STATUS_SECONDS,
@@ -203,29 +204,43 @@ describe('layoutPaletteTooltip', () => {
     });
 });
 
-describe('drawPaletteTooltip', () => {
-    it('draws via foreground overlay APIs so tooltips stay above custom stats rows', () => {
+describe('drawPaletteTooltipChrome', () => {
+    it('draws tooltip body and border via drawBarFill', () => {
         const layoutScratch = {
             body: new Rect2i(),
             swatch: new Rect2i(40, 180, 7, 7),
             textPos: new Vector2i(),
         };
         const layout = layoutPaletteTooltip(layoutScratch, layoutScratch.swatch, '42', 320, 240);
-        const renderer = {
-            drawRectFillForeground: vi.fn(),
-            drawRectFillOnTop: vi.fn(),
-            drawRect: vi.fn(),
-            drawBitmapTextForeground: vi.fn(),
-            drawBitmapTextOnTop: vi.fn(),
+        const target = {
+            drawBarFill: vi.fn(),
+            drawLabel: vi.fn(),
         };
 
-        drawPaletteTooltip(renderer as never, mockFont, layout, '42', DEFAULT_IDX_BG, DEFAULT_IDX_TEXT);
+        drawPaletteTooltipChrome(target, layout, DEFAULT_IDX_BG, DEFAULT_IDX_TEXT);
 
-        expect(renderer.drawRectFillForeground).toHaveBeenCalled();
-        expect(renderer.drawRectFillOnTop).not.toHaveBeenCalled();
-        expect(renderer.drawRect).not.toHaveBeenCalled();
-        expect(renderer.drawBitmapTextForeground).toHaveBeenCalled();
-        expect(renderer.drawBitmapTextOnTop).not.toHaveBeenCalled();
+        expect(target.drawBarFill).toHaveBeenCalled();
+        expect(target.drawLabel).not.toHaveBeenCalled();
+    });
+});
+
+describe('drawPaletteTooltipLabel', () => {
+    it('draws tooltip text via drawLabel', () => {
+        const layoutScratch = {
+            body: new Rect2i(),
+            swatch: new Rect2i(40, 180, 7, 7),
+            textPos: new Vector2i(),
+        };
+        const layout = layoutPaletteTooltip(layoutScratch, layoutScratch.swatch, '42', 320, 240);
+        const target = {
+            drawBarFill: vi.fn(),
+            drawLabel: vi.fn(),
+        };
+
+        drawPaletteTooltipLabel(target, mockFont, layout, '42', DEFAULT_IDX_TEXT);
+
+        expect(target.drawLabel).toHaveBeenCalled();
+        expect(target.drawBarFill).not.toHaveBeenCalled();
     });
 });
 
@@ -277,54 +292,41 @@ describe('StatsOverlayPaletteInteraction clipboard', () => {
         await vi.waitFor(async () => {
             await Promise.resolve();
             const probe = {
-                drawRectFillForeground: vi.fn(),
-                drawRectFillOnTop: vi.fn(),
-                drawRect: vi.fn(),
-                drawBitmapTextForeground: vi.fn(),
-                drawBitmapTextOnTop: vi.fn(),
+                drawBarFill: vi.fn(),
+                drawLabel: vi.fn(),
                 drawPixel: vi.fn(),
             };
 
-            interaction.drawTooltip(
+            interaction.drawTooltipLabel(
                 probe as never,
                 mockFont,
                 plan,
                 grid,
                 layout.displayWidth,
                 layout.displayHeight,
-                DEFAULT_IDX_BG,
                 DEFAULT_IDX_TEXT,
             );
 
-            expect(probe.drawBitmapTextForeground).toHaveBeenCalled();
+            expect(probe.drawLabel).toHaveBeenCalled();
         });
 
         const renderer = {
-            drawRectFillForeground: vi.fn(),
-            drawRectFillOnTop: vi.fn(),
-            drawRect: vi.fn(),
-            drawBitmapTextForeground: vi.fn(),
-            drawBitmapTextOnTop: vi.fn(),
+            drawBarFill: vi.fn(),
+            drawLabel: vi.fn(),
             drawPixel: vi.fn(),
         };
 
-        interaction.drawTooltip(
+        interaction.drawTooltipLabel(
             renderer as never,
             mockFont,
             plan,
             grid,
             layout.displayWidth,
             layout.displayHeight,
-            DEFAULT_IDX_BG,
             DEFAULT_IDX_TEXT,
         );
 
-        expect(renderer.drawBitmapTextForeground).toHaveBeenCalledWith(
-            mockFont,
-            expect.any(Vector2i),
-            'Copied 7',
-            expect.any(Number),
-        );
+        expect(renderer.drawLabel).toHaveBeenCalledWith(mockFont, expect.any(Vector2i), 'Copied 7', expect.any(Number));
     });
 
     it('shows Copy failed when clipboard write is denied', async () => {
@@ -355,26 +357,22 @@ describe('StatsOverlayPaletteInteraction clipboard', () => {
 
         await vi.waitFor(() => {
             const renderer = {
-                drawRectFillForeground: vi.fn(),
-                drawRectFillOnTop: vi.fn(),
-                drawRect: vi.fn(),
-                drawBitmapTextForeground: vi.fn(),
-                drawBitmapTextOnTop: vi.fn(),
+                drawBarFill: vi.fn(),
+                drawLabel: vi.fn(),
                 drawPixel: vi.fn(),
             };
 
-            interaction.drawTooltip(
+            interaction.drawTooltipLabel(
                 renderer as never,
                 mockFont,
                 plan,
                 grid,
                 layout.displayWidth,
                 layout.displayHeight,
-                DEFAULT_IDX_BG,
                 DEFAULT_IDX_TEXT,
             );
 
-            expect(renderer.drawBitmapTextForeground).toHaveBeenCalledWith(
+            expect(renderer.drawLabel).toHaveBeenCalledWith(
                 mockFont,
                 expect.any(Vector2i),
                 'Copy failed',
@@ -416,11 +414,8 @@ describe('StatsOverlayPaletteInteraction clipboard', () => {
         interaction.tickCopyStatus(expiryTick);
 
         const renderer = {
-            drawRectFillForeground: vi.fn(),
-            drawRectFillOnTop: vi.fn(),
-            drawRect: vi.fn(),
-            drawBitmapTextForeground: vi.fn(),
-            drawBitmapTextOnTop: vi.fn(),
+            drawBarFill: vi.fn(),
+            drawLabel: vi.fn(),
             drawPixel: vi.fn(),
         };
 
@@ -437,23 +432,17 @@ describe('StatsOverlayPaletteInteraction clipboard', () => {
             layout.lineHeight,
         );
 
-        interaction.drawTooltip(
+        interaction.drawTooltipLabel(
             renderer as never,
             mockFont,
             plan,
             grid,
             layout.displayWidth,
             layout.displayHeight,
-            DEFAULT_IDX_BG,
             DEFAULT_IDX_TEXT,
         );
 
-        expect(renderer.drawBitmapTextForeground).toHaveBeenCalledWith(
-            mockFont,
-            expect.any(Vector2i),
-            '9',
-            expect.any(Number),
-        );
+        expect(renderer.drawLabel).toHaveBeenCalledWith(mockFont, expect.any(Vector2i), '9', expect.any(Number));
     });
 
     it('starts copy-status expiry from clipboard completion tick', async () => {
@@ -498,22 +487,21 @@ describe('StatsOverlayPaletteInteraction clipboard', () => {
             await Promise.resolve();
 
             const probe = {
-                drawRectFillForeground: vi.fn(),
-                drawBitmapTextForeground: vi.fn(),
+                drawBarFill: vi.fn(),
+                drawLabel: vi.fn(),
             };
 
-            interaction.drawTooltip(
+            interaction.drawTooltipLabel(
                 probe as never,
                 mockFont,
                 plan,
                 grid,
                 layout.displayWidth,
                 layout.displayHeight,
-                DEFAULT_IDX_BG,
                 DEFAULT_IDX_TEXT,
             );
 
-            expect(probe.drawBitmapTextForeground).toHaveBeenCalledWith(
+            expect(probe.drawLabel).toHaveBeenCalledWith(
                 mockFont,
                 expect.any(Vector2i),
                 'Copied 9',
@@ -525,32 +513,23 @@ describe('StatsOverlayPaletteInteraction clipboard', () => {
         const pressExpiryTick = 10 + Math.ceil(PALETTE_COPY_STATUS_SECONDS * 60);
 
         const renderer = {
-            drawRectFillForeground: vi.fn(),
-            drawRectFillOnTop: vi.fn(),
-            drawRect: vi.fn(),
-            drawBitmapTextForeground: vi.fn(),
-            drawBitmapTextOnTop: vi.fn(),
+            drawBarFill: vi.fn(),
+            drawLabel: vi.fn(),
             drawPixel: vi.fn(),
         };
 
         interaction.tickCopyStatus(pressExpiryTick);
-        interaction.drawTooltip(
+        interaction.drawTooltipLabel(
             renderer as never,
             mockFont,
             plan,
             grid,
             layout.displayWidth,
             layout.displayHeight,
-            DEFAULT_IDX_BG,
             DEFAULT_IDX_TEXT,
         );
 
-        expect(renderer.drawBitmapTextForeground).toHaveBeenCalledWith(
-            mockFont,
-            expect.any(Vector2i),
-            'Copied 9',
-            expect.any(Number),
-        );
+        expect(renderer.drawLabel).toHaveBeenCalledWith(mockFont, expect.any(Vector2i), 'Copied 9', expect.any(Number));
 
         interaction.tickCopyStatus(completionExpiryTick);
         interaction.updateHover(
@@ -565,22 +544,16 @@ describe('StatsOverlayPaletteInteraction clipboard', () => {
             layout.displayWidth,
             layout.lineHeight,
         );
-        interaction.drawTooltip(
+        interaction.drawTooltipLabel(
             renderer as never,
             mockFont,
             plan,
             grid,
             layout.displayWidth,
             layout.displayHeight,
-            DEFAULT_IDX_BG,
             DEFAULT_IDX_TEXT,
         );
 
-        expect(renderer.drawBitmapTextForeground).toHaveBeenLastCalledWith(
-            mockFont,
-            expect.any(Vector2i),
-            '9',
-            expect.any(Number),
-        );
+        expect(renderer.drawLabel).toHaveBeenLastCalledWith(mockFont, expect.any(Vector2i), '9', expect.any(Number));
     });
 });

--- a/src/render/stats-overlay/StatsOverlayPaletteInteraction.ts
+++ b/src/render/stats-overlay/StatsOverlayPaletteInteraction.ts
@@ -7,9 +7,9 @@ import type { PointerInput } from '../../input/PointerInput';
 import { POINTER_SLOT_COUNT } from '../../input/PointerInput';
 import { Rect2i } from '../../utils/Rect2i';
 import { Vector2i } from '../../utils/Vector2i';
-import type { IRenderer } from '../IRenderer';
 import { POINTER_PRIMARY_BUTTON, STATS_EDGE_MARGIN_PX, SYSTEM_CHAR_ADVANCE } from './constants';
 import { statsBitmapTextPaletteOffset } from './layoutHelpers';
+import type { StatsOverlayDrawTarget } from './StatsOverlayDrawTarget';
 import {
     PALETTE_GRID_PADDING_PX,
     resolvePaletteHintExclusionRect,
@@ -262,28 +262,20 @@ export function layoutPaletteTooltip(
 }
 
 /**
- * Draws a docked palette swatch tooltip (filled body, 1px border, label text).
+ * Draws a docked palette swatch tooltip body and 1px border.
  *
- * @param renderer - Active renderer.
- * @param font - System bitmap font.
+ * @param target - Stats overlay draw target.
  * @param layout - Tooltip layout from {@link layoutPaletteTooltip}.
- * @param label - Tooltip label text.
  * @param barIndex - Palette index for tooltip body fill (stats overlay background).
- * @param textIndex - Palette index for the border and label text.
+ * @param textIndex - Palette index for the border stroke.
  */
-export function drawPaletteTooltip(
-    renderer: IRenderer,
-    font: BitmapFont,
+export function drawPaletteTooltipChrome(
+    target: StatsOverlayDrawTarget,
     layout: PaletteTooltipLayout,
-    label: string,
     barIndex: number,
     textIndex: number,
 ): void {
-    if (label.length === 0) {
-        return;
-    }
-
-    renderer.drawRectFillForeground(layout.body, barIndex);
+    target.drawBarFill(layout.body, barIndex);
 
     const edge = tooltipScratch.outlineEdge;
     const x0 = layout.body.x;
@@ -291,17 +283,38 @@ export function drawPaletteTooltip(
     const x1 = layout.body.x + layout.body.width - 1;
     const y1 = layout.body.y + layout.body.height - 1;
 
-    renderer.drawRectFillForeground(edge.set(x0, y0, x1 - x0 + 1, 1), textIndex);
-    renderer.drawRectFillForeground(edge.set(x0, y1, x1 - x0 + 1, 1), textIndex);
+    target.drawBarFill(edge.set(x0, y0, x1 - x0 + 1, 1), textIndex);
+    target.drawBarFill(edge.set(x0, y1, x1 - x0 + 1, 1), textIndex);
 
     if (y1 - y0 > 1) {
-        renderer.drawRectFillForeground(edge.set(x0, y0 + 1, 1, y1 - y0 - 1), textIndex);
-        renderer.drawRectFillForeground(edge.set(x1, y0 + 1, 1, y1 - y0 - 1), textIndex);
+        target.drawBarFill(edge.set(x0, y0 + 1, 1, y1 - y0 - 1), textIndex);
+        target.drawBarFill(edge.set(x1, y0 + 1, 1, y1 - y0 - 1), textIndex);
+    }
+}
+
+/**
+ * Draws a docked palette swatch tooltip label.
+ *
+ * @param target - Stats overlay draw target.
+ * @param font - System bitmap font.
+ * @param layout - Tooltip layout from {@link layoutPaletteTooltip}.
+ * @param label - Tooltip label text.
+ * @param textIndex - Palette index for label text.
+ */
+export function drawPaletteTooltipLabel(
+    target: StatsOverlayDrawTarget,
+    font: BitmapFont,
+    layout: PaletteTooltipLayout,
+    label: string,
+    textIndex: number,
+): void {
+    if (label.length === 0) {
+        return;
     }
 
     const textPaletteOffset = statsBitmapTextPaletteOffset(textIndex);
 
-    renderer.drawBitmapTextForeground(font, layout.textPos, label, textPaletteOffset);
+    target.drawLabel(font, layout.textPos, label, textPaletteOffset);
 }
 
 // #endregion
@@ -510,20 +523,52 @@ export class StatsOverlayPaletteInteraction {
     }
 
     /**
-     * Draws the hover or copy-status tooltip when applicable.
+     * Lays out the active hover or copy-status tooltip, or returns `null` when none applies.
      *
-     * @param renderer - Active renderer.
-     * @param font - System bitmap font.
+     * @param plan - Layout plan for this frame.
+     * @param grid - Palette grid layout.
+     * @param displayWidth - Logical display width.
+     * @param displayHeight - Logical display height.
+     * @returns Tooltip layout and label, or `null`.
+     */
+    #layoutActiveTooltip(
+        plan: StatsOverlayLayoutPlan,
+        grid: PaletteGridLayout,
+        displayWidth: number,
+        displayHeight: number,
+    ): { layout: PaletteTooltipLayout; label: string } | null {
+        const label = this.#resolveTooltipLabel();
+
+        if (label.length === 0) {
+            return null;
+        }
+
+        const index = this.#copyStatus !== 'idle' ? this.#copyStatusIndex : this.#hoveredIndex;
+
+        if (index === null || index < 0) {
+            return null;
+        }
+
+        writePaletteSwatchTopLeft(tooltipScratch.swatch, index, plan.paletteBand, grid, this.#scrollRowOffset);
+
+        const layout = layoutPaletteTooltip(tooltipScratch, tooltipScratch.swatch, label, displayWidth, displayHeight);
+
+        return { layout, label };
+    }
+
+    /**
+     * Draws tooltip body and border during the overlay fill phase.
+     *
+     * @param target - Stats overlay draw target.
      * @param plan - Layout plan for this frame.
      * @param grid - Palette grid layout.
      * @param displayWidth - Logical display width.
      * @param displayHeight - Logical display height.
      * @param barIndex - Tooltip body fill palette index.
-     * @param textIndex - Tooltip stroke/text palette index.
+     * @param textIndex - Tooltip border palette index.
      */
-    drawTooltip(
-        renderer: IRenderer,
-        font: BitmapFont,
+    drawTooltipChrome(
+        target: StatsOverlayDrawTarget,
         plan: StatsOverlayLayoutPlan,
         grid: PaletteGridLayout,
         displayWidth: number,
@@ -531,23 +576,42 @@ export class StatsOverlayPaletteInteraction {
         barIndex: number,
         textIndex: number,
     ): void {
-        const label = this.#resolveTooltipLabel();
+        const active = this.#layoutActiveTooltip(plan, grid, displayWidth, displayHeight);
 
-        if (label.length === 0) {
+        if (active === null) {
             return;
         }
 
-        const index = this.#copyStatus !== 'idle' ? this.#copyStatusIndex : this.#hoveredIndex;
+        drawPaletteTooltipChrome(target, active.layout, barIndex, textIndex);
+    }
 
-        if (index === null || index < 0) {
+    /**
+     * Draws tooltip label text during the overlay label phase.
+     *
+     * @param target - Stats overlay draw target.
+     * @param font - System bitmap font.
+     * @param plan - Layout plan for this frame.
+     * @param grid - Palette grid layout.
+     * @param displayWidth - Logical display width.
+     * @param displayHeight - Logical display height.
+     * @param textIndex - Tooltip label palette index.
+     */
+    drawTooltipLabel(
+        target: StatsOverlayDrawTarget,
+        font: BitmapFont,
+        plan: StatsOverlayLayoutPlan,
+        grid: PaletteGridLayout,
+        displayWidth: number,
+        displayHeight: number,
+        textIndex: number,
+    ): void {
+        const active = this.#layoutActiveTooltip(plan, grid, displayWidth, displayHeight);
+
+        if (active === null) {
             return;
         }
 
-        writePaletteSwatchTopLeft(tooltipScratch.swatch, index, plan.paletteBand, grid, this.#scrollRowOffset);
-
-        const layout = layoutPaletteTooltip(tooltipScratch, tooltipScratch.swatch, label, displayWidth, displayHeight);
-
-        drawPaletteTooltip(renderer, font, layout, label, barIndex, textIndex);
+        drawPaletteTooltipLabel(target, font, active.layout, active.label, textIndex);
     }
 
     /**

--- a/src/render/stats-overlay/StatsOverlayPaletteView.alloc.test.ts
+++ b/src/render/stats-overlay/StatsOverlayPaletteView.alloc.test.ts
@@ -50,7 +50,7 @@ describe('StatsOverlayPaletteView allocation', () => {
         const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, palette.size);
         const paletteBand = new Rect2i(0, paletteBandY(240, grid.totalHeight), 320, grid.totalHeight);
         const view = new StatsOverlayPaletteView(true);
-        const renderer = { drawRectFillOnTop: vi.fn() } as never;
+        const renderer = { drawBarFill: vi.fn() } as never;
 
         for (let i = 0; i < 8; i++) {
             view.draw(
@@ -92,7 +92,7 @@ describe('StatsOverlayPaletteView allocation', () => {
         const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, palette.size);
         const paletteBand = new Rect2i(0, paletteBandY(240, grid.totalHeight), 320, grid.totalHeight);
         const view = new StatsOverlayPaletteView(true);
-        const renderer = { drawRectFillOnTop: vi.fn() } as never;
+        const renderer = { drawBarFill: vi.fn() } as never;
 
         for (let i = 0; i < 4; i++) {
             view.draw(

--- a/src/render/stats-overlay/StatsOverlayPaletteView.bench.ts
+++ b/src/render/stats-overlay/StatsOverlayPaletteView.bench.ts
@@ -39,7 +39,7 @@ const paletteBand256 = new Rect2i(0, 120, 320, 120);
 const paletteView = new StatsOverlayPaletteView(true);
 
 const noopRenderer = {
-    drawRectFillOnTop: () => {},
+    drawBarFill: () => {},
     getCameraOffset: () => new Vector2i(0, 0),
     resetCamera: () => {},
 };

--- a/src/render/stats-overlay/StatsOverlayPaletteView.test.ts
+++ b/src/render/stats-overlay/StatsOverlayPaletteView.test.ts
@@ -35,18 +35,18 @@ function buildUsageMask(indices: readonly number[], size = 256): Uint8Array {
 
 /** Mock that snapshots each rect fill at call time (production reuses scratch rects). */
 function createRectFillMock(): {
-    drawRectFillOnTop: ReturnType<typeof vi.fn>;
+    drawBarFill: ReturnType<typeof vi.fn>;
     calls: { rect: Rect2i; index: number }[];
 } {
     const calls: { rect: Rect2i; index: number }[] = [];
-    const drawRectFillOnTop = vi.fn((rect: Rect2i, index: number) => {
+    const drawBarFill = vi.fn((rect: Rect2i, index: number) => {
         calls.push({
             rect: new Rect2i(rect.x, rect.y, rect.width, rect.height),
             index,
         });
     });
 
-    return { drawRectFillOnTop, calls };
+    return { drawBarFill, calls };
 }
 
 /** Returns the top-left pixel for one palette index in the bottom-band grid. */
@@ -151,9 +151,9 @@ describe('StatsOverlayPaletteView.draw', () => {
         const grid = computePaletteGrid(320, swatchSize, palette.size, 1);
         const paletteBandTop = paletteBandY(240, grid.totalHeight);
         const view = new StatsOverlayPaletteView(true);
-        const { drawRectFillOnTop, calls } = createRectFillMock();
+        const { drawBarFill, calls } = createRectFillMock();
         const renderer = {
-            drawRectFillOnTop,
+            drawBarFill,
         } as never;
 
         view.draw(
@@ -168,7 +168,7 @@ describe('StatsOverlayPaletteView.draw', () => {
             DEFAULT_IDX_TEXT,
         );
 
-        expect(drawRectFillOnTop).toHaveBeenCalled();
+        expect(drawBarFill).toHaveBeenCalled();
 
         const usedPos = swatchTopLeft(5, grid.cols, paletteBandTop, swatchSize, grid.gap);
         const usedSwatch = calls.find(
@@ -216,9 +216,9 @@ describe('StatsOverlayPaletteView.draw', () => {
         const grid = computePaletteGrid(320, swatchSize, palette.size, 1);
         const paletteBandTop = paletteBandY(240, grid.totalHeight);
         const view = new StatsOverlayPaletteView(true);
-        const { drawRectFillOnTop, calls } = createRectFillMock();
+        const { drawBarFill, calls } = createRectFillMock();
         const renderer = {
-            drawRectFillOnTop,
+            drawBarFill,
         } as never;
 
         view.draw(
@@ -233,7 +233,7 @@ describe('StatsOverlayPaletteView.draw', () => {
             DEFAULT_IDX_TEXT,
         );
 
-        expect(drawRectFillOnTop).toHaveBeenCalled();
+        expect(drawBarFill).toHaveBeenCalled();
 
         const swatch1 = swatchTopLeft(1, grid.cols, paletteBandTop, swatchSize, grid.gap);
         const swatch3 = swatchTopLeft(3, grid.cols, paletteBandTop, swatchSize, grid.gap);
@@ -261,8 +261,8 @@ describe('StatsOverlayPaletteView.draw', () => {
         const paletteBandTop = paletteBandY(240, grid.totalHeight);
         const swatchOriginY = paletteBandTop + PALETTE_GRID_PADDING_PX;
         const view = new StatsOverlayPaletteView(true);
-        const drawRectFillOnTop = vi.fn();
-        const renderer = { drawRectFillOnTop } as never;
+        const drawBarFill = vi.fn();
+        const renderer = { drawBarFill } as never;
 
         view.draw(
             renderer,
@@ -283,8 +283,8 @@ describe('StatsOverlayPaletteView.draw', () => {
 
     it('is a no-op when disabled', () => {
         const view = new StatsOverlayPaletteView(false);
-        const drawRectFillOnTop = vi.fn();
-        const renderer = { drawRectFillOnTop } as never;
+        const drawBarFill = vi.fn();
+        const renderer = { drawBarFill } as never;
 
         view.draw(
             renderer,
@@ -298,6 +298,6 @@ describe('StatsOverlayPaletteView.draw', () => {
             DEFAULT_IDX_TEXT,
         );
 
-        expect(drawRectFillOnTop).not.toHaveBeenCalled();
+        expect(drawBarFill).not.toHaveBeenCalled();
     });
 });

--- a/src/render/stats-overlay/StatsOverlayPaletteView.ts
+++ b/src/render/stats-overlay/StatsOverlayPaletteView.ts
@@ -8,9 +8,9 @@
 
 import type { Palette } from '../../assets/Palette';
 import { Rect2i } from '../../utils/Rect2i';
-import type { IRenderer } from '../IRenderer';
 import { STATS_BOTTOM_HINT_LABEL, STATS_EDGE_MARGIN_PX } from './constants';
 import { statsToggleHintTextWidth, statsToggleHintTextX } from './layoutHelpers';
+import type { StatsOverlayDrawTarget } from './StatsOverlayDrawTarget';
 import type { PaletteGridLayout } from './types';
 
 /** Default swatch size in pixels. */
@@ -261,7 +261,7 @@ export function computeUnusedSwatchMarkerRect(x: number, y: number, swatchSize: 
 /**
  * Draws a centered filled marker inside an unused swatch.
  *
- * @param renderer - Active renderer.
+ * @param target - Stats overlay draw target.
  * @param markerScratch - Reusable marker rect mutated in place.
  * @param x - Swatch left edge in display pixels.
  * @param y - Swatch top edge in display pixels.
@@ -269,7 +269,7 @@ export function computeUnusedSwatchMarkerRect(x: number, y: number, swatchSize: 
  * @param markIndex - Palette index for the marker fill.
  */
 function drawUnusedSwatch(
-    renderer: IRenderer,
+    target: StatsOverlayDrawTarget,
     markerScratch: Rect2i,
     x: number,
     y: number,
@@ -286,7 +286,7 @@ function drawUnusedSwatch(
         return;
     }
 
-    renderer.drawRectFillOnTop(markerScratch, markIndex);
+    target.drawBarFill(markerScratch, markIndex);
 }
 
 /**
@@ -304,7 +304,7 @@ function isPaletteSlotUsed(usedMask: Uint8Array, index: number): boolean {
 /**
  * Draws one palette swatch or its unused marker.
  *
- * @param renderer - Active renderer.
+ * @param target - Stats overlay draw target.
  * @param swatchScratch - Reusable swatch rect mutated in place.
  * @param markerScratch - Reusable marker rect mutated in place.
  * @param x - Swatch left edge in display pixels.
@@ -315,7 +315,7 @@ function isPaletteSlotUsed(usedMask: Uint8Array, index: number): boolean {
  * @param unusedMarkIndex - Palette index for unused swatch marker fills.
  */
 function drawPaletteSwatch(
-    renderer: IRenderer,
+    target: StatsOverlayDrawTarget,
     swatchScratch: Rect2i,
     markerScratch: Rect2i,
     x: number,
@@ -327,9 +327,9 @@ function drawPaletteSwatch(
 ): void {
     if (isPaletteSlotUsed(usedMask, index)) {
         swatchScratch.set(x, y, swatchSize, swatchSize);
-        renderer.drawRectFillOnTop(swatchScratch, index);
+        target.drawBarFill(swatchScratch, index);
     } else {
-        drawUnusedSwatch(renderer, markerScratch, x, y, swatchSize, unusedMarkIndex);
+        drawUnusedSwatch(target, markerScratch, x, y, swatchSize, unusedMarkIndex);
     }
 }
 
@@ -363,7 +363,7 @@ export function writePaletteSwatchTopLeft(
 /**
  * Draws the full palette swatch grid inside the bottom band.
  *
- * @param renderer - Active renderer.
+ * @param target - Stats overlay draw target.
  * @param paletteBand - Palette band rect from layout plan.
  * @param colorCount - Active palette slot count.
  * @param grid - Precomputed grid layout.
@@ -372,7 +372,7 @@ export function writePaletteSwatchTopLeft(
  * @param unusedMarkIndex - Palette index for unused swatch marker fills.
  */
 function drawPaletteSwatchGrid(
-    renderer: IRenderer,
+    target: StatsOverlayDrawTarget,
     paletteBand: Rect2i,
     colorCount: number,
     grid: PaletteGridLayout,
@@ -395,7 +395,7 @@ function drawPaletteSwatchGrid(
             continue;
         }
 
-        drawPaletteSwatch(renderer, swatchScratch, markerScratch, x, y, swatchSize, index, usedMask, unusedMarkIndex);
+        drawPaletteSwatch(target, swatchScratch, markerScratch, x, y, swatchSize, index, usedMask, unusedMarkIndex);
     }
 }
 
@@ -426,7 +426,7 @@ export class StatsOverlayPaletteView {
     /**
      * Draws palette swatches in the bottom band.
      *
-     * @param renderer - Active renderer.
+     * @param target - Stats overlay draw target.
      * @param paletteBand - Palette band rect from layout plan.
      * @param palette - Active demo palette.
      * @param grid - Precomputed grid layout.
@@ -437,7 +437,7 @@ export class StatsOverlayPaletteView {
      * @param unusedMarkIndex - Palette index for unused swatch marker fills.
      */
     draw(
-        renderer: IRenderer,
+        target: StatsOverlayDrawTarget,
         paletteBand: Rect2i,
         palette: Palette | null,
         grid: PaletteGridLayout,
@@ -453,6 +453,6 @@ export class StatsOverlayPaletteView {
 
         const hintExclusion = resolvePaletteHintExclusionRect(bottomTextY, displayWidth, lineHeight);
 
-        drawPaletteSwatchGrid(renderer, paletteBand, palette.size, grid, hintExclusion, usedMask, unusedMarkIndex);
+        drawPaletteSwatchGrid(target, paletteBand, palette.size, grid, hintExclusion, usedMask, unusedMarkIndex);
     }
 }

--- a/src/render/stats-overlay/StatsOverlayTimingChart.test.ts
+++ b/src/render/stats-overlay/StatsOverlayTimingChart.test.ts
@@ -30,7 +30,7 @@ describe('StatsOverlayTimingChart', () => {
             eventBarIndex: 5,
         });
 
-        expect(renderer.drawRectFillOnTop).not.toHaveBeenCalled();
+        expect(renderer.drawBarFill).not.toHaveBeenCalled();
     });
 
     it('wraps ring buffer and keeps newest samples on the right', () => {
@@ -85,7 +85,7 @@ describe('StatsOverlayTimingChart', () => {
         chart.draw(renderer, new Rect2i(0, 14, 4, 32), style);
 
         expect(
-            renderer.drawRectFillOnTop.mock.calls.some(
+            renderer.drawBarFill.mock.calls.some(
                 (call) =>
                     (call[0] as { width: number; height: number }).width === 1 &&
                     (call[0] as { height: number }).height === 1 &&
@@ -109,7 +109,7 @@ describe('StatsOverlayTimingChart', () => {
         });
 
         const dots = getRectFillCalls(renderer).filter((rect) => rect.width === 1 && rect.height === 1);
-        const paletteIndices = renderer.drawRectFillOnTop.mock.calls
+        const paletteIndices = renderer.drawBarFill.mock.calls
             .filter(
                 (call) => (call[0] as { width: number }).width === 1 && (call[0] as { height: number }).height === 1,
             )

--- a/src/render/stats-overlay/StatsOverlayTimingChart.ts
+++ b/src/render/stats-overlay/StatsOverlayTimingChart.ts
@@ -3,8 +3,8 @@
  */
 
 import { Rect2i } from '../../utils/Rect2i';
-import type { IRenderer } from '../IRenderer';
 import { TIMING_CHART_FULL_SCALE_MS } from './constants';
+import type { StatsOverlayDrawTarget } from './StatsOverlayDrawTarget';
 import { computeTimingChartBarHeight, type ResolvedStatsOverlayTimingChartStyle } from './timingChartStyle';
 import type { StatsOverlayTimingSnapshot } from './types';
 
@@ -95,14 +95,14 @@ export class StatsOverlayTimingChart {
     /**
      * Draws one-pixel timing dots for each populated ring-buffer column.
      *
-     * Uses {@link IRenderer.drawRectFillOnTop} with 1x1 rects so update and render samples stay
+     * Uses {@link StatsOverlayDrawTarget.drawBarFill} with 1x1 rects so update and render samples stay
      * visible without alpha blending (palette-indexed engine).
      *
-     * @param renderer - Active renderer.
+     * @param target - Stats overlay draw target.
      * @param chartRect - Screen-space chart band from layout plan.
      * @param style - Resolved chart palette indices.
      */
-    draw(renderer: IRenderer, chartRect: Rect2i, style: StatsOverlayTimingChartDrawStyle): void {
+    draw(target: StatsOverlayDrawTarget, chartRect: Rect2i, style: StatsOverlayTimingChartDrawStyle): void {
         if (!this.#enabled || chartRect.width <= 0 || chartRect.height <= 0) {
             return;
         }
@@ -126,15 +126,15 @@ export class StatsOverlayTimingChart {
             /* eslint-enable security/detect-object-injection */
             const x = chartRect.x + column;
 
-            this.#drawDot(renderer, x, baselineY, renderMs, chartRect, style.renderBarIndex);
-            this.#drawDot(renderer, x, baselineY, updateMs, chartRect, style.updateBarIndex);
+            this.#drawDot(target, x, baselineY, renderMs, chartRect, style.renderBarIndex);
+            this.#drawDot(target, x, baselineY, updateMs, chartRect, style.updateBarIndex);
         }
     }
 
     /**
      * Draws one timing sample as a single pixel above the chart baseline.
      *
-     * @param renderer - Active renderer.
+     * @param target - Stats overlay draw target.
      * @param x - Column X in screen space.
      * @param baselineY - Bottom row of the chart band.
      * @param ms - Timing sample in milliseconds.
@@ -142,7 +142,7 @@ export class StatsOverlayTimingChart {
      * @param paletteIndex - Palette index for the dot.
      */
     #drawDot(
-        renderer: IRenderer,
+        target: StatsOverlayDrawTarget,
         x: number,
         baselineY: number,
         ms: number,
@@ -158,6 +158,6 @@ export class StatsOverlayTimingChart {
         const y = Math.max(chartRect.y, baselineY - offset + 1);
 
         this.#dotScratch.set(x, y, 1, 1);
-        renderer.drawRectFillOnTop(this.#dotScratch, paletteIndex);
+        target.drawBarFill(this.#dotScratch, paletteIndex);
     }
 }

--- a/src/render/stats-overlay/testFixtures.ts
+++ b/src/render/stats-overlay/testFixtures.ts
@@ -7,11 +7,11 @@ import { vi } from 'vitest';
 import type { BitmapFont } from '../../assets/BitmapFont';
 import { Rect2i } from '../../utils/Rect2i';
 import { Vector2i } from '../../utils/Vector2i';
-import type { IRenderer } from '../IRenderer';
 import { STATS_BAR_HEIGHT } from './constants';
 import { customBarY } from './layoutHelpers';
+import type { StatsOverlayRenderer } from './StatsOverlayDrawTarget';
 
-/** Parsed {@link IRenderer.drawBitmapTextOnTop} call from a mock renderer. */
+/** Parsed {@link StatsOverlayDrawTarget.drawLabel} call from a mock renderer. */
 export type BitmapTextCall = {
     pos: Vector2i;
     text: string;
@@ -23,21 +23,19 @@ export type BitmapTextCall = {
  *
  * @returns Renderer with spied camera, bar fills, and bitmap text draws.
  */
-export function createMockRenderer(): IRenderer & {
+export function createMockRenderer(): StatsOverlayRenderer & {
     drawBitmapText: ReturnType<typeof vi.fn>;
-    drawBitmapTextOnTop: ReturnType<typeof vi.fn>;
-    drawBitmapTextForeground: ReturnType<typeof vi.fn>;
+    drawLabel: ReturnType<typeof vi.fn>;
     drawPixel: ReturnType<typeof vi.fn>;
     drawRectFill: ReturnType<typeof vi.fn>;
-    drawRectFillOnTop: ReturnType<typeof vi.fn> & { rectSnapshots: Rect2i[] };
-    drawRectFillForeground: ReturnType<typeof vi.fn>;
+    drawBarFill: ReturnType<typeof vi.fn> & { rectSnapshots: Rect2i[] };
 } {
     const rectSnapshots: Rect2i[] = [];
-    const drawRectFillOnTop = vi.fn((rect: Rect2i) => {
+    const drawBarFill = vi.fn((rect: Rect2i) => {
         rectSnapshots.push(new Rect2i(rect.x, rect.y, rect.width, rect.height));
     }) as ReturnType<typeof vi.fn> & { rectSnapshots: Rect2i[] };
-    drawRectFillOnTop.rectSnapshots = rectSnapshots;
-    const drawBitmapTextOnTop = vi.fn();
+    drawBarFill.rectSnapshots = rectSnapshots;
+    const drawLabel = vi.fn();
     const drawPixel = vi.fn();
     const drawRect = vi.fn();
 
@@ -46,24 +44,22 @@ export function createMockRenderer(): IRenderer & {
         resetCamera: vi.fn(),
         setCameraOffset: vi.fn(),
         drawRectFill: vi.fn(),
-        drawRectFillOnTop,
-        drawRectFillForeground: vi.fn(),
+        drawBarFill,
         drawRect,
         drawBitmapText: vi.fn(),
-        drawBitmapTextOnTop,
-        drawBitmapTextForeground: vi.fn(),
+        drawLabel,
         drawPixel,
     } as never;
 }
 
 /**
- * Collects {@link IRenderer.drawBitmapTextOnTop} calls from a mock renderer.
+ * Collects {@link StatsOverlayDrawTarget.drawLabel} calls from a mock renderer.
  *
  * @param renderer - Mock from {@link createMockRenderer}.
  * @returns Parsed draw calls in invocation order.
  */
 export function getBitmapTextCalls(renderer: ReturnType<typeof createMockRenderer>): BitmapTextCall[] {
-    return renderer.drawBitmapTextOnTop.mock.calls.map((call) => ({
+    return renderer.drawLabel.mock.calls.map((call) => ({
         pos: call[1] as Vector2i,
         text: call[2] as string,
         paletteOffset: call[3] as number,
@@ -71,13 +67,13 @@ export function getBitmapTextCalls(renderer: ReturnType<typeof createMockRendere
 }
 
 /**
- * Collects {@link IRenderer.drawRectFillOnTop} rects from a mock renderer.
+ * Collects {@link StatsOverlayDrawTarget.drawBarFill} rects from a mock renderer.
  *
  * @param renderer - Mock from {@link createMockRenderer}.
  * @returns Filled rectangles in invocation order.
  */
 export function getRectFillCalls(renderer: ReturnType<typeof createMockRenderer>): Rect2i[] {
-    return [...renderer.drawRectFillOnTop.rectSnapshots];
+    return [...renderer.drawBarFill.rectSnapshots];
 }
 
 /**

--- a/src/render/stats-overlay/testFixtures.ts
+++ b/src/render/stats-overlay/testFixtures.ts
@@ -62,7 +62,7 @@ export function getBitmapTextCalls(renderer: ReturnType<typeof createMockRendere
     return renderer.drawLabel.mock.calls.map((call) => ({
         pos: call[1] as Vector2i,
         text: call[2] as string,
-        paletteOffset: call[3] as number,
+        paletteOffset: (call[3] as number | undefined) ?? 0,
     }));
 }
 


### PR DESCRIPTION
Remove OnTop/Foreground overlay methods from IRenderer and drop the
WebGPU foreground overlay pipelines. Stats HUD now uses an internal
drawBarFill/drawLabel port with fill-then-label ordering so tooltips
composite correctly without a third z-tier.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Description

This refactoring moves stats overlay rendering to a dedicated internal draw target interface, streamlining the renderer API by removing overlay-specific batching methods and consolidating WebGPU rendering pipelines.

## Changes

**Core API Changes**
- Removed overlay-specific drawing methods from `IRenderer`: `drawRectFillOnTop`, `drawRectFillForeground`, `drawBitmapTextOnTop`, and `drawBitmapTextForeground`
- Introduced `StatsOverlayDrawTarget` interface with two compositor-style methods:
  - `drawBarFill(rect: Rect2i, paletteIndex: number)` for filled rectangle primitives
  - `drawLabel(font: BitmapFont, pos: Vector2i, text: string, paletteOffset?: number)` for bitmap-font text rendering
- Added `StatsOverlayRenderer` type that composes camera helper methods with the draw target

**Renderer Implementation Updates**
- Both `SoftwareRenderer` and `WebGpuRenderer` now implement `StatsOverlayDrawTarget`
- `WebGpuRenderer` removed its separate "foreground overlay" tier by deleting `foregroundOverlayPrimitives` and `foregroundOverlaySprites` pipelines and all associated initialization, reset, and encoding logic
- Simplified render pass ordering to primary, sprite, and overlay primitive+sprite sequences

**Stats Overlay Refactoring**
- Updated `StatsOverlay` to accept `StatsOverlayRenderer` instead of generic `IRenderer`
- Reorganized drawing sequences with fill-then-label ordering to ensure correct tooltip compositing without requiring a third rendering tier
- Split palette tooltip rendering into separate phases: `drawPaletteTooltipChrome` (border + fill) and `drawPaletteTooltipLabel` (text)
- Split custom row rendering into fill (`drawCustomRowFills`) and label (`drawCustomRowLabels`) phases
- Updated all stats overlay modules (`StatsOverlayBars`, `StatsOverlayPaletteView`, `StatsOverlayTimingChart`, `StatsOverlayPaletteInteraction`) to use `StatsOverlayDrawTarget`

**Test Fixture Updates**
- Updated `testFixtures.ts` to mock `StatsOverlayRenderer` instead of generic `IRenderer`
- Modified `getBitmapTextCalls` helper to parse `drawLabel` calls and default missing `paletteOffset` to `0`
- Updated all related test suites to verify new draw target methods

**Documentation**
- Updated `CLAUDE.md` architecture map to document `StatsOverlayDrawTarget` and `StatsOverlayPaletteInteraction` modules
- Updated `docs/api-core.md` to describe the new overlay composition approach without referencing removed APIs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/225?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->