### PR TITLE
feat(overlay): add timing chart grid lines and bottom-anchored dots

### DIFF
--- a/docs/api-core.md
+++ b/docs/api-core.md
@@ -211,16 +211,20 @@ otherwise.
 - **Timing chart (optional):** when `overlayTimingChart: true`, a scrolling band of **one-pixel dots** shows raw
   per-frame `update()` vs `render()` CPU time (one column per present frame, not per fixed `update()` tick). Band height
   defaults to **22 px**; override with `overlayTimingChartHeight`. Dot height scales linearly so about **16 ms** fills
-  the band; any non-zero sample draws at least one pixel (sub-millisecond work shows as a baseline dot). The band
-  background uses `overlayStyle.barPaletteIndex`; dot colors default to `overlayStyle.barPaletteIndex` /
-  `textPaletteIndex`; override with `overlayTimingChartStyle`. **Semantic tints (VV-545):** when a column is classified
-  as a runtime risk, both update and render dots use the warning or error palette index instead of the normal bar
-  colors. Classification uses the prior frame's `Frame` wall time against `1000 / targetFPS` (warning at **1.10x**
-  budget, error at **1.50x**) and dropped-frame events from the game loop (one dropped frame = warning, two or more =
-  error; error wins when both apply). Default warning/error/event palette indices are **3**, **4**, and **5** when not
-  overridden. Drop detection for the chart runs whenever `overlayTimingChart: true` (independent of
-  `detectDroppedFrames`, which only controls console warnings). The `eventPaletteIndex` slot is reserved for chart event
-  tags (VV-541).
+  the band; any non-zero sample draws at least one pixel (sub-millisecond work shows as a baseline dot). **Grid lines
+  (VV-7):** faint horizontal reference rows at **5**, **10**, and **33.33** ms plus a frame-budget line at
+  **`1000 / targetFPS`** ms are drawn behind the dots (qualitative scale on a ~22 px band, not a precision ruler). The
+  band bottom row is the zero baseline (sub-ms / light samples); top- and bottom-edge rows are not drawn as grid lines.
+  Grid color defaults to `overlayStyle.gapPaletteIndex` (then `barPaletteIndex`); override with
+  `overlayTimingChartStyle.gridPaletteIndex`. The band background uses `overlayStyle.barPaletteIndex`; dot colors
+  default to `overlayStyle.barPaletteIndex` / `textPaletteIndex`; override with `overlayTimingChartStyle`. **Semantic
+  tints (VV-545):** when a column is classified as a runtime risk, both update and render dots use the warning or error
+  palette index instead of the normal bar colors. Classification uses the prior frame's `Frame` wall time against
+  `1000 / targetFPS` (warning at **1.10x** budget, error at **1.50x**) and dropped-frame events from the game loop (one
+  dropped frame = warning, two or more = error; error wins when both apply). Default warning/error/event palette indices
+  are **3**, **4**, and **5** when not overridden. Drop detection for the chart runs whenever `overlayTimingChart: true`
+  (independent of `detectDroppedFrames`, which only controls console warnings). The `eventPaletteIndex` slot is reserved
+  for chart event tags (VV-541).
 - **Top row 2 (left):** `Present: N FPS | Target: T FPS | Draw Calls: C`
 - **Top row 3 (left):** `Frame: Xms | update(): Yms | render(): Zms` (shows `xN` on `update()` when multiple fixed
   updates ran this frame)
