### PR TITLE
docs: remove Linear VV-* references and sync overlay docs

### DIFF
--- a/.claude/skills/perf/SKILL.md
+++ b/.claude/skills/perf/SKILL.md
@@ -52,10 +52,10 @@ CPU benchmark regression checks run in CI with the `perf` label.
 - CI fails if any benchmark regresses by more than **25%** (see `ci.yml` `--threshold 25`)
 
 New `*.bench.ts` files are picked up automatically on the next `main` baseline upload. No allowlist
-change is required. After adding benchmarks for overlay work (VV-543), label the PR `perf` if you
+change is required. After adding benchmarks for overlay work, label the PR `perf` if you
 want regression feedback before merge.
 
-### Overlay palette grid benchmarks (VV-543)
+### Overlay palette grid benchmarks
 
 | Benchmark file | What it measures |
 | --- | --- |

--- a/.github/ISSUE_TEMPLATE/security-risk-acceptance.yml
+++ b/.github/ISSUE_TEMPLATE/security-risk-acceptance.yml
@@ -76,8 +76,8 @@ body:
     id: remediation-issue
     attributes:
       label: Linked remediation issue
-      description: Linear or GitHub issue URL that tracks the fix
-      placeholder: https://linear.app/...
+      description: GitHub issue URL that tracks the fix
+      placeholder: https://github.com/vancura/blit-tech/issues/...
     validations:
       required: true
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,11 +56,13 @@ src/
   overlay/
     Overlay.ts             # Orchestrator: sample, toggle, layout plan, delegate draws
     OverlayDrawTarget.ts   # Internal draw port (drawBarFill / drawLabel); not on IRenderer or BT
+    OverlayToggleIcon.ts   # Bottom-left bitmap toggle hint icon draw + anchor/exclusion helpers
+    toggleIconData.ts      # Inline row-major mask data for the toggle hint icon
     index.ts               # Barrel exports for BTAPI and unit tests
     layout/                # layoutPlan, layoutHelpers, layout types/constants
     bars/                  # OverlayBars (Bars.ts)
     timing-chart/          # TimingChart, style, constants
-    palette/               # PaletteView, PaletteInteraction
+    palette/               # PaletteView, PaletteInteraction (swatch hover tooltip, clipboard copy, scroll)
     sampling/              # FpsSampler, TimingSampler
     input/                 # Toggle
   render/
@@ -153,7 +155,8 @@ Two backends selectable via `HardwareSettings.backend` (default `'webgpu'`):
 - Face buttons: players `0` and `1` are keyboard OR gamepad; players `2` and `3` are gamepad-only
 - Input previous-state rollover is end-of-frame aligned (same snapshot model across pointer/keyboard/gamepad)
 - Default gamepad stick dead zone is `0.75`
-- Triggers are axis-only for now (`AXIS_TRIGGER_L` / `AXIS_TRIGGER_R`); trigger button constants are tracked in `VV-481`
+- Triggers are axis-only for now (`AXIS_TRIGGER_L` / `AXIS_TRIGGER_R`); dedicated trigger button constants are not
+  implemented yet
 
 ## BT API: getters vs methods
 
@@ -327,8 +330,8 @@ Claude Code reusable skill:
 
 ## Working with Claude
 
-- **Planning vs implementation sessions**: During planning work (reviewing Linear tickets, discussing architecture), do
-  not modify source files. Only update Linear. Wait for a separate implementation session before touching code.
+- **Planning vs implementation sessions**: During planning work (reviewing issues, discussing architecture), do not
+  modify source files. Only update Linear. Wait for a separate implementation session before touching code.
 - **User-facing strings**: Follow the two-tier voice guide for all throws, error messages, and canvas-visible text. See
   [docs/voice.md](docs/voice.md) before writing any throw or user-facing string.
 - **Documentation is part of every feature**: After completing any feature or fix, always update documentation without

--- a/README.md
+++ b/README.md
@@ -181,10 +181,13 @@ WebGPU support varies by browser:
 | Safari      | 26+            | Enabled by default; Safari 18-25 available via Feature Flags     |
 
 When WebGPU is unavailable the engine falls back to the Canvas 2D software renderer automatically. By default the engine
-draws a overlay after each frame: measured FPS, configured target FPS, the active backend name (via `BT.activeBackend`),
-logical resolution, and a short demo title derived from `document.title`. Toggle the overlay with `~` (Backquote) or a
-primary press in the bottom-left corner; disable it with `overlayEnabled: false` in `configure()`. Use
-`BT.activeBackend` to read which backend is running (`'webgpu'`, `'software'`, or `null` before init).
+draws a stats overlay after each frame: measured FPS, configured target FPS, the active backend name (via
+`BT.activeBackend`), logical resolution, and a short demo title derived from `document.title`. The overlay **body starts
+hidden** with a bitmap toggle hint in the bottom-left corner; toggle it with `~` (Backquote) or a primary press in the
+bottom-left corner. Use `overlayVisibleAtStart: true` to show the body on the first frame,
+`overlayToggleHintVisible: false` to hide the hint icon on immersive demos, or `overlayEnabled: false` to disable the
+overlay entirely in `configure()`. Use `BT.activeBackend` to read which backend is running (`'webgpu'`, `'software'`, or
+`null` before init).
 
 ## Contributors
 

