### PR TITLE
feat(overlay): fill row gaps and cluster separators via gapPaletteIndex

### DIFF
--- a/docs/api-core.md
+++ b/docs/api-core.md
@@ -119,7 +119,7 @@ example no `drawingBufferSize` means a 1:1 drawing buffer).
 | `overlayToggleEnabled`     | `boolean`                 | `true`      | Enable Backquote and bottom-left corner toggle input                 |
 | `overlayPaletteView`       | `boolean`                 | `false`     | Live palette swatch grid in the overlay bottom band (opt-in)         |
 | `overlayPaletteColumns`    | `number`                  | _unset_     | Max palette swatches per grid row (default: widest fit)              |
-| `overlayStyle`             | `OverlayStyle`            | _unset_     | Optional bar/text palette indices for overlay                        |
+| `overlayStyle`             | `OverlayStyle`            | _unset_     | Optional bar/text/gap palette indices for overlay                    |
 | `overlayTimingChart`       | `boolean`                 | `false`     | Scrolling update/render timing chart between title and metrics rows  |
 | `overlayTimingChartHeight` | `number`                  | `22`        | Timing chart band height in pixels when the chart is enabled         |
 | `overlayTimingChartStyle`  | `OverlayTimingChartStyle` | _unset_     | Optional timing chart palette indices (defaults to overlay bar/text) |
@@ -217,15 +217,17 @@ otherwise.
 - **Top row 3 (left):** `Frame: Xms | update(): Yms | render(): Zms` (shows `xN` on `update()` when multiple fixed
   updates ran this frame)
 - **Bottom band:** default **13 px** hint bar with the `[~]` toggle label anchored bottom-left (over the toggle hit
-  region). Set `overlayPaletteView: true` to stack a live palette swatch grid **above** a **1 px** gap and that hint
-  bar; slots referenced by demo draw calls this frame are filled with their color, and unused slots render as empty
+  region). Set `overlayPaletteView: true` to stack a live palette swatch grid **above** a **1 px** filled gap and that
+  hint bar; slots referenced by demo draw calls this frame are filled with their color, and unused slots render as empty
   squares with a small centered marker. The timing chart and palette grid bands use the same
   `overlayStyle.barPaletteIndex` fill as the other overlay rows (bars draw first; chart dots and swatches render on
-  top). Palette usage tracking (sprite and bitmap-text pixel scans) runs only when the overlay is enabled,
-  `overlayPaletteView` is true, **and** the overlay body is visible (not hidden with Backquote or the corner toggle).
-  Default demos do not pay that scanning cost while the overlay is hidden.
-- **Custom rows (optional):** extra bars from `overlayRows()` stacked above the bottom band, **1 px** apart, each with
-  left text and optional right text (same 13 px bar style as the built-in rows)
+  top). **1 px row gaps** between stacked overlay bands and **cluster separators** (below the top metrics cluster and
+  above the bottom footer cluster) are filled with `overlayStyle.gapPaletteIndex`, defaulting to
+  `overlayStyle.barPaletteIndex` when omitted. Palette usage tracking (sprite and bitmap-text pixel scans) runs only
+  when the overlay is enabled, `overlayPaletteView` is true, **and** the overlay body is visible (not hidden with
+  Backquote or the corner toggle). Default demos do not pay that scanning cost while the overlay is hidden.
+- **Custom rows (optional):** extra bars from `overlayRows()` stacked above the bottom band, **1 px** filled gaps apart,
+  each with left text and optional right text (same 13 px bar style as the built-in rows)
 
 Demos may implement optional `overlayRows()` on `IBlitTechDemo`. The engine calls it once per render frame after
 `render()` when the overlay is enabled and the **body** is visible (not hidden with Backquote or the corner toggle).
@@ -252,9 +254,10 @@ hint bar while the body stays hidden. Set `overlayToggleEnabled: false` to lock 
 input (for example release builds). On WebGPU, the engine draws the overlay HUD after your `render()` call, composited
 above demo sprites via internal overlay draw batches (not available on `BT`).
 
-Overlay colors follow one path: use `overlayStyle` when set, otherwise defaults `1` (bar) and `2` (text). You can
-override globally in `configure()` with `overlayStyle: { barPaletteIndex, textPaletteIndex }`, or per custom row on
-`OverlayRow` (`barPaletteIndex`, `textPaletteIndex`).
+Overlay colors follow one path: use `overlayStyle` when set, otherwise defaults `1` (bar and gap) and `2` (text). You
+can override globally in `configure()` with `overlayStyle: { barPaletteIndex, textPaletteIndex, gapPaletteIndex }`, or
+per custom row on `OverlayRow` (`barPaletteIndex`, `textPaletteIndex`). `gapPaletteIndex` fills inter-band row gaps and
+cluster separators; when omitted it matches `barPaletteIndex`.
 
 The overlay label `Present: N FPS` is **not** the same as `BT.targetFPS`: present FPS reflects how often `render()` runs
 (browser refresh rate), while `Target` is the fixed `update()` rate. Present FPS is sampled only while the overlay body