@@ -328,6 +332,7 @@ configure() {
     overlayTimingChartStyle: {
       updateBarPaletteIndex: 2, // defaults to barPaletteIndex when omitted
       renderBarPaletteIndex: 3, // defaults to textPaletteIndex when omitted
+      gridPaletteIndex: 2, // horizontal grid lines; defaults to gapPaletteIndex
       warningPaletteIndex: 3, // soft over-budget / single drop; default 3
       errorPaletteIndex: 4, // hard over-budget / 2+ drops; default 4
     },

--- a/src/core/IBlitTechDemo.ts
+++ b/src/core/IBlitTechDemo.ts
@@ -230,6 +230,12 @@ export interface OverlayTimingChartStyle {
 
     /** Event/tag tint for future chart markers (VV-541). */
     eventPaletteIndex?: number;
+
+    /**
+     * Faint horizontal grid lines behind chart dots (VV-7). Defaults to
+     * {@link OverlayStyle.gapPaletteIndex} or {@link OverlayStyle.barPaletteIndex} when omitted.
+     */
+    gridPaletteIndex?: number;
 }
 
 /**

--- a/src/overlay/index.ts
+++ b/src/overlay/index.ts
@@ -38,7 +38,16 @@ export { computePaletteGrid, PaletteView } from './palette/PaletteView';
 export { FpsSampler } from './sampling/FpsSampler';
 export { TimingSampler } from './sampling/TimingSampler';
 export type { ResolvedOverlayTimingChartStyle } from './timing-chart/style';
-export { computeTimingChartBarHeight, resolveOverlayTimingChartStyle } from './timing-chart/style';
+export {
+    computeTimingChartBarHeight,
+    computeTimingChartDotY,
+    computeTimingChartGridLineY,
+    resolveOverlayTimingChartStyle,
+    shouldDrawTimingChartGridLineY,
+    timingChartBaselineY,
+    timingChartFrameBudgetMs,
+    writeTimingChartGridMarkers,
+} from './timing-chart/style';
 export type { OverlayTimingChartDrawStyle } from './timing-chart/TimingChart';
 export { TimingChart } from './timing-chart/TimingChart';
 export type { OverlayTimingSnapshot, PaletteGridLayout } from './types';

--- a/src/overlay/timing-chart/TimingChart.test.ts
+++ b/src/overlay/timing-chart/TimingChart.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { Rect2i } from '../../utils/Rect2i';
 import { createMockRenderer, getRectFillCalls } from '../testFixtures';
 import { TIMING_CHART_FULL_SCALE_MS } from './constants';
-import { computeTimingChartBarHeight } from './style';
+import { computeTimingChartBarHeight, computeTimingChartDotY } from './style';
 import { TimingChart } from './TimingChart';
 
 // #region computeTimingChartBarHeight tests
@@ -41,6 +41,7 @@ describe('TimingChart', () => {
             warningBarIndex: 3,
             errorBarIndex: 4,
             eventBarIndex: 5,
+            gridBarIndex: 6,
         });
 
         expect(renderer.drawBarFill).not.toHaveBeenCalled();
@@ -55,9 +56,9 @@ describe('TimingChart', () => {
             warningBarIndex: 3,
             errorBarIndex: 4,
             eventBarIndex: 5,
+            gridBarIndex: 6,
         };
         const chartRect = new Rect2i(0, 0, 3, 22);
-        const baselineY = chartRect.y + chartRect.height - 1;
 
         chart.reset(3);
         chart.sample({ frameMs: 0, updateMs: 4, renderMs: 0, updateSteps: 1, drawCalls: 0, droppedFrames: 0 });
@@ -67,8 +68,7 @@ describe('TimingChart', () => {
 
         chart.draw(renderer, chartRect, style);
 
-        const updateDotY = (ms: number) =>
-            baselineY - computeTimingChartBarHeight(ms, chartRect.height, TIMING_CHART_FULL_SCALE_MS) + 1;
+        const updateDotY = (ms: number) => computeTimingChartDotY(ms, chartRect, TIMING_CHART_FULL_SCALE_MS);
 
         const updateDots = getRectFillCalls(renderer).filter(
             (rect) => rect.width === 1 && rect.height === 1 && rect.y === updateDotY(8),
@@ -91,6 +91,7 @@ describe('TimingChart', () => {
             warningBarIndex: 3,
             errorBarIndex: 4,
             eventBarIndex: 5,
+            gridBarIndex: 6,
         };
 
         chart.reset(4);
@@ -119,18 +120,16 @@ describe('TimingChart', () => {
             warningBarIndex: 3,
             errorBarIndex: 4,
             eventBarIndex: 5,
+            gridBarIndex: 6,
         });
 
-        const dots = getRectFillCalls(renderer).filter((rect) => rect.width === 1 && rect.height === 1);
-        const paletteIndices = renderer.drawBarFill.mock.calls
-            .filter(
-                (call) => (call[0] as { width: number }).width === 1 && (call[0] as { height: number }).height === 1,
-            )
+        const dotPaletteIndices = renderer.drawBarFill.mock.calls
+            .filter((call) => call[1] === 8 || call[1] === 9)
             .map((call) => call[1] as number);
 
-        expect(paletteIndices).toContain(8);
-        expect(paletteIndices).toContain(9);
-        expect(dots).toHaveLength(2);
+        expect(dotPaletteIndices).toContain(8);
+        expect(dotPaletteIndices).toContain(9);
+        expect(dotPaletteIndices).toHaveLength(2);
     });
 
     it('tints both dots with warning palette when frame is over soft budget', () => {
@@ -142,6 +141,7 @@ describe('TimingChart', () => {
             warningBarIndex: 3,
             errorBarIndex: 4,
             eventBarIndex: 5,
+            gridBarIndex: 6,
         };
 
         chart.reset(1);
@@ -155,11 +155,13 @@ describe('TimingChart', () => {
         });
         chart.draw(renderer, new Rect2i(0, 14, 1, 22), style);
 
-        const paletteIndices = renderer.drawBarFill.mock.calls.map((call) => call[1] as number);
+        const dotPaletteIndices = renderer.drawBarFill.mock.calls
+            .filter((call) => call[1] === 3)
+            .map((call) => call[1] as number);
 
-        expect(paletteIndices.every((index) => index === 3)).toBe(true);
-        expect(paletteIndices).not.toContain(8);
-        expect(paletteIndices).not.toContain(9);
+        expect(dotPaletteIndices.length).toBeGreaterThanOrEqual(2);
+        expect(renderer.drawBarFill.mock.calls.some((call) => call[1] === 8)).toBe(false);
+        expect(renderer.drawBarFill.mock.calls.some((call) => call[1] === 9)).toBe(false);
     });
 
     it('tints with error palette when two or more frames were dropped', () => {
@@ -181,9 +183,13 @@ describe('TimingChart', () => {
             warningBarIndex: 3,
             errorBarIndex: 4,
             eventBarIndex: 5,
+            gridBarIndex: 6,
         });
 
-        expect(renderer.drawBarFill.mock.calls.every((call) => call[1] === 4)).toBe(true);
+        const severityCalls = renderer.drawBarFill.mock.calls.filter((call) => call[1] === 4);
+
+        expect(severityCalls.length).toBeGreaterThanOrEqual(1);
+        expect(renderer.drawBarFill.mock.calls.every((call) => call[1] === 4 || call[1] === 6)).toBe(true);
     });
 
     it('draws a baseline error marker when drop severity is active with zero timing samples', () => {
@@ -207,9 +213,93 @@ describe('TimingChart', () => {
             warningBarIndex: 3,
             errorBarIndex: 4,
             eventBarIndex: 5,
+            gridBarIndex: 6,
         });
 
         expect(renderer.drawBarFill).toHaveBeenCalledWith(expect.objectContaining({ x: 5, y: baselineY }), 3);
+    });
+
+    it('draws full-width grid lines before dots when enabled', () => {
+        const chart = new TimingChart(true, 60);
+        const renderer = createMockRenderer();
+        const chartRect = new Rect2i(10, 14, 8, 22);
+        const style = {
+            updateBarIndex: 8,
+            renderBarIndex: 9,
+            warningBarIndex: 3,
+            errorBarIndex: 4,
+            eventBarIndex: 5,
+            gridBarIndex: 6,
+        };
+
+        chart.reset(chartRect.width);
+        chart.sample({ frameMs: 0, updateMs: 12, renderMs: 8, updateSteps: 1, drawCalls: 0, droppedFrames: 0 });
+        chart.draw(renderer, chartRect, style);
+
+        const mockCalls = renderer.drawBarFill.mock.calls;
+        const firstDotIndex = mockCalls.findIndex(
+            (call) => call[1] === style.updateBarIndex || call[1] === style.renderBarIndex,
+        );
+        const lastGridIndex = mockCalls.reduce((last, call, index) => (call[1] === 6 ? index : last), -1);
+
+        expect(lastGridIndex).toBeGreaterThanOrEqual(0);
+        expect(firstDotIndex).toBeGreaterThanOrEqual(0);
+        expect(lastGridIndex).toBeLessThan(firstDotIndex);
+    });
+
+    it('omits grid lines on top and bottom band rows', () => {
+        const chart = new TimingChart(true, 60);
+        const renderer = createMockRenderer();
+        const chartRect = new Rect2i(0, 14, 4, 22);
+
+        chart.reset(chartRect.width);
+        chart.draw(renderer, chartRect, {
+            updateBarIndex: 8,
+            renderBarIndex: 9,
+            warningBarIndex: 3,
+            errorBarIndex: 4,
+            eventBarIndex: 5,
+            gridBarIndex: 6,
+        });
+
+        expect(renderer.drawBarFill.mock.calls.filter((call) => call[1] === 6)).toHaveLength(2);
+    });
+
+    it('draws grid lines even when the ring buffer has no samples yet', () => {
+        const chart = new TimingChart(true, 60);
+        const renderer = createMockRenderer();
+        const chartRect = new Rect2i(0, 14, 4, 22);
+
+        chart.reset(4);
+        chart.draw(renderer, chartRect, {
+            updateBarIndex: 8,
+            renderBarIndex: 9,
+            warningBarIndex: 3,
+            errorBarIndex: 4,
+            eventBarIndex: 5,
+            gridBarIndex: 6,
+        });
+
+        const gridCallCount = renderer.drawBarFill.mock.calls.filter((call) => call[1] === 6).length;
+
+        expect(gridCallCount).toBeGreaterThan(0);
+    });
+
+    it('does not draw grid lines when disabled', () => {
+        const chart = new TimingChart(false, 60);
+        const renderer = createMockRenderer();
+
+        chart.reset(4);
+        chart.draw(renderer, new Rect2i(0, 14, 4, 22), {
+            updateBarIndex: 8,
+            renderBarIndex: 9,
+            warningBarIndex: 3,
+            errorBarIndex: 4,
+            eventBarIndex: 5,
+            gridBarIndex: 6,
+        });
+
+        expect(renderer.drawBarFill).not.toHaveBeenCalled();
     });
 });
 

--- a/src/overlay/timing-chart/TimingChart.ts
+++ b/src/overlay/timing-chart/TimingChart.ts
@@ -1,5 +1,5 @@
 /**
- * Scrolling update/render timing chart band for the overlay (VV-539, VV-545 severity).
+ * Scrolling update/render timing chart band for the overlay (VV-539, VV-545 severity, VV-7 grid).
  */
 
 import { Rect2i } from '../../utils/Rect2i';
@@ -12,7 +12,15 @@ import {
     TIMING_CHART_SEVERITY_NONE,
     TIMING_CHART_SEVERITY_WARNING,
 } from './severity';
-import { computeTimingChartBarHeight, type ResolvedOverlayTimingChartStyle } from './style';
+import {
+    computeTimingChartBarHeight,
+    computeTimingChartDotY,
+    computeTimingChartGridLineY,
+    type ResolvedOverlayTimingChartStyle,
+    shouldDrawTimingChartGridLineY,
+    timingChartBaselineY,
+    writeTimingChartGridMarkers,
+} from './style';
 
 /** Palette indices for chart drawing. */
 export type OverlayTimingChartDrawStyle = ResolvedOverlayTimingChartStyle;
@@ -38,6 +46,11 @@ export class TimingChart {
     #severityBuffer = new Uint8Array(0);
 
     readonly #dotScratch = new Rect2i(0, 0, 1, 1);
+
+    readonly #lineScratch = new Rect2i(0, 0, 1, 1);
+
+    /** Reusable marker list: fixed thresholds plus one frame-budget slot. */
+    readonly #gridMarkerMs = new Float32Array(8);
 
     /**
      * Creates a timing chart with the given feature flag.
@@ -108,7 +121,7 @@ export class TimingChart {
     }
 
     /**
-     * Draws one-pixel timing dots for each populated ring-buffer column.
+     * Draws horizontal grid reference lines, then one-pixel timing dots for each populated ring-buffer column.
      *
      * Uses {@link OverlayDrawTarget.drawBarFill} with 1x1 rects so update and render samples stay
      * visible without alpha blending (palette-indexed engine).
@@ -124,11 +137,13 @@ export class TimingChart {
 
         this.reset(chartRect.width);
 
+        this.#drawGridLines(target, chartRect, style);
+
         if (this.#sampleCount <= 0) {
             return;
         }
 
-        const baselineY = chartRect.y + chartRect.height - 1;
+        const baselineY = timingChartBaselineY(chartRect);
 
         for (let column = 0; column < this.#sampleCount; column++) {
             const bufferIndex =
@@ -155,8 +170,8 @@ export class TimingChart {
                     TIMING_CHART_FULL_SCALE_MS,
                 );
 
-                this.#drawDot(target, x, baselineY, renderMs, chartRect, tintIndex);
-                this.#drawDot(target, x, baselineY, updateMs, chartRect, tintIndex);
+                this.#drawDot(target, x, renderMs, chartRect, tintIndex);
+                this.#drawDot(target, x, updateMs, chartRect, tintIndex);
 
                 if (renderOffset <= 0 && updateOffset <= 0) {
                     this.#drawBaselineMarker(target, x, baselineY, tintIndex);
@@ -165,8 +180,36 @@ export class TimingChart {
                 continue;
             }
 
-            this.#drawDot(target, x, baselineY, renderMs, chartRect, style.renderBarIndex);
-            this.#drawDot(target, x, baselineY, updateMs, chartRect, style.updateBarIndex);
+            this.#drawDot(target, x, renderMs, chartRect, style.renderBarIndex);
+            this.#drawDot(target, x, updateMs, chartRect, style.updateBarIndex);
+        }
+    }
+
+    /**
+     * Draws faint horizontal grid lines behind timing dots (VV-7).
+     *
+     * @param target - Overlay draw target.
+     * @param chartRect - Screen-space chart band from layout plan.
+     * @param style - Resolved chart palette indices.
+     */
+    #drawGridLines(target: OverlayDrawTarget, chartRect: Rect2i, style: OverlayTimingChartDrawStyle): void {
+        const markerCount = writeTimingChartGridMarkers(this.#targetFps, this.#gridMarkerMs);
+        let lastY = -1;
+
+        for (let index = 0; index < markerCount; index++) {
+            /* eslint-disable security/detect-object-injection -- index bounded by markerCount */
+            const ms = this.#gridMarkerMs[index] ?? 0;
+            /* eslint-enable security/detect-object-injection */
+
+            const y = computeTimingChartGridLineY(ms, chartRect, TIMING_CHART_FULL_SCALE_MS);
+
+            if (y === null || !shouldDrawTimingChartGridLineY(y, chartRect) || y === lastY) {
+                continue;
+            }
+
+            lastY = y;
+            this.#lineScratch.set(chartRect.x, y, chartRect.width, 1);
+            target.drawBarFill(this.#lineScratch, style.gridBarIndex);
         }
     }
 
@@ -203,30 +246,20 @@ export class TimingChart {
     }
 
     /**
-     * Draws one timing sample as a single pixel above the chart baseline.
+     * Draws one timing sample as a single pixel anchored from the chart bottom row.
      *
      * @param target - Overlay draw target.
      * @param x - Column X in screen space.
-     * @param baselineY - Bottom row of the chart band.
      * @param ms - Timing sample in milliseconds.
      * @param chartRect - Chart band bounds for clamping.
      * @param paletteIndex - Palette index for the dot.
      */
-    #drawDot(
-        target: OverlayDrawTarget,
-        x: number,
-        baselineY: number,
-        ms: number,
-        chartRect: Rect2i,
-        paletteIndex: number,
-    ): void {
-        const offset = computeTimingChartBarHeight(ms, chartRect.height, TIMING_CHART_FULL_SCALE_MS);
+    #drawDot(target: OverlayDrawTarget, x: number, ms: number, chartRect: Rect2i, paletteIndex: number): void {
+        const y = computeTimingChartDotY(ms, chartRect, TIMING_CHART_FULL_SCALE_MS);
 
-        if (offset <= 0) {
+        if (y === null) {
             return;
         }
-
-        const y = Math.max(chartRect.y, baselineY - offset + 1);
 
         this.#dotScratch.set(x, y, 1, 1);
         target.drawBarFill(this.#dotScratch, paletteIndex);

--- a/src/overlay/timing-chart/constants.ts
+++ b/src/overlay/timing-chart/constants.ts
@@ -12,3 +12,9 @@ export const TIMING_CHART_DEFAULT_ERROR_IDX = 4;
 
 /** Default event/tag palette index for timing chart semantic overlays. */
 export const TIMING_CHART_DEFAULT_EVENT_IDX = 5;
+
+/**
+ * Fixed interior grid markers in milliseconds (VV-7). Excludes 1 ms (band bottom edge).
+ * Frame budget is added at draw time from targetFPS.
+ */
+export const TIMING_CHART_GRID_MARKER_MS: readonly number[] = [5, 10, 33.33];

--- a/src/overlay/timing-chart/style.test.ts
+++ b/src/overlay/timing-chart/style.test.ts
@@ -1,12 +1,22 @@
 import { describe, expect, it } from 'vitest';
 
+import { Rect2i } from '../../utils/Rect2i';
 import {
     TIMING_CHART_DEFAULT_ERROR_IDX,
     TIMING_CHART_DEFAULT_EVENT_IDX,
     TIMING_CHART_DEFAULT_WARNING_IDX,
     TIMING_CHART_FULL_SCALE_MS,
 } from './constants';
-import { computeTimingChartBarHeight, resolveOverlayTimingChartStyle } from './style';
+import {
+    computeTimingChartBarHeight,
+    computeTimingChartDotY,
+    computeTimingChartGridLineY,
+    resolveOverlayTimingChartStyle,
+    shouldDrawTimingChartGridLineY,
+    timingChartBaselineY,
+    timingChartFrameBudgetMs,
+    writeTimingChartGridMarkers,
+} from './style';
 
 describe('computeTimingChartBarHeight', () => {
     const chartHeight = 22;
@@ -33,17 +43,19 @@ describe('resolveOverlayTimingChartStyle', () => {
         expect(resolved.warningBarIndex).toBe(TIMING_CHART_DEFAULT_WARNING_IDX);
         expect(resolved.errorBarIndex).toBe(TIMING_CHART_DEFAULT_ERROR_IDX);
         expect(resolved.eventBarIndex).toBe(TIMING_CHART_DEFAULT_EVENT_IDX);
+        expect(resolved.gridBarIndex).toBe(10);
     });
 
     it('honors timing chart palette overrides', () => {
         const resolved = resolveOverlayTimingChartStyle(
-            { barPaletteIndex: 1, textPaletteIndex: 2 },
+            { barPaletteIndex: 1, textPaletteIndex: 2, gapPaletteIndex: 12 },
             {
                 updateBarPaletteIndex: 20,
                 renderBarPaletteIndex: 21,
                 warningPaletteIndex: 22,
                 errorPaletteIndex: 23,
                 eventPaletteIndex: 24,
+                gridPaletteIndex: 25,
             },
         );
 
@@ -52,5 +64,106 @@ describe('resolveOverlayTimingChartStyle', () => {
         expect(resolved.warningBarIndex).toBe(22);
         expect(resolved.errorBarIndex).toBe(23);
         expect(resolved.eventBarIndex).toBe(24);
+        expect(resolved.gridBarIndex).toBe(25);
+    });
+
+    it('defaults grid lines to gap palette index when grid override is omitted', () => {
+        const resolved = resolveOverlayTimingChartStyle(
+            { barPaletteIndex: 1, textPaletteIndex: 2, gapPaletteIndex: 7 },
+            {},
+        );
+
+        expect(resolved.gridBarIndex).toBe(7);
+    });
+
+    it('falls back grid lines to bar index when gap palette is omitted', () => {
+        const resolved = resolveOverlayTimingChartStyle({ barPaletteIndex: 9, textPaletteIndex: 2 }, undefined);
+
+        expect(resolved.gridBarIndex).toBe(9);
+    });
+});
+
+describe('computeTimingChartGridLineY', () => {
+    const chartRect22 = new Rect2i(0, 14, 320, 22);
+    const baselineY = timingChartBaselineY(chartRect22);
+
+    const gridY = (ms: number, rect = chartRect22) => computeTimingChartGridLineY(ms, rect, TIMING_CHART_FULL_SCALE_MS);
+
+    it('returns null for non-positive inputs', () => {
+        expect(gridY(0)).toBeNull();
+        expect(gridY(-1)).toBeNull();
+        expect(computeTimingChartGridLineY(5, new Rect2i(0, 0, 10, 0), TIMING_CHART_FULL_SCALE_MS)).toBeNull();
+    });
+
+    it('maps fixed thresholds at default 22 px band height', () => {
+        expect(gridY(5)).toBe(baselineY - computeTimingChartBarHeight(5, 22, TIMING_CHART_FULL_SCALE_MS) + 1);
+        expect(gridY(10)).toBe(baselineY - computeTimingChartBarHeight(10, 22, TIMING_CHART_FULL_SCALE_MS) + 1);
+        expect(gridY(33.33)).toBe(chartRect22.y);
+    });
+
+    it('skips top and bottom band edges for grid draw', () => {
+        expect(shouldDrawTimingChartGridLineY(chartRect22.y, chartRect22)).toBe(false);
+        expect(shouldDrawTimingChartGridLineY(baselineY, chartRect22)).toBe(false);
+        const gridLineY5 = gridY(5);
+
+        expect(gridLineY5).not.toBeNull();
+        if (gridLineY5 === null) {
+            return;
+        }
+
+        expect(shouldDrawTimingChartGridLineY(gridLineY5, chartRect22)).toBe(true);
+    });
+
+    it('maps frame-budget marker from targetFPS at 60 Hz', () => {
+        const budgetMs = timingChartFrameBudgetMs(60);
+
+        expect(gridY(budgetMs)).toBe(
+            baselineY - computeTimingChartBarHeight(budgetMs, 22, TIMING_CHART_FULL_SCALE_MS) + 1,
+        );
+    });
+
+    it('maps thresholds at non-default chart height', () => {
+        const chartRect32 = new Rect2i(0, 14, 320, 32);
+        const baseline32 = chartRect32.y + chartRect32.height - 1;
+
+        expect(gridY(8, chartRect32)).toBe(
+            baseline32 - computeTimingChartBarHeight(8, 32, TIMING_CHART_FULL_SCALE_MS) + 1,
+        );
+        expect(gridY(33.33, chartRect32)).toBe(chartRect32.y);
+    });
+});
+
+describe('computeTimingChartDotY', () => {
+    const chartRect22 = new Rect2i(0, 14, 320, 22);
+    const baselineY = timingChartBaselineY(chartRect22);
+
+    it('anchors light samples on the bottom band row', () => {
+        expect(computeTimingChartDotY(0.1, chartRect22)).toBe(baselineY);
+        expect(computeTimingChartDotY(1, chartRect22)).toBe(baselineY);
+    });
+
+    it('keeps full-scale samples on the top band row', () => {
+        expect(computeTimingChartDotY(33.33, chartRect22)).toBe(chartRect22.y);
+    });
+});
+
+describe('writeTimingChartGridMarkers', () => {
+    it('writes fixed markers plus dynamic frame budget', () => {
+        const buffer = new Float32Array(8);
+        const count = writeTimingChartGridMarkers(60, buffer);
+
+        expect(count).toBe(4);
+        expect(buffer[0]).toBe(5);
+        expect(buffer[1]).toBe(10);
+        expect(buffer[2]).toBeCloseTo(33.33, 5);
+        expect(buffer[3]).toBeCloseTo(1000 / 60, 5);
+    });
+
+    it('uses targetFPS for budget marker at 30 Hz', () => {
+        const buffer = new Float32Array(8);
+
+        writeTimingChartGridMarkers(30, buffer);
+
+        expect(buffer[3]).toBeCloseTo(1000 / 30, 5);
     });
 });

--- a/src/overlay/timing-chart/style.ts
+++ b/src/overlay/timing-chart/style.ts
@@ -1,9 +1,12 @@
 import type { OverlayStyle, OverlayTimingChartStyle } from '../../core/IBlitTechDemo';
+import type { Rect2i } from '../../utils/Rect2i';
 import { DEFAULT_IDX_BG, DEFAULT_IDX_TEXT } from '../constants';
 import {
     TIMING_CHART_DEFAULT_ERROR_IDX,
     TIMING_CHART_DEFAULT_EVENT_IDX,
     TIMING_CHART_DEFAULT_WARNING_IDX,
+    TIMING_CHART_FULL_SCALE_MS,
+    TIMING_CHART_GRID_MARKER_MS,
 } from './constants';
 
 /** Resolved palette indices used when drawing the timing chart band. */
@@ -13,7 +16,20 @@ export interface ResolvedOverlayTimingChartStyle {
     readonly warningBarIndex: number;
     readonly errorBarIndex: number;
     readonly eventBarIndex: number;
+    readonly gridBarIndex: number;
 }
+
+const pickPaletteIndex = (preferred: number | undefined, fallback: number): number => preferred ?? fallback;
+
+const pickOverlayBarTextGap = (
+    overlayStyle: OverlayStyle | undefined,
+): { barIndex: number; textIndex: number; gapIndex: number } => {
+    const barIndex = overlayStyle?.barPaletteIndex ?? DEFAULT_IDX_BG;
+    const textIndex = overlayStyle?.textPaletteIndex ?? DEFAULT_IDX_TEXT;
+    const gapIndex = overlayStyle?.gapPaletteIndex ?? barIndex;
+
+    return { barIndex, textIndex, gapIndex };
+};
 
 /**
  * Resolves timing chart palette indices from overlay and chart-specific settings.
@@ -26,15 +42,15 @@ export function resolveOverlayTimingChartStyle(
     overlayStyle: OverlayStyle | undefined,
     chartStyle: OverlayTimingChartStyle | undefined,
 ): ResolvedOverlayTimingChartStyle {
-    const barIndex = overlayStyle?.barPaletteIndex ?? DEFAULT_IDX_BG;
-    const textIndex = overlayStyle?.textPaletteIndex ?? DEFAULT_IDX_TEXT;
+    const { barIndex, textIndex, gapIndex } = pickOverlayBarTextGap(overlayStyle);
 
     return {
-        updateBarIndex: chartStyle?.updateBarPaletteIndex ?? barIndex,
-        renderBarIndex: chartStyle?.renderBarPaletteIndex ?? textIndex,
-        warningBarIndex: chartStyle?.warningPaletteIndex ?? TIMING_CHART_DEFAULT_WARNING_IDX,
-        errorBarIndex: chartStyle?.errorPaletteIndex ?? TIMING_CHART_DEFAULT_ERROR_IDX,
-        eventBarIndex: chartStyle?.eventPaletteIndex ?? TIMING_CHART_DEFAULT_EVENT_IDX,
+        updateBarIndex: pickPaletteIndex(chartStyle?.updateBarPaletteIndex, barIndex),
+        renderBarIndex: pickPaletteIndex(chartStyle?.renderBarPaletteIndex, textIndex),
+        warningBarIndex: pickPaletteIndex(chartStyle?.warningPaletteIndex, TIMING_CHART_DEFAULT_WARNING_IDX),
+        errorBarIndex: pickPaletteIndex(chartStyle?.errorPaletteIndex, TIMING_CHART_DEFAULT_ERROR_IDX),
+        eventBarIndex: pickPaletteIndex(chartStyle?.eventPaletteIndex, TIMING_CHART_DEFAULT_EVENT_IDX),
+        gridBarIndex: pickPaletteIndex(chartStyle?.gridPaletteIndex, gapIndex),
     };
 }
 
@@ -57,4 +73,120 @@ export function computeTimingChartBarHeight(ms: number, chartHeight: number, ful
     const scaled = Math.floor((ms * chartHeight) / fullScaleMs);
 
     return Math.min(chartHeight, Math.max(1, scaled));
+}
+
+/**
+ * Maps a timing threshold in milliseconds to the screen Y row for a horizontal grid line.
+ *
+ * Uses the same baseline and bar-height scale as timing chart dots.
+ *
+ * @param ms - Threshold in milliseconds.
+ * @param chartRect - Chart band bounds.
+ * @param fullScaleMs - Milliseconds mapped to full band height.
+ * @returns Screen Y for a 1 px row, or `null` when the line would not be visible.
+ */
+export function computeTimingChartGridLineY(
+    ms: number,
+    chartRect: Rect2i,
+    fullScaleMs: number = TIMING_CHART_FULL_SCALE_MS,
+): number | null {
+    if (chartRect.height <= 0 || ms <= 0 || fullScaleMs <= 0) {
+        return null;
+    }
+
+    const baselineY = timingChartBaselineY(chartRect);
+    const offset = computeTimingChartBarHeight(ms, chartRect.height, fullScaleMs);
+
+    if (offset <= 0) {
+        return null;
+    }
+
+    return Math.max(chartRect.y, baselineY - offset + 1);
+}
+
+/**
+ * Maps a timing sample in milliseconds to the screen Y row for a one-pixel chart dot.
+ *
+ * Dots anchor to the bottom band row for light samples (see {@link timingChartBaselineY}).
+ *
+ * @param ms - Sample value in milliseconds.
+ * @param chartRect - Chart band bounds.
+ * @param fullScaleMs - Milliseconds mapped to full band height.
+ * @returns Screen Y for the dot, or `null` when the sample is zero.
+ */
+export function computeTimingChartDotY(
+    ms: number,
+    chartRect: Rect2i,
+    fullScaleMs: number = TIMING_CHART_FULL_SCALE_MS,
+): number | null {
+    if (chartRect.height <= 0 || ms <= 0 || fullScaleMs <= 0) {
+        return null;
+    }
+
+    const baselineY = timingChartBaselineY(chartRect);
+    const offset = computeTimingChartBarHeight(ms, chartRect.height, fullScaleMs);
+
+    if (offset <= 0) {
+        return null;
+    }
+
+    let y = Math.max(chartRect.y, baselineY - offset + 1);
+
+    if (y === baselineY - 1) {
+        y = baselineY;
+    }
+
+    return y;
+}
+
+/**
+ * Bottom row of the timing chart band (zero / sub-ms samples sit here).
+ *
+ * @param chartRect - Chart band bounds from layout plan.
+ * @returns Screen Y of the last inclusive row in the band.
+ */
+export function timingChartBaselineY(chartRect: Rect2i): number {
+    return chartRect.y + chartRect.height - 1;
+}
+
+/**
+ * Whether a mapped grid line should be drawn (skips top and bottom band edges).
+ *
+ * @param y - Screen Y from {@link computeTimingChartGridLineY}.
+ * @param chartRect - Chart band bounds.
+ * @returns `true` when the row is strictly between the band edges.
+ */
+export function shouldDrawTimingChartGridLineY(y: number, chartRect: Rect2i): boolean {
+    return y !== chartRect.y && y !== timingChartBaselineY(chartRect);
+}
+
+/**
+ * Frame-budget grid marker in milliseconds from configured fixed-step rate.
+ *
+ * @param targetFps - Configured `targetFPS` (clamped to at least 1).
+ * @returns `1000 / targetFps`.
+ */
+export function timingChartFrameBudgetMs(targetFps: number): number {
+    return 1000 / Math.max(1, targetFps);
+}
+
+/**
+ * Writes timing-chart grid marker values (fixed thresholds plus frame budget) into `out`.
+ *
+ * @param targetFps - Configured fixed-step rate for the dynamic budget line.
+ * @param out - Reusable buffer; must hold at least `TIMING_CHART_GRID_MARKER_MS.length + 1` elements.
+ * @returns Number of marker values written.
+ */
+export function writeTimingChartGridMarkers(targetFps: number, out: Float32Array): number {
+    const fixedCount = TIMING_CHART_GRID_MARKER_MS.length;
+
+    for (let index = 0; index < fixedCount; index++) {
+        /* eslint-disable-next-line security/detect-object-injection -- index bounded by fixedCount */
+        out[index] = TIMING_CHART_GRID_MARKER_MS[index] ?? 0;
+    }
+
+    /* eslint-disable-next-line security/detect-object-injection -- slot after fixed markers */
+    out[fixedCount] = timingChartFrameBudgetMs(targetFps);
+
+    return fixedCount + 1;
 }


### PR DESCRIPTION
Draw horizontal reference rows at 5/10/33.33 ms plus a targetFPS
budget line behind chart dots, skipping top and bottom band edges.
Add gridPaletteIndex to OverlayTimingChartStyle, shared Y helpers,
and unit tests for grid mapping and draw order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR adds horizontal grid reference lines to the timing chart overlay, with bottom-anchored dots and a computed frame-budget line. Grid lines are drawn at 5 ms, 10 ms, 33.33 ms intervals, plus a dynamic line at 1000/targetFPS milliseconds. The implementation includes new shared Y-coordinate helpers, expanded public API exports for styling utilities, and comprehensive unit test coverage for grid rendering and draw order.

## Changes

### API & Interface Updates

- **OverlayTimingChartStyle** (`IBlitTechDemo.ts`): Added optional `gridPaletteIndex` field to allow customization of grid line colors, with fallback to gap/bar palette indices when omitted.

- **Timing chart exports** (`overlay/index.ts`): Expanded public API to include newly added layout and coordinate helpers: `computeTimingChartDotY`, `computeTimingChartGridLineY`, `shouldDrawTimingChartGridLineY`, `timingChartBaselineY`, `timingChartFrameBudgetMs`, and `writeTimingChartGridMarkers`.

### Core Implementation

- **TimingChart rendering** (`TimingChart.ts`): 
  - Added private `#drawGridLines()` method to render horizontal grid reference lines before plotting dots.
  - Refactored dot rendering via new `#drawDot()` helper using `computeTimingChartDotY` for cleaner Y-coordinate calculations.
  - Maintains reusable buffers for line geometry and grid marker thresholds.

- **Style utilities** (`style.ts`):
  - Refactored palette index resolution with internal helpers for cleaner code and added `gridBarIndex` to returned style object.
  - Implemented six new exported helpers for coordinate mapping and marker generation:
    - `computeTimingChartGridLineY()` and `computeTimingChartDotY()` for ms-to-screen coordinate conversion.
    - `timingChartBaselineY()`, `shouldDrawTimingChartGridLineY()` for baseline and edge detection.
    - `timingChartFrameBudgetMs()` for dynamic budget calculation.
    - `writeTimingChartGridMarkers()` for batch marker generation.

- **Grid constants** (`constants.ts`): Added `TIMING_CHART_GRID_MARKER_MS` to define fixed grid marker positions (5, 10, 33.33 ms), with frame budget added dynamically at render time.

### Documentation & Tests

- **API documentation** (`docs/api-core.md`): Clarified grid line behavior, color derivation through `overlayStyle` vs `overlayTimingChartStyle`, and updated configuration example with `gridPaletteIndex: 2`.

- **Unit test coverage** (`TimingChart.test.ts`, `style.test.ts`): Added 107+ lines of new tests covering grid-line rendering behavior (enabled/disabled states), grid line ordering relative to dots, edge skipping on top/bottom band rows, and style resolution including `gridPaletteIndex` fallback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/235?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->