--- a/docs/api-core.md
+++ b/docs/api-core.md
@@ -213,35 +213,34 @@ otherwise.
 - **Timing chart (optional):** when `overlayTimingChart: true`, a scrolling band of **one-pixel dots** shows raw
   per-frame `update()` vs `render()` CPU time (one column per present frame, not per fixed `update()` tick). Band height
   defaults to **22 px**; override with `overlayTimingChartHeight`. Dot height scales linearly so about **16 ms** fills
-  the band; any non-zero sample draws at least one pixel (sub-millisecond work shows as a baseline dot). **Grid lines
-  (VV-7):** faint horizontal reference rows at **5**, **10**, and **33.33** ms plus a frame-budget line at
-  **`1000 / targetFPS`** ms are drawn behind the dots (qualitative scale on a ~22 px band, not a precision ruler). The
-  band bottom row is the zero baseline (sub-ms / light samples); top- and bottom-edge rows are not drawn as grid lines.
-  Grid color defaults to `overlayStyle.gapPaletteIndex` (then `barPaletteIndex`); override with
-  `overlayTimingChartStyle.gridPaletteIndex`. The band background uses `overlayStyle.barPaletteIndex`; dot colors
-  default to `overlayStyle.barPaletteIndex` / `textPaletteIndex`; override with `overlayTimingChartStyle`. **Semantic
-  tints (VV-545):** when a column is classified as a runtime risk, both update and render dots use the warning or error
-  palette index instead of the normal bar colors. Classification uses the prior frame's `Frame` wall time against
-  `1000 / targetFPS` (warning at **1.10x** budget, error at **1.50x**) and dropped-frame events from the game loop (one
-  dropped frame = warning, two or more = error; error wins when both apply). Default warning/error/event palette indices
-  are **3**, **4**, and **5** when not overridden. Drop detection for the chart runs whenever `overlayTimingChart: true`
-  (independent of `detectDroppedFrames`, which only controls console warnings). **Event tags (VV-541):** call
-  `BT.assignTag(label?)` from `update()` or `init()` to anchor a short label on the scrolling chart at the current
-  `BT.ticks`. Empty or omitted labels become `"Untitled"`. Each tag column draws a tick row (relative ticks since chart
-  reset, capped at **100000**) and stacked label rows above the chart band; spacing is fixed in `tags.ts`
-  (`TIMING_CHART_TAG_LABEL_Y_GAP`, `TIMING_CHART_TAG_LABEL_STACK_SPACING`). Tick and label text share the same
-  horizontal offset from the timing column. A faint vertical grid-colored line marks the column on the chart band. Tag
-  columns follow timing **samples** (one per rendered frame), not `BT.ticks`, which can advance multiple fixed-update
-  steps per frame: they fill from the left while the ring buffer is not full, then scroll left one column per sample
-  once full, in lockstep with the dots. Tags are removed when they scroll one full chart width past the left edge (text
-  keeps drawing at negative x until the display clips it); pruning runs on each timing sample while the chart is
-  enabled. Chart width resets (for example on resize) clear tags and add an automatic `"Start"` marker. Tint tags with
-  `overlayTimingChartStyle.tagPaletteIndex` (default **5**). **Renderer diagnostics (optional):** when the chart is
-  enabled, `overlayTimingChartDiagnostics` defaults to **`'minimal'`** (set `false` to disable chart markers).
-  **Minimal** mode bumps semantic severity when either pipeline overflowed that frame and draws a baseline overflow
-  marker (palette index from `overlayTimingChartStyle.overflowPaletteIndex`, defaulting to the warning index).
-  **`'rich'`** adds per-column vertex-pressure dots in the lower third of the band (primitive vs sprite submitted counts
-  scaled to the 50k vertex cap). Set **`overlayRendererDiagnosticsBar: true`** for a dedicated text row
+  the band; any non-zero sample draws at least one pixel (sub-millisecond work shows as a baseline dot). **Grid lines:**
+  faint horizontal reference rows at **5**, **10**, and **33.33** ms plus a frame-budget line at **`1000 / targetFPS`**
+  ms are drawn behind the dots (qualitative scale on a ~22 px band, not a precision ruler). The band bottom row is the
+  zero baseline (sub-ms / light samples); top- and bottom-edge rows are not drawn as grid lines. Grid color defaults to
+  `overlayStyle.gapPaletteIndex` (then `barPaletteIndex`); override with `overlayTimingChartStyle.gridPaletteIndex`. The
+  band background uses `overlayStyle.barPaletteIndex`; dot colors default to `overlayStyle.barPaletteIndex` /
+  `textPaletteIndex`; override with `overlayTimingChartStyle`. **Semantic tints:** when a column is classified as a
+  runtime risk, both update and render dots use the warning or error palette index instead of the normal bar colors.
+  Classification uses the prior frame's `Frame` wall time against `1000 / targetFPS` (warning at **1.10x** budget, error
+  at **1.50x**) and dropped-frame events from the game loop (one dropped frame = warning, two or more = error; error
+  wins when both apply). Default warning/error/event palette indices are **3**, **4**, and **5** when not overridden.
+  Drop detection for the chart runs whenever `overlayTimingChart: true` (independent of `detectDroppedFrames`, which
+  only controls console warnings). **Event tags:** call `BT.assignTag(label?)` from `update()` or `init()` to anchor a
+  short label on the scrolling chart at the current `BT.ticks`. Empty or omitted labels become `"Untitled"`. Each tag
+  column draws a tick row (relative ticks since chart reset, capped at **100000**) and stacked label rows above the
+  chart band; spacing is fixed in `tags.ts` (`TIMING_CHART_TAG_LABEL_Y_GAP`, `TIMING_CHART_TAG_LABEL_STACK_SPACING`).
+  Tick and label text share the same horizontal offset from the timing column. A faint vertical grid-colored line marks
+  the column on the chart band. Tag columns follow timing **samples** (one per rendered frame), not `BT.ticks`, which
+  can advance multiple fixed-update steps per frame: they fill from the left while the ring buffer is not full, then
+  scroll left one column per sample once full, in lockstep with the dots. Tags are removed when they scroll one full
+  chart width past the left edge (text keeps drawing at negative x until the display clips it); pruning runs on each
+  timing sample while the chart is enabled. Chart width resets (for example on resize) clear tags and add an automatic
+  `"Start"` marker. Tint tags with `overlayTimingChartStyle.tagPaletteIndex` (default **5**). **Renderer diagnostics
+  (optional):** when the chart is enabled, `overlayTimingChartDiagnostics` defaults to **`'minimal'`** (set `false` to
+  disable chart markers). **Minimal** mode bumps semantic severity when either pipeline overflowed that frame and draws
+  a baseline overflow marker (palette index from `overlayTimingChartStyle.overflowPaletteIndex`, defaulting to the
+  warning index). **`'rich'`** adds per-column vertex-pressure dots in the lower third of the band (primitive vs sprite
+  submitted counts scaled to the 50k vertex cap). Set **`overlayRendererDiagnosticsBar: true`** for a dedicated text row
   (`Prim Nv ov: X | Spr Nv ov: X`) below the frame timing line; collection runs when either the chart diagnostics mode
   is not `false` or the diagnostics bar is enabled. Overflow counts apply on WebGPU; the software backend reports
   `ov: 0` with GPU-equivalent vertex totals for primitive and sprite work.

