### PR TITLE
feat(overlay): add timing chart severity tints for drops and over-budget

### DIFF
--- a/docs/api-core.md
+++ b/docs/api-core.md
@@ -212,8 +212,14 @@ otherwise.
   defaults to **22 px**; override with `overlayTimingChartHeight`. Dot height scales linearly so about **16 ms** fills
   the band; any non-zero sample draws at least one pixel (sub-millisecond work shows as a baseline dot). The band
   background uses `overlayStyle.barPaletteIndex`; dot colors default to `overlayStyle.barPaletteIndex` /
-  `textPaletteIndex`; override with `overlayTimingChartStyle`. Additional warning/error/event palette slots are reserved
-  for future chart overlays.
+  `textPaletteIndex`; override with `overlayTimingChartStyle`. **Semantic tints (VV-545):** when a column is classified
+  as a runtime risk, both update and render dots use the warning or error palette index instead of the normal bar
+  colors. Classification uses the prior frame's `Frame` wall time against `1000 / targetFPS` (warning at **1.10x**
+  budget, error at **1.50x**) and dropped-frame events from the game loop (one dropped frame = warning, two or more =
+  error; error wins when both apply). Default warning/error/event palette indices are **3**, **4**, and **5** when not
+  overridden. Drop detection for the chart runs whenever `overlayTimingChart: true` (independent of
+  `detectDroppedFrames`, which only controls console warnings). The `eventPaletteIndex` slot is reserved for chart event
+  tags (VV-541).
 - **Top row 2 (left):** `Present: N FPS | Target: T FPS | Draw Calls: C`
 - **Top row 3 (left):** `Frame: Xms | update(): Yms | render(): Zms` (shows `xN` on `update()` when multiple fixed
   updates ran this frame)
@@ -321,6 +327,8 @@ configure() {
     overlayTimingChartStyle: {
       updateBarPaletteIndex: 2, // defaults to barPaletteIndex when omitted
       renderBarPaletteIndex: 3, // defaults to textPaletteIndex when omitted
+      warningPaletteIndex: 3, // soft over-budget / single drop; default 3
+      errorPaletteIndex: 4, // hard over-budget / 2+ drops; default 4
     },
   };
 }

