### PR TITLE
feat(overlay): add palette row viewport scroll and cap

### DIFF
--- a/docs/api-core.md
+++ b/docs/api-core.md
@@ -104,25 +104,26 @@ See [Post-Process Effects](post-process-effects.md) for tier routing and presets
 output buffer. Include `displaySize` when you want a custom logical size; optional fields you omit then stay unset (for
 example no `drawingBufferSize` means a 1:1 drawing buffer).
 
-| Field                      | Type                      | Default     | Description                                                          |
-| -------------------------- | ------------------------- | ----------- | -------------------------------------------------------------------- |
-| `displaySize`              | `Vector2i`                | `320×240`   | **Logical** render resolution                                        |
-| `drawingBufferSize`        | `Vector2i`                | `640×480`   | **Drawing buffer** size; enables **display-tier** effects when set   |
-| `maxCanvasSize`            | `Vector2i`                | `960×720`   | **CSS cap** — maximum on-screen canvas size                          |
-| `targetFPS`                | `number`                  | `60`        | Fixed `update()` rate (simulation ticks per second)                  |
-| `backend`                  | `'webgpu' \| 'software'`  | `'webgpu'`  | Force rendering backend                                              |
-| `outputUpscaleFilter`      | `'nearest' \| 'linear'`   | `'nearest'` | Upscale filter                                                       |
-| `detectDroppedFrames`      | `boolean`                 | `false`     | Log a console warning on missed vsync                                |
-| `overlayEnabled`           | `boolean`                 | `true`      | Engine overlay HUD after each `render()`                             |
-| `overlayVisibleAtStart`    | `boolean`                 | `false`     | Show overlay body (metrics/palette/custom rows) on first frame       |
-| `overlayToggleHintVisible` | `boolean`                 | `true`      | Draw `[~]` hint bar while overlay body is hidden                     |
-| `overlayToggleEnabled`     | `boolean`                 | `true`      | Enable Backquote and bottom-left corner toggle input                 |
-| `overlayPaletteView`       | `boolean`                 | `false`     | Live palette swatch grid in the overlay bottom band (opt-in)         |
-| `overlayPaletteColumns`    | `number`                  | _unset_     | Max palette swatches per grid row (default: widest fit)              |
-| `overlayStyle`             | `OverlayStyle`            | _unset_     | Optional bar/text/gap palette indices for overlay                    |
-| `overlayTimingChart`       | `boolean`                 | `false`     | Scrolling update/render timing chart between title and metrics rows  |
-| `overlayTimingChartHeight` | `number`                  | `22`        | Timing chart band height in pixels when the chart is enabled         |
-| `overlayTimingChartStyle`  | `OverlayTimingChartStyle` | _unset_     | Optional timing chart palette indices (defaults to overlay bar/text) |
+| Field                       | Type                      | Default     | Description                                                           |
+| --------------------------- | ------------------------- | ----------- | --------------------------------------------------------------------- |
+| `displaySize`               | `Vector2i`                | `320×240`   | **Logical** render resolution                                         |
+| `drawingBufferSize`         | `Vector2i`                | `640×480`   | **Drawing buffer** size; enables **display-tier** effects when set    |
+| `maxCanvasSize`             | `Vector2i`                | `960×720`   | **CSS cap** — maximum on-screen canvas size                           |
+| `targetFPS`                 | `number`                  | `60`        | Fixed `update()` rate (simulation ticks per second)                   |
+| `backend`                   | `'webgpu' \| 'software'`  | `'webgpu'`  | Force rendering backend                                               |
+| `outputUpscaleFilter`       | `'nearest' \| 'linear'`   | `'nearest'` | Upscale filter                                                        |
+| `detectDroppedFrames`       | `boolean`                 | `false`     | Log a console warning on missed vsync                                 |
+| `overlayEnabled`            | `boolean`                 | `true`      | Engine overlay HUD after each `render()`                              |
+| `overlayVisibleAtStart`     | `boolean`                 | `false`     | Show overlay body (metrics/palette/custom rows) on first frame        |
+| `overlayToggleHintVisible`  | `boolean`                 | `true`      | Draw `[~]` hint bar while overlay body is hidden                      |
+| `overlayToggleEnabled`      | `boolean`                 | `true`      | Enable Backquote and bottom-left corner toggle input                  |
+| `overlayPaletteView`        | `boolean`                 | `false`     | Live palette swatch grid in the overlay bottom band (opt-in)          |
+| `overlayPaletteColumns`     | `number`                  | _unset_     | Max palette swatches per grid row (default: widest fit)               |
+| `overlayPaletteRowsVisible` | `number`                  | _unset_     | Max visible palette grid rows (default: all rows; band height capped) |
+| `overlayStyle`              | `OverlayStyle`            | _unset_     | Optional bar/text/gap palette indices for overlay                     |
+| `overlayTimingChart`        | `boolean`                 | `false`     | Scrolling update/render timing chart between title and metrics rows   |
+| `overlayTimingChartHeight`  | `number`                  | `22`        | Timing chart band height in pixels when the chart is enabled          |
+| `overlayTimingChartStyle`   | `OverlayTimingChartStyle` | _unset_     | Optional timing chart palette indices (defaults to overlay bar/text)  |
 
 `displaySize`, `drawingBufferSize`, and `maxCanvasSize` must be positive whole-number pixel dimensions. Each size is
 capped at `8192×8192` per axis and `16,777,216` total pixels (`4096×4096`). Invalid sizes make initialization fail
@@ -219,7 +220,10 @@ otherwise.
 - **Bottom band:** default **13 px** hint bar with the `[~]` toggle label anchored bottom-left (over the toggle hit
   region). Set `overlayPaletteView: true` to stack a live palette swatch grid **above** a **1 px** filled gap and that
   hint bar; slots referenced by demo draw calls this frame are filled with their color, and unused slots render as empty
-  squares with a small centered marker. The timing chart and palette grid bands use the same
+  squares with a small centered marker. When `overlayPaletteRowsVisible` is set, only that many rows are shown in a
+  scrollable viewport with a right-side scrollbar thumb (proportional to visible vs total rows, minimum 4 px, inset 1 px
+  from the band top, right, and bottom); wheel input over the palette band scrolls rows and does not reach
+  `BT.pointerScrollDelta` outside that region. The timing chart and palette grid bands use the same
   `overlayStyle.barPaletteIndex` fill as the other overlay rows (bars draw first; chart dots and swatches render on
   top). **1 px row gaps** between stacked overlay bands and **cluster separators** (below the top metrics cluster and
   above the bottom footer cluster) are filled with `overlayStyle.gapPaletteIndex`, defaulting to
@@ -282,9 +286,14 @@ height matches `resolveOverlayFooterHeight()` in `layoutPlan.ts`:
 ```text
 cols = pickPaletteGridColumnCount(displayWidth, swatchSize, gap, palette.size, maxColumns?)
 rows = ceil(palette.size / cols)
-paletteGridHeight = rows * swatchSize + max(0, rows - 1) * gap + 2 * paletteGridPadding
+visibleRows = overlayPaletteRowsVisible ?? rows   // clamped to [1, rows] when set
+paletteGridHeight = visibleRows * swatchSize + max(0, visibleRows - 1) * gap + 2 * paletteGridPadding
 bottomReserve = paletteGridHeight + 1 + 13
 ```
