### PR TITLE
feat(overlay): add scrolling timing chart event tags via BT.assignTag

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -144,12 +144,12 @@ jobs:
 
       - name: Check size limits
         run: |
-          # Fail if gzipped ESM exceeds 50 KB (adjust as needed)
+          # Fail if gzipped ESM exceeds 55 KB (adjust as needed)
           ESM_GZIP=${{ steps.size.outputs.esm_gzip }}
-          MAX_SIZE=51200  # 50 KB in bytes
+          MAX_SIZE=56320  # 55 KB in bytes
 
           if [ "$ESM_GZIP" -gt "$MAX_SIZE" ]; then
-            echo "::error::Bundle size (${{ steps.size.outputs.esm_gzip_kb }} KB gzipped) exceeds limit (50 KB)"
+            echo "::error::Bundle size (${{ steps.size.outputs.esm_gzip_kb }} KB gzipped) exceeds limit (55 KB)"
             exit 1
           fi
 

--- a/docs/api-core.md
+++ b/docs/api-core.md
@@ -223,8 +223,18 @@ otherwise.
   `1000 / targetFPS` (warning at **1.10x** budget, error at **1.50x**) and dropped-frame events from the game loop (one
   dropped frame = warning, two or more = error; error wins when both apply). Default warning/error/event palette indices
   are **3**, **4**, and **5** when not overridden. Drop detection for the chart runs whenever `overlayTimingChart: true`
-  (independent of `detectDroppedFrames`, which only controls console warnings). The `eventPaletteIndex` slot is reserved
-  for chart event tags (VV-541).
+  (independent of `detectDroppedFrames`, which only controls console warnings). **Event tags (VV-541):** call
+  `BT.assignTag(label?)` from `update()` or `init()` to anchor a short label on the scrolling chart at the current
+  `BT.ticks`. Empty or omitted labels become `"Untitled"`. Each tag column draws a tick row (relative ticks since chart
+  reset, capped at **100000**) and stacked label rows above the chart band; spacing is fixed in `tags.ts`
+  (`TIMING_CHART_TAG_LABEL_Y_GAP`, `TIMING_CHART_TAG_LABEL_STACK_SPACING`). Tick and label text share the same
+  horizontal offset from the timing column. A faint vertical grid-colored line marks the column on the chart band. Tag
+  columns follow timing **samples** (one per rendered frame), not `BT.ticks`, which can advance multiple fixed-update
+  steps per frame: they fill from the left while the ring buffer is not full, then scroll left one column per sample
+  once full, in lockstep with the dots. Tags are removed when they scroll one full chart width past the left edge (text
+  keeps drawing at negative x until the display clips it); pruning runs on each timing sample while the chart is
+  enabled. Chart width resets (for example on resize) clear tags and add an automatic `"Start"` marker. Tint tags with
+  `overlayTimingChartStyle.tagPaletteIndex` (default **5**).
 - **Top row 2 (left):** `Present: N FPS | Target: T FPS | Draw Calls: C`
 - **Top row 3 (left):** `Frame: Xms | update(): Yms | render(): Zms` (shows `xN` on `update()` when multiple fixed
   updates ran this frame)
@@ -335,6 +345,7 @@ configure() {
       gridPaletteIndex: 2, // horizontal grid lines; defaults to gapPaletteIndex
       warningPaletteIndex: 3, // soft over-budget / single drop; default 3
       errorPaletteIndex: 4, // hard over-budget / 2+ drops; default 4
+      tagPaletteIndex: 5, // tag and tick text; default 5
     },
   };
 }
@@ -359,6 +370,7 @@ BT.deltaSeconds; // seconds per fixed tick (1 / BT.targetFPS)
 BT.timeSeconds; // elapsed seconds since init (ticks × deltaSeconds)
 BT.ticks; // current tick counter (increments each update)
 BT.ticksReset(); // reset tick counter to 0
