### PR TITLE
fix(core): lazy-load WebGpuRenderer for software fallback without WebGPU globals

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ sprites, and bitmap text resolve color through the active `Palette` before final
 src/
   BlitTech.ts              # Public API (BT namespace exports)
   core/
-    BTAPI.ts               # Internal singleton managing subsystems
+    BTAPI.ts               # Internal singleton managing subsystems (lazy-loads WebGpuRenderer on WebGPU init)
     IBlitTechDemo.ts       # Demo interface + HardwareSettings
     GameLoop.ts            # Fixed-timestep game loop
     WebGPUContext.ts       # WebGPU adapter/device/context setup

--- a/README.md
+++ b/README.md
@@ -180,14 +180,15 @@ WebGPU support varies by browser:
 | Firefox     | 141+ (Windows) | Enabled by default; 145+/147+ on macOS; Nightly on Linux/Android |
 | Safari      | 26+            | Enabled by default; Safari 18-25 available via Feature Flags     |
 
-When WebGPU is unavailable the engine falls back to the Canvas 2D software renderer automatically. By default the engine
-draws a stats overlay after each frame: measured FPS, configured target FPS, the active backend name (via
-`BT.activeBackend`), logical resolution, and a short demo title derived from `document.title`. The overlay **body starts
-hidden** with a bitmap toggle hint in the bottom-left corner; toggle it with `~` (Backquote) or a primary press in the
-bottom-left corner. Use `overlayVisibleAtStart: true` to show the body on the first frame,
-`overlayToggleHintVisible: false` to hide the hint icon on immersive demos, or `overlayEnabled: false` to disable the
-overlay entirely in `configure()`. Use `BT.activeBackend` to read which backend is running (`'webgpu'`, `'software'`, or
-`null` before init).
+When WebGPU is unavailable the engine falls back to the Canvas 2D software renderer automatically. The software path
+also works on browsers that do not expose WebGPU globals at all (for example Firefox on Linux without Nightly); the
+WebGPU renderer is loaded only when WebGPU init succeeds. By default the engine draws a stats overlay after each frame:
+measured FPS, configured target FPS, the active backend name (via `BT.activeBackend`), logical resolution, and a short
+demo title derived from `document.title`. The overlay **body starts hidden** with a bitmap toggle hint in the
+bottom-left corner; toggle it with `~` (Backquote) or a primary press in the bottom-left corner. Use
+`overlayVisibleAtStart: true` to show the body on the first frame, `overlayToggleHintVisible: false` to hide the hint
+icon on immersive demos, or `overlayEnabled: false` to disable the overlay entirely in `configure()`. Use
+`BT.activeBackend` to read which backend is running (`'webgpu'`, `'software'`, or `null` before init).
 
 ## Contributors
 

--- a/docs/api-core.md
+++ b/docs/api-core.md
@@ -165,6 +165,10 @@ post-merge resolution:
 **Fallback:** When `requestedBackend` is `'webgpu'` (explicit or default) and WebGPU init fails, the engine logs a
 warning and starts the software renderer. Then `activeBackend === 'software'` while `requestedBackend` stays `'webgpu'`.
 
