### PR TITLE
fix(overlay): render palette tooltips above custom row labels

### DIFF
--- a/src/overlay/Overlay.test.ts
+++ b/src/overlay/Overlay.test.ts
@@ -468,6 +468,50 @@ describe('Overlay', () => {
         expect(customRowFill).toMatchObject({ y: row0BarY, width: 320, height: OVERLAY_BAR_HEIGHT });
     });
 
+    it('draws palette tooltip label after custom row and hint labels', () => {
+        const layout = createOverlayLayout(320, 240, 14);
+        const overlay = createOverlay(layout, 'Demo', { paletteView: true, visibleAtStart: true });
+        const renderer = createMockRenderer();
+        const palette = Palette.vga();
+        const usedMask = buildUsageMask([1, 2, 3, 4, 5, 6, 7, 8]);
+        const grid = computePaletteGrid(320, undefined, palette.size);
+        const paletteBandTop = paletteBandY(240, grid.totalHeight);
+        const paletteBand = new Rect2i(0, paletteBandTop, 320, grid.totalHeight);
+        const swatch = new Rect2i();
+        const hoveredIndex = 7;
+
+        writePaletteSwatchTopLeft(swatch, hoveredIndex, paletteBand, grid);
+
+        const customRows = [{ leftText: 'Bounces: 11' }, { leftText: 'Position: (43, 166)' }];
+        const pointer = {
+            isValid: () => true,
+            getPos: () => new Vector2i(swatch.x + 1, swatch.y + 1),
+        };
+
+        overlay.updateAndRender(
+            renderer,
+            mockFont,
+            pointer as never,
+            null,
+            0,
+            () => customRows,
+            undefined,
+            palette,
+            usedMask,
+        );
+
+        const calls = getBitmapTextCalls(renderer);
+
+        expect(calls.some((call) => call.text === 'Position: (43, 166)')).toBe(true);
+        expect(renderer.drawLabelOnTop).toHaveBeenCalledWith(
+            mockFont,
+            expect.any(Vector2i),
+            String(hoveredIndex),
+            expect.any(Number),
+        );
+        expect(renderer.drawBarFillOnTop).toHaveBeenCalled();
+    });
+
     it('draws timing chart dots when overlayTimingChart is enabled', () => {
         const layout = createOverlayLayout(320, 240, 14);
         const overlay = createOverlay(layout, 'Demo', {

--- a/src/overlay/Overlay.ts
+++ b/src/overlay/Overlay.ts
@@ -433,16 +433,6 @@ export class Overlay {
                 this.#layout.displayWidth,
                 this.#layout.lineHeight,
             );
-
-            this.#paletteInteraction.drawTooltipChrome(
-                renderer,
-                plan,
-                paletteGrid,
-                this.#layout.displayWidth,
-                this.#layout.displayHeight,
-                this.#idxBg,
-                this.#idxText,
-            );
         }
 
         this.#bars.drawHintBarFill(renderer, plan, this.#idxBg);
@@ -462,6 +452,20 @@ export class Overlay {
                 topMetricsLabel,
                 topTimingLabel,
             );
+        }
+
+        this.#bars.drawHintLabel(renderer, font, plan, this.#idxText, OVERLAY_BOTTOM_HINT_LABEL);
+
+        if (bodyVisible) {
+            this.#paletteInteraction.drawTooltipChrome(
+                renderer,
+                plan,
+                paletteGrid,
+                this.#layout.displayWidth,
+                this.#layout.displayHeight,
+                this.#idxBg,
+                this.#idxText,
+            );
 
             this.#paletteInteraction.drawTooltipLabel(
                 renderer,
@@ -473,8 +477,6 @@ export class Overlay {
                 this.#idxText,
             );
         }
-
-        this.#bars.drawHintLabel(renderer, font, plan, this.#idxText, OVERLAY_BOTTOM_HINT_LABEL);
     }
 
     // #endregion