--- a/docs/performance-testing.md
+++ b/docs/performance-testing.md
@@ -51,7 +51,7 @@ Current benchmark files:
 - `src/assets/SystemFont.bench.ts`
 - `src/overlay/palette/PaletteView.bench.ts`
 
-### Overlay palette grid (VV-543)
+### Overlay palette grid
 
 These benchmarks guard perf follow-ups for the live palette swatch grid:
 

--- a/docs/post-process-effects.md
+++ b/docs/post-process-effects.md
@@ -299,7 +299,7 @@ Demos that want the full kitchen-sink effect should use this.
 ### `BT.preset.amber()`
 
 Amber monochrome PC monitor (think IBM 5151 / Hercules). Currently ships as a parameter-only set - the actual amber tint
-quantization will land with [VV-479](https://linear.app/vancura/issue/VV-479/monochrome-re-quantization-display-effect).
+quantization is planned but not yet implemented.
 
 ### `BT.preset.green()`
 
@@ -412,6 +412,5 @@ aberration via offset sampling) are common shader patterns and not original to a
 composition mirrors the PipBoy fork. The Blit-Tech port is original WGSL.
 
 If you intend to reuse `Interference`, `RollLine`, or `PixelGlitch` in a context with stricter licensing requirements,
-confirm provenance first. The license audit is tracked in
-[VV-480](https://linear.app/vancura/issue/VV-480/audit-and-resolve-pipboy-fork-licensing). If you can identify the
-upstream PipBoy fork, please open a PR to add a verifiable author / URL / license header.
+confirm provenance first. The license audit is still open. If you can identify the upstream PipBoy fork, please open a
+PR to add a verifiable author / URL / license header.

--- a/docs/security/security-runbook.md
+++ b/docs/security/security-runbook.md
@@ -19,11 +19,11 @@ the `/security-run` skill and `pnpm run security:mcp-preflight`.
 2. Run [Repo-native commands](#repo-native-commands) for the affected repo (`pnpm run security:audit`,
    `pnpm run preflight`).
 3. Follow [dependency-policy.md](./dependency-policy.md) for CI failures or temporary risk acceptance.
-4. Record findings using the [Report template](#report-template) (Linear comment or issue body).
+4. Record findings using the [Report template](#report-template) (issue tracker or PR description).
 
-Bus-factor evidence (optional): run the `security-ownership-map` skill and attach `summary.json` to hardening reviews.
-VV-522 (backup-owner process) was canceled; the **Maintainers** section above (including incident triage) is the
-documented fallback instead of a fictional backup owner.
+Bus-factor evidence (optional): run the `security-ownership-map` skill and attach `summary.json` to hardening reviews. A
+formal backup-owner process is intentionally not used; the **Maintainers** section above (including incident triage) is
+the documented fallback instead of a fictional backup owner.
 
 ## When to run
 
@@ -163,7 +163,7 @@ node "<blit-tech-root>/scripts/security/mcp-preflight.mjs" \
 
 ## Report template
 
-Use this structure in agent output or Linear comments:
+Use this structure in agent output or issue/PR comments:
 
 ```md
 ## Security run report

--- a/docs/software-fallback-smoke-matrix.md
+++ b/docs/software-fallback-smoke-matrix.md
@@ -1,7 +1,7 @@
 # Software Fallback Smoke Matrix
 
-This checklist is for quick manual verification of the software renderer. Originally written for `VV-490` (MVP); updated
-for auto-fallback and the engine overlay (backend shown on the top bar when `overlayEnabled` is true).
+This checklist is for quick manual verification of the software renderer. Originally written for the software-renderer
+MVP; updated for auto-fallback and the engine overlay (backend shown on the top bar when `overlayEnabled` is true).
 
 ## Scope
 

--- a/src/BlitTech.ts
+++ b/src/BlitTech.ts
@@ -372,12 +372,12 @@ export const BT = {
     BTN_POINTER_ANY: (1 << 12) | (1 << 13) | (1 << 14) | (1 << 15),
 
     /**
-     * Default `KeyboardEvent.code` values for player 1 face buttons (VV-435).
+     * Default `KeyboardEvent.code` values for player 1 face buttons.
      */
     DEFAULT_KEYBOARD_PLAYER1,
 
     /**
-     * Default `KeyboardEvent.code` values for player 2 face buttons (VV-435).
+     * Default `KeyboardEvent.code` values for player 2 face buttons.
      */
     DEFAULT_KEYBOARD_PLAYER2,
 
@@ -1241,7 +1241,7 @@ export const BT = {
     },
 
     /**
-     * Restores built-in default keyboard maps for players `0` and `1` (VV-435).
+     * Restores built-in default keyboard maps for players `0` and `1`.
      *
      * Same tables as `BT.DEFAULT_KEYBOARD_PLAYER1` and `BT.DEFAULT_KEYBOARD_PLAYER2`.
      */

--- a/src/assets/SpriteSheet.ts
+++ b/src/assets/SpriteSheet.ts
@@ -7,7 +7,7 @@ import { Vector2i } from '../utils/Vector2i';
 import { AssetLoader } from './AssetLoader';
 import type { Palette } from './Palette';
 
-/** Reused per-call bitmask of sheet indices seen while scanning a source rect (VV-543). */
+/** Reused per-call bitmask of sheet indices seen while scanning a source rect. */
 const markPaletteIndicesInRectScratch = new Uint8Array(256);
 
 /**
@@ -502,7 +502,7 @@ export class SpriteSheet {
      *
      * Used by the engine to build the overlay palette grid from demo draw
      * calls. Does not allocate; writes into the supplied usage mask. Each unique
-     * sheet index in the rect is resolved once (VV-543).
+     * sheet index in the rect is resolved once.
      *
      * @param srcRect - Region to scan in sheet coordinates.
      * @param paletteOffset - Palette offset applied at draw time.

--- a/src/core/BTAPI.test.ts
+++ b/src/core/BTAPI.test.ts
@@ -1147,7 +1147,7 @@ describe('BTAPI', () => {
 
     // #endregion
 
-    // #region Timing chart tags (VV-541)
+    // #region Timing chart tags
 
     describe('assignTag', () => {
         it('forwards tags to Overlay when the timing chart is enabled', async () => {
@@ -1192,7 +1192,7 @@ describe('BTAPI', () => {
 
     // #endregion
 
-    // #region Renderer diagnostics (VV-544)
+    // #region Renderer diagnostics
 
     describe('renderer diagnostics in overlay timing snapshot', () => {
         /**
@@ -1349,7 +1349,7 @@ describe('BTAPI', () => {
 
     // #endregion
 
-    // #region Palette usage tracking (VV-543)
+    // #region Palette usage tracking
 
     describe('palette usage tracking', () => {
         function getOverlay(): Overlay | null {

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -183,10 +183,10 @@ export class BTAPI {
     /** Pointer / mouse / touch input subsystem. Created during {@link init}. */
     private pointer: PointerInput | null = null;
 
-    /** Keyboard input (VV-134). Created during {@link init}. */
+    /** Keyboard input. Created during {@link init}. */
     private keyboard: KeyboardInput | null = null;
 
-    /** Gamepad input (VV-135). Created during {@link init}. */
+    /** Gamepad input. Created during {@link init}. */
     private gamepad: GamepadInput | null = null;
 
     // TODO: Additional subsystems for future implementation:
@@ -531,7 +531,7 @@ export class BTAPI {
     }
 
     /**
-     * Assigns an event tag on the stats overlay timing chart (VV-541).
+     * Assigns an event tag on the stats overlay timing chart.
      *
      * No-op when the overlay or timing chart is disabled.
      *

--- a/src/core/IBlitTechDemo.ts
+++ b/src/core/IBlitTechDemo.ts
@@ -189,7 +189,7 @@ export interface HardwareSettings {
     /**
      * Optional palette indices for the timing chart band. Update/render bar colors default to
      * {@link OverlayStyle} bar/text indices; warning/error/event slots control semantic
-     * chart tints (VV-545) and future tag markers (VV-541).
+     * chart tints and future tag markers.
      */
     overlayTimingChartStyle?: OverlayTimingChartStyle;
 
@@ -237,17 +237,17 @@ export interface OverlayTimingChartStyle {
     /** Render bar color; defaults to {@link OverlayStyle.textPaletteIndex} or overlay text index. */
     renderBarPaletteIndex?: number;
 
-    /** Warning tint when a chart column is over budget or dropped one frame (VV-545). */
+    /** Warning tint when a chart column is over budget or dropped one frame. */
     warningPaletteIndex?: number;
 
-    /** Error tint when a chart column is severely over budget or dropped 2+ frames (VV-545). */
+    /** Error tint when a chart column is severely over budget or dropped 2+ frames. */
     errorPaletteIndex?: number;
 
-    /** Palette index for timing chart tag and tick text (VV-541). */
+    /** Palette index for timing chart tag and tick text. */
     tagPaletteIndex?: number;
 
     /**
-     * Faint horizontal grid lines behind chart dots (VV-7). Defaults to
+     * Faint horizontal grid lines behind chart dots. Defaults to
      * {@link OverlayStyle.gapPaletteIndex} or {@link OverlayStyle.barPaletteIndex} when omitted.
      */
     gridPaletteIndex?: number;

--- a/src/input/GamepadInput.ts
+++ b/src/input/GamepadInput.ts
@@ -1,5 +1,5 @@
 /**
- * Gamepad input subsystem (VV-135).
+ * Gamepad input subsystem.
  *
  * Uses the browser Gamepad API and snapshots previous-state at end-of-frame for
  * edge detection (`pressed`/`released`) and optional repeat timing.

--- a/src/input/KeyboardInput.ts
+++ b/src/input/KeyboardInput.ts
@@ -1,6 +1,6 @@
 /**
  * Keyboard input: DOM `code` tracking, edge detection, optional tick-based repeat,
- * and text accumulation via `beforeinput` (VV-396 / `inputString`).
+ * and text accumulation via `beforeinput` (`inputString`).
  */
 
 // #region Types

--- a/src/input/defaultKeyboardMap.ts
+++ b/src/input/defaultKeyboardMap.ts
@@ -1,5 +1,5 @@
 /**
- * Default keyboard bindings for face buttons (VV-435 key mapping).
+ * Default keyboard bindings for face buttons (key mapping).
  *
  * Values are `KeyboardEvent.code` strings. Logical button state is the OR of
  * all listed keys for that button.

--- a/src/overlay/Overlay.test.ts
+++ b/src/overlay/Overlay.test.ts
@@ -55,7 +55,7 @@ interface OverlayTestOptions {
     backend?: 'webgpu' | 'software';
 }
 
-/** Builds a {@link Overlay} with explicit VV-546 visibility defaults for tests. */
+/** Builds a {@link Overlay} with explicit visibility defaults for tests. */
 function createOverlay(
     layout: ReturnType<typeof createOverlayLayout>,
     label: string,
@@ -121,7 +121,7 @@ describe('Overlay', () => {
         expect(overlay.tracksPaletteUsage).toBe(false);
     });
 
-    it('swatch press in the toggle corner does not toggle overlay body (VV-549)', () => {
+    it('swatch press in the toggle corner does not toggle overlay body', () => {
         const layout = createOverlayLayout(320, 240, 14);
         const overlay = createOverlay(layout, 'Test Demo', { paletteView: true, visibleAtStart: true });
         const grid = computePaletteGrid(320);
@@ -144,7 +144,7 @@ describe('Overlay', () => {
         expect(overlay.bodyVisible).toBe(true);
     });
 
-    it('scrollbar track press blocks toggle but swatch press still copies first (VV-550)', () => {
+    it('scrollbar track press blocks toggle but swatch press still copies first', () => {
         const layout = createOverlayLayout(320, 240, 14);
         const overlay = createOverlay(layout, 'Test Demo', {
             paletteView: true,

--- a/src/overlay/Overlay.ts
+++ b/src/overlay/Overlay.ts
@@ -1,8 +1,8 @@
 /**
  * Screen-space overlay HUD orchestrator.
  *
- * Delegates layout planning, bar drawing, toggle input, timing chart (VV-539),
- * and palette grid (VV-540) to submodules under `overlay/`.
+ * Delegates layout planning, bar drawing, toggle input, timing chart,
+ * and palette grid to submodules under `overlay/`.
  */
 
 import type { BitmapFont } from '../assets/BitmapFont';
@@ -199,7 +199,7 @@ export class Overlay {
     // #region Public API
 
     /**
-     * Records a timing-chart event tag at the current tick (VV-541).
+     * Records a timing-chart event tag at the current tick.
      *
      * No-op when the timing chart is disabled.
      *

--- a/src/overlay/OverlayToggleIcon.ts
+++ b/src/overlay/OverlayToggleIcon.ts
@@ -1,5 +1,5 @@
 /**
- * Draw helper for the inline overlay toggle hint bitmap icon (VV-548).
+ * Draw helper for the inline overlay toggle hint bitmap icon.
  */
 
 import { Rect2i } from '../utils/Rect2i';

--- a/src/overlay/layout/layoutPlan.ts
+++ b/src/overlay/layout/layoutPlan.ts
@@ -2,8 +2,8 @@
  * Dynamic Y-band planner for the overlay.
  *
  * Computes bar rects and text anchors each frame from display size, custom row count,
- * and optional timing-chart / palette-grid feature flags (timing chart default off per
- * VV-539 timing chart opt-in via {@link HardwareSettings.overlayTimingChart}).
+ * and optional timing-chart / palette-grid feature flags (timing chart default off,
+ * opt-in via {@link HardwareSettings.overlayTimingChart}).
  */
 
 import { Rect2i } from '../../utils/Rect2i';

--- a/src/overlay/palette/PaletteInteraction.test.ts
+++ b/src/overlay/palette/PaletteInteraction.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for palette swatch hit testing, tooltip layout, and clipboard copy (VV-549).
+ * Unit tests for palette swatch hit testing, tooltip layout, and clipboard copy.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';

--- a/src/overlay/palette/PaletteInteraction.ts
+++ b/src/overlay/palette/PaletteInteraction.ts
@@ -1,5 +1,5 @@
 /**
- * Palette swatch hover tooltips and clipboard copy for the overlay (VV-549).
+ * Palette swatch hover tooltips and clipboard copy for the overlay.
  */
 
 import type { BitmapFont } from '../../assets/BitmapFont';
@@ -25,7 +25,7 @@ import {
 
 // #region Constants and types
 
-/** Reserved width on the right edge of the palette band excluded from swatch hits (VV-550 scrollbar). */
+/** Reserved width on the right edge of the palette band excluded from swatch hits (scrollbar). */
 export const PALETTE_SCROLLBAR_TRACK_WIDTH_PX = 4;
 
 /** Minimum wheel delta in pixels before advancing one palette row. */
@@ -167,7 +167,7 @@ function resolvePaletteIndexAtBandLocal(
  * @param colorCount - Active palette slot count.
  * @param hintExclusion - Region to skip for the toggle hint icon.
  * @param displayWidth - Logical display width for scrollbar track exclusion.
- * @param scrollRowOffset - First visible grid row (default `0`; VV-550 scroll).
+ * @param scrollRowOffset - First visible grid row (default `0`).
  * @param scrollbarTrackWidth - Right-edge track width excluded from hits (default {@link PALETTE_SCROLLBAR_TRACK_WIDTH_PX}).
  * @returns Palette index, or `null` when the pointer is not over a hittable swatch.
  */

--- a/src/overlay/palette/PaletteView.alloc.test.ts
+++ b/src/overlay/palette/PaletteView.alloc.test.ts
@@ -1,5 +1,5 @@
 /**
- * Allocation regression tests for {@link PaletteView} draw hot path (VV-543).
+ * Allocation regression tests for {@link PaletteView} draw hot path.
  */
 
 // #region Imports

--- a/src/overlay/palette/PaletteView.ts
+++ b/src/overlay/palette/PaletteView.ts
@@ -1,5 +1,5 @@
 /**
- * Live palette swatch grid for the overlay bottom band (VV-540).
+ * Live palette swatch grid for the overlay bottom band.
  *
  * {@link computePaletteGrid} picks adaptive column counts from the active palette
  * size; {@link PaletteView.draw} renders indexed swatches with gaps and
@@ -208,7 +208,7 @@ function swatchIntersectsRect(x: number, y: number, swatchSize: number, exclusio
     return rectsIntersect(x, y, swatchSize, swatchSize, exclusion.x, exclusion.y, exclusion.width, exclusion.height);
 }
 
-/** Cached hint exclusion rect; recomputed only when layout inputs change (VV-543). */
+/** Cached hint exclusion rect; recomputed only when layout inputs change. */
 const hintExclusionCache = {
     hintBarTopY: Number.NaN,
     displayWidth: Number.NaN,

--- a/src/overlay/timing-chart/TimingChart.ts
+++ b/src/overlay/timing-chart/TimingChart.ts
@@ -1,5 +1,5 @@
 /**
- * Scrolling update/render timing chart band for the overlay (VV-539, VV-545 severity, VV-7 grid, VV-541 tags).
+ * Scrolling update/render timing chart band for the overlay (severity tints, grid lines, event tags).
  */
 
 import type { BitmapFont } from '../../assets/BitmapFont';
@@ -73,7 +73,7 @@ export class TimingChart {
     /** Reusable marker list: fixed thresholds plus one frame-budget slot. */
     readonly #gridMarkerMs = new Float32Array(8);
 
-    /** Event tags anchored to absolute ticks (VV-541). */
+    /** Event tags anchored to absolute ticks. */
     readonly #tags: TimingChartTag[] = [];
 
     /** Tick at last chart reset; used for relative tick labels. */
@@ -312,7 +312,7 @@ export class TimingChart {
     }
 
     /**
-     * Draws a one-pixel vertical marker per tag, aligned with timing columns (VV-541).
+     * Draws a one-pixel vertical marker per tag, aligned with timing columns.
      *
      * @param target - Overlay draw target.
      * @param chartRect - Screen-space chart band.
@@ -338,7 +338,7 @@ export class TimingChart {
     }
 
     /**
-     * Draws event tag labels above the chart band (VV-541).
+     * Draws event tag labels above the chart band.
      *
      * @param target - Overlay draw target.
      * @param chartRect - Screen-space chart band.
@@ -399,7 +399,7 @@ export class TimingChart {
     }
 
     /**
-     * Draws faint horizontal grid lines behind timing dots (VV-7).
+     * Draws faint horizontal grid lines behind timing dots.
      *
      * @param target - Overlay draw target.
      * @param chartRect - Screen-space chart band from layout plan.

--- a/src/overlay/timing-chart/constants.ts
+++ b/src/overlay/timing-chart/constants.ts
@@ -32,7 +32,7 @@ export const TIMING_CHART_MAX_PIPELINE_VERTICES = 50000;
 export const TIMING_CHART_PRESSURE_REGION_RATIO = 1 / 3;
 
 /**
- * Fixed interior grid markers in milliseconds (VV-7). Excludes 1 ms (band bottom edge).
+ * Fixed interior grid markers in milliseconds. Excludes 1 ms (band bottom edge).
  * Frame budget is added at draw time from targetFPS.
  */
 export const TIMING_CHART_GRID_MARKER_MS: readonly number[] = [5, 10, 33.33];

--- a/src/overlay/timing-chart/severity.ts
+++ b/src/overlay/timing-chart/severity.ts
@@ -1,5 +1,5 @@
 /**
- * Timing chart severity classification (VV-545).
+ * Timing chart severity classification.
  */
 
 /** No semantic tint for this chart column. */

--- a/src/overlay/timing-chart/tags.ts
+++ b/src/overlay/timing-chart/tags.ts
@@ -1,5 +1,5 @@
 /**
- * Pure helpers for timing chart event tags (VV-541, RetroBlit AssignTag parity).
+ * Pure helpers for timing chart event tags (RetroBlit AssignTag parity).
  */
 
 /** Label added automatically when the timing chart ring buffer is reset (RetroBlit Reset parity). */

--- a/src/overlay/toggleIconData.ts
+++ b/src/overlay/toggleIconData.ts
@@ -1,5 +1,5 @@
 /**
- * Inline row-major mask for the overlay toggle hint icon (VV-548).
+ * Inline row-major mask for the overlay toggle hint icon.
  *
  * `1` draws a foreground pixel; `0` is transparent.
  */

--- a/src/render/effects/presets/amber.ts
+++ b/src/render/effects/presets/amber.ts
@@ -10,8 +10,7 @@ import type { Effect } from '../Effect';
  * Amber monochrome PC monitor look (think IBM 5151 / Hercules).
  *
  * Ships as a parameter-only set - the underlying colors stay full-RGB until
- * the {@link MonochromeQuantize} effect lands (tracked in
- * [VV-479](https://linear.app/vancura/issue/VV-479/monochrome-re-quantization-display-effect)).
+ * the planned {@link MonochromeQuantize} effect lands.
  * For now this preset gives you the *feel* (CRT curvature + scanlines +
  * vignette + warm-tinted bloom) without the actual amber re-quantization.
  *

--- a/src/render/effects/presets/green.ts
+++ b/src/render/effects/presets/green.ts
@@ -10,7 +10,7 @@ import type { Effect } from '../Effect';
  * Green monochrome PC monitor look (think original IBM monochrome / VT100).
  *
  * Ships as a parameter-only set - see the {@link amber} preset for the
- * caveat about re-quantization (VV-479). Same effect stack as `amber()`,
+ * caveat about re-quantization. Same effect stack as `amber()`,
  * tuned slightly toward a cooler / more flickery aesthetic.
  *
  * @returns Array of pre-configured display-tier effects.


### PR DESCRIPTION
Strip all VV-* ticket IDs and linear.app links from code comments, JSDoc, docs, the perf skill, and the security issue template ahead of the public release; the project no longer tracks work in Linear.

Also add the OverlayToggleIcon and toggleIconData modules to the CLAUDE.md architecture map and update the README overlay section for the hidden-by-default body, bottom-left toggle, and the new overlayVisibleAtStart / overlayToggleHintVisible / overlayToggleEnabled flags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR removes all Linear VV-* ticket references and updates overlay-related documentation in preparation for the public release.

The changes span three main categories:

**Removal of Linear ticket references (primary focus):** Systematically removes VV-#### annotations from JSDoc comments, documentation comments, region headers, and documentation files across the codebase. This includes references like VV-543, VV-481, VV-480, VV-479, VV-546, VV-549, VV-550, VV-522, VV-490, VV-435, VV-134, VV-541, VV-7, VV-539, VV-135, and others. Files affected include:
- Core API documentation (src/core/BTAPI.ts, src/core/BTAPI.test.ts, src/core/IBlitTechDemo.ts)
- Overlay modules (src/overlay/*.ts, src/overlay/palette/*.ts, src/overlay/timing-chart/*.ts)
- Input subsystem (src/input/GamepadInput.ts, src/input/KeyboardInput.ts, src/input/defaultKeyboardMap.ts)
- Asset management (src/assets/SpriteSheet.ts)
- Render effects (src/render/effects/presets/amber.ts, green.ts)
- Public exports (src/BlitTech.ts)
- Test files and configuration

**Overlay documentation enhancements:** 
- CLAUDE.md updated to include `OverlayToggleIcon.ts` and `toggleIconData.ts` modules in the src/overlay/ architecture map
- README.md expanded the Browser Compatibility section to document overlay behavior: body starts hidden behind a bottom-left toggle hint, with new configuration flags (`overlayVisibleAtStart`, `overlayToggleHintVisible`, `overlayEnabled`) and explanation of `BT.activeBackend`

**Documentation clarifications and improvements:**
- docs/api-core.md: Timing chart section reworded to remove internal references while clarifying grid lines, runtime-risk tinting, event-tag labeling, and renderer diagnostics modes (minimal vs rich)
- docs/performance-testing.md and .claude/skills/perf/SKILL.md: Removed ticket references from overlay benchmark sections
- docs/post-process-effects.md: Updated to state `MonochromeQuantize` is planned but not yet implemented, and clarified attribution/licensing guidance for reused effects
- docs/security/security-runbook.md: Adjusted incident triage wording around bus-factor and backup-owner process
- docs/software-fallback-smoke-matrix.md: Clarified MVP content and auto-fallback behavior documentation
- src/overlay/layout/layoutPlan.ts: Changed overlay timing-chart feature flag documentation from "default off per VV-539" to "default off, opt-in via `HardwareSettings.overlayTimingChart`"
- .github/ISSUE_TEMPLATE/security-risk-acceptance.yml: Updated to require GitHub issue URL instead of allowing Linear URLs

All changes are documentation-only with no modifications to runtime logic, function signatures, type declarations, or exported API behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/238?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->