+The WebGPU renderer module is loaded lazily during init (only after a successful adapter/device setup). Browsers without
+WebGPU globals (for example Firefox on Linux without Nightly) can therefore start the software backend or auto-fallback
+without hitting module-load errors from WebGPU-only code.
+
 **Runtime checks (post-process, capture, etc.):** use `activeBackend`, not `requestedBackend`:
 
 ```ts

--- a/docs/software-fallback-smoke-matrix.md
+++ b/docs/software-fallback-smoke-matrix.md
@@ -14,7 +14,7 @@ MVP; updated for auto-fallback and the engine overlay (backend shown on the top 
 
 ## Environment
 
-- Browser: latest Chrome or Edge
+- Browser: latest Chrome or Edge; Firefox on Linux without WebGPU (software path / auto-fallback)
 - URL override for software mode:
   - `?backend=software`
 - Optional baseline comparison:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -36,9 +36,9 @@ and `vi` for browser API stubs. Tests that need a full DOM (Bootstrap, Bootstrap
 - **PrimitivePipeline** - vertex buffer math, line algorithm (Node + GPU mocks)
 - **SpritePipeline** - texture batching, UV coordinates (Node + GPU mocks)
 - **WebGPUContext** - initialization with mock adapter/device (Node + GPU mocks)
-- **BTAPI** - singleton coordinator; lazy-loads {@link WebGpuRenderer} after WebGPU init succeeds; includes
-  software-mode init, `?backend=software` URL override, `BT.requestedBackend` vs `BT.activeBackend` after WebGPU
-  fallback, `captureFrame()` in software mode, and overlay render path (Node + GPU mocks + 2D canvas mocks)
+- **BTAPI** - singleton coordinator; lazy-loads `WebGpuRenderer` after WebGPU init succeeds; includes software-mode
+  init, `?backend=software` URL override, `BT.requestedBackend` vs `BT.activeBackend` after WebGPU fallback,
+  `captureFrame()` in software mode, and overlay render path (Node + GPU mocks + 2D canvas mocks)
 - **Overlay** - colocated tests under `src/overlay/*.test.ts`: label parsing, layout helpers, `layoutPlan` golden Y
   positions for 320x240 (including custom rows, palette grid variable bottom band, and timing chart scaffold cases),
   `PaletteView.computePaletteGrid` width/size matrix, toggle hit-testing, and `updateAndRender` integration (Node)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -36,9 +36,9 @@ and `vi` for browser API stubs. Tests that need a full DOM (Bootstrap, Bootstrap
 - **PrimitivePipeline** - vertex buffer math, line algorithm (Node + GPU mocks)
 - **SpritePipeline** - texture batching, UV coordinates (Node + GPU mocks)
 - **WebGPUContext** - initialization with mock adapter/device (Node + GPU mocks)
-- **BTAPI** - singleton coordinator; includes software-mode init, `?backend=software` URL override,
-  `BT.requestedBackend` vs `BT.activeBackend` after WebGPU fallback, `captureFrame()` in software mode, and overlay
-  render path (Node + GPU mocks + 2D canvas mocks)
+- **BTAPI** - singleton coordinator; lazy-loads {@link WebGpuRenderer} after WebGPU init succeeds; includes
+  software-mode init, `?backend=software` URL override, `BT.requestedBackend` vs `BT.activeBackend` after WebGPU
+  fallback, `captureFrame()` in software mode, and overlay render path (Node + GPU mocks + 2D canvas mocks)
 - **Overlay** - colocated tests under `src/overlay/*.test.ts`: label parsing, layout helpers, `layoutPlan` golden Y
   positions for 320x240 (including custom rows, palette grid variable bottom band, and timing chart scaffold cases),
   `PaletteView.computePaletteGrid` width/size matrix, toggle hit-testing, and `updateAndRender` integration (Node)

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -18,7 +18,6 @@ import type { OverlayDrawTarget } from '../overlay/OverlayDrawTarget';
 import type { Effect } from '../render/effects/Effect';
 import type { IRenderer } from '../render/IRenderer';
 import { SoftwareRenderer } from '../render/SoftwareRenderer';
-import { WebGpuRenderer } from '../render/WebGpuRenderer';
 import { applyCanvasLayoutStyles, DEFAULT_MAX_CANVAS_SIZE } from '../utils/CanvasLayoutStyles';
 import type { Color32 } from '../utils/Color32';
 import type { EasingFunction } from '../utils/Easing';
@@ -1158,6 +1157,10 @@ export class BTAPI {
                 this.context = webGPUResult.context;
 
                 console.log('[BT] Initializing renderer (backend: webgpu)');
+
+                // Lazy-load WebGPU renderer code so browsers without WebGPU globals
+                // (e.g. Firefox on Linux) can still start with the software backend.
+                const { WebGpuRenderer } = await import('../render/WebGpuRenderer');
 
                 this.renderer = new WebGpuRenderer(
                     webGPUResult.device,


### PR DESCRIPTION
Static import of WebGpuRenderer evaluated GPUTextureUsage at module load, crashing browsers without WebGPU (e.g. Firefox on Linux) before the software backend could start. Load the renderer dynamically only after WebGPU init succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes Overview

This PR addresses a critical issue where browsers without WebGPU support (e.g., Firefox on Linux) would crash during module initialization. The static import of `WebGpuRenderer` caused evaluation of `GPUTextureUsage` at module load time, preventing the software fallback from initializing on platforms lacking WebGPU globals.

## Solution

**src/core/BTAPI.ts** - The main implementation change replaces the static import of `WebGpuRenderer` with a dynamic import that occurs at runtime when the WebGPU backend is selected. This defers the loading of WebGPU-specific code until after successful adapter/device setup, allowing environments without WebGPU to initialize the software backend without encountering module-load errors.

## Documentation Updates

**CLAUDE.md** - Updated architecture description to specify that the singleton lazily loads `WebGpuRenderer` during WebGPU initialization.

**README.md** - Clarified the Browser Compatibility section to explain that the Canvas 2D software renderer works when browsers don't expose WebGPU globals, and the WebGPU renderer is only loaded after successful WebGPU initialization.

**docs/api-core.md** - Added clarification that the WebGPU renderer module is loaded lazily during initialization only after successful adapter/device setup.

**docs/testing.md** - Updated the BTAPI test description to explicitly state it lazy-loads `WebGpuRenderer` after WebGPU initialization succeeds.

**docs/software-fallback-smoke-matrix.md** - Added a Linux-specific Firefox note indicating it should use the software fallback when WebGPU is unavailable.

## Impact

The fix enables the software fallback to gracefully start on WebGPU-unsupported browsers without initialization crashes, while maintaining full WebGPU functionality on supported platforms through dynamic module loading.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vancura/blit-tech/pull/240?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->