--- a/src/overlay/OverlayDrawTarget.ts
+++ b/src/overlay/OverlayDrawTarget.ts
@@ -21,6 +21,16 @@ export interface OverlayDrawTarget {
     drawBarFill(rect: Rect2i, paletteIndex: number): void;
 
     /**
+     * Filled rectangles composited above overlay labels (for example palette tooltips).
+     *
+     * On WebGPU, batched in `overlayTopPrimitives` after the overlay label pass.
+     *
+     * @param rect - Rectangle bounds in display coordinates.
+     * @param paletteIndex - Palette color index.
+     */
+    drawBarFillOnTop(rect: Rect2i, paletteIndex: number): void;
+
+    /**
      * Bitmap text composited above overlay bar fills for the overlay.
      *
      * On WebGPU, batched in `overlaySprites` after overlay bar fills.
@@ -31,6 +41,18 @@ export interface OverlayDrawTarget {
      * @param paletteOffset - Palette index offset applied to all glyphs (default 0).
      */
     drawLabel(font: BitmapFont, pos: Vector2i, text: string, paletteOffset?: number): void;
+
+    /**
+     * Bitmap text composited above {@link drawBarFillOnTop} fills.
+     *
+     * On WebGPU, batched in `overlayTopSprites` after `overlayTopPrimitives`.
+     *
+     * @param font - Bitmap font with character glyphs (underlying sheet must be indexized).
+     * @param pos - Text position (top-left corner).
+     * @param text - String to render.
+     * @param paletteOffset - Palette index offset applied to all glyphs (default 0).
+     */
+    drawLabelOnTop(font: BitmapFont, pos: Vector2i, text: string, paletteOffset?: number): void;
 }
 
 /**

--- a/src/overlay/palette/PaletteInteraction.test.ts
+++ b/src/overlay/palette/PaletteInteraction.test.ts
@@ -205,7 +205,7 @@ describe('layoutPaletteTooltip', () => {
 });
 
 describe('drawPaletteTooltipChrome', () => {
-    it('draws tooltip body and border via drawBarFill', () => {
+    it('draws tooltip body and border via drawBarFillOnTop', () => {
         const layoutScratch = {
             body: new Rect2i(),
             swatch: new Rect2i(40, 180, 7, 7),
@@ -214,18 +214,21 @@ describe('drawPaletteTooltipChrome', () => {
         const layout = layoutPaletteTooltip(layoutScratch, layoutScratch.swatch, '42', 320, 240);
         const target = {
             drawBarFill: vi.fn(),
+            drawBarFillOnTop: vi.fn(),
             drawLabel: vi.fn(),
+            drawLabelOnTop: vi.fn(),
         };
 
         drawPaletteTooltipChrome(target, layout, DEFAULT_IDX_BG, DEFAULT_IDX_TEXT);
 
-        expect(target.drawBarFill).toHaveBeenCalled();
-        expect(target.drawLabel).not.toHaveBeenCalled();
+        expect(target.drawBarFillOnTop).toHaveBeenCalled();
+        expect(target.drawBarFill).not.toHaveBeenCalled();
+        expect(target.drawLabelOnTop).not.toHaveBeenCalled();
     });
 });
 
 describe('drawPaletteTooltipLabel', () => {
-    it('draws tooltip text via drawLabel', () => {
+    it('draws tooltip text via drawLabelOnTop', () => {
         const layoutScratch = {
             body: new Rect2i(),
             swatch: new Rect2i(40, 180, 7, 7),
@@ -234,13 +237,16 @@ describe('drawPaletteTooltipLabel', () => {
         const layout = layoutPaletteTooltip(layoutScratch, layoutScratch.swatch, '42', 320, 240);
         const target = {
             drawBarFill: vi.fn(),
+            drawBarFillOnTop: vi.fn(),
             drawLabel: vi.fn(),
+            drawLabelOnTop: vi.fn(),
         };
 
         drawPaletteTooltipLabel(target, mockFont, layout, '42', DEFAULT_IDX_TEXT);
 
-        expect(target.drawLabel).toHaveBeenCalled();
+        expect(target.drawLabelOnTop).toHaveBeenCalled();
         expect(target.drawBarFill).not.toHaveBeenCalled();
+        expect(target.drawBarFillOnTop).not.toHaveBeenCalled();
     });
 });
 
@@ -293,7 +299,7 @@ describe('PaletteInteraction clipboard', () => {
             await Promise.resolve();
             const probe = {
                 drawBarFill: vi.fn(),
-                drawLabel: vi.fn(),
+                drawLabelOnTop: vi.fn(),
                 drawPixel: vi.fn(),
             };
 
@@ -307,12 +313,12 @@ describe('PaletteInteraction clipboard', () => {
                 DEFAULT_IDX_TEXT,
             );
 
-            expect(probe.drawLabel).toHaveBeenCalled();
+            expect(probe.drawLabelOnTop).toHaveBeenCalled();
         });
 
         const renderer = {
             drawBarFill: vi.fn(),
-            drawLabel: vi.fn(),
+            drawLabelOnTop: vi.fn(),
             drawPixel: vi.fn(),
         };
 
@@ -326,7 +332,12 @@ describe('PaletteInteraction clipboard', () => {
             DEFAULT_IDX_TEXT,
         );
 
-        expect(renderer.drawLabel).toHaveBeenCalledWith(mockFont, expect.any(Vector2i), 'Copied 7', expect.any(Number));
+        expect(renderer.drawLabelOnTop).toHaveBeenCalledWith(
+            mockFont,
+            expect.any(Vector2i),
+            'Copied 7',
+            expect.any(Number),
+        );
     });
 
     it('shows Copy failed when clipboard write is denied', async () => {
@@ -358,7 +369,7 @@ describe('PaletteInteraction clipboard', () => {
         await vi.waitFor(() => {
             const renderer = {
                 drawBarFill: vi.fn(),
-                drawLabel: vi.fn(),
+                drawLabelOnTop: vi.fn(),
                 drawPixel: vi.fn(),
             };
 
@@ -372,7 +383,7 @@ describe('PaletteInteraction clipboard', () => {
                 DEFAULT_IDX_TEXT,
             );
 
-            expect(renderer.drawLabel).toHaveBeenCalledWith(
+            expect(renderer.drawLabelOnTop).toHaveBeenCalledWith(
                 mockFont,
                 expect.any(Vector2i),
                 'Copy failed',
@@ -415,7 +426,7 @@ describe('PaletteInteraction clipboard', () => {
 
         const renderer = {
             drawBarFill: vi.fn(),
-            drawLabel: vi.fn(),
+            drawLabelOnTop: vi.fn(),
             drawPixel: vi.fn(),
         };
 
@@ -442,7 +453,7 @@ describe('PaletteInteraction clipboard', () => {
             DEFAULT_IDX_TEXT,
         );
 
-        expect(renderer.drawLabel).toHaveBeenCalledWith(mockFont, expect.any(Vector2i), '9', expect.any(Number));
+        expect(renderer.drawLabelOnTop).toHaveBeenCalledWith(mockFont, expect.any(Vector2i), '9', expect.any(Number));
     });
 
     it('starts copy-status expiry from clipboard completion tick', async () => {
@@ -488,7 +499,7 @@ describe('PaletteInteraction clipboard', () => {
 
             const probe = {
                 drawBarFill: vi.fn(),
-                drawLabel: vi.fn(),
+                drawLabelOnTop: vi.fn(),
             };
 
             interaction.drawTooltipLabel(
@@ -501,7 +512,7 @@ describe('PaletteInteraction clipboard', () => {
                 DEFAULT_IDX_TEXT,
             );
 
-            expect(probe.drawLabel).toHaveBeenCalledWith(
+            expect(probe.drawLabelOnTop).toHaveBeenCalledWith(
                 mockFont,
                 expect.any(Vector2i),
                 'Copied 9',
@@ -514,7 +525,7 @@ describe('PaletteInteraction clipboard', () => {
 
         const renderer = {
             drawBarFill: vi.fn(),
-            drawLabel: vi.fn(),
+            drawLabelOnTop: vi.fn(),
             drawPixel: vi.fn(),
         };
 
@@ -529,7 +540,12 @@ describe('PaletteInteraction clipboard', () => {
             DEFAULT_IDX_TEXT,
         );
 
-        expect(renderer.drawLabel).toHaveBeenCalledWith(mockFont, expect.any(Vector2i), 'Copied 9', expect.any(Number));
+        expect(renderer.drawLabelOnTop).toHaveBeenCalledWith(
+            mockFont,
+            expect.any(Vector2i),
+            'Copied 9',
+            expect.any(Number),
+        );
 
         interaction.tickCopyStatus(completionExpiryTick);
         interaction.updateHover(
@@ -554,6 +570,11 @@ describe('PaletteInteraction clipboard', () => {
             DEFAULT_IDX_TEXT,
         );
 
-        expect(renderer.drawLabel).toHaveBeenLastCalledWith(mockFont, expect.any(Vector2i), '9', expect.any(Number));
+        expect(renderer.drawLabelOnTop).toHaveBeenLastCalledWith(
+            mockFont,
+            expect.any(Vector2i),
+            '9',
+            expect.any(Number),
+        );
     });
 });

--- a/src/overlay/palette/PaletteInteraction.ts
+++ b/src/overlay/palette/PaletteInteraction.ts
@@ -274,7 +274,7 @@ export function drawPaletteTooltipChrome(
     barIndex: number,
     textIndex: number,
 ): void {
-    target.drawBarFill(layout.body, barIndex);
+    target.drawBarFillOnTop(layout.body, barIndex);
 
     const edge = tooltipScratch.outlineEdge;
     const x0 = layout.body.x;
@@ -282,12 +282,12 @@ export function drawPaletteTooltipChrome(
     const x1 = layout.body.x + layout.body.width - 1;
     const y1 = layout.body.y + layout.body.height - 1;
 
-    target.drawBarFill(edge.set(x0, y0, x1 - x0 + 1, 1), textIndex);
-    target.drawBarFill(edge.set(x0, y1, x1 - x0 + 1, 1), textIndex);
+    target.drawBarFillOnTop(edge.set(x0, y0, x1 - x0 + 1, 1), textIndex);
+    target.drawBarFillOnTop(edge.set(x0, y1, x1 - x0 + 1, 1), textIndex);
 
     if (y1 - y0 > 1) {
-        target.drawBarFill(edge.set(x0, y0 + 1, 1, y1 - y0 - 1), textIndex);
-        target.drawBarFill(edge.set(x1, y0 + 1, 1, y1 - y0 - 1), textIndex);
+        target.drawBarFillOnTop(edge.set(x0, y0 + 1, 1, y1 - y0 - 1), textIndex);
+        target.drawBarFillOnTop(edge.set(x1, y0 + 1, 1, y1 - y0 - 1), textIndex);
     }
 }
 
@@ -313,7 +313,7 @@ export function drawPaletteTooltipLabel(
 
     const textPaletteOffset = overlayBitmapTextPaletteOffset(textIndex);
 
-    target.drawLabel(font, layout.textPos, label, textPaletteOffset);
+    target.drawLabelOnTop(font, layout.textPos, label, textPaletteOffset);
 }
 
 // #endregion

--- a/src/overlay/testFixtures.ts
+++ b/src/overlay/testFixtures.ts
@@ -35,7 +35,11 @@ export function createMockRenderer(): OverlayRenderer & {
         rectSnapshots.push(new Rect2i(rect.x, rect.y, rect.width, rect.height));
     }) as ReturnType<typeof vi.fn> & { rectSnapshots: Rect2i[] };
     drawBarFill.rectSnapshots = rectSnapshots;
+    const drawBarFillOnTop = vi.fn((rect: Rect2i) => {
+        rectSnapshots.push(new Rect2i(rect.x, rect.y, rect.width, rect.height));
+    });
     const drawLabel = vi.fn();
+    const drawLabelOnTop = vi.fn();
     const drawPixel = vi.fn();
     const drawRect = vi.fn();
 
@@ -45,9 +49,11 @@ export function createMockRenderer(): OverlayRenderer & {
         setCameraOffset: vi.fn(),
         drawRectFill: vi.fn(),
         drawBarFill,
+        drawBarFillOnTop,
         drawRect,
         drawBitmapText: vi.fn(),
         drawLabel,
+        drawLabelOnTop,
         drawPixel,
     } as never;
 }

--- a/src/render/SoftwareRenderer.ts
+++ b/src/render/SoftwareRenderer.ts
@@ -268,6 +268,16 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
     }
 
     /**
+     * Queues an overlay bar fill above prior overlay labels (same FIFO queue as {@link drawRectFill}).
+     *
+     * @param rect - Rectangle to fill in logical pixels.
+     * @param paletteIndex - Palette entry index for the fill color.
+     */
+    drawBarFillOnTop(rect: Rect2i, paletteIndex: number): void {
+        this.drawBarFill(rect, paletteIndex);
+    }
+
+    /**
      * Queues a single pixel draw command at the given position.
      *
      * @param pos - Pixel position in logical coordinates.
@@ -380,6 +390,18 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
      */
     drawLabel(font: BitmapFont, pos: Vector2i, text: string, paletteOffset: number = 0): void {
         this.drawBitmapText(font, pos, text, paletteOffset);
+    }
+
+    /**
+     * Queues an overlay label above prior overlay bar fills (same FIFO queue as {@link drawBitmapText}).
+     *
+     * @param font - Bitmap font with character glyphs.
+     * @param pos - Text origin in logical pixels.
+     * @param text - String to render.
+     * @param paletteOffset - Palette index offset applied to all glyphs (default 0).
+     */
+    drawLabelOnTop(font: BitmapFont, pos: Vector2i, text: string, paletteOffset: number = 0): void {
+        this.drawLabel(font, pos, text, paletteOffset);
     }
 
     // #endregion

