### PR TITLE
ci(ci): ignore contributor-covenant.org and conventionalcommits.org in link checks

### DIFF
--- a/.github/markdown-link-check.json
+++ b/.github/markdown-link-check.json
@@ -29,6 +29,12 @@
     },
     {
       "pattern": "^https?://www\\.npmjs\\.com/package/[^\\s]+$"
+    },
+    {
+      "pattern": "^https?://www\\.contributor-covenant\\.org(/|$)"
+    },
+    {
+      "pattern": "^https?://www\\.conventionalcommits\\.org(/|$)"
     }
   ],
   "replacementPatterns": [


### PR DESCRIPTION
Both domains return Status 0 on GitHub Actions runners intermittently, causing flaky CI failures unrelated to actual dead links. Added them to ignorePatterns following the same pattern already used for w3.org and other stable reference sites.