+
+When `overlayPaletteRowsVisible` is unset, `visibleRows` equals `rows` (full palette). Wheel scrolling applies only
+while the pointer is over the palette footer band (grid or scrollbar); demos reading `BT.pointerScrollDelta` elsewhere
+are unaffected.
 
 Default swatch size is **7 px** with **1 px** gaps and **3 px** padding above and below the grid. Set
 `overlayPaletteView: true` to enable the grid, or `overlayEnabled: false` for full-screen layouts (for example
@@ -305,6 +314,7 @@ configure() {
     displaySize: new Vector2i(320, 240),
     overlayEnabled: true,
     overlayPaletteView: true,
+    overlayPaletteRowsVisible: 3,
     overlayTimingChart: true,
     overlayTimingChartHeight: 32, // optional; default 22
     overlayStyle: { barPaletteIndex: 2, textPaletteIndex: 3, gapPaletteIndex: 2 },

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -410,6 +410,7 @@ export class BTAPI {
             hw.overlayStyle,
             hw.overlayPaletteView === true,
             hw.overlayPaletteColumns,
+            hw.overlayPaletteRowsVisible,
             hw.overlayTimingChart === true,
             hw.overlayTimingChartStyle,
             hw.overlayTimingChartHeight,

--- a/src/core/IBlitTechDemo.ts
+++ b/src/core/IBlitTechDemo.ts
@@ -157,6 +157,14 @@ export interface HardwareSettings {
     overlayPaletteColumns?: number;
 
     /**
+     * Maximum visible palette grid rows in the overlay footer viewport. When unset,
+     * all rows are shown (current behavior). When set, the bottom band height uses
+     * this row count rather than the full palette row count; values are clamped to
+     * at least `1` and at most the total row count.
+     */
+    overlayPaletteRowsVisible?: number;
+
+    /**
      * Palette indices for the built-in overlay bars (top and bottom), row gaps,
      * and as defaults for custom {@link OverlayRow} entries that omit per-row colors.
      *
@@ -474,6 +482,7 @@ function pickDefinedOverlaySettings(picked: Partial<HardwareSettings>, partial: 
     pickIfDefinedPartial(picked, partial, 'overlayToggleEnabled');
     pickIfDefinedPartial(picked, partial, 'overlayPaletteView');
     pickIfDefinedPartial(picked, partial, 'overlayPaletteColumns');
+    pickIfDefinedPartial(picked, partial, 'overlayPaletteRowsVisible');
     pickIfDefinedPartial(picked, partial, 'overlayTimingChart');
     pickIfDefinedPartial(picked, partial, 'overlayTimingChartHeight');
 
@@ -630,6 +639,8 @@ function assignFullDefaultMergeScalars(
 
     assignIfDefined(optionals, 'overlayPaletteColumns', picked.overlayPaletteColumns);
 
+    assignIfDefined(optionals, 'overlayPaletteRowsVisible', picked.overlayPaletteRowsVisible);
+
     assignIfDefined(optionals, 'overlayTimingChart', picked.overlayTimingChart ?? defaults.overlayTimingChart);
 
     assignIfDefined(
@@ -690,6 +701,7 @@ function buildExplicitDisplayOptionals(
     assignIfDefined(optionals, 'detectDroppedFrames', picked.detectDroppedFrames);
     assignIfDefined(optionals, 'overlayStyle', shallowCloneOptional(picked.overlayStyle));
     assignIfDefined(optionals, 'overlayPaletteColumns', picked.overlayPaletteColumns);
+    assignIfDefined(optionals, 'overlayPaletteRowsVisible', picked.overlayPaletteRowsVisible);
     assignIfDefined(optionals, 'overlayTimingChart', picked.overlayTimingChart);
     assignIfDefined(optionals, 'overlayTimingChartHeight', picked.overlayTimingChartHeight);
     assignIfDefined(optionals, 'overlayTimingChartStyle', shallowCloneOptional(picked.overlayTimingChartStyle));

--- a/src/input/PointerInput.ts
+++ b/src/input/PointerInput.ts
@@ -354,6 +354,16 @@ export class PointerInput {
     }
 
     /**
+     * Clears accumulated wheel delta for the current frame.
+     *
+     * Used when the overlay consumes scroll input over the palette footer so
+     * demo code reading {@link BT.pointerScrollDelta} does not see the same delta.
+     */
+    public consumeScrollDelta(): void {
+        this.scrollDeltaY = 0;
+    }
+
+    /**
      * Reports whether the given pointer button is held in slot `slot`.
      *
      * For slot 0 (mouse): `BTN_POINTER_A` is left, `B` is right, `C` is middle,

--- a/src/overlay/Overlay.test.ts
+++ b/src/overlay/Overlay.test.ts
@@ -14,7 +14,7 @@ import { OVERLAY_BAR_HEIGHT, OVERLAY_ROW_GAP_PX } from './layout/constants';
 import { createOverlayLayout, overlayRightAlignedTextX, overlayToggleHintTextX } from './layout/layoutHelpers';
 import { hintBarY, paletteBandY } from './layout/layoutPlan';
 import { Overlay } from './Overlay';
-import { computePaletteGrid, writePaletteSwatchTopLeft } from './palette/PaletteView';
+import { computePaletteGrid, writePaletteScrollbarRects, writePaletteSwatchTopLeft } from './palette/PaletteView';
 import {
     createMockRenderer,
     customRowBarY,
@@ -36,6 +36,7 @@ interface OverlayTestOptions {
     style?: { barPaletteIndex?: number; textPaletteIndex?: number; gapPaletteIndex?: number };
     paletteView?: boolean;
     paletteColumns?: number;
+    paletteRowsVisible?: number;
     timingChart?: boolean;
     timingChartStyle?: { updateBarPaletteIndex?: number; renderBarPaletteIndex?: number };
     timingChartHeight?: number;
@@ -59,6 +60,7 @@ function createOverlay(
         options.style,
         options.paletteView ?? OVERLAY_PALETTE_VIEW_OFF,
         options.paletteColumns,
+        options.paletteRowsVisible,
         options.timingChart ?? false,
         options.timingChartStyle,
         options.timingChartHeight,
@@ -123,6 +125,36 @@ describe('Overlay', () => {
             {
                 isButtonPressed: () => true,
                 getPos: () => new Vector2i(swatch.x + 1, swatch.y + 1),
+            } as never,
+            null,
+            1,
+        );
+
+        expect(overlay.bodyVisible).toBe(true);
+    });
+
+    it('scrollbar track press blocks toggle but swatch press still copies first (VV-550)', () => {
+        const layout = createOverlayLayout(320, 240, 14);
+        const overlay = createOverlay(layout, 'Test Demo', {
+            paletteView: true,
+            visibleAtStart: true,
+            paletteRowsVisible: 3,
+        });
+        const grid = computePaletteGrid(320, undefined, 256, undefined, undefined, 3);
+        const paletteBandTop = paletteBandY(240, grid.totalHeight);
+        const paletteBand = new Rect2i(0, paletteBandTop, 320, grid.totalHeight);
+        const track = new Rect2i();
+        const thumb = new Rect2i();
+        writePaletteScrollbarRects(track, thumb, paletteBand, grid, 0, 4);
+
+        overlay.handleFrameInput(
+            {
+                isButtonPressed: () => true,
+                isButtonDown: () => true,
+                isValid: () => true,
+                getPos: () => new Vector2i(track.x + 1, track.y + 1),
+                getScrollDelta: () => 0,
+                consumeScrollDelta: vi.fn(),
             } as never,
             null,
             1,

--- a/src/overlay/Overlay.ts
+++ b/src/overlay/Overlay.ts
@@ -68,6 +68,8 @@ export class Overlay {
 
     readonly #paletteColumns: number | undefined;
 
+    readonly #paletteRowsVisible: number | undefined;
+
     readonly #layoutScratch = createOverlayLayoutPlanScratch();
 
     readonly #barStyle = { barIndex: DEFAULT_IDX_BG, textIndex: DEFAULT_IDX_TEXT };
@@ -92,6 +94,7 @@ export class Overlay {
      * @param style - Optional palette indices from {@link HardwareSettings.overlayStyle}.
      * @param overlayPaletteView - When true, draws the live palette swatch grid.
      * @param paletteColumns - Optional max swatches per row from {@link HardwareSettings.overlayPaletteColumns}.
+     * @param overlayPaletteRowsVisible - Optional max visible palette grid rows from {@link HardwareSettings.overlayPaletteRowsVisible}.
      * @param overlayTimingChart - When true, draws the update/render timing chart band.
      * @param overlayTimingChartStyle - Optional timing chart palette overrides.
      * @param overlayTimingChartHeight - Chart band height in pixels (default 22).
@@ -107,6 +110,7 @@ export class Overlay {
         style?: OverlayStyle,
         overlayPaletteView = false,
         paletteColumns?: number,
+        overlayPaletteRowsVisible?: number,
         overlayTimingChart = false,
         overlayTimingChartStyle?: OverlayTimingChartStyle,
         overlayTimingChartHeight?: number,
@@ -128,6 +132,7 @@ export class Overlay {
         this.#paletteView = new PaletteView(overlayPaletteView);
         this.#paletteInteraction = new PaletteInteraction(targetFps);
         this.#paletteColumns = paletteColumns;
+        this.#paletteRowsVisible = overlayPaletteRowsVisible;
         this.#toggle = new Toggle(overlayVisibleAtStart, overlayToggleEnabled);
         this.#toggleHintVisible = overlayToggleHintVisible;
 
@@ -186,6 +191,8 @@ export class Overlay {
             const colorCount = palette?.size ?? 256;
 
             if (grid !== undefined && plan.paletteBand.height > 0) {
+                this.#paletteInteraction.syncScrollBounds(grid);
+
                 pointerPressConsumed = this.#paletteInteraction.handlePress(
                     pointer,
                     currentTick,
@@ -196,6 +203,10 @@ export class Overlay {
                     this.#layout.displayWidth,
                     this.#layout.lineHeight,
                 );
+
+                pointerPressConsumed =
+                    this.#paletteInteraction.handleScroll(pointer, plan, grid, pointerPressConsumed) ||
+                    pointerPressConsumed;
             }
         }
 
@@ -299,7 +310,14 @@ export class Overlay {
         const overlayPaletteView = this.#paletteView.enabled;
         const colorCount = palette?.size ?? 256;
         const paletteGrid = overlayPaletteView
-            ? computePaletteGrid(this.#layout.displayWidth, undefined, colorCount, undefined, this.#paletteColumns)
+            ? computePaletteGrid(
+                  this.#layout.displayWidth,
+                  undefined,
+                  colorCount,
+                  undefined,
+                  this.#paletteColumns,
+                  this.#paletteRowsVisible,
+              )
             : undefined;
 
         return {
@@ -420,6 +438,9 @@ export class Overlay {
                 this.#layout.displayWidth,
                 this.#layout.lineHeight,
                 usedPaletteMask,
+                this.#idxText,
+                this.#paletteInteraction.scrollRowOffset,
+                this.#paletteInteraction.scrollbarTrackWidth,
                 this.#idxText,
             );
 

--- a/src/overlay/layout/layoutPlan.test.ts
+++ b/src/overlay/layout/layoutPlan.test.ts
@@ -122,17 +122,27 @@ describe('buildOverlayLayoutPlan', () => {
 
     it('resolveOverlayFooterHeight reserves hint bar or palette plus gap plus hint', () => {
         const paletteGrid = computePaletteGrid(320, 4, 256, 1);
+        const cappedGrid = computePaletteGrid(320, 4, 256, 1, undefined, 3);
         const hintOnlyConfig = createDefaultLayoutConfig(320, 240, 14, 0);
         const paletteConfig = {
             ...hintOnlyConfig,
             overlayPaletteView: true,
             paletteGrid,
         };
+        const cappedPaletteConfig = {
+            ...hintOnlyConfig,
+            overlayPaletteView: true,
+            paletteGrid: cappedGrid,
+        };
 
         expect(resolveOverlayFooterHeight(hintOnlyConfig)).toBe(OVERLAY_BAR_HEIGHT);
         expect(resolveOverlayFooterHeight(paletteConfig)).toBe(
             paletteGrid.totalHeight + OVERLAY_ROW_GAP_PX + OVERLAY_BAR_HEIGHT,
         );
+        expect(resolveOverlayFooterHeight(cappedPaletteConfig)).toBe(
+            cappedGrid.totalHeight + OVERLAY_ROW_GAP_PX + OVERLAY_BAR_HEIGHT,
+        );
+        expect(cappedGrid.totalHeight).toBeLessThan(paletteGrid.totalHeight);
     });
 });
 

--- a/src/overlay/palette/PaletteInteraction.test.ts
+++ b/src/overlay/palette/PaletteInteraction.test.ts
@@ -12,19 +12,28 @@ import { paletteBandY } from '../layout/layoutPlan';
 import type { OverlayLayoutPlan } from '../layout/types';
 import { mockFont } from '../testFixtures';
 import {
+    clampScrollRowOffset,
     drawPaletteTooltipChrome,
     drawPaletteTooltipLabel,
     hitTestPaletteSwatch,
+    isPointerInPaletteScrollbarTrack,
     layoutPaletteTooltip,
+    maxScrollRowOffset,
     PALETTE_COPY_STATUS_SECONDS,
+    PALETTE_SCROLLBAR_TRACK_WIDTH_PX,
     PaletteInteraction,
+    resolveScrollRowOffsetFromTrackPointerY,
     writePaletteIndexToClipboard,
 } from './PaletteInteraction';
 import {
     computePaletteGrid,
+    computePaletteScrollbarThumbHeight,
     DEFAULT_PALETTE_SWATCH_SIZE,
+    PALETTE_SCROLLBAR_EDGE_PADDING_PX,
+    PALETTE_SCROLLBAR_MIN_THUMB_HEIGHT_PX,
     PALETTE_SWATCH_GAP_PX,
     resolvePaletteHintExclusionRect,
+    writePaletteScrollbarRects,
     writePaletteSwatchTopLeft,
 } from './PaletteView';
 
@@ -98,7 +107,7 @@ describe('hitTestPaletteSwatch', () => {
     });
 
     it('excludes the right scrollbar track from hits', () => {
-        const trackWidth = 8;
+        const trackWidth = PALETTE_SCROLLBAR_TRACK_WIDTH_PX;
         const swatch = new Rect2i();
 
         writePaletteSwatchTopLeft(swatch, 31, paletteBand, grid);
@@ -157,6 +166,165 @@ describe('hitTestPaletteSwatch', () => {
             ),
         ).toBe(index);
         expect(layout.toggleRect.contains(new Vector2i(swatch.x + 1, swatch.y + 1))).toBe(true);
+    });
+});
+
+describe('palette scroll helpers', () => {
+    const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 256, PALETTE_SWATCH_GAP_PX, undefined, 3);
+
+    it('computes maxScrollRowOffset from total and visible rows', () => {
+        expect(maxScrollRowOffset(grid)).toBe(grid.rows - grid.visibleRows);
+    });
+
+    it('clamps scroll row offset into valid bounds', () => {
+        expect(clampScrollRowOffset(-4, grid)).toBe(0);
+        expect(clampScrollRowOffset(999, grid)).toBe(maxScrollRowOffset(grid));
+        expect(clampScrollRowOffset(2, grid)).toBe(2);
+    });
+
+    it('sizes thumb proportionally to visible rows with a 4 px minimum', () => {
+        const paletteBand = new Rect2i(0, 200, 320, grid.totalHeight);
+        const trackHeight = paletteBand.height - PALETTE_SCROLLBAR_EDGE_PADDING_PX * 2;
+        const thumbHeight = computePaletteScrollbarThumbHeight(trackHeight, grid);
+
+        expect(thumbHeight).toBeGreaterThanOrEqual(PALETTE_SCROLLBAR_MIN_THUMB_HEIGHT_PX);
+        expect(thumbHeight).toBe(Math.floor((grid.visibleRows / grid.rows) * trackHeight));
+    });
+
+    it('positions scrollbar thumb by scroll ratio', () => {
+        const paletteBandTop = paletteBandY(240, grid.totalHeight);
+        const paletteBand = new Rect2i(0, paletteBandTop, 320, grid.totalHeight);
+        const track = new Rect2i();
+        const thumb = new Rect2i();
+        const scrollRowOffset = 3;
+        const pad = PALETTE_SCROLLBAR_EDGE_PADDING_PX;
+
+        writePaletteScrollbarRects(track, thumb, paletteBand, grid, scrollRowOffset, PALETTE_SCROLLBAR_TRACK_WIDTH_PX);
+
+        expect(track).toMatchObject({
+            x: paletteBand.x + paletteBand.width - PALETTE_SCROLLBAR_TRACK_WIDTH_PX - pad,
+            y: paletteBand.y + pad,
+            width: PALETTE_SCROLLBAR_TRACK_WIDTH_PX,
+            height: paletteBand.height - pad * 2,
+        });
+        expect(thumb.width).toBe(PALETTE_SCROLLBAR_TRACK_WIDTH_PX);
+        expect(thumb.height).toBeGreaterThanOrEqual(PALETTE_SCROLLBAR_MIN_THUMB_HEIGHT_PX);
+        expect(thumb.y).toBeGreaterThanOrEqual(track.y);
+        expect(thumb.y + thumb.height).toBeLessThanOrEqual(track.y + track.height);
+
+        const maxOffset = maxScrollRowOffset(grid);
+        const topThumb = new Rect2i();
+        const bottomThumb = new Rect2i();
+
+        writePaletteScrollbarRects(track, topThumb, paletteBand, grid, 0, PALETTE_SCROLLBAR_TRACK_WIDTH_PX);
+        writePaletteScrollbarRects(track, bottomThumb, paletteBand, grid, maxOffset, PALETTE_SCROLLBAR_TRACK_WIDTH_PX);
+
+        expect(topThumb.y).toBe(track.y);
+        expect(bottomThumb.y + bottomThumb.height).toBe(track.y + track.height);
+    });
+
+    it('maps track pointer Y to scroll row offset', () => {
+        const paletteBandTop = paletteBandY(240, grid.totalHeight);
+        const paletteBand = new Rect2i(0, paletteBandTop, 320, grid.totalHeight);
+        const track = new Rect2i();
+        const thumb = new Rect2i();
+
+        writePaletteScrollbarRects(track, thumb, paletteBand, grid, 0, PALETTE_SCROLLBAR_TRACK_WIDTH_PX);
+
+        expect(
+            resolveScrollRowOffsetFromTrackPointerY(track.y, paletteBand, grid, PALETTE_SCROLLBAR_TRACK_WIDTH_PX),
+        ).toBe(0);
+        expect(
+            resolveScrollRowOffsetFromTrackPointerY(
+                track.y + track.height,
+                paletteBand,
+                grid,
+                PALETTE_SCROLLBAR_TRACK_WIDTH_PX,
+            ),
+        ).toBe(maxScrollRowOffset(grid));
+    });
+});
+
+describe('PaletteInteraction scroll', () => {
+    it('advances scroll offset from wheel delta over the palette band and consumes scroll', () => {
+        const interaction = new PaletteInteraction(60);
+        const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 256, PALETTE_SWATCH_GAP_PX, undefined, 3);
+        const paletteBandTop = paletteBandY(240, grid.totalHeight);
+        const plan = paletteOnlyPlan(new Rect2i(0, paletteBandTop, 320, grid.totalHeight));
+        const swatch = new Rect2i();
+
+        writePaletteSwatchTopLeft(swatch, 0, plan.paletteBand, grid);
+
+        const pointer = {
+            isValid: () => true,
+            getPos: () => new Vector2i(swatch.x + 1, swatch.y + 1),
+            getScrollDelta: () => 16,
+            consumeScrollDelta: vi.fn(),
+            isButtonPressed: () => false,
+            isButtonDown: () => false,
+        };
+
+        interaction.handleScroll(pointer as never, plan, grid, false);
+
+        expect(interaction.scrollRowOffset).toBe(2);
+        expect(pointer.consumeScrollDelta).toHaveBeenCalled();
+    });
+
+    it('does not consume wheel delta when pointer is outside the palette band', () => {
+        const interaction = new PaletteInteraction(60);
+        const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 256, PALETTE_SWATCH_GAP_PX, undefined, 3);
+        const paletteBandTop = paletteBandY(240, grid.totalHeight);
+        const plan = paletteOnlyPlan(new Rect2i(0, paletteBandTop, 320, grid.totalHeight));
+        const pointer = {
+            isValid: () => true,
+            getPos: () => new Vector2i(0, 0),
+            getScrollDelta: () => 16,
+            consumeScrollDelta: vi.fn(),
+            isButtonPressed: () => false,
+            isButtonDown: () => false,
+        };
+
+        interaction.handleScroll(pointer as never, plan, grid, false);
+
+        expect(interaction.scrollRowOffset).toBe(0);
+        expect(pointer.consumeScrollDelta).not.toHaveBeenCalled();
+    });
+
+    it('blocks toggle when primary press starts on the scrollbar track', () => {
+        const interaction = new PaletteInteraction(60);
+        const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 256, PALETTE_SWATCH_GAP_PX, undefined, 3);
+        const paletteBandTop = paletteBandY(240, grid.totalHeight);
+        const plan = paletteOnlyPlan(new Rect2i(0, paletteBandTop, 320, grid.totalHeight));
+        const track = new Rect2i();
+        const thumb = new Rect2i();
+
+        writePaletteScrollbarRects(track, thumb, plan.paletteBand, grid, 0, PALETTE_SCROLLBAR_TRACK_WIDTH_PX);
+
+        const consumed = interaction.handleScroll(
+            {
+                isValid: () => true,
+                getPos: () => new Vector2i(track.x + 1, track.y + 2),
+                getScrollDelta: () => 0,
+                consumeScrollDelta: vi.fn(),
+                isButtonPressed: () => true,
+                isButtonDown: () => true,
+            } as never,
+            plan,
+            grid,
+            false,
+        );
+
+        expect(consumed).toBe(true);
+        expect(
+            isPointerInPaletteScrollbarTrack(
+                track.x + 1,
+                track.y + 2,
+                plan.paletteBand,
+                grid,
+                interaction.scrollRowOffset,
+                PALETTE_SCROLLBAR_TRACK_WIDTH_PX,
+            ),
+        ).toBe(true);
     });
 });
 

--- a/src/overlay/palette/PaletteInteraction.ts
+++ b/src/overlay/palette/PaletteInteraction.ts
@@ -14,12 +14,25 @@ import { overlayBitmapTextPaletteOffset } from '../layout/layoutHelpers';
 import type { OverlayLayoutPlan } from '../layout/types';
 import type { OverlayDrawTarget } from '../OverlayDrawTarget';
 import type { PaletteGridLayout } from '../types';
-import { PALETTE_GRID_PADDING_PX, resolvePaletteHintExclusionRect, writePaletteSwatchTopLeft } from './PaletteView';
+import {
+    computePaletteScrollbarThumbHeight,
+    PALETTE_GRID_PADDING_PX,
+    PALETTE_SCROLLBAR_EDGE_PADDING_PX,
+    resolvePaletteHintExclusionRect,
+    writePaletteScrollbarRects,
+    writePaletteSwatchTopLeft,
+} from './PaletteView';
 
 // #region Constants and types
 
 /** Reserved width on the right edge of the palette band excluded from swatch hits (VV-550 scrollbar). */
-export const PALETTE_SCROLLBAR_TRACK_WIDTH_PX = 0;
+export const PALETTE_SCROLLBAR_TRACK_WIDTH_PX = 4;
+
+/** Minimum wheel delta in pixels before advancing one palette row. */
+const PALETTE_SCROLL_WHEEL_ROW_PX = 8;
+
+/** Minimum pointer drag delta in pixels before advancing one palette row. */
+const PALETTE_SCROLL_DRAG_ROW_PX = 4;
 
 /** Duration for transient copy status tooltips in seconds. */
 export const PALETTE_COPY_STATUS_SECONDS = 0.75;
@@ -175,7 +188,10 @@ export function hitTestPaletteSwatch(
         return null;
     }
 
-    const bandRight = Math.min(paletteBand.x + paletteBand.width, displayWidth) - scrollbarTrackWidth;
+    const bandRight =
+        Math.min(paletteBand.x + paletteBand.width, displayWidth) -
+        scrollbarTrackWidth -
+        PALETTE_SCROLLBAR_EDGE_PADDING_PX;
 
     if (isPointerOutsidePaletteBand(pointerX, pointerY, paletteBand, bandRight)) {
         return null;
@@ -198,6 +214,125 @@ export function hitTestPaletteSwatch(
     }
 
     return index;
+}
+
+/**
+ * Returns the maximum scroll row offset for a palette grid viewport.
+ *
+ * @param grid - Precomputed grid layout.
+ * @returns Last valid `scrollRowOffset` (0 when all rows are visible).
+ */
+export function maxScrollRowOffset(grid: PaletteGridLayout): number {
+    return Math.max(0, grid.rows - grid.visibleRows);
+}
+
+/**
+ * Clamps a scroll row offset into the valid range for a palette grid viewport.
+ *
+ * @param offset - Requested first visible row.
+ * @param grid - Precomputed grid layout.
+ * @returns Clamped offset in `[0, maxScrollRowOffset]`.
+ */
+export function clampScrollRowOffset(offset: number, grid: PaletteGridLayout): number {
+    const maxOffset = maxScrollRowOffset(grid);
+
+    if (offset <= 0) {
+        return 0;
+    }
+
+    if (offset >= maxOffset) {
+        return maxOffset;
+    }
+
+    return offset;
+}
+
+/**
+ * Returns whether a pointer lies inside the palette footer scroll region.
+ *
+ * @param pointerX - Pointer X in display coordinates.
+ * @param pointerY - Pointer Y in display coordinates.
+ * @param paletteBand - Palette band rect from the layout plan.
+ * @returns `true` when wheel or drag scrolling may apply.
+ */
+function isPointerInPaletteScrollRegion(pointerX: number, pointerY: number, paletteBand: Rect2i): boolean {
+    return (
+        pointerX >= paletteBand.x &&
+        pointerX < paletteBand.x + paletteBand.width &&
+        pointerY >= paletteBand.y &&
+        pointerY < paletteBand.y + paletteBand.height
+    );
+}
+
+/**
+ * Returns whether a pointer lies inside the palette scrollbar track.
+ *
+ * @param pointerX - Pointer X in display coordinates.
+ * @param pointerY - Pointer Y in display coordinates.
+ * @param paletteBand - Palette band rect from the layout plan.
+ * @param grid - Precomputed grid layout.
+ * @param scrollRowOffset - First visible grid row.
+ * @param trackWidth - Scrollbar track width in pixels.
+ * @returns `true` when the pointer is over the track rect.
+ */
+export function isPointerInPaletteScrollbarTrack(
+    pointerX: number,
+    pointerY: number,
+    paletteBand: Rect2i,
+    grid: PaletteGridLayout,
+    scrollRowOffset: number,
+    trackWidth: number,
+): boolean {
+    const trackScratch = tooltipScratch.swatch;
+    const thumbScratch = tooltipScratch.outlineEdge;
+
+    if (!writePaletteScrollbarRects(trackScratch, thumbScratch, paletteBand, grid, scrollRowOffset, trackWidth)) {
+        return false;
+    }
+
+    return (
+        pointerX >= trackScratch.x &&
+        pointerX < trackScratch.x + trackScratch.width &&
+        pointerY >= trackScratch.y &&
+        pointerY < trackScratch.y + trackScratch.height
+    );
+}
+
+/**
+ * Maps a pointer Y position within the scrollbar track to a scroll row offset.
+ *
+ * @param pointerY - Pointer Y in display coordinates.
+ * @param paletteBand - Palette band rect from the layout plan.
+ * @param grid - Precomputed grid layout.
+ * @param trackWidth - Scrollbar track width in pixels.
+ * @returns Clamped scroll row offset.
+ */
+export function resolveScrollRowOffsetFromTrackPointerY(
+    pointerY: number,
+    paletteBand: Rect2i,
+    grid: PaletteGridLayout,
+    trackWidth: number,
+): number {
+    const maxOffset = maxScrollRowOffset(grid);
+
+    if (maxOffset <= 0) {
+        return 0;
+    }
+
+    const trackScratch = tooltipScratch.swatch;
+    const thumbScratch = tooltipScratch.outlineEdge;
+
+    writePaletteScrollbarRects(trackScratch, thumbScratch, paletteBand, grid, 0, trackWidth);
+
+    const trackTop = trackScratch.y;
+    const trackHeight = trackScratch.height;
+    const thumbHeight = computePaletteScrollbarThumbHeight(trackHeight, grid);
+    const scrollRange = Math.max(1, trackHeight - thumbHeight);
+    const localY = pointerY - trackTop - Math.floor(thumbHeight / 2);
+    const ratio = localY / scrollRange;
+    const offset = Math.round(ratio * maxOffset);
+
+    return clampScrollRowOffset(offset, grid);
 }
 
 // #endregion
@@ -362,6 +497,12 @@ export class PaletteInteraction {
 
     #scrollbarTrackWidth = PALETTE_SCROLLBAR_TRACK_WIDTH_PX;
 
+    #scrollDragSlot: number | null = null;
+
+    #scrollDragStartY = 0;
+
+    #scrollDragStartOffset = 0;
+
     /** Latest fixed-update tick observed from {@link tickCopyStatus} or {@link handlePress}. */
     #lastKnownTick = 0;
 
@@ -372,6 +513,226 @@ export class PaletteInteraction {
      */
     constructor(targetFps: number) {
         this.#targetFps = targetFps;
+    }
+
+    /**
+     * Current first visible palette grid row.
+     *
+     * @returns Scroll row offset in `[0, maxScrollRowOffset]`.
+     */
+    get scrollRowOffset(): number {
+        return this.#scrollRowOffset;
+    }
+
+    /**
+     * Scrollbar track width reserved on the right edge of the palette band.
+     *
+     * @returns Track width in pixels.
+     */
+    get scrollbarTrackWidth(): number {
+        return this.#scrollbarTrackWidth;
+    }
+
+    /**
+     * Clamps scroll offset when grid dimensions change between frames.
+     *
+     * @param grid - Precomputed grid layout for this frame.
+     */
+    syncScrollBounds(grid: PaletteGridLayout): void {
+        this.#scrollRowOffset = clampScrollRowOffset(this.#scrollRowOffset, grid);
+    }
+
+    /**
+     * Handles wheel and primary-drag scrolling for the palette footer region.
+     *
+     * Wheel delta is consumed only while the pointer is over the palette band so
+     * demo code reading {@link BT.pointerScrollDelta} elsewhere is unaffected.
+     *
+     * @param pointer - Pointer subsystem, or `null` when unavailable.
+     * @param plan - Layout plan for this frame.
+     * @param grid - Palette grid layout.
+     * @param swatchPressConsumed - When true, drag scrolling is skipped this frame.
+     * @returns `true` when a scrollbar-track press should block the toggle corner.
+     */
+    handleScroll(
+        pointer: PointerInput | null,
+        plan: OverlayLayoutPlan,
+        grid: PaletteGridLayout,
+        swatchPressConsumed: boolean,
+    ): boolean {
+        if (plan.paletteBand.height <= 0 || grid.cols <= 0 || maxScrollRowOffset(grid) <= 0 || !pointer) {
+            this.#scrollDragSlot = null;
+
+            return false;
+        }
+
+        this.syncScrollBounds(grid);
+
+        let togglePressConsumed = false;
+
+        for (let slot = 0; slot < POINTER_SLOT_COUNT; slot++) {
+            if (!pointer.isValid(slot)) {
+                if (this.#scrollDragSlot === slot) {
+                    this.#scrollDragSlot = null;
+                }
+
+                continue;
+            }
+
+            const pos = pointer.getPos(slot);
+
+            if (pointer.isButtonPressed(POINTER_PRIMARY_BUTTON, slot)) {
+                if (
+                    isPointerInPaletteScrollbarTrack(
+                        pos.x,
+                        pos.y,
+                        plan.paletteBand,
+                        grid,
+                        this.#scrollRowOffset,
+                        this.#scrollbarTrackWidth,
+                    )
+                ) {
+                    this.#scrollDragSlot = slot;
+                    this.#scrollDragStartY = pos.y;
+                    this.#scrollDragStartOffset = this.#scrollRowOffset;
+                    togglePressConsumed = true;
+                }
+            }
+        }
+
+        if (!swatchPressConsumed) {
+            togglePressConsumed = this.#applyScrollDrag(pointer, plan, grid) || togglePressConsumed;
+        } else {
+            this.#scrollDragSlot = null;
+        }
+
+        togglePressConsumed = this.#applyScrollWheel(pointer, plan, grid) || togglePressConsumed;
+
+        return togglePressConsumed;
+    }
+
+    /**
+     * Applies wheel scrolling when the pointer is over the palette footer region.
+     *
+     * @param pointer - Pointer subsystem.
+     * @param plan - Layout plan for this frame.
+     * @param grid - Palette grid layout.
+     * @returns `true` when wheel delta was consumed.
+     */
+    #applyScrollWheel(pointer: PointerInput, plan: OverlayLayoutPlan, grid: PaletteGridLayout): boolean {
+        const scrollDelta = pointer.getScrollDelta();
+
+        if (scrollDelta === 0) {
+            return false;
+        }
+
+        for (let slot = 0; slot < POINTER_SLOT_COUNT; slot++) {
+            if (!pointer.isValid(slot)) {
+                continue;
+            }
+
+            const pos = pointer.getPos(slot);
+
+            if (!isPointerInPaletteScrollRegion(pos.x, pos.y, plan.paletteBand)) {
+                continue;
+            }
+
+            const rowStep = Math.max(1, Math.trunc(Math.abs(scrollDelta) / PALETTE_SCROLL_WHEEL_ROW_PX));
+            const nextOffset = this.#scrollRowOffset + (scrollDelta > 0 ? rowStep : -rowStep);
+
+            this.#scrollRowOffset = clampScrollRowOffset(nextOffset, grid);
+            pointer.consumeScrollDelta();
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Applies primary-button drag scrolling over the palette grid or scrollbar track.
+     *
+     * @param pointer - Pointer subsystem.
+     * @param plan - Layout plan for this frame.
+     * @param grid - Palette grid layout.
+     * @returns `true` when drag scrolling consumed a toggle-corner press.
+     */
+    #applyScrollDrag(pointer: PointerInput, plan: OverlayLayoutPlan, grid: PaletteGridLayout): boolean {
+        let togglePressConsumed = false;
+
+        for (let slot = 0; slot < POINTER_SLOT_COUNT; slot++) {
+            if (!pointer.isButtonDown(POINTER_PRIMARY_BUTTON, slot) || !pointer.isValid(slot)) {
+                if (this.#scrollDragSlot === slot) {
+                    this.#scrollDragSlot = null;
+                }
+
+                continue;
+            }
+
+            const pos = pointer.getPos(slot);
+            const inScrollRegion = isPointerInPaletteScrollRegion(pos.x, pos.y, plan.paletteBand);
+
+            if (!inScrollRegion && this.#scrollDragSlot !== slot) {
+                continue;
+            }
+
+            if (
+                isPointerInPaletteScrollbarTrack(
+                    pos.x,
+                    pos.y,
+                    plan.paletteBand,
+                    grid,
+                    this.#scrollRowOffset,
+                    this.#scrollbarTrackWidth,
+                )
+            ) {
+                togglePressConsumed = true;
+            }
+
+            if (this.#scrollDragSlot === slot) {
+                if (
+                    isPointerInPaletteScrollbarTrack(
+                        pos.x,
+                        pos.y,
+                        plan.paletteBand,
+                        grid,
+                        this.#scrollRowOffset,
+                        this.#scrollbarTrackWidth,
+                    )
+                ) {
+                    this.#scrollRowOffset = resolveScrollRowOffsetFromTrackPointerY(
+                        pos.y,
+                        plan.paletteBand,
+                        grid,
+                        this.#scrollbarTrackWidth,
+                    );
+                } else {
+                    const deltaY = pos.y - this.#scrollDragStartY;
+                    const rowStep = Math.trunc(deltaY / PALETTE_SCROLL_DRAG_ROW_PX);
+
+                    this.#scrollRowOffset = clampScrollRowOffset(this.#scrollDragStartOffset - rowStep, grid);
+                }
+
+                continue;
+            }
+
+            if (!inScrollRegion) {
+                continue;
+            }
+
+            this.#scrollDragSlot = slot;
+            this.#scrollDragStartY = pos.y;
+            this.#scrollDragStartOffset = this.#scrollRowOffset;
+
+            const deltaY = pos.y - this.#scrollDragStartY;
+            const rowStep = Math.trunc(deltaY / PALETTE_SCROLL_DRAG_ROW_PX);
+
+            if (rowStep !== 0) {
+                this.#scrollRowOffset = clampScrollRowOffset(this.#scrollDragStartOffset - rowStep, grid);
+            }
+        }
+
+        return togglePressConsumed;
     }
 
     /**

--- a/src/overlay/palette/PaletteView.test.ts
+++ b/src/overlay/palette/PaletteView.test.ts
@@ -21,6 +21,7 @@ import {
     paletteGridRowWidth,
     PaletteView,
     pickPaletteGridColumnCount,
+    resolvePaletteGridVisibleRows,
 } from './PaletteView';
 
 /** Builds a usage mask from palette slot indices for tests. */
@@ -149,6 +150,17 @@ describe('computePaletteGrid', () => {
         expect(computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 16, PALETTE_SWATCH_GAP_PX, 8).cols).toBe(8);
         expect(computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 16, PALETTE_SWATCH_GAP_PX, 8).rows).toBe(2);
         expect(pickPaletteGridColumnCount(320, DEFAULT_PALETTE_SWATCH_SIZE, PALETTE_SWATCH_GAP_PX, 256, 8)).toBe(8);
+    });
+});
+
+describe('resolvePaletteGridVisibleRows', () => {
+    it('ignores non-finite caps and returns all rows', () => {
+        expect(resolvePaletteGridVisibleRows(8, Number.NaN)).toBe(8);
+        expect(resolvePaletteGridVisibleRows(8, Number.POSITIVE_INFINITY)).toBe(8);
+    });
+
+    it('truncates fractional caps before clamping', () => {
+        expect(resolvePaletteGridVisibleRows(8, 2.9)).toBe(2);
     });
 });
 

--- a/src/overlay/palette/PaletteView.test.ts
+++ b/src/overlay/palette/PaletteView.test.ts
@@ -109,10 +109,34 @@ describe('computePaletteGrid', () => {
         expect(computePaletteGrid(320, 4, 0, 1)).toEqual({
             cols: 0,
             rows: 0,
+            visibleRows: 0,
             swatchSize: 4,
             gap: 1,
             totalHeight: 0,
         });
+    });
+
+    it('caps visible rows and band height when overlayPaletteRowsVisible is set', () => {
+        const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 256, PALETTE_SWATCH_GAP_PX, undefined, 3);
+
+        expect(grid.rows).toBe(8);
+        expect(grid.visibleRows).toBe(3);
+        expect(grid.totalHeight).toBe(
+            paletteGridRowStackHeight(3, grid.swatchSize, grid.gap) + PALETTE_GRID_PADDING_PX * 2,
+        );
+    });
+
+    it('clamps overlayPaletteRowsVisible below 1 up to one visible row', () => {
+        const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 256, PALETTE_SWATCH_GAP_PX, undefined, 0);
+
+        expect(grid.visibleRows).toBe(1);
+    });
+
+    it('clamps overlayPaletteRowsVisible above total rows down to total rows', () => {
+        const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 16, PALETTE_SWATCH_GAP_PX, undefined, 99);
+
+        expect(grid.rows).toBe(1);
+        expect(grid.visibleRows).toBe(1);
     });
 
     it('matches pickPaletteGridColumnCount helper cases', () => {
@@ -300,5 +324,36 @@ describe('PaletteView.draw', () => {
         );
 
         expect(drawBarFill).not.toHaveBeenCalled();
+    });
+
+    it('draws only the visible row window when scroll offset is non-zero', () => {
+        const layout = createOverlayLayout(320, 240, 14);
+        const palette = new Palette(256);
+        const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, palette.size, 1, undefined, 3);
+        const scrollRowOffset = 2;
+        const paletteBandTop = paletteBandY(240, grid.totalHeight);
+        const view = new PaletteView(true);
+        const { drawBarFill, calls } = createRectFillMock();
+        const renderer = { drawBarFill } as never;
+        const usedMask = buildUsageMask([grid.cols * scrollRowOffset]);
+
+        view.draw(
+            renderer,
+            new Rect2i(0, paletteBandTop, 320, grid.totalHeight),
+            palette,
+            grid,
+            layout.bottomTextY,
+            layout.displayWidth,
+            layout.lineHeight,
+            usedMask,
+            DEFAULT_IDX_TEXT,
+            scrollRowOffset,
+        );
+
+        const visibleIndex = grid.cols * scrollRowOffset;
+        const hiddenIndex = visibleIndex - grid.cols;
+
+        expect(calls.some((call) => call.index === visibleIndex)).toBe(true);
+        expect(calls.some((call) => call.index === hiddenIndex)).toBe(false);
     });
 });