--- a/src/render/WebGpuRenderer.test.ts
+++ b/src/render/WebGpuRenderer.test.ts
@@ -39,8 +39,10 @@ import { WebGpuRenderer } from './WebGpuRenderer';
 type WebGpuRendererPipelineAccess = {
     primitives: PrimitivePipeline;
     overlayPrimitives: PrimitivePipeline;
+    overlayTopPrimitives: PrimitivePipeline;
     sprites: SpritePipeline;
     overlaySprites: SpritePipeline;
+    overlayTopSprites: SpritePipeline;
 };
 
 /**
@@ -444,23 +446,28 @@ describe('with initialized renderer', () => {
         const pipelines = getRendererPipelines(renderer);
         const sceneFill = vi.spyOn(pipelines.primitives, 'drawRectFill');
         const overlayFill = vi.spyOn(pipelines.overlayPrimitives, 'drawRectFill');
+        const overlayTopFill = vi.spyOn(pipelines.overlayTopPrimitives, 'drawRectFill');
         const rect = new Rect2i(1, 2, 8, 8);
 
         renderer.beginFrame();
         renderer.drawRectFill(rect, 2);
         renderer.drawBarFill(rect, 5);
+        renderer.drawBarFillOnTop(rect, 6);
         renderer.endFrame();
 
         expect(sceneFill).toHaveBeenCalledOnce();
         expect(sceneFill).toHaveBeenCalledWith(rect, 2);
         expect(overlayFill).toHaveBeenCalledOnce();
         expect(overlayFill).toHaveBeenCalledWith(rect, 5);
+        expect(overlayTopFill).toHaveBeenCalledOnce();
+        expect(overlayTopFill).toHaveBeenCalledWith(rect, 6);
     });
 
     it('drawLabel routes text to overlaySprites, not sprites', () => {
         const pipelines = getRendererPipelines(renderer);
         const sceneText = vi.spyOn(pipelines.sprites, 'drawBitmapText');
         const overlayText = vi.spyOn(pipelines.overlaySprites, 'drawBitmapText');
+        const overlayTopText = vi.spyOn(pipelines.overlayTopSprites, 'drawBitmapText');
         const mockFont = {
             getSpriteSheet: () => ({}),
             getGlyphByCode: () => null,
@@ -469,12 +476,15 @@ describe('with initialized renderer', () => {
         renderer.beginFrame();
         renderer.drawBitmapText(mockFont, new Vector2i(0, 0), '');
         renderer.drawLabel(mockFont, new Vector2i(4, 4), '');
+        renderer.drawLabelOnTop(mockFont, new Vector2i(8, 8), 'Tip');
         renderer.endFrame();
 
         expect(sceneText).toHaveBeenCalledOnce();
         expect(sceneText).toHaveBeenCalledWith(mockFont, new Vector2i(0, 0), '', 0);
         expect(overlayText).toHaveBeenCalledOnce();
         expect(overlayText).toHaveBeenCalledWith(mockFont, new Vector2i(4, 4), '', 0);
+        expect(overlayTopText).toHaveBeenCalledOnce();
+        expect(overlayTopText).toHaveBeenCalledWith(mockFont, new Vector2i(8, 8), 'Tip', 0);
     });
 
     it('encodes scene pass as primitives, sprites, then overlay batches', () => {
@@ -493,6 +503,12 @@ describe('with initialized renderer', () => {
         vi.spyOn(pipelines.overlaySprites, 'encodePass').mockImplementation(() => {
             encodeOrder.push('overlaySprites');
         });
+        vi.spyOn(pipelines.overlayTopPrimitives, 'encodePass').mockImplementation(() => {
+            encodeOrder.push('overlayTopPrimitives');
+        });
+        vi.spyOn(pipelines.overlayTopSprites, 'encodePass').mockImplementation(() => {
+            encodeOrder.push('overlayTopSprites');
+        });
 
         const mockFont = {
             getSpriteSheet: () => ({}),
@@ -504,20 +520,33 @@ describe('with initialized renderer', () => {
         renderer.drawBitmapText(mockFont, new Vector2i(0, 0), '');
         renderer.drawBarFill(new Rect2i(0, 220, 320, 16), 1);
         renderer.drawLabel(mockFont, new Vector2i(5, 225), 'HUD');
+        renderer.drawBarFillOnTop(new Rect2i(10, 200, 20, 13), 1);
+        renderer.drawLabelOnTop(mockFont, new Vector2i(14, 200), '7');
         renderer.endFrame();
 
-        expect(encodeOrder).toEqual(['primitives', 'sprites', 'overlayPrimitives', 'overlaySprites']);
+        expect(encodeOrder).toEqual([
+            'primitives',
+            'sprites',
+            'overlayPrimitives',
+            'overlaySprites',
+            'overlayTopPrimitives',
+            'overlayTopSprites',
+        ]);
     });
 
     it('resets overlay batches on beginFrame', () => {
         const pipelines = getRendererPipelines(renderer);
         const overlayPrimitiveReset = vi.spyOn(pipelines.overlayPrimitives, 'reset');
+        const overlayTopPrimitiveReset = vi.spyOn(pipelines.overlayTopPrimitives, 'reset');
         const overlaySpriteReset = vi.spyOn(pipelines.overlaySprites, 'reset');
+        const overlayTopSpriteReset = vi.spyOn(pipelines.overlayTopSprites, 'reset');
 
         renderer.beginFrame();
 
         expect(overlayPrimitiveReset).toHaveBeenCalledOnce();
+        expect(overlayTopPrimitiveReset).toHaveBeenCalledOnce();
         expect(overlaySpriteReset).toHaveBeenCalledOnce();
+        expect(overlayTopSpriteReset).toHaveBeenCalledOnce();
 
         renderer.endFrame();
     });

--- a/src/render/WebGpuRenderer.ts
+++ b/src/render/WebGpuRenderer.ts
@@ -128,6 +128,16 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
      */
     private readonly overlaySprites: SpritePipeline;
 