+BT.assignTag('Round start'); // timing chart event tag at current tick (requires overlayTimingChart)
 ```
 
 ### Timer

--- a/src/BlitTech.test.ts
+++ b/src/BlitTech.test.ts
@@ -352,6 +352,20 @@ describe('BT.ticksReset', () => {
     });
 });
 
+describe('BT.assignTag', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('delegates to BTAPI.instance.assignTag', () => {
+        const spy = vi.spyOn(BTAPI.instance, 'assignTag').mockReturnValue(undefined);
+
+        BT.assignTag('Milestone');
+
+        expect(spy).toHaveBeenCalledWith('Milestone');
+    });
+});
+
 // #endregion
 
 // #region BT.paletteCreate / BT.paletteSet / BT.palette

--- a/src/BlitTech.ts
+++ b/src/BlitTech.ts
@@ -522,6 +522,19 @@ export const BT = {
     },
 
     /**
+     * Places a labeled marker on the overlay timing chart at the current tick.
+     *
+     * Requires `overlayTimingChart: true` in `configure()`. Tags scroll with the chart
+     * history and are pruned when they leave the visible window. Empty labels become
+     * `"Untitled"`. Chart width resets add an automatic `"Start"` tag.
+     *
+     * @param label - Short event name (for example `'Round start'`).
+     */
+    assignTag: (label?: string): void => {
+        BTAPI.instance.assignTag(label);
+    },
+
+    /**
      * Rendering backend that is currently active.
      *
      * `'webgpu'` or `'software'` after successful init; `null` before init or on failure.

--- a/src/core/BTAPI.test.ts
+++ b/src/core/BTAPI.test.ts
@@ -1135,6 +1135,51 @@ describe('BTAPI', () => {
 
     // #endregion
 
+    // #region Timing chart tags (VV-541)
+
+    describe('assignTag', () => {
+        it('forwards tags to Overlay when the timing chart is enabled', async () => {
+            const assignSpy = vi.spyOn(Overlay.prototype, 'assignTag');
+            const demo: IBlitTechDemo = {
+                configure: () => ({
+                    displaySize: new Vector2i(320, 240),
+                    targetFPS: 60,
+                    overlayTimingChart: true,
+                }),
+                init: vi.fn().mockResolvedValue(true),
+                update: vi.fn(),
+                render: vi.fn(),
+            };
+
+            await BTAPI.instance.init(demo, makeMockCanvas());
+            BTAPI.instance.assignTag('Checkpoint');
+
+            expect(assignSpy).toHaveBeenCalledWith('Checkpoint', expect.any(Number));
+        });
+
+        it('does not store tags when overlayTimingChart is disabled', async () => {
+            const { TimingChart } = await import('../overlay/timing-chart/TimingChart');
+            const assignSpy = vi.spyOn(TimingChart.prototype, 'assignTag');
+            const demo: IBlitTechDemo = {
+                configure: () => ({
+                    displaySize: new Vector2i(320, 240),
+                    targetFPS: 60,
+                    overlayTimingChart: false,
+                }),
+                init: vi.fn().mockResolvedValue(true),
+                update: vi.fn(),
+                render: vi.fn(),
+            };
+
+            await BTAPI.instance.init(demo, makeMockCanvas());
+            BTAPI.instance.assignTag('Ignored');
+
+            expect(assignSpy).not.toHaveBeenCalled();
+        });
+    });
+
+    // #endregion
+
     // #region Palette usage tracking (VV-543)
 
     describe('palette usage tracking', () => {

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -484,6 +484,17 @@ export class BTAPI {
         this.loop?.resetTicks();
     }
 
+    /**
+     * Assigns an event tag on the stats overlay timing chart (VV-541).
+     *
+     * No-op when the overlay or timing chart is disabled.
+     *
+     * @param label - Tag text; empty becomes `"Untitled"`.
+     */
+    public assignTag(label?: string): void {
+        this.overlay?.assignTag(label, this.getTicks());
+    }
+
     // #endregion
 
     // #region Demo State Accessors

--- a/src/core/IBlitTechDemo.ts
+++ b/src/core/IBlitTechDemo.ts
@@ -213,7 +213,7 @@ export interface OverlayStyle {
 }
 
 /**
- * Palette indices for the overlay timing chart band.
+ * Palette indices for the timing chart band.
  */
 export interface OverlayTimingChartStyle {
     /** Update bar color; defaults to {@link OverlayStyle.barPaletteIndex} or overlay bar index. */
@@ -228,8 +228,8 @@ export interface OverlayTimingChartStyle {
     /** Error tint when a chart column is severely over budget or dropped 2+ frames (VV-545). */
     errorPaletteIndex?: number;
 
-    /** Event/tag tint for future chart markers (VV-541). */
-    eventPaletteIndex?: number;
+    /** Palette index for timing chart tag and tick text (VV-541). */
+    tagPaletteIndex?: number;
 
     /**
      * Faint horizontal grid lines behind chart dots (VV-7). Defaults to

--- a/src/overlay/Overlay.test.ts
+++ b/src/overlay/Overlay.test.ts
@@ -38,14 +38,15 @@ interface OverlayTestOptions {
     paletteView?: boolean;
     paletteColumns?: number;
     paletteRowsVisible?: number;
-    timingChart?: boolean;
-    timingChartStyle?: {
+    overlayTimingChart?: boolean;
+    overlayTimingChartStyle?: {
         updateBarPaletteIndex?: number;
         renderBarPaletteIndex?: number;
         warningPaletteIndex?: number;
         errorPaletteIndex?: number;
+        tagPaletteIndex?: number;
     };
-    timingChartHeight?: number;
+    overlayTimingChartHeight?: number;
     visibleAtStart?: boolean;
     toggleHintVisible?: boolean;
     toggleEnabled?: boolean;
@@ -67,9 +68,9 @@ function createOverlay(
         options.paletteView ?? OVERLAY_PALETTE_VIEW_OFF,
         options.paletteColumns,
         options.paletteRowsVisible,
-        options.timingChart ?? false,
-        options.timingChartStyle,
-        options.timingChartHeight,
+        options.overlayTimingChart ?? false,
+        options.overlayTimingChartStyle,
+        options.overlayTimingChartHeight,
         options.visibleAtStart ?? false,
         options.toggleHintVisible ?? true,
         options.toggleEnabled ?? true,
@@ -595,13 +596,38 @@ describe('Overlay', () => {
         expect(renderer.drawBarFillOnTop).toHaveBeenCalled();
     });
 
+    it('forwards timing chart tags to drawLabelOnTop with event palette offset', () => {
+        const layout = createOverlayLayout(320, 240, 14);
+        const overlay = createOverlay(layout, 'Demo', {
+            overlayTimingChart: true,
+            overlayTimingChartStyle: { tagPaletteIndex: 7 },
+            visibleAtStart: true,
+        });
+        const renderer = createMockRenderer();
+
+        overlay.assignTag('Spawn', 42);
+        overlay.updateAndRender(renderer, mockFont, null, null, 42, undefined, {
+            frameMs: 1,
+            updateMs: 1,
+            renderMs: 1,
+            updateSteps: 1,
+            drawCalls: 0,
+            droppedFrames: 0,
+        });
+
+        const tagCall = renderer.drawLabelOnTop.mock.calls.find((call) => call[2] === 'Spawn');
+
+        expect(tagCall).toBeDefined();
+        expect(tagCall?.[3]).toBe(6);
+    });
+
     it('draws timing chart dots when overlayTimingChart is enabled', () => {
         const layout = createOverlayLayout(320, 240, 14);
         const overlay = createOverlay(layout, 'Demo', {
             style: { barPaletteIndex: 8, textPaletteIndex: 9 },
-            timingChart: true,
-            timingChartStyle: { updateBarPaletteIndex: 10, renderBarPaletteIndex: 11 },
-            timingChartHeight: 36,
+            overlayTimingChart: true,
+            overlayTimingChartStyle: { updateBarPaletteIndex: 10, renderBarPaletteIndex: 11 },
+            overlayTimingChartHeight: 36,
             visibleAtStart: true,
         });
         const renderer = createMockRenderer();
@@ -627,8 +653,8 @@ describe('Overlay', () => {
     it('tints timing chart dots with warning palette when frame exceeds soft budget', () => {
         const layout = createOverlayLayout(320, 240, 14);
         const overlay = createOverlay(layout, 'Demo', {
-            timingChart: true,
-            timingChartStyle: {
+            overlayTimingChart: true,
+            overlayTimingChartStyle: {
                 updateBarPaletteIndex: 10,
                 renderBarPaletteIndex: 11,
                 warningPaletteIndex: 3,
@@ -659,8 +685,8 @@ describe('Overlay', () => {
     it('does not draw overlay while hidden but keeps timing chart samples for re-show', () => {
         const layout = createOverlayLayout(320, 240, 14);
         const overlay = createOverlay(layout, 'Demo', {
-            timingChart: true,
-            timingChartStyle: { updateBarPaletteIndex: 10, renderBarPaletteIndex: 11 },
+            overlayTimingChart: true,
+            overlayTimingChartStyle: { updateBarPaletteIndex: 10, renderBarPaletteIndex: 11 },
             visibleAtStart: true,
             toggleHintVisible: false,
         });
@@ -711,8 +737,8 @@ describe('Overlay', () => {
     it('records drop severity in chart history while body is hidden', () => {
         const layout = createOverlayLayout(320, 240, 14);
         const overlay = createOverlay(layout, 'Demo', {
-            timingChart: true,
-            timingChartStyle: { warningPaletteIndex: 3, errorPaletteIndex: 4 },
+            overlayTimingChart: true,
+            overlayTimingChartStyle: { warningPaletteIndex: 3, errorPaletteIndex: 4 },
             visibleAtStart: true,
             toggleHintVisible: false,
         });

--- a/src/overlay/Overlay.ts
+++ b/src/overlay/Overlay.ts
@@ -22,8 +22,8 @@ import { computePaletteGrid, DEFAULT_PALETTE_GRID, PaletteView } from './palette
 import { FpsSampler } from './sampling/FpsSampler';
 import { TimingSampler } from './sampling/TimingSampler';
 import { DEFAULT_TIMING_CHART_HEIGHT } from './timing-chart/constants';
-import type { ResolvedOverlayTimingChartStyle } from './timing-chart/style';
-import { resolveOverlayTimingChartStyle } from './timing-chart/style';
+import type { TimingChartDrawStyle } from './timing-chart/style';
+import { resolveTimingChartStyle } from './timing-chart/style';
 import { TimingChart } from './timing-chart/TimingChart';
 import type { OverlayTimingSnapshot } from './types';
 
@@ -61,7 +61,7 @@ export class Overlay {
 
     readonly #timingChartHeight: number;
 
-    readonly #timingChartStyle: ResolvedOverlayTimingChartStyle;
+    readonly #timingChartStyle: TimingChartDrawStyle;
 
     readonly #paletteView: PaletteView;
 
@@ -127,7 +127,7 @@ export class Overlay {
         this.#idxText = style?.textPaletteIndex ?? DEFAULT_IDX_TEXT;
         this.#idxGap = style?.gapPaletteIndex ?? this.#idxBg;
         this.#topRightLabel = `${activeBackend} | ${layout.displayWidth}x${layout.displayHeight}`;
-        this.#timingChartStyle = resolveOverlayTimingChartStyle(style, overlayTimingChartStyle);
+        this.#timingChartStyle = resolveTimingChartStyle(style, overlayTimingChartStyle);
         this.#timingChartHeight = overlayTimingChartHeight ?? DEFAULT_TIMING_CHART_HEIGHT;
         this.#timingChart = new TimingChart(overlayTimingChart, targetFps);
         this.#paletteView = new PaletteView(overlayPaletteView);
@@ -138,13 +138,29 @@ export class Overlay {
         this.#toggleHintVisible = overlayToggleHintVisible;
 
         if (overlayTimingChart) {
-            this.#timingChart.reset(layout.displayWidth);
+            this.#timingChart.reset(layout.displayWidth, 0);
         }
     }
 
     // #endregion
 
     // #region Public API
+
+    /**
+     * Records a timing-chart event tag at the current tick (VV-541).
+     *
+     * No-op when the timing chart is disabled.
+     *
+     * @param label - Tag text; empty becomes `"Untitled"`.
+     * @param currentTick - Current fixed-update tick (`BT.ticks`).
+     */
+    assignTag(label: string | undefined, currentTick: number): void {
+        if (!this.#timingChart.enabled) {
+            return;
+        }
+
+        this.#timingChart.assignTag(label, currentTick);
+    }
 
     /**
      * Whether the overlay body is currently drawn (runtime toggle).
@@ -420,7 +436,7 @@ export class Overlay {
                 `render(): ${this.#timing.renderMs.toFixed(1)}ms`;
 
             this.#bars.drawTopBars(renderer, plan, this.#idxBg);
-            this.#timingChart.draw(renderer, plan.timingChart, this.#timingChartStyle);
+            this.#timingChart.draw(renderer, plan.timingChart, this.#timingChartStyle, font, currentTick);
 
             if (customRows !== undefined && customRows.length > 0) {
                 this.#bars.drawCustomRowFills(renderer, plan, customRows, this.#barStyle);

--- a/src/overlay/index.ts
+++ b/src/overlay/index.ts
@@ -37,17 +37,16 @@ export { PaletteInteraction } from './palette/PaletteInteraction';
 export { computePaletteGrid, PaletteView } from './palette/PaletteView';
 export { FpsSampler } from './sampling/FpsSampler';
 export { TimingSampler } from './sampling/TimingSampler';
-export type { ResolvedOverlayTimingChartStyle } from './timing-chart/style';
+export type { TimingChartDrawStyle } from './timing-chart/style';
 export {
     computeTimingChartBarHeight,
     computeTimingChartDotY,
     computeTimingChartGridLineY,
-    resolveOverlayTimingChartStyle,
+    resolveTimingChartStyle,
     shouldDrawTimingChartGridLineY,
     timingChartBaselineY,
     timingChartFrameBudgetMs,
     writeTimingChartGridMarkers,
 } from './timing-chart/style';
-export type { OverlayTimingChartDrawStyle } from './timing-chart/TimingChart';
 export { TimingChart } from './timing-chart/TimingChart';
 export type { OverlayTimingSnapshot, PaletteGridLayout } from './types';

--- a/src/overlay/testFixtures.ts
+++ b/src/overlay/testFixtures.ts
@@ -77,6 +77,20 @@ export function getBitmapTextCalls(renderer: ReturnType<typeof createMockRendere
 }
 
 /**
+ * Collects {@link OverlayDrawTarget.drawLabelOnTop} calls from a mock renderer.
+ *
+ * @param renderer - Mock from {@link createMockRenderer}.
+ * @returns Parsed draw calls in invocation order.
+ */
+export function getLabelOnTopCalls(renderer: ReturnType<typeof createMockRenderer>): BitmapTextCall[] {
+    return renderer.drawLabelOnTop.mock.calls.map((call) => ({
+        pos: call[1] as Vector2i,
+        text: call[2] as string,
+        paletteOffset: (call[3] as number | undefined) ?? 0,
+    }));
+}
+
+/**
  * Collects {@link OverlayDrawTarget.drawBarFill} rects from a mock renderer.
  *
  * @param renderer - Mock from {@link createMockRenderer}.
@@ -100,6 +114,6 @@ export function customRowBarY(displayHeight: number, rowIndex: number, footerHei
     return customBarY(footerStackTopY, rowIndex);
 }
 
-export const mockFont = {} as BitmapFont;
+export const mockFont = { lineHeight: 14 } as BitmapFont;
 
 export { OVERLAY_BAR_HEIGHT, OVERLAY_EDGE_MARGIN_PX, OVERLAY_ROW_GAP_PX, OVERLAY_TOP_TEXT_Y } from './layout/constants';

--- a/src/overlay/timing-chart/TimingChart.test.ts
+++ b/src/overlay/timing-chart/TimingChart.test.ts
@@ -1,10 +1,43 @@
 import { describe, expect, it } from 'vitest';
 
 import { Rect2i } from '../../utils/Rect2i';
-import { createMockRenderer, getRectFillCalls } from '../testFixtures';
+import { Vector2i } from '../../utils/Vector2i';
+import { createMockRenderer, getLabelOnTopCalls, getRectFillCalls, mockFont } from '../testFixtures';
 import { TIMING_CHART_FULL_SCALE_MS } from './constants';
 import { computeTimingChartBarHeight, computeTimingChartDotY } from './style';
+import {
+    computeTimingChartTagLabelY,
+    computeTimingChartTagTextX,
+    computeTimingChartTagTickY,
+    TIMING_CHART_TAG_TEXT_X_OFFSET,
+} from './tags';
 import { TimingChart } from './TimingChart';
+
+const defaultStyle = {
+    updateBarIndex: 8,
+    renderBarIndex: 9,
+    warningBarIndex: 3,
+    errorBarIndex: 4,
+    tagBarIndex: 5,
+    gridBarIndex: 6,
+};
+
+/**
+ * Draws a chart band in tests with the required font and tick arguments.
+ *
+ * @param chart - Timing chart under test.
+ * @param renderer - Mock overlay renderer.
+ * @param chartRect - Chart band rectangle.
+ * @param currentTick - Simulated fixed-update tick.
+ */
+function drawChart(
+    chart: TimingChart,
+    renderer: ReturnType<typeof createMockRenderer>,
+    chartRect: Rect2i,
+    currentTick: number,
+): void {
+    chart.draw(renderer, chartRect, defaultStyle, mockFont, currentTick);
+}
 
 // #region computeTimingChartBarHeight tests
 
@@ -35,38 +68,24 @@ describe('TimingChart', () => {
             drawCalls: 1,
             droppedFrames: 0,
         });
-        chart.draw(renderer, new Rect2i(0, 14, 4, 22), {
-            updateBarIndex: 1,
-            renderBarIndex: 2,
-            warningBarIndex: 3,
-            errorBarIndex: 4,
-            eventBarIndex: 5,
-            gridBarIndex: 6,
-        });
+        drawChart(chart, renderer, new Rect2i(0, 14, 4, 22), 0);
 
         expect(renderer.drawBarFill).not.toHaveBeenCalled();
+        expect(renderer.drawLabelOnTop).not.toHaveBeenCalled();
     });
 
     it('wraps ring buffer and keeps newest samples on the right', () => {
         const chart = new TimingChart(true);
         const renderer = createMockRenderer();
-        const style = {
-            updateBarIndex: 8,
-            renderBarIndex: 9,
-            warningBarIndex: 3,
-            errorBarIndex: 4,
-            eventBarIndex: 5,
-            gridBarIndex: 6,
-        };
         const chartRect = new Rect2i(0, 0, 3, 22);
 
-        chart.reset(3);
+        chart.reset(3, 0);
         chart.sample({ frameMs: 0, updateMs: 4, renderMs: 0, updateSteps: 1, drawCalls: 0, droppedFrames: 0 });
         chart.sample({ frameMs: 0, updateMs: 8, renderMs: 0, updateSteps: 1, drawCalls: 0, droppedFrames: 0 });
         chart.sample({ frameMs: 0, updateMs: 12, renderMs: 0, updateSteps: 1, drawCalls: 0, droppedFrames: 0 });
         chart.sample({ frameMs: 0, updateMs: 16, renderMs: 0, updateSteps: 1, drawCalls: 0, droppedFrames: 0 });
 
-        chart.draw(renderer, chartRect, style);
+        drawChart(chart, renderer, chartRect, 4);
 
         const updateDotY = (ms: number) => computeTimingChartDotY(ms, chartRect, TIMING_CHART_FULL_SCALE_MS);
 
@@ -85,18 +104,10 @@ describe('TimingChart', () => {
     it('draws render dots for sub-millisecond samples', () => {
         const chart = new TimingChart(true);
         const renderer = createMockRenderer();
-        const style = {
-            updateBarIndex: 8,
-            renderBarIndex: 9,
-            warningBarIndex: 3,
-            errorBarIndex: 4,
-            eventBarIndex: 5,
-            gridBarIndex: 6,
-        };
 
-        chart.reset(4);
+        chart.reset(4, 0);
         chart.sample({ frameMs: 0, updateMs: 0, renderMs: 0.1, updateSteps: 1, drawCalls: 1, droppedFrames: 0 });
-        chart.draw(renderer, new Rect2i(0, 14, 4, 32), style);
+        drawChart(chart, renderer, new Rect2i(0, 14, 4, 32), 1);
 
         expect(
             renderer.drawBarFill.mock.calls.some(
@@ -112,16 +123,9 @@ describe('TimingChart', () => {
         const chart = new TimingChart(true);
         const renderer = createMockRenderer();
 
-        chart.reset(1);
+        chart.reset(1, 0);
         chart.sample({ frameMs: 0, updateMs: 12, renderMs: 8, updateSteps: 1, drawCalls: 0, droppedFrames: 0 });
-        chart.draw(renderer, new Rect2i(10, 14, 1, 22), {
-            updateBarIndex: 8,
-            renderBarIndex: 9,
-            warningBarIndex: 3,
-            errorBarIndex: 4,
-            eventBarIndex: 5,
-            gridBarIndex: 6,
-        });
+        drawChart(chart, renderer, new Rect2i(10, 14, 1, 22), 1);
 
         const dotPaletteIndices = renderer.drawBarFill.mock.calls
             .filter((call) => call[1] === 8 || call[1] === 9)
@@ -135,16 +139,8 @@ describe('TimingChart', () => {
     it('tints both dots with warning palette when frame is over soft budget', () => {
         const chart = new TimingChart(true, 60);
         const renderer = createMockRenderer();
-        const style = {
-            updateBarIndex: 8,
-            renderBarIndex: 9,
-            warningBarIndex: 3,
-            errorBarIndex: 4,
-            eventBarIndex: 5,
-            gridBarIndex: 6,
-        };
 
-        chart.reset(1);
+        chart.reset(1, 0);
         chart.sample({
             frameMs: 20,
             updateMs: 12,
@@ -153,7 +149,7 @@ describe('TimingChart', () => {
             drawCalls: 0,
             droppedFrames: 0,
         });
-        chart.draw(renderer, new Rect2i(0, 14, 1, 22), style);
+        drawChart(chart, renderer, new Rect2i(0, 14, 1, 22), 1);
 
         const dotPaletteIndices = renderer.drawBarFill.mock.calls
             .filter((call) => call[1] === 3)
@@ -168,7 +164,7 @@ describe('TimingChart', () => {
         const chart = new TimingChart(true, 60);
         const renderer = createMockRenderer();
 
-        chart.reset(1);
+        chart.reset(1, 0);
         chart.sample({
             frameMs: 0,
             updateMs: 0,
@@ -177,14 +173,7 @@ describe('TimingChart', () => {
             drawCalls: 0,
             droppedFrames: 2,
         });
-        chart.draw(renderer, new Rect2i(0, 14, 1, 22), {
-            updateBarIndex: 8,
-            renderBarIndex: 9,
-            warningBarIndex: 3,
-            errorBarIndex: 4,
-            eventBarIndex: 5,
-            gridBarIndex: 6,
-        });
+        drawChart(chart, renderer, new Rect2i(0, 14, 1, 22), 1);
 
         const severityCalls = renderer.drawBarFill.mock.calls.filter((call) => call[1] === 4);
 
@@ -198,7 +187,7 @@ describe('TimingChart', () => {
         const chartRect = new Rect2i(5, 14, 1, 22);
         const baselineY = chartRect.y + chartRect.height - 1;
 
-        chart.reset(1);
+        chart.reset(1, 0);
         chart.sample({
             frameMs: 0,
             updateMs: 0,
@@ -207,14 +196,7 @@ describe('TimingChart', () => {
             drawCalls: 0,
             droppedFrames: 1,
         });
-        chart.draw(renderer, chartRect, {
-            updateBarIndex: 8,
-            renderBarIndex: 9,
-            warningBarIndex: 3,
-            errorBarIndex: 4,
-            eventBarIndex: 5,
-            gridBarIndex: 6,
-        });
+        drawChart(chart, renderer, chartRect, 1);
 
         expect(renderer.drawBarFill).toHaveBeenCalledWith(expect.objectContaining({ x: 5, y: baselineY }), 3);
     });
@@ -223,22 +205,14 @@ describe('TimingChart', () => {
         const chart = new TimingChart(true, 60);
         const renderer = createMockRenderer();
         const chartRect = new Rect2i(10, 14, 8, 22);
-        const style = {
-            updateBarIndex: 8,
-            renderBarIndex: 9,
-            warningBarIndex: 3,
-            errorBarIndex: 4,
-            eventBarIndex: 5,
-            gridBarIndex: 6,
-        };
 
-        chart.reset(chartRect.width);
+        chart.reset(chartRect.width, 0);
         chart.sample({ frameMs: 0, updateMs: 12, renderMs: 8, updateSteps: 1, drawCalls: 0, droppedFrames: 0 });
-        chart.draw(renderer, chartRect, style);
+        drawChart(chart, renderer, chartRect, 1);
 
         const mockCalls = renderer.drawBarFill.mock.calls;
         const firstDotIndex = mockCalls.findIndex(
-            (call) => call[1] === style.updateBarIndex || call[1] === style.renderBarIndex,
+            (call) => call[1] === defaultStyle.updateBarIndex || call[1] === defaultStyle.renderBarIndex,
         );
         const lastGridIndex = mockCalls.reduce((last, call, index) => (call[1] === 6 ? index : last), -1);
 
@@ -252,17 +226,15 @@ describe('TimingChart', () => {
         const renderer = createMockRenderer();
         const chartRect = new Rect2i(0, 14, 4, 22);
 
-        chart.reset(chartRect.width);
-        chart.draw(renderer, chartRect, {
-            updateBarIndex: 8,
-            renderBarIndex: 9,
-            warningBarIndex: 3,
-            errorBarIndex: 4,
-            eventBarIndex: 5,
-            gridBarIndex: 6,
-        });
+        chart.reset(chartRect.width, 0);
+        drawChart(chart, renderer, chartRect, 0);
 
-        expect(renderer.drawBarFill.mock.calls.filter((call) => call[1] === 6)).toHaveLength(2);
+        const fills = getRectFillCalls(renderer);
+        const horizontalGrid = fills.filter((rect) => rect.height === 1 && rect.width === chartRect.width);
+        const initMarker = fills.filter((rect) => rect.width === 1 && rect.height === chartRect.height);
+
+        expect(horizontalGrid).toHaveLength(2);
+        expect(initMarker).toHaveLength(1);
     });
 
     it('draws grid lines even when the ring buffer has no samples yet', () => {
@@ -270,15 +242,8 @@ describe('TimingChart', () => {
         const renderer = createMockRenderer();
         const chartRect = new Rect2i(0, 14, 4, 22);
 
-        chart.reset(4);
-        chart.draw(renderer, chartRect, {
-            updateBarIndex: 8,
-            renderBarIndex: 9,
-            warningBarIndex: 3,
-            errorBarIndex: 4,
-            eventBarIndex: 5,
-            gridBarIndex: 6,
-        });
+        chart.reset(4, 0);
+        drawChart(chart, renderer, chartRect, 0);
 
         const gridCallCount = renderer.drawBarFill.mock.calls.filter((call) => call[1] === 6).length;
 
@@ -290,16 +255,252 @@ describe('TimingChart', () => {
         const renderer = createMockRenderer();
 
         chart.reset(4);
-        chart.draw(renderer, new Rect2i(0, 14, 4, 22), {
-            updateBarIndex: 8,
-            renderBarIndex: 9,
-            warningBarIndex: 3,
-            errorBarIndex: 4,
-            eventBarIndex: 5,
-            gridBarIndex: 6,
-        });
+        drawChart(chart, renderer, new Rect2i(0, 14, 4, 22), 0);
 
         expect(renderer.drawBarFill).not.toHaveBeenCalled();
+    });
+
+    it('adds Start tag when chart width is first allocated', () => {
+        const chart = new TimingChart(true);
+        const renderer = createMockRenderer();
+        const chartRect = new Rect2i(0, 14, 8, 22);
+
+        drawChart(chart, renderer, chartRect, 100);
+
+        const labels = getLabelOnTopCalls(renderer).map((call) => call.text);
+
+        expect(labels).toContain('Start');
+    });
+
+    it('defaults empty assignTag labels to Untitled', () => {
+        const chart = new TimingChart(true);
+        const renderer = createMockRenderer();
+        const chartRect = new Rect2i(0, 14, 8, 22);
+
+        const sample = {
+            frameMs: 0,
+            updateMs: 1,
+            renderMs: 0,
+            updateSteps: 1,
+            drawCalls: 0,
+            droppedFrames: 0,
+        };
+
+        drawChart(chart, renderer, chartRect, 50);
+        chart.sample(sample);
+        renderer.drawLabelOnTop.mockClear();
+        chart.assignTag('', 51);
+        drawChart(chart, renderer, chartRect, 52);
+
+        expect(getLabelOnTopCalls(renderer).some((call) => call.text === 'Untitled')).toBe(true);
+    });
+
+    it('draws a vertical grid-colored marker at each tag column', () => {
+        const chart = new TimingChart(true);
+        const renderer = createMockRenderer();
+        const chartRect = new Rect2i(10, 20, 100, 22);
+
+        chart.reset(chartRect.width, 0);
+        chart.assignTag('Bounce 1', 40);
+        chart.sample({
+            frameMs: 0,
+            updateMs: 1,
+            renderMs: 0,
+            updateSteps: 1,
+            drawCalls: 0,
+            droppedFrames: 0,
+        });
+        drawChart(chart, renderer, chartRect, 1);
+
+        const markerRect = getRectFillCalls(renderer).find(
+            (rect) => rect.width === 1 && rect.height === chartRect.height && rect.y === chartRect.y,
+        );
+
+        expect(markerRect).toEqual(expect.objectContaining({ x: 10, width: 1, height: 22 }));
+    });
+
+    it('draws tags aligned with ring-buffer columns and event palette offset', () => {
+        const chart = new TimingChart(true);
+        const renderer = createMockRenderer();
+        const chartRect = new Rect2i(10, 20, 100, 22);
+        const tagTick = 450;
+        const currentTick = 500;
+
+        const sample = {
+            frameMs: 0,
+            updateMs: 1,
+            renderMs: 0,
+            updateSteps: 1,
+            drawCalls: 0,
+            droppedFrames: 0,
+        };
+
+        chart.reset(chartRect.width, 0);
+        for (let tick = 1; tick < tagTick; tick++) {
+            chart.sample(sample);
+        }
+        chart.assignTag('Milestone', tagTick);
+        for (let tick = tagTick; tick <= currentTick; tick++) {
+            chart.sample(sample);
+        }
+        drawChart(chart, renderer, chartRect, currentTick);
+
+        const expectedTextX = computeTimingChartTagTextX(chartRect.x, chartRect.width, tagTick - 1, currentTick);
+
+        expect(expectedTextX).not.toBeNull();
+
+        const labelCall = getLabelOnTopCalls(renderer).find((call) => call.text === 'Milestone');
+
+        expect(labelCall).toEqual({
+            pos: new Vector2i(expectedTextX as number, computeTimingChartTagLabelY(chartRect.y, 0)),
+            text: 'Milestone',
+            paletteOffset: defaultStyle.tagBarIndex - 1,
+        });
+
+        const tickCall = getLabelOnTopCalls(renderer).find((call) => call.text === String(tagTick));
+
+        expect(tickCall?.pos).toEqual(new Vector2i(expectedTextX as number, computeTimingChartTagTickY(chartRect.y)));
+    });
+
+    it('stacks multiple labels on the same column below one tick row', () => {
+        const chart = new TimingChart(true);
+        const renderer = createMockRenderer();
+        const chartRect = new Rect2i(0, 30, 80, 22);
+        chart.reset(chartRect.width, 0);
+        chart.assignTag('First', 0);
+        chart.assignTag('Second', 0);
+        drawChart(chart, renderer, chartRect, 0);
+
+        const calls = getLabelOnTopCalls(renderer);
+        const tickCall = calls.find((call) => call.text === '0');
+        const firstCall = calls.find((call) => call.text === 'First');
+        const secondCall = calls.find((call) => call.text === 'Second');
+
+        expect(tickCall?.pos.y).toBe(computeTimingChartTagTickY(chartRect.y));
+        expect(firstCall?.pos.y).toBe(computeTimingChartTagLabelY(chartRect.y, 1));
+        expect(secondCall?.pos.y).toBe(computeTimingChartTagLabelY(chartRect.y, 2));
+        expect(
+            getRectFillCalls(renderer).filter((rect) => rect.width === 1 && rect.height === chartRect.height).length,
+        ).toBe(1);
+    });
+
+    it('places Start on the left edge before the chart buffer fills', () => {
+        const chart = new TimingChart(true);
+        const renderer = createMockRenderer();
+        const chartRect = new Rect2i(5, 10, 80, 22);
+
+        chart.reset(chartRect.width, 0);
+        chart.sample({
+            frameMs: 0,
+            updateMs: 1,
+            renderMs: 0,
+            updateSteps: 1,
+            drawCalls: 0,
+            droppedFrames: 0,
+        });
+        drawChart(chart, renderer, chartRect, 1);
+
+        const startCall = getLabelOnTopCalls(renderer).find((call) => call.text === 'Start');
+
+        expect(startCall?.pos.x).toBe(chartRect.x + TIMING_CHART_TAG_TEXT_X_OFFSET);
+    });
+
+    it('draws tags while they slide off the left edge of the chart', () => {
+        const chart = new TimingChart(true);
+        const renderer = createMockRenderer();
+        const chartRect = new Rect2i(10, 20, 100, 22);
+        const sample = {
+            frameMs: 0,
+            updateMs: 1,
+            renderMs: 0,
+            updateSteps: 1,
+            drawCalls: 0,
+            droppedFrames: 0,
+        };
+
+        chart.reset(chartRect.width, 0);
+        chart.assignTag('Exit', 0);
+        for (let index = 0; index < 160; index++) {
+            chart.sample(sample);
+        }
+        drawChart(chart, renderer, chartRect, 0);
+
+        const exitCall = getLabelOnTopCalls(renderer).find((call) => call.text === 'Exit');
+
+        expect(exitCall?.pos.x).toBeLessThan(chartRect.x + TIMING_CHART_TAG_TEXT_X_OFFSET);
+        expect(exitCall?.pos.x).toBeGreaterThan(chartRect.x - chartRect.width);
+    });
+
+    it('does not jump tags when the ring buffer becomes full', () => {
+        const chart = new TimingChart(true);
+        const renderer = createMockRenderer();
+        const chartRect = new Rect2i(0, 14, 100, 22);
+        const width = chartRect.width;
+        const sample = {
+            frameMs: 0,
+            updateMs: 1,
+            renderMs: 0,
+            updateSteps: 1,
+            drawCalls: 0,
+            droppedFrames: 0,
+        };
+
+        chart.reset(width, 0);
+        for (let index = 0; index < 40; index++) {
+            chart.sample(sample);
+        }
+        chart.assignTag('Milestone', 9999);
+        for (let index = 40; index < width - 1; index++) {
+            chart.sample(sample);
+        }
+
+        drawChart(chart, renderer, chartRect, 99_999);
+        const beforeFull = getLabelOnTopCalls(renderer).find((call) => call.text === 'Milestone')?.pos.x;
+
+        renderer.drawLabelOnTop.mockClear();
+        chart.sample(sample);
+        drawChart(chart, renderer, chartRect, 99_999);
+
+        const afterFull = getLabelOnTopCalls(renderer).find((call) => call.text === 'Milestone')?.pos.x;
+
+        expect(beforeFull).toBe(chartRect.x + 40 + TIMING_CHART_TAG_TEXT_X_OFFSET);
+        expect(afterFull).toBe(beforeFull);
+    });
+
+    it('prunes tags once they scroll one chart width past the left edge', () => {
+        const chart = new TimingChart(true);
+        const renderer = createMockRenderer();
+        const chartRect = new Rect2i(0, 14, 100, 22);
+        const width = chartRect.width;
+        const sample = {
+            frameMs: 0,
+            updateMs: 1,
+            renderMs: 0,
+            updateSteps: 1,
+            drawCalls: 0,
+            droppedFrames: 0,
+        };
+
+        chart.reset(width, 0);
+        chart.assignTag('Old', 0);
+        for (let tick = 0; tick < 450; tick++) {
+            chart.sample(sample);
+        }
+        chart.assignTag('Fresh', 450);
+        for (let tick = 450; tick < 500; tick++) {
+            chart.sample(sample);
+        }
+
+        drawChart(chart, renderer, chartRect, 500);
+
+        renderer.drawLabelOnTop.mockClear();
+        chart.sample(sample);
+        drawChart(chart, renderer, chartRect, 501);
+
+        const labels = getLabelOnTopCalls(renderer).map((call) => call.text);
+
+        expect(labels).not.toContain('Old');
+        expect(labels).toContain('Fresh');
     });
 });
 

--- a/src/overlay/timing-chart/TimingChart.ts
+++ b/src/overlay/timing-chart/TimingChart.ts
@@ -1,29 +1,36 @@
 /**
- * Scrolling update/render timing chart band for the overlay (VV-539, VV-545 severity, VV-7 grid).
+ * Scrolling update/render timing chart band for the overlay (VV-539, VV-545 severity, VV-7 grid, VV-541 tags).
  */
 
+import type { BitmapFont } from '../../assets/BitmapFont';
 import { Rect2i } from '../../utils/Rect2i';
+import { Vector2i } from '../../utils/Vector2i';
 import type { OverlayDrawTarget } from '../OverlayDrawTarget';
 import type { OverlayTimingSnapshot } from '../types';
 import { TIMING_CHART_FULL_SCALE_MS } from './constants';
-import {
-    classifyTimingChartSeverity,
-    TIMING_CHART_SEVERITY_ERROR,
-    TIMING_CHART_SEVERITY_NONE,
-    TIMING_CHART_SEVERITY_WARNING,
-} from './severity';
+import { classifyTimingChartSeverity, TIMING_CHART_SEVERITY_ERROR, TIMING_CHART_SEVERITY_WARNING } from './severity';
 import {
     computeTimingChartBarHeight,
     computeTimingChartDotY,
     computeTimingChartGridLineY,
-    type ResolvedOverlayTimingChartStyle,
     shouldDrawTimingChartGridLineY,
     timingChartBaselineY,
+    type TimingChartDrawStyle,
     writeTimingChartGridMarkers,
 } from './style';
-
-/** Palette indices for chart drawing. */
-export type OverlayTimingChartDrawStyle = ResolvedOverlayTimingChartStyle;
+import {
+    computeTimingChartTagLabelY,
+    computeTimingChartTagMarkerX,
+    computeTimingChartTagTextX,
+    computeTimingChartTagTickY,
+    formatTimingChartTagRelTick,
+    groupTimingChartTagsByColumn,
+    normalizeTimingChartTagLabel,
+    pruneTimingChartTagsInPlace,
+    TIMING_CHART_TAG_START,
+    type TimingChartTag,
+    type TimingChartTagColumnGroup,
+} from './tags';
 
 /**
  * Scrolling update/render timing chart with a fixed-capacity ring buffer.
@@ -52,6 +59,17 @@ export class TimingChart {
     /** Reusable marker list: fixed thresholds plus one frame-budget slot. */
     readonly #gridMarkerMs = new Float32Array(8);
 
+    /** Event tags anchored to absolute ticks (VV-541). */
+    readonly #tags: TimingChartTag[] = [];
+
+    /** Tick at last chart reset; used for relative tick labels. */
+    #chartStartTick = 0;
+
+    /** Timing samples recorded since the last chart width reset (one per overlay frame). */
+    #totalSamples = 0;
+
+    readonly #tagLabelPos = new Vector2i(0, 0);
+
     /**
      * Creates a timing chart with the given feature flag.
      *
@@ -73,15 +91,41 @@ export class TimingChart {
     }
 
     /**
+     * Records an event tag on the scrolling timeline (RetroBlit AssignTag parity).
+     *
+     * No-op when the chart is disabled. Empty labels become `"Untitled"`.
+     *
+     * @param label - Tag text shown above the chart band.
+     * @param currentTick - Current fixed-update tick (`BT.ticks`).
+     */
+    assignTag(label: string | undefined, currentTick: number): void {
+        if (this.#bufferWidth <= 0) {
+            return;
+        }
+
+        this.#tags.push({
+            label: normalizeTimingChartTagLabel(label),
+            tick: currentTick,
+            sampleIndex: this.#totalSamples,
+        });
+    }
+
+    /**
      * Clears ring-buffer state when the chart width changes.
      *
+     * Resets tags and adds a {@link TIMING_CHART_TAG_START} marker (RetroBlit Reset parity).
+     *
      * @param width - New chart width in pixels.
+     * @param currentTick - Current fixed-update tick for tag epoch and start marker.
      */
-    reset(width: number): void {
+    reset(width: number, currentTick = 0): void {
         if (width <= 0) {
             this.#bufferWidth = 0;
             this.#writeIndex = 0;
             this.#sampleCount = 0;
+            this.#tags.length = 0;
+            this.#totalSamples = 0;
+
             return;
         }
 
@@ -92,9 +136,14 @@ export class TimingChart {
         this.#bufferWidth = width;
         this.#writeIndex = 0;
         this.#sampleCount = 0;
+        this.#totalSamples = 0;
         this.#updateMsBuffer = new Float32Array(width);
         this.#renderMsBuffer = new Float32Array(width);
         this.#severityBuffer = new Uint8Array(width);
+        this.#chartStartTick = currentTick;
+        this.#tags.length = 0;
+
+        this.assignTag(TIMING_CHART_TAG_START, currentTick);
     }
 
     /**
@@ -108,20 +157,26 @@ export class TimingChart {
         }
 
         const index = this.#writeIndex;
-        const droppedFrames = timing.droppedFrames ?? 0;
 
         /* eslint-disable security/detect-object-injection -- index is ring-buffer write cursor bounded by bufferWidth */
         this.#updateMsBuffer[index] = Math.max(0, timing.updateMs);
         this.#renderMsBuffer[index] = Math.max(0, timing.renderMs);
-        this.#severityBuffer[index] = classifyTimingChartSeverity(timing.frameMs, this.#targetFps, droppedFrames);
+        this.#severityBuffer[index] = classifyTimingChartSeverity(
+            timing.frameMs,
+            this.#targetFps,
+            timing.droppedFrames,
+        );
         /* eslint-enable security/detect-object-injection */
 
         this.#writeIndex = (this.#writeIndex + 1) % this.#bufferWidth;
         this.#sampleCount = Math.min(this.#sampleCount + 1, this.#bufferWidth);
+        this.#totalSamples++;
+
+        pruneTimingChartTagsInPlace(this.#tags, this.#totalSamples, this.#bufferWidth);
     }
 
     /**
-     * Draws horizontal grid reference lines, then one-pixel timing dots for each populated ring-buffer column.
+     * Draws horizontal grid reference lines, timing dots, and event tags.
      *
      * Uses {@link OverlayDrawTarget.drawBarFill} with 1x1 rects so update and render samples stay
      * visible without alpha blending (palette-indexed engine).
@@ -129,20 +184,43 @@ export class TimingChart {
      * @param target - Overlay draw target.
      * @param chartRect - Screen-space chart band from layout plan.
      * @param style - Resolved chart palette indices.
+     * @param font - System bitmap font for tag labels.
+     * @param currentTick - Current fixed-update tick for tag scroll and prune.
      */
-    draw(target: OverlayDrawTarget, chartRect: Rect2i, style: OverlayTimingChartDrawStyle): void {
+    draw(
+        target: OverlayDrawTarget,
+        chartRect: Rect2i,
+        style: TimingChartDrawStyle,
+        font: BitmapFont,
+        currentTick: number,
+    ): void {
         if (!this.#enabled || chartRect.width <= 0 || chartRect.height <= 0) {
             return;
         }
 
-        this.reset(chartRect.width);
+        this.reset(chartRect.width, currentTick);
 
         this.#drawGridLines(target, chartRect, style);
 
-        if (this.#sampleCount <= 0) {
-            return;
+        const tagGroups = groupTimingChartTagsByColumn(this.#tags, this.#totalSamples, this.#bufferWidth);
+
+        this.#drawTagMarkers(target, chartRect, style, tagGroups);
+
+        if (this.#sampleCount > 0) {
+            this.#drawSamples(target, chartRect, style);
         }
 
+        this.#drawTags(target, chartRect, style, font, tagGroups);
+    }
+
+    /**
+     * Draws one-pixel timing samples for each populated ring-buffer column.
+     *
+     * @param target - Overlay draw target.
+     * @param chartRect - Screen-space chart band.
+     * @param style - Resolved chart palette indices.
+     */
+    #drawSamples(target: OverlayDrawTarget, chartRect: Rect2i, style: TimingChartDrawStyle): void {
         const baselineY = timingChartBaselineY(chartRect);
 
         for (let column = 0; column < this.#sampleCount; column++) {
@@ -150,9 +228,9 @@ export class TimingChart {
                 this.#sampleCount < this.#bufferWidth ? column : (this.#writeIndex + column) % this.#bufferWidth;
 
             /* eslint-disable security/detect-object-injection -- bufferIndex derived from bounded ring cursor */
-            const updateMs = this.#updateMsBuffer[bufferIndex] ?? 0;
-            const renderMs = this.#renderMsBuffer[bufferIndex] ?? 0;
-            const severity = this.#severityBuffer[bufferIndex] ?? TIMING_CHART_SEVERITY_NONE;
+            const updateMs = this.#updateMsBuffer[bufferIndex] as number;
+            const renderMs = this.#renderMsBuffer[bufferIndex] as number;
+            const severity = this.#severityBuffer[bufferIndex] as number;
             /* eslint-enable security/detect-object-injection */
 
             const x = chartRect.x + column;
@@ -164,6 +242,7 @@ export class TimingChart {
                     chartRect.height,
                     TIMING_CHART_FULL_SCALE_MS,
                 );
+
                 const updateOffset = computeTimingChartBarHeight(
                     updateMs,
                     chartRect.height,
@@ -186,19 +265,106 @@ export class TimingChart {
     }
 
     /**
+     * Draws a one-pixel vertical marker per tag, aligned with timing columns (VV-541).
+     *
+     * @param target - Overlay draw target.
+     * @param chartRect - Screen-space chart band.
+     * @param style - Resolved chart palette indices.
+     * @param tagGroups - Tags grouped by sample column.
+     */
+    #drawTagMarkers(
+        target: OverlayDrawTarget,
+        chartRect: Rect2i,
+        style: TimingChartDrawStyle,
+        tagGroups: readonly TimingChartTagColumnGroup[],
+    ): void {
+        for (const group of tagGroups) {
+            const x = computeTimingChartTagMarkerX(chartRect.x, chartRect.width, group.sampleIndex, this.#totalSamples);
+
+            if (x === null) {
+                continue;
+            }
+
+            this.#lineScratch.set(x, chartRect.y, 1, chartRect.height);
+            target.drawBarFill(this.#lineScratch, style.gridBarIndex);
+        }
+    }
+
+    /**
+     * Draws event tag labels above the chart band (VV-541).
+     *
+     * @param target - Overlay draw target.
+     * @param chartRect - Screen-space chart band.
+     * @param style - Resolved chart palette indices.
+     * @param font - System bitmap font.
+     * @param tagGroups - Tags grouped by sample column.
+     */
+    #drawTags(
+        target: OverlayDrawTarget,
+        chartRect: Rect2i,
+        style: TimingChartDrawStyle,
+        font: BitmapFont,
+        tagGroups: readonly TimingChartTagColumnGroup[],
+    ): void {
+        const paletteOffset = style.tagBarIndex - 1;
+
+        for (const group of tagGroups) {
+            const textX = computeTimingChartTagTextX(
+                chartRect.x,
+                chartRect.width,
+                group.sampleIndex,
+                this.#totalSamples,
+            );
+
+            if (textX === null) {
+                continue;
+            }
+
+            const leadTag = group.tags[0];
+
+            if (leadTag !== undefined) {
+                this.#tagLabelPos.x = textX;
+                this.#tagLabelPos.y = computeTimingChartTagTickY(chartRect.y);
+
+                target.drawLabelOnTop(
+                    font,
+                    this.#tagLabelPos.clone(),
+                    formatTimingChartTagRelTick(leadTag.tick, this.#chartStartTick),
+                    paletteOffset,
+                );
+            }
+
+            for (let stackIndex = 0; stackIndex < group.tags.length; stackIndex++) {
+                /* eslint-disable security/detect-object-injection -- stackIndex bounded by group.tags.length */
+                const tag = group.tags[stackIndex];
+
+                if (tag === undefined) {
+                    continue;
+                }
+
+                this.#tagLabelPos.x = textX;
+                this.#tagLabelPos.y = computeTimingChartTagLabelY(chartRect.y, stackIndex);
+
+                target.drawLabelOnTop(font, this.#tagLabelPos.clone(), tag.label, paletteOffset);
+                /* eslint-enable security/detect-object-injection */
+            }
+        }
+    }
+
+    /**
      * Draws faint horizontal grid lines behind timing dots (VV-7).
      *
      * @param target - Overlay draw target.
      * @param chartRect - Screen-space chart band from layout plan.
      * @param style - Resolved chart palette indices.
      */
-    #drawGridLines(target: OverlayDrawTarget, chartRect: Rect2i, style: OverlayTimingChartDrawStyle): void {
+    #drawGridLines(target: OverlayDrawTarget, chartRect: Rect2i, style: TimingChartDrawStyle): void {
         const markerCount = writeTimingChartGridMarkers(this.#targetFps, this.#gridMarkerMs);
         let lastY = -1;
 
         for (let index = 0; index < markerCount; index++) {
             /* eslint-disable security/detect-object-injection -- index bounded by markerCount */
-            const ms = this.#gridMarkerMs[index] ?? 0;
+            const ms: number = this.#gridMarkerMs[index] as number;
             /* eslint-enable security/detect-object-injection */
 
             const y = computeTimingChartGridLineY(ms, chartRect, TIMING_CHART_FULL_SCALE_MS);
@@ -208,7 +374,9 @@ export class TimingChart {
             }
 
             lastY = y;
+
             this.#lineScratch.set(chartRect.x, y, chartRect.width, 1);
+
             target.drawBarFill(this.#lineScratch, style.gridBarIndex);
         }
     }
@@ -220,7 +388,7 @@ export class TimingChart {
      * @param style - Resolved chart palette indices.
      * @returns Palette index, or `null` to use per-bar update/render colors.
      */
-    #severityPaletteIndex(severity: number, style: OverlayTimingChartDrawStyle): number | null {
+    #severityPaletteIndex(severity: number, style: TimingChartDrawStyle): number | null {
         if (severity === TIMING_CHART_SEVERITY_ERROR) {
             return style.errorBarIndex;
         }
@@ -262,6 +430,7 @@ export class TimingChart {
         }
 
         this.#dotScratch.set(x, y, 1, 1);
+
         target.drawBarFill(this.#dotScratch, paletteIndex);
     }
 }

--- a/src/overlay/timing-chart/constants.ts
+++ b/src/overlay/timing-chart/constants.ts
@@ -10,8 +10,8 @@ export const TIMING_CHART_DEFAULT_WARNING_IDX = 3;
 /** Default error palette index for timing chart semantic overlays. */
 export const TIMING_CHART_DEFAULT_ERROR_IDX = 4;
 
-/** Default event/tag palette index for timing chart semantic overlays. */
-export const TIMING_CHART_DEFAULT_EVENT_IDX = 5;
+/** Default palette index for timing chart tag and tick text. */
+export const TIMING_CHART_DEFAULT_TAG_IDX = 5;
 
 /**
  * Fixed interior grid markers in milliseconds (VV-7). Excludes 1 ms (band bottom edge).

--- a/src/overlay/timing-chart/style.test.ts
+++ b/src/overlay/timing-chart/style.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { Rect2i } from '../../utils/Rect2i';
 import {
     TIMING_CHART_DEFAULT_ERROR_IDX,
-    TIMING_CHART_DEFAULT_EVENT_IDX,
+    TIMING_CHART_DEFAULT_TAG_IDX,
     TIMING_CHART_DEFAULT_WARNING_IDX,
     TIMING_CHART_FULL_SCALE_MS,
 } from './constants';
@@ -11,7 +11,7 @@ import {
     computeTimingChartBarHeight,
     computeTimingChartDotY,
     computeTimingChartGridLineY,
-    resolveOverlayTimingChartStyle,
+    resolveTimingChartStyle,
     shouldDrawTimingChartGridLineY,
     timingChartBaselineY,
     timingChartFrameBudgetMs,
@@ -34,27 +34,27 @@ describe('computeTimingChartBarHeight', () => {
     });
 });
 
-describe('resolveOverlayTimingChartStyle', () => {
+describe('resolveTimingChartStyle', () => {
     it('defaults update/render bars to overlay style indices', () => {
-        const resolved = resolveOverlayTimingChartStyle({ barPaletteIndex: 10, textPaletteIndex: 11 }, undefined);
+        const resolved = resolveTimingChartStyle({ barPaletteIndex: 10, textPaletteIndex: 11 }, undefined);
 
         expect(resolved.updateBarIndex).toBe(10);
         expect(resolved.renderBarIndex).toBe(11);
         expect(resolved.warningBarIndex).toBe(TIMING_CHART_DEFAULT_WARNING_IDX);
         expect(resolved.errorBarIndex).toBe(TIMING_CHART_DEFAULT_ERROR_IDX);
-        expect(resolved.eventBarIndex).toBe(TIMING_CHART_DEFAULT_EVENT_IDX);
+        expect(resolved.tagBarIndex).toBe(TIMING_CHART_DEFAULT_TAG_IDX);
         expect(resolved.gridBarIndex).toBe(10);
     });
 
     it('honors timing chart palette overrides', () => {
-        const resolved = resolveOverlayTimingChartStyle(
+        const resolved = resolveTimingChartStyle(
             { barPaletteIndex: 1, textPaletteIndex: 2, gapPaletteIndex: 12 },
             {
                 updateBarPaletteIndex: 20,
                 renderBarPaletteIndex: 21,
                 warningPaletteIndex: 22,
                 errorPaletteIndex: 23,
-                eventPaletteIndex: 24,
+                tagPaletteIndex: 24,
                 gridPaletteIndex: 25,
             },
         );
@@ -63,21 +63,18 @@ describe('resolveOverlayTimingChartStyle', () => {
         expect(resolved.renderBarIndex).toBe(21);
         expect(resolved.warningBarIndex).toBe(22);
         expect(resolved.errorBarIndex).toBe(23);
-        expect(resolved.eventBarIndex).toBe(24);
+        expect(resolved.tagBarIndex).toBe(24);
         expect(resolved.gridBarIndex).toBe(25);
     });
 
     it('defaults grid lines to gap palette index when grid override is omitted', () => {
-        const resolved = resolveOverlayTimingChartStyle(
-            { barPaletteIndex: 1, textPaletteIndex: 2, gapPaletteIndex: 7 },
-            {},
-        );
+        const resolved = resolveTimingChartStyle({ barPaletteIndex: 1, textPaletteIndex: 2, gapPaletteIndex: 7 }, {});
 
         expect(resolved.gridBarIndex).toBe(7);
     });
 
     it('falls back grid lines to bar index when gap palette is omitted', () => {
-        const resolved = resolveOverlayTimingChartStyle({ barPaletteIndex: 9, textPaletteIndex: 2 }, undefined);
+        const resolved = resolveTimingChartStyle({ barPaletteIndex: 9, textPaletteIndex: 2 }, undefined);
 
         expect(resolved.gridBarIndex).toBe(9);
     });

--- a/src/overlay/timing-chart/style.ts
+++ b/src/overlay/timing-chart/style.ts
@@ -3,19 +3,19 @@ import type { Rect2i } from '../../utils/Rect2i';
 import { DEFAULT_IDX_BG, DEFAULT_IDX_TEXT } from '../constants';
 import {
     TIMING_CHART_DEFAULT_ERROR_IDX,
-    TIMING_CHART_DEFAULT_EVENT_IDX,
+    TIMING_CHART_DEFAULT_TAG_IDX,
     TIMING_CHART_DEFAULT_WARNING_IDX,
     TIMING_CHART_FULL_SCALE_MS,
     TIMING_CHART_GRID_MARKER_MS,
 } from './constants';
 
-/** Resolved palette indices used when drawing the timing chart band. */
-export interface ResolvedOverlayTimingChartStyle {
+/** Resolved palette indices used when drawing the overlay timing chart band. */
+export interface TimingChartDrawStyle {
     readonly updateBarIndex: number;
     readonly renderBarIndex: number;
     readonly warningBarIndex: number;
     readonly errorBarIndex: number;
-    readonly eventBarIndex: number;
+    readonly tagBarIndex: number;
     readonly gridBarIndex: number;
 }
 
@@ -38,10 +38,10 @@ const pickOverlayBarTextGap = (
  * @param chartStyle - Optional timing-chart palette overrides.
  * @returns Resolved indices for chart draw and semantic severity tints.
  */
-export function resolveOverlayTimingChartStyle(
+export function resolveTimingChartStyle(
     overlayStyle: OverlayStyle | undefined,
     chartStyle: OverlayTimingChartStyle | undefined,
-): ResolvedOverlayTimingChartStyle {
+): TimingChartDrawStyle {
     const { barIndex, textIndex, gapIndex } = pickOverlayBarTextGap(overlayStyle);
 
     return {
@@ -49,7 +49,7 @@ export function resolveOverlayTimingChartStyle(
         renderBarIndex: pickPaletteIndex(chartStyle?.renderBarPaletteIndex, textIndex),
         warningBarIndex: pickPaletteIndex(chartStyle?.warningPaletteIndex, TIMING_CHART_DEFAULT_WARNING_IDX),
         errorBarIndex: pickPaletteIndex(chartStyle?.errorPaletteIndex, TIMING_CHART_DEFAULT_ERROR_IDX),
-        eventBarIndex: pickPaletteIndex(chartStyle?.eventPaletteIndex, TIMING_CHART_DEFAULT_EVENT_IDX),
+        tagBarIndex: pickPaletteIndex(chartStyle?.tagPaletteIndex, TIMING_CHART_DEFAULT_TAG_IDX),
         gridBarIndex: pickPaletteIndex(chartStyle?.gridPaletteIndex, gapIndex),
     };
 }

--- a/src/overlay/timing-chart/tags.test.ts
+++ b/src/overlay/timing-chart/tags.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    computeTimingChartTagColumn,
+    computeTimingChartTagLabelY,
+    computeTimingChartTagMarkerX,
+    computeTimingChartTagTextX,
+    computeTimingChartTagTickY,
+    formatTimingChartTagRelTick,
+    groupTimingChartTagsByColumn,
+    normalizeTimingChartTagLabel,
+    pruneTimingChartTagsInPlace,
+    shouldPruneTimingChartTag,
+    TIMING_CHART_TAG_LABEL_STACK_SPACING,
+    TIMING_CHART_TAG_LABEL_Y_GAP,
+    TIMING_CHART_TAG_REL_TICK_MAX,
+    TIMING_CHART_TAG_TEXT_X_OFFSET,
+    TIMING_CHART_TAG_TICK_Y_OFFSET,
+    type TimingChartTag,
+} from './tags';
+
+describe('normalizeTimingChartTagLabel', () => {
+    it('defaults empty labels to Untitled', () => {
+        expect(normalizeTimingChartTagLabel(undefined)).toBe('Untitled');
+        expect(normalizeTimingChartTagLabel('')).toBe('Untitled');
+    });
+
+    it('preserves non-empty labels', () => {
+        expect(normalizeTimingChartTagLabel('Start')).toBe('Start');
+    });
+});
+
+describe('shouldPruneTimingChartTag', () => {
+    const width = 320;
+
+    it('keeps tags while they are sliding off the left but still within one chart width', () => {
+        expect(shouldPruneTimingChartTag(600, 0, width)).toBe(false);
+    });
+
+    it('prunes tags one full chart width past the left edge', () => {
+        expect(shouldPruneTimingChartTag(640, 0, width)).toBe(true);
+    });
+
+    it('prunes tags past the right edge', () => {
+        expect(shouldPruneTimingChartTag(100, 500, width)).toBe(true);
+    });
+});
+
+describe('computeTimingChartTagColumn', () => {
+    const width = 100;
+
+    it('fills from the left while the buffer is not full', () => {
+        expect(computeTimingChartTagColumn(0, 5, width)).toBe(0);
+        expect(computeTimingChartTagColumn(4, 5, width)).toBe(4);
+        expect(computeTimingChartTagColumn(50, 55, width)).toBe(50);
+    });
+
+    it('allows negative columns while sliding off the left', () => {
+        expect(computeTimingChartTagColumn(0, 150, width)).toBe(-50);
+        expect(computeTimingChartTagColumn(40, 150, width)).toBe(-10);
+    });
+
+    it('keeps column fixed when the buffer becomes full', () => {
+        expect(computeTimingChartTagColumn(40, 100, width)).toBe(40);
+    });
+
+    it('scrolls left one column per sample once the buffer is full', () => {
+        expect(computeTimingChartTagColumn(40, 101, width)).toBe(39);
+        expect(computeTimingChartTagColumn(0, 100, width)).toBe(0);
+        expect(computeTimingChartTagColumn(99, 100, width)).toBe(99);
+        expect(computeTimingChartTagColumn(99, 101, width)).toBe(98);
+    });
+
+    it('returns null when the tag scrolled past the right edge', () => {
+        expect(computeTimingChartTagColumn(100, 100, width)).toBeNull();
+        expect(computeTimingChartTagColumn(501, 500, width)).toBeNull();
+    });
+});
+
+describe('computeTimingChartTagMarkerX and computeTimingChartTagTextX', () => {
+    it('aligns markers with dot columns and text with the text offset', () => {
+        expect(computeTimingChartTagMarkerX(10, 100, 40, 101)).toBe(49);
+        expect(computeTimingChartTagTextX(10, 100, 40, 101)).toBe(49 + TIMING_CHART_TAG_TEXT_X_OFFSET);
+    });
+
+    it('places Start at the left text offset during fill', () => {
+        expect(computeTimingChartTagTextX(10, 100, 0, 3)).toBe(10 + TIMING_CHART_TAG_TEXT_X_OFFSET);
+    });
+
+    it('returns null when the tag column is past the right edge', () => {
+        expect(computeTimingChartTagTextX(0, 100, 100, 100)).toBeNull();
+    });
+});
+
+describe('computeTimingChartTagTickY and computeTimingChartTagLabelY', () => {
+    const chartTopY = 30;
+
+    it('places the tick row above stacked labels with a fixed gap and stack spacing', () => {
+        const tickY = chartTopY - TIMING_CHART_TAG_TICK_Y_OFFSET;
+
+        expect(computeTimingChartTagTickY(chartTopY)).toBe(tickY);
+        expect(computeTimingChartTagLabelY(chartTopY, 0)).toBe(tickY + TIMING_CHART_TAG_LABEL_Y_GAP);
+        expect(computeTimingChartTagLabelY(chartTopY, 1)).toBe(
+            tickY + TIMING_CHART_TAG_LABEL_Y_GAP + TIMING_CHART_TAG_LABEL_STACK_SPACING,
+        );
+    });
+});
+
+describe('groupTimingChartTagsByColumn', () => {
+    it('groups tags that share a column and preserves assignment order', () => {
+        const tags: TimingChartTag[] = [
+            { label: 'A', tick: 1, sampleIndex: 5 },
+            { label: 'B', tick: 1, sampleIndex: 5 },
+            { label: 'C', tick: 2, sampleIndex: 9 },
+        ];
+
+        expect(groupTimingChartTagsByColumn(tags, 10, 100)).toEqual([
+            { sampleIndex: 5, tags: [tags[0], tags[1]] },
+            { sampleIndex: 9, tags: [tags[2]] },
+        ]);
+    });
+});
+
+describe('formatTimingChartTagRelTick', () => {
+    it('returns relative tick text within the display cap', () => {
+        expect(formatTimingChartTagRelTick(150, 100)).toBe('50');
+    });
+
+    it('caps display at the maximum relative tick', () => {
+        expect(formatTimingChartTagRelTick(200_001, 0)).toBe(String(TIMING_CHART_TAG_REL_TICK_MAX));
+    });
+});
+
+describe('pruneTimingChartTagsInPlace', () => {
+    it('removes only off-screen tags without allocating', () => {
+        const tags: TimingChartTag[] = [
+            { label: 'old', tick: 0, sampleIndex: 0 },
+            { label: 'keep', tick: 500, sampleIndex: 300 },
+        ];
+
+        pruneTimingChartTagsInPlace(tags, 700, 320);
+
+        expect(tags).toEqual([{ label: 'keep', tick: 500, sampleIndex: 300 }]);
+    });
+});

--- a/src/overlay/timing-chart/tags.ts
+++ b/src/overlay/timing-chart/tags.ts
@@ -1,0 +1,249 @@
+/**
+ * Pure helpers for timing chart event tags (VV-541, RetroBlit AssignTag parity).
+ */
+
+/** Label added automatically when the timing chart ring buffer is reset (RetroBlit Reset parity). */
+export const TIMING_CHART_TAG_START = 'Start';
+
+/** Maximum relative tick value shown on the tag tick row. */
+export const TIMING_CHART_TAG_REL_TICK_MAX = 100_000;
+
+/** Horizontal offset from the timing column to tick and label text (RetroBlit column +2, +1). */
+export const TIMING_CHART_TAG_TEXT_X_OFFSET = 3;
+
+/** Relative tick row offset above the chart band top. */
+export const TIMING_CHART_TAG_TICK_Y_OFFSET = 1;
+
+/** Vertical gap between the tick row and the first stacked label row. */
+export const TIMING_CHART_TAG_LABEL_Y_GAP = 9;
+
+/** Vertical distance between stacked tag label rows. */
+export const TIMING_CHART_TAG_LABEL_STACK_SPACING = 9;
+
+/** Stored tag entry for the timing chart ring timeline. */
+export type TimingChartTag = {
+    label: string;
+    /** Absolute fixed-update tick when the tag was assigned (tick row only). */
+    tick: number;
+    /** Overlay timing sample ordinal at assign; drives horizontal column. */
+    sampleIndex: number;
+};
+
+/** Tags sharing one timing-chart column, in assignment order. */
+export type TimingChartTagColumnGroup = {
+    sampleIndex: number;
+    tags: TimingChartTag[];
+};
+
+/**
+ * Normalizes a tag label; empty or missing labels become `"Untitled"`.
+ *
+ * @param label - Caller-provided label.
+ * @returns Non-empty label string.
+ */
+export function normalizeTimingChartTagLabel(label: string | undefined): string {
+    return label === undefined || label.length === 0 ? 'Untitled' : label;
+}
+
+/**
+ * Ring-buffer column for a tag so it stays aligned with timing dots.
+ *
+ * Columns follow timing samples (one per overlay frame), not fixed-update ticks.
+ *
+ * @param sampleIndex - Sample ordinal when the tag was assigned.
+ * @param totalSamples - Timing samples recorded since the last chart width reset.
+ * @param chartWidth - Chart width in pixels (ring buffer width).
+ * @returns Column index, or `null` when the tag is past the right edge.
+ */
+export function computeTimingChartTagColumn(
+    sampleIndex: number,
+    totalSamples: number,
+    chartWidth: number,
+): number | null {
+    if (chartWidth <= 0) {
+        return null;
+    }
+
+    const scrollOffset = Math.max(0, totalSamples - chartWidth);
+    const column = sampleIndex - scrollOffset;
+
+    if (column >= chartWidth) {
+        return null;
+    }
+
+    return column;
+}
+
+/**
+ * Returns whether a tag should be removed from the active list.
+ *
+ * @param totalSamples - Timing samples recorded since the last chart width reset.
+ * @param sampleIndex - Sample ordinal stored on the tag.
+ * @param chartWidth - Chart width in pixels.
+ * @returns `true` when the tag should be dropped.
+ */
+export function shouldPruneTimingChartTag(totalSamples: number, sampleIndex: number, chartWidth: number): boolean {
+    const column = computeTimingChartTagColumn(sampleIndex, totalSamples, chartWidth);
+
+    return column === null || column <= -chartWidth;
+}
+
+/**
+ * Screen-space X for tick and label text above the chart band.
+ *
+ * @param chartX - Left edge of the chart band.
+ * @param chartWidth - Chart width in pixels.
+ * @param sampleIndex - Sample ordinal when the tag was assigned.
+ * @param totalSamples - Timing samples recorded since the last chart width reset.
+ * @returns Pixel X for text left edge, or `null` when past the right edge.
+ */
+export function computeTimingChartTagTextX(
+    chartX: number,
+    chartWidth: number,
+    sampleIndex: number,
+    totalSamples: number,
+): number | null {
+    const column = computeTimingChartTagColumn(sampleIndex, totalSamples, chartWidth);
+
+    if (column === null) {
+        return null;
+    }
+
+    return chartX + column + TIMING_CHART_TAG_TEXT_X_OFFSET;
+}
+
+/**
+ * Screen-space X for the one-pixel vertical marker (aligned with timing dots).
+ *
+ * @param chartX - Left edge of the chart band.
+ * @param chartWidth - Chart width in pixels.
+ * @param sampleIndex - Sample ordinal when the tag was assigned.
+ * @param totalSamples - Timing samples recorded since the last chart width reset.
+ * @returns Pixel X for the marker column, or `null` when past the right edge.
+ */
+export function computeTimingChartTagMarkerX(
+    chartX: number,
+    chartWidth: number,
+    sampleIndex: number,
+    totalSamples: number,
+): number | null {
+    const column = computeTimingChartTagColumn(sampleIndex, totalSamples, chartWidth);
+
+    if (column === null) {
+        return null;
+    }
+
+    return chartX + column;
+}
+
+/**
+ * Screen-space Y for the relative tick row above the chart band.
+ *
+ * @param chartTopY - Top edge of the chart band.
+ * @returns Pixel Y for the tick text baseline.
+ */
+export function computeTimingChartTagTickY(chartTopY: number): number {
+    return chartTopY - TIMING_CHART_TAG_TICK_Y_OFFSET;
+}
+
+/**
+ * Screen-space Y for a stacked tag label row below the tick row.
+ *
+ * @param chartTopY - Top edge of the chart band.
+ * @param stackIndex - Zero-based row below the tick (0 = first label).
+ * @returns Pixel Y for the label text baseline.
+ */
+export function computeTimingChartTagLabelY(chartTopY: number, stackIndex: number): number {
+    return (
+        computeTimingChartTagTickY(chartTopY) +
+        TIMING_CHART_TAG_LABEL_Y_GAP +
+        TIMING_CHART_TAG_LABEL_STACK_SPACING * stackIndex
+    );
+}
+
+/**
+ * Groups on-screen tags by sample column for stacked drawing.
+ *
+ * @param tags - Active tags for the current frame.
+ * @param totalSamples - Timing samples recorded since the last chart width reset.
+ * @param chartWidth - Chart width in pixels.
+ * @returns Groups in first-seen column order.
+ */
+export function groupTimingChartTagsByColumn(
+    tags: readonly TimingChartTag[],
+    totalSamples: number,
+    chartWidth: number,
+): TimingChartTagColumnGroup[] {
+    const groups = new Map<number, TimingChartTag[]>();
+    const order: number[] = [];
+
+    for (const tag of tags) {
+        if (shouldPruneTimingChartTag(totalSamples, tag.sampleIndex, chartWidth)) {
+            continue;
+        }
+
+        let bucket = groups.get(tag.sampleIndex);
+
+        if (bucket === undefined) {
+            bucket = [];
+            groups.set(tag.sampleIndex, bucket);
+            order.push(tag.sampleIndex);
+        }
+
+        bucket.push(tag);
+    }
+
+    const result: TimingChartTagColumnGroup[] = [];
+
+    for (const sampleIndex of order) {
+        const bucket = groups.get(sampleIndex);
+
+        if (bucket !== undefined && bucket.length > 0) {
+            result.push({ sampleIndex, tags: bucket });
+        }
+    }
+
+    return result;
+}
+
+/**
+ * Relative tick text for the tag tick row (ticks since chart reset).
+ *
+ * @param tagTick - Absolute tick when the tag was assigned.
+ * @param chartStartTick - Tick recorded when the chart last reset.
+ * @returns Relative tick string capped at {@link TIMING_CHART_TAG_REL_TICK_MAX}.
+ */
+export function formatTimingChartTagRelTick(tagTick: number, chartStartTick: number): string {
+    const relTick = tagTick - chartStartTick;
+
+    return String(Math.min(relTick, TIMING_CHART_TAG_REL_TICK_MAX));
+}
+
+/**
+ * Removes off-screen tags using an in-place compact (no allocation).
+ *
+ * @param tags - Mutable tag list.
+ * @param totalSamples - Timing samples recorded since the last chart width reset.
+ * @param chartWidth - Chart width in pixels.
+ */
+export function pruneTimingChartTagsInPlace(tags: TimingChartTag[], totalSamples: number, chartWidth: number): void {
+    let write = 0;
+
+    for (let read = 0; read < tags.length; read++) {
+        /* eslint-disable security/detect-object-injection -- read index bounded by tags.length */
+        const tag = tags[read];
+
+        if (tag === undefined || shouldPruneTimingChartTag(totalSamples, tag.sampleIndex, chartWidth)) {
+            continue;
+        }
+
+        if (write !== read) {
+            tags[write] = tag;
+        }
+
+        write++;
+        /* eslint-enable security/detect-object-injection */
+    }
+
+    tags.length = write;
+}


### PR DESCRIPTION
Implement VV-541 milestone markers on the overlay timing chart: tag columns scroll with per-frame samples, draw tick rows and stacked labels above the band, prune when off-screen, and auto-add "Start" on chart reset. Expose BT.assignTag, rename eventPaletteIndex to tagPaletteIndex, and document tag behavior in api-core.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR implements timing-chart event tags on the overlay and exposes a new BT.assignTag(label?) API to place labeled markers on the scrolling chart at the current tick.

API Additions
- Added BT.assignTag(label?: string): void (public) in BT and BTAPI. Delegates to the overlay timing chart and is a no-op when the overlay/timing chart is disabled. Labels default to "Untitled" when omitted.

Timing Chart Tag Visualization
- TimingChart now records and renders event tags:
  - Vertical 1px marker lines and stacked labels above the timing band.
  - Automatic "Start" tag injected on chart reset for relative tick labeling.
  - Relative tick text for the leading tag in a column (capped).
  - Tags scroll with per-frame samples and are pruned in-place when off-screen to avoid unbounded growth.
  - Column grouping stacks multiple tags assigned to the same column with controlled vertical spacing.
- New public APIs / signature changes:
  - assignTag(label: string | undefined, currentTick: number): void added to TimingChart.
  - reset(width: number, currentTick?: number = 0) now accepts currentTick to establish the tag epoch.
  - draw(target, chartRect, style, font: BitmapFont, currentTick: number) now requires font and currentTick to render labels/ticks.

Styling and Exports
- Timing-chart style API refactor:
  - ResolvedOverlayTimingChartStyle → TimingChartDrawStyle
  - resolveOverlayTimingChartStyle() → resolveTimingChartStyle()
  - Added tagBarIndex to the resolved style (default TIMING_CHART_DEFAULT_TAG_IDX = 5) for tag/tick text coloring; removed eventBarIndex.
- Configuration rename: OverlayTimingChartStyle.eventPaletteIndex renamed to tagPaletteIndex (defaults to 5).
- Barrel export updates in src/overlay/index.ts to re-export TimingChartDrawStyle and resolveTimingChartStyle (removed resolveOverlayTimingChartStyle).

Tag Utilities
- New pure helper module src/overlay/timing-chart/tags.ts exporting constants, types, and functions for:
  - Label normalization (default "Untitled"), column computation, on-screen X/Y calculations for tick text and marker, grouping tags by column while pruning off-screen tags, relative tick formatting, and in-place pruning.

Documentation
- docs/api-core.md updated to document BT.assignTag usage, defaulting/label behavior, rendering/pruning limits, alignment with render-frame samples, and default tag palette. Example usage added to the game loop section.

Testing
- Added/updated comprehensive tests:
  - New BT.assignTag test in BlitTech.test.ts.
  - assignTag tests in BTAPI.test.ts covering overlay integration and no-op behavior when disabled.
  - Refactored TimingChart.test.ts with centralized draw helper and extensive tag-related assertions.
  - New tags.test.ts for tag helper unit tests (normalization, column math, pruning, stacking, formatting).
  - Overlay.test.ts updated to use overlayTimingChart/overlayTimingChartStyle names and tests verifying renderer.drawLabelOnTop calls for tags.
  - Added test fixture helper getLabelOnTopCalls and updated mockFont to include lineHeight for label rendering tests.

Other Changes
- Overlay now resolves timing-chart draw style from ./timing-chart/style and passes currentTick into TimingChart.draw; Overlay.assignTag(label, currentTick) was added and is a no-op when the timing chart is disabled.
- src/overlay/timing-chart/TimingChart.ts: recording of `#totalSamples` and tag pruning logic added; draw flow extended to include tag rendering helpers.
- CI: bundle size check increased from 50 KB to 55 KB (gzipped ESM limit raised to 56320 bytes) to accommodate recent overlay additions.

Breaking / Notable API Changes
- eventPaletteIndex → tagPaletteIndex (configuration)
- ResolvedOverlayTimingChartStyle → TimingChartDrawStyle; resolveOverlayTimingChartStyle → resolveTimingChartStyle
- TimingChart.reset(width, currentTick?) signature changed
- TimingChart.draw(...) now requires BitmapFont and currentTick

This PR is documentation-, test-, and feature-heavy (notable changes to overlay timing-chart rendering, style types/exports, and public BT API).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/236?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->