@@ -267,13 +270,14 @@ demo-issued draw API calls during the rendered frame. Do not use present FPS for
 `BT.deltaSeconds`, or `Timer` instead.
 
 Demos should not duplicate engine overlay text; the overlay provides it. Reserve about **14 px** per custom overlay row
-above the bottom band (13 px bar + 1 px gap). When drawing custom top or bottom HUD panels, leave about **42 px** clear
-at the top (three built-in text rows + gaps; add `overlayTimingChartHeight` or **22 px** when
-`overlayTimingChart: true`). Leave about **13 px** clear at the bottom by default (hint bar). When
-`overlayPaletteView: true`, reserve additional space for the palette grid, the **1 px** row gap, and the **13 px** hint
-bar—for example about **83 px** on the default `320×240` layout with a 256-slot palette (32 columns × 8 rows of 7 px
-swatches with 1 px gaps, plus the gap and hint bar). Column count is chosen by halving from `palette.size` until the row
-fits `displayWidth - 2 * edgeMargin`. The footer band height matches `resolveOverlayFooterHeight()` in `layoutPlan.ts`:
+above the bottom band (13 px bar + 1 px filled gap). When drawing custom top or bottom HUD panels, leave about **43 px**
+clear at the top (three built-in text rows + filled gaps + separator below the top cluster; add
+`overlayTimingChartHeight` or **22 px** when `overlayTimingChart: true`). Leave about **14 px** clear at the bottom by
+default (1 px separator + 13 px hint bar). When `overlayPaletteView: true`, reserve additional space for the palette
+grid, the **1 px** filled row gap, and the **13 px** hint bar—for example about **83 px** on the default `320×240`
+layout with a 256-slot palette (32 columns × 8 rows of 7 px swatches with 1 px gaps, plus the gap and hint bar). Column
+count is chosen by halving from `palette.size` until the row fits `displayWidth - 2 * edgeMargin`. The footer band
+height matches `resolveOverlayFooterHeight()` in `layoutPlan.ts`:
 
 ```text
 cols = pickPaletteGridColumnCount(displayWidth, swatchSize, gap, palette.size, maxColumns?)
@@ -303,7 +307,7 @@ configure() {
     overlayPaletteView: true,
     overlayTimingChart: true,
     overlayTimingChartHeight: 32, // optional; default 22
-    overlayStyle: { barPaletteIndex: 2, textPaletteIndex: 3 },
+    overlayStyle: { barPaletteIndex: 2, textPaletteIndex: 3, gapPaletteIndex: 2 },
     overlayTimingChartStyle: {
       updateBarPaletteIndex: 2, // defaults to barPaletteIndex when omitted
       renderBarPaletteIndex: 3, // defaults to textPaletteIndex when omitted

--- a/src/core/IBlitTechDemo.test.ts
+++ b/src/core/IBlitTechDemo.test.ts
@@ -153,11 +153,12 @@ describe('mergeHardwareSettings', () => {
 
     it('merges overlayStyle from configure()', () => {
         const settings = mergeHardwareSettings({
-            overlayStyle: { barPaletteIndex: 2, textPaletteIndex: 3 },
+            overlayStyle: { barPaletteIndex: 2, textPaletteIndex: 3, gapPaletteIndex: 4 },
         });
 
         expect(settings.overlayStyle?.barPaletteIndex).toBe(2);
         expect(settings.overlayStyle?.textPaletteIndex).toBe(3);
+        expect(settings.overlayStyle?.gapPaletteIndex).toBe(4);
     });
 
     it('merges overlay visibility and toggle flags from configure()', () => {

--- a/src/core/IBlitTechDemo.ts
+++ b/src/core/IBlitTechDemo.ts
@@ -157,10 +157,10 @@ export interface HardwareSettings {
     overlayPaletteColumns?: number;
 
     /**
-     * Palette indices for the built-in overlay bars (top and bottom) and as defaults
-     * for custom {@link OverlayRow} entries that omit per-row colors.
+     * Palette indices for the built-in overlay bars (top and bottom), row gaps,
+     * and as defaults for custom {@link OverlayRow} entries that omit per-row colors.
      *
-     * When omitted, the overlay uses palette index `1` for bars and `2` for text.
+     * When omitted, the overlay uses palette index `1` for bars and gaps and `2` for text.
      */
     overlayStyle?: OverlayStyle;
 
@@ -195,6 +195,13 @@ export interface OverlayStyle {
 
     /** Palette index for overlay text (built-in labels and custom rows unless overridden). */
     textPaletteIndex?: number;
+
+    /**
+     * Palette index for 1 px row gaps between overlay bands and boundary separators
+     * (below the top cluster, above the bottom hint bar). Defaults to
+     * {@link OverlayStyle.barPaletteIndex} when omitted.
+     */
+    gapPaletteIndex?: number;
 }
 
 /**

--- a/src/overlay/Overlay.test.ts
+++ b/src/overlay/Overlay.test.ts
@@ -33,7 +33,7 @@ import {
 const OVERLAY_PALETTE_VIEW_OFF = false;
 
 interface OverlayTestOptions {
-    style?: { barPaletteIndex?: number; textPaletteIndex?: number };
+    style?: { barPaletteIndex?: number; textPaletteIndex?: number; gapPaletteIndex?: number };
     paletteView?: boolean;
     paletteColumns?: number;
     timingChart?: boolean;
@@ -257,8 +257,13 @@ describe('Overlay', () => {
 
         overlay.updateAndRender(renderer, mockFont, null, null, 0);
 
-        expect(getRectFillCalls(renderer)).toHaveLength(1);
+        expect(getRectFillCalls(renderer)).toHaveLength(2);
         expect(getRectFillCalls(renderer)[0]).toMatchObject({
+            y: hintBarY(240) - OVERLAY_ROW_GAP_PX,
+            height: OVERLAY_ROW_GAP_PX,
+            width: 320,
+        });
+        expect(getRectFillCalls(renderer)[1]).toMatchObject({
             y: hintBarY(240),
             height: OVERLAY_BAR_HEIGHT,
             width: 320,
@@ -282,8 +287,13 @@ describe('Overlay', () => {
 
         const fills = getRectFillCalls(renderer);
 
-        expect(fills).toHaveLength(1);
-        expect(fills[0]).toMatchObject({ y: hintBarY(240), height: OVERLAY_BAR_HEIGHT, width: 320 });
+        expect(fills).toHaveLength(2);
+        expect(fills[0]).toMatchObject({
+            y: hintBarY(240) - OVERLAY_ROW_GAP_PX,
+            height: OVERLAY_ROW_GAP_PX,
+            width: 320,
+        });
+        expect(fills[1]).toMatchObject({ y: hintBarY(240), height: OVERLAY_BAR_HEIGHT, width: 320 });
         expect(fills.some((rect) => rect.y === paletteBandY(240, grid.totalHeight))).toBe(false);
     });
 
@@ -310,6 +320,42 @@ describe('Overlay', () => {
 
         expect(calls.every((call) => call.paletteOffset === 1)).toBe(true);
         expect(renderer.drawBarFill).toHaveBeenCalledWith(expect.anything(), 1);
+    });
+
+    it('uses overlayStyle gap palette index when provided', () => {
+        const layout = createOverlayLayout(320, 240, 14);
+        const overlay = createOverlay(layout, 'Demo', {
+            style: { barPaletteIndex: 8, textPaletteIndex: 9, gapPaletteIndex: 12 },
+            visibleAtStart: true,
+        });
+        const renderer = createMockRenderer();
+
+        overlay.updateAndRender(renderer, mockFont, null, null, 0);
+
+        expect(renderer.drawBarFill).toHaveBeenCalledWith(
+            expect.objectContaining({ y: 13, height: OVERLAY_ROW_GAP_PX }),
+            12,
+        );
+        expect(renderer.drawBarFill).toHaveBeenCalledWith(
+            expect.objectContaining({ y: 41, height: OVERLAY_ROW_GAP_PX }),
+            12,
+        );
+    });
+
+    it('falls back gap fills to bar palette index when gapPaletteIndex is omitted', () => {
+        const layout = createOverlayLayout(320, 240, 14);
+        const overlay = createOverlay(layout, 'Demo', {
+            style: { barPaletteIndex: 8, textPaletteIndex: 9 },
+            visibleAtStart: true,
+        });
+        const renderer = createMockRenderer();
+
+        overlay.updateAndRender(renderer, mockFont, null, null, 0);
+
+        expect(renderer.drawBarFill).toHaveBeenCalledWith(
+            expect.objectContaining({ y: 13, height: OVERLAY_ROW_GAP_PX }),
+            8,
+        );
     });
 
     it('uses overlayStyle palette indices when provided', () => {
@@ -360,10 +406,10 @@ describe('Overlay', () => {
         const row0BarY = customRowBarY(240, 0);
         const row1BarY = customRowBarY(240, 1);
 
-        expect(fills).toHaveLength(6);
+        expect(fills).toHaveLength(12);
         expect(fills[3]).toMatchObject({ y: row0BarY, width: 320, height: OVERLAY_BAR_HEIGHT });
         expect(fills[4]).toMatchObject({ y: row1BarY, width: 320, height: OVERLAY_BAR_HEIGHT });
-        expect(fills[5]).toMatchObject({ y: hintBarY(240), width: 320, height: OVERLAY_BAR_HEIGHT });
+        expect(fills[11]).toMatchObject({ y: hintBarY(240), width: 320, height: OVERLAY_BAR_HEIGHT });
         expect(row0BarY - row1BarY).toBe(OVERLAY_BAR_HEIGHT + OVERLAY_ROW_GAP_PX);
 
         const calls = getBitmapTextCalls(renderer);
@@ -394,7 +440,7 @@ describe('Overlay', () => {
 
         overlay.updateAndRender(renderer, mockFont, null, null, 0, () => []);
 
-        expect(getRectFillCalls(renderer)).toHaveLength(4);
+        expect(getRectFillCalls(renderer)).toHaveLength(8);
         expect(getBitmapTextCalls(renderer)).toHaveLength(5);
     });
 
@@ -443,7 +489,7 @@ describe('Overlay', () => {
         overlay.updateAndRender(renderer, mockFont, null, null, 0, undefined, undefined, palette);
 
         const fills = getRectFillCalls(renderer);
-        expect(fills[3]).toMatchObject({ y: hintBarY(240), height: OVERLAY_BAR_HEIGHT, width: 320 });
+        expect(fills.some((rect) => rect.y === hintBarY(240) && rect.height === OVERLAY_BAR_HEIGHT)).toBe(true);
         const swatchCalls = renderer.drawBarFill.mock.calls.filter(
             (call) => (call[0] as { width: number }).width === 1,
         );
@@ -501,8 +547,26 @@ describe('Overlay', () => {
         );
 
         const calls = getBitmapTextCalls(renderer);
+        const positionLabelIndex = renderer.drawLabel.mock.calls.findIndex((call) => call[2] === 'Position: (43, 166)');
 
         expect(calls.some((call) => call.text === 'Position: (43, 166)')).toBe(true);
+        expect(positionLabelIndex).toBeGreaterThanOrEqual(0);
+        const labelDrawOrder = renderer.drawLabel.mock.invocationCallOrder.at(positionLabelIndex);
+        const tooltipLabelDrawOrder = renderer.drawLabelOnTop.mock.invocationCallOrder.at(0);
+        const lastBarFillOrder = renderer.drawBarFill.mock.invocationCallOrder.at(-1);
+        const firstBarFillOnTopOrder = renderer.drawBarFillOnTop.mock.invocationCallOrder.at(0);
+
+        if (
+            labelDrawOrder === undefined ||
+            tooltipLabelDrawOrder === undefined ||
+            lastBarFillOrder === undefined ||
+            firstBarFillOnTopOrder === undefined
+        ) {
+            expect.fail('overlay draw-order snapshots missing');
+        }
+
+        expect(labelDrawOrder).toBeLessThan(tooltipLabelDrawOrder);
+        expect(lastBarFillOrder).toBeLessThan(firstBarFillOnTopOrder);
         expect(renderer.drawLabelOnTop).toHaveBeenCalledWith(
             mockFont,
             expect.any(Vector2i),

--- a/src/overlay/Overlay.ts
+++ b/src/overlay/Overlay.ts
@@ -76,6 +76,8 @@ export class Overlay {
 
     #idxText = DEFAULT_IDX_TEXT;
 
+    #idxGap = DEFAULT_IDX_BG;
+
     // #endregion
 
     // #region Constructor
@@ -118,6 +120,7 @@ export class Overlay {
         this.#fps = new FpsSampler(this.#targetFps);
         this.#idxBg = style?.barPaletteIndex ?? DEFAULT_IDX_BG;
         this.#idxText = style?.textPaletteIndex ?? DEFAULT_IDX_TEXT;
+        this.#idxGap = style?.gapPaletteIndex ?? this.#idxBg;
         this.#topRightLabel = `${activeBackend} | ${layout.displayWidth}x${layout.displayHeight}`;
         this.#timingChartStyle = resolveOverlayTimingChartStyle(style, overlayTimingChartStyle);
         this.#timingChartHeight = overlayTimingChartHeight ?? DEFAULT_TIMING_CHART_HEIGHT;
@@ -433,6 +436,13 @@ export class Overlay {
                 this.#layout.displayWidth,
                 this.#layout.lineHeight,
             );
+
+            this.#bars.drawRowGaps(renderer, plan, this.#idxGap);
+            this.#bars.drawClusterSeparators(renderer, plan, this.#idxGap, true, true);
+        }
+
+        if (!bodyVisible) {
+            this.#bars.drawHintClusterSeparator(renderer, plan.hintBar, this.#idxGap);
         }
 
         this.#bars.drawHintBarFill(renderer, plan, this.#idxBg);

--- a/src/overlay/bars/Bars.ts
+++ b/src/overlay/bars/Bars.ts
@@ -2,8 +2,9 @@
 
 import type { BitmapFont } from '../../assets/BitmapFont';
 import type { OverlayRow } from '../../core/IBlitTechDemo';
+import { Rect2i } from '../../utils/Rect2i';
 import { Vector2i } from '../../utils/Vector2i';
-import { OVERLAY_EDGE_MARGIN_PX, OVERLAY_TOP_TEXT_Y } from '../layout/constants';
+import { OVERLAY_EDGE_MARGIN_PX, OVERLAY_ROW_GAP_PX, OVERLAY_TOP_TEXT_Y } from '../layout/constants';
 import { overlayBitmapTextPaletteOffset, overlayRightAlignedTextX } from '../layout/layoutHelpers';
 import type { OverlayLayoutPlan } from '../layout/types';
 import type { OverlayDrawTarget } from '../OverlayDrawTarget';
@@ -30,6 +31,8 @@ export class OverlayBars {
 
     readonly #customRightPos: Vector2i[] = [];
 
+    readonly #hintSeparatorRect = new Rect2i(0, 0, 0, OVERLAY_ROW_GAP_PX);
+
     // #endregion
 
     // #region Private helpers
@@ -49,6 +52,59 @@ export class OverlayBars {
     // #endregion
 
     // #region Draw methods
+
+    /**
+     * Draws 1 px row gaps between stacked overlay bands.
+     *
+     * @param target - Overlay draw target.
+     * @param plan - Computed layout plan.
+     * @param gapIndex - Palette index for gap fills.
+     */
+    drawRowGaps(target: OverlayDrawTarget, plan: OverlayLayoutPlan, gapIndex: number): void {
+        for (const gapRect of plan.rowGapRects) {
+            target.drawBarFill(gapRect, gapIndex);
+        }
+    }
+
+    /**
+     * Draws the 1 px separator immediately above the bottom hint bar.
+     *
+     * @param target - Overlay draw target.
+     * @param hintBar - Bottom hint bar rect.
+     * @param gapIndex - Palette index for separator fill.
+     */
+    drawHintClusterSeparator(target: OverlayDrawTarget, hintBar: Rect2i, gapIndex: number): void {
+        this.#hintSeparatorRect.x = 0;
+        this.#hintSeparatorRect.y = hintBar.y - OVERLAY_ROW_GAP_PX;
+        this.#hintSeparatorRect.width = hintBar.width;
+        this.#hintSeparatorRect.height = OVERLAY_ROW_GAP_PX;
+        target.drawBarFill(this.#hintSeparatorRect, gapIndex);
+    }
+
+    /**
+     * Draws boundary separators between overlay clusters and demo content.
+     *
+     * @param target - Overlay draw target.
+     * @param plan - Computed layout plan.
+     * @param gapIndex - Palette index for separator fills.
+     * @param drawTop - When true, draws the separator below the top overlay cluster.
+     * @param drawBottom - When true, draws the separator above the bottom overlay cluster.
+     */
+    drawClusterSeparators(
+        target: OverlayDrawTarget,
+        plan: OverlayLayoutPlan,
+        gapIndex: number,
+        drawTop: boolean,
+        drawBottom: boolean,
+    ): void {
+        if (drawTop) {
+            target.drawBarFill(plan.topClusterSeparator, gapIndex);
+        }
+
+        if (drawBottom) {
+            target.drawBarFill(plan.bottomClusterSeparator, gapIndex);
+        }
+    }
 
     /**
      * Draws title, timing chart, metrics, and timing text bar fills.

--- a/src/overlay/layout/layoutPlan.test.ts
+++ b/src/overlay/layout/layoutPlan.test.ts
@@ -32,6 +32,15 @@ describe('buildOverlayLayoutPlan', () => {
         expect(plan.paletteBand).toMatchObject({ x: 0, y: hintBarY(240), width: 320, height: 0 });
         expect(plan.hintBar).toMatchObject({ x: 0, y: hintBarY(240), width: 320, height: OVERLAY_BAR_HEIGHT });
         expect(plan.timingChart.height).toBe(0);
+        expect(plan.rowGapRects).toHaveLength(2);
+        expect(plan.rowGapRects[0]).toMatchObject({ y: 13, width: 320, height: OVERLAY_ROW_GAP_PX });
+        expect(plan.rowGapRects[1]).toMatchObject({ y: 27, width: 320, height: OVERLAY_ROW_GAP_PX });
+        expect(plan.topClusterSeparator).toMatchObject({ y: 41, width: 320, height: OVERLAY_ROW_GAP_PX });
+        expect(plan.bottomClusterSeparator).toMatchObject({
+            y: hintBarY(240) - OVERLAY_ROW_GAP_PX,
+            width: 320,
+            height: OVERLAY_ROW_GAP_PX,
+        });
     });
 
     it('stacks custom rows above the bottom band with 1px gaps', () => {
@@ -49,6 +58,8 @@ describe('buildOverlayLayoutPlan', () => {
         expect(row0?.y).toBeDefined();
         expect(row1?.y).toBeDefined();
         expect((row0?.y ?? 0) - (row1?.y ?? 0)).toBe(OVERLAY_BAR_HEIGHT + OVERLAY_ROW_GAP_PX);
+        expect(plan.rowGapRects).toHaveLength(4);
+        expect(plan.bottomClusterSeparator).toMatchObject({ y: 198, width: 320, height: OVERLAY_ROW_GAP_PX });
     });
 
     it('inserts timing chart band when enabled', () => {

--- a/src/overlay/layout/layoutPlan.ts
+++ b/src/overlay/layout/layoutPlan.ts
@@ -30,6 +30,9 @@ export interface OverlayLayoutPlanScratch {
     topMetricsPos: Vector2i;
     topTimingPos: Vector2i;
     hintLabelPos: Vector2i;
+    rowGapRects: Rect2i[];
+    topClusterSeparator: Rect2i;
+    bottomClusterSeparator: Rect2i;
 }
 
 /**
@@ -52,6 +55,9 @@ export function createOverlayLayoutPlanScratch(): OverlayLayoutPlanScratch {
         topMetricsPos: new Vector2i(OVERLAY_EDGE_MARGIN_PX, 0),
         topTimingPos: new Vector2i(OVERLAY_EDGE_MARGIN_PX, 0),
         hintLabelPos: new Vector2i(0, 0),
+        rowGapRects: [],
+        topClusterSeparator: new Rect2i(0, 0, 0, OVERLAY_ROW_GAP_PX),
+        bottomClusterSeparator: new Rect2i(0, 0, 0, OVERLAY_ROW_GAP_PX),
     };
 }
 
@@ -136,6 +142,109 @@ function ensureCustomBarPool(scratch: OverlayLayoutPlanScratch, count: number, d
     while (scratch.customBars.length < count) {
         scratch.customBars.push(new Rect2i(0, 0, displayWidth, OVERLAY_BAR_HEIGHT));
     }
+}
+
+/**
+ * Writes a 1 px row gap rect immediately below a bar band.
+ *
+ * @param scratch - Layout scratch object.
+ * @param bar - Bar whose bottom edge precedes the gap.
+ * @param displayWidth - Logical display width.
+ * @param gapIndex - Index into {@link OverlayLayoutPlanScratch.rowGapRects}.
+ * @returns Next gap index.
+ */
+function writeRowGapBelow(
+    scratch: OverlayLayoutPlanScratch,
+    bar: Rect2i,
+    displayWidth: number,
+    gapIndex: number,
+): number {
+    while (scratch.rowGapRects.length <= gapIndex) {
+        scratch.rowGapRects.push(new Rect2i(0, 0, displayWidth, OVERLAY_ROW_GAP_PX));
+    }
+
+    const rect = scratch.rowGapRects.at(gapIndex);
+
+    if (rect === undefined) {
+        return gapIndex;
+    }
+
+    rect.x = 0;
+    rect.y = bar.y + bar.height;
+    rect.width = displayWidth;
+    rect.height = OVERLAY_ROW_GAP_PX;
+
+    return gapIndex + 1;
+}
+
+/**
+ * Resolves the top Y of the footer overlay cluster (custom rows, palette band, or hint bar).
+ *
+ * @param scratch - Layout scratch with footer rects populated.
+ * @param customRowCount - Demo custom row count for this frame.
+ * @returns Top Y of the uppermost footer band.
+ */
+function resolveFooterClusterTopY(scratch: OverlayLayoutPlanScratch, customRowCount: number): number {
+    if (customRowCount > 0) {
+        const topCustomBar = scratch.customBars[customRowCount - 1];
+
+        if (topCustomBar !== undefined) {
+            return topCustomBar.y;
+        }
+    }
+
+    if (scratch.paletteBand.height > 0) {
+        return scratch.paletteBand.y;
+    }
+
+    return scratch.hintBar.y;
+}
+
+/**
+ * Populates row gap rects and cluster boundary separators from bar geometry.
+ *
+ * @param scratch - Layout scratch with bar rects already assigned.
+ * @param config - Layout configuration.
+ * @param displayWidth - Logical display width.
+ */
+function populateGapLayout(scratch: OverlayLayoutPlanScratch, config: OverlayLayoutConfig, displayWidth: number): void {
+    let gapIndex = 0;
+
+    gapIndex = writeRowGapBelow(scratch, scratch.titleBar, displayWidth, gapIndex);
+
+    if (scratch.timingChart.height > 0) {
+        gapIndex = writeRowGapBelow(scratch, scratch.timingChart, displayWidth, gapIndex);
+    }
+
+    gapIndex = writeRowGapBelow(scratch, scratch.metricsBar, displayWidth, gapIndex);
+
+    /* eslint-disable security/detect-object-injection -- rowIndex bounded by customRowCount */
+    for (let rowIndex = 0; rowIndex < config.customRowCount; rowIndex++) {
+        const bar = scratch.customBars[rowIndex];
+
+        if (bar !== undefined) {
+            gapIndex = writeRowGapBelow(scratch, bar, displayWidth, gapIndex);
+        }
+    }
+    /* eslint-enable security/detect-object-injection */
+
+    if (scratch.paletteBand.height > 0) {
+        gapIndex = writeRowGapBelow(scratch, scratch.paletteBand, displayWidth, gapIndex);
+    }
+
+    scratch.rowGapRects.length = gapIndex;
+
+    scratch.topClusterSeparator.x = 0;
+    scratch.topClusterSeparator.y = scratch.timingTextBar.y + scratch.timingTextBar.height;
+    scratch.topClusterSeparator.width = displayWidth;
+    scratch.topClusterSeparator.height = OVERLAY_ROW_GAP_PX;
+
+    const footerTopY = resolveFooterClusterTopY(scratch, config.customRowCount);
+
+    scratch.bottomClusterSeparator.x = 0;
+    scratch.bottomClusterSeparator.y = footerTopY - OVERLAY_ROW_GAP_PX;
+    scratch.bottomClusterSeparator.width = displayWidth;
+    scratch.bottomClusterSeparator.height = OVERLAY_ROW_GAP_PX;
 }
 
 // #endregion
@@ -244,6 +353,8 @@ export function buildOverlayLayoutPlan(
 
     scratch.hintLabelPos.x = overlayToggleHintTextX();
     scratch.hintLabelPos.y = hintLabelBaselineY;
+
+    populateGapLayout(scratch, config, displayWidth);
 
     return scratch;
 }

--- a/src/overlay/layout/types.ts
+++ b/src/overlay/layout/types.ts
@@ -73,4 +73,13 @@ export interface OverlayLayoutPlan {
 
     /** Bottom-left `[~]` toggle hint label anchor. */
     readonly hintLabelPos: Vector2i;
+
+    /** 1 px row gaps between stacked overlay bands (top stack, custom rows, palette/hint). */
+    readonly rowGapRects: readonly Rect2i[];
+
+    /** 1 px separator below the top overlay cluster (between overlay and demo content). */
+    readonly topClusterSeparator: Rect2i;
+
+    /** 1 px separator above the bottom hint bar (between demo content and overlay footer). */
+    readonly bottomClusterSeparator: Rect2i;
 }

--- a/src/overlay/testFixtures.ts
+++ b/src/overlay/testFixtures.ts
@@ -26,9 +26,11 @@ export type BitmapTextCall = {
 export function createMockRenderer(): OverlayRenderer & {
     drawBitmapText: ReturnType<typeof vi.fn>;
     drawLabel: ReturnType<typeof vi.fn>;
+    drawLabelOnTop: ReturnType<typeof vi.fn>;
     drawPixel: ReturnType<typeof vi.fn>;
     drawRectFill: ReturnType<typeof vi.fn>;
     drawBarFill: ReturnType<typeof vi.fn> & { rectSnapshots: Rect2i[] };
+    drawBarFillOnTop: ReturnType<typeof vi.fn> & { rectSnapshots: Rect2i[] };
 } {
     const rectSnapshots: Rect2i[] = [];
     const drawBarFill = vi.fn((rect: Rect2i) => {
@@ -37,7 +39,8 @@ export function createMockRenderer(): OverlayRenderer & {
     drawBarFill.rectSnapshots = rectSnapshots;
     const drawBarFillOnTop = vi.fn((rect: Rect2i) => {
         rectSnapshots.push(new Rect2i(rect.x, rect.y, rect.width, rect.height));
-    });
+    }) as ReturnType<typeof vi.fn> & { rectSnapshots: Rect2i[] };
+    drawBarFillOnTop.rectSnapshots = rectSnapshots;
     const drawLabel = vi.fn();
     const drawLabelOnTop = vi.fn();
     const drawPixel = vi.fn();

--- a/src/render/WebGpuRenderer.test.ts
+++ b/src/render/WebGpuRenderer.test.ts
@@ -46,10 +46,10 @@ type WebGpuRendererPipelineAccess = {
 };
 
 /**
- * Returns the four scene-pass pipeline batches for encode-order and routing tests.
+ * Returns the six scene-pass pipeline batches for encode-order and routing tests.
  *
  * @param renderer - Initialized {@link WebGpuRenderer}.
- * @returns Primitive and sprite pipeline instances.
+ * @returns Primitive, sprite, overlay, and overlay-top pipeline instances.
  */
 function getRendererPipelines(renderer: WebGpuRenderer): WebGpuRendererPipelineAccess {
     return renderer as unknown as WebGpuRendererPipelineAccess;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR introduces a new `gapPaletteIndex` configuration option for overlay styling, enabling independent palette index control for 1-pixel row gaps and cluster separators in the overlay system. When omitted, gap fills default to using the `barPaletteIndex`.

## Core Changes

**Interface & Configuration Updates** (`IBlitTechDemo.ts`):
- Added optional `gapPaletteIndex?: number` field to the `OverlayStyle` interface to specify the palette index used for 1px gaps between overlay bands and boundary separators
- Updated documentation to clarify that palette index `1` applies to both built-in overlay bars and row gaps by default, with `2` used for text

**Layout System** (`layoutPlan.ts`, `types.ts`):
- Extended `OverlayLayoutPlan` interface with three new computed layout anchors:
  - `rowGapRects`: array of 1px row-gap rectangles between stacked overlay bands
  - `topClusterSeparator`: 1px separator rectangle marking the top cluster boundary
  - `bottomClusterSeparator`: 1px separator rectangle marking the bottom cluster boundary
- Added internal layout helpers to compute and populate gap rects and separator positions:
  - `writeRowGapBelow()`: computes 1px gaps directly below each bar band
  - `resolveFooterClusterTopY()`: determines the uppermost footer cluster position
  - `populateGapLayout()`: generates all gap rects and cluster boundary separators based on enabled bands and custom rows
- Updated `buildOverlayLayoutPlan()` to calculate gap/separator geometry each frame

**Rendering Implementation** (`Overlay.ts`, `Bars.ts`):
- `Overlay` now reads `gapPaletteIndex` from style config with fallback to `barPaletteIndex`
- When overlay body is visible, renders row gaps and cluster separators using the configured gap palette index
- When overlay body is hidden, renders a hint-area cluster separator before the hint bar
- `OverlayBars` class adds three new public methods:
  - `drawRowGaps()`: fills all computed row gap rectangles
  - `drawHintClusterSeparator()`: computes and draws a 1-row separator above the hint bar
  - `drawClusterSeparators()`: optionally draws top and/or bottom cluster boundary separators

## Documentation Updates

Updated `docs/api-core.md` to:
- Introduce and clarify `overlayStyle.gapPaletteIndex` as part of the `OverlayStyle` configuration
- Specify overlayPaletteView behavior with stacked palette swatch grid above a 1px filled gap
- Detail additional space requirements when `overlayPaletteView` is enabled with example height calculations
- Refresh overlay configuration examples to include `gapPaletteIndex`

## Test Coverage

**Unit Tests** (`IBlitTechDemo.test.ts`, `layoutPlan.test.ts`):
- Added test coverage for `mergeHardwareSettings` to validate `gapPaletteIndex` is properly merged from configuration
- Added layout plan tests verifying exact count and positions of row gap rects and cluster separator placement

**Integration Tests** (`Overlay.test.ts`):
- Updated assertions to reflect new gap/separator rendering behavior
- Added tests validating `gapPaletteIndex` behavior: when provided, gaps use that index; when omitted, they fall back to `barPaletteIndex`
- Updated hint-only rendering path expectations with adjusted rect-fill counts
- Updated palette view assertions to check for palette-view-specific spacing and rendering
- Strengthened palette tooltip draw-order test to capture and validate relative ordering of label, tooltip, and bar-fill layers

**Test Fixtures** (`testFixtures.ts`):
- Enhanced `createMockRenderer()` to expose `drawBarFillOnTop` with attached `rectSnapshots` array for capturing emitted rectangles
- Added `drawLabelOnTop` mock to the returned mock renderer type

**Documentation Tests** (`WebGpuRenderer.test.ts`):
- Updated helper function documentation to reflect six scene-pass pipeline batches instead of four

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/230?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->