+    /**
+     * Primitives encoded after overlay label sprites (tooltip chrome, etc.).
+     */
+    private readonly overlayTopPrimitives: PrimitivePipeline;
+
+    /**
+     * Sprites encoded after overlay top primitives (tooltip labels, etc.).
+     */
+    private readonly overlayTopSprites: SpritePipeline;
+
     /** Pixel-tier post-process chain (logical resolution). */
     private pixelChain: PostProcessChain | null = null;
 
@@ -184,8 +194,10 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
         this.upscaleFilterMode = upscaleFilter;
         this.primitives = new PrimitivePipeline();
         this.overlayPrimitives = new PrimitivePipeline();
+        this.overlayTopPrimitives = new PrimitivePipeline();
         this.sprites = new SpritePipeline();
         this.overlaySprites = new SpritePipeline();
+        this.overlayTopSprites = new SpritePipeline();
     }
 
     // #endregion
@@ -231,8 +243,15 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
             // the camera scaling here cares about logical size.
             await this.primitives.init(this.device, this.displaySize, this.paletteBuffer, LOGICAL_TARGET_FORMAT);
             await this.overlayPrimitives.init(this.device, this.displaySize, this.paletteBuffer, LOGICAL_TARGET_FORMAT);
+            await this.overlayTopPrimitives.init(
+                this.device,
+                this.displaySize,
+                this.paletteBuffer,
+                LOGICAL_TARGET_FORMAT,
+            );
             await this.sprites.init(this.device, this.displaySize, this.paletteBuffer, LOGICAL_TARGET_FORMAT);
             await this.overlaySprites.init(this.device, this.displaySize, this.paletteBuffer, LOGICAL_TARGET_FORMAT);