--- a/src/core/BTAPI.test.ts
+++ b/src/core/BTAPI.test.ts
@@ -888,7 +888,14 @@ describe('BTAPI', () => {
             const lastCall = overlaySpy.mock.calls.at(-1);
             const getCustomRows = lastCall?.[5] as (() => typeof customRows) | undefined;
             const timing = lastCall?.[6] as
-                | { frameMs: number; updateMs: number; renderMs: number; updateSteps: number; drawCalls: number }
+                | {
+                      frameMs: number;
+                      updateMs: number;
+                      renderMs: number;
+                      updateSteps: number;
+                      drawCalls: number;
+                      droppedFrames: number;
+                  }
                 | undefined;
 
             expect(getCustomRows?.()).toBe(customRows);
@@ -898,6 +905,7 @@ describe('BTAPI', () => {
             expect(timing?.renderMs).toBeGreaterThanOrEqual(0);
             expect(timing?.updateSteps).toBeGreaterThanOrEqual(0);
             expect(timing?.drawCalls).toBeGreaterThanOrEqual(0);
+            expect(timing?.droppedFrames).toBeGreaterThanOrEqual(0);
         });
 
         it('calls gamepad.endFrame during render-phase input flush', async () => {

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -141,12 +141,14 @@ export class BTAPI {
         renderMs: number;
         updateSteps: number;
         drawCalls: number;
+        droppedFrames: number;
     } = {
         frameMs: 0,
         updateMs: 0,
         renderMs: 0,
         updateSteps: 0,
         drawCalls: 0,
+        droppedFrames: 0,
     };
 
     /** Pointer / mouse / touch input subsystem. Created during {@link init}. */
@@ -253,8 +255,11 @@ export class BTAPI {
 
         // Start the loop. The GameLoop's double-RAF delay ensures the canvas is
         // fully ready before the first tick.
-        const onFrameDrop: FrameDropCallback | undefined =
-            hwSettings.detectDroppedFrames === true ? (event) => this.handleFrameDrop(event) : undefined;
+        const needsFrameDropCallback =
+            hwSettings.detectDroppedFrames === true || hwSettings.overlayTimingChart === true;
+        const onFrameDrop: FrameDropCallback | undefined = needsFrameDropCallback
+            ? (event) => this.handleFrameDrop(event, hwSettings.detectDroppedFrames === true)
+            : undefined;
 
         this.pendingUpdateMs = 0;
         this.pendingUpdateSteps = 0;
@@ -264,6 +269,7 @@ export class BTAPI {
         this.overlayTiming.renderMs = 0;
         this.overlayTiming.updateSteps = 0;
         this.overlayTiming.drawCalls = 0;
+        this.overlayTiming.droppedFrames = 0;
 
         this.loop = new GameLoop(
             updateInterval,
@@ -329,6 +335,7 @@ export class BTAPI {
                 this.overlayTiming.renderMs = renderMs;
                 this.overlayTiming.updateSteps = this.pendingUpdateSteps;
                 this.overlayTiming.drawCalls = this.pendingDrawCalls;
+                this.overlayTiming.droppedFrames = 0;
 
                 this.pendingUpdateMs = 0;
                 this.pendingUpdateSteps = 0;
@@ -1247,20 +1254,24 @@ export class BTAPI {
     // #region Private Helpers
 
     /**
-     * Logs a dropped-frame event from the {@link GameLoop} as a console warning.
+     * Records dropped-frame severity for the timing chart and optionally logs a warning.
      *
-     * One line per event. The {@link GameLoop} auto-calibrates its baseline
-     * to the actual rAF cadence, so sustained slowness re-baselines instead
-     * of generating sustained log spam, leaving only genuine missed-vsync
-     * events to be reported here.
+     * When {@link logToConsole} is true, emits one line per event. The {@link GameLoop}
+     * auto-calibrates its baseline to the actual rAF cadence, so sustained slowness
+     * re-baselines instead of generating sustained log spam.
      *
-     * @param event - Dropped-frame event.
+     * @param event - Dropped-frame event from {@link GameLoop}.
+     * @param logToConsole - When true, emits a one-line console warning.
      */
-    private handleFrameDrop(event: FrameDropEvent): void {
-        console.warn(
-            `[BT] Dropped ${event.droppedFrames} frame(s) ` +
-                `(frame time ${event.deltaTime.toFixed(1)}ms, expected ${event.expectedInterval.toFixed(1)}ms)`,
-        );
+    private handleFrameDrop(event: FrameDropEvent, logToConsole: boolean): void {
+        this.overlayTiming.droppedFrames = event.droppedFrames;
+
+        if (logToConsole) {
+            console.warn(
+                `[BT] Dropped ${event.droppedFrames} frame(s) ` +
+                    `(frame time ${event.deltaTime.toFixed(1)}ms, expected ${event.expectedInterval.toFixed(1)}ms)`,
+            );
+        }
     }
 
     /**

--- a/src/core/IBlitTechDemo.ts
+++ b/src/core/IBlitTechDemo.ts
@@ -188,8 +188,8 @@ export interface HardwareSettings {
 
     /**
      * Optional palette indices for the timing chart band. Update/render bar colors default to
-     * {@link OverlayStyle} bar/text indices; warning/error/event slots provision semantic
-     * tints for follow-up chart overlays (VV-545).
+     * {@link OverlayStyle} bar/text indices; warning/error/event slots control semantic
+     * chart tints (VV-545) and future tag markers (VV-541).
      */
     overlayTimingChartStyle?: OverlayTimingChartStyle;
 }
@@ -222,10 +222,10 @@ export interface OverlayTimingChartStyle {
     /** Render bar color; defaults to {@link OverlayStyle.textPaletteIndex} or overlay text index. */
     renderBarPaletteIndex?: number;
 
-    /** Warning tint for future severity overlays (VV-545). */
+    /** Warning tint when a chart column is over budget or dropped one frame (VV-545). */
     warningPaletteIndex?: number;
 
-    /** Error tint for future severity overlays (VV-545). */
+    /** Error tint when a chart column is severely over budget or dropped 2+ frames (VV-545). */
     errorPaletteIndex?: number;
 
     /** Event/tag tint for future chart markers (VV-541). */

--- a/src/overlay/Overlay.test.ts
+++ b/src/overlay/Overlay.test.ts
@@ -38,7 +38,12 @@ interface OverlayTestOptions {
     paletteColumns?: number;
     paletteRowsVisible?: number;
     timingChart?: boolean;
-    timingChartStyle?: { updateBarPaletteIndex?: number; renderBarPaletteIndex?: number };
+    timingChartStyle?: {
+        updateBarPaletteIndex?: number;
+        renderBarPaletteIndex?: number;
+        warningPaletteIndex?: number;
+        errorPaletteIndex?: number;
+    };
     timingChartHeight?: number;
     visibleAtStart?: boolean;
     toggleHintVisible?: boolean;
@@ -260,6 +265,7 @@ describe('Overlay', () => {
             renderMs: 3.75,
             updateSteps: 3,
             drawCalls: 42,
+            droppedFrames: 0,
         });
 
         const calls = getBitmapTextCalls(renderer);
@@ -625,6 +631,7 @@ describe('Overlay', () => {
             renderMs: 100,
             updateSteps: 1,
             drawCalls: 4,
+            droppedFrames: 0,
         });
 
         const dotCalls = renderer.drawBarFill.mock.calls.filter(
@@ -634,6 +641,38 @@ describe('Overlay', () => {
 
         expect(paletteIndices).toContain(10);
         expect(paletteIndices).toContain(11);
+    });
+
+    it('tints timing chart dots with warning palette when frame exceeds soft budget', () => {
+        const layout = createOverlayLayout(320, 240, 14);
+        const overlay = createOverlay(layout, 'Demo', {
+            timingChart: true,
+            timingChartStyle: {
+                updateBarPaletteIndex: 10,
+                renderBarPaletteIndex: 11,
+                warningPaletteIndex: 3,
+                errorPaletteIndex: 4,
+            },
+            visibleAtStart: true,
+        });
+        const renderer = createMockRenderer();
+
+        overlay.updateAndRender(renderer, mockFont, null, null, 0, undefined, {
+            frameMs: 20,
+            updateMs: 12,
+            renderMs: 8,
+            updateSteps: 1,
+            drawCalls: 4,
+            droppedFrames: 0,
+        });
+
+        const dotCalls = renderer.drawBarFill.mock.calls.filter(
+            (call) => (call[0] as { width: number }).width === 1 && (call[0] as { height: number }).height === 1,
+        );
+        const paletteIndices = dotCalls.map((call) => call[1] as number);
+
+        expect(paletteIndices.length).toBeGreaterThan(0);
+        expect(paletteIndices.every((index) => index === 3)).toBe(true);
     });
 
     it('does not draw overlay while hidden but keeps timing chart samples for re-show', () => {
@@ -653,6 +692,7 @@ describe('Overlay', () => {
             renderMs: 8,
             updateSteps: 1,
             drawCalls: 4,
+            droppedFrames: 0,
         });
 
         expect(renderer.drawBarFill).not.toHaveBeenCalled();
@@ -664,6 +704,7 @@ describe('Overlay', () => {
             renderMs: 8,
             updateSteps: 1,
             drawCalls: 4,
+            droppedFrames: 1,
         });
 
         expect(renderer.drawBarFill.mock.calls.some((call) => call[1] === 10)).toBe(true);
@@ -680,9 +721,45 @@ describe('Overlay', () => {
             renderMs: 100,
             updateSteps: 1,
             drawCalls: 4,
+            droppedFrames: 0,
         });
 
         expect(renderer.drawBarFill.mock.calls.some((call) => call[1] === 10)).toBe(false);
+    });
+
+    it('records drop severity in chart history while body is hidden', () => {
+        const layout = createOverlayLayout(320, 240, 14);
+        const overlay = createOverlay(layout, 'Demo', {
+            timingChart: true,
+            timingChartStyle: { warningPaletteIndex: 3, errorPaletteIndex: 4 },
+            visibleAtStart: true,
+            toggleHintVisible: false,
+        });
+        const renderer = createMockRenderer();
+
+        overlay.handleToggle(null, { isKeyPressed: (key: string) => key === 'Backquote' } as never, 1);
+        overlay.updateAndRender(renderer, mockFont, null, null, 0, undefined, {
+            frameMs: 0,
+            updateMs: 0,
+            renderMs: 0,
+            updateSteps: 0,
+            drawCalls: 0,
+            droppedFrames: 1,
+        });
+
+        expect(renderer.drawBarFill).not.toHaveBeenCalled();
+
+        overlay.handleToggle(null, { isKeyPressed: (key: string) => key === 'Backquote' } as never, 2);
+        overlay.updateAndRender(renderer, mockFont, null, null, 0, undefined, {
+            frameMs: 0,
+            updateMs: 0,
+            renderMs: 0,
+            updateSteps: 0,
+            drawCalls: 0,
+            droppedFrames: 0,
+        });
+
+        expect(renderer.drawBarFill.mock.calls.some((call) => call[1] === 3)).toBe(true);
     });
 
     it('ignores toggle input when overlayToggleEnabled is false', () => {

--- a/src/overlay/Overlay.ts
+++ b/src/overlay/Overlay.ts
@@ -128,7 +128,7 @@ export class Overlay {
         this.#topRightLabel = `${activeBackend} | ${layout.displayWidth}x${layout.displayHeight}`;
         this.#timingChartStyle = resolveOverlayTimingChartStyle(style, overlayTimingChartStyle);
         this.#timingChartHeight = overlayTimingChartHeight ?? DEFAULT_TIMING_CHART_HEIGHT;
-        this.#timingChart = new TimingChart(overlayTimingChart);
+        this.#timingChart = new TimingChart(overlayTimingChart, targetFps);
         this.#paletteView = new PaletteView(overlayPaletteView);
         this.#paletteInteraction = new PaletteInteraction(targetFps);
         this.#paletteColumns = paletteColumns;

--- a/src/overlay/timing-chart/TimingChart.test.ts
+++ b/src/overlay/timing-chart/TimingChart.test.ts
@@ -27,7 +27,14 @@ describe('TimingChart', () => {
         const renderer = createMockRenderer();
 
         chart.reset(4);
-        chart.sample({ frameMs: 1, updateMs: 2, renderMs: 3, updateSteps: 1, drawCalls: 1 });
+        chart.sample({
+            frameMs: 1,
+            updateMs: 2,
+            renderMs: 3,
+            updateSteps: 1,
+            drawCalls: 1,
+            droppedFrames: 0,
+        });
         chart.draw(renderer, new Rect2i(0, 14, 4, 22), {
             updateBarIndex: 1,
             renderBarIndex: 2,
@@ -53,10 +60,10 @@ describe('TimingChart', () => {
         const baselineY = chartRect.y + chartRect.height - 1;
 
         chart.reset(3);
-        chart.sample({ frameMs: 0, updateMs: 4, renderMs: 0, updateSteps: 1, drawCalls: 0 });
-        chart.sample({ frameMs: 0, updateMs: 8, renderMs: 0, updateSteps: 1, drawCalls: 0 });
-        chart.sample({ frameMs: 0, updateMs: 12, renderMs: 0, updateSteps: 1, drawCalls: 0 });
-        chart.sample({ frameMs: 0, updateMs: 16, renderMs: 0, updateSteps: 1, drawCalls: 0 });
+        chart.sample({ frameMs: 0, updateMs: 4, renderMs: 0, updateSteps: 1, drawCalls: 0, droppedFrames: 0 });
+        chart.sample({ frameMs: 0, updateMs: 8, renderMs: 0, updateSteps: 1, drawCalls: 0, droppedFrames: 0 });
+        chart.sample({ frameMs: 0, updateMs: 12, renderMs: 0, updateSteps: 1, drawCalls: 0, droppedFrames: 0 });
+        chart.sample({ frameMs: 0, updateMs: 16, renderMs: 0, updateSteps: 1, drawCalls: 0, droppedFrames: 0 });
 
         chart.draw(renderer, chartRect, style);
 
@@ -87,7 +94,7 @@ describe('TimingChart', () => {
         };
 
         chart.reset(4);
-        chart.sample({ frameMs: 0, updateMs: 0, renderMs: 0.1, updateSteps: 1, drawCalls: 1 });
+        chart.sample({ frameMs: 0, updateMs: 0, renderMs: 0.1, updateSteps: 1, drawCalls: 1, droppedFrames: 0 });
         chart.draw(renderer, new Rect2i(0, 14, 4, 32), style);
 
         expect(
@@ -105,7 +112,7 @@ describe('TimingChart', () => {
         const renderer = createMockRenderer();
 
         chart.reset(1);
-        chart.sample({ frameMs: 0, updateMs: 12, renderMs: 8, updateSteps: 1, drawCalls: 0 });
+        chart.sample({ frameMs: 0, updateMs: 12, renderMs: 8, updateSteps: 1, drawCalls: 0, droppedFrames: 0 });
         chart.draw(renderer, new Rect2i(10, 14, 1, 22), {
             updateBarIndex: 8,
             renderBarIndex: 9,
@@ -124,6 +131,85 @@ describe('TimingChart', () => {
         expect(paletteIndices).toContain(8);
         expect(paletteIndices).toContain(9);
         expect(dots).toHaveLength(2);
+    });
+
+    it('tints both dots with warning palette when frame is over soft budget', () => {
+        const chart = new TimingChart(true, 60);
+        const renderer = createMockRenderer();
+        const style = {
+            updateBarIndex: 8,
+            renderBarIndex: 9,
+            warningBarIndex: 3,
+            errorBarIndex: 4,
+            eventBarIndex: 5,
+        };
+
+        chart.reset(1);
+        chart.sample({
+            frameMs: 20,
+            updateMs: 12,
+            renderMs: 8,
+            updateSteps: 1,
+            drawCalls: 0,
+            droppedFrames: 0,
+        });
+        chart.draw(renderer, new Rect2i(0, 14, 1, 22), style);
+
+        const paletteIndices = renderer.drawBarFill.mock.calls.map((call) => call[1] as number);
+
+        expect(paletteIndices.every((index) => index === 3)).toBe(true);
+        expect(paletteIndices).not.toContain(8);
+        expect(paletteIndices).not.toContain(9);
+    });
+
+    it('tints with error palette when two or more frames were dropped', () => {
+        const chart = new TimingChart(true, 60);
+        const renderer = createMockRenderer();
+
+        chart.reset(1);
+        chart.sample({
+            frameMs: 0,
+            updateMs: 0,
+            renderMs: 0,
+            updateSteps: 1,
+            drawCalls: 0,
+            droppedFrames: 2,
+        });
+        chart.draw(renderer, new Rect2i(0, 14, 1, 22), {
+            updateBarIndex: 8,
+            renderBarIndex: 9,
+            warningBarIndex: 3,
+            errorBarIndex: 4,
+            eventBarIndex: 5,
+        });
+
+        expect(renderer.drawBarFill.mock.calls.every((call) => call[1] === 4)).toBe(true);
+    });
+
+    it('draws a baseline error marker when drop severity is active with zero timing samples', () => {
+        const chart = new TimingChart(true, 60);
+        const renderer = createMockRenderer();
+        const chartRect = new Rect2i(5, 14, 1, 22);
+        const baselineY = chartRect.y + chartRect.height - 1;
+
+        chart.reset(1);
+        chart.sample({
+            frameMs: 0,
+            updateMs: 0,
+            renderMs: 0,
+            updateSteps: 0,
+            drawCalls: 0,
+            droppedFrames: 1,
+        });
+        chart.draw(renderer, chartRect, {
+            updateBarIndex: 8,
+            renderBarIndex: 9,
+            warningBarIndex: 3,
+            errorBarIndex: 4,
+            eventBarIndex: 5,
+        });
+
+        expect(renderer.drawBarFill).toHaveBeenCalledWith(expect.objectContaining({ x: 5, y: baselineY }), 3);
     });
 });
 

--- a/src/overlay/timing-chart/TimingChart.ts
+++ b/src/overlay/timing-chart/TimingChart.ts
@@ -1,11 +1,17 @@
 /**
- * Scrolling update/render timing chart band for the overlay (VV-539).
+ * Scrolling update/render timing chart band for the overlay (VV-539, VV-545 severity).
  */
 
 import { Rect2i } from '../../utils/Rect2i';
 import type { OverlayDrawTarget } from '../OverlayDrawTarget';
 import type { OverlayTimingSnapshot } from '../types';
 import { TIMING_CHART_FULL_SCALE_MS } from './constants';
+import {
+    classifyTimingChartSeverity,
+    TIMING_CHART_SEVERITY_ERROR,
+    TIMING_CHART_SEVERITY_NONE,
+    TIMING_CHART_SEVERITY_WARNING,
+} from './severity';
 import { computeTimingChartBarHeight, type ResolvedOverlayTimingChartStyle } from './style';
 
 /** Palette indices for chart drawing. */
@@ -17,6 +23,8 @@ export type OverlayTimingChartDrawStyle = ResolvedOverlayTimingChartStyle;
 export class TimingChart {
     readonly #enabled: boolean;
 
+    readonly #targetFps: number;
+
     #bufferWidth = 0;
 
     #writeIndex = 0;
@@ -27,15 +35,19 @@ export class TimingChart {
 
     #renderMsBuffer = new Float32Array(0);
 
+    #severityBuffer = new Uint8Array(0);
+
     readonly #dotScratch = new Rect2i(0, 0, 1, 1);
 
     /**
      * Creates a timing chart with the given feature flag.
      *
      * @param enabled - When false, sample/draw are no-ops.
+     * @param targetFps - Configured fixed-step rate for frame-budget classification.
      */
-    constructor(enabled = false) {
+    constructor(enabled = false, targetFps = 60) {
         this.#enabled = enabled;
+        this.#targetFps = targetFps;
     }
 
     /**
@@ -69,6 +81,7 @@ export class TimingChart {
         this.#sampleCount = 0;
         this.#updateMsBuffer = new Float32Array(width);
         this.#renderMsBuffer = new Float32Array(width);
+        this.#severityBuffer = new Uint8Array(width);
     }
 
     /**
@@ -82,10 +95,12 @@ export class TimingChart {
         }
 
         const index = this.#writeIndex;
+        const droppedFrames = timing.droppedFrames ?? 0;
 
         /* eslint-disable security/detect-object-injection -- index is ring-buffer write cursor bounded by bufferWidth */
         this.#updateMsBuffer[index] = Math.max(0, timing.updateMs);
         this.#renderMsBuffer[index] = Math.max(0, timing.renderMs);
+        this.#severityBuffer[index] = classifyTimingChartSeverity(timing.frameMs, this.#targetFps, droppedFrames);
         /* eslint-enable security/detect-object-injection */
 
         this.#writeIndex = (this.#writeIndex + 1) % this.#bufferWidth;
@@ -122,13 +137,69 @@ export class TimingChart {
             /* eslint-disable security/detect-object-injection -- bufferIndex derived from bounded ring cursor */
             const updateMs = this.#updateMsBuffer[bufferIndex] ?? 0;
             const renderMs = this.#renderMsBuffer[bufferIndex] ?? 0;
-
+            const severity = this.#severityBuffer[bufferIndex] ?? TIMING_CHART_SEVERITY_NONE;
             /* eslint-enable security/detect-object-injection */
+
             const x = chartRect.x + column;
+            const tintIndex = this.#severityPaletteIndex(severity, style);
+
+            if (tintIndex !== null) {
+                const renderOffset = computeTimingChartBarHeight(
+                    renderMs,
+                    chartRect.height,
+                    TIMING_CHART_FULL_SCALE_MS,
+                );
+                const updateOffset = computeTimingChartBarHeight(
+                    updateMs,
+                    chartRect.height,
+                    TIMING_CHART_FULL_SCALE_MS,
+                );
+
+                this.#drawDot(target, x, baselineY, renderMs, chartRect, tintIndex);
+                this.#drawDot(target, x, baselineY, updateMs, chartRect, tintIndex);
+
+                if (renderOffset <= 0 && updateOffset <= 0) {
+                    this.#drawBaselineMarker(target, x, baselineY, tintIndex);
+                }
+
+                continue;
+            }
 
             this.#drawDot(target, x, baselineY, renderMs, chartRect, style.renderBarIndex);
             this.#drawDot(target, x, baselineY, updateMs, chartRect, style.updateBarIndex);
         }
+    }
+
+    /**
+     * Resolves semantic tint palette index for a severity level.
+     *
+     * @param severity - {@link TIMING_CHART_SEVERITY_NONE} | WARNING | ERROR.
+     * @param style - Resolved chart palette indices.
+     * @returns Palette index, or `null` to use per-bar update/render colors.
+     */
+    #severityPaletteIndex(severity: number, style: OverlayTimingChartDrawStyle): number | null {
+        if (severity === TIMING_CHART_SEVERITY_ERROR) {
+            return style.errorBarIndex;
+        }
+
+        if (severity === TIMING_CHART_SEVERITY_WARNING) {
+            return style.warningBarIndex;
+        }
+
+        return null;
+    }
+
+    /**
+     * Draws a one-pixel severity marker on the chart baseline.
+     *
+     * @param target - Overlay draw target.
+     * @param x - Column X in screen space.
+     * @param baselineY - Bottom row of the chart band.
+     * @param paletteIndex - Palette index for the marker.
+     */
+    #drawBaselineMarker(target: OverlayDrawTarget, x: number, baselineY: number, paletteIndex: number): void {
+        this.#dotScratch.set(x, baselineY, 1, 1);
+        target.drawBarFill(this.#dotScratch, paletteIndex);
     }
 
     /**

--- a/src/overlay/timing-chart/severity.test.ts
+++ b/src/overlay/timing-chart/severity.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    classifyTimingChartSeverity,
+    severityFromDroppedFrames,
+    severityFromFrameBudget,
+    TIMING_CHART_BUDGET_ERROR_RATIO,
+    TIMING_CHART_BUDGET_WARNING_RATIO,
+    TIMING_CHART_SEVERITY_ERROR,
+    TIMING_CHART_SEVERITY_NONE,
+    TIMING_CHART_SEVERITY_WARNING,
+} from './severity';
+
+describe('severityFromFrameBudget', () => {
+    const targetFps = 60;
+    const budgetMs = 1000 / targetFps;
+
+    it('returns none for non-positive or invalid inputs', () => {
+        expect(severityFromFrameBudget(0, targetFps)).toBe(TIMING_CHART_SEVERITY_NONE);
+        expect(severityFromFrameBudget(-1, targetFps)).toBe(TIMING_CHART_SEVERITY_NONE);
+        expect(severityFromFrameBudget(20, 0)).toBe(TIMING_CHART_SEVERITY_NONE);
+    });
+
+    it('maps soft and hard budget thresholds at 60 FPS', () => {
+        const softMs = budgetMs * TIMING_CHART_BUDGET_WARNING_RATIO - 0.01;
+        const atSoftMs = budgetMs * TIMING_CHART_BUDGET_WARNING_RATIO;
+        const hardMs = budgetMs * TIMING_CHART_BUDGET_ERROR_RATIO;
+
+        expect(severityFromFrameBudget(softMs, targetFps)).toBe(TIMING_CHART_SEVERITY_NONE);
+        expect(severityFromFrameBudget(atSoftMs, targetFps)).toBe(TIMING_CHART_SEVERITY_WARNING);
+        expect(severityFromFrameBudget(hardMs, targetFps)).toBe(TIMING_CHART_SEVERITY_ERROR);
+    });
+});
+
+describe('severityFromDroppedFrames', () => {
+    it('maps dropped-frame counts to warning and error', () => {
+        expect(severityFromDroppedFrames(0)).toBe(TIMING_CHART_SEVERITY_NONE);
+        expect(severityFromDroppedFrames(1)).toBe(TIMING_CHART_SEVERITY_WARNING);
+        expect(severityFromDroppedFrames(2)).toBe(TIMING_CHART_SEVERITY_ERROR);
+        expect(severityFromDroppedFrames(5)).toBe(TIMING_CHART_SEVERITY_ERROR);
+    });
+});
+
+describe('classifyTimingChartSeverity', () => {
+    it('prefers error when budget and drop signals disagree', () => {
+        const targetFps = 60;
+        const budgetMs = 1000 / targetFps;
+        const warningFrameMs = budgetMs * TIMING_CHART_BUDGET_WARNING_RATIO;
+
+        expect(classifyTimingChartSeverity(warningFrameMs, targetFps, 2)).toBe(TIMING_CHART_SEVERITY_ERROR);
+    });
+
+    it('uses budget warning when no drop is reported', () => {
+        const targetFps = 60;
+        const budgetMs = 1000 / targetFps;
+        const warningFrameMs = budgetMs * TIMING_CHART_BUDGET_WARNING_RATIO;
+
+        expect(classifyTimingChartSeverity(warningFrameMs, targetFps, 0)).toBe(TIMING_CHART_SEVERITY_WARNING);
+    });
+});

--- a/src/overlay/timing-chart/severity.ts
+++ b/src/overlay/timing-chart/severity.ts
@@ -1,0 +1,82 @@
+/**
+ * Timing chart severity classification (VV-545).
+ */
+
+/** No semantic tint for this chart column. */
+export const TIMING_CHART_SEVERITY_NONE = 0;
+
+/** Soft runtime risk (over-budget or single dropped frame). */
+export const TIMING_CHART_SEVERITY_WARNING = 1;
+
+/** Hard runtime risk (severe over-budget or multiple dropped frames). */
+export const TIMING_CHART_SEVERITY_ERROR = 2;
+
+/** Frame budget soft threshold: warning at or above this fraction of target frame time. */
+export const TIMING_CHART_BUDGET_WARNING_RATIO = 1.1;
+
+/** Frame budget hard threshold: error at or above this fraction of target frame time. */
+export const TIMING_CHART_BUDGET_ERROR_RATIO = 1.5;
+
+/**
+ * Maps dropped-frame count from {@link GameLoop} to chart severity.
+ *
+ * @param droppedFrames - Estimated skipped refresh intervals (0 = none).
+ * @returns Warning, error, or none.
+ */
+export function severityFromDroppedFrames(droppedFrames: number): number {
+    if (droppedFrames >= 2) {
+        return TIMING_CHART_SEVERITY_ERROR;
+    }
+
+    if (droppedFrames >= 1) {
+        return TIMING_CHART_SEVERITY_WARNING;
+    }
+
+    return TIMING_CHART_SEVERITY_NONE;
+}
+
+/**
+ * Maps frame wall time against the configured fixed-step budget.
+ *
+ * @param frameMs - Total frame CPU time in milliseconds.
+ * @param targetFps - Configured simulation rate from {@link HardwareSettings.targetFPS}.
+ * @returns Warning, error, or none.
+ */
+export function severityFromFrameBudget(frameMs: number, targetFps: number): number {
+    if (!Number.isFinite(frameMs) || frameMs <= 0 || !Number.isFinite(targetFps) || targetFps <= 0) {
+        return TIMING_CHART_SEVERITY_NONE;
+    }
+
+    const budgetMs = 1000 / targetFps;
+
+    if (budgetMs <= 0) {
+        return TIMING_CHART_SEVERITY_NONE;
+    }
+
+    const ratio = frameMs / budgetMs;
+
+    if (ratio >= TIMING_CHART_BUDGET_ERROR_RATIO) {
+        return TIMING_CHART_SEVERITY_ERROR;
+    }
+
+    if (ratio >= TIMING_CHART_BUDGET_WARNING_RATIO) {
+        return TIMING_CHART_SEVERITY_WARNING;
+    }
+
+    return TIMING_CHART_SEVERITY_NONE;
+}
+
+/**
+ * Combines budget and dropped-frame signals; error wins over warning.
+ *
+ * @param frameMs - Total frame CPU time in milliseconds.
+ * @param targetFps - Configured simulation rate.
+ * @param droppedFrames - Dropped frames detected this present interval (0 when none).
+ * @returns Highest severity for the chart column.
+ */
+export function classifyTimingChartSeverity(frameMs: number, targetFps: number, droppedFrames: number): number {
+    const budgetSeverity = severityFromFrameBudget(frameMs, targetFps);
+    const dropSeverity = severityFromDroppedFrames(droppedFrames);
+
+    return Math.max(budgetSeverity, dropSeverity);
+}

--- a/src/overlay/timing-chart/style.ts
+++ b/src/overlay/timing-chart/style.ts
@@ -20,7 +20,7 @@ export interface ResolvedOverlayTimingChartStyle {
  *
  * @param overlayStyle - Global overlay bar/text indices from hardware settings.
  * @param chartStyle - Optional timing-chart palette overrides.
- * @returns Resolved indices for chart draw and future semantic overlays.
+ * @returns Resolved indices for chart draw and semantic severity tints.
  */
 export function resolveOverlayTimingChartStyle(
     overlayStyle: OverlayStyle | undefined,

--- a/src/overlay/types.ts
+++ b/src/overlay/types.ts
@@ -19,6 +19,12 @@ export interface OverlayTimingSnapshot {
 
     /** Number of draw API calls issued by the demo for this frame. */
     readonly drawCalls: number;
+
+    /**
+     * Estimated dropped refresh intervals detected at the start of this present frame.
+     * Zero when none; set from {@link GameLoop} before the overlay samples the chart.
+     */
+    readonly droppedFrames: number;
 }
 
 /** Computed palette swatch grid dimensions for the palette band. */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This pull request introduces severity-aware tinting for timing chart visualizations. When update/render operations exceed budget thresholds or dropped-frame events occur, the timing chart now displays dots with warning or error color palette indices rather than the default per-bar colors.

## Key Changes

### Severity Classification Framework
- New module `src/overlay/timing-chart/severity.ts` defines severity levels (`NONE`, `WARNING`, `ERROR`) and three exported helper functions:
  - `severityFromDroppedFrames()`: Maps dropped-frame counts to severity (0 → none, 1 → warning, 2+ → error)
  - `severityFromFrameBudget()`: Converts frame CPU time against a budget derived from target FPS into severity using configurable warning and error ratios
  - `classifyTimingChartSeverity()`: Combines both signals with error taking precedence over warning

### TimingChart Enhancements
- Constructor now accepts a `targetFps` parameter (defaults to 60) for budget calculations
- Added `#severityBuffer` ring-buffer to store per-sample severity levels
- During sampling, `droppedFrames` field is read from timing input and severity is computed
- During rendering, severity values are consulted to resolve tint palette indices; when severity is active, update/render dots use the warning or error palette index instead of per-bar colors
- Draws a one-pixel baseline severity marker when severity is present but no visible bars are rendered

### Dropped-Frame Tracking
- `OverlayTimingSnapshot` interface now includes a required `droppedFrames: number` field
- `BTAPI` extended to track dropped frames in `overlayTiming.droppedFrames`, initialized and reset to 0 during init and after each frame
- Frame-drop callback registration consolidated so the engine registers a single callback when either dropped-frame detection or overlay timing chart is enabled; the callback records dropped-frame counts and only emits console warnings when `detectDroppedFrames` is enabled

### Documentation Updates
- JSDoc comments updated in `IBlitTechDemo.ts` and API documentation to clarify palette "chart tints" semantics for over-budget frames and dropped-frame severity
- `overlayTimingChartStyle` documentation revised to define `warningPaletteIndex` and `errorPaletteIndex` behavior with explicit defaults

### Test Coverage
- New test file `src/overlay/timing-chart/severity.test.ts` validates severity classification logic
- `TimingChart.test.ts` extended with test cases for severity-based tinting and baseline marker rendering
- `Overlay.test.ts` expanded to verify timing-chart styling options and severity behavior, including a case for recording drop severity while the overlay is hidden
- `BTAPI.test.ts` updated to assert `droppedFrames` presence in timing snapshots

## Impact

The changes enable visual severity indication in the timing chart without modifying the core timing measurement system, allowing developers to quickly identify frames that exceed budget thresholds or experience dropped-frame events through color-coded visual feedback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/233?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->