--- a/src/overlay/palette/PaletteView.ts
+++ b/src/overlay/palette/PaletteView.ts
@@ -124,11 +124,13 @@ export function resolvePaletteGridVisibleRows(totalRows: number, maxVisibleRows?
         return 0;
     }
 
-    if (maxVisibleRows === undefined) {
+    if (maxVisibleRows === undefined || !Number.isFinite(maxVisibleRows)) {
         return totalRows;
     }
 
-    return Math.min(totalRows, Math.max(1, maxVisibleRows));
+    const parsedMax = Math.max(1, Math.trunc(maxVisibleRows));
+
+    return Math.min(totalRows, parsedMax);
 }
 
 /**

--- a/src/overlay/palette/PaletteView.ts
+++ b/src/overlay/palette/PaletteView.ts
@@ -25,10 +25,17 @@ export const PALETTE_SWATCH_GAP_PX = 1;
 /** Padding below the swatch grid inside the bottom band. */
 export const PALETTE_GRID_PADDING_PX = 3;
 
+/** Minimum palette scrollbar thumb height in pixels (macOS-style overlay scroll indicator). */
+export const PALETTE_SCROLLBAR_MIN_THUMB_HEIGHT_PX = 4;
+
+/** Inset of the scrollbar track from the palette band top, right, and bottom edges. */
+export const PALETTE_SCROLLBAR_EDGE_PADDING_PX = 1;
+
 /** Empty grid placeholder when the palette view is disabled. */
 export const DEFAULT_PALETTE_GRID: PaletteGridLayout = {
     cols: 0,
     rows: 0,
+    visibleRows: 0,
     swatchSize: 0,
     gap: 0,
     totalHeight: 0,
@@ -106,6 +113,25 @@ export function pickPaletteGridColumnCount(
 }
 
 /**
+ * Resolves the visible row count for a palette grid viewport.
+ *
+ * @param totalRows - Full palette row count.
+ * @param maxVisibleRows - Optional cap from {@link HardwareSettings.overlayPaletteRowsVisible}.
+ * @returns Visible rows (0 when `totalRows` is 0; otherwise clamped to `[1, totalRows]`).
+ */
+export function resolvePaletteGridVisibleRows(totalRows: number, maxVisibleRows?: number): number {
+    if (totalRows <= 0) {
+        return 0;
+    }
+
+    if (maxVisibleRows === undefined) {
+        return totalRows;
+    }
+
+    return Math.min(totalRows, Math.max(1, maxVisibleRows));
+}
+
+/**
  * Computes palette grid layout for the bottom band.
  *
  * @param displayWidth - Logical display width in pixels.
@@ -113,7 +139,8 @@ export function pickPaletteGridColumnCount(
  * @param colorCount - Number of palette slots to show (default 256).
  * @param gap - Gap between swatches (default 1).
  * @param maxColumns - Optional cap from {@link HardwareSettings.overlayPaletteColumns}.
- * @returns Grid dimensions and total bottom band height.
+ * @param maxVisibleRows - Optional cap from {@link HardwareSettings.overlayPaletteRowsVisible}.
+ * @returns Grid dimensions and viewport band height.
  */
 export function computePaletteGrid(
     displayWidth: number,
@@ -121,16 +148,18 @@ export function computePaletteGrid(
     colorCount = 256,
     gap = PALETTE_SWATCH_GAP_PX,
     maxColumns?: number,
+    maxVisibleRows?: number,
 ): PaletteGridLayout {
     if (colorCount <= 0) {
-        return { cols: 0, rows: 0, swatchSize, gap, totalHeight: 0 };
+        return { cols: 0, rows: 0, visibleRows: 0, swatchSize, gap, totalHeight: 0 };
     }
 
     const cols = pickPaletteGridColumnCount(displayWidth, swatchSize, gap, colorCount, maxColumns);
     const rows = Math.ceil(colorCount / cols);
-    const totalHeight = paletteGridRowStackHeight(rows, swatchSize, gap) + PALETTE_GRID_PADDING_PX * 2;
+    const visibleRows = resolvePaletteGridVisibleRows(rows, maxVisibleRows);
+    const totalHeight = paletteGridRowStackHeight(visibleRows, swatchSize, gap) + PALETTE_GRID_PADDING_PX * 2;
 
-    return { cols, rows, swatchSize, gap, totalHeight };
+    return { cols, rows, visibleRows, swatchSize, gap, totalHeight };
 }
 
 // #endregion
@@ -381,7 +410,7 @@ export function writePaletteSwatchTopLeft(
 }
 
 /**
- * Draws the full palette swatch grid inside the bottom band.
+ * Draws the visible palette swatch window inside the bottom band.
  *
  * @param target - Overlay draw target.
  * @param paletteBand - Palette band rect from layout plan.
@@ -390,6 +419,7 @@ export function writePaletteSwatchTopLeft(
  * @param hintExclusion - Region to skip for the `[~]` hint label.
  * @param usedMask - Per-frame usage mask from BTAPI.
  * @param unusedMarkIndex - Palette index for unused swatch marker fills.
+ * @param scrollRowOffset - First visible grid row (default `0`).
  */
 function drawPaletteSwatchGrid(
     target: OverlayDrawTarget,
@@ -399,13 +429,16 @@ function drawPaletteSwatchGrid(
     hintExclusion: Rect2i,
     usedMask: Uint8Array,
     unusedMarkIndex: number,
+    scrollRowOffset = 0,
 ): void {
-    const { swatchSize } = grid;
+    const { cols, visibleRows, swatchSize } = grid;
     const swatchScratch = paletteGridDrawScratch.swatch;
     const markerScratch = paletteGridDrawScratch.marker;
+    const firstIndex = scrollRowOffset * cols;
+    const lastIndex = Math.min(colorCount, (scrollRowOffset + visibleRows) * cols);
 
-    for (let index = 0; index < colorCount; index++) {
-        writePaletteSwatchTopLeft(swatchScratch, index, paletteBand, grid);
+    for (let index = firstIndex; index < lastIndex; index++) {
+        writePaletteSwatchTopLeft(swatchScratch, index, paletteBand, grid, scrollRowOffset);
         const x = swatchScratch.x;
         const y = swatchScratch.y;
 
@@ -417,6 +450,107 @@ function drawPaletteSwatchGrid(
 
         drawPaletteSwatch(target, swatchScratch, markerScratch, x, y, swatchSize, index, usedMask, unusedMarkIndex);
     }
+}
+
+/**
+ * Computes macOS-style thumb height: visible fraction of total rows, clamped to the track.
+ *
+ * @param trackHeight - Full palette band height in pixels.
+ * @param grid - Precomputed grid layout.
+ * @returns Thumb height in pixels, or `0` when inputs are invalid.
+ */
+export function computePaletteScrollbarThumbHeight(trackHeight: number, grid: PaletteGridLayout): number {
+    const { rows, visibleRows } = grid;
+
+    if (rows <= 0 || trackHeight <= 0) {
+        return 0;
+    }
+
+    const proportional = Math.floor((visibleRows / rows) * trackHeight);
+
+    return Math.min(trackHeight, Math.max(PALETTE_SCROLLBAR_MIN_THUMB_HEIGHT_PX, proportional));
+}
+
+/**
+ * Writes the palette scrollbar track and thumb rects for the bottom band.
+ *
+ * The track is inset 1 px from the palette band top, right, and bottom edges. Only the
+ * thumb is drawn; the track rect is used for hit testing and thumb placement.
+ *
+ * @param trackTarget - Reusable track rect mutated in place.
+ * @param thumbTarget - Reusable thumb rect mutated in place.
+ * @param paletteBand - Palette band rect from layout plan.
+ * @param grid - Precomputed grid layout.
+ * @param scrollRowOffset - First visible grid row.
+ * @param trackWidth - Scrollbar track width in pixels.
+ * @returns `true` when scrolling is possible and rects were written.
+ */
+export function writePaletteScrollbarRects(
+    trackTarget: Rect2i,
+    thumbTarget: Rect2i,
+    paletteBand: Rect2i,
+    grid: PaletteGridLayout,
+    scrollRowOffset: number,
+    trackWidth: number,
+): boolean {
+    const maxOffset = Math.max(0, grid.rows - grid.visibleRows);
+
+    if (maxOffset <= 0 || trackWidth <= 0 || grid.visibleRows <= 0) {
+        trackTarget.set(paletteBand.x, paletteBand.y, 0, 0);
+        thumbTarget.set(paletteBand.x, paletteBand.y, 0, 0);
+
+        return false;
+    }
+
+    const pad = PALETTE_SCROLLBAR_EDGE_PADDING_PX;
+    const trackX = paletteBand.x + paletteBand.width - trackWidth - pad;
+    const trackY = paletteBand.y + pad;
+    const trackHeight = paletteBand.height - pad * 2;
+
+    if (trackHeight <= 0) {
+        trackTarget.set(paletteBand.x, paletteBand.y, 0, 0);
+        thumbTarget.set(paletteBand.x, paletteBand.y, 0, 0);
+
+        return false;
+    }
+
+    trackTarget.set(trackX, trackY, trackWidth, trackHeight);
+
+    const thumbHeight = computePaletteScrollbarThumbHeight(trackHeight, grid);
+    const scrollRange = Math.max(0, trackHeight - thumbHeight);
+    const thumbY = trackY + Math.floor((scrollRowOffset / maxOffset) * scrollRange);
+
+    thumbTarget.set(trackX, thumbY, trackWidth, thumbHeight);
+
+    return true;
+}
+
+/**
+ * Draws the palette scrollbar thumb inside the bottom band (no track fill).
+ *
+ * @param target - Overlay draw target.
+ * @param paletteBand - Palette band rect from layout plan.
+ * @param grid - Precomputed grid layout.
+ * @param scrollRowOffset - First visible grid row.
+ * @param trackWidth - Scrollbar track width in pixels.
+ * @param thumbIndex - Palette index for the thumb fill.
+ */
+function drawPaletteScrollbar(
+    target: OverlayDrawTarget,
+    paletteBand: Rect2i,
+    grid: PaletteGridLayout,
+    scrollRowOffset: number,
+    trackWidth: number,
+    thumbIndex: number,
+): void {
+    const trackScratch = paletteGridDrawScratch.swatch;
+    const thumbScratch = paletteGridDrawScratch.marker;
+
+    if (!writePaletteScrollbarRects(trackScratch, thumbScratch, paletteBand, grid, scrollRowOffset, trackWidth)) {
+        return;
+    }
+
+    target.drawBarFill(thumbScratch, thumbIndex);
 }
 
 // #endregion
@@ -459,6 +593,9 @@ export class PaletteView {
      * @param lineHeight - System font line height for hint exclusion.
      * @param usedMask - Per-frame usage mask populated during demo render.
      * @param unusedMarkIndex - Palette index for unused swatch marker fills.
+     * @param scrollRowOffset - First visible grid row (default `0`).
+     * @param scrollbarTrackWidth - Right-edge scrollbar track width (default `0`).
+     * @param scrollbarThumbIndex - Palette index for scrollbar thumb fill.
      */
     draw(
         target: OverlayDrawTarget,
@@ -470,6 +607,9 @@ export class PaletteView {
         lineHeight: number,
         usedMask: Uint8Array,
         unusedMarkIndex: number,
+        scrollRowOffset = 0,
+        scrollbarTrackWidth = 0,
+        scrollbarThumbIndex = unusedMarkIndex,
     ): void {
         if (!this.#enabled || palette === null || grid.cols <= 0) {
             return;
@@ -477,7 +617,18 @@ export class PaletteView {
 
         const hintExclusion = resolvePaletteHintExclusionRect(bottomTextY, displayWidth, lineHeight);
 
-        drawPaletteSwatchGrid(target, paletteBand, palette.size, grid, hintExclusion, usedMask, unusedMarkIndex);
+        drawPaletteSwatchGrid(
+            target,
+            paletteBand,
+            palette.size,
+            grid,
+            hintExclusion,
+            usedMask,
+            unusedMarkIndex,
+            scrollRowOffset,
+        );
+
+        drawPaletteScrollbar(target, paletteBand, grid, scrollRowOffset, scrollbarTrackWidth, scrollbarThumbIndex);
     }
 }
 

--- a/src/overlay/types.ts
+++ b/src/overlay/types.ts
@@ -26,8 +26,11 @@ export interface PaletteGridLayout {
     /** Number of columns in the grid. */
     readonly cols: number;
 
-    /** Number of rows in the grid. */
+    /** Number of rows in the full palette grid. */
     readonly rows: number;
+
+    /** Number of rows visible in the viewport (<= {@link rows}). */
+    readonly visibleRows: number;
 
     /** Side length of each swatch in pixels. */
     readonly swatchSize: number;
@@ -35,6 +38,6 @@ export interface PaletteGridLayout {
     /** Gap between swatches horizontally and vertically. */
     readonly gap: number;
 
-    /** Total palette band height including padding. */
+    /** Total palette band height including padding (based on {@link visibleRows}). */
     readonly totalHeight: number;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR adds a viewport for the overlay palette with row capping and scrolling, plus a scrollbar in the overlay footer. When the palette contains more rows than the viewport, users can scroll via wheel or drag the scrollbar thumb; the visible row count can be capped via hardware settings.

## Key Features

Palette row viewport
- New optional hardware setting HardwareSettings.overlayPaletteRowsVisible to cap the maximum visible palette rows.
- Visible rows are clamped to at least 1 and at most the grid's total rows.
- PaletteGridLayout now includes visibleRows and totalHeight is computed from visibleRows.

Scroll interaction
- Wheel scrolling is consumed only when the pointer is inside the palette footer band; scroll deltas outside that region are not consumed.
- Primary-button drags on the scrollbar track start scroll dragging; clicking the track updates the scroll position.
- Clicking the scrollbar track prevents the overlay from toggling while keeping the overlay body visible (covered by a new VV-550 integration test).
- New PointerInput.consumeScrollDelta() clears per-frame wheel delta after consumption.

Scrollbar rendering and metrics
- A macOS-style scrollbar is drawn in the palette footer.
- Scrollbar track width constant set to 4px (PALETTE_SCROLLBAR_TRACK_WIDTH_PX).
- Thumb height is proportional to visibleRows/rows with a 4px minimum (PALETTE_SCROLLBAR_MIN_THUMB_HEIGHT_PX).
- Helpers added to compute track/thumb rects and map track pointer Y to scroll offsets.

APIs and implementation
- Overlay constructor accepts optional overlayPaletteRowsVisible (passed from BTAPI.setupOverlay via HardwareSettings).
- computePaletteGrid gained maxVisibleRows and returns visibleRows; computePaletteGrid and related helpers updated accordingly.
- PaletteView.draw now accepts scrollRowOffset, scrollbarTrackWidth, and scrollbarThumbIndex and only renders swatches in the visible window; writePaletteSwatchTopLeft accepts scrollRowOffset.
- PaletteInteraction was extended with scroll state and public API: getters scrollRowOffset and scrollbarTrackWidth, syncScrollBounds(), and handleScroll(pointer, plan, grid, swatchPressConsumed) which handles wheel and drag-based scrolling. New helpers: maxScrollRowOffset, clampScrollRowOffset, isPointerInPaletteScrollbarTrack, resolveScrollRowOffsetFromTrackPointerY.
- Overlay synchronizes palette scroll bounds before processing pointer presses and incorporates palette scroll consumption into press handling. Palette drawing receives scroll rendering state parameters.

Configuration propagation
- HardwareSettings.overlayPaletteRowsVisible added to configuration flow and merged across configure()/full-default/explicit display-size paths.
- Example overlay configuration in docs set overlayPaletteRowsVisible: 3.

Testing
- Integration test (VV-550) added to ensure scrollbar track presses don’t toggle the overlay.
- Unit tests expanded: computePaletteGrid visibleRows behavior and clamping, resolvePaletteGridVisibleRows tests, layout footer height when grid is capped, palette scroll helpers (clamping, thumb sizing and mapping), and PaletteInteraction scroll behavior (wheel consumption only inside palette band, drag behavior, track hit tests).

Documentation
- docs/api-core.md updated to document overlayPaletteRowsVisible behavior, clamped visible-row count, scrollbar thumb sizing/behavior, wheel-scroll consumption constrained to the palette footer band, and updated overlay sizing snippet using visibleRows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->