+            await this.overlayTopSprites.init(this.device, this.displaySize, this.paletteBuffer, LOGICAL_TARGET_FORMAT);
 
             this.swapFormat = navigator.gpu.getPreferredCanvasFormat();
 
@@ -314,8 +333,10 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
 
         this.primitives.reset();
         this.overlayPrimitives.reset();
+        this.overlayTopPrimitives.reset();
         this.sprites.reset();
         this.overlaySprites.reset();
+        this.overlayTopSprites.reset();
     }
 
     /**
@@ -382,6 +403,16 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
      */
     drawBarFill(rect: Rect2i, paletteIndex: number): void {
         this.overlayPrimitives.drawRectFill(rect, paletteIndex);
+    }
+
+    /**
+     * Draws a filled rectangle above overlay labels (tooltip chrome, etc.).
+     *
+     * @param rect - Rectangle bounds in pixel coordinates.
+     * @param paletteIndex - Palette color index.
+     */
+    drawBarFillOnTop(rect: Rect2i, paletteIndex: number): void {
+        this.overlayTopPrimitives.drawRectFill(rect, paletteIndex);
     }
 
     /**
@@ -467,6 +498,18 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
         this.overlaySprites.drawBitmapText(font, pos, text, paletteOffset);
     }
 
+    /**
+     * Draws bitmap text above overlay top bar fills (tooltip labels, etc.).
+     *
+     * @param font - Bitmap font with character glyphs.
+     * @param pos - Text position (top-left corner).
+     * @param text - String to render.
+     * @param paletteOffset - Palette index offset applied to all glyphs (default 0).
+     */
+    drawLabelOnTop(font: BitmapFont, pos: Vector2i, text: string, paletteOffset: number = 0): void {
+        this.overlayTopSprites.drawBitmapText(font, pos, text, paletteOffset);
+    }
+
     // #endregion
 
     // #region Frame Capture API
@@ -490,7 +533,8 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
      * Sets the camera offset for scrolling.
      *
      * The offset is propagated to all scene pipelines: `primitives`,
-     * `overlayPrimitives`, `sprites`, and `overlaySprites`.
+     * `overlayPrimitives`, `overlayTopPrimitives`, `sprites`, `overlaySprites`,
+     * and `overlayTopSprites`.
      *
      * @param offset - Camera position in pixels.
      */
@@ -498,8 +542,10 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
         this.cameraOffset = offset.clone();
         this.primitives.setCameraOffset(this.cameraOffset);
         this.overlayPrimitives.setCameraOffset(this.cameraOffset);
+        this.overlayTopPrimitives.setCameraOffset(this.cameraOffset);
         this.sprites.setCameraOffset(this.cameraOffset);
         this.overlaySprites.setCameraOffset(this.cameraOffset);
+        this.overlayTopSprites.setCameraOffset(this.cameraOffset);
     }
 
     /**
@@ -518,8 +564,10 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
         this.cameraOffset = Vector2i.zero();
         this.primitives.setCameraOffset(this.cameraOffset);
         this.overlayPrimitives.setCameraOffset(this.cameraOffset);
+        this.overlayTopPrimitives.setCameraOffset(this.cameraOffset);
         this.sprites.setCameraOffset(this.cameraOffset);
         this.overlaySprites.setCameraOffset(this.cameraOffset);
+        this.overlayTopSprites.setCameraOffset(this.cameraOffset);
     }
 
     // #endregion
@@ -613,8 +661,10 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
 
             this.primitives.reset();
             this.overlayPrimitives.reset();
+            this.overlayTopPrimitives.reset();
             this.sprites.reset();
             this.overlaySprites.reset();
+            this.overlayTopSprites.reset();
 
             return null;
         }
@@ -624,8 +674,10 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
 
             this.primitives.reset();
             this.overlayPrimitives.reset();
+            this.overlayTopPrimitives.reset();
             this.sprites.reset();
             this.overlaySprites.reset();
+            this.overlayTopSprites.reset();
 
             return null;
         }
@@ -650,7 +702,9 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
      * Encodes the scene render pass into the supplied target view.
      *
      * Draw order: `primitives`, `sprites`, `overlayPrimitives` (overlay bars via
-     * {@link drawBarFill}), then `overlaySprites` (overlay labels via {@link drawLabel}).
+     * {@link drawBarFill}), `overlaySprites` (overlay labels via {@link drawLabel}),
+     * `overlayTopPrimitives` ({@link drawBarFillOnTop}), then `overlayTopSprites`
+     * ({@link drawLabelOnTop}).
      *
      * @param encoder - Active command encoder.
      * @param sceneView - Logical scene attachment view to render into.
@@ -678,6 +732,8 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
         this.sprites.encodePass(renderPass);
         this.overlayPrimitives.encodePass(renderPass);
         this.overlaySprites.encodePass(renderPass);
+        this.overlayTopPrimitives.encodePass(renderPass);
+        this.overlayTopSprites.encodePass(renderPass);
 
         renderPass.end();
     }
@@ -742,8 +798,10 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
         // persisting across frames.
         this.primitives.reset();
         this.overlayPrimitives.reset();
+        this.overlayTopPrimitives.reset();
         this.sprites.reset();
         this.overlaySprites.reset();
+        this.overlayTopSprites.reset();
     }
 
     // #endregion


### PR DESCRIPTION
Add `drawBarFillOnTop()` and `drawLabelOnTop() to `OverlayDrawTarget` so tooltip chrome and text composite above overlay labels. WebGPU encodes new overlayTop primitive and sprite batches after the normal overlay label pass; `SoftwareRenderer` delegates to the same FIFO queue so call order in Overlay still controls layering on fallback.

Move palette tooltip draws to the end of the overlay label phase and route PaletteInteraction through the OnTop APIs. Add regression tests for overlay draw order and WebGPU batch routing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR fixes the z-ordering of palette tooltips by introducing a new OnTop rendering tier in the overlay system. Palette tooltips now render above custom row labels and other overlay elements by routing their chrome (background) and text through dedicated `drawBarFillOnTop()` and `drawLabelOnTop()` APIs.

## Key Changes

### New Drawing APIs

Added two new methods to the overlay rendering interface:
- `OverlayDrawTarget.drawBarFillOnTop(rect, paletteIndex)`: Renders filled rectangles above overlay labels
- `OverlayDrawTarget.drawLabelOnTop(font, pos, text, paletteOffset?)`: Renders text above on-top bar fills

These are implemented in both `SoftwareRenderer` and `WebGpuRenderer`.

### Overlay Rendering Reordering

Modified `Overlay.#drawFrame` to reorganize the drawing sequence, moving palette tooltip rendering to occur after custom row and hint labels are drawn. This ensures tooltips composite above other overlay elements while maintaining proper layering control.

### WebGPU Pipeline Enhancement

`WebGpuRenderer` now maintains separate overlay-top rendering tiers:
- Added `overlayTopPrimitives` and `overlayTopSprites` pipelines
- These are initialized during `init()` and reset in `beginFrame()` and other frame-boundary methods
- Scene encoding order places overlay-top primitives and sprites after the regular overlay tier

### SoftwareRenderer Fallback

`SoftwareRenderer` delegates OnTop drawing to its existing FIFO queue, preserving the property that overlay call order controls layering in the software fallback path.

### PaletteInteraction Updates

`PaletteInteraction` now routes both tooltip chrome and text rendering through the new OnTop APIs:
- `drawPaletteTooltipChrome()` uses `drawBarFillOnTop()` for background fills and border strokes
- `drawPaletteTooltipLabel()` uses `drawLabelOnTop()` for text rendering

### Testing Updates

- Added integration test in `Overlay.test.ts` verifying palette tooltips are drawn after row labels via `drawLabelOnTop` and `drawBarFillOnTop` calls
- Updated `PaletteInteraction.test.ts` to verify new rendering contract, including clipboard result tooltips that show copy status via `drawLabelOnTop`
- Extended `WebGpuRenderer.test.ts` with routing and batch assertions for the new overlay-top pipelines
- Updated `testFixtures.ts` mock renderer to include `drawBarFillOnTop` and `drawLabelOnTop` stubs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/229?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->