### PR TITLE
refactor: clean up the API

### DIFF
--- a/.claude/rules/bt-api-getters.md
+++ b/.claude/rules/bt-api-getters.md
@@ -1,6 +1,6 @@
 # BT API: getters vs methods
 
-Canonical reference: [CLAUDE.md](../../CLAUDE.md) (**BT API: getters vs methods**).
+Canonical reference: [CLAUDE.md](../../CLAUDE.md) (**BT API: getters vs methods**, **Boolean naming**).
 
 Quick rules when changing `src/BlitTech.ts` or demos:
 
@@ -22,6 +22,22 @@ Quick rules when changing `src/BlitTech.ts` or demos:
 `Vector2i` getters return a clone per read. `activeBackend` is what actually started after fallback, not
 `configure().backend`.
 `palette` is a live reference - mutating slots affects rendering on the next frame.
+
+## Boolean queries on `BT` (Tier A; always methods)
+
+- Hold: `isDown(...)`, `isKeyDown(...)`
+- Edge: `isPressed(...)`, `isReleased(...)`, `isKeyPressed(...)`, `isKeyReleased(...)`
+- Pointer: `isPointerActive(slot?)`
+- Internal input classes mirror the same names (`isButtonDown`, `isKeyDown`, …). No embedded second `Is` (`\bis[A-Za-z]+Is[A-Z]`).
+
+## Configure flags (Tier B)
+
+Mirror `HardwareSettings` / `BootstrapOptions` field names: `isOverlayEnabled`, `isOverlayVisibleAtStart`,
+`isDetectingDroppedFrames`, `isWaitingForDOMReady`, `canvasID`, `containerID`. Use `-ing` for ongoing behavior flags.
+
+## Side-effect booleans (Tier C)
+
+Not `is*`: `Timer.fireIfElapsed()`, `remove(): boolean`, `init(): Promise<boolean>`.
 
 ## Naming when adding getters
 

--- a/.claude/rules/bt-api-getters.md
+++ b/.claude/rules/bt-api-getters.md
@@ -45,4 +45,4 @@ Not `is*`: `Timer.fireIfElapsed()`, `remove(): boolean`, `init(): Promise<boolea
 - Use a derived getter when the value is computed from configure fields (`outputSize`); do not add a matching field
 - Use a runtime-descriptive name when no configure field exists (`activeBackend`, not `renderer`)
 
-Cursor: `.cursor/rules/bt-api-getters.mdc` (always applied in this repo).
+Cursor: `.cursor/rules/bt-api-getters.mdc` and `.cursor/rules/internal-scoped-naming.mdc` (always applied in this repo).

--- a/.claude/rules/internal-scoped-naming.md
+++ b/.claude/rules/internal-scoped-naming.md
@@ -1,0 +1,15 @@
+# Internal scoped naming
+
+Canonical reference: [CLAUDE.md](../../CLAUDE.md) (**Internal scoped naming**).
+
+When editing non-public symbols in `src/`:
+
+- **Do not repeat** the class or file name in private fields, private methods, protected members, or module-local
+  constants/types.
+- **Do rename** redundant prefixes when you touch a file (`requestCapture` → `request` on `FrameCapture`, `pollGamepads`
+  → `poll` on `GamepadInput`, `BLOOM_FRAGMENT_WGSL` → `FRAGMENT_WGSL` in `Bloom.ts`).
+- **Never rename** `BT.*`, barrel exports, public class methods, or documented configure/API names.
+- **JSDoc to public API:** use full public names (`BT.BTN_POINTER_A`, not internal `BTN_A` or gamepad `BT.BTN_A`).
+- **Avoid global shadows:** do not use `JSON` as a file-local type alias; prefer neutral names like `Serialized`.
+
+Cursor: `.cursor/rules/internal-scoped-naming.mdc` (always applied in this repo).

--- a/.claude/skills/bt-deep-review/SKILL.md
+++ b/.claude/skills/bt-deep-review/SKILL.md
@@ -50,6 +50,8 @@ pushing significant changes or creating pull requests.
    - Integer coordinates (Vector2i, Rect2i) for all rendering
    - TypeScript strict types (no `any`)
    - Type imports use `import type` syntax
+   - Internal scoped naming: private/protected/module-local names must not repeat class or file; public `BT.*` and
+     exports unchanged (`CLAUDE.md` **Internal scoped naming**)
 
 6. **Generate PR-ready summary**
    - Create a summary suitable for PR description

--- a/.claude/skills/bt-review/SKILL.md
+++ b/.claude/skills/bt-review/SKILL.md
@@ -31,6 +31,9 @@ Review current changes against project rules and quality standards.
    - Type imports use `import type` syntax
    - Proper error handling (guard clauses, null checks)
    - Consistent naming conventions
+   - **Internal scoped naming:** private/protected/module-local names must not repeat class or file name (`request()` on
+     `FrameCapture`, not `requestCapture()`). Public `BT.*` and barrel exports stay unchanged. See `CLAUDE.md`
+     (**Internal scoped naming**).
    - **BT API shape:** read-only zero-arg snapshots use getters (`BT.displaySize`, `BT.targetFPS`), not `BT.foo()`.
      Actions and parameterized queries stay methods. New configure mirrors use `HardwareSettings` field names
      (`targetFPS`, not `fps`). Derived getters (e.g. `outputSize`) have no matching field. See `CLAUDE.md` (**BT API:

--- a/.cursor/rules/bt-api-getters.mdc
+++ b/.cursor/rules/bt-api-getters.mdc
@@ -25,8 +25,24 @@ Bad: `BT.displaySize()`, `BT.fps()`, `BT.getActiveBackend()` (removed; use prope
 ## Keep as methods
 
 - Mutations and draws: `cameraSet`, `paletteSet`, `drawSprite`, `effectAdd`, …
-- Any **parameter**: `pointerPos(0)`, `buttonDown(BT.BTN_A)`, `cameraClamp(...)`
+- Any **parameter**: `pointerPos(0)`, `isDown(BT.BTN_A)`, `cameraClamp(...)`
+- **Boolean queries with parameters** (Tier A; always methods on `BT`): `isPointerActive(0)`, `isDown(...)`,
+  `isPressed(...)`, `isReleased(...)`, `isKeyDown(...)`, `isKeyPressed(...)`, `isKeyReleased(...)`
+- **Side-effect booleans** (Tier C): `Timer.fireIfElapsed()` — not `is*` because the call advances state
 - **Async**: `captureFrame`, `downloadFrame`
+
+## Boolean naming (three tiers)
+
+| Tier | Use | Examples |
+| ---- | --- | -------- |
+| **A** Runtime queries | `is*` / `has*` | `isPointerActive`, `isIndexed`, `hasGlyph`, `Palette.isDirty` |
+| **B** Configure flags | grammatical `is*` | `isOverlayEnabled`, `isDetectingDroppedFrames`, `isOverlayPaletteEnabled` |
+| **C** Side effects / results | imperative verbs | `fireIfElapsed()`, `remove(): boolean`, `init(): Promise<boolean>` |
+
+- Use **`-ing`** for configure flags that enable ongoing behavior (`isDetectingDroppedFrames`).
+- **Hold vs edge on `BT`:** `isDown` / `isKeyDown`; `isPressed` / `isReleased`; `isKeyPressed` / `isKeyReleased`.
+  Internal input classes mirror those names. No embedded second `Is` — audit with `\bis[A-Za-z]+Is[A-Z]`.
+- Identifier acronyms: `canvasID`, `containerID` (not `canvasId`).
 
 ## Naming
 
@@ -41,4 +57,4 @@ Bad: `BT.displaySize()`, `BT.fps()`, `BT.getActiveBackend()` (removed; use prope
 3. Mirrors configure? → **same field name** as `HardwareSettings` (exception: derived getters like `outputSize` have no field)
 4. Update `docs/api-*.md`, `CLAUDE.md`, demos if public
 
-See `CLAUDE.md` section **BT API: getters vs methods** and `docs/api-core.md`.
+See `CLAUDE.md` section **BT API: getters vs methods**, **Boolean naming**, and `docs/api-core.md`.

--- a/.cursor/rules/bt-api-getters.mdc
+++ b/.cursor/rules/bt-api-getters.mdc
@@ -57,4 +57,4 @@ Bad: `BT.displaySize()`, `BT.fps()`, `BT.getActiveBackend()` (removed; use prope
 3. Mirrors configure? → **same field name** as `HardwareSettings` (exception: derived getters like `outputSize` have no field)
 4. Update `docs/api-*.md`, `CLAUDE.md`, demos if public
 
-See `CLAUDE.md` section **BT API: getters vs methods**, **Boolean naming**, and `docs/api-core.md`.
+See `CLAUDE.md` section **BT API: getters vs methods**, **Boolean naming**, **Internal scoped naming**, and `docs/api-core.md`.

--- a/.cursor/rules/claude-canonical.mdc
+++ b/.cursor/rules/claude-canonical.mdc
@@ -6,7 +6,7 @@ alwaysApply: true
 # blit-tech CLAUDE Is Canonical
 
 - Treat `/Users/vancura/Repos/_BLIT_TECH_/blit-tech/CLAUDE.md` as canonical for implementation in this repo.
-- Follow its API conventions (especially BT getters vs methods), architecture map, command set, and docs-update rules.
+- Follow its API conventions (especially BT getters vs methods), architecture map, command set, internal scoped naming, and docs-update rules.
 - Do not invent alternate conventions when `CLAUDE.md` provides project-specific direction.
 - Public API or behavior changes must include matching docs updates in `docs/` as described in `CLAUDE.md`.
 - Keep performance-first and strict TypeScript standards from `CLAUDE.md` (no `any`, use type-only imports, integer coordinates where required).

--- a/.cursor/rules/internal-scoped-naming.mdc
+++ b/.cursor/rules/internal-scoped-naming.mdc
@@ -1,0 +1,60 @@
+---
+description: Internal names must not repeat their class or file; public API names stay stable
+alwaysApply: true
+---
+
+# Internal scoped naming
+
+When adding or renaming **non-public** symbols in `src/` (library TypeScript):
+
+## Rule
+
+**Private fields, private methods, protected members, and module-local constants/types must not repeat the enclosing
+class or file name.** Context already supplies that scope.
+
+| Scope | Applies |
+| ----- | ------- |
+| `#privateField`, `private method()` | yes |
+| `protected readonly fragmentShader` | yes |
+| Module `const`, file-local `type` / `interface` | yes |
+| `BT.*`, barrel exports, public class methods | **no** — public API stays stable |
+| JSDoc `@link` to another module's public symbol | use the **full public name** |
+
+## Good vs bad (same file provides context)
+
+```typescript
+// FrameCapture.ts
+request();              // not requestCapture()
+hasPending();           // not hasPendingCapture()
+private width = 0;      // not captureWidth
+
+// GamepadInput.ts
+private poll(): void    // not pollGamepads()
+
+// Bloom.ts
+const FRAGMENT_WGSL     // not BLOOM_FRAGMENT_WGSL
+
+// Palette.ts (file-local type)
+type Serialized = { … } // not PaletteJSON or JSON (JSON shadows global)
+
+// PointerInput.ts (module-local wire codes)
+const BTN_A = 20;       // OK — short local name
+// JSDoc: maps to BT.BTN_POINTER_A, not BT.BTN_A (gamepad)
+```
+
+## Do not rename
+
+- `BT` namespace members, `HardwareSettings` / `BootstrapOptions` fields, or anything in the `BlitTech.ts` export block
+- Public methods on exported classes (`Palette.toJSON()`, `SpriteSheet.loadIndexed()`, …)
+- Documented public constants (`BT.BTN_POINTER_*`, preset effect names, overlay configure flags)
+- Cross-subsystem method names when two types expose similar verbs (e.g. keep `Overlay.handleToggle()` vs
+  `Toggle.handleInput()`)
+
+## When refactoring existing code
+
+- Prefer shortening **internal** names in the same change that touches the file; do not drive renames through public
+  callers.
+- After shortening a local alias, update JSDoc that references **public** API to the correct public symbol (internal
+  `BTN_A` comments must point at `BT.BTN_POINTER_A`, not `BT.BTN_A`).
+
+Full policy: `CLAUDE.md` (**Internal scoped naming**), `docs/developer-experience-guide.md` (Naming conventions).

--- a/.github/markdown-link-check.json
+++ b/.github/markdown-link-check.json
@@ -28,6 +28,9 @@
       "pattern": "^https?://github\\.com/[^/]+/[^/]+/actions(/|$)"
     },
     {
+      "pattern": "^https?://github\\.com/[^/]+/[^/]+/security(/|$)"
+    },
+    {
       "pattern": "^https?://www\\.npmjs\\.com/package/[^\\s]+$"
     },
     {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ Before writing new code, reviewing existing code, or preflighting, check here fi
 | Is this API exported publicly?                             | `src/BlitTech.ts` export block (lines 1460-1501)                                                                                                                                                        |
 | What test mock do I need for GPU code?                     | `src/__test__/webgpu-mock.ts`                                                                                                                                                                           |
 | Declaration tooling / TS version alignment?                | `docs/tooling.md`, `docs/developer-experience-guide.md`, `scripts/check-declaration-tooling.mjs`                                                                                                        |
+| Should this private name repeat the class/file?            | **Internal scoped naming** below; `docs/developer-experience-guide.md` (Naming conventions)                                                                                                             |
 
 ## Architecture
 
@@ -211,6 +212,25 @@ Runtime queries use **`is*`** / **`has*`** (`isPointerActive`, `isIndexed`, `has
 `Is` (`isKeyPressed`). Audit: `\bis[A-Za-z]+Is[A-Z]`. Identifier acronyms: `canvasID`, `containerID`.
 
 Full tiers: `docs/developer-experience-guide.md` (Boolean naming).
+
+## Internal scoped naming
+
+**Private fields, private methods, protected members, and module-local constants/types must not repeat the enclosing
+class or file name.** The type or file already provides scope; strip redundant prefixes from internal identifiers.
+
+Examples:
+
+- `FrameCapture.request()` not `requestCapture()`; `width` not `captureWidth`
+- `GamepadInput.poll()` not `pollGamepads()`
+- `Bloom.ts`: `FRAGMENT_WGSL` not `BLOOM_FRAGMENT_WGSL`
+- `Palette.ts`: file-local `Serialized` (or similar), not `PaletteJSON` or `JSON`
+
+**Does not apply to public API:** `BT.*`, the `BlitTech.ts` export block, public methods on exported classes, or
+documented configure field names. When JSDoc references public symbols, use their full public names (e.g. internal
+pointer wire codes map to `BT.BTN_POINTER_A`, not gamepad `BT.BTN_A`).
+
+Apply when adding new internal symbols or when refactoring a file you are already changing; do not rename public surface
+or drive breaking changes through consumers for naming-only cleanup.
 
 ## API Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Before writing new code, reviewing existing code, or preflighting, check here fi
 | How does a subsystem work internally?                      | The relevant `src/core/` or `src/render/` file                                                                                                                                                          |
 | What does a demo implement?                                | `src/core/IBlitTechDemo.ts` (interface + HardwareSettings)                                                                                                                                              |
 | How does palette usage tracking work for the overlay grid? | `src/core/RenderPaletteUsage.ts`, `src/overlay/palette/PaletteView.ts`                                                                                                                                  |
-| How does the overlay work?                                 | `src/overlay/` (orchestrator + `layout/layoutPlan.ts`), `docs/api-core.md` (Overlay), `HardwareSettings.overlayEnabled`                                                                                 |
+| How does the overlay work?                                 | `src/overlay/` (orchestrator + `layout/layoutPlan.ts`), `docs/api-core.md` (Overlay), `HardwareSettings.isOverlayEnabled`                                                                               |
 | What palette/sprite setup pattern is correct?              | `docs/palette-guide.md`, then `docs/api-assets.md`                                                                                                                                                      |
 | What are the render/asset dimension limits?                | `src/utils/RenderLimits.ts` (constants), `src/utils/AssetLimits.ts` (asset + glyph limits), `docs/api-assets.md` (asset size limits table), `docs/api-core.md` (HardwareSettings dimension constraints) |
 | Which preset has which exact color values?                 | `docs/palette-presets.md`                                                                                                                                                                               |
@@ -131,9 +131,12 @@ Two backends selectable via `HardwareSettings.backend` (default `'webgpu'`):
 
 ### Core Types
 
-- `Vector2i` - integer 2D vector. Constructor auto-floors. Has `width`/`height` aliases.
-- `Rect2i` - integer rectangle. Methods: `contains()`, `intersects()`, `intersection()`.
-- `Color32` - 32-bit RGBA (0-255). Static colors, hex parsing, named-color registry, float array conversion.
+- `Vector2i` - integer 2D vector. Constructor auto-floors. Has `width`/`height` aliases. Predicates: `isEqual()`,
+  `isEqualXY()`, `isZero()`.
+- `Rect2i` - integer rectangle. Predicates: `isContaining()`, `isContainingXY()`, `isIntersecting()`, `isEqual()`.
+  Geometry: `intersection()`, `intersectTo()`.
+- `Color32` - 32-bit RGBA (0-255). Static colors, hex parsing, named-color registry, float array conversion. Predicate:
+  `isEqual()`.
 
 ## Critical Rules
 
@@ -151,7 +154,7 @@ Two backends selectable via `HardwareSettings.backend` (default `'webgpu'`):
 ## Input Conventions
 
 - `BTN_*` constants are bit flags (powers of 2), not sequential integers
-- `BT.buttonDown` / `BT.buttonPressed` / `BT.buttonReleased` use ANY-match semantics for masks
+- `BT.isDown` / `BT.isPressed` / `BT.isReleased` use ANY-match semantics for masks
 - Face buttons: players `0` and `1` are keyboard OR gamepad; players `2` and `3` are gamepad-only
 - Input previous-state rollover is end-of-frame aligned (same snapshot model across pointer/keyboard/gamepad)
 - Default gamepad stick dead zone is `0.75`
@@ -180,8 +183,8 @@ Examples: `BT.displaySize.y`, `BT.targetFPS`, `BT.ticks % 60`, `if (BT.activeBac
 
 - **Lifecycle / mutations:** `init`, `ticksReset`, `cameraSet`, `cameraReset`, `paletteSet`, `hideCursor`, all
   draw/clear/effect APIs.
-- **Parameterized queries:** `pointerPos(index?)`, `pointerDelta`, `pointerPosValid`, `buttonDown` / `Pressed` /
-  `Released`, `getAxis`, `gamepadConnected`, `keyDown` / `Pressed` / `Released`.
+- **Parameterized queries:** `pointerPos(index?)`, `pointerDelta`, `isPointerActive`, `isDown`, `isPressed`,
+  `isReleased`, `getAxis`, `isGamepadConnected`, `isKeyDown`, `isKeyPressed`, `isKeyReleased`.
 - **Utilities with arguments:** `cameraClamp(camera, worldSize, viewSize?)`, `systemPrintMeasure(text)`.
 - **Async:** `captureFrame`, `downloadFrame`.
 
@@ -195,6 +198,19 @@ Examples: `BT.displaySize.y`, `BT.targetFPS`, `BT.ticks % 60`, `if (BT.activeBac
   for runtime gates (post-process, capture). They differ when WebGPU was requested but fell back to software.
 
 Full tables: `docs/api-core.md`. Style guide: `docs/developer-experience-guide.md` (Naming conventions).
+
+## Boolean naming
+
+Runtime queries use **`is*`** / **`has*`** (`isPointerActive`, `isIndexed`, `hasGlyph`, `isDirty`). Configure flags in
+`HardwareSettings` and `BootstrapOptions` also use grammatical **`is*`** (`isOverlayEnabled`,
+`isDetectingDroppedFrames`). Side-effect or operation-result booleans use imperative verbs, not `is*`
+(`Timer.fireIfElapsed()`, `intersectTo(other, out): boolean`, `remove(): boolean`).
+
+**Input hold vs edge on `BT`:** `BT.isDown` / `BT.isKeyDown` (held), `BT.isPressed` / `BT.isReleased` (button masks),
+`BT.isKeyPressed` / `BT.isKeyReleased` (keyboard codes). Internal input classes mirror those names; never embed a second
+`Is` (`isKeyIsPressed`). Audit: `\bis[A-Za-z]+Is[A-Z]`. Identifier acronyms: `canvasID`, `containerID`.
+
+Full tiers: `docs/developer-experience-guide.md` (Boolean naming).
 
 ## API Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,7 +208,7 @@ Runtime queries use **`is*`** / **`has*`** (`isPointerActive`, `isIndexed`, `has
 
 **Input hold vs edge on `BT`:** `BT.isDown` / `BT.isKeyDown` (held), `BT.isPressed` / `BT.isReleased` (button masks),
 `BT.isKeyPressed` / `BT.isKeyReleased` (keyboard codes). Internal input classes mirror those names; never embed a second
-`Is` (`isKeyIsPressed`). Audit: `\bis[A-Za-z]+Is[A-Z]`. Identifier acronyms: `canvasID`, `containerID`.
+`Is` (`isKeyPressed`). Audit: `\bis[A-Za-z]+Is[A-Z]`. Identifier acronyms: `canvasID`, `containerID`.
 
 Full tiers: `docs/developer-experience-guide.md` (Boolean naming).
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ complex frameworks, just sprites, primitives, and fonts.
 - **Fixed timestep**: deterministic update loop with tick counter, `Timer`, and timing helpers
 - **Frame capture**: `BT.captureFrame()` and `BT.downloadFrame()` for PNG export
 - **Overlay**: engine-drawn FPS, backend, resolution, and demo title (toggle with `~` or bottom-left corner; disable via
-  `overlayEnabled: false` in `configure()`)
+  `isOverlayEnabled: false` in `configure()`)
 
 ## Why Blit-Tech?
 
@@ -186,8 +186,8 @@ WebGPU renderer is loaded only when WebGPU init succeeds. By default the engine 
 measured FPS, configured target FPS, the active backend name (via `BT.activeBackend`), logical resolution, and a short
 demo title derived from `document.title`. The overlay **body starts hidden** with a bitmap toggle hint in the
 bottom-left corner; toggle it with `~` (Backquote) or a primary press in the bottom-left corner. Use
-`overlayVisibleAtStart: true` to show the body on the first frame, `overlayToggleHintVisible: false` to hide the hint
-icon on immersive demos, or `overlayEnabled: false` to disable the overlay entirely in `configure()`. Use
+`isOverlayVisibleAtStart: true` to show the body on the first frame, `isOverlayToggleHintVisible: false` to hide the
+hint icon on immersive demos, or `isOverlayEnabled: false` to disable the overlay entirely in `configure()`. Use
 `BT.activeBackend` to read which backend is running (`'webgpu'`, `'software'`, or `null` before init).
 
 ## Contributors

--- a/docs/api-assets.md
+++ b/docs/api-assets.md
@@ -150,7 +150,7 @@ BT.systemPrintMeasure('Score: 100'); // → Vector2i (pixel width, height)
 
 Use `BT.systemPrint()` for demo-specific HUD panels and labels. The engine draws a default overlay (present FPS, target
 FPS, draw calls, frame/update()/render() timings, backend, resolution, demo title) after each `render()` when
-`overlayEnabled` is true; see [API: Core - Overlay](api-core.md#overlay). For styled variable-width text, use a bitmap
+`isOverlayEnabled` is true; see [API: Core - Overlay](api-core.md#overlay). For styled variable-width text, use a bitmap
 font instead.
 
 ---

--- a/docs/api-core.md
+++ b/docs/api-core.md
@@ -316,14 +316,15 @@ clear at the top (three built-in text rows + filled gaps + separator below the t
 13 px hint bar). When `isOverlayPaletteEnabled: true`, reserve additional space for the palette grid, the **1 px**
 filled row gap, and the **13 px** hint bar—for example about **83 px** on the default `320×240` layout with a 256-slot
 palette (32 columns × 8 rows of 7 px swatches with 1 px gaps, plus the gap and hint bar). Column count is chosen by
-halving from `palette.size` until the row fits `displayWidth - 2 * edgeMargin`. The footer band height matches
-`resolveOverlayFooterHeight()` in `layoutPlan.ts`:
+halving from `palette.size` until the row fits `displayWidth - 2 * edgeMargin`. Implementation lives in
+`src/overlay/palette/PaletteView.ts` (`computeGrid`, `pickGridColumnCount`, `resolveGridVisibleRows`). The footer band
+height matches `resolveOverlayFooterHeight()` in `layoutPlan.ts`:
 
 ```text
-cols = pickPaletteGridColumnCount(displayWidth, swatchSize, gap, palette.size, maxColumns?)
+cols = pickGridColumnCount(displayWidth, swatchSize, gap, palette.size, maxColumns?)
 rows = ceil(palette.size / cols)
-visibleRows = overlayPaletteRowsVisible ?? rows   // clamped to [1, rows] when set
-paletteGridHeight = visibleRows * swatchSize + max(0, visibleRows - 1) * gap + 2 * paletteGridPadding
+visibleRows = resolveGridVisibleRows(rows, overlayPaletteRowsVisible)
+paletteGridHeight = gridRowStackHeight(visibleRows, swatchSize, gap) + 2 * PALETTE_GRID_PADDING_PX
 bottomReserve = paletteGridHeight + 1 + 13
 ```
 

--- a/docs/api-core.md
+++ b/docs/api-core.md
@@ -399,7 +399,7 @@ BT.assignTag('Round start'); // timing chart event tag at current tick (requires
 const spawn = new Timer(180); // every 180 ticks (3 s when BT.targetFPS === 60)
 
 // Inside update():
-if (spawn.tick()) {
+if (spawn.shouldFire()) {
   spawnEnemy();
 }
 
@@ -410,7 +410,7 @@ spawn.remainingTicks(); // ticks until next fire
 spawn.intervalTicks; // readonly interval size
 ```
 
-`Timer.tick()` advances the internal baseline on each true return. Pass `BT.ticks` explicitly only when you need a
+`Timer.shouldFire()` advances the internal baseline on each true return. Pass `BT.ticks` explicitly only when you need a
 specific snapshot; the default is the engine tick counter.
 
 ---

--- a/docs/api-core.md
+++ b/docs/api-core.md
@@ -17,23 +17,23 @@ bootstrap(MyDemo);
 
 // With options
 bootstrap(MyDemo, {
-  canvasId: 'my-canvas',
-  containerId: 'error-wrapper',
+  canvasID: 'my-canvas',
+  containerID: 'error-wrapper',
   onSuccess: () => console.log('started'),
   onError: (err) => trackError(err),
-  waitForDOMReady: true, // default true; set false in Electron after DOMContentLoaded
+  isWaitingForDOMReady: true, // default true; set false in Electron after DOMContentLoaded
 });
 ```
 
 **`BootstrapOptions` fields:**
 
-| Field             | Type                     | Default              | Description                    |
-| ----------------- | ------------------------ | -------------------- | ------------------------------ |
-| `canvasId`        | `string`                 | `'blit-tech-canvas'` | Canvas element id              |
-| `containerId`     | `string`                 | `'canvas-container'` | Container id for error display |
-| `onSuccess`       | `() => void`             | -                    | Called after successful init   |
-| `onError`         | `(error: Error) => void` | -                    | Called on any init failure     |
-| `waitForDOMReady` | `boolean`                | `true`               | Wait for `DOMContentLoaded`    |
+| Field                  | Type                     | Default              | Description                    |
+| ---------------------- | ------------------------ | -------------------- | ------------------------------ |
+| `canvasID`             | `string`                 | `'blit-tech-canvas'` | Canvas element id              |
+| `containerID`          | `string`                 | `'canvas-container'` | Container id for error display |
+| `onSuccess`            | `() => void`             | -                    | Called after successful init   |
+| `onError`              | `(error: Error) => void` | -                    | Called on any init failure     |
+| `isWaitingForDOMReady` | `boolean`                | `true`               | Wait for `DOMContentLoaded`    |
 
 **Manual utilities** (for custom initialization flows):
 
@@ -104,28 +104,28 @@ See [Post-Process Effects](post-process-effects.md) for tier routing and presets
 output buffer. Include `displaySize` when you want a custom logical size; optional fields you omit then stay unset (for
 example no `drawingBufferSize` means a 1:1 drawing buffer).
 
-| Field                           | Type                           | Default     | Description                                                                                        |
-| ------------------------------- | ------------------------------ | ----------- | -------------------------------------------------------------------------------------------------- |
-| `displaySize`                   | `Vector2i`                     | `320×240`   | **Logical** render resolution                                                                      |
-| `drawingBufferSize`             | `Vector2i`                     | `640×480`   | **Drawing buffer** size; enables **display-tier** effects when set                                 |
-| `maxCanvasSize`                 | `Vector2i`                     | `960×720`   | **CSS cap** — maximum on-screen canvas size                                                        |
-| `targetFPS`                     | `number`                       | `60`        | Fixed `update()` rate (simulation ticks per second)                                                |
-| `backend`                       | `'webgpu' \| 'software'`       | `'webgpu'`  | Force rendering backend                                                                            |
-| `outputUpscaleFilter`           | `'nearest' \| 'linear'`        | `'nearest'` | Upscale filter                                                                                     |
-| `detectDroppedFrames`           | `boolean`                      | `false`     | Log a console warning on missed vsync                                                              |
-| `overlayEnabled`                | `boolean`                      | `true`      | Engine overlay HUD after each `render()`                                                           |
-| `overlayVisibleAtStart`         | `boolean`                      | `false`     | Show overlay body (metrics/palette/custom rows) on first frame                                     |
-| `overlayToggleHintVisible`      | `boolean`                      | `true`      | Draw toggle hint icon while overlay body is hidden                                                 |
-| `overlayToggleEnabled`          | `boolean`                      | `true`      | Enable Backquote and bottom-left corner toggle input                                               |
-| `overlayPaletteView`            | `boolean`                      | `false`     | Live palette swatch grid in the overlay bottom band (opt-in)                                       |
-| `overlayPaletteColumns`         | `number`                       | _unset_     | Max palette swatches per grid row (default: widest fit)                                            |
-| `overlayPaletteRowsVisible`     | `number`                       | _unset_     | Max visible palette grid rows (default: all rows; band height capped)                              |
-| `overlayStyle`                  | `OverlayStyle`                 | _unset_     | Optional bar/text/gap palette indices for overlay                                                  |
-| `overlayTimingChart`            | `boolean`                      | `false`     | Scrolling update/render timing chart between title and metrics rows                                |
-| `overlayTimingChartHeight`      | `number`                       | `22`        | Timing chart band height in pixels when the chart is enabled                                       |
-| `overlayTimingChartStyle`       | `OverlayTimingChartStyle`      | _unset_     | Optional timing chart palette indices (defaults to overlay bar/text)                               |
-| `overlayTimingChartDiagnostics` | `false \| 'minimal' \| 'rich'` | _unset_     | Renderer diagnostic visualization on the timing chart (`'minimal'` when chart enabled and omitted) |
-| `overlayRendererDiagnosticsBar` | `boolean`                      | `false`     | Optional GPU diagnostics text row below frame timing metrics                                       |
+| Field                                    | Type                           | Default     | Description                                                                                        |
+| ---------------------------------------- | ------------------------------ | ----------- | -------------------------------------------------------------------------------------------------- |
+| `displaySize`                            | `Vector2i`                     | `320×240`   | **Logical** render resolution                                                                      |
+| `drawingBufferSize`                      | `Vector2i`                     | `640×480`   | **Drawing buffer** size; enables **display-tier** effects when set                                 |
+| `maxCanvasSize`                          | `Vector2i`                     | `960×720`   | **CSS cap** — maximum on-screen canvas size                                                        |
+| `targetFPS`                              | `number`                       | `60`        | Fixed `update()` rate (simulation ticks per second)                                                |
+| `backend`                                | `'webgpu' \| 'software'`       | `'webgpu'`  | Force rendering backend                                                                            |
+| `outputUpscaleFilter`                    | `'nearest' \| 'linear'`        | `'nearest'` | Upscale filter                                                                                     |
+| `isDetectingDroppedFrames`               | `boolean`                      | `false`     | Log a console warning on missed vsync                                                              |
+| `isOverlayEnabled`                       | `boolean`                      | `true`      | Engine overlay HUD after each `render()`                                                           |
+| `isOverlayVisibleAtStart`                | `boolean`                      | `false`     | Show overlay body (metrics/palette/custom rows) on first frame                                     |
+| `isOverlayToggleHintVisible`             | `boolean`                      | `true`      | Draw toggle hint icon while overlay body is hidden                                                 |
+| `isOverlayToggleEnabled`                 | `boolean`                      | `true`      | Enable Backquote and bottom-left corner toggle input                                               |
+| `isOverlayPaletteEnabled`                | `boolean`                      | `false`     | Live palette swatch grid in the overlay bottom band (opt-in)                                       |
+| `overlayPaletteColumns`                  | `number`                       | _unset_     | Max palette swatches per grid row (default: widest fit)                                            |
+| `overlayPaletteRowsVisible`              | `number`                       | _unset_     | Max visible palette grid rows (default: all rows; band height capped)                              |
+| `overlayStyle`                           | `OverlayStyle`                 | _unset_     | Optional bar/text/gap palette indices for overlay                                                  |
+| `isOverlayTimingChartEnabled`            | `boolean`                      | `false`     | Scrolling update/render timing chart between title and metrics rows                                |
+| `overlayTimingChartHeight`               | `number`                       | `22`        | Timing chart band height in pixels when the chart is enabled                                       |
+| `overlayTimingChartStyle`                | `OverlayTimingChartStyle`      | _unset_     | Optional timing chart palette indices (defaults to overlay bar/text)                               |
+| `overlayTimingChartDiagnostics`          | `false \| 'minimal' \| 'rich'` | _unset_     | Renderer diagnostic visualization on the timing chart (`'minimal'` when chart enabled and omitted) |
+| `isOverlayRendererDiagnosticsBarEnabled` | `boolean`                      | `false`     | Optional GPU diagnostics text row below frame timing metrics                                       |
 
 `displaySize`, `drawingBufferSize`, and `maxCanvasSize` must be positive whole-number pixel dimensions. Each size is
 capped at `8192×8192` per axis and `16,777,216` total pixels (`4096×4096`). Invalid sizes make initialization fail
@@ -198,53 +198,54 @@ configure() {
 
 ### Overlay
 
-When `overlayEnabled` is `true` (default), the engine draws a screen-space HUD after each demo `render()` call, on top
+When `isOverlayEnabled` is `true` (default), the engine draws a screen-space HUD after each demo `render()` call, on top
 of all demo content. The **overlay body** (title, metrics, timing chart, palette grid, custom rows) starts **hidden**
-unless `overlayVisibleAtStart: true`. While the body is hidden, the engine may still draw the **toggle hint icon** when
-`overlayToggleHintVisible` is `true` (default), without the footer hint bar background. Bar bands and text anchors for
-the full body are computed each frame by the internal layout planner in `src/overlay/layout/layoutPlan.ts` from
-`displaySize`, custom row count, and optional feature flags (timing chart default off; palette grid opt-in via
-`overlayPaletteView`). Init still caches stable values such as the bottom-left toggle rect and text baselines from the
-system font metrics.
+unless `isOverlayVisibleAtStart: true`. While the body is hidden, the engine may still draw the **toggle hint icon**
+when `isOverlayToggleHintVisible` is `true` (default), without the footer hint bar background. Bar bands and text
+anchors for the full body are computed each frame by the internal layout planner in `src/overlay/layout/layoutPlan.ts`
+from `displaySize`, custom row count, and optional feature flags (timing chart default off; palette grid opt-in via
+`isOverlayPaletteEnabled`). Init still caches stable values such as the bottom-left toggle rect and text baselines from
+the system font metrics.
 
 **Migration note:** Upgrading demos now starts with the overlay body hidden. Teaching demos that relied on
-always-visible metrics should opt back in with `overlayVisibleAtStart: true` in `configure()` until authors choose
+always-visible metrics should opt back in with `isOverlayVisibleAtStart: true` in `configure()` until authors choose
 otherwise.
 
 - **Top row 1 (left):** short demo title derived from `document.title` (registry pages titled
   `Blit-Tech Demo NNN - Topic` show as `Topic Demo`); **top row 1 (right):** active backend and logical resolution (for
   example `webgpu | 320x240`)
-- **Timing chart (optional):** when `overlayTimingChart: true`, a scrolling band of **one-pixel dots** shows raw
-  per-frame `update()` vs `render()` CPU time (one column per present frame, not per fixed `update()` tick). Band height
-  defaults to **22 px**; override with `overlayTimingChartHeight`. Dot height scales linearly so about **16 ms** fills
-  the band; any non-zero sample draws at least one pixel (sub-millisecond work shows as a baseline dot). **Grid lines:**
-  faint horizontal reference rows at **5**, **10**, and **33.33** ms plus a frame-budget line at **`1000 / targetFPS`**
-  ms are drawn behind the dots (qualitative scale on a ~22 px band, not a precision ruler). The band bottom row is the
-  zero baseline (sub-ms / light samples); top- and bottom-edge rows are not drawn as grid lines. Grid color defaults to
-  `overlayStyle.gapPaletteIndex` (then `barPaletteIndex`); override with `overlayTimingChartStyle.gridPaletteIndex`. The
-  band background uses `overlayStyle.barPaletteIndex`; dot colors default to `overlayStyle.barPaletteIndex` /
-  `textPaletteIndex`; override with `overlayTimingChartStyle`. **Semantic tints:** when a column is classified as a
-  runtime risk, both update and render dots use the warning or error palette index instead of the normal bar colors.
-  Classification uses the prior frame's `Frame` wall time against `1000 / targetFPS` (warning at **1.10x** budget, error
-  at **1.50x**) and dropped-frame events from the game loop (one dropped frame = warning, two or more = error; error
-  wins when both apply). Default warning/error/event palette indices are **3**, **4**, and **5** when not overridden.
-  Drop detection for the chart runs whenever `overlayTimingChart: true` (independent of `detectDroppedFrames`, which
-  only controls console warnings). **Event tags:** call `BT.assignTag(label?)` from `update()` or `init()` to anchor a
-  short label on the scrolling chart at the current `BT.ticks`. Empty or omitted labels become `"Untitled"`. Each tag
-  column draws a tick row (relative ticks since chart reset, capped at **100000**) and stacked label rows above the
-  chart band; spacing is fixed in `tags.ts` (`TIMING_CHART_TAG_LABEL_Y_GAP`, `TIMING_CHART_TAG_LABEL_STACK_SPACING`).
-  Tick and label text share the same horizontal offset from the timing column. A faint vertical grid-colored line marks
-  the column on the chart band. Tag columns follow timing **samples** (one per rendered frame), not `BT.ticks`, which
-  can advance multiple fixed-update steps per frame: they fill from the left while the ring buffer is not full, then
-  scroll left one column per sample once full, in lockstep with the dots. Tags are removed when they scroll one full
-  chart width past the left edge (text keeps drawing at negative x until the display clips it); pruning runs on each
-  timing sample while the chart is enabled. Chart width resets (for example on resize) clear tags and add an automatic
-  `"Start"` marker. Tint tags with `overlayTimingChartStyle.tagPaletteIndex` (default **5**). **Renderer diagnostics
-  (optional):** when the chart is enabled, `overlayTimingChartDiagnostics` defaults to **`'minimal'`** (set `false` to
-  disable chart markers). **Minimal** mode bumps semantic severity when either pipeline overflowed that frame and draws
-  a baseline overflow marker (palette index from `overlayTimingChartStyle.overflowPaletteIndex`, defaulting to the
-  warning index). **`'rich'`** adds per-column vertex-pressure dots in the lower third of the band (primitive vs sprite
-  submitted counts scaled to the 50k vertex cap). Set **`overlayRendererDiagnosticsBar: true`** for a dedicated text row
+- **Timing chart (optional):** when `isOverlayTimingChartEnabled: true`, a scrolling band of **one-pixel dots** shows
+  raw per-frame `update()` vs `render()` CPU time (one column per present frame, not per fixed `update()` tick). Band
+  height defaults to **22 px**; override with `overlayTimingChartHeight`. Dot height scales linearly so about **16 ms**
+  fills the band; any non-zero sample draws at least one pixel (sub-millisecond work shows as a baseline dot). **Grid
+  lines:** faint horizontal reference rows at **5**, **10**, and **33.33** ms plus a frame-budget line at
+  **`1000 / targetFPS`** ms are drawn behind the dots (qualitative scale on a ~22 px band, not a precision ruler). The
+  band bottom row is the zero baseline (sub-ms / light samples); top- and bottom-edge rows are not drawn as grid lines.
+  Grid color defaults to `overlayStyle.gapPaletteIndex` (then `barPaletteIndex`); override with
+  `overlayTimingChartStyle.gridPaletteIndex`. The band background uses `overlayStyle.barPaletteIndex`; dot colors
+  default to `overlayStyle.barPaletteIndex` / `textPaletteIndex`; override with `overlayTimingChartStyle`. **Semantic
+  tints:** when a column is classified as a runtime risk, both update and render dots use the warning or error palette
+  index instead of the normal bar colors. Classification uses the prior frame's `Frame` wall time against
+  `1000 / targetFPS` (warning at **1.10x** budget, error at **1.50x**) and dropped-frame events from the game loop (one
+  dropped frame = warning, two or more = error; error wins when both apply). Default warning/error/event palette indices
+  are **3**, **4**, and **5** when not overridden. Drop detection for the chart runs whenever
+  `isOverlayTimingChartEnabled: true` (independent of `isDetectingDroppedFrames`, which only controls console warnings).
+  **Event tags:** call `BT.assignTag(label?)` from `update()` or `init()` to anchor a short label on the scrolling chart
+  at the current `BT.ticks`. Empty or omitted labels become `"Untitled"`. Each tag column draws a tick row (relative
+  ticks since chart reset, capped at **100000**) and stacked label rows above the chart band; spacing is fixed in
+  `tags.ts` (`TIMING_CHART_TAG_LABEL_Y_GAP`, `TIMING_CHART_TAG_LABEL_STACK_SPACING`). Tick and label text share the same
+  horizontal offset from the timing column. A faint vertical grid-colored line marks the column on the chart band. Tag
+  columns follow timing **samples** (one per rendered frame), not `BT.ticks`, which can advance multiple fixed-update
+  steps per frame: they fill from the left while the ring buffer is not full, then scroll left one column per sample
+  once full, in lockstep with the dots. Tags are removed when they scroll one full chart width past the left edge (text
+  keeps drawing at negative x until the display clips it); pruning runs on each timing sample while the chart is
+  enabled. Chart width resets (for example on resize) clear tags and add an automatic `"Start"` marker. Tint tags with
+  `overlayTimingChartStyle.tagPaletteIndex` (default **5**). **Renderer diagnostics (optional):** when the chart is
+  enabled, `overlayTimingChartDiagnostics` defaults to **`'minimal'`** (set `false` to disable chart markers).
+  **Minimal** mode bumps semantic severity when either pipeline overflowed that frame and draws a baseline overflow
+  marker (palette index from `overlayTimingChartStyle.overflowPaletteIndex`, defaulting to the warning index).
+  **`'rich'`** adds per-column vertex-pressure dots in the lower third of the band (primitive vs sprite submitted counts
+  scaled to the 50k vertex cap). Set **`isOverlayRendererDiagnosticsBarEnabled: true`** for a dedicated text row
   (`Prim Nv ov: X | Spr Nv ov: X`) below the frame timing line; collection runs when either the chart diagnostics mode
   is not `false` or the diagnostics bar is enabled. Overflow counts apply on WebGPU; the software backend reports
   `ov: 0` with GPU-equivalent vertex totals for primitive and sprite work.
@@ -252,17 +253,17 @@ otherwise.
 - **Top row 3 (left):** `Frame: Xms | update(): Yms | render(): Zms` (shows `xN` on `update()` when multiple fixed
   updates ran this frame)
 - **Bottom band:** default **13 px** hint bar with a bottom-left **bitmap toggle icon** (over the toggle hit region).
-  Set `overlayPaletteView: true` to stack a live palette swatch grid **above** a **1 px** filled gap and that hint bar;
-  slots referenced by demo draw calls this frame are filled with their color, and unused slots render as empty squares
-  with a small centered marker. When `overlayPaletteRowsVisible` is set, only that many rows are shown in a scrollable
-  viewport with a right-side scrollbar thumb (proportional to visible vs total rows, minimum 4 px, inset 1 px from the
-  band top, right, and bottom); wheel input over the palette band scrolls rows and does not reach
+  Set `isOverlayPaletteEnabled: true` to stack a live palette swatch grid **above** a **1 px** filled gap and that hint
+  bar; slots referenced by demo draw calls this frame are filled with their color, and unused slots render as empty
+  squares with a small centered marker. When `overlayPaletteRowsVisible` is set, only that many rows are shown in a
+  scrollable viewport with a right-side scrollbar thumb (proportional to visible vs total rows, minimum 4 px, inset 1 px
+  from the band top, right, and bottom); wheel input over the palette band scrolls rows and does not reach
   `BT.pointerScrollDelta` outside that region. The timing chart and palette grid bands use the same
   `overlayStyle.barPaletteIndex` fill as the other overlay rows (bars draw first; chart dots and swatches render on
   top). **1 px row gaps** between stacked overlay bands and **cluster separators** (below the top metrics cluster and
   above the bottom footer cluster) are filled with `overlayStyle.gapPaletteIndex`, defaulting to
   `overlayStyle.barPaletteIndex` when omitted. Palette usage tracking (sprite and bitmap-text pixel scans) runs only
-  when the overlay is enabled, `overlayPaletteView` is true, **and** the overlay body is visible (not hidden with
+  when the overlay is enabled, `isOverlayPaletteEnabled` is true, **and** the overlay body is visible (not hidden with
   Backquote or the corner toggle). Default demos do not pay that scanning cost while the overlay is hidden.
 - **Custom rows (optional):** extra bars from `overlayRows()` stacked above the bottom band, **1 px** filled gaps apart,
   each with left text and optional right text (same 13 px bar style as the built-in rows)
@@ -286,11 +287,11 @@ class Demo {
 ```
 
 Toggle overlay **body** visibility at runtime with **Backquote** (`~`) or a primary pointer press in the **bottom-left
-48x48 px** corner when `overlayToggleEnabled` is `true` (default). Set `overlayToggleHintVisible: false` to hide the
-hint icon while the body stays hidden. Set `overlayToggleEnabled: false` to lock body visibility at
-`overlayVisibleAtStart`. Set `overlayEnabled: false` in `configure()` to disable the overlay subsystem and all toggle
-input (for example release builds). On WebGPU, the engine draws the overlay HUD after your `render()` call, composited
-above demo sprites via internal overlay draw batches (not available on `BT`).
+48x48 px** corner when `isOverlayToggleEnabled` is `true` (default). Set `isOverlayToggleHintVisible: false` to hide the
+hint icon while the body stays hidden. Set `isOverlayToggleEnabled: false` to lock body visibility at
+`isOverlayVisibleAtStart`. Set `isOverlayEnabled: false` in `configure()` to disable the overlay subsystem and all
+toggle input (for example release builds). On WebGPU, the engine draws the overlay HUD after your `render()` call,
+composited above demo sprites via internal overlay draw batches (not available on `BT`).
 
 Overlay colors follow one path: use `overlayStyle` when set, otherwise defaults `1` (bar and gap) and `2` (text). You
 can override globally in `configure()` with `overlayStyle: { barPaletteIndex, textPaletteIndex, gapPaletteIndex }`, or
@@ -310,12 +311,12 @@ counts demo-issued draw API calls during the rendered frame. Do not use present 
 Demos should not duplicate engine overlay text; the overlay provides it. Reserve about **14 px** per custom overlay row
 above the bottom band (13 px bar + 1 px filled gap). When drawing custom top or bottom HUD panels, leave about **43 px**
 clear at the top (three built-in text rows + filled gaps + separator below the top cluster; add
-`overlayTimingChartHeight` or **22 px** when `overlayTimingChart: true`; add **14 px** when
-`overlayRendererDiagnosticsBar: true`). Leave about **14 px** clear at the bottom by default (1 px separator + 13 px
-hint bar). When `overlayPaletteView: true`, reserve additional space for the palette grid, the **1 px** filled row gap,
-and the **13 px** hint bar—for example about **83 px** on the default `320×240` layout with a 256-slot palette (32
-columns × 8 rows of 7 px swatches with 1 px gaps, plus the gap and hint bar). Column count is chosen by halving from
-`palette.size` until the row fits `displayWidth - 2 * edgeMargin`. The footer band height matches
+`overlayTimingChartHeight` or **22 px** when `isOverlayTimingChartEnabled: true`; add **14 px** when
+`isOverlayRendererDiagnosticsBarEnabled: true`). Leave about **14 px** clear at the bottom by default (1 px separator +
+13 px hint bar). When `isOverlayPaletteEnabled: true`, reserve additional space for the palette grid, the **1 px**
+filled row gap, and the **13 px** hint bar—for example about **83 px** on the default `320×240` layout with a 256-slot
+palette (32 columns × 8 rows of 7 px swatches with 1 px gaps, plus the gap and hint bar). Column count is chosen by
+halving from `palette.size` until the row fits `displayWidth - 2 * edgeMargin`. The footer band height matches
 `resolveOverlayFooterHeight()` in `layoutPlan.ts`:
 
 ```text
@@ -331,7 +332,7 @@ while the pointer is over the palette footer band (grid or scrollbar); demos rea
 are unaffected.
 
 Default swatch size is **7 px** with **1 px** gaps and **3 px** padding above and below the grid. Set
-`overlayPaletteView: true` to enable the grid, or `overlayEnabled: false` for full-screen layouts (for example
+`isOverlayPaletteEnabled: true` to enable the grid, or `isOverlayEnabled: false` for full-screen layouts (for example
 terminal-style demos).
 
 ```ts
@@ -339,7 +340,7 @@ terminal-style demos).
 configure() {
   return {
     displaySize: new Vector2i(320, 240),
-    overlayEnabled: false,
+    isOverlayEnabled: false,
   };
 }
 
@@ -347,13 +348,13 @@ configure() {
 configure() {
   return {
     displaySize: new Vector2i(320, 240),
-    overlayEnabled: true,
-    overlayPaletteView: true,
+    isOverlayEnabled: true,
+    isOverlayPaletteEnabled: true,
     overlayPaletteRowsVisible: 3,
-    overlayTimingChart: true,
+    isOverlayTimingChartEnabled: true,
     overlayTimingChartHeight: 32, // optional; default 22
     overlayTimingChartDiagnostics: 'rich', // optional; default 'minimal' when chart enabled
-    overlayRendererDiagnosticsBar: true, // optional; default false
+    isOverlayRendererDiagnosticsBarEnabled: true, // optional; default false
     overlayStyle: { barPaletteIndex: 2, textPaletteIndex: 3, gapPaletteIndex: 2 },
     overlayTimingChartStyle: {
       updateBarPaletteIndex: 2, // defaults to barPaletteIndex when omitted
@@ -387,7 +388,7 @@ BT.deltaSeconds; // seconds per fixed tick (1 / BT.targetFPS)
 BT.timeSeconds; // elapsed seconds since init (ticks × deltaSeconds)
 BT.ticks; // current tick counter (increments each update)
 BT.ticksReset(); // reset tick counter to 0
-BT.assignTag('Round start'); // timing chart event tag at current tick (requires overlayTimingChart)
+BT.assignTag('Round start'); // timing chart event tag at current tick (requires isOverlayTimingChartEnabled)
 ```
 
 ### Timer
@@ -399,7 +400,7 @@ BT.assignTag('Round start'); // timing chart event tag at current tick (requires
 const spawn = new Timer(180); // every 180 ticks (3 s when BT.targetFPS === 60)
 
 // Inside update():
-if (spawn.shouldFire()) {
+if (spawn.fireIfElapsed()) {
   spawnEnemy();
 }
 
@@ -410,8 +411,8 @@ spawn.remainingTicks(); // ticks until next fire
 spawn.intervalTicks; // readonly interval size
 ```
 
-`Timer.shouldFire()` advances the internal baseline on each true return. Pass `BT.ticks` explicitly only when you need a
-specific snapshot; the default is the engine tick counter.
+`Timer.fireIfElapsed()` advances the internal baseline on each true return. Pass `BT.ticks` explicitly only when you
+need a specific snapshot; the default is the engine tick counter.
 
 ---
 
@@ -462,8 +463,8 @@ Vector2i.lerp(a, b, t); // interpolate, t clamped [0,1], result truncated
 Vector2i.lerpTo(a, b, t, out); // zero-allocation lerp into existing vector
 ```
 
-Instance methods: `.add()`, `.sub()`, `.scale()`, `.dot()`, `.clone()`, `.equals()`, `.negate()`, `.abs()`, `.min()`,
-`.max()`, etc. See `src/utils/Vector2i.ts` for the full list.
+Instance methods: `.add()`, `.sub()`, `.scale()`, `.dot()`, `.clone()`, `.isEqual(other)`, `.isEqualXY(x, y)`,
+`.isZero()`, `.negate()`, `.abs()`, `.min()`, `.max()`, etc. See `src/utils/Vector2i.ts` for the full list.
 
 ### Rect2i
 
@@ -480,9 +481,12 @@ Rect2i.fromCenterSize(center, size); // centered rectangle
 Rect2i.fromCenterSizeXY(cx, cy, w, h); // zero-allocation variant
 
 // Instance methods
-r.contains(point); // boolean - point inside rect
-r.intersects(other); // boolean - rects overlap
+r.isContaining(point); // boolean - point inside rect
+r.isContainingXY(px, py); // boolean - raw coordinates, no Vector2i alloc
+r.isIntersecting(other); // boolean - rects overlap
+r.isEqual(other); // boolean - same position and size
 r.intersection(other); // Rect2i | null - overlap area
+r.intersectTo(other, out); // boolean - write overlap into out when it exists
 r.center; // Vector2i getter
 r.min; // Vector2i getter (top-left)
 r.max; // Vector2i getter (bottom-right)
@@ -518,6 +522,7 @@ c.lerp(other, t);            // same semantics as static helper
 c.toFloat32Array()            // [r/255, g/255, b/255, a/255]
 c.luminance                   // perceived brightness: 0.299r + 0.587g + 0.114b
 c.toHex()                     // '#rrggbb' string
+c.isEqual(other)              // boolean - all RGBA channels match
 ```
 
 ---

--- a/docs/api-palette.md
+++ b/docs/api-palette.md
@@ -161,7 +161,7 @@ const slot = palette.findColor(color); // → index, or -1 if not found
 
 Animated effects run automatically each frame in the engine's end-of-frame pass (after `demo.render()`, before the GPU
 upload). Multiple effects can run simultaneously on different palette ranges and will not conflict. Effects process via
-the `dirty` flag - no polling needed.
+the `isDirty` flag - no polling needed.
 
 ```ts
 // Cycle a range of slots (water, fire, plasma)

--- a/docs/api-rendering.md
+++ b/docs/api-rendering.md
@@ -168,6 +168,21 @@ await BT.downloadFrame();
 await BT.downloadFrame('screenshot-001.png'); // custom filename
 ```
 
+### Internal `FrameCapture` flow reference
+
+`BT.captureFrame()` uses `FrameCapture` internally. The capture lifecycle is:
+
+1. `FrameCapture.request()` - queue one capture
+2. `FrameCapture.executeInEncoder(device, texture, commandEncoder)` - record GPU copy in the frame encoder
+3. `FrameCapture.resolve(device)` - wait for submit completion, map readback, encode PNG
+
+Reference methods:
+
+- `FrameCapture.hasPending()`
+- `FrameCapture.request()`
+- `FrameCapture.executeInEncoder(device, texture, commandEncoder)`
+- `FrameCapture.resolve(device)`
+
 ---
 
 ## See Also

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -1,0 +1,56 @@
+# Deprecation Timeline
+
+Central tracker for public API compatibility aliases and planned removals.
+
+Use this file as the single source of truth when pruning old names.
+
+---
+
+## 2026-05-31 - compatibility aliases added
+
+These aliases were introduced to preserve backward compatibility after the API naming refactor.
+
+### `BT` namespace
+
+- `BT.pointerPosValid()` -> `BT.isPointerActive()`
+- `BT.buttonDown()` -> `BT.isDown()`
+- `BT.buttonPressed()` -> `BT.isPressed()`
+- `BT.buttonReleased()` -> `BT.isReleased()`
+- `BT.gamepadConnected()` -> `BT.isGamepadConnected()`
+- `BT.keyDown()` -> `BT.isKeyDown()`
+- `BT.keyPressed()` -> `BT.isKeyPressed()`
+- `BT.keyReleased()` -> `BT.isKeyReleased()`
+
+### `HardwareSettings` compatibility fields
+
+- `detectDroppedFrames` -> `isDetectingDroppedFrames`
+- `overlayEnabled` -> `isOverlayEnabled`
+- `overlayVisibleAtStart` -> `isOverlayVisibleAtStart`
+- `overlayToggleHintVisible` -> `isOverlayToggleHintVisible`
+- `overlayToggleEnabled` -> `isOverlayToggleEnabled`
+- `overlayPaletteView` -> `isOverlayPaletteEnabled`
+- `overlayTimingChart` -> `isOverlayTimingChartEnabled`
+- `overlayRendererDiagnosticsBar` -> `isOverlayRendererDiagnosticsBarEnabled`
+
+### `BootstrapOptions` compatibility fields
+
+- `canvasId` -> `canvasID`
+- `containerId` -> `containerID`
+- `waitForDOMReady` -> `isWaitingForDOMReady`
+
+### Class method aliases
+
+- `SpriteSheet.isIndexized()` -> `SpriteSheet.isIndexed()`
+- `Timer.tick()` -> `Timer.fireIfElapsed()`
+- `Vector2i.equals()` -> `Vector2i.isEqual()`
+- `Rect2i.contains()` -> `Rect2i.isContaining()`
+- `Rect2i.containsXY()` -> `Rect2i.isContainingXY()`
+- `Rect2i.intersects()` -> `Rect2i.isIntersecting()`
+- `Rect2i.intersectionTo()` -> `Rect2i.intersectTo()`
+- `Rect2i.equals()` -> `Rect2i.isEqual()`
+- `Color32.equals()` -> `Color32.isEqual()`
+
+### Removal checklist
+
+- Search for `@deprecated Deprecated since 2026-05-31` in `src/`.
+- Remove aliases only after confirming downstream demos/apps have migrated.

--- a/docs/developer-experience-guide.md
+++ b/docs/developer-experience-guide.md
@@ -154,7 +154,7 @@ AI-assisted commits add a trailer: `Co-Authored-By: Claude <noreply@anthropic.co
 - **Hold vs edge on `BT`:** `isDown` / `isKeyDown` (held), `isPressed` / `isReleased` (button masks), `isKeyPressed` /
   `isKeyReleased` (keyboard codes). Internal input classes use the same names (`PointerInput.isButtonDown`,
   `KeyboardInput.isKeyDown`, `GamepadInput.isButtonDown`). Do **not** embed a second `Is` in the identifier
-  (`isKeyIsPressed` — grep: `\bis[A-Za-z]+Is[A-Z]`).
+  (`isKeyPressed` — grep: `\bis[A-Za-z]+Is[A-Z]`).
 - Identifier acronyms use both capitals: `canvasID`, `containerID` (not `canvasId`).
 
 ---

--- a/docs/developer-experience-guide.md
+++ b/docs/developer-experience-guide.md
@@ -76,6 +76,7 @@ exceptions: [audit-exceptions.md](security/audit-exceptions.md).
 | [Input Guide](input.md)                                     | pointer, keyboard, gamepad                             |
 | [Post-Process Effects](post-process-effects.md)             | effect chain, built-in effects, custom effects         |
 | [Bitmap Fonts](bitmap-fonts.md)                             | .btfont format, BMFont conversion                      |
+| [Deprecation Timeline](deprecations.md)                     | dated compatibility aliases and cleanup checklist      |
 | [Testing](testing.md)                                       | test tiers, WebGPU mocks, visual regression            |
 | [Performance Testing](performance-testing.md)               | CPU benchmarks, CI regression checks                   |
 | [Performance Best Practices](performance-best-practices.md) | optimization guidelines                                |

--- a/docs/developer-experience-guide.md
+++ b/docs/developer-experience-guide.md
@@ -132,6 +132,12 @@ AI-assisted commits add a trailer: `Co-Authored-By: Claude <noreply@anthropic.co
 - Constants: `SCREAMING_SNAKE_CASE` for module-level; camelCase for local
 - Named exports only; no default exports
 - JSDoc required for all public API members
+- **Internal scoped naming:** private fields, private methods, protected members, and module-local constants/types
+  **must not repeat the class or file name** (context already scopes them). Examples: `FrameCapture.request()` not
+  `requestCapture()`; `FRAGMENT_WGSL` in `Bloom.ts` not `BLOOM_FRAGMENT_WGSL`; file-local `Serialized` in `Palette.ts`
+  not `PaletteJSON` or `JSON`. Does **not** apply to `BT.*`, barrel exports, or public class methods. JSDoc that points
+  at public API uses full public names (`BT.BTN_POINTER_A`, not shortened internal aliases). See
+  [CLAUDE.md](../CLAUDE.md) (**Internal scoped naming**).
 - **`BT` getters vs methods:** zero-argument read-only snapshots are getters (`BT.displaySize.y`); actions,
   parameterized queries, and async work are methods (`BT.cameraSet`, `BT.pointerPos(0)`). Full rules:
   [CLAUDE.md](../CLAUDE.md) (**BT API: getters vs methods**).

--- a/docs/developer-experience-guide.md
+++ b/docs/developer-experience-guide.md
@@ -141,6 +141,22 @@ AI-assisted commits add a trailer: `Co-Authored-By: Claude <noreply@anthropic.co
   names (`activeBackend`, `requestedBackend`, `ticks`, `deltaSeconds`). Use `activeBackend` for runtime capability
   checks; `requestedBackend` mirrors resolved `HardwareSettings.backend` (including `?backend=software`).
 
+**Boolean naming (three tiers):**
+
+| Tier                                          | Use                         | Examples                                                                   |
+| --------------------------------------------- | --------------------------- | -------------------------------------------------------------------------- |
+| **A** Runtime read-only queries               | `is*` / `has*`              | `isPointerActive`, `isIndexed`, `hasGlyph`, `isDirty`                      |
+| **B** `HardwareSettings` / `BootstrapOptions` | grammatical `is*`           | `isOverlayEnabled`, `isDetectingDroppedFrames`                             |
+| **C** Side effects / operation results        | imperative verbs, not `is*` | `fireIfElapsed()`, `intersectTo(other, out): boolean`, `remove(): boolean` |
+
+- Use **`-ing`** for configure flags that enable ongoing behavior (`isDetectingDroppedFrames`, not
+  `isDetectDroppedFrames`).
+- **Hold vs edge on `BT`:** `isDown` / `isKeyDown` (held), `isPressed` / `isReleased` (button masks), `isKeyPressed` /
+  `isKeyReleased` (keyboard codes). Internal input classes use the same names (`PointerInput.isButtonDown`,
+  `KeyboardInput.isKeyDown`, `GamepadInput.isButtonDown`). Do **not** embed a second `Is` in the identifier
+  (`isKeyIsPressed` — grep: `\bis[A-Za-z]+Is[A-Z]`).
+- Identifier acronyms use both capitals: `canvasID`, `containerID` (not `canvasId`).
+
 ---
 
 ## IDE Setup

--- a/docs/input.md
+++ b/docs/input.md
@@ -47,10 +47,10 @@ const delta = BT.pointerDelta(); // slot 0 (mouse)
 const td = BT.pointerDelta(1); // slot 1
 
 // Validity check - false means no live pointer in this slot
-if (BT.pointerPosValid()) {
+if (BT.isPointerActive()) {
   /* mouse is over the canvas */
 }
-if (BT.pointerPosValid(1)) {
+if (BT.isPointerActive(1)) {
   /* touch slot 1 is active */
 }
 ```
@@ -60,21 +60,21 @@ if (BT.pointerPosValid(1)) {
 
 ## Buttons
 
-Use `BT.buttonDown()`, `BT.buttonPressed()`, and `BT.buttonReleased()` with the `BTN_POINTER_*` constants. The second
-parameter is the pointer slot (defaults to `0`):
+Use `BT.isDown()`, `BT.isPressed()`, and `BT.isReleased()` with the `BTN_POINTER_*` constants. The second parameter is
+the pointer slot (defaults to `0`):
 
 ```ts
 // Hold detection
-BT.buttonDown(BT.BTN_POINTER_A); // left mouse button held
-BT.buttonDown(BT.BTN_POINTER_B); // right mouse button held
-BT.buttonDown(BT.BTN_POINTER_C); // middle mouse button held
-BT.buttonDown(BT.BTN_POINTER_D); // back / forward button held
-BT.buttonDown(BT.BTN_POINTER_A, 1); // touch slot 1 in contact
+BT.isDown(BT.BTN_POINTER_A); // left mouse button held
+BT.isDown(BT.BTN_POINTER_B); // right mouse button held
+BT.isDown(BT.BTN_POINTER_C); // middle mouse button held
+BT.isDown(BT.BTN_POINTER_D); // back / forward button held
+BT.isDown(BT.BTN_POINTER_A, 1); // touch slot 1 in contact
 
 // Edge detection (true only on the transition frame)
-BT.buttonPressed(BT.BTN_POINTER_A); // left button just pressed
-BT.buttonReleased(BT.BTN_POINTER_A); // left button just released
-BT.buttonPressed(BT.BTN_POINTER_A, 2); // touch slot 2 just touched down
+BT.isPressed(BT.BTN_POINTER_A); // left button just pressed
+BT.isReleased(BT.BTN_POINTER_A); // left button just released
+BT.isPressed(BT.BTN_POINTER_A, 2); // touch slot 2 just touched down
 ```
 
 ### Mouse button mapping
@@ -100,17 +100,17 @@ Use these for direct key checks:
 
 ```ts
 // Held state
-if (BT.keyDown('KeyW')) {
+if (BT.isKeyDown('KeyW')) {
   /* W key held */
 }
 
 // Edge and optional tick-based repeat (repeat interval in fixed-update ticks)
-if (BT.keyPressed('ArrowUp', 10)) {
+if (BT.isKeyPressed('ArrowUp', 10)) {
   /* first press or repeat every 10 ticks while held */
 }
 
 // Release edge
-if (BT.keyReleased('Escape')) {
+if (BT.isKeyReleased('Escape')) {
   /* Escape released this frame */
 }
 ```
@@ -118,21 +118,21 @@ if (BT.keyReleased('Escape')) {
 ### Face buttons (`BTN_UP` through `BTN_SELECT`)
 
 Face button constants are bit flags. You can pass a single button or a combined mask; matching uses **ANY** semantics:
-`BT.buttonDown(BT.BTN_A | BT.BTN_B)` is true when either A or B is down.
+`BT.isDown(BT.BTN_A | BT.BTN_B)` is true when either A or B is down.
 
 For **player 0** and **player 1**, face-button reads merge keyboard maps and gamepad state (logical OR). For **player
 2** and **player 3**, face-button reads use gamepad only.
 
-`BT.buttonPressed` supports optional tick-based repeat via `repeatRate` (`0` or omitted = edge only), matching
-`BT.keyPressed` semantics.
+`BT.isPressed` supports optional tick-based repeat via `repeatRate` (`0` or omitted = edge only), matching
+`BT.isKeyPressed` semantics.
 
 ```ts
 // Player 0 (default: WASD-style + Space / KeyB for A, etc.)
-BT.buttonDown(BT.BTN_UP, 0);
-BT.buttonPressed(BT.BTN_A, 0, 6); // edge + repeat every 6 ticks while held
+BT.isDown(BT.BTN_UP, 0);
+BT.isPressed(BT.BTN_A, 0, 6); // edge + repeat every 6 ticks while held
 
 // Player 1 (default: arrow keys + alternate bindings)
-BT.buttonDown(BT.BTN_LEFT, 1);
+BT.isDown(BT.BTN_LEFT, 1);
 ```
 
 Built-in defaults are exposed as read-only tables (same values the engine starts with):
@@ -163,7 +163,7 @@ BT.inputMap(0, BT.BTN_X); // player 0 X has no keyboard keys until remapped
 ### Gamepad API
 
 ```ts
-BT.gamepadConnected(0); // true when player 0 has a connected gamepad
+BT.isGamepadConnected(0); // true when player 0 has a connected gamepad
 BT.gamepadCount; // number of connected gamepads (0..4)
 
 BT.getAxis(BT.AXIS_LEFT_X, 0); // -1.0 .. 1.0 (dead-zone filtered)
@@ -232,8 +232,8 @@ means:
   aligns with pointer flush).
 - Gamepad previous-state rollover also happens at end-of-frame, while current gamepad state is polled from the Gamepad
   API during button/axis queries.
-- `buttonPressed()` / `buttonReleased()` edges are never lost even when a press and release both arrive in the same
-  inter-frame gap (they appear as pressed-then-released across consecutive frames).
+- `isPressed()` / `isReleased()` edges are never lost even when a press and release both arrive in the same inter-frame
+  gap (they appear as pressed-then-released across consecutive frames).
 
 ## Page-Interaction Guards
 

--- a/docs/performance-best-practices.md
+++ b/docs/performance-best-practices.md
@@ -241,7 +241,7 @@ if (elapsedTime >= 1.0) {
 
 If your `update()` or `render()` takes too long:
 
-1. **Confirm the symptom** - Set `detectDroppedFrames: true` in `configure()` to log a console warning whenever the
+1. **Confirm the symptom** - Set `isDetectingDroppedFrames: true` in `configure()` to log a console warning whenever the
    browser misses a vsync deadline. The detector auto-calibrates to the actual rAF cadence so it works on any refresh
    rate (60 / 120 / 144 Hz, etc.) and on Firefox where rAF often fires at the display rate rather than at `targetFPS`.
 2. **Profile with browser dev tools** - Find the actual bottleneck
@@ -277,7 +277,7 @@ Don't guess what's slow - **measure it**. Use:
 - Chrome DevTools Performance tab
 - `console.time()` / `console.timeEnd()`
 - Simulation rate: `BT.targetFPS` and `BT.ticks`
-- Render rate: overlay `Present: N FPS` when `overlayEnabled` is true (measured rAF cadence, not `targetFPS`)
+- Render rate: overlay `Present: N FPS` when `isOverlayEnabled` is true (measured rAF cadence, not `targetFPS`)
 
 ### 3. Allocating in Hot Paths
 

--- a/docs/performance-testing.md
+++ b/docs/performance-testing.md
@@ -32,7 +32,7 @@ Examples:
 - `Vector2i.add()` vs `Vector2i.addInPlace()`
 - `Color32.toFloat32Array()` vs `Color32.writeToFloat32Array()`
 - `BitmapFont.measureText()` cold vs warm cache
-- `Rect2i.containsXY()` vs `Rect2i.contains()`
+- `Rect2i.isContainingXY()` vs `Rect2i.isContaining()`
 
 ---
 

--- a/docs/post-process-effects.md
+++ b/docs/post-process-effects.md
@@ -148,7 +148,7 @@ interface HardwareSettings {
   drawingBufferSize?: Vector2i; // drives drawing buffer + CSS, enables display tier
   outputUpscaleFilter?: 'nearest' | 'linear'; // default 'nearest'
   targetFPS: number;
-  detectDroppedFrames?: boolean;
+  isDetectingDroppedFrames?: boolean;
   backend?: 'webgpu' | 'software'; // default 'webgpu'; 'software' disables all post-process effects
 }
 ```

--- a/docs/software-fallback-smoke-matrix.md
+++ b/docs/software-fallback-smoke-matrix.md
@@ -1,7 +1,7 @@
 # Software Fallback Smoke Matrix
 
 This checklist is for quick manual verification of the software renderer. Originally written for the software-renderer
-MVP; updated for auto-fallback and the engine overlay (backend shown on the top bar when `overlayEnabled` is true).
+MVP; updated for auto-fallback and the engine overlay (backend shown on the top bar when `isOverlayEnabled` is true).
 
 ## Scope
 
@@ -22,16 +22,16 @@ MVP; updated for auto-fallback and the engine overlay (backend shown on the top 
 
 ## Matrix
 
-| Scene                                   | What to verify                                   | Software expected result                                    | Notes                                 |
-| --------------------------------------- | ------------------------------------------------ | ----------------------------------------------------------- | ------------------------------------- |
-| Any page without `?backend=software`    | Auto-fallback when WebGPU is absent              | Demo boots; `BT.activeBackend` = `'software'`               | No error page or hard stop            |
-| Any page with software active           | Overlay top bar shows `software`                 | Top bar reads `software \| WxH` (toggle with `~` or corner) | Disable with `overlayEnabled: false`  |
-| `tests/visual/fixtures/primitives.html` | clear + clearRect + primitive rasterization      | Matches expected primitive layout and colors                | Check pixel edges are crisp           |
-| `tests/visual/fixtures/camera.html`     | camera offset applied to all draw calls          | Geometry is shifted consistently by camera offset           | No partial drift between primitives   |
-| `tests/visual/fixtures/sprites.html`    | indexed sprites + palette offsets + transparency | Sprite shapes/colors match expected output                  | Transparent pixels stay see-through   |
-| `tests/visual/fixtures/fonts.html`      | system text + bitmap font rendering              | Text positions and glyph colors are correct                 | No missing glyph blocks               |
-| `tests/visual/fixtures/mixed.html`      | primitives + sprites + layering order            | Same stacking as WebGPU for this fixture                    | Parity covered by Playwright snapshot |
-| Frame capture via `BT.captureFrame()`   | PNG export in software mode                      | Promise resolves with PNG blob                              | Repeat capture across multiple frames |
+| Scene                                   | What to verify                                   | Software expected result                                    | Notes                                  |
+| --------------------------------------- | ------------------------------------------------ | ----------------------------------------------------------- | -------------------------------------- |
+| Any page without `?backend=software`    | Auto-fallback when WebGPU is absent              | Demo boots; `BT.activeBackend` = `'software'`               | No error page or hard stop             |
+| Any page with software active           | Overlay top bar shows `software`                 | Top bar reads `software \| WxH` (toggle with `~` or corner) | Disable with `isOverlayEnabled: false` |
+| `tests/visual/fixtures/primitives.html` | clear + clearRect + primitive rasterization      | Matches expected primitive layout and colors                | Check pixel edges are crisp            |
+| `tests/visual/fixtures/camera.html`     | camera offset applied to all draw calls          | Geometry is shifted consistently by camera offset           | No partial drift between primitives    |
+| `tests/visual/fixtures/sprites.html`    | indexed sprites + palette offsets + transparency | Sprite shapes/colors match expected output                  | Transparent pixels stay see-through    |
+| `tests/visual/fixtures/fonts.html`      | system text + bitmap font rendering              | Text positions and glyph colors are correct                 | No missing glyph blocks                |
+| `tests/visual/fixtures/mixed.html`      | primitives + sprites + layering order            | Same stacking as WebGPU for this fixture                    | Parity covered by Playwright snapshot  |
+| Frame capture via `BT.captureFrame()`   | PNG export in software mode                      | Promise resolves with PNG blob                              | Repeat capture across multiple frames  |
 
 ## Automated regression
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -41,7 +41,9 @@ and `vi` for browser API stubs. Tests that need a full DOM (Bootstrap, Bootstrap
   `captureFrame()` in software mode, and overlay render path (Node + GPU mocks + 2D canvas mocks)
 - **Overlay** - colocated tests under `src/overlay/*.test.ts`: label parsing, layout helpers, `layoutPlan` golden Y
   positions for 320x240 (including custom rows, palette grid variable bottom band, and timing chart scaffold cases),
-  `PaletteView.computePaletteGrid` width/size matrix, toggle hit-testing, and `updateAndRender` integration (Node)
+  `PaletteView.computeGrid` width/size matrix, `PaletteInteraction` hit-test/scroll/tooltip helpers,
+  `RenderPaletteUsage` mask helpers (`markIndexUsed`, `collectUsedIndices`), toggle hit-testing, and `updateAndRender`
+  integration (Node)
 - **FrameCapture** - GPU readback, PNG conversion (Node + GPU mocks + browser stubs)
 
 ### Tier 3: Visual Regression (Playwright, Chromium)

--- a/docs/voice.md
+++ b/docs/voice.md
@@ -49,7 +49,7 @@ non-public `src/assets/` paths.
 
 | Context                                | Before (avoid)                  | After (Tier 1 style)                                                                                                                                                   |
 | -------------------------------------- | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Canvas not found                       | `Element not found`             | `Can't find the canvas on the page. Make sure your HTML has a <canvas id='${canvasId}'> element.`                                                                      |
+| Canvas not found                       | `Element not found`             | `Can't find the canvas on the page. Make sure your HTML has a <canvas id='${canvasID}'> element.`                                                                      |
 | No active palette                      | `No palette`                    | `No palette set yet. Call BT.paletteSet(somePalette) before drawing or running palette effects.`                                                                       |
 | Palette index out of range             | `Index out of bounds: ${index}` | `The color number ${index} is too big for this palette. The palette has ${size} colors, so use a number from 0 to ${size - 1}.`                                        |
 | Sprite not indexized                   | `Sheet not indexized`           | `This sprite sheet hasn't been prepared yet. Use SpriteSheet.loadIndexed(...) for one-step setup, or call sheet.indexize(palette) after BT.paletteSet.`                |

--- a/knip.json
+++ b/knip.json
@@ -3,6 +3,11 @@
   "entry": ["src/**/*.test.ts", "src/**/*.bench.ts"],
   "project": ["src/**/*.ts"],
   "ignoreExportsUsedInFile": true,
+  "tags": ["-deprecated"],
+  "ignoreIssues": {
+    "src/core/RenderPaletteUsage.ts": ["duplicates"],
+    "src/overlay/palette/PaletteView.ts": ["duplicates"]
+  },
   "ignoreDependencies": ["vite-plugin-istanbul"],
   "typescript": {
     "config": ["tsconfig.json"]

--- a/knip.json
+++ b/knip.json
@@ -6,7 +6,8 @@
   "tags": ["-deprecated"],
   "ignoreIssues": {
     "src/core/RenderPaletteUsage.ts": ["duplicates"],
-    "src/overlay/palette/PaletteView.ts": ["duplicates"]
+    "src/overlay/palette/PaletteView.ts": ["duplicates"],
+    "src/overlay/timing-chart/style.ts": ["duplicates"]
   },
   "ignoreDependencies": ["vite-plugin-istanbul"],
   "typescript": {

--- a/src/BlitTech.test.ts
+++ b/src/BlitTech.test.ts
@@ -635,9 +635,9 @@ describe('BT.cameraReset', () => {
 
 // #endregion
 
-// #region BT.buttonDown / BT.buttonPressed / BT.buttonReleased
+// #region BT.isDown / BT.isPressed / BT.isReleased
 
-describe('BT.buttonDown', () => {
+describe('BT.isDown', () => {
     beforeEach(() => {
         BT.inputMapReset();
     });
@@ -648,64 +648,64 @@ describe('BT.buttonDown', () => {
     });
 
     it('returns false for face buttons when keyboard and gamepad are unavailable', () => {
-        expect(BT.buttonDown(BT.BTN_A)).toBe(false);
+        expect(BT.isDown(BT.BTN_A)).toBe(false);
     });
 
     it('accepts an optional player index without throwing', () => {
-        expect(BT.buttonDown(BT.BTN_START, 2)).toBe(false);
+        expect(BT.isDown(BT.BTN_START, 2)).toBe(false);
     });
 
     it('delegates pointer buttons to the pointer subsystem', () => {
-        const isButtonDown = vi.fn().mockReturnValue(true);
-        vi.spyOn(BTAPI.instance, 'getPointer').mockReturnValue({ isButtonDown } as never);
+        const isDown = vi.fn().mockReturnValue(true);
+        vi.spyOn(BTAPI.instance, 'getPointer').mockReturnValue({ isButtonDown: isDown } as never);
 
-        expect(BT.buttonDown(BT.BTN_POINTER_A, 0)).toBe(true);
-        expect(isButtonDown).toHaveBeenCalledWith(20, 0);
+        expect(BT.isDown(BT.BTN_POINTER_A, 0)).toBe(true);
+        expect(isDown).toHaveBeenCalledWith(20, 0);
     });
 
     it('uses ANY semantics for combined button masks', () => {
-        const isButtonDown = vi.fn().mockImplementation((codes: readonly string[]) => codes.includes('KeyA'));
-        vi.spyOn(BTAPI.instance, 'getKeyboard').mockReturnValue({ isButtonDown } as never);
+        const isDown = vi.fn().mockImplementation((codes: readonly string[]) => codes.includes('KeyA'));
+        vi.spyOn(BTAPI.instance, 'getKeyboard').mockReturnValue({ isButtonDown: isDown } as never);
 
         BT.inputMap(0, BT.BTN_A, 'KeyA');
 
-        expect(BT.buttonDown(BT.BTN_A | BT.BTN_B, 0)).toBe(true);
+        expect(BT.isDown(BT.BTN_A | BT.BTN_B, 0)).toBe(true);
     });
 
     it('returns false for pointer buttons when the engine is not initialized', () => {
         vi.spyOn(BTAPI.instance, 'getPointer').mockReturnValue(null);
 
-        expect(BT.buttonDown(BT.BTN_POINTER_A)).toBe(false);
-        expect(BT.buttonDown(BT.BTN_POINTER_D, 3)).toBe(false);
+        expect(BT.isDown(BT.BTN_POINTER_A)).toBe(false);
+        expect(BT.isDown(BT.BTN_POINTER_D, 3)).toBe(false);
     });
 
     it('uses gamepad for player 2+ when keyboard maps are unavailable', () => {
-        const isButtonDown = vi.fn().mockReturnValue(true);
-        vi.spyOn(BTAPI.instance, 'getGamepad').mockReturnValue({ isButtonDown } as never);
+        const isDown = vi.fn().mockReturnValue(true);
+        vi.spyOn(BTAPI.instance, 'getGamepad').mockReturnValue({ isButtonDown: isDown } as never);
 
-        expect(BT.buttonDown(BT.BTN_START, 2)).toBe(true);
-        expect(isButtonDown).toHaveBeenCalledWith(BT.BTN_START, 2);
+        expect(BT.isDown(BT.BTN_START, 2)).toBe(true);
+        expect(isDown).toHaveBeenCalledWith(BT.BTN_START, 2);
     });
 });
 
-describe('BT.buttonPressed', () => {
+describe('BT.isPressed', () => {
     afterEach(() => {
         vi.restoreAllMocks();
     });
 
     it('returns false for face buttons when keyboard and gamepad are unavailable', () => {
-        expect(BT.buttonPressed(BT.BTN_B)).toBe(false);
+        expect(BT.isPressed(BT.BTN_B)).toBe(false);
     });
 
     it('accepts an optional player index without throwing', () => {
-        expect(BT.buttonPressed(BT.BTN_B, 1)).toBe(false);
+        expect(BT.isPressed(BT.BTN_B, 1)).toBe(false);
     });
 
     it('delegates pointer buttons to the pointer subsystem', () => {
         const isButtonPressed = vi.fn().mockReturnValue(true);
         vi.spyOn(BTAPI.instance, 'getPointer').mockReturnValue({ isButtonPressed } as never);
 
-        expect(BT.buttonPressed(BT.BTN_POINTER_B, 0)).toBe(true);
+        expect(BT.isPressed(BT.BTN_POINTER_B, 0)).toBe(true);
         expect(isButtonPressed).toHaveBeenCalledWith(21, 0);
     });
 
@@ -724,7 +724,7 @@ describe('BT.buttonPressed', () => {
             isButtonPressed: isButtonPressedGamepad,
         } as never);
 
-        BT.buttonPressed(BT.BTN_A, 0, 6);
+        BT.isPressed(BT.BTN_A, 0, 6);
 
         expect(isButtonPressedKeyboard).toHaveBeenCalledWith(expect.any(Array), 6, 120);
         expect(isButtonPressedGamepad).toHaveBeenCalledWith(BT.BTN_A, 0, 6, 120);
@@ -741,7 +741,7 @@ describe('BT.buttonPressed', () => {
             isButtonPressed: vi.fn().mockReturnValue(true),
         } as never);
 
-        expect(BT.buttonPressed(BT.BTN_A, 0)).toBe(false);
+        expect(BT.isPressed(BT.BTN_A, 0)).toBe(false);
     });
 
     it('allows repeat events during dual-source hold when repeatRate is enabled', () => {
@@ -755,28 +755,28 @@ describe('BT.buttonPressed', () => {
             isButtonPressed: vi.fn().mockReturnValue(false),
         } as never);
 
-        expect(BT.buttonPressed(BT.BTN_A, 0, 6)).toBe(true);
+        expect(BT.isPressed(BT.BTN_A, 0, 6)).toBe(true);
     });
 });
 
-describe('BT.buttonReleased', () => {
+describe('BT.isReleased', () => {
     afterEach(() => {
         vi.restoreAllMocks();
     });
 
     it('returns false for face buttons when keyboard is unavailable', () => {
-        expect(BT.buttonReleased(BT.BTN_X)).toBe(false);
+        expect(BT.isReleased(BT.BTN_X)).toBe(false);
     });
 
     it('accepts an optional player index without throwing', () => {
-        expect(BT.buttonReleased(BT.BTN_X, 3)).toBe(false);
+        expect(BT.isReleased(BT.BTN_X, 3)).toBe(false);
     });
 
     it('delegates pointer buttons to the pointer subsystem', () => {
         const isButtonReleased = vi.fn().mockReturnValue(true);
         vi.spyOn(BTAPI.instance, 'getPointer').mockReturnValue({ isButtonReleased } as never);
 
-        expect(BT.buttonReleased(BT.BTN_POINTER_C, 2)).toBe(true);
+        expect(BT.isReleased(BT.BTN_POINTER_C, 2)).toBe(true);
         expect(isButtonReleased).toHaveBeenCalledWith(22, 2);
     });
 
@@ -784,14 +784,14 @@ describe('BT.buttonReleased', () => {
         const isButtonReleasedKeyboard = vi.fn().mockReturnValue(false);
         const isButtonReleased = vi.fn().mockReturnValue(true);
         const isButtonDownKeyboard = vi.fn().mockReturnValue(false);
-        const isButtonDown = vi.fn().mockReturnValue(false);
+        const isDown = vi.fn().mockReturnValue(false);
         vi.spyOn(BTAPI.instance, 'getKeyboard').mockReturnValue({
             isButtonDown: isButtonDownKeyboard,
             isButtonReleased: isButtonReleasedKeyboard,
         } as never);
-        vi.spyOn(BTAPI.instance, 'getGamepad').mockReturnValue({ isButtonDown, isButtonReleased } as never);
+        vi.spyOn(BTAPI.instance, 'getGamepad').mockReturnValue({ isButtonDown: isDown, isButtonReleased } as never);
 
-        expect(BT.buttonReleased(BT.BTN_A, 1)).toBe(true);
+        expect(BT.isReleased(BT.BTN_A, 1)).toBe(true);
         expect(isButtonReleased).toHaveBeenCalledWith(BT.BTN_A, 1);
     });
 
@@ -805,7 +805,7 @@ describe('BT.buttonReleased', () => {
             isButtonReleased: vi.fn().mockReturnValue(true),
         } as never);
 
-        expect(BT.buttonReleased(BT.BTN_A, 0)).toBe(false);
+        expect(BT.isReleased(BT.BTN_A, 0)).toBe(false);
     });
 });
 
@@ -820,86 +820,82 @@ describe('BT.inputMap / BT.inputMapReset', () => {
     });
 
     it('remaps player 0 face buttons through the keyboard subsystem', () => {
-        const isButtonDown = vi.fn().mockReturnValue(true);
-        vi.spyOn(BTAPI.instance, 'getKeyboard').mockReturnValue({ isButtonDown } as never);
+        const isDown = vi.fn().mockReturnValue(true);
+        vi.spyOn(BTAPI.instance, 'getKeyboard').mockReturnValue({ isButtonDown: isDown } as never);
 
         BT.inputMap(0, BT.BTN_A, 'KeyZ');
 
-        expect(BT.buttonDown(BT.BTN_A, 0)).toBe(true);
-        expect(isButtonDown).toHaveBeenCalledWith(['KeyZ']);
+        expect(BT.isDown(BT.BTN_A, 0)).toBe(true);
+        expect(isDown).toHaveBeenCalledWith(['KeyZ']);
     });
 
     it('remaps player 1 independently of player 0', () => {
-        const isButtonDown = vi.fn().mockImplementation((codes: readonly string[]) => codes.includes('Numpad9'));
-        vi.spyOn(BTAPI.instance, 'getKeyboard').mockReturnValue({ isButtonDown } as never);
+        const isDown = vi.fn().mockImplementation((codes: readonly string[]) => codes.includes('Numpad9'));
+        vi.spyOn(BTAPI.instance, 'getKeyboard').mockReturnValue({ isButtonDown: isDown } as never);
 
         BT.inputMap(0, BT.BTN_A, 'KeyX');
         BT.inputMap(1, BT.BTN_A, 'Numpad9');
 
-        BT.buttonDown(BT.BTN_A, 0);
-        expect(isButtonDown).toHaveBeenLastCalledWith(['KeyX']);
+        BT.isDown(BT.BTN_A, 0);
+        expect(isDown).toHaveBeenLastCalledWith(['KeyX']);
 
-        BT.buttonDown(BT.BTN_A, 1);
-        expect(isButtonDown).toHaveBeenLastCalledWith(['Numpad9']);
+        BT.isDown(BT.BTN_A, 1);
+        expect(isDown).toHaveBeenLastCalledWith(['Numpad9']);
     });
 
     it('passes multiple keys per button for OR semantics', () => {
-        const isButtonDown = vi.fn().mockReturnValue(true);
-        vi.spyOn(BTAPI.instance, 'getKeyboard').mockReturnValue({ isButtonDown } as never);
+        const isDown = vi.fn().mockReturnValue(true);
+        vi.spyOn(BTAPI.instance, 'getKeyboard').mockReturnValue({ isButtonDown: isDown } as never);
 
         BT.inputMap(0, BT.BTN_UP, 'ArrowUp', 'KeyW');
 
-        BT.buttonDown(BT.BTN_UP, 0);
-        expect(isButtonDown).toHaveBeenCalledWith(['ArrowUp', 'KeyW']);
+        BT.isDown(BT.BTN_UP, 0);
+        expect(isDown).toHaveBeenCalledWith(['ArrowUp', 'KeyW']);
     });
 
     it('restores default key lists for both keyboard players', () => {
-        const isButtonDown = vi.fn().mockReturnValue(false);
-        vi.spyOn(BTAPI.instance, 'getKeyboard').mockReturnValue({ isButtonDown } as never);
+        const isDown = vi.fn().mockReturnValue(false);
+        vi.spyOn(BTAPI.instance, 'getKeyboard').mockReturnValue({ isButtonDown: isDown } as never);
 
         BT.inputMap(0, BT.BTN_UP, 'F1');
         BT.inputMap(1, BT.BTN_UP, 'F2');
         BT.inputMapReset();
 
-        BT.buttonDown(BT.BTN_UP, 0);
-        expect(isButtonDown).toHaveBeenCalledWith([
-            ...(BT.DEFAULT_KEYBOARD_PLAYER1[BT.BTN_UP as FaceButtonCode] ?? []),
-        ]);
+        BT.isDown(BT.BTN_UP, 0);
+        expect(isDown).toHaveBeenCalledWith([...(BT.DEFAULT_KEYBOARD_PLAYER1[BT.BTN_UP as FaceButtonCode] ?? [])]);
 
-        BT.buttonDown(BT.BTN_UP, 1);
-        expect(isButtonDown).toHaveBeenCalledWith([
-            ...(BT.DEFAULT_KEYBOARD_PLAYER2[BT.BTN_UP as FaceButtonCode] ?? []),
-        ]);
+        BT.isDown(BT.BTN_UP, 1);
+        expect(isDown).toHaveBeenCalledWith([...(BT.DEFAULT_KEYBOARD_PLAYER2[BT.BTN_UP as FaceButtonCode] ?? [])]);
     });
 
     it('ignores remap attempts for unsupported keyboard players', () => {
-        const isButtonDown = vi.fn().mockReturnValue(false);
-        vi.spyOn(BTAPI.instance, 'getKeyboard').mockReturnValue({ isButtonDown } as never);
+        const isDown = vi.fn().mockReturnValue(false);
+        vi.spyOn(BTAPI.instance, 'getKeyboard').mockReturnValue({ isButtonDown: isDown } as never);
 
         BT.inputMap(2, BT.BTN_A, 'KeyZ');
 
-        BT.buttonDown(BT.BTN_A, 0);
-        expect(isButtonDown).toHaveBeenCalledWith([...(BT.DEFAULT_KEYBOARD_PLAYER1[BT.BTN_A as FaceButtonCode] ?? [])]);
+        BT.isDown(BT.BTN_A, 0);
+        expect(isDown).toHaveBeenCalledWith([...(BT.DEFAULT_KEYBOARD_PLAYER1[BT.BTN_A as FaceButtonCode] ?? [])]);
     });
 
     it('ignores remap attempts with out-of-range face button ids', () => {
-        const isButtonDown = vi.fn().mockReturnValue(false);
-        vi.spyOn(BTAPI.instance, 'getKeyboard').mockReturnValue({ isButtonDown } as never);
+        const isDown = vi.fn().mockReturnValue(false);
+        vi.spyOn(BTAPI.instance, 'getKeyboard').mockReturnValue({ isButtonDown: isDown } as never);
 
         BT.inputMap(0, 99, 'KeyZ');
 
-        BT.buttonDown(BT.BTN_A, 0);
-        expect(isButtonDown).toHaveBeenCalledWith([...(BT.DEFAULT_KEYBOARD_PLAYER1[BT.BTN_A as FaceButtonCode] ?? [])]);
+        BT.isDown(BT.BTN_A, 0);
+        expect(isDown).toHaveBeenCalledWith([...(BT.DEFAULT_KEYBOARD_PLAYER1[BT.BTN_A as FaceButtonCode] ?? [])]);
     });
 
     it('allows clearing keyboard bindings with an empty key list', () => {
-        const isButtonDown = vi.fn().mockReturnValue(false);
-        vi.spyOn(BTAPI.instance, 'getKeyboard').mockReturnValue({ isButtonDown } as never);
+        const isDown = vi.fn().mockReturnValue(false);
+        vi.spyOn(BTAPI.instance, 'getKeyboard').mockReturnValue({ isButtonDown: isDown } as never);
 
         BT.inputMap(0, BT.BTN_A);
 
-        BT.buttonDown(BT.BTN_A, 0);
-        expect(isButtonDown).toHaveBeenCalledWith([]);
+        BT.isDown(BT.BTN_A, 0);
+        expect(isDown).toHaveBeenCalledWith([]);
     });
 });
 
@@ -966,7 +962,7 @@ describe('BT.pointerDelta', () => {
     });
 });
 
-describe('BT.pointerPosValid', () => {
+describe('BT.isPointerActive', () => {
     afterEach(() => {
         vi.restoreAllMocks();
     });
@@ -974,7 +970,7 @@ describe('BT.pointerPosValid', () => {
     it('returns false when the engine is not initialized', () => {
         vi.spyOn(BTAPI.instance, 'getPointer').mockReturnValue(null);
 
-        expect(BT.pointerPosValid()).toBe(false);
+        expect(BT.isPointerActive()).toBe(false);
     });
 
     it('delegates to the pointer subsystem', () => {
@@ -1020,7 +1016,7 @@ describe('Pointer button constants', () => {
 
 // #endregion
 
-// #region BT gamepad constants and APIs / BT.keyDown / BT.keyPressed / BT.keyReleased
+// #region BT gamepad constants and APIs / BT.isKeyDown / BT.isKeyPressed / BT.isKeyReleased
 
 describe('BT gamepad constants and APIs', () => {
     afterEach(() => {
@@ -1049,7 +1045,7 @@ describe('BT gamepad constants and APIs', () => {
         expect(BT.BTN_POINTER_ANY).toBe(BT.BTN_POINTER_A | BT.BTN_POINTER_B | BT.BTN_POINTER_C | BT.BTN_POINTER_D);
     });
 
-    it('delegates getAxis/gamepadConnected/gamepadCount to gamepad subsystem', () => {
+    it('delegates getAxis/isGamepadConnected/gamepadCount to gamepad subsystem', () => {
         const getAxis = vi.fn().mockReturnValue(0.25);
         const isConnected = vi.fn().mockReturnValue(true);
         const connectedCount = vi.fn().mockReturnValue(2);
@@ -1057,7 +1053,7 @@ describe('BT gamepad constants and APIs', () => {
 
         expect(BT.getAxis(BT.AXIS_LEFT_X, 1)).toBe(0.25);
         expect(getAxis).toHaveBeenCalledWith(BT.AXIS_LEFT_X, 1);
-        expect(BT.gamepadConnected(1)).toBe(true);
+        expect(BT.isGamepadConnected(1)).toBe(true);
         expect(isConnected).toHaveBeenCalledWith(1);
         expect(BT.gamepadCount).toBe(2);
         expect(connectedCount).toHaveBeenCalledWith();
@@ -1069,10 +1065,10 @@ describe('BT gamepad constants and APIs', () => {
         expect(BT.getAxis(BT.AXIS_LEFT_X, 1)).toBe(0);
     });
 
-    it('returns false from gamepadConnected when the gamepad subsystem is not initialized', () => {
+    it('returns false from isGamepadConnected when the gamepad subsystem is not initialized', () => {
         vi.spyOn(BTAPI.instance, 'getGamepad').mockReturnValue(null);
 
-        expect(BT.gamepadConnected(1)).toBe(false);
+        expect(BT.isGamepadConnected(1)).toBe(false);
     });
 
     it('returns 0 from gamepadCount when the gamepad subsystem is not initialized', () => {
@@ -1082,21 +1078,21 @@ describe('BT gamepad constants and APIs', () => {
     });
 });
 
-describe('BT.keyDown', () => {
+describe('BT.isKeyDown', () => {
     it('returns false when the engine is not initialized', () => {
-        expect(BT.keyDown('Space')).toBe(false);
+        expect(BT.isKeyDown('Space')).toBe(false);
     });
 });
 
-describe('BT.keyPressed', () => {
+describe('BT.isKeyPressed', () => {
     it('returns false when the engine is not initialized', () => {
-        expect(BT.keyPressed('ArrowUp')).toBe(false);
+        expect(BT.isKeyPressed('ArrowUp')).toBe(false);
     });
 });
 
-describe('BT.keyReleased', () => {
+describe('BT.isKeyReleased', () => {
     it('returns false when the engine is not initialized', () => {
-        expect(BT.keyReleased('KeyA')).toBe(false);
+        expect(BT.isKeyReleased('KeyA')).toBe(false);
     });
 });
 

--- a/src/BlitTech.test.ts
+++ b/src/BlitTech.test.ts
@@ -978,11 +978,11 @@ describe('BT.pointerPosValid', () => {
     });
 
     it('delegates to the pointer subsystem', () => {
-        const isValid = vi.fn().mockReturnValue(true);
-        vi.spyOn(BTAPI.instance, 'getPointer').mockReturnValue({ isValid } as never);
+        const isActive = vi.fn().mockReturnValue(true);
+        vi.spyOn(BTAPI.instance, 'getPointer').mockReturnValue({ isActive } as never);
 
-        expect(BT.pointerPosValid(0)).toBe(true);
-        expect(isValid).toHaveBeenCalledWith(0);
+        expect(BT.isPointerActive(0)).toBe(true);
+        expect(isActive).toHaveBeenCalledWith(0);
     });
 });
 

--- a/src/BlitTech.test.ts
+++ b/src/BlitTech.test.ts
@@ -605,7 +605,7 @@ describe('BT.cameraClamp', () => {
     it('clamps camera coordinates when viewSize is provided', () => {
         const clamped = BT.cameraClamp(new Vector2i(500, 300), new Vector2i(640, 480), new Vector2i(320, 240));
 
-        expect(clamped.equalsXY(320, 240)).toBe(true);
+        expect(clamped.isEqualXY(320, 240)).toBe(true);
     });
 
     it('uses BT.displaySize when viewSize is omitted', () => {
@@ -615,7 +615,7 @@ describe('BT.cameraClamp', () => {
 
         const clamped = BT.cameraClamp(new Vector2i(100, 100), new Vector2i(250, 200));
 
-        expect(clamped.equalsXY(50, 50)).toBe(true);
+        expect(clamped.isEqualXY(50, 50)).toBe(true);
     });
 });
 

--- a/src/BlitTech.ts
+++ b/src/BlitTech.ts
@@ -976,8 +976,8 @@ export const BT = {
      * @param pointerIndex - Pointer slot (defaults to 0 = mouse).
      * @returns `true` while the slot has live position data.
      */
-    pointerPosValid: (pointerIndex: number = 0): boolean => {
-        return BTAPI.instance.getPointer()?.isValid(pointerIndex) ?? false;
+    isPointerActive: (pointerIndex: number = 0): boolean => {
+        return BTAPI.instance.getPointer()?.isActive(pointerIndex) ?? false;
     },
 
     /**
@@ -1042,7 +1042,7 @@ export const BT = {
      * @returns `true` while the button remains pressed.
      */
     // eslint-disable-next-line complexity -- explicit per-flag routing keeps input semantics easy to audit.
-    buttonDown: (button: number, player: number = 0): boolean => {
+    isDown: (button: number, player: number = 0): boolean => {
         if (!Number.isInteger(button) || button <= 0) {
             return false;
         }
@@ -1070,11 +1070,11 @@ export const BT = {
                 continue;
             }
 
-            const keyboardMatch =
+            const isKeyboardDown =
                 BTAPI.instance.getKeyboard()?.isButtonDown(faceButtonKeys(faceButton, player) ?? []) ?? false;
-            const gamepadMatch = BTAPI.instance.getGamepad()?.isButtonDown(faceButton, player) ?? false;
+            const isGamepadDown = BTAPI.instance.getGamepad()?.isButtonDown(faceButton, player) ?? false;
 
-            if (keyboardMatch || gamepadMatch) {
+            if (isKeyboardDown || isGamepadDown) {
                 return true;
             }
         }
@@ -1085,7 +1085,7 @@ export const BT = {
     /**
      * Checks whether a button was pressed on the current frame.
      *
-     * Same parameter semantics as {@link buttonDown}; returns `true` only on
+     * Same parameter semantics as {@link isDown}; returns `true` only on
      * the frame the button transitions from up to down.
      *
      * @param button - Button constant from the `BTN_*` set.
@@ -1095,7 +1095,7 @@ export const BT = {
      * @returns `true` on the transition frame.
      */
     // eslint-disable-next-line complexity -- explicit per-flag routing keeps input semantics easy to audit.
-    buttonPressed: (button: number, player: number = 0, repeatRate?: number): boolean => {
+    isPressed: (button: number, player: number = 0, repeatRate?: number): boolean => {
         if (!Number.isInteger(button) || button <= 0) {
             return false;
         }
@@ -1130,17 +1130,17 @@ export const BT = {
             const keyboard = BTAPI.instance.getKeyboard();
             const gamepad = BTAPI.instance.getGamepad();
             const keyboardCodes = faceButtonKeys(faceButton, player) ?? [];
-            const keyboardDown = keyboard?.isButtonDown(keyboardCodes) ?? false;
-            const gamepadDown = gamepad?.isButtonDown(faceButton, player) ?? false;
-            const keyboardPressed = keyboard?.isButtonPressed(keyboardCodes, repeatRate, tick) ?? false;
-            const gamepadPressed = gamepad?.isButtonPressed(faceButton, player, repeatRate, tick) ?? false;
-            const repeatEnabled = repeatRate !== undefined && repeatRate > 0;
-            const mergedPressed = repeatEnabled
-                ? keyboardPressed || gamepadPressed
-                : (keyboardPressed && !(gamepadDown && !gamepadPressed)) ||
-                  (gamepadPressed && !(keyboardDown && !keyboardPressed));
+            const isKeyboardDown = keyboard?.isButtonDown(keyboardCodes) ?? false;
+            const isGamepadDown = gamepad?.isButtonDown(faceButton, player) ?? false;
+            const keyboardIsPressed = keyboard?.isButtonPressed(keyboardCodes, repeatRate, tick) ?? false;
+            const gamepadIsPressed = gamepad?.isButtonPressed(faceButton, player, repeatRate, tick) ?? false;
+            const isRepeatEnabled = repeatRate !== undefined && repeatRate > 0;
+            const mergedIsPressed = isRepeatEnabled
+                ? keyboardIsPressed || gamepadIsPressed
+                : (keyboardIsPressed && !(isGamepadDown && !gamepadIsPressed)) ||
+                  (gamepadIsPressed && !(isKeyboardDown && !keyboardIsPressed));
 
-            if (mergedPressed) {
+            if (mergedIsPressed) {
                 return true;
             }
         }
@@ -1151,7 +1151,7 @@ export const BT = {
     /**
      * Checks whether a button was released on the current frame.
      *
-     * Same parameter semantics as {@link buttonDown}; returns `true` only on
+     * Same parameter semantics as {@link isDown}; returns `true` only on
      * the frame the button transitions from down to up.
      *
      * @param button - Button constant from the `BTN_*` set.
@@ -1160,7 +1160,7 @@ export const BT = {
      * @returns `true` on the release frame.
      */
     // eslint-disable-next-line complexity -- explicit per-flag routing keeps input semantics easy to audit.
-    buttonReleased: (button: number, player: number = 0): boolean => {
+    isReleased: (button: number, player: number = 0): boolean => {
         if (!Number.isInteger(button) || button <= 0) {
             return false;
         }
@@ -1194,15 +1194,15 @@ export const BT = {
             const keyboard = BTAPI.instance.getKeyboard();
             const gamepad = BTAPI.instance.getGamepad();
             const keyboardCodes = faceButtonKeys(faceButton, player) ?? [];
-            const keyboardDown = keyboard?.isButtonDown(keyboardCodes) ?? false;
-            const gamepadDown = gamepad?.isButtonDown(faceButton, player) ?? false;
-            const keyboardReleased = keyboard?.isButtonReleased(keyboardCodes) ?? false;
-            const gamepadReleased = gamepad?.isButtonReleased(faceButton, player) ?? false;
-            const mergedReleased =
-                (keyboardReleased && !(gamepadDown && !gamepadReleased)) ||
-                (gamepadReleased && !(keyboardDown && !keyboardReleased));
+            const isKeyboardDown = keyboard?.isButtonDown(keyboardCodes) ?? false;
+            const isGamepadDown = gamepad?.isButtonDown(faceButton, player) ?? false;
+            const keyboardIsReleased = keyboard?.isButtonReleased(keyboardCodes) ?? false;
+            const gamepadIsReleased = gamepad?.isButtonReleased(faceButton, player) ?? false;
+            const mergedIsReleased =
+                (keyboardIsReleased && !(isGamepadDown && !gamepadIsReleased)) ||
+                (gamepadIsReleased && !(isKeyboardDown && !keyboardIsReleased));
 
-            if (mergedReleased) {
+            if (mergedIsReleased) {
                 return true;
             }
         }
@@ -1269,7 +1269,7 @@ export const BT = {
      * @param player - Zero-based player index (`0`..`3`).
      * @returns `true` when a gamepad is available for that slot.
      */
-    gamepadConnected: (player: number = 0): boolean => {
+    isGamepadConnected: (player: number = 0): boolean => {
         return BTAPI.instance.getGamepad()?.isConnected(player) ?? false;
     },
 
@@ -1294,7 +1294,7 @@ export const BT = {
      * @param key - DOM keyboard code string.
      * @returns `true` while the key remains pressed.
      */
-    keyDown: (key: string): boolean => {
+    isKeyDown: (key: string): boolean => {
         return BTAPI.instance.getKeyboard()?.isKeyDown(key) ?? false;
     },
 
@@ -1309,7 +1309,7 @@ export const BT = {
      * @param repeatRate - Ticks between repeat triggers; omit or `0` for no repeat.
      * @returns `true` on the press edge (and on repeat ticks when configured).
      */
-    keyPressed: (key: string, repeatRate?: number): boolean => {
+    isKeyPressed: (key: string, repeatRate?: number): boolean => {
         const tick = BTAPI.instance.getTicks();
 
         return BTAPI.instance.getKeyboard()?.isKeyPressed(key, repeatRate, tick) ?? false;
@@ -1321,7 +1321,7 @@ export const BT = {
      * @param key - DOM keyboard code string.
      * @returns `true` on the release edge.
      */
-    keyReleased: (key: string): boolean => {
+    isKeyReleased: (key: string): boolean => {
         return BTAPI.instance.getKeyboard()?.isKeyReleased(key) ?? false;
     },
 

--- a/src/BlitTech.ts
+++ b/src/BlitTech.ts
@@ -981,6 +981,17 @@ export const BT = {
     },
 
     /**
+     * Backward-compatible alias for {@link isPointerActive}.
+     *
+     * @deprecated Deprecated since 2026-05-31. Use {@link isPointerActive} instead.
+     * @param pointerIndex - Pointer slot (defaults to 0 = mouse).
+     * @returns `true` while the slot has live position data.
+     */
+    pointerPosValid: (pointerIndex: number = 0): boolean => {
+        return BT.isPointerActive(pointerIndex);
+    },
+
+    /**
      * Wheel scroll delta accumulated during the current frame, in pixels.
      *
      * Aggregates `WheelEvent.deltaY` across all wheel events received since
@@ -1083,6 +1094,18 @@ export const BT = {
     },
 
     /**
+     * Backward-compatible alias for {@link isDown}.
+     *
+     * @deprecated Deprecated since 2026-05-31. Use {@link isDown} instead.
+     * @param button - Button constant from the `BTN_*` set.
+     * @param player - Zero-based player index for gamepads / keyboard, or pointer slot.
+     * @returns `true` while the button remains pressed.
+     */
+    buttonDown: (button: number, player: number = 0): boolean => {
+        return BT.isDown(button, player);
+    },
+
+    /**
      * Checks whether a button was pressed on the current frame.
      *
      * Same parameter semantics as {@link isDown}; returns `true` only on
@@ -1149,6 +1172,19 @@ export const BT = {
     },
 
     /**
+     * Backward-compatible alias for {@link isPressed}.
+     *
+     * @deprecated Deprecated since 2026-05-31. Use {@link isPressed} instead.
+     * @param button - Button constant from the `BTN_*` set.
+     * @param player - Zero-based player index for gamepads, or pointer slot.
+     * @param repeatRate - Optional repeat interval in fixed ticks (`0`/omitted = edge only).
+     * @returns `true` on the transition frame.
+     */
+    buttonPressed: (button: number, player: number = 0, repeatRate?: number): boolean => {
+        return BT.isPressed(button, player, repeatRate);
+    },
+
+    /**
      * Checks whether a button was released on the current frame.
      *
      * Same parameter semantics as {@link isDown}; returns `true` only on
@@ -1208,6 +1244,18 @@ export const BT = {
         }
 
         return false;
+    },
+
+    /**
+     * Backward-compatible alias for {@link isReleased}.
+     *
+     * @deprecated Deprecated since 2026-05-31. Use {@link isReleased} instead.
+     * @param button - Button constant from the `BTN_*` set.
+     * @param player - Zero-based player index for gamepads, or pointer slot.
+     * @returns `true` on the release frame.
+     */
+    buttonReleased: (button: number, player: number = 0): boolean => {
+        return BT.isReleased(button, player);
     },
 
     /**
@@ -1274,6 +1322,17 @@ export const BT = {
     },
 
     /**
+     * Backward-compatible alias for {@link isGamepadConnected}.
+     *
+     * @deprecated Deprecated since 2026-05-31. Use {@link isGamepadConnected} instead.
+     * @param player - Zero-based player index (`0`..`3`).
+     * @returns `true` when a gamepad is available for that slot.
+     */
+    gamepadConnected: (player: number = 0): boolean => {
+        return BT.isGamepadConnected(player);
+    },
+
+    /**
      * Number of currently connected gamepads (max 4).
      *
      * @returns Connected gamepad count (0..4).
@@ -1299,6 +1358,17 @@ export const BT = {
     },
 
     /**
+     * Backward-compatible alias for {@link isKeyDown}.
+     *
+     * @deprecated Deprecated since 2026-05-31. Use {@link isKeyDown} instead.
+     * @param key - DOM keyboard code string.
+     * @returns `true` while the key remains pressed.
+     */
+    keyDown: (key: string): boolean => {
+        return BT.isKeyDown(key);
+    },
+
+    /**
      * Checks whether a keyboard key was pressed on the current fixed-update tick.
      *
      * Optional `repeatRate` is in fixed ticks between repeats (`0` or omitted =
@@ -1316,6 +1386,18 @@ export const BT = {
     },
 
     /**
+     * Backward-compatible alias for {@link isKeyPressed}.
+     *
+     * @deprecated Deprecated since 2026-05-31. Use {@link isKeyPressed} instead.
+     * @param key - DOM keyboard code string.
+     * @param repeatRate - Ticks between repeat triggers; omit or `0` for no repeat.
+     * @returns `true` on the press edge (and on repeat ticks when configured).
+     */
+    keyPressed: (key: string, repeatRate?: number): boolean => {
+        return BT.isKeyPressed(key, repeatRate);
+    },
+
+    /**
      * Checks whether a keyboard key was released on the current frame.
      *
      * @param key - DOM keyboard code string.
@@ -1323,6 +1405,17 @@ export const BT = {
      */
     isKeyReleased: (key: string): boolean => {
         return BTAPI.instance.getKeyboard()?.isKeyReleased(key) ?? false;
+    },
+
+    /**
+     * Backward-compatible alias for {@link isKeyReleased}.
+     *
+     * @deprecated Deprecated since 2026-05-31. Use {@link isKeyReleased} instead.
+     * @param key - DOM keyboard code string.
+     * @returns `true` on the release edge.
+     */
+    keyReleased: (key: string): boolean => {
+        return BT.isKeyReleased(key);
     },
 
     /**

--- a/src/BlitTech.ts
+++ b/src/BlitTech.ts
@@ -524,7 +524,7 @@ export const BT = {
     /**
      * Places a labeled marker on the overlay timing chart at the current tick.
      *
-     * Requires `overlayTimingChart: true` in `configure()`. Tags scroll with the chart
+     * Requires `isOverlayTimingChartEnabled: true` in `configure()`. Tags scroll with the chart
      * history and are pruned when they leave the visible window. Empty labels become
      * `"Untitled"`. Chart width resets add an automatic `"Start"` tag.
      *

--- a/src/assets/BitmapFont.ts
+++ b/src/assets/BitmapFont.ts
@@ -60,7 +60,7 @@ interface GlyphData {
 /**
  * Serialized bitmap-font descriptor loaded from disk.
  */
-interface FontFileData {
+interface FileData {
     /** Font display name. */
     name: string;
 
@@ -262,7 +262,7 @@ export class BitmapFont {
         const response = await fetch(url);
 
         if (!response.ok) {
-            throw new Error(BitmapFont.buildFontLoadErrorMessage(url, response.status));
+            throw new Error(BitmapFont.buildLoadErrorMessage(url, response.status));
         }
 
         const { data, glyphEntries } = BitmapFont.parseBtfontFile(url, await response.text());
@@ -276,9 +276,9 @@ export class BitmapFont {
         const atlasHeight = spriteSheet.height;
 
         const { glyphs, asciiGlyphs } = BitmapFont.buildGlyphsFromEntries(glyphEntries, atlasWidth, atlasHeight);
-        const size = BitmapFont.resolvePositiveFontMetric(data.size, 12);
-        const lineHeight = BitmapFont.resolvePositiveFontMetric(data.lineHeight, size);
-        const baseline = BitmapFont.resolvePositiveFontMetric(data.baseline, size);
+        const size = BitmapFont.resolvePositiveMetric(data.size, 12);
+        const lineHeight = BitmapFont.resolvePositiveMetric(data.lineHeight, size);
+        const baseline = BitmapFont.resolvePositiveMetric(data.baseline, size);
 
         return new BitmapFont(spriteSheet, glyphs, asciiGlyphs, data.name || 'Unknown', size, lineHeight, baseline);
     }
@@ -292,7 +292,7 @@ export class BitmapFont {
      * @param fallback - Value used when `value` is missing or invalid.
      * @returns Safe positive metric for {@link BitmapFont} construction.
      */
-    private static resolvePositiveFontMetric(value: unknown, fallback: number): number {
+    private static resolvePositiveMetric(value: unknown, fallback: number): number {
         const parsed = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : Number.NaN;
 
         if (Number.isFinite(parsed) && parsed > 0) {
@@ -312,7 +312,7 @@ export class BitmapFont {
     private static parseBtfontFile(
         url: string,
         jsonText: string,
-    ): { data: FontFileData; glyphEntries: Array<[string, GlyphData]> } {
+    ): { data: FileData; glyphEntries: Array<[string, GlyphData]> } {
         const jsonByteLength = new TextEncoder().encode(jsonText).length;
         const jsonSizeError = validateBtfontJsonByteSize(jsonByteLength);
 
@@ -320,10 +320,10 @@ export class BitmapFont {
             throw new AssetLimitError(jsonSizeError);
         }
 
-        let data: FontFileData;
+        let data: FileData;
 
         try {
-            data = JSON.parse(jsonText) as FontFileData;
+            data = JSON.parse(jsonText) as FileData;
         } catch {
             throw new Error(
                 `The font file '${url}' is broken or not a valid .btfont file. Check that it's the right file.` +
@@ -433,17 +433,17 @@ export class BitmapFont {
      * Loads a texture from either a base64 data URI or a relative path.
      *
      * @param texture - Data URI (starts with "data:") or relative path.
-     * @param fontUrl - URL of the .btfont file (used to resolve relative paths).
+     * @param url - URL of the .btfont file (used to resolve relative paths).
      * @returns Loaded texture image for the font atlas.
      */
-    private static loadTexture(texture: string, fontUrl: string): Promise<HTMLImageElement> {
+    private static loadTexture(texture: string, url: string): Promise<HTMLImageElement> {
         // Embedded PNG data URIs are validated in parseBtfontFile before decode.
         if (texture.toLowerCase().startsWith(BTFONT_EMBEDDED_TEXTURE_PREFIX)) {
             return BitmapFont.loadImage(texture);
         }
 
         // Otherwise, resolve the path relative to the font file.
-        const baseUrl = fontUrl.substring(0, fontUrl.lastIndexOf('/') + 1);
+        const baseUrl = url.substring(0, url.lastIndexOf('/') + 1);
         const textureUrl = baseUrl + texture;
 
         return BitmapFont.loadImage(textureUrl);
@@ -456,7 +456,7 @@ export class BitmapFont {
      * @param status - HTTP status code from fetch.
      * @returns Beginner-friendly message with useful hints.
      */
-    private static buildFontLoadErrorMessage(url: string, status: number): string {
+    private static buildLoadErrorMessage(url: string, status: number): string {
         const statusMessage =
             status === 404
                 ? `Can't find the font file '${url}'. Check that the file exists and the path is spelled correctly.`

--- a/src/assets/Palette.test.ts
+++ b/src/assets/Palette.test.ts
@@ -32,19 +32,19 @@ describe('Palette', () => {
     it('keeps index 0 transparent and rejects opaque writes there', () => {
         const palette = new Palette(16);
 
-        expect(palette.get(0).equals(Color32.transparent)).toBe(true);
+        expect(palette.get(0).isEqual(Color32.transparent)).toBe(true);
         expect(() => palette.set(0, Color32.red)).toThrow(
             'Slot 0 is always see-through (transparent). Put solid colors in slot 1 or higher.',
         );
 
         palette.set(0, new Color32(12, 34, 56, 0));
 
-        expect(palette.get(0).equals(Color32.transparent)).toBe(true);
+        expect(palette.get(0).isEqual(Color32.transparent)).toBe(true);
 
         // get() returns a clone, so mutating the result must not change the stored entry.
         const copy = palette.get(0);
         copy.r = 99;
-        expect(palette.get(0).equals(Color32.transparent)).toBe(true);
+        expect(palette.get(0).isEqual(Color32.transparent)).toBe(true);
     });
 
     it('sets and gets entries within range and throws out of range', () => {
@@ -53,7 +53,7 @@ describe('Palette', () => {
 
         palette.set(5, color);
 
-        expect(palette.get(5).equals(color)).toBe(true);
+        expect(palette.get(5).isEqual(color)).toBe(true);
         expect(palette.get(5)).not.toBe(color);
         expect(() => palette.get(16)).toThrow('The color number 16 is too big');
         expect(() => palette.set(-1, color)).toThrow('0 or higher');
@@ -69,7 +69,7 @@ describe('Palette', () => {
         copy.g = 99;
         copy.b = 99;
 
-        expect(palette.get(3).equals(new Color32(10, 20, 30, 255))).toBe(true);
+        expect(palette.get(3).isEqual(new Color32(10, 20, 30, 255))).toBe(true);
     });
 
     it('supports named indices and named color lookups', () => {
@@ -80,7 +80,7 @@ describe('Palette', () => {
         palette.setNamed('uiAccent', 3);
 
         expect(palette.getNamed('uiAccent')).toBe(3);
-        expect(palette.getNamedColor('uiAccent').equals(color)).toBe(true);
+        expect(palette.getNamedColor('uiAccent').isEqual(color)).toBe(true);
         expect(() => palette.getNamed('missing')).toThrow(
             "There's no color named 'missing' in this palette. Did you call palette.setNamed('missing', someIndex) first?",
         );
@@ -122,7 +122,7 @@ describe('Palette', () => {
 
         target.copyFrom(source);
 
-        expect(target.get(4).equals(source.get(4))).toBe(true);
+        expect(target.get(4).isEqual(source.get(4))).toBe(true);
         expect(target.get(4)).not.toBe(source.get(4));
         expect(target.getNamed('wall')).toBe(4);
     });
@@ -136,9 +136,9 @@ describe('Palette', () => {
         const restored = Palette.fromJSON(palette.toJSON());
 
         expect(restored.size).toBe(16);
-        expect(restored.get(1).equals(new Color32(11, 22, 33, 255))).toBe(true);
+        expect(restored.get(1).isEqual(new Color32(11, 22, 33, 255))).toBe(true);
         expect(restored.getNamed('primary')).toBe(1);
-        expect(restored.get(0).equals(Color32.transparent)).toBe(true);
+        expect(restored.get(0).isEqual(Color32.transparent)).toBe(true);
     });
 
     it('rejects invalid JSON payloads', () => {
@@ -174,9 +174,9 @@ describe('Palette', () => {
         const restored = Palette.fromUint8Array(palette.toUint8Array());
 
         expect(restored.size).toBe(16);
-        expect(restored.get(1).equals(new Color32(1, 2, 3, 255))).toBe(true);
-        expect(restored.get(15).equals(new Color32(250, 251, 252, 255))).toBe(true);
-        expect(restored.get(0).equals(Color32.transparent)).toBe(true);
+        expect(restored.get(1).isEqual(new Color32(1, 2, 3, 255))).toBe(true);
+        expect(restored.get(15).isEqual(new Color32(250, 251, 252, 255))).toBe(true);
+        expect(restored.get(0).isEqual(Color32.transparent)).toBe(true);
     });
 
     it('rejects invalid raw RGB byte payloads', () => {
@@ -204,12 +204,12 @@ describe('Palette', () => {
         target.copyFrom(source);
         smallTarget.copyFrom(source);
 
-        expect(target.get(1).equals(new Color32(10, 20, 30, 255))).toBe(true);
-        expect(target.get(15).equals(new Color32(200, 210, 220, 255))).toBe(true);
-        expect(target.get(16).equals(Color32.transparent)).toBe(true);
+        expect(target.get(1).isEqual(new Color32(10, 20, 30, 255))).toBe(true);
+        expect(target.get(15).isEqual(new Color32(200, 210, 220, 255))).toBe(true);
+        expect(target.get(16).isEqual(Color32.transparent)).toBe(true);
         expect(target.getNamed('last')).toBe(15);
 
-        expect(smallTarget.get(1).equals(new Color32(10, 20, 30, 255))).toBe(true);
+        expect(smallTarget.get(1).isEqual(new Color32(10, 20, 30, 255))).toBe(true);
         expect(() => smallTarget.getNamed('last')).toThrow(
             "There's no color named 'last' in this palette. Did you call palette.setNamed('last', someIndex) first?",
         );
@@ -247,10 +247,10 @@ describe('Palette', () => {
         expect(Palette.pico8().size).toBe(16);
         expect(Palette.nes().size).toBe(64);
         expect(Palette.c64().findColor(Color32.fromHex('#813338'))).toBe(2);
-        expect(Palette.vga().get(0).equals(Color32.transparent)).toBe(true);
-        expect(Palette.gameboy().get(1).equals(Color32.fromHex('#306230'))).toBe(true);
-        expect(Palette.nes().get(1).equals(Color32.fromHex('#0000fc'))).toBe(true);
-        expect(Palette.pico8().get(12).equals(Color32.fromHex('#29adff'))).toBe(true);
+        expect(Palette.vga().get(0).isEqual(Color32.transparent)).toBe(true);
+        expect(Palette.gameboy().get(1).isEqual(Color32.fromHex('#306230'))).toBe(true);
+        expect(Palette.nes().get(1).isEqual(Color32.fromHex('#0000fc'))).toBe(true);
+        expect(Palette.pico8().get(12).isEqual(Color32.fromHex('#29adff'))).toBe(true);
     });
 });
 
@@ -332,12 +332,12 @@ describe('applyHUD', () => {
 
         palette.applyHUD();
 
-        expect(palette.get(1).equals(Color32.fromHex('#ffffff'))).toBe(true);
-        expect(palette.get(2).equals(Color32.fromHex('#1e1428'))).toBe(true);
-        expect(palette.get(3).equals(Color32.fromHex('#c8c8c8'))).toBe(true);
-        expect(palette.get(4).equals(Color32.fromHex('#ffdc64'))).toBe(true);
-        expect(palette.get(5).equals(Color32.fromHex('#646464'))).toBe(true);
-        expect(palette.get(6).equals(Color32.fromHex('#6496c8'))).toBe(true);
+        expect(palette.get(1).isEqual(Color32.fromHex('#ffffff'))).toBe(true);
+        expect(palette.get(2).isEqual(Color32.fromHex('#1e1428'))).toBe(true);
+        expect(palette.get(3).isEqual(Color32.fromHex('#c8c8c8'))).toBe(true);
+        expect(palette.get(4).isEqual(Color32.fromHex('#ffdc64'))).toBe(true);
+        expect(palette.get(5).isEqual(Color32.fromHex('#646464'))).toBe(true);
+        expect(palette.get(6).isEqual(Color32.fromHex('#6496c8'))).toBe(true);
     });
 
     it('fills slots at an explicit non-default startSlot', () => {
@@ -345,10 +345,10 @@ describe('applyHUD', () => {
 
         palette.applyHUD(10);
 
-        expect(palette.get(10).equals(Color32.fromHex('#ffffff'))).toBe(true);
-        expect(palette.get(15).equals(Color32.fromHex('#6496c8'))).toBe(true);
-        expect(palette.get(9).equals(Color32.black)).toBe(true);
-        expect(palette.get(16).equals(Color32.black)).toBe(true);
+        expect(palette.get(10).isEqual(Color32.fromHex('#ffffff'))).toBe(true);
+        expect(palette.get(15).isEqual(Color32.fromHex('#6496c8'))).toBe(true);
+        expect(palette.get(9).isEqual(Color32.black)).toBe(true);
+        expect(palette.get(16).isEqual(Color32.black)).toBe(true);
     });
 
     it('registers named aliases at the correct indices', () => {
@@ -379,7 +379,7 @@ describe('applyHUD', () => {
         palette.set(7, new Color32(1, 2, 3, 255));
         palette.applyHUD(1);
 
-        expect(palette.get(7).equals(new Color32(1, 2, 3, 255))).toBe(true);
+        expect(palette.get(7).isEqual(new Color32(1, 2, 3, 255))).toBe(true);
     });
 
     it('throws when startSlot is 0', () => {

--- a/src/assets/Palette.test.ts
+++ b/src/assets/Palette.test.ts
@@ -260,7 +260,7 @@ describe('Palette', () => {
 
 describe('Palette dirty flag', () => {
     it('starts clean after construction', () => {
-        expect(new Palette(16).dirty).toBe(false);
+        expect(new Palette(16).isDirty).toBe(false);
     });
 
     it('becomes dirty after set()', () => {
@@ -268,7 +268,7 @@ describe('Palette dirty flag', () => {
 
         palette.set(1, new Color32(255, 0, 0, 255));
 
-        expect(palette.dirty).toBe(true);
+        expect(palette.isDirty).toBe(true);
     });
 
     it('clearDirty() resets the flag', () => {
@@ -277,7 +277,7 @@ describe('Palette dirty flag', () => {
         palette.set(1, new Color32(255, 0, 0, 255));
         palette.clearDirty();
 
-        expect(palette.dirty).toBe(false);
+        expect(palette.isDirty).toBe(false);
     });
 
     it('becomes dirty after copyFrom()', () => {
@@ -286,7 +286,7 @@ describe('Palette dirty flag', () => {
 
         dest.copyFrom(src);
 
-        expect(dest.dirty).toBe(true);
+        expect(dest.isDirty).toBe(true);
     });
 
     it('clone() returns a non-dirty palette regardless of source state', () => {
@@ -294,8 +294,8 @@ describe('Palette dirty flag', () => {
 
         palette.set(1, new Color32(255, 0, 0, 255));
 
-        expect(palette.dirty).toBe(true);
-        expect(palette.clone().dirty).toBe(false);
+        expect(palette.isDirty).toBe(true);
+        expect(palette.clone().isDirty).toBe(false);
     });
 
     it('setting index 0 to transparent does not mark dirty', () => {
@@ -303,7 +303,7 @@ describe('Palette dirty flag', () => {
 
         palette.set(0, new Color32(0, 0, 0, 0));
 
-        expect(palette.dirty).toBe(false);
+        expect(palette.isDirty).toBe(false);
     });
 
     it('remains dirty through multiple set() calls until cleared', () => {
@@ -314,11 +314,11 @@ describe('Palette dirty flag', () => {
         palette.set(3, new Color32(0, 0, 255, 255));
         palette.clearDirty();
 
-        expect(palette.dirty).toBe(false);
+        expect(palette.isDirty).toBe(false);
 
         palette.set(4, new Color32(255, 255, 0, 255));
 
-        expect(palette.dirty).toBe(true);
+        expect(palette.isDirty).toBe(true);
     });
 });
 
@@ -434,7 +434,7 @@ describe('applyHUD', () => {
         palette.clearDirty();
         palette.applyHUD(1);
 
-        expect(palette.dirty).toBe(true);
+        expect(palette.isDirty).toBe(true);
     });
 });
 

--- a/src/assets/Palette.ts
+++ b/src/assets/Palette.ts
@@ -612,7 +612,7 @@ export class Palette {
      */
     public findColor(color: Color32): number {
         for (let i = 0; i < this.size; i++) {
-            if (this.colorAt(i).equals(color)) {
+            if (this.colorAt(i).isEqual(color)) {
                 return i;
             }
         }

--- a/src/assets/Palette.ts
+++ b/src/assets/Palette.ts
@@ -17,10 +17,10 @@ import { HUD_SLOTS } from './palettes/hudData';
 import { C64_HEX, CGA_HEX, GAMEBOY_HEX, NES_HEX, PICO8_HEX, VGA_HEX } from './palettes/presetData';
 
 /** Supported palette sizes exposed by the public API. */
-const VALID_PALETTE_SIZES = [2, 4, 16, 32, 64, 128, 256] as const;
+const VALID_SIZES = [2, 4, 16, 32, 64, 128, 256] as const;
 
 /** Uniform-buffer slot count used by the renderer regardless of active palette size. */
-const GPU_PALETTE_SIZE = 256;
+const GPU_SIZE = 256;
 
 /** Number of normalized floats stored per palette color in GPU upload buffers. */
 const GPU_FLOATS_PER_COLOR = 4;
@@ -31,7 +31,7 @@ const GPU_FLOATS_PER_COLOR = 4;
  * `colors` stores `#RRGGBBAA` values and `names` maps friendly aliases to
  * palette indices.
  */
-type PaletteJSON = {
+type Serialized = {
     colors: string[];
     names?: Record<string, number>;
     size: number;
@@ -43,8 +43,8 @@ type PaletteJSON = {
  * @param size - Candidate palette size.
  * @returns `true` when the size is supported.
  */
-function isValidPaletteSize(size: number): boolean {
-    return VALID_PALETTE_SIZES.includes(size as (typeof VALID_PALETTE_SIZES)[number]);
+function isValidSize(size: number): boolean {
+    return VALID_SIZES.includes(size as (typeof VALID_SIZES)[number]);
 }
 
 /**
@@ -53,8 +53,8 @@ function isValidPaletteSize(size: number): boolean {
  * @param size - Palette size to validate.
  * @throws Error if the size is not one of the supported indexed formats.
  */
-function validatePaletteSize(size: number): void {
-    if (!isValidPaletteSize(size)) {
+function validateSize(size: number): void {
+    if (!isValidSize(size)) {
         throw new Error(`A palette can hold 2, 4, 16, 32, 64, 128, or 256 colors. Got ${size}.`);
     }
 }
@@ -150,7 +150,7 @@ export class Palette {
      *
      * Set by {@link set} and {@link copyFrom}. Cleared by {@link clearDirty} after
      * the renderer has uploaded the updated palette uniform buffer. Not set by the
-     * constructor - initial upload is always triggered by {@link Renderer.setPalette}.
+     * constructor - initial upload is always triggered by {@link IRenderer.setPalette}.
      */
     private _isDirty: boolean = false;
 
@@ -159,8 +159,8 @@ export class Palette {
      *
      * @param size - Palette size. Must be one of `2, 4, 16, 32, 64, 128, 256`.
      */
-    constructor(size: number = GPU_PALETTE_SIZE) {
-        validatePaletteSize(size);
+    constructor(size: number = GPU_SIZE) {
+        validateSize(size);
 
         this.size = size;
         this.colors = new Array<Color32>(size);
@@ -180,7 +180,7 @@ export class Palette {
      * @throws Error if the payload shape or size is invalid.
      */
     public static fromJSON(data: object): Palette {
-        const json = data as Partial<PaletteJSON>;
+        const json = data as Partial<Serialized>;
         const { colors, names, size } = json;
 
         if (!Array.isArray(colors) || typeof size !== 'number') {
@@ -223,7 +223,7 @@ export class Palette {
         const inferredSize = data.length / 3;
         const resolvedSize = size ?? inferredSize;
 
-        validatePaletteSize(resolvedSize);
+        validateSize(resolvedSize);
 
         if (data.length !== resolvedSize * 3) {
             throw new Error(`Palette byte array length ${data.length} does not match palette size ${resolvedSize}`);
@@ -452,7 +452,7 @@ export class Palette {
      * Creates a deep copy of the palette, including named indices.
      *
      * The returned clone starts with a clean dirty flag regardless of the source
-     * palette's state. When passed to {@link Renderer.setPalette}, the renderer's
+     * palette's state. When passed to {@link IRenderer.setPalette}, the renderer's
      * own dirty flag ensures the first upload.
      *
      * @returns Independent palette clone.
@@ -520,7 +520,7 @@ export class Palette {
      * Clears the dirty flag after the renderer has uploaded the palette to the GPU.
      *
      * Do not call this from application code. It is part of the internal renderer
-     * contract between {@link Palette} and {@link Renderer}.
+     * contract between {@link Palette} and {@link IRenderer}.
      */
     public clearDirty(): void {
         this._isDirty = false;
@@ -542,7 +542,7 @@ export class Palette {
      *
      * @returns Plain object containing size, colors, and optional names.
      */
-    public toJSON(): PaletteJSON {
+    public toJSON(): Serialized {
         return {
             colors: this.colors.map((color) => color.toHex()),
             names: Object.fromEntries(this.namedIndices.entries()),
@@ -583,7 +583,7 @@ export class Palette {
      * @returns Float buffer containing normalized RGBA values.
      */
     public toFloat32Array(): Float32Array {
-        const floats = new Float32Array(GPU_PALETTE_SIZE * GPU_FLOATS_PER_COLOR);
+        const floats = new Float32Array(GPU_SIZE * GPU_FLOATS_PER_COLOR);
 
         this.toFloat32ArrayInto(floats);
 

--- a/src/assets/Palette.ts
+++ b/src/assets/Palette.ts
@@ -152,7 +152,7 @@ export class Palette {
      * the renderer has uploaded the updated palette uniform buffer. Not set by the
      * constructor - initial upload is always triggered by {@link Renderer.setPalette}.
      */
-    private _dirty: boolean = false;
+    private _isDirty: boolean = false;
 
     /**
      * Creates a new palette with the requested indexed size.
@@ -365,7 +365,7 @@ export class Palette {
 
         // eslint-disable-next-line security/detect-object-injection -- Index range is validated by assertIndexInRange above
         this.colors[index] = color.clone();
-        this._dirty = true;
+        this._isDirty = true;
     }
 
     /**
@@ -499,7 +499,7 @@ export class Palette {
             }
         }
 
-        this._dirty = true;
+        this._isDirty = true;
     }
 
     /**
@@ -512,8 +512,8 @@ export class Palette {
      * @returns `true` if any color has been written via {@link set} or {@link copyFrom}
      *   since the last call to {@link clearDirty}.
      */
-    public get dirty(): boolean {
-        return this._dirty;
+    public get isDirty(): boolean {
+        return this._isDirty;
     }
 
     /**
@@ -523,7 +523,7 @@ export class Palette {
      * contract between {@link Palette} and {@link Renderer}.
      */
     public clearDirty(): void {
-        this._dirty = false;
+        this._isDirty = false;
     }
 
     /**
@@ -534,7 +534,7 @@ export class Palette {
      * only needed when bypassing them for performance.
      */
     public markDirty(): void {
-        this._dirty = true;
+        this._isDirty = true;
     }
 
     /**

--- a/src/assets/PaletteEffect.test.ts
+++ b/src/assets/PaletteEffect.test.ts
@@ -109,7 +109,7 @@ describe('PaletteEffectManager', () => {
         clock.advance(16);
         manager.update(palette);
 
-        expect(palette.dirty).toBe(true);
+        expect(palette.isDirty).toBe(true);
     });
 
     it('skips first-frame delta (delta is 0 on first call)', () => {
@@ -536,7 +536,7 @@ describe('paletteSwap', () => {
         palette.clearDirty();
         paletteSwap(palette, 1, 2);
 
-        expect(palette.dirty).toBe(true);
+        expect(palette.isDirty).toBe(true);
     });
 
     it('is a no-op when indices are the same', () => {
@@ -547,7 +547,7 @@ describe('paletteSwap', () => {
         paletteSwap(palette, 5, 5);
 
         expect(palette.getRef(5).equals(original)).toBe(true);
-        expect(palette.dirty).toBe(false);
+        expect(palette.isDirty).toBe(false);
     });
 });
 

--- a/src/assets/PaletteEffect.test.ts
+++ b/src/assets/PaletteEffect.test.ts
@@ -203,9 +203,9 @@ describe('CycleEffect', () => {
         effect.update(palette, 1000);
 
         // Forward rotation: [1,2,3] -> [2,3,1]
-        expect(palette.getRef(1).equals(original2)).toBe(true);
-        expect(palette.getRef(2).equals(original3)).toBe(true);
-        expect(palette.getRef(3).equals(original1)).toBe(true);
+        expect(palette.getRef(1).isEqual(original2)).toBe(true);
+        expect(palette.getRef(2).isEqual(original3)).toBe(true);
+        expect(palette.getRef(3).isEqual(original1)).toBe(true);
     });
 
     it('rotates entries backward with negative speed', () => {
@@ -218,9 +218,9 @@ describe('CycleEffect', () => {
         effect.update(palette, 1000);
 
         // Backward rotation: [1,2,3] -> [3,1,2]
-        expect(palette.getRef(1).equals(original3)).toBe(true);
-        expect(palette.getRef(2).equals(original1)).toBe(true);
-        expect(palette.getRef(3).equals(original2)).toBe(true);
+        expect(palette.getRef(1).isEqual(original3)).toBe(true);
+        expect(palette.getRef(2).isEqual(original1)).toBe(true);
+        expect(palette.getRef(3).isEqual(original2)).toBe(true);
     });
 
     it('uses fractional accumulator for sub-frame precision', () => {
@@ -231,13 +231,13 @@ describe('CycleEffect', () => {
         // 400ms = 0.8 steps -> no rotation yet.
         effect.update(palette, 400);
 
-        expect(palette.getRef(1).equals(original1)).toBe(true);
+        expect(palette.getRef(1).isEqual(original1)).toBe(true);
 
         // 200ms more = 1.2 steps total -> 1 rotation.
         effect.update(palette, 200);
 
         // Should have rotated once.
-        expect(palette.getRef(1).equals(original1)).toBe(false);
+        expect(palette.getRef(1).isEqual(original1)).toBe(false);
     });
 
     it('handles multiple rotations in a single frame', () => {
@@ -250,9 +250,9 @@ describe('CycleEffect', () => {
         // 3 seconds = 3 full rotations of 3 entries -> back to original.
         effect.update(palette, 3000);
 
-        expect(palette.getRef(1).equals(original1)).toBe(true);
-        expect(palette.getRef(2).equals(original2)).toBe(true);
-        expect(palette.getRef(3).equals(original3)).toBe(true);
+        expect(palette.getRef(1).isEqual(original1)).toBe(true);
+        expect(palette.getRef(2).isEqual(original2)).toBe(true);
+        expect(palette.getRef(3).isEqual(original3)).toBe(true);
     });
 
     it('runs indefinitely (always returns true)', () => {
@@ -271,7 +271,7 @@ describe('CycleEffect', () => {
 
         effect.update(palette, 1000);
 
-        expect(palette.getRef(1).equals(original1)).toBe(true);
+        expect(palette.getRef(1).isEqual(original1)).toBe(true);
     });
 
     it('does nothing when start >= end', () => {
@@ -281,7 +281,7 @@ describe('CycleEffect', () => {
 
         effect.update(palette, 1000);
 
-        expect(palette.getRef(5).equals(original5)).toBe(true);
+        expect(palette.getRef(5).isEqual(original5)).toBe(true);
     });
 });
 
@@ -412,7 +412,7 @@ describe('FadeRangeEffect', () => {
         effect.update(source, 1000);
 
         // Index 1 should be unchanged (outside range).
-        expect(source.getRef(1).equals(originalOutside)).toBe(true);
+        expect(source.getRef(1).isEqual(originalOutside)).toBe(true);
 
         // Index 5 should be at target.
         expect(source.getRef(5).r).toBe(255);
@@ -499,7 +499,7 @@ describe('FlashEffect', () => {
             const original = originalColors[i];
 
             if (original) {
-                expect(palette.getRef(i).equals(original)).toBe(true);
+                expect(palette.getRef(i).isEqual(original)).toBe(true);
             }
         }
     });
@@ -526,8 +526,8 @@ describe('paletteSwap', () => {
 
         paletteSwap(palette, 3, 7);
 
-        expect(palette.getRef(3).equals(color7)).toBe(true);
-        expect(palette.getRef(7).equals(color3)).toBe(true);
+        expect(palette.getRef(3).isEqual(color7)).toBe(true);
+        expect(palette.getRef(7).isEqual(color3)).toBe(true);
     });
 
     it('marks palette dirty', () => {
@@ -546,7 +546,7 @@ describe('paletteSwap', () => {
         palette.clearDirty();
         paletteSwap(palette, 5, 5);
 
-        expect(palette.getRef(5).equals(original)).toBe(true);
+        expect(palette.getRef(5).isEqual(original)).toBe(true);
         expect(palette.isDirty).toBe(false);
     });
 });

--- a/src/assets/PaletteEffect.ts
+++ b/src/assets/PaletteEffect.ts
@@ -230,31 +230,31 @@ export class FadeEffect implements PaletteEffect {
     /**
      * Creates a full-palette fade effect.
      *
-     * @param sourcePalette - Snapshot of the starting palette (cloned internally).
-     * @param targetPalette - Target palette to fade toward.
+     * @param source - Snapshot of the starting palette (cloned internally).
+     * @param target - Target palette to fade toward.
      * @param durationMs - Fade duration in milliseconds.
      * @param easing - Easing curve to apply. Defaults to `'linear'`.
      */
     constructor(
-        sourcePalette: Palette,
-        targetPalette: Palette,
+        source: Palette,
+        target: Palette,
         private readonly durationMs: number,
         private readonly easing: EasingFunction = 'linear',
     ) {
-        this.size = sourcePalette.size;
+        this.size = source.size;
 
         // Snapshot source colors once (one-time allocation).
         this.snapshotColors = [];
 
         for (let i = 0; i < this.size; i++) {
-            this.snapshotColors.push(sourcePalette.get(i));
+            this.snapshotColors.push(source.get(i));
         }
 
         // Cache target colors to avoid repeated cloning.
         this.targetColors = [];
 
-        for (let i = 0; i < targetPalette.size; i++) {
-            this.targetColors.push(targetPalette.get(i));
+        for (let i = 0; i < target.size; i++) {
+            this.targetColors.push(target.get(i));
         }
     }
 
@@ -308,16 +308,16 @@ export class FadeRangeEffect implements PaletteEffect {
      *
      * @param start - First palette index to fade (inclusive).
      * @param end - Last palette index to fade (inclusive).
-     * @param sourcePalette - Snapshot of the starting palette (cloned internally).
-     * @param targetPalette - Target palette to fade toward.
+     * @param source - Snapshot of the starting palette (cloned internally).
+     * @param target - Target palette to fade toward.
      * @param durationMs - Fade duration in milliseconds.
      * @param easing - Easing curve to apply. Defaults to `'linear'`.
      */
     constructor(
         private readonly start: number,
         private readonly end: number,
-        sourcePalette: Palette,
-        targetPalette: Palette,
+        source: Palette,
+        target: Palette,
         private readonly durationMs: number,
         private readonly easing: EasingFunction = 'linear',
     ) {
@@ -325,13 +325,13 @@ export class FadeRangeEffect implements PaletteEffect {
         this.snapshotColors = [];
 
         for (let i = start; i <= end; i++) {
-            this.snapshotColors.push(sourcePalette.get(i));
+            this.snapshotColors.push(source.get(i));
         }
 
         this.targetColors = [];
 
         for (let i = start; i <= end; i++) {
-            this.targetColors.push(targetPalette.get(i));
+            this.targetColors.push(target.get(i));
         }
     }
 

--- a/src/assets/SpriteSheet.bench.ts
+++ b/src/assets/SpriteSheet.bench.ts
@@ -2,7 +2,7 @@
 
 import { bench, describe } from 'vitest';
 
-import { resetRenderPaletteUsage } from '../core/RenderPaletteUsage';
+import { resetUsage } from '../core/RenderPaletteUsage';
 import { Rect2i } from '../utils/Rect2i';
 import { SpriteSheet } from './SpriteSheet';
 
@@ -55,7 +55,7 @@ describe('SpriteSheet.markPaletteIndicesInRect', () => {
     bench(
         'glyph rect (8x8)',
         () => {
-            resetRenderPaletteUsage(usageMask);
+            resetUsage(usageMask);
             glyphSheet.markPaletteIndicesInRect(GLYPH_RECT, 0, usageMask);
         },
         BENCH_OPTIONS,
@@ -64,7 +64,7 @@ describe('SpriteSheet.markPaletteIndicesInRect', () => {
     bench(
         'sprite rect (64x64)',
         () => {
-            resetRenderPaletteUsage(usageMask);
+            resetUsage(usageMask);
             spriteSheet.markPaletteIndicesInRect(SPRITE_RECT, 0, usageMask);
         },
         BENCH_OPTIONS,

--- a/src/assets/SpriteSheet.test.ts
+++ b/src/assets/SpriteSheet.test.ts
@@ -17,7 +17,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { createMockGPUDevice } from '../__test__/webgpu-mock';
-import { collectUsedRenderPaletteIndices, resetRenderPaletteUsage } from '../core/RenderPaletteUsage';
+import { collectUsedIndices, resetUsage } from '../core/RenderPaletteUsage';
 import { AssetLimitError, MAX_ASSET_DIMENSION, MAX_ASSET_PIXELS } from '../utils/AssetLimits';
 import { Color32 } from '../utils/Color32';
 import { Rect2i } from '../utils/Rect2i';
@@ -735,7 +735,7 @@ describe('SpriteSheet', () => {
 
             sheet.markPaletteIndicesInRect(new Rect2i(0, 0, 4, 4), 0, mask);
 
-            expect(collectUsedRenderPaletteIndices(mask, 16, scratch)).toEqual([1, 2, 3]);
+            expect(collectUsedIndices(mask, 16, scratch)).toEqual([1, 2, 3]);
         });
 
         it('applies palette offset when marking resolved slots', () => {
@@ -746,7 +746,7 @@ describe('SpriteSheet', () => {
 
             sheet.markPaletteIndicesInRect(new Rect2i(0, 0, 2, 2), 4, mask);
 
-            expect(collectUsedRenderPaletteIndices(mask, 16, scratch)).toEqual([5, 6]);
+            expect(collectUsedIndices(mask, 16, scratch)).toEqual([5, 6]);
         });
 
         it('ignores transparent sheet pixels and leaves the mask unchanged when none are used', () => {
@@ -757,7 +757,7 @@ describe('SpriteSheet', () => {
 
             sheet.markPaletteIndicesInRect(new Rect2i(0, 0, 2, 2), 0, mask);
 
-            expect(collectUsedRenderPaletteIndices(mask, 16, scratch)).toEqual([]);
+            expect(collectUsedIndices(mask, 16, scratch)).toEqual([]);
         });
 
         it('is a no-op when the sheet is not indexized', () => {
@@ -765,10 +765,10 @@ describe('SpriteSheet', () => {
             const mask = new Uint8Array(16);
             const scratch: number[] = [];
 
-            resetRenderPaletteUsage(mask);
+            resetUsage(mask);
             sheet.markPaletteIndicesInRect(new Rect2i(0, 0, 16, 16), 0, mask);
 
-            expect(collectUsedRenderPaletteIndices(mask, 16, scratch)).toEqual([]);
+            expect(collectUsedIndices(mask, 16, scratch)).toEqual([]);
         });
     });
 

--- a/src/assets/SpriteSheet.test.ts
+++ b/src/assets/SpriteSheet.test.ts
@@ -410,7 +410,7 @@ describe('SpriteSheet', () => {
             expect(loadOrder).toBeLessThan(indexizeOrder);
             expect(result.sheet).toBe(sheet);
             expect(result.colors).toBe(colors);
-            expect(result.srcRect.equals(new Rect2i(0, 0, 12, 8))).toBe(true);
+            expect(result.srcRect.isEqual(new Rect2i(0, 0, 12, 8))).toBe(true);
         });
 
         it('forwards sort option to color registration', async () => {
@@ -585,9 +585,9 @@ describe('SpriteSheet', () => {
             );
 
             const after = [13, 14, 15].map((i) => palette.get(i));
-            expect(after[0]?.equals(before[0] as Color32)).toBe(true);
-            expect(after[1]?.equals(before[1] as Color32)).toBe(true);
-            expect(after[2]?.equals(before[2] as Color32)).toBe(true);
+            expect(after[0]?.isEqual(before[0] as Color32)).toBe(true);
+            expect(after[1]?.isEqual(before[1] as Color32)).toBe(true);
+            expect(after[2]?.isEqual(before[2] as Color32)).toBe(true);
         });
     });
 

--- a/src/assets/SpriteSheet.test.ts
+++ b/src/assets/SpriteSheet.test.ts
@@ -175,10 +175,10 @@ describe('SpriteSheet', () => {
 
     // #region Indexization
 
-    describe('isIndexized', () => {
+    describe('isIndexed', () => {
         it('returns false before indexize is called', () => {
             const sheet = new SpriteSheet(mockImage);
-            expect(sheet.isIndexized()).toBe(false);
+            expect(sheet.isIndexed()).toBe(false);
         });
     });
 
@@ -188,14 +188,14 @@ describe('SpriteSheet', () => {
             vi.unstubAllGlobals();
         });
 
-        it('sets isIndexized to true after conversion', () => {
+        it('sets isIndexed to true after conversion', () => {
             // Default stub from setup.ts returns all-zero pixels (all transparent).
             const palette = new Palette(16);
             const sheet = new SpriteSheet(mockImage);
 
             sheet.indexize(palette);
 
-            expect(sheet.isIndexized()).toBe(true);
+            expect(sheet.isIndexed()).toBe(true);
         });
 
         it('maps transparent pixels (alpha=0) to palette index 0', () => {
@@ -204,7 +204,7 @@ describe('SpriteSheet', () => {
             const sheet = new SpriteSheet({ width: 2, height: 2 } as HTMLImageElement);
 
             expect(() => sheet.indexize(palette)).not.toThrow();
-            expect(sheet.isIndexized()).toBe(true);
+            expect(sheet.isIndexed()).toBe(true);
         });
 
         it('maps opaque pixels to the matching palette index', () => {
@@ -221,7 +221,7 @@ describe('SpriteSheet', () => {
             const sheet = new SpriteSheet({ width: w, height: h } as HTMLImageElement);
             sheet.indexize(palette);
 
-            expect(sheet.isIndexized()).toBe(true);
+            expect(sheet.isIndexed()).toBe(true);
         });
 
         it('throws when an opaque pixel color is not in the palette', () => {
@@ -608,7 +608,7 @@ describe('SpriteSheet', () => {
             const pixels = new Uint8Array(8 * 8) as Uint8Array<ArrayBuffer>;
             const sheet = SpriteSheet.fromIndexedPixels(8, 8, pixels);
 
-            expect(sheet.isIndexized()).toBe(true);
+            expect(sheet.isIndexed()).toBe(true);
         });
 
         it('throws on indexize (no source image)', () => {

--- a/src/assets/SpriteSheet.ts
+++ b/src/assets/SpriteSheet.ts
@@ -1,5 +1,5 @@
-import { markRenderPaletteIndexUsed } from '../core/RenderPaletteUsage';
-import { assertAssetDimensions, assertImageElementWithinLimits, assertIndexedPixelInput } from '../utils/AssetLimits';
+import { markIndexUsed } from '../core/RenderPaletteUsage';
+import { assertDimensions, assertImageElementWithinLimits, assertIndexedPixelInput } from '../utils/AssetLimits';
 import { Color32 } from '../utils/Color32';
 import { spriteColorNotInPaletteError } from '../utils/errorMessages';
 import { Rect2i } from '../utils/Rect2i';
@@ -8,7 +8,7 @@ import { AssetLoader } from './AssetLoader';
 import type { Palette } from './Palette';
 
 /** Reused per-call bitmask of sheet indices seen while scanning a source rect. */
-const markPaletteIndicesInRectScratch = new Uint8Array(256);
+const markIndicesInRectScratch = new Uint8Array(256);
 
 /**
  * Result object returned by {@link SpriteSheet.loadIndexed}.
@@ -76,7 +76,7 @@ export class SpriteSheet {
             assertImageElementWithinLimits('sprite sheet', image);
             this.size = new Vector2i(image.width, image.height);
         } else if (size) {
-            assertAssetDimensions('sprite sheet', size.x, size.y);
+            assertDimensions('sprite sheet', size.x, size.y);
             this.size = size;
         } else {
             throw new Error('Either an image or explicit size must be provided.');
@@ -519,7 +519,7 @@ export class SpriteSheet {
         const startY = Math.max(0, srcRect.y);
         const endX = Math.min(this.size.x, srcRect.x + srcRect.width);
         const endY = Math.min(this.size.y, srcRect.y + srcRect.height);
-        const seenSheetIndices = markPaletteIndicesInRectScratch;
+        const seenSheetIndices = markIndicesInRectScratch;
 
         seenSheetIndices.fill(0);
 
@@ -541,7 +541,7 @@ export class SpriteSheet {
                 // eslint-disable-next-line security/detect-object-injection -- sheet indices are 0-255
                 seenSheetIndices[sheetIndex] = 1;
 
-                markRenderPaletteIndexUsed(usedMask, sheetIndex + paletteOffset);
+                markIndexUsed(usedMask, sheetIndex + paletteOffset);
             }
         }
     }
@@ -675,7 +675,7 @@ export class SpriteSheet {
             throw new Error('createTexture: no source image available.');
         }
 
-        assertAssetDimensions('sprite sheet texture', this.size.x, this.size.y);
+        assertDimensions('sprite sheet texture', this.size.x, this.size.y);
         this.texture = device.createTexture({
             label: 'Sprite Sheet Texture',
             size: [this.size.x, this.size.y, 1],
@@ -704,7 +704,7 @@ export class SpriteSheet {
      * @param device - WebGPU device for texture creation.
      */
     private createIndexedTexture(device: GPUDevice): void {
-        assertAssetDimensions('sprite sheet texture', this.size.x, this.size.y);
+        assertDimensions('sprite sheet texture', this.size.x, this.size.y);
         this.texture = device.createTexture({
             label: 'Sprite Sheet Indexed Texture',
             size: [this.size.x, this.size.y, 1],

--- a/src/assets/SpriteSheet.ts
+++ b/src/assets/SpriteSheet.ts
@@ -482,6 +482,16 @@ export class SpriteSheet {
     }
 
     /**
+     * Backward-compatible alias for {@link isIndexed}.
+     *
+     * @deprecated Deprecated since 2026-05-31. Use {@link isIndexed} instead.
+     * @returns True if `indexize()` has been called successfully.
+     */
+    isIndexized(): boolean {
+        return this.isIndexed();
+    }
+
+    /**
      * Returns a copy of the palette-indexed pixel buffer.
      *
      * @returns Indexed pixels as row-major palette indices (1 byte per pixel).

--- a/src/assets/SpriteSheet.ts
+++ b/src/assets/SpriteSheet.ts
@@ -477,7 +477,7 @@ export class SpriteSheet {
      *
      * @returns True if `indexize()` has been called successfully.
      */
-    isIndexized(): boolean {
+    isIndexed(): boolean {
         return this.indexedPixels !== null;
     }
 

--- a/src/assets/SystemFont.test.ts
+++ b/src/assets/SystemFont.test.ts
@@ -145,7 +145,7 @@ describe('system font sprite sheet', () => {
         const font = createSystemFont();
         const sheet = font.getSpriteSheet();
 
-        expect(sheet.isIndexized()).toBe(true);
+        expect(sheet.isIndexed()).toBe(true);
     });
 
     it('sprite sheet has correct atlas dimensions', () => {

--- a/src/core/BTAPI.test.ts
+++ b/src/core/BTAPI.test.ts
@@ -34,7 +34,7 @@ import { OVERLAY_EDGE_MARGIN_PX } from '../overlay/layout/constants';
 import { paletteBandY } from '../overlay/layout/layoutPlan';
 import type { OverlayDrawTarget } from '../overlay/OverlayDrawTarget';
 import {
-    computePaletteGrid,
+    computeGrid,
     DEFAULT_PALETTE_SWATCH_SIZE,
     PALETTE_GRID_PADDING_PX,
     PALETTE_SWATCH_GAP_PX,
@@ -44,7 +44,7 @@ import { Rect2i } from '../utils/Rect2i';
 import { Vector2i } from '../utils/Vector2i';
 import { BTAPI } from './BTAPI';
 import type { IBlitTechDemo, OverlayRow } from './IBlitTechDemo';
-import { collectUsedRenderPaletteIndices } from './RenderPaletteUsage';
+import { collectUsedIndices } from './RenderPaletteUsage';
 
 // #region Helpers
 
@@ -1554,9 +1554,9 @@ describe('BTAPI', () => {
             const maskScratch: number[] = [];
 
             expect(usedMask).toBeDefined();
-            expect(collectUsedRenderPaletteIndices(usedMask as Uint8Array, palette.size, maskScratch)).toEqual([5, 6]);
+            expect(collectUsedIndices(usedMask as Uint8Array, palette.size, maskScratch)).toEqual([5, 6]);
 
-            const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, palette.size, PALETTE_SWATCH_GAP_PX);
+            const grid = computeGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, palette.size, PALETTE_SWATCH_GAP_PX);
             const paletteBandTop = paletteBandY(240, grid.totalHeight);
             const { cols, swatchSize, gap } = grid;
 
@@ -1641,7 +1641,7 @@ describe('BTAPI', () => {
                 .framePaletteUsageMask;
             const scratch: number[] = [];
 
-            expect(collectUsedRenderPaletteIndices(usageMask, 16, scratch)).toEqual([textPaletteIndex]);
+            expect(collectUsedIndices(usageMask, 16, scratch)).toEqual([textPaletteIndex]);
         });
 
         it('drawBitmapText scans glyph rects when palette tracking is enabled', async () => {
@@ -1748,7 +1748,7 @@ describe('BTAPI', () => {
             const usedMask = overlaySpy.mock.calls.at(-1)?.[8] as Uint8Array | undefined;
             const scratch: number[] = [];
 
-            expect(collectUsedRenderPaletteIndices(usedMask as Uint8Array, 16, scratch)).toEqual([7]);
+            expect(collectUsedIndices(usedMask as Uint8Array, 16, scratch)).toEqual([7]);
         });
     });
 

--- a/src/core/BTAPI.test.ts
+++ b/src/core/BTAPI.test.ts
@@ -291,14 +291,14 @@ describe('BTAPI', () => {
         });
 
         it('drawSprite should not throw before init', () => {
-            const mockSheet = { isIndexized: () => true } as unknown as SpriteSheet;
+            const mockSheet = { isIndexed: () => true } as unknown as SpriteSheet;
             expect(() =>
                 BTAPI.instance.drawSprite(mockSheet, new Rect2i(0, 0, 16, 16), new Vector2i(0, 0)),
             ).not.toThrow();
         });
 
         it('drawSprite should throw when sprite sheet is not indexized', () => {
-            const mockSheet = { isIndexized: () => false } as unknown as SpriteSheet;
+            const mockSheet = { isIndexed: () => false } as unknown as SpriteSheet;
             expect(() => BTAPI.instance.drawSprite(mockSheet, new Rect2i(0, 0, 16, 16), new Vector2i(0, 0))).toThrow(
                 "This sprite sheet hasn't been prepared yet.",
             );
@@ -307,7 +307,7 @@ describe('BTAPI', () => {
         it('drawSprite should register the sheet for spritesRefresh tracking', () => {
             const palette = new Palette(16);
             const reindexize = vi.fn();
-            const mockSheet = { isIndexized: () => true, reindexize } as unknown as SpriteSheet;
+            const mockSheet = { isIndexed: () => true, reindexize } as unknown as SpriteSheet;
 
             BTAPI.instance.setPalette(palette);
             BTAPI.instance.drawSprite(mockSheet, new Rect2i(0, 0, 16, 16), new Vector2i(0, 0));
@@ -317,13 +317,13 @@ describe('BTAPI', () => {
         });
 
         it('drawBitmapText should not throw before init', () => {
-            const mockSheet = { isIndexized: () => true } as unknown as SpriteSheet;
+            const mockSheet = { isIndexed: () => true } as unknown as SpriteSheet;
             const mockFont = { getSpriteSheet: () => mockSheet } as unknown as BitmapFont;
             expect(() => BTAPI.instance.drawBitmapText(mockFont, new Vector2i(0, 0), 'hi')).not.toThrow();
         });
 
         it('drawBitmapText should throw when font sprite sheet is not indexized', () => {
-            const mockSheet = { isIndexized: () => false } as unknown as SpriteSheet;
+            const mockSheet = { isIndexed: () => false } as unknown as SpriteSheet;
             const mockFont = { getSpriteSheet: () => mockSheet } as unknown as BitmapFont;
             expect(() => BTAPI.instance.drawBitmapText(mockFont, new Vector2i(0, 0), 'hi')).toThrow(
                 "This sprite sheet hasn't been prepared yet.",
@@ -333,7 +333,7 @@ describe('BTAPI', () => {
         it('drawBitmapText should register the font sheet for spritesRefresh tracking', () => {
             const palette = new Palette(16);
             const reindexize = vi.fn();
-            const mockSheet = { isIndexized: () => true, reindexize } as unknown as SpriteSheet;
+            const mockSheet = { isIndexed: () => true, reindexize } as unknown as SpriteSheet;
             const mockFont = { getSpriteSheet: () => mockSheet } as unknown as BitmapFont;
 
             BTAPI.instance.setPalette(palette);
@@ -1358,7 +1358,7 @@ describe('BTAPI', () => {
 
         function makeIndexizedSpriteSheet(markSpy: ReturnType<typeof vi.fn>): SpriteSheet {
             return {
-                isIndexized: () => true,
+                isIndexed: () => true,
                 markPaletteIndicesInRect: markSpy,
             } as unknown as SpriteSheet;
         }

--- a/src/core/BTAPI.test.ts
+++ b/src/core/BTAPI.test.ts
@@ -1475,8 +1475,8 @@ describe('BTAPI', () => {
 
             const overlay = getOverlay();
             expect(overlay).not.toBeNull();
-            expect(overlay?.bodyVisible).toBe(false);
             expect(overlay?.tracksPaletteUsage).toBe(false);
+            expect(overlay?.isBodyVisible).toBe(false);
 
             BTAPI.instance.drawSprite(mockSheet, new Rect2i(0, 0, 16, 16), new Vector2i(0, 0));
 
@@ -1730,7 +1730,7 @@ describe('BTAPI', () => {
 
             const overlay = getOverlay();
             expect(overlay).not.toBeNull();
-            expect(overlay?.bodyVisible).toBe(true);
+            expect(overlay?.isBodyVisible).toBe(true);
 
             drainRafUntilRenderCount(1);
 

--- a/src/core/BTAPI.test.ts
+++ b/src/core/BTAPI.test.ts
@@ -845,7 +845,7 @@ describe('BTAPI', () => {
                     displaySize: new Vector2i(320, 240),
                     drawingBufferSize: new Vector2i(640, 480),
                     targetFPS: 60,
-                    overlayVisibleAtStart: true,
+                    isOverlayVisibleAtStart: true,
                 }),
                 overlayRows: vi.fn().mockReturnValue(customRows),
             };
@@ -1156,7 +1156,7 @@ describe('BTAPI', () => {
                 configure: () => ({
                     displaySize: new Vector2i(320, 240),
                     targetFPS: 60,
-                    overlayTimingChart: true,
+                    isOverlayTimingChartEnabled: true,
                 }),
                 init: vi.fn().mockResolvedValue(true),
                 update: vi.fn(),
@@ -1169,14 +1169,14 @@ describe('BTAPI', () => {
             expect(assignSpy).toHaveBeenCalledWith('Checkpoint', expect.any(Number));
         });
 
-        it('does not store tags when overlayTimingChart is disabled', async () => {
+        it('does not store tags when isOverlayTimingChartEnabled is disabled', async () => {
             const { TimingChart } = await import('../overlay/timing-chart/TimingChart');
             const assignSpy = vi.spyOn(TimingChart.prototype, 'assignTag');
             const demo: IBlitTechDemo = {
                 configure: () => ({
                     displaySize: new Vector2i(320, 240),
                     targetFPS: 60,
-                    overlayTimingChart: false,
+                    isOverlayTimingChartEnabled: false,
                 }),
                 init: vi.fn().mockResolvedValue(true),
                 update: vi.fn(),
@@ -1245,7 +1245,7 @@ describe('BTAPI', () => {
             return overlaySpy;
         }
 
-        it('calls getFrameDiagnostics when overlayTimingChart is enabled', async () => {
+        it('calls getFrameDiagnostics when isOverlayTimingChartEnabled is enabled', async () => {
             const diagnosticsSpy = vi.spyOn(
                 (await import('../render/WebGpuRenderer')).WebGpuRenderer.prototype,
                 'getFrameDiagnostics',
@@ -1254,7 +1254,7 @@ describe('BTAPI', () => {
                 configure: () => ({
                     displaySize: new Vector2i(320, 240),
                     targetFPS: 60,
-                    overlayTimingChart: true,
+                    isOverlayTimingChartEnabled: true,
                 }),
                 init: vi.fn().mockResolvedValue(true),
                 update: vi.fn(),
@@ -1266,7 +1266,7 @@ describe('BTAPI', () => {
             expect(diagnosticsSpy).toHaveBeenCalled();
         });
 
-        it('does not call getFrameDiagnostics when overlayTimingChart is disabled', async () => {
+        it('does not call getFrameDiagnostics when isOverlayTimingChartEnabled is disabled', async () => {
             const diagnosticsSpy = vi.spyOn(
                 (await import('../render/WebGpuRenderer')).WebGpuRenderer.prototype,
                 'getFrameDiagnostics',
@@ -1275,8 +1275,8 @@ describe('BTAPI', () => {
                 configure: () => ({
                     displaySize: new Vector2i(320, 240),
                     targetFPS: 60,
-                    overlayTimingChart: false,
-                    overlayRendererDiagnosticsBar: false,
+                    isOverlayTimingChartEnabled: false,
+                    isOverlayRendererDiagnosticsBarEnabled: false,
                 }),
                 init: vi.fn().mockResolvedValue(true),
                 update: vi.fn(),
@@ -1288,7 +1288,7 @@ describe('BTAPI', () => {
             expect(diagnosticsSpy).not.toHaveBeenCalled();
         });
 
-        it('calls getFrameDiagnostics when overlayRendererDiagnosticsBar is enabled without chart', async () => {
+        it('calls getFrameDiagnostics when isOverlayRendererDiagnosticsBarEnabled is enabled without chart', async () => {
             const diagnosticsSpy = vi.spyOn(
                 (await import('../render/WebGpuRenderer')).WebGpuRenderer.prototype,
                 'getFrameDiagnostics',
@@ -1297,8 +1297,8 @@ describe('BTAPI', () => {
                 configure: () => ({
                     displaySize: new Vector2i(320, 240),
                     targetFPS: 60,
-                    overlayTimingChart: false,
-                    overlayRendererDiagnosticsBar: true,
+                    isOverlayTimingChartEnabled: false,
+                    isOverlayRendererDiagnosticsBarEnabled: true,
                 }),
                 init: vi.fn().mockResolvedValue(true),
                 update: vi.fn(),
@@ -1327,7 +1327,7 @@ describe('BTAPI', () => {
                 configure: () => ({
                     displaySize: new Vector2i(320, 240),
                     targetFPS: 60,
-                    overlayTimingChart: true,
+                    isOverlayTimingChartEnabled: true,
                 }),
                 init: vi.fn().mockResolvedValue(true),
                 update: vi.fn(),
@@ -1372,7 +1372,7 @@ describe('BTAPI', () => {
             vi.spyOn(renderer as NonNullable<typeof renderer>, 'drawBitmapText').mockImplementation(() => {});
         }
 
-        it('skips sprite and bitmap-text palette scans when overlayPaletteView is false', async () => {
+        it('skips sprite and bitmap-text palette scans when isOverlayPaletteEnabled is false', async () => {
             const markSpy = vi.fn();
             const mockSheet = makeIndexizedSpriteSheet(markSpy);
             const mockFont = { getSpriteSheet: () => mockSheet } as unknown as BitmapFont;
@@ -1380,7 +1380,7 @@ describe('BTAPI', () => {
                 configure: () => ({
                     displaySize: new Vector2i(320, 240),
                     targetFPS: 60,
-                    overlayPaletteView: false,
+                    isOverlayPaletteEnabled: false,
                 }),
                 init: vi.fn().mockResolvedValue(true),
                 update: vi.fn(),
@@ -1397,7 +1397,7 @@ describe('BTAPI', () => {
             expect(markSpy).not.toHaveBeenCalled();
         });
 
-        it('scans sprite and bitmap-text palette usage when overlayPaletteView is true and overlay body is visible', async () => {
+        it('scans sprite and bitmap-text palette usage when isOverlayPaletteEnabled is true and overlay body is visible', async () => {
             const markSpy = vi.fn();
             const mockSheet = makeIndexizedSpriteSheet(markSpy);
             const mockFont = {
@@ -1408,8 +1408,8 @@ describe('BTAPI', () => {
                 configure: () => ({
                     displaySize: new Vector2i(320, 240),
                     targetFPS: 60,
-                    overlayPaletteView: true,
-                    overlayVisibleAtStart: true,
+                    isOverlayPaletteEnabled: true,
+                    isOverlayVisibleAtStart: true,
                 }),
                 init: vi.fn().mockResolvedValue(true),
                 update: vi.fn(),
@@ -1433,7 +1433,7 @@ describe('BTAPI', () => {
                 configure: () => ({
                     displaySize: new Vector2i(320, 240),
                     targetFPS: 60,
-                    overlayPaletteView: true,
+                    isOverlayPaletteEnabled: true,
                 }),
                 init: vi.fn().mockResolvedValue(true),
                 update: vi.fn(),
@@ -1446,8 +1446,8 @@ describe('BTAPI', () => {
 
             const overlay = getOverlay();
             expect(overlay).not.toBeNull();
-            expect(overlay?.bodyVisible).toBe(false);
-            expect(overlay?.tracksPaletteUsage).toBe(false);
+            expect(overlay?.isBodyVisible).toBe(false);
+            expect(overlay?.isTrackingPaletteUsage).toBe(false);
 
             BTAPI.instance.drawSprite(mockSheet, new Rect2i(0, 0, 16, 16), new Vector2i(0, 0));
 
@@ -1461,8 +1461,8 @@ describe('BTAPI', () => {
                 configure: () => ({
                     displaySize: new Vector2i(320, 240),
                     targetFPS: 60,
-                    overlayPaletteView: true,
-                    overlayToggleHintVisible: true,
+                    isOverlayPaletteEnabled: true,
+                    isOverlayToggleHintVisible: true,
                 }),
                 init: vi.fn().mockResolvedValue(true),
                 update: vi.fn(),
@@ -1475,8 +1475,8 @@ describe('BTAPI', () => {
 
             const overlay = getOverlay();
             expect(overlay).not.toBeNull();
-            expect(overlay?.tracksPaletteUsage).toBe(false);
             expect(overlay?.isBodyVisible).toBe(false);
+            expect(overlay?.isTrackingPaletteUsage).toBe(false);
 
             BTAPI.instance.drawSprite(mockSheet, new Rect2i(0, 0, 16, 16), new Vector2i(0, 0));
 
@@ -1501,8 +1501,8 @@ describe('BTAPI', () => {
                 configure: () => ({
                     displaySize: new Vector2i(320, 240),
                     targetFPS: 60,
-                    overlayPaletteView: true,
-                    overlayVisibleAtStart: true,
+                    isOverlayPaletteEnabled: true,
+                    isOverlayVisibleAtStart: true,
                 }),
                 init: vi.fn().mockResolvedValue(true),
                 update: vi.fn(),
@@ -1611,8 +1611,8 @@ describe('BTAPI', () => {
                 configure: () => ({
                     displaySize: new Vector2i(320, 240),
                     targetFPS: 60,
-                    overlayPaletteView: true,
-                    overlayVisibleAtStart: true,
+                    isOverlayPaletteEnabled: true,
+                    isOverlayVisibleAtStart: true,
                 }),
                 init: vi.fn().mockResolvedValue(true),
                 update: vi.fn(),
@@ -1655,8 +1655,8 @@ describe('BTAPI', () => {
                 configure: () => ({
                     displaySize: new Vector2i(320, 240),
                     targetFPS: 60,
-                    overlayPaletteView: true,
-                    overlayVisibleAtStart: true,
+                    isOverlayPaletteEnabled: true,
+                    isOverlayVisibleAtStart: true,
                 }),
                 init: vi.fn().mockResolvedValue(true),
                 update: vi.fn(),
@@ -1717,8 +1717,8 @@ describe('BTAPI', () => {
                 configure: () => ({
                     displaySize: new Vector2i(320, 240),
                     targetFPS: 60,
-                    overlayPaletteView: true,
-                    overlayVisibleAtStart: true,
+                    isOverlayPaletteEnabled: true,
+                    isOverlayVisibleAtStart: true,
                 }),
                 init: vi.fn().mockResolvedValue(true),
                 update: vi.fn(),
@@ -1735,12 +1735,12 @@ describe('BTAPI', () => {
             drainRafUntilRenderCount(1);
 
             overlay?.handleToggle(null, { isKeyPressed: (key: string) => key === 'Backquote' } as never, 1);
-            expect(overlay?.tracksPaletteUsage).toBe(false);
+            expect(overlay?.isTrackingPaletteUsage).toBe(false);
 
             drainRafUntilRenderCount(2);
 
             overlay?.handleToggle(null, { isKeyPressed: (key: string) => key === 'Backquote' } as never, 2);
-            expect(overlay?.tracksPaletteUsage).toBe(true);
+            expect(overlay?.isTrackingPaletteUsage).toBe(true);
 
             overlaySpy.mockClear();
             drainRafUntilRenderCount(3);

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -29,7 +29,7 @@ import {
     spriteNotIndexizedError,
 } from '../utils/errorMessages';
 import type { Rect2i } from '../utils/Rect2i';
-import { RenderDimensionLimitError, validateRenderDimensions } from '../utils/RenderLimits';
+import { RenderDimensionLimitError, validateDimensions } from '../utils/RenderLimits';
 import { Vector2i } from '../utils/Vector2i';
 import type { FrameDropCallback, FrameDropEvent } from './GameLoop';
 import { GameLoop } from './GameLoop';
@@ -40,11 +40,7 @@ import {
     needsOverlayRendererDiagnostics,
     resolveOverlayTimingChartDiagnostics,
 } from './IBlitTechDemo';
-import {
-    markRenderPaletteIndexUsed,
-    RENDER_PALETTE_USAGE_CAPACITY,
-    resetRenderPaletteUsage,
-} from './RenderPaletteUsage';
+import { markIndexUsed, resetUsage, USAGE_CAPACITY } from './RenderPaletteUsage';
 import { initWebGPU } from './WebGPUContext';
 
 /**
@@ -136,7 +132,7 @@ export class BTAPI {
     private pendingDrawCalls = 0;
 
     /** Bitmask of palette indices referenced by demo draw calls this frame. */
-    private readonly framePaletteUsageMask = new Uint8Array(RENDER_PALETTE_USAGE_CAPACITY);
+    private readonly framePaletteUsageMask = new Uint8Array(USAGE_CAPACITY);
 
     /** Reused timing snapshot passed into the overlay each frame. */
     private readonly overlayTiming: {
@@ -413,7 +409,7 @@ export class BTAPI {
 
         this.applyBackendQueryOverride();
 
-        const renderDimensionError = validateRenderDimensions(this.hwSettings);
+        const renderDimensionError = validateDimensions(this.hwSettings);
 
         if (renderDimensionError) {
             console.error(`[BT] ${renderDimensionError}`);
@@ -1414,7 +1410,7 @@ export class BTAPI {
             );
         }
 
-        resetRenderPaletteUsage(this.framePaletteUsageMask);
+        resetUsage(this.framePaletteUsageMask);
     }
 
     /**
@@ -1436,7 +1432,7 @@ export class BTAPI {
             return;
         }
 
-        markRenderPaletteIndexUsed(this.framePaletteUsageMask, index);
+        markIndexUsed(this.framePaletteUsageMask, index);
     }
 
     /**

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -102,7 +102,7 @@ export class BTAPI {
     private activeBackend: Backend | null = null;
 
     /**
-     * Engine overlay; non-null when {@link HardwareSettings.overlayEnabled}
+     * Engine overlay; non-null when {@link HardwareSettings.isOverlayEnabled}
      * is not `false`. Layout is fixed at init; drawn after demo `render()` each frame.
      */
     private overlay: Overlay | null = null;
@@ -177,7 +177,7 @@ export class BTAPI {
     };
 
     /** When true, {@link captureRendererDiagnostics} reads renderer pipeline counters each frame. */
-    private collectRendererDiagnosticsEnabled = false;
+    private isCollectRendererDiagnosticsEnabled = false;
 
     /** Pointer / mouse / touch input subsystem. Created during {@link init}. */
     private pointer: PointerInput | null = null;
@@ -283,13 +283,13 @@ export class BTAPI {
 
         // Start the loop. The GameLoop's double-RAF delay ensures the canvas is
         // fully ready before the first tick.
-        const needsFrameDropCallback =
-            hwSettings.detectDroppedFrames === true || hwSettings.overlayTimingChart === true;
-        const onFrameDrop: FrameDropCallback | undefined = needsFrameDropCallback
-            ? (event) => this.handleFrameDrop(event, hwSettings.detectDroppedFrames === true)
+        const isFrameDropCallbackNeeded =
+            hwSettings.isDetectingDroppedFrames === true || hwSettings.isOverlayTimingChartEnabled === true;
+        const onFrameDrop: FrameDropCallback | undefined = isFrameDropCallbackNeeded
+            ? (event) => this.handleFrameDrop(event, hwSettings.isDetectingDroppedFrames === true)
             : undefined;
 
-        this.collectRendererDiagnosticsEnabled = needsOverlayRendererDiagnostics(hwSettings);
+        this.isCollectRendererDiagnosticsEnabled = needsOverlayRendererDiagnostics(hwSettings);
 
         this.pendingUpdateMs = 0;
         this.pendingUpdateSteps = 0;
@@ -440,7 +440,7 @@ export class BTAPI {
 
         const hw = this.hwSettings;
 
-        if (!hw || hw.overlayEnabled === false || !this.systemFont) {
+        if (!hw || hw.isOverlayEnabled === false || !this.systemFont) {
             return;
         }
 
@@ -458,17 +458,17 @@ export class BTAPI {
             hw.targetFPS,
             this.activeBackend,
             hw.overlayStyle,
-            hw.overlayPaletteView === true,
+            hw.isOverlayPaletteEnabled === true,
             hw.overlayPaletteColumns,
             hw.overlayPaletteRowsVisible,
-            hw.overlayTimingChart === true,
+            hw.isOverlayTimingChartEnabled === true,
             hw.overlayTimingChartStyle,
             hw.overlayTimingChartHeight,
             resolveOverlayTimingChartDiagnostics(hw),
-            hw.overlayRendererDiagnosticsBar === true,
-            hw.overlayVisibleAtStart === true,
-            hw.overlayToggleHintVisible !== false,
-            hw.overlayToggleEnabled !== false,
+            hw.isOverlayRendererDiagnosticsBarEnabled === true,
+            hw.isOverlayVisibleAtStart === true,
+            hw.isOverlayToggleHintVisible !== false,
+            hw.isOverlayToggleEnabled !== false,
         );
     }
 
@@ -833,7 +833,7 @@ export class BTAPI {
         this.assertPaletteIndex(paletteOffset);
         this.requireIndexizedSheet(spriteSheet);
 
-        if (this.renderer && this.shouldTrackFramePaletteUsage()) {
+        if (this.renderer && this.isTrackingFramePaletteUsage()) {
             spriteSheet.markPaletteIndicesInRect(srcRect, paletteOffset, this.framePaletteUsageMask);
         }
 
@@ -1385,7 +1385,7 @@ export class BTAPI {
      * resets pipeline batch state.
      */
     private captureRendererDiagnostics(): void {
-        if (!this.collectRendererDiagnosticsEnabled || !this.renderer) {
+        if (!this.isCollectRendererDiagnosticsEnabled || !this.renderer) {
             return;
         }
 
@@ -1422,8 +1422,8 @@ export class BTAPI {
      *
      * @returns `true` when the overlay palette grid is active and visible.
      */
-    private shouldTrackFramePaletteUsage(): boolean {
-        return this.overlay?.tracksPaletteUsage ?? false;
+    private isTrackingFramePaletteUsage(): boolean {
+        return this.overlay?.isTrackingPaletteUsage ?? false;
     }
 
     /**
@@ -1432,7 +1432,7 @@ export class BTAPI {
      * @param index - Palette index to track.
      */
     private trackPaletteIndexUsed(index: number): void {
-        if (!this.shouldTrackFramePaletteUsage() || !this.renderer) {
+        if (!this.isTrackingFramePaletteUsage() || !this.renderer) {
             return;
         }
 
@@ -1447,7 +1447,7 @@ export class BTAPI {
      * @param paletteOffset - Palette offset applied at draw time.
      */
     private markBitmapTextPaletteUsage(font: BitmapFont, text: string, paletteOffset: number): void {
-        if (!this.shouldTrackFramePaletteUsage()) {
+        if (!this.isTrackingFramePaletteUsage()) {
             return;
         }
 

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -885,7 +885,7 @@ export class BTAPI {
         let refreshed = 0;
 
         for (const sheet of this.spriteSheets) {
-            if (!sheet.isIndexized()) {
+            if (!sheet.isIndexed()) {
                 this.spriteSheets.delete(sheet);
                 continue;
             }
@@ -1341,7 +1341,7 @@ export class BTAPI {
      * @throws If the sprite sheet has not been indexized.
      */
     private requireIndexizedSheet(sheet: SpriteSheet): void {
-        if (!sheet.isIndexized()) {
+        if (!sheet.isIndexed()) {
             throw new Error(spriteNotIndexizedError());
         }
 

--- a/src/core/IBlitTechDemo.test.ts
+++ b/src/core/IBlitTechDemo.test.ts
@@ -9,7 +9,7 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { validateRenderDimensions } from '../utils/RenderLimits';
+import { validateDimensions } from '../utils/RenderLimits';
 import { Vector2i } from '../utils/Vector2i';
 import {
     defaultConfig,
@@ -235,7 +235,7 @@ describe('mergeHardwareSettings', () => {
         });
 
         expect(settings.displaySize).toEqual(new Vector2i(0, 0));
-        expect(validateRenderDimensions(settings)).not.toBeNull();
+        expect(validateDimensions(settings)).not.toBeNull();
     });
 
     it('surfaces null optional vectors via dimension validation in the explicit profile path', () => {
@@ -245,7 +245,7 @@ describe('mergeHardwareSettings', () => {
         });
 
         expect(settings.drawingBufferSize).toEqual(new Vector2i(0, 0));
-        expect(validateRenderDimensions(settings)).not.toBeNull();
+        expect(validateDimensions(settings)).not.toBeNull();
     });
 
     it('surfaces null maxCanvasSize via dimension validation in the explicit profile path', () => {
@@ -255,6 +255,6 @@ describe('mergeHardwareSettings', () => {
         });
 
         expect(settings.maxCanvasSize).toEqual(new Vector2i(0, 0));
-        expect(validateRenderDimensions(settings)).not.toBeNull();
+        expect(validateDimensions(settings)).not.toBeNull();
     });
 });

--- a/src/core/IBlitTechDemo.test.ts
+++ b/src/core/IBlitTechDemo.test.ts
@@ -61,37 +61,37 @@ describe('defaultConfig', () => {
     it('should enable overlay by default', () => {
         const settings = defaultConfig();
 
-        expect(settings.overlayEnabled).toBe(true);
+        expect(settings.isOverlayEnabled).toBe(true);
     });
 
     it('should disable overlay palette view by default', () => {
         const settings = defaultConfig();
 
-        expect(settings.overlayPaletteView).toBe(false);
+        expect(settings.isOverlayPaletteEnabled).toBe(false);
     });
 
     it('should hide overlay body by default', () => {
         const settings = defaultConfig();
 
-        expect(settings.overlayVisibleAtStart).toBe(false);
+        expect(settings.isOverlayVisibleAtStart).toBe(false);
     });
 
     it('should show overlay toggle hint by default', () => {
         const settings = defaultConfig();
 
-        expect(settings.overlayToggleHintVisible).toBe(true);
+        expect(settings.isOverlayToggleHintVisible).toBe(true);
     });
 
     it('should enable overlay toggle input by default', () => {
         const settings = defaultConfig();
 
-        expect(settings.overlayToggleEnabled).toBe(true);
+        expect(settings.isOverlayToggleEnabled).toBe(true);
     });
 
     it('should disable overlay timing chart by default', () => {
         const settings = defaultConfig();
 
-        expect(settings.overlayTimingChart).toBe(false);
+        expect(settings.isOverlayTimingChartEnabled).toBe(false);
     });
 
     it('should return a fresh object on each call', () => {
@@ -121,7 +121,7 @@ describe('mergeHardwareSettings', () => {
         expect(settings.displaySize.x).toBe(320);
         expect(settings.drawingBufferSize?.x).toBe(640);
         expect(settings.targetFPS).toBe(30);
-        expect(settings.overlayPaletteView).toBe(false);
+        expect(settings.isOverlayPaletteEnabled).toBe(false);
     });
 
     it('keeps drawingBufferSize unset when displaySize is provided without output sizing', () => {
@@ -146,14 +146,14 @@ describe('mergeHardwareSettings', () => {
         expect(settings.drawingBufferSize?.x).toBe(640);
         expect(settings.backend).toBe('software');
         expect(settings.targetFPS).toBe(60);
-        expect(settings.overlayEnabled).toBe(true);
-        expect(settings.overlayPaletteView).toBe(false);
+        expect(settings.isOverlayEnabled).toBe(true);
+        expect(settings.isOverlayPaletteEnabled).toBe(false);
     });
 
-    it('honors overlayEnabled: false from configure()', () => {
-        const settings = mergeHardwareSettings({ overlayEnabled: false });
+    it('honors isOverlayEnabled: false from configure()', () => {
+        const settings = mergeHardwareSettings({ isOverlayEnabled: false });
 
-        expect(settings.overlayEnabled).toBe(false);
+        expect(settings.isOverlayEnabled).toBe(false);
     });
 
     it('merges overlayStyle from configure()', () => {
@@ -168,19 +168,19 @@ describe('mergeHardwareSettings', () => {
 
     it('merges overlay visibility and toggle flags from configure()', () => {
         const settings = mergeHardwareSettings({
-            overlayVisibleAtStart: true,
-            overlayToggleHintVisible: false,
-            overlayToggleEnabled: false,
+            isOverlayVisibleAtStart: true,
+            isOverlayToggleHintVisible: false,
+            isOverlayToggleEnabled: false,
         });
 
-        expect(settings.overlayVisibleAtStart).toBe(true);
-        expect(settings.overlayToggleHintVisible).toBe(false);
-        expect(settings.overlayToggleEnabled).toBe(false);
+        expect(settings.isOverlayVisibleAtStart).toBe(true);
+        expect(settings.isOverlayToggleHintVisible).toBe(false);
+        expect(settings.isOverlayToggleEnabled).toBe(false);
     });
 
-    it('merges overlayTimingChart flags from configure()', () => {
+    it('merges isOverlayTimingChartEnabled flags from configure()', () => {
         const settings = mergeHardwareSettings({
-            overlayTimingChart: true,
+            isOverlayTimingChartEnabled: true,
             overlayTimingChartStyle: {
                 updateBarPaletteIndex: 20,
                 renderBarPaletteIndex: 21,
@@ -188,7 +188,7 @@ describe('mergeHardwareSettings', () => {
             },
         });
 
-        expect(settings.overlayTimingChart).toBe(true);
+        expect(settings.isOverlayTimingChartEnabled).toBe(true);
         expect(settings.overlayTimingChartStyle?.updateBarPaletteIndex).toBe(20);
         expect(settings.overlayTimingChartStyle?.renderBarPaletteIndex).toBe(21);
         expect(settings.overlayTimingChartStyle?.warningPaletteIndex).toBe(22);
@@ -196,7 +196,7 @@ describe('mergeHardwareSettings', () => {
 
     it('merges overlayTimingChartHeight from configure()', () => {
         const settings = mergeHardwareSettings({
-            overlayTimingChart: true,
+            isOverlayTimingChartEnabled: true,
             overlayTimingChartHeight: 36,
         });
 
@@ -205,25 +205,25 @@ describe('mergeHardwareSettings', () => {
 
     it('merges renderer diagnostics overlay flags from configure()', () => {
         const settings = mergeHardwareSettings({
-            overlayTimingChart: true,
+            isOverlayTimingChartEnabled: true,
             overlayTimingChartDiagnostics: 'rich',
-            overlayRendererDiagnosticsBar: true,
+            isOverlayRendererDiagnosticsBarEnabled: true,
         });
 
         expect(settings.overlayTimingChartDiagnostics).toBe('rich');
-        expect(settings.overlayRendererDiagnosticsBar).toBe(true);
+        expect(settings.isOverlayRendererDiagnosticsBarEnabled).toBe(true);
     });
 
     it('resolveOverlayTimingChartDiagnostics defaults to minimal when chart enabled', () => {
-        const settings = mergeHardwareSettings({ overlayTimingChart: true });
+        const settings = mergeHardwareSettings({ isOverlayTimingChartEnabled: true });
 
         expect(resolveOverlayTimingChartDiagnostics(settings)).toBe('minimal');
     });
 
     it('needsOverlayRendererDiagnostics is true for diagnostics bar alone', () => {
         const settings = mergeHardwareSettings({
-            overlayTimingChart: false,
-            overlayRendererDiagnosticsBar: true,
+            isOverlayTimingChartEnabled: false,
+            isOverlayRendererDiagnosticsBarEnabled: true,
         });
 
         expect(needsOverlayRendererDiagnostics(settings)).toBe(true);

--- a/src/core/IBlitTechDemo.ts
+++ b/src/core/IBlitTechDemo.ts
@@ -410,7 +410,7 @@ function cloneVector2i(size: Vector2i): Vector2i {
     return new Vector2i(size.x, size.y);
 }
 
-/** Non-positive sentinel surfaced when configure() passes null vectors; rejected by {@link validateRenderDimensions}. */
+/** Non-positive sentinel surfaced when configure() passes null vectors; rejected by {@link validateDimensions}. */
 const INVALID_CONFIGURE_VECTOR_SIZE = new Vector2i(0, 0);
 
 /**
@@ -433,7 +433,7 @@ function pickConfigureVector(value: Vector2i | undefined | null): Vector2i | und
  * Resolves required `displaySize` for the explicit-profile merge path.
  *
  * Uses defaults only when the field was omitted (`undefined`). Explicit `null` maps to
- * {@link INVALID_CONFIGURE_VECTOR_SIZE} so {@link validateRenderDimensions} can reject it.
+ * {@link INVALID_CONFIGURE_VECTOR_SIZE} so {@link validateDimensions} can reject it.
  *
  * @param partialDisplaySize - Raw `configure()` value.
  * @param pickedDisplaySize - Cloned value from {@link pickDefinedHardwareSettings}, if any.

--- a/src/core/IBlitTechDemo.ts
+++ b/src/core/IBlitTechDemo.ts
@@ -103,6 +103,11 @@ export interface HardwareSettings {
     isDetectingDroppedFrames?: boolean;
 
     /**
+     * @deprecated Deprecated since 2026-05-31. Use {@link isDetectingDroppedFrames} instead.
+     */
+    detectDroppedFrames?: boolean;
+
+    /**
      * Rendering backend to use. Defaults to `'webgpu'`.
      *
      * Set to `'software'` to opt into the Canvas 2D fallback backend.
@@ -123,11 +128,21 @@ export interface HardwareSettings {
     isOverlayEnabled?: boolean;
 
     /**
+     * @deprecated Deprecated since 2026-05-31. Use {@link isOverlayEnabled} instead.
+     */
+    overlayEnabled?: boolean;
+
+    /**
      * When `true`, the overlay body (metrics bars, palette grid, custom rows) is
      * visible on the first frame. Defaults to `false` in {@link defaultConfig}; the
      * toggle hint may still draw when {@link isOverlayToggleHintVisible} is `true`.
      */
     isOverlayVisibleAtStart?: boolean;
+
+    /**
+     * @deprecated Deprecated since 2026-05-31. Use {@link isOverlayVisibleAtStart} instead.
+     */
+    overlayVisibleAtStart?: boolean;
 
     /**
      * When `true` (default), the engine draws the toggle hint icon while the overlay
@@ -137,6 +152,11 @@ export interface HardwareSettings {
     isOverlayToggleHintVisible?: boolean;
 
     /**
+     * @deprecated Deprecated since 2026-05-31. Use {@link isOverlayToggleHintVisible} instead.
+     */
+    overlayToggleHintVisible?: boolean;
+
+    /**
      * When `true` (default), Backquote and the bottom-left corner pointer press toggle
      * overlay body visibility. Set to `false` to lock body visibility at
      * {@link isOverlayVisibleAtStart}.
@@ -144,11 +164,21 @@ export interface HardwareSettings {
     isOverlayToggleEnabled?: boolean;
 
     /**
+     * @deprecated Deprecated since 2026-05-31. Use {@link isOverlayToggleEnabled} instead.
+     */
+    overlayToggleEnabled?: boolean;
+
+    /**
      * When `true`, the engine draws a live palette swatch grid in the overlay
      * footer stacked above the hint bar. Defaults to `false` in {@link defaultConfig};
      * set to `true` to opt in.
      */
     isOverlayPaletteEnabled?: boolean;
+
+    /**
+     * @deprecated Deprecated since 2026-05-31. Use {@link isOverlayPaletteEnabled} instead.
+     */
+    overlayPaletteView?: boolean;
 
     /**
      * Maximum palette swatches per row in the overlay grid. When unset, the engine
@@ -181,6 +211,11 @@ export interface HardwareSettings {
     isOverlayTimingChartEnabled?: boolean;
 
     /**
+     * @deprecated Deprecated since 2026-05-31. Use {@link isOverlayTimingChartEnabled} instead.
+     */
+    overlayTimingChart?: boolean;
+
+    /**
      * Height in pixels of the timing chart band when {@link isOverlayTimingChartEnabled} is `true`.
      * Defaults to 22 pixels when omitted.
      */
@@ -207,6 +242,11 @@ export interface HardwareSettings {
      * overflow counts and submitted vertex totals. Defaults to `false`.
      */
     isOverlayRendererDiagnosticsBarEnabled?: boolean;
+
+    /**
+     * @deprecated Deprecated since 2026-05-31. Use {@link isOverlayRendererDiagnosticsBarEnabled} instead.
+     */
+    overlayRendererDiagnosticsBar?: boolean;
 }
 
 /**
@@ -554,6 +594,42 @@ function pickDefinedHardwareSettings(partial: Partial<HardwareSettings>): Partia
     return picked;
 }
 
+/** Legacy-to-current boolean field aliases accepted by configure() compatibility handling. */
+const DEPRECATED_BOOLEAN_ALIASES = [
+    { current: 'isDetectingDroppedFrames', legacy: 'detectDroppedFrames' },
+    { current: 'isOverlayEnabled', legacy: 'overlayEnabled' },
+    { current: 'isOverlayVisibleAtStart', legacy: 'overlayVisibleAtStart' },
+    { current: 'isOverlayToggleHintVisible', legacy: 'overlayToggleHintVisible' },
+    { current: 'isOverlayToggleEnabled', legacy: 'overlayToggleEnabled' },
+    { current: 'isOverlayPaletteEnabled', legacy: 'overlayPaletteView' },
+    { current: 'isOverlayTimingChartEnabled', legacy: 'overlayTimingChart' },
+    { current: 'isOverlayRendererDiagnosticsBarEnabled', legacy: 'overlayRendererDiagnosticsBar' },
+] as const;
+
+/**
+ * Normalizes deprecated configure() keys onto current HardwareSettings fields.
+ *
+ * New names always win when both are provided in the same object.
+ *
+ * @param partial - Raw values returned by configure().
+ * @returns Partial settings with legacy keys mapped to current keys.
+ */
+function normalizeDeprecatedHardwareSettings(partial: Partial<HardwareSettings>): Partial<HardwareSettings> {
+    const normalized = { ...partial };
+
+    for (const alias of DEPRECATED_BOOLEAN_ALIASES) {
+        const currentValue = normalized[alias.current];
+
+        const legacyValue = partial[alias.legacy];
+
+        if (currentValue === undefined && legacyValue !== undefined) {
+            normalized[alias.current] = legacyValue;
+        }
+    }
+
+    return normalized;
+}
+
 /**
  * Resolves an optional vector from picked configure values or defaults.
  *
@@ -832,13 +908,14 @@ export function mergeHardwareSettings(partial?: Partial<HardwareSettings>): Hard
         return defaults;
     }
 
-    const picked = pickDefinedHardwareSettings(partial);
+    const normalized = normalizeDeprecatedHardwareSettings(partial);
+    const picked = pickDefinedHardwareSettings(normalized);
 
-    if (partial.displaySize === undefined) {
-        return mergePartialWithFullDefaults(partial, picked, defaults);
+    if (normalized.displaySize === undefined) {
+        return mergePartialWithFullDefaults(normalized, picked, defaults);
     }
 
-    return mergeExplicitDisplayProfile(partial, picked, defaults);
+    return mergeExplicitDisplayProfile(normalized, picked, defaults);
 }
 
 /** Resolved timing-chart renderer diagnostic visualization mode. */

--- a/src/core/IBlitTechDemo.ts
+++ b/src/core/IBlitTechDemo.ts
@@ -100,7 +100,7 @@ export interface HardwareSettings {
      * such as Firefox where rAF often fires at the display rate rather than
      * at `targetFPS`.
      */
-    detectDroppedFrames?: boolean;
+    isDetectingDroppedFrames?: boolean;
 
     /**
      * Rendering backend to use. Defaults to `'webgpu'`.
@@ -114,41 +114,41 @@ export interface HardwareSettings {
     /**
      * When `true` (default), the engine draws a screen-space overlay after
      * each demo `render()` call (FPS, target rate, resolution, backend, demo title).
-     * The overlay body starts hidden unless {@link overlayVisibleAtStart} is
+     * The overlay body starts hidden unless {@link isOverlayVisibleAtStart} is
      * `true`. Users can show or hide the body with Backquote or a primary press in
-     * the bottom-left 48x48 px corner when {@link overlayToggleEnabled} is
+     * the bottom-left 48x48 px corner when {@link isOverlayToggleEnabled} is
      * `true`. Set to `false` to disable the overlay subsystem and all toggle input
      * (for release builds that must not expose debug HUD).
      */
-    overlayEnabled?: boolean;
+    isOverlayEnabled?: boolean;
 
     /**
      * When `true`, the overlay body (metrics bars, palette grid, custom rows) is
      * visible on the first frame. Defaults to `false` in {@link defaultConfig}; the
-     * toggle hint may still draw when {@link overlayToggleHintVisible} is `true`.
+     * toggle hint may still draw when {@link isOverlayToggleHintVisible} is `true`.
      */
-    overlayVisibleAtStart?: boolean;
+    isOverlayVisibleAtStart?: boolean;
 
     /**
      * When `true` (default), the engine draws the toggle hint icon while the overlay
      * body is hidden. Set to `false` for expert/minimal demos that want no on-screen
      * overlay affordance until the body is shown.
      */
-    overlayToggleHintVisible?: boolean;
+    isOverlayToggleHintVisible?: boolean;
 
     /**
      * When `true` (default), Backquote and the bottom-left corner pointer press toggle
      * overlay body visibility. Set to `false` to lock body visibility at
-     * {@link overlayVisibleAtStart}.
+     * {@link isOverlayVisibleAtStart}.
      */
-    overlayToggleEnabled?: boolean;
+    isOverlayToggleEnabled?: boolean;
 
     /**
      * When `true`, the engine draws a live palette swatch grid in the overlay
      * footer stacked above the hint bar. Defaults to `false` in {@link defaultConfig};
      * set to `true` to opt in.
      */
-    overlayPaletteView?: boolean;
+    isOverlayPaletteEnabled?: boolean;
 
     /**
      * Maximum palette swatches per row in the overlay grid. When unset, the engine
@@ -178,10 +178,10 @@ export interface HardwareSettings {
      *
      * Chart bars use raw per-frame CPU samples from BTAPI (not EMA-smoothed text row values).
      */
-    overlayTimingChart?: boolean;
+    isOverlayTimingChartEnabled?: boolean;
 
     /**
-     * Height in pixels of the timing chart band when {@link overlayTimingChart} is `true`.
+     * Height in pixels of the timing chart band when {@link isOverlayTimingChartEnabled} is `true`.
      * Defaults to 22 pixels when omitted.
      */
     overlayTimingChartHeight?: number;
@@ -194,7 +194,7 @@ export interface HardwareSettings {
     overlayTimingChartStyle?: OverlayTimingChartStyle;
 
     /**
-     * Renderer diagnostic visualization on the timing chart when {@link overlayTimingChart} is enabled.
+     * Renderer diagnostic visualization on the timing chart when {@link isOverlayTimingChartEnabled} is enabled.
      *
      * - `'minimal'`: bottom-column marker and warning tint when GPU batch overflow occurred (default when chart enabled)
      * - `'rich'`: minimal plus vertex-pressure dots in the lower third of the chart band
@@ -206,7 +206,7 @@ export interface HardwareSettings {
      * When `true`, adds a 13 px row below the Frame/update/render timing text showing primitive/sprite
      * overflow counts and submitted vertex totals. Defaults to `false`.
      */
-    overlayRendererDiagnosticsBar?: boolean;
+    isOverlayRendererDiagnosticsBarEnabled?: boolean;
 }
 
 /**
@@ -260,7 +260,7 @@ export interface OverlayTimingChartStyle {
  * One optional overlay row supplied by a demo (left label, optional right label).
  *
  * Rendered as a 13 px bar stacked above the footer (palette grid + hint bar when
- * {@link HardwareSettings.overlayPaletteView} is `true`, or the hint bar alone) with 1 px gaps.
+ * {@link HardwareSettings.isOverlayPaletteEnabled} is `true`, or the hint bar alone) with 1 px gaps.
  * Reuse the same array instance from {@link IBlitTechDemo.overlayRows} when possible to avoid
  * per-frame allocations.
  */
@@ -292,7 +292,7 @@ export interface OverlayRow {
  * 2. init() - Called after renderer setup, load assets here
  * 3. update() - Fixed timestep via accumulator (may run 0..N times per frame)
  * 4. render() - Called once per requestAnimationFrame (browser refresh rate)
- * 5. (engine) overlay - When {@link HardwareSettings.overlayEnabled} is true, drawn after `render()` on top
+ * 5. (engine) overlay - When {@link HardwareSettings.isOverlayEnabled} is true, drawn after `render()` on top
  */
 export interface IBlitTechDemo {
     /**
@@ -338,12 +338,12 @@ export interface IBlitTechDemo {
      * Called once per `requestAnimationFrame` tick (browser refresh rate).
      * Issue all draw calls for the current frame here.
      *
-     * When {@link HardwareSettings.overlayEnabled} is `true` (default), the engine
+     * When {@link HardwareSettings.isOverlayEnabled} is `true` (default), the engine
      * draws a screen-space overlay HUD after this method returns (present FPS, target FPS, draw calls,
      * frame/update()/render() timings, backend, demo title). Optional {@link overlayRows} adds stacked bars above
      * the footer.
      * Demos do not need to duplicate engine overlay text. Reserve about ~42 px at the top and space for the bottom palette
-     * grid (or ~13 px when {@link HardwareSettings.overlayPaletteView} is `false`) at the bottom (plus ~14 px per
+     * grid (or ~13 px when {@link HardwareSettings.isOverlayPaletteEnabled} is `false`) at the bottom (plus ~14 px per
      * custom overlay row) for overlay bars, or disable the overlay in `configure()` when using custom full-screen HUD
      * layouts.
      *
@@ -357,7 +357,7 @@ export interface IBlitTechDemo {
     /**
      * Optional hook returning extra overlay rows for the current frame.
      *
-     * Called once per render frame after `render()` when {@link HardwareSettings.overlayEnabled}
+     * Called once per render frame after `render()` when {@link HardwareSettings.isOverlayEnabled}
      * is `true` and the overlay body is visible (not hidden via Backquote or corner toggle). Rows stack
      * upward from just above the bottom hint bar (1 px gap between bars). Omit this hook or return
      * an empty array when no custom rows are needed.
@@ -391,12 +391,12 @@ export function defaultConfig(): HardwareSettings {
         targetFPS: 60,
         outputUpscaleFilter: 'nearest',
         backend: 'webgpu',
-        overlayEnabled: true,
-        overlayVisibleAtStart: false,
-        overlayToggleHintVisible: true,
-        overlayToggleEnabled: true,
-        overlayPaletteView: false,
-        overlayTimingChart: false,
+        isOverlayEnabled: true,
+        isOverlayVisibleAtStart: false,
+        isOverlayToggleHintVisible: true,
+        isOverlayToggleEnabled: true,
+        isOverlayPaletteEnabled: false,
+        isOverlayTimingChartEnabled: false,
     };
 }
 
@@ -500,17 +500,17 @@ function pickIfDefinedPartial<K extends keyof HardwareSettings>(
  * @param partial - Values returned by the demo's `configure()` hook.
  */
 function pickDefinedOverlaySettings(picked: Partial<HardwareSettings>, partial: Partial<HardwareSettings>): void {
-    pickIfDefinedPartial(picked, partial, 'overlayEnabled');
-    pickIfDefinedPartial(picked, partial, 'overlayVisibleAtStart');
-    pickIfDefinedPartial(picked, partial, 'overlayToggleHintVisible');
-    pickIfDefinedPartial(picked, partial, 'overlayToggleEnabled');
-    pickIfDefinedPartial(picked, partial, 'overlayPaletteView');
+    pickIfDefinedPartial(picked, partial, 'isOverlayEnabled');
+    pickIfDefinedPartial(picked, partial, 'isOverlayVisibleAtStart');
+    pickIfDefinedPartial(picked, partial, 'isOverlayToggleHintVisible');
+    pickIfDefinedPartial(picked, partial, 'isOverlayToggleEnabled');
+    pickIfDefinedPartial(picked, partial, 'isOverlayPaletteEnabled');
     pickIfDefinedPartial(picked, partial, 'overlayPaletteColumns');
     pickIfDefinedPartial(picked, partial, 'overlayPaletteRowsVisible');
-    pickIfDefinedPartial(picked, partial, 'overlayTimingChart');
+    pickIfDefinedPartial(picked, partial, 'isOverlayTimingChartEnabled');
     pickIfDefinedPartial(picked, partial, 'overlayTimingChartHeight');
     pickIfDefinedPartial(picked, partial, 'overlayTimingChartDiagnostics');
-    pickIfDefinedPartial(picked, partial, 'overlayRendererDiagnosticsBar');
+    pickIfDefinedPartial(picked, partial, 'isOverlayRendererDiagnosticsBarEnabled');
 
     if (partial.overlayStyle !== undefined) {
         picked.overlayStyle = { ...partial.overlayStyle };
@@ -547,7 +547,7 @@ function pickDefinedHardwareSettings(partial: Partial<HardwareSettings>): Partia
 
     pickIfDefinedPartial(picked, partial, 'targetFPS');
     pickIfDefinedPartial(picked, partial, 'outputUpscaleFilter');
-    pickIfDefinedPartial(picked, partial, 'detectDroppedFrames');
+    pickIfDefinedPartial(picked, partial, 'isDetectingDroppedFrames');
     pickIfDefinedPartial(picked, partial, 'backend');
     pickDefinedOverlaySettings(picked, partial);
 
@@ -646,28 +646,48 @@ function assignFullDefaultMergeScalars(
     defaults: HardwareSettings,
 ): void {
     assignIfDefined(optionals, 'outputUpscaleFilter', picked.outputUpscaleFilter ?? defaults.outputUpscaleFilter);
-    assignIfDefined(optionals, 'detectDroppedFrames', picked.detectDroppedFrames ?? defaults.detectDroppedFrames);
+    assignIfDefined(
+        optionals,
+        'isDetectingDroppedFrames',
+        picked.isDetectingDroppedFrames ?? defaults.isDetectingDroppedFrames,
+    );
     assignIfDefined(optionals, 'backend', picked.backend ?? defaults.backend);
 
     assignIfDefined(optionals, 'overlayStyle', shallowCloneOptional(picked.overlayStyle ?? defaults.overlayStyle));
 
-    assignIfDefined(optionals, 'overlayVisibleAtStart', picked.overlayVisibleAtStart ?? defaults.overlayVisibleAtStart);
+    assignIfDefined(
+        optionals,
+        'isOverlayVisibleAtStart',
+        picked.isOverlayVisibleAtStart ?? defaults.isOverlayVisibleAtStart,
+    );
 
     assignIfDefined(
         optionals,
-        'overlayToggleHintVisible',
-        picked.overlayToggleHintVisible ?? defaults.overlayToggleHintVisible,
+        'isOverlayToggleHintVisible',
+        picked.isOverlayToggleHintVisible ?? defaults.isOverlayToggleHintVisible,
     );
 
-    assignIfDefined(optionals, 'overlayToggleEnabled', picked.overlayToggleEnabled ?? defaults.overlayToggleEnabled);
+    assignIfDefined(
+        optionals,
+        'isOverlayToggleEnabled',
+        picked.isOverlayToggleEnabled ?? defaults.isOverlayToggleEnabled,
+    );
 
-    assignIfDefined(optionals, 'overlayPaletteView', picked.overlayPaletteView ?? defaults.overlayPaletteView);
+    assignIfDefined(
+        optionals,
+        'isOverlayPaletteEnabled',
+        picked.isOverlayPaletteEnabled ?? defaults.isOverlayPaletteEnabled,
+    );
 
     assignIfDefined(optionals, 'overlayPaletteColumns', picked.overlayPaletteColumns);
 
     assignIfDefined(optionals, 'overlayPaletteRowsVisible', picked.overlayPaletteRowsVisible);
 
-    assignIfDefined(optionals, 'overlayTimingChart', picked.overlayTimingChart ?? defaults.overlayTimingChart);
+    assignIfDefined(
+        optionals,
+        'isOverlayTimingChartEnabled',
+        picked.isOverlayTimingChartEnabled ?? defaults.isOverlayTimingChartEnabled,
+    );
 
     assignIfDefined(
         optionals,
@@ -683,7 +703,7 @@ function assignFullDefaultMergeScalars(
 
     assignIfDefined(optionals, 'overlayTimingChartDiagnostics', picked.overlayTimingChartDiagnostics);
 
-    assignIfDefined(optionals, 'overlayRendererDiagnosticsBar', picked.overlayRendererDiagnosticsBar);
+    assignIfDefined(optionals, 'isOverlayRendererDiagnosticsBarEnabled', picked.isOverlayRendererDiagnosticsBarEnabled);
 }
 
 /**
@@ -728,15 +748,15 @@ function buildExplicitDisplayOptionals(
         resolveExplicitOptionalVector(partial.maxCanvasSize, picked.maxCanvasSize),
     );
     assignIfDefined(optionals, 'outputUpscaleFilter', picked.outputUpscaleFilter);
-    assignIfDefined(optionals, 'detectDroppedFrames', picked.detectDroppedFrames);
+    assignIfDefined(optionals, 'isDetectingDroppedFrames', picked.isDetectingDroppedFrames);
     assignIfDefined(optionals, 'overlayStyle', shallowCloneOptional(picked.overlayStyle));
     assignIfDefined(optionals, 'overlayPaletteColumns', picked.overlayPaletteColumns);
     assignIfDefined(optionals, 'overlayPaletteRowsVisible', picked.overlayPaletteRowsVisible);
-    assignIfDefined(optionals, 'overlayTimingChart', picked.overlayTimingChart);
+    assignIfDefined(optionals, 'isOverlayTimingChartEnabled', picked.isOverlayTimingChartEnabled);
     assignIfDefined(optionals, 'overlayTimingChartHeight', picked.overlayTimingChartHeight);
     assignIfDefined(optionals, 'overlayTimingChartStyle', shallowCloneOptional(picked.overlayTimingChartStyle));
     assignIfDefined(optionals, 'overlayTimingChartDiagnostics', picked.overlayTimingChartDiagnostics);
-    assignIfDefined(optionals, 'overlayRendererDiagnosticsBar', picked.overlayRendererDiagnosticsBar);
+    assignIfDefined(optionals, 'isOverlayRendererDiagnosticsBarEnabled', picked.isOverlayRendererDiagnosticsBarEnabled);
     return optionals;
 }
 
@@ -757,11 +777,11 @@ function mergePartialWithFullDefaults(
     return {
         displaySize: cloneVector2i(defaults.displaySize),
         targetFPS: picked.targetFPS ?? defaults.targetFPS,
-        overlayEnabled: picked.overlayEnabled ?? defaults.overlayEnabled ?? true,
-        overlayVisibleAtStart: picked.overlayVisibleAtStart ?? defaults.overlayVisibleAtStart ?? false,
-        overlayToggleHintVisible: picked.overlayToggleHintVisible ?? defaults.overlayToggleHintVisible ?? true,
-        overlayToggleEnabled: picked.overlayToggleEnabled ?? defaults.overlayToggleEnabled ?? true,
-        overlayPaletteView: picked.overlayPaletteView ?? defaults.overlayPaletteView ?? false,
+        isOverlayEnabled: picked.isOverlayEnabled ?? defaults.isOverlayEnabled ?? true,
+        isOverlayVisibleAtStart: picked.isOverlayVisibleAtStart ?? defaults.isOverlayVisibleAtStart ?? false,
+        isOverlayToggleHintVisible: picked.isOverlayToggleHintVisible ?? defaults.isOverlayToggleHintVisible ?? true,
+        isOverlayToggleEnabled: picked.isOverlayToggleEnabled ?? defaults.isOverlayToggleEnabled ?? true,
+        isOverlayPaletteEnabled: picked.isOverlayPaletteEnabled ?? defaults.isOverlayPaletteEnabled ?? false,
         ...buildFullDefaultMergeOptionals(partial, picked, defaults),
     };
 }
@@ -783,11 +803,11 @@ function mergeExplicitDisplayProfile(
     return {
         displaySize: resolveExplicitDisplaySize(partial.displaySize, picked.displaySize, defaults.displaySize),
         targetFPS: picked.targetFPS ?? defaults.targetFPS,
-        overlayEnabled: picked.overlayEnabled ?? defaults.overlayEnabled ?? true,
-        overlayVisibleAtStart: picked.overlayVisibleAtStart ?? defaults.overlayVisibleAtStart ?? false,
-        overlayToggleHintVisible: picked.overlayToggleHintVisible ?? defaults.overlayToggleHintVisible ?? true,
-        overlayToggleEnabled: picked.overlayToggleEnabled ?? defaults.overlayToggleEnabled ?? true,
-        overlayPaletteView: picked.overlayPaletteView ?? defaults.overlayPaletteView ?? false,
+        isOverlayEnabled: picked.isOverlayEnabled ?? defaults.isOverlayEnabled ?? true,
+        isOverlayVisibleAtStart: picked.isOverlayVisibleAtStart ?? defaults.isOverlayVisibleAtStart ?? false,
+        isOverlayToggleHintVisible: picked.isOverlayToggleHintVisible ?? defaults.isOverlayToggleHintVisible ?? true,
+        isOverlayToggleEnabled: picked.isOverlayToggleEnabled ?? defaults.isOverlayToggleEnabled ?? true,
+        isOverlayPaletteEnabled: picked.isOverlayPaletteEnabled ?? defaults.isOverlayPaletteEnabled ?? false,
         backend: picked.backend ?? defaults.backend ?? 'webgpu',
         ...buildExplicitDisplayOptionals(partial, picked),
     };
@@ -797,10 +817,10 @@ function mergeExplicitDisplayProfile(
  * Resolves demo `configure()` output into complete {@link HardwareSettings}.
  *
  * When `displaySize` is omitted from `partial`, unset fields inherit from
- * {@link defaultConfig} (including `drawingBufferSize` and `overlayEnabled`).
+ * {@link defaultConfig} (including `drawingBufferSize` and `isOverlayEnabled`).
  * When `displaySize` is provided, only fields present in `partial` are applied;
  * omitted optionals such as `drawingBufferSize` remain unset so the drawing buffer
- * can match logical resolution. `overlayEnabled` defaults to `true` when omitted.
+ * can match logical resolution. `isOverlayEnabled` defaults to `true` when omitted.
  *
  * @param partial - Optional partial settings from `configure()`.
  * @returns Resolved hardware settings for initialization.
@@ -837,7 +857,7 @@ export function resolveOverlayTimingChartDiagnostics(settings: HardwareSettings)
         return settings.overlayTimingChartDiagnostics;
     }
 
-    return settings.overlayTimingChart === true ? 'minimal' : false;
+    return settings.isOverlayTimingChartEnabled === true ? 'minimal' : false;
 }
 
 /**
@@ -847,7 +867,10 @@ export function resolveOverlayTimingChartDiagnostics(settings: HardwareSettings)
  * @returns `true` when chart diagnostics or the renderer diagnostics bar needs data.
  */
 export function needsOverlayRendererDiagnostics(settings: HardwareSettings): boolean {
-    return resolveOverlayTimingChartDiagnostics(settings) !== false || settings.overlayRendererDiagnosticsBar === true;
+    return (
+        resolveOverlayTimingChartDiagnostics(settings) !== false ||
+        settings.isOverlayRendererDiagnosticsBarEnabled === true
+    );
 }
 
 // #endregion

--- a/src/core/RenderPaletteUsage.test.ts
+++ b/src/core/RenderPaletteUsage.test.ts
@@ -4,32 +4,28 @@
 
 import { describe, expect, it } from 'vitest';
 
-import {
-    collectUsedRenderPaletteIndices,
-    markRenderPaletteIndexUsed,
-    resetRenderPaletteUsage,
-} from './RenderPaletteUsage';
+import { collectUsedIndices, markIndexUsed, resetUsage } from './RenderPaletteUsage';
 
 describe('RenderPaletteUsage', () => {
     it('collects sorted used indices and skips transparent slot 0', () => {
         const mask = new Uint8Array(256);
         const scratch: number[] = [];
 
-        markRenderPaletteIndexUsed(mask, 0);
-        markRenderPaletteIndexUsed(mask, 3);
-        markRenderPaletteIndexUsed(mask, 1);
-        markRenderPaletteIndexUsed(mask, 7);
+        markIndexUsed(mask, 0);
+        markIndexUsed(mask, 3);
+        markIndexUsed(mask, 1);
+        markIndexUsed(mask, 7);
 
-        expect(collectUsedRenderPaletteIndices(mask, 16, scratch)).toEqual([1, 3, 7]);
+        expect(collectUsedIndices(mask, 16, scratch)).toEqual([1, 3, 7]);
     });
 
     it('reset clears prior marks', () => {
         const mask = new Uint8Array(256);
         const scratch: number[] = [];
 
-        markRenderPaletteIndexUsed(mask, 2);
-        resetRenderPaletteUsage(mask);
+        markIndexUsed(mask, 2);
+        resetUsage(mask);
 
-        expect(collectUsedRenderPaletteIndices(mask, 16, scratch)).toEqual([]);
+        expect(collectUsedIndices(mask, 16, scratch)).toEqual([]);
     });
 });

--- a/src/core/RenderPaletteUsage.ts
+++ b/src/core/RenderPaletteUsage.ts
@@ -9,12 +9,27 @@
 export const USAGE_CAPACITY = 256;
 
 /**
+ * @deprecated Deprecated since 2026-05-31. Use {@link USAGE_CAPACITY} instead.
+ */
+export const RENDER_PALETTE_USAGE_CAPACITY = USAGE_CAPACITY;
+
+/**
  * Clears a palette usage bitmask.
  *
  * @param usedMask - Mutable usage mask cleared in place.
  */
 export function resetUsage(usedMask: Uint8Array): void {
     usedMask.fill(0);
+}
+
+/**
+ * Backward-compatible alias for {@link resetUsage}.
+ *
+ * @deprecated Deprecated since 2026-05-31. Use {@link resetUsage} instead.
+ * @param usedMask - Mutable usage mask cleared in place.
+ */
+export function resetRenderPaletteUsage(usedMask: Uint8Array): void {
+    resetUsage(usedMask);
 }
 
 /**
@@ -32,6 +47,17 @@ export function markIndexUsed(usedMask: Uint8Array, index: number): void {
 
     // eslint-disable-next-line security/detect-object-injection -- index bounds checked above
     usedMask[index] = 1;
+}
+
+/**
+ * Backward-compatible alias for {@link markIndexUsed}.
+ *
+ * @deprecated Deprecated since 2026-05-31. Use {@link markIndexUsed} instead.
+ * @param usedMask - Mutable usage mask.
+ * @param index - Palette index referenced by a draw call.
+ */
+export function markRenderPaletteIndexUsed(usedMask: Uint8Array, index: number): void {
+    markIndexUsed(usedMask, index);
 }
 
 /**
@@ -55,4 +81,21 @@ export function collectUsedIndices(usedMask: Uint8Array, paletteSize: number, sc
     }
 
     return scratch;
+}
+
+/**
+ * Backward-compatible alias for {@link collectUsedIndices}.
+ *
+ * @deprecated Deprecated since 2026-05-31. Use {@link collectUsedIndices} instead.
+ * @param usedMask - Usage mask populated during the current frame.
+ * @param paletteSize - Active palette size upper bound.
+ * @param scratch - Reusable output buffer mutated in place.
+ * @returns The same scratch array containing sorted used indices.
+ */
+export function collectUsedRenderPaletteIndices(
+    usedMask: Uint8Array,
+    paletteSize: number,
+    scratch: number[],
+): readonly number[] {
+    return collectUsedIndices(usedMask, paletteSize, scratch);
 }

--- a/src/core/RenderPaletteUsage.ts
+++ b/src/core/RenderPaletteUsage.ts
@@ -6,14 +6,14 @@
  */
 
 /** Maximum palette slots tracked by the usage mask. */
-export const RENDER_PALETTE_USAGE_CAPACITY = 256;
+export const USAGE_CAPACITY = 256;
 
 /**
  * Clears a palette usage bitmask.
  *
  * @param usedMask - Mutable usage mask cleared in place.
  */
-export function resetRenderPaletteUsage(usedMask: Uint8Array): void {
+export function resetUsage(usedMask: Uint8Array): void {
     usedMask.fill(0);
 }
 
@@ -25,7 +25,7 @@ export function resetRenderPaletteUsage(usedMask: Uint8Array): void {
  * @param usedMask - Mutable usage mask.
  * @param index - Palette index referenced by a draw call.
  */
-export function markRenderPaletteIndexUsed(usedMask: Uint8Array, index: number): void {
+export function markIndexUsed(usedMask: Uint8Array, index: number): void {
     if (!Number.isInteger(index) || index <= 0 || index >= usedMask.length) {
         return;
     }
@@ -42,11 +42,7 @@ export function markRenderPaletteIndexUsed(usedMask: Uint8Array, index: number):
  * @param scratch - Reusable output buffer mutated in place.
  * @returns The same scratch array containing sorted used indices.
  */
-export function collectUsedRenderPaletteIndices(
-    usedMask: Uint8Array,
-    paletteSize: number,
-    scratch: number[],
-): readonly number[] {
+export function collectUsedIndices(usedMask: Uint8Array, paletteSize: number, scratch: number[]): readonly number[] {
     scratch.length = 0;
 
     const limit = Math.min(paletteSize, usedMask.length);

--- a/src/core/WebGPUContext.ts
+++ b/src/core/WebGPUContext.ts
@@ -7,7 +7,7 @@ import type { Vector2i } from '../utils/Vector2i';
 /**
  * Result returned when WebGPU canvas initialization succeeds.
  */
-export interface WebGPUContextResult {
+export interface Result {
     /** Initialized WebGPU device. */
     device: GPUDevice;
 
@@ -48,7 +48,7 @@ export async function initWebGPU(
     canvas: HTMLCanvasElement,
     displaySize: Vector2i,
     configuredDrawingBufferSize?: Vector2i,
-): Promise<WebGPUContextResult | null> {
+): Promise<Result | null> {
     if (!navigator.gpu) {
         console.error("[BT] WebGPU isn't supported in this browser.");
         console.error('[BT] Please use Chrome/Edge 113+ or Firefox Nightly with WebGPU enabled.');

--- a/src/input/GamepadInput.test.ts
+++ b/src/input/GamepadInput.test.ts
@@ -9,7 +9,7 @@ import { BT } from '../BlitTech';
 import { DEFAULT_GAMEPAD_DEAD_ZONE, GamepadInput } from './GamepadInput';
 
 interface PadState {
-    connected?: boolean;
+    isConnected?: boolean;
     buttons?: number[];
     pressed?: number[];
     axes?: number[];
@@ -25,7 +25,7 @@ function makeGamepad(state: PadState): Gamepad {
     return {
         id: 'test-pad',
         index: 0,
-        connected: state.connected ?? true,
+        connected: state.isConnected ?? true,
         mapping: 'standard',
         timestamp: 0,
         axes: state.axes ?? [0, 0, 0, 0],
@@ -61,8 +61,8 @@ describe('GamepadInput', () => {
     });
 
     it('tracks connected gamepads and counts connected players', () => {
-        pads[0] = makeGamepad({ connected: true });
-        pads[1] = makeGamepad({ connected: true });
+        pads[0] = makeGamepad({ isConnected: true });
+        pads[1] = makeGamepad({ isConnected: true });
 
         expect(input.isConnected(0)).toBe(true);
         expect(input.isConnected(1)).toBe(true);

--- a/src/input/GamepadInput.ts
+++ b/src/input/GamepadInput.ts
@@ -83,7 +83,7 @@ const VALID_AXIS_INDICES = [
  */
 interface PlayerSnapshot {
     /** Whether a gamepad is connected for this player slot. */
-    connected: boolean;
+    isConnected: boolean;
     /** Current button-state bitmask (`BTN_*`). */
     buttons: number;
     /** Snapshot axis values in `AXIS_*` order. */
@@ -206,11 +206,11 @@ export class GamepadInput {
                 continue;
             }
 
-            previous.connected = current.connected;
+            previous.isConnected = current.isConnected;
             previous.buttons = current.buttons;
             previous.axes = [...current.axes] as PlayerSnapshot['axes'];
 
-            if (!current.connected) {
+            if (!current.isConnected) {
                 this.firstPressTick[i]?.clear();
             }
         }
@@ -234,7 +234,7 @@ export class GamepadInput {
 
         const current = this.current[index];
 
-        if (!current?.connected) {
+        if (!current?.isConnected) {
             return false;
         }
 
@@ -269,7 +269,7 @@ export class GamepadInput {
         const current = this.current[index];
         const previous = this.previous[index];
 
-        if (!current?.connected || !previous) {
+        if (!current?.isConnected || !previous) {
             return false;
         }
 
@@ -324,11 +324,11 @@ export class GamepadInput {
             return false;
         }
 
-        if (!current?.connected && previous.connected) {
+        if (!current?.isConnected && previous.isConnected) {
             return (previous.buttons & buttonMask) !== 0;
         }
 
-        if (!current?.connected) {
+        if (!current?.isConnected) {
             return false;
         }
 
@@ -355,7 +355,7 @@ export class GamepadInput {
 
         const snapshot = this.current[index];
 
-        if (!snapshot?.connected) {
+        if (!snapshot?.isConnected) {
             return 0;
         }
 
@@ -377,7 +377,7 @@ export class GamepadInput {
 
         this.pollGamepads();
 
-        return this.current[index]?.connected ?? false;
+        return this.current[index]?.isConnected ?? false;
     }
 
     /**
@@ -391,7 +391,7 @@ export class GamepadInput {
         let count = 0;
 
         for (let i = 0; i < GAMEPAD_PLAYER_COUNT; i++) {
-            if (this.current[i]?.connected) {
+            if (this.current[i]?.isConnected) {
                 count++;
             }
         }
@@ -408,7 +408,7 @@ export class GamepadInput {
      */
     private createEmptySnapshot(): PlayerSnapshot {
         return {
-            connected: false,
+            isConnected: false,
             buttons: 0,
             axes: [0, 0, 0, 0, 0, 0],
         };
@@ -444,13 +444,13 @@ export class GamepadInput {
             const pad = pads[player];
 
             if (!pad?.connected) {
-                snapshot.connected = false;
+                snapshot.isConnected = false;
                 snapshot.buttons = 0;
                 snapshot.axes = [0, 0, 0, 0, 0, 0];
                 continue;
             }
 
-            snapshot.connected = true;
+            snapshot.isConnected = true;
             snapshot.buttons = this.mapButtons(pad);
             snapshot.axes = this.mapAxes(pad);
             this.dropReleasedTickAnchors(player, snapshot.buttons);
@@ -702,13 +702,13 @@ export class GamepadInput {
             const previous = this.previous[i];
 
             if (current) {
-                current.connected = false;
+                current.isConnected = false;
                 current.buttons = 0;
                 current.axes = [0, 0, 0, 0, 0, 0];
             }
 
             if (previous) {
-                previous.connected = false;
+                previous.isConnected = false;
                 previous.buttons = 0;
                 previous.axes = [0, 0, 0, 0, 0, 0];
             }

--- a/src/input/GamepadInput.ts
+++ b/src/input/GamepadInput.ts
@@ -76,6 +76,63 @@ const VALID_AXIS_INDICES = [
 
 // #endregion
 
+// #region Raw gamepad reads
+
+/**
+ * Reads and clamps a raw stick axis to `[-1, 1]`.
+ *
+ * @param pad - Gamepad object.
+ * @param index - Raw axis index.
+ * @returns Clamped axis value.
+ */
+function getAxis(pad: Gamepad, index: number): number {
+    const value = pad.axes[index] ?? 0;
+
+    if (!Number.isFinite(value)) {
+        return 0;
+    }
+
+    return Math.max(-1, Math.min(1, value));
+}
+
+/**
+ * Reads a trigger/button analog value and clamps to `[0, 1]`.
+ *
+ * @param pad - Gamepad object.
+ * @param index - Raw button index.
+ * @returns Clamped analog value.
+ */
+function getButtonValue(pad: Gamepad, index: number): number {
+    const button = pad.buttons[index];
+
+    if (!button) {
+        return 0;
+    }
+
+    const value = Number.isFinite(button.value) ? button.value : button.pressed ? 1 : 0;
+
+    return Math.max(0, Math.min(1, value));
+}
+
+/**
+ * Checks digital down-state for a gamepad button.
+ *
+ * @param pad - Gamepad object.
+ * @param index - Raw button index.
+ * @returns `true` when considered pressed.
+ */
+function isButtonDown(pad: Gamepad, index: number): boolean {
+    const button = pad.buttons[index];
+
+    if (!button) {
+        return false;
+    }
+
+    return button.pressed || button.value >= 0.5;
+}
+
+// #endregion
+
 // #region Types
 
 /**
@@ -141,8 +198,8 @@ export class GamepadInput {
         ];
         this.firstPressTick = [new Map(), new Map(), new Map(), new Map()];
         this.deadZone = this.sanitizeDeadZone(deadZone);
-        this.onConnected = () => this.pollGamepads();
-        this.onDisconnected = () => this.pollGamepads();
+        this.onConnected = () => this.poll();
+        this.onDisconnected = () => this.poll();
     }
 
     /**
@@ -157,7 +214,7 @@ export class GamepadInput {
             globalThis.window.addEventListener('gamepaddisconnected', this.onDisconnected);
         }
 
-        this.pollGamepads();
+        this.poll();
     }
 
     /**
@@ -196,7 +253,7 @@ export class GamepadInput {
      * @param _currentTick - Current engine tick (unused; kept for BTAPI parity).
      */
     public endFrame(_currentTick: number): void {
-        this.pollGamepads();
+        this.poll();
 
         for (let i = 0; i < GAMEPAD_PLAYER_COUNT; i++) {
             const current = this.current[i];
@@ -230,7 +287,7 @@ export class GamepadInput {
             return false;
         }
 
-        this.pollGamepads();
+        this.poll();
 
         const current = this.current[index];
 
@@ -264,7 +321,7 @@ export class GamepadInput {
             return false;
         }
 
-        this.pollGamepads();
+        this.poll();
 
         const current = this.current[index];
         const previous = this.previous[index];
@@ -315,7 +372,7 @@ export class GamepadInput {
             return false;
         }
 
-        this.pollGamepads();
+        this.poll();
 
         const current = this.current[index];
         const previous = this.previous[index];
@@ -351,7 +408,7 @@ export class GamepadInput {
             return 0;
         }
 
-        this.pollGamepads();
+        this.poll();
 
         const snapshot = this.current[index];
 
@@ -375,7 +432,7 @@ export class GamepadInput {
             return false;
         }
 
-        this.pollGamepads();
+        this.poll();
 
         return this.current[index]?.isConnected ?? false;
     }
@@ -386,7 +443,7 @@ export class GamepadInput {
      * @returns Number of connected gamepads in `[0, GAMEPAD_PLAYER_COUNT]`.
      */
     public connectedCount(): number {
-        this.pollGamepads();
+        this.poll();
 
         let count = 0;
 
@@ -431,8 +488,8 @@ export class GamepadInput {
     /**
      * Polls `navigator.getGamepads()` and refreshes current snapshots.
      */
-    private pollGamepads(): void {
-        const pads = this.readGamepads();
+    private poll(): void {
+        const pads = this.read();
 
         for (let player = 0; player < GAMEPAD_PLAYER_COUNT; player++) {
             const snapshot = this.current[player];
@@ -462,7 +519,7 @@ export class GamepadInput {
      *
      * @returns Current browser gamepad array or an empty array.
      */
-    private readGamepads(): readonly (Gamepad | null)[] {
+    private read(): readonly (Gamepad | null)[] {
         if (typeof globalThis.navigator === 'undefined' || typeof globalThis.navigator.getGamepads !== 'function') {
             return [];
         }
@@ -479,40 +536,40 @@ export class GamepadInput {
     private mapButtons(pad: Gamepad): number {
         let mask = 0;
 
-        if (this.isPadButtonDown(pad, GP_BUTTON_UP)) {
+        if (isButtonDown(pad, GP_BUTTON_UP)) {
             mask |= BTN_UP;
         }
-        if (this.isPadButtonDown(pad, GP_BUTTON_DOWN)) {
+        if (isButtonDown(pad, GP_BUTTON_DOWN)) {
             mask |= BTN_DOWN;
         }
-        if (this.isPadButtonDown(pad, GP_BUTTON_LEFT)) {
+        if (isButtonDown(pad, GP_BUTTON_LEFT)) {
             mask |= BTN_LEFT;
         }
-        if (this.isPadButtonDown(pad, GP_BUTTON_RIGHT)) {
+        if (isButtonDown(pad, GP_BUTTON_RIGHT)) {
             mask |= BTN_RIGHT;
         }
-        if (this.isPadButtonDown(pad, GP_BUTTON_A)) {
+        if (isButtonDown(pad, GP_BUTTON_A)) {
             mask |= BTN_A;
         }
-        if (this.isPadButtonDown(pad, GP_BUTTON_B)) {
+        if (isButtonDown(pad, GP_BUTTON_B)) {
             mask |= BTN_B;
         }
-        if (this.isPadButtonDown(pad, GP_BUTTON_X)) {
+        if (isButtonDown(pad, GP_BUTTON_X)) {
             mask |= BTN_X;
         }
-        if (this.isPadButtonDown(pad, GP_BUTTON_Y)) {
+        if (isButtonDown(pad, GP_BUTTON_Y)) {
             mask |= BTN_Y;
         }
-        if (this.isPadButtonDown(pad, GP_BUTTON_L)) {
+        if (isButtonDown(pad, GP_BUTTON_L)) {
             mask |= BTN_L;
         }
-        if (this.isPadButtonDown(pad, GP_BUTTON_R)) {
+        if (isButtonDown(pad, GP_BUTTON_R)) {
             mask |= BTN_R;
         }
-        if (this.isPadButtonDown(pad, GP_BUTTON_START)) {
+        if (isButtonDown(pad, GP_BUTTON_START)) {
             mask |= BTN_START;
         }
-        if (this.isPadButtonDown(pad, GP_BUTTON_SELECT)) {
+        if (isButtonDown(pad, GP_BUTTON_SELECT)) {
             mask |= BTN_SELECT;
         }
 
@@ -526,67 +583,14 @@ export class GamepadInput {
      * @returns Axis tuple in engine API order.
      */
     private mapAxes(pad: Gamepad): PlayerSnapshot['axes'] {
-        const leftX = this.applyStickDeadZone(this.getPadAxis(pad, 0));
-        const leftY = this.applyStickDeadZone(this.getPadAxis(pad, 1));
-        const rightX = this.applyStickDeadZone(this.getPadAxis(pad, 2));
-        const rightY = this.applyStickDeadZone(this.getPadAxis(pad, 3));
-        const triggerL = this.getPadButtonValue(pad, 6);
-        const triggerR = this.getPadButtonValue(pad, 7);
+        const leftX = this.applyStickDeadZone(getAxis(pad, 0));
+        const leftY = this.applyStickDeadZone(getAxis(pad, 1));
+        const rightX = this.applyStickDeadZone(getAxis(pad, 2));
+        const rightY = this.applyStickDeadZone(getAxis(pad, 3));
+        const triggerL = getButtonValue(pad, 6);
+        const triggerR = getButtonValue(pad, 7);
 
         return [leftX, leftY, rightX, rightY, triggerL, triggerR];
-    }
-
-    /**
-     * Reads and clamps a raw stick axis to `[-1, 1]`.
-     *
-     * @param pad - Gamepad object.
-     * @param index - Raw axis index.
-     * @returns Clamped axis value.
-     */
-    private getPadAxis(pad: Gamepad, index: number): number {
-        const value = pad.axes[index] ?? 0;
-
-        if (!Number.isFinite(value)) {
-            return 0;
-        }
-
-        return Math.max(-1, Math.min(1, value));
-    }
-
-    /**
-     * Reads a trigger/button analog value and clamps to `[0, 1]`.
-     *
-     * @param pad - Gamepad object.
-     * @param index - Raw button index.
-     * @returns Clamped analog value.
-     */
-    private getPadButtonValue(pad: Gamepad, index: number): number {
-        const button = pad.buttons[index];
-
-        if (!button) {
-            return 0;
-        }
-
-        const value = Number.isFinite(button.value) ? button.value : button.pressed ? 1 : 0;
-
-        return Math.max(0, Math.min(1, value));
-    }
-
-    /**
-     * Checks digital down-state for a gamepad button.
-     *
-     * @param pad - Gamepad object.
-     * @param index - Raw button index.
-     * @returns `true` when considered pressed.
-     */
-    private isPadButtonDown(pad: Gamepad, index: number): boolean {
-        const button = pad.buttons[index];
-
-        if (!button) {
-            return false;
-        }
-
-        return button.pressed || button.value >= 0.5;
     }
 
     /**

--- a/src/input/KeyboardInput.ts
+++ b/src/input/KeyboardInput.ts
@@ -9,7 +9,7 @@
 export interface KeyboardAttachOptions {
     /**
      * Returns the current fixed-update tick (same as `BT.ticks`).
-     * Used when recording first key-down time for `keyPressed(..., repeatRate)`.
+     * Used when recording first key-down time for `isKeyPressed(..., repeatRate)`.
      */
     getTicks: () => number;
 }
@@ -136,13 +136,13 @@ export class KeyboardInput {
      * @returns `true` on the initial press edge or on repeat ticks when configured.
      */
     public isKeyPressed(code: string, repeatRate: number | undefined, currentTick: number): boolean {
-        const edge = this.held.has(code) && !this.prevHeld.has(code);
+        const isPressEdge = this.held.has(code) && !this.prevHeld.has(code);
 
         if (repeatRate === undefined || repeatRate <= 0) {
-            return edge;
+            return isPressEdge;
         }
 
-        if (edge) {
+        if (isPressEdge) {
             return true;
         }
 
@@ -213,14 +213,14 @@ export class KeyboardInput {
             return false;
         }
 
-        const down = this.isButtonDown(codes);
-        const prevDown = codes.some((c) => this.prevHeld.has(c));
+        const isDown = this.isButtonDown(codes);
+        const isPrevDown = codes.some((c) => this.prevHeld.has(c));
 
-        if (!down) {
+        if (!isDown) {
             return false;
         }
 
-        if (!prevDown) {
+        if (!isPrevDown) {
             return true;
         }
 

--- a/src/input/PointerInput.test.ts
+++ b/src/input/PointerInput.test.ts
@@ -106,7 +106,7 @@ describe('PointerInput', () => {
             const fresh = new PointerInput();
 
             for (let i = 0; i < POINTER_SLOT_COUNT; i++) {
-                expect(fresh.isValid(i)).toBe(false);
+                expect(fresh.isActive(i)).toBe(false);
             }
 
             expect(fresh.getScrollDelta()).toBe(0);
@@ -157,7 +157,7 @@ describe('PointerInput', () => {
                 }),
             );
 
-            expect(input.isValid(0)).toBe(false);
+            expect(input.isActive(0)).toBe(false);
         });
 
         it('safe to call detach before attach', () => {
@@ -181,7 +181,7 @@ describe('PointerInput', () => {
                 }),
             );
 
-            expect(input.isValid(0)).toBe(true);
+            expect(input.isActive(0)).toBe(true);
 
             otherCanvas.remove();
         });
@@ -276,11 +276,11 @@ describe('PointerInput', () => {
                 }),
             );
 
-            expect(input.isValid(0)).toBe(true);
             expect(input.isButtonDown(BTN_POINTER_A, 0)).toBe(true);
             expect(input.isButtonDown(BTN_POINTER_B, 0)).toBe(false);
             expect(input.isButtonDown(BTN_POINTER_C, 0)).toBe(false);
             expect(input.isButtonDown(BTN_POINTER_D, 0)).toBe(false);
+            expect(input.isActive(0)).toBe(true);
         });
 
         it.each([
@@ -308,7 +308,7 @@ describe('PointerInput', () => {
                 pointerEvent('pointermove', { pointerId: 1, pointerType: 'mouse', clientX: 50, clientY: 50 }),
             );
 
-            expect(input.isValid(0)).toBe(true);
+            expect(input.isActive(0)).toBe(true);
         });
 
         it('clears all four mouse buttons and deactivates slot 0 on pointerleave', () => {
@@ -335,9 +335,9 @@ describe('PointerInput', () => {
                 pointerEvent('pointerleave', { pointerId: 1, pointerType: 'mouse', clientX: 50, clientY: 50 }),
             );
 
-            expect(input.isValid(0)).toBe(false);
             expect(input.isButtonDown(BTN_POINTER_A, 0)).toBe(false);
             expect(input.isButtonDown(BTN_POINTER_B, 0)).toBe(false);
+            expect(input.isActive(0)).toBe(false);
         });
 
         it('keeps slot 0 valid after pointerup (only the button releases)', () => {
@@ -355,8 +355,8 @@ describe('PointerInput', () => {
                 pointerEvent('pointerup', { pointerId: 1, pointerType: 'mouse', button: 0, clientX: 50, clientY: 50 }),
             );
 
-            expect(input.isValid(0)).toBe(true);
             expect(input.isButtonDown(BTN_POINTER_A, 0)).toBe(false);
+            expect(input.isActive(0)).toBe(true);
         });
 
         it('ignores an unknown DOM mouse button code (default case in setMouseButton)', () => {
@@ -387,13 +387,13 @@ describe('PointerInput', () => {
                 }),
             );
 
-            expect(input.isValid(0)).toBe(true);
+            expect(input.isActive(0)).toBe(true);
 
             canvas.dispatchEvent(
                 pointerEvent('pointercancel', { pointerId: 1, pointerType: 'mouse', clientX: 50, clientY: 50 }),
             );
 
-            expect(input.isValid(0)).toBe(false);
+            expect(input.isActive(0)).toBe(false);
         });
 
         it('handles pointerleave for mouse when slot was never activated (null pointerId path)', () => {
@@ -401,7 +401,7 @@ describe('PointerInput', () => {
                 pointerEvent('pointerleave', { pointerId: 1, pointerType: 'mouse', clientX: 50, clientY: 50 }),
             );
 
-            expect(input.isValid(0)).toBe(false);
+            expect(input.isActive(0)).toBe(false);
         });
     });
 
@@ -439,12 +439,12 @@ describe('PointerInput', () => {
                 }),
             );
 
-            expect(input.isValid(1)).toBe(true);
-            expect(input.isValid(2)).toBe(true);
-            expect(input.isValid(3)).toBe(true);
             expect(input.isButtonDown(BTN_POINTER_A, 1)).toBe(true);
             expect(input.isButtonDown(BTN_POINTER_A, 2)).toBe(true);
             expect(input.isButtonDown(BTN_POINTER_A, 3)).toBe(true);
+            expect(input.isActive(1)).toBe(true);
+            expect(input.isActive(2)).toBe(true);
+            expect(input.isActive(3)).toBe(true);
         });
 
         it('drops a 4th simultaneous touch silently when all slots are full', () => {
@@ -461,9 +461,9 @@ describe('PointerInput', () => {
             }
 
             // Slots 1-3 occupied; 4th touch should not throw or appear anywhere.
-            expect(input.isValid(1)).toBe(true);
-            expect(input.isValid(2)).toBe(true);
-            expect(input.isValid(3)).toBe(true);
+            expect(input.isActive(1)).toBe(true);
+            expect(input.isActive(2)).toBe(true);
+            expect(input.isActive(3)).toBe(true);
         });
 
         it('frees a touch slot on pointerup; the next touch reuses it', () => {
@@ -486,7 +486,7 @@ describe('PointerInput', () => {
                 }),
             );
 
-            expect(input.isValid(1)).toBe(false);
+            expect(input.isActive(1)).toBe(false);
 
             canvas.dispatchEvent(
                 pointerEvent('pointerdown', {
@@ -498,7 +498,7 @@ describe('PointerInput', () => {
                 }),
             );
 
-            expect(input.isValid(1)).toBe(true);
+            expect(input.isActive(1)).toBe(true);
         });
 
         it('frees a touch slot on pointercancel', () => {
@@ -516,7 +516,7 @@ describe('PointerInput', () => {
                 pointerEvent('pointercancel', { pointerId: 400, pointerType: 'touch', clientX: 10, clientY: 10 }),
             );
 
-            expect(input.isValid(1)).toBe(false);
+            expect(input.isActive(1)).toBe(false);
         });
 
         it('reports BTN_POINTER_B/C/D as false for touch slots even when valid', () => {
@@ -530,11 +530,11 @@ describe('PointerInput', () => {
                 }),
             );
 
-            expect(input.isValid(1)).toBe(true);
             expect(input.isButtonDown(BTN_POINTER_A, 1)).toBe(true);
             expect(input.isButtonDown(BTN_POINTER_B, 1)).toBe(false);
             expect(input.isButtonDown(BTN_POINTER_C, 1)).toBe(false);
             expect(input.isButtonDown(BTN_POINTER_D, 1)).toBe(false);
+            expect(input.isActive(1)).toBe(true);
         });
 
         it('routes pen input to touch slots 1-3 (not slot 0)', () => {
@@ -548,8 +548,8 @@ describe('PointerInput', () => {
                 }),
             );
 
-            expect(input.isValid(0)).toBe(false);
-            expect(input.isValid(1)).toBe(true);
+            expect(input.isActive(0)).toBe(false);
+            expect(input.isActive(1)).toBe(true);
         });
 
         it('ignores a duplicate pointerdown for the same touch ID', () => {
@@ -563,7 +563,7 @@ describe('PointerInput', () => {
                 }),
             );
 
-            expect(input.isValid(1)).toBe(true);
+            expect(input.isActive(1)).toBe(true);
 
             canvas.dispatchEvent(
                 pointerEvent('pointerdown', {
@@ -575,8 +575,8 @@ describe('PointerInput', () => {
                 }),
             );
 
-            expect(input.isValid(1)).toBe(true);
-            expect(input.isValid(2)).toBe(false);
+            expect(input.isActive(1)).toBe(true);
+            expect(input.isActive(2)).toBe(false);
         });
 
         it('ignores touch pointermove with no prior pointerdown (unknown slot)', () => {
@@ -586,7 +586,7 @@ describe('PointerInput', () => {
                 );
             }).not.toThrow();
 
-            expect(input.isValid(1)).toBe(false);
+            expect(input.isActive(1)).toBe(false);
         });
 
         it('ignores touch pointerup with no prior pointerdown (unknown slot)', () => {
@@ -622,13 +622,13 @@ describe('PointerInput', () => {
                 }),
             );
 
-            expect(input.isValid(1)).toBe(true);
+            expect(input.isActive(1)).toBe(true);
 
             canvas.dispatchEvent(
                 pointerEvent('pointerleave', { pointerId: 1001, pointerType: 'touch', clientX: 10, clientY: 10 }),
             );
 
-            expect(input.isValid(1)).toBe(false);
+            expect(input.isActive(1)).toBe(false);
 
             expect(() => {
                 canvas.dispatchEvent(
@@ -1116,10 +1116,10 @@ describe('PointerInput', () => {
             expect(pos.y).toBe(0);
             expect(delta.x).toBe(0);
             expect(delta.y).toBe(0);
-            expect(input.isValid(slot)).toBe(false);
             expect(input.isButtonDown(BTN_POINTER_A, slot)).toBe(false);
             expect(input.isButtonPressed(BTN_POINTER_A, slot)).toBe(false);
             expect(input.isButtonReleased(BTN_POINTER_A, slot)).toBe(false);
+            expect(input.isActive(slot)).toBe(false);
         });
 
         it('returns false for unknown button codes', () => {

--- a/src/input/PointerInput.test.ts
+++ b/src/input/PointerInput.test.ts
@@ -191,7 +191,7 @@ describe('PointerInput', () => {
             const p = new PointerInput();
             p.attach(c, new Vector2i(DISPLAY_WIDTH, DISPLAY_HEIGHT));
 
-            // Register a touch contact so a pointerId is tracked in pointerIdToSlot.
+            // Register a touch contact so a pointerId is tracked in idToSlot.
             c.dispatchEvent(
                 pointerEvent('pointerdown', {
                     pointerId: 42,

--- a/src/input/PointerInput.ts
+++ b/src/input/PointerInput.ts
@@ -26,17 +26,17 @@ export const POINTER_SLOT_COUNT = 4;
 /** Pixels-per-line conversion for `WheelEvent.deltaMode === DOM_DELTA_LINE`. */
 const WHEEL_LINE_HEIGHT_PX = 16;
 
-/** Primary pointer button code (mouse left / touch contact). Mirrors `BT.BTN_POINTER_A`. */
-const BTN_POINTER_A = 20;
+/** Primary pointer button code (mouse left / touch contact). Maps to `BT.BTN_POINTER_A`. */
+const BTN_A = 20;
 
-/** Secondary pointer button code (mouse right). Mirrors `BT.BTN_POINTER_B`. */
-const BTN_POINTER_B = 21;
+/** Secondary pointer button code (mouse right). Maps to `BT.BTN_POINTER_B`. */
+const BTN_B = 21;
 
-/** Tertiary pointer button code (mouse middle). Mirrors `BT.BTN_POINTER_C`. */
-const BTN_POINTER_C = 22;
+/** Tertiary pointer button code (mouse middle). Maps to `BT.BTN_POINTER_C`. */
+const BTN_C = 22;
 
-/** Auxiliary pointer button code (mouse back / forward). Mirrors `BT.BTN_POINTER_D`. */
-const BTN_POINTER_D = 23;
+/** Auxiliary pointer button code (mouse back / forward). Maps to `BT.BTN_POINTER_D`. */
+const BTN_D = 23;
 
 // #endregion
 
@@ -48,7 +48,7 @@ const BTN_POINTER_D = 23;
  * `pos` and `prevPos` are reused `Vector2i` instances; allocation discipline
  * keeps the event hot path free of per-call object churn.
  */
-interface PointerSlot {
+interface Slot {
     /** Native `pointerId` currently bound to this slot, or `null` when the slot is empty. */
     pointerId: number | null;
 
@@ -64,16 +64,16 @@ interface PointerSlot {
     /** Snapshot of `pos` taken at `endFrame()`; used to compute the per-frame delta. */
     prevPos: Vector2i;
 
-    /** Current state of `BTN_POINTER_A` for this slot. */
+    /** Current state of `BTN_A` for this slot. */
     a: boolean;
 
-    /** Current state of `BTN_POINTER_B` for this slot. */
+    /** Current state of `BTN_B` for this slot. */
     b: boolean;
 
-    /** Current state of `BTN_POINTER_C` for this slot. */
+    /** Current state of `BTN_C` for this slot. */
     c: boolean;
 
-    /** Current state of `BTN_POINTER_D` for this slot. */
+    /** Current state of `BTN_D` for this slot. */
     d: boolean;
 
     /** Snapshot of `a` taken at `endFrame()`, used for isPressed/released edge detection. */
@@ -112,10 +112,10 @@ export class PointerInput {
      * Per-slot pointer state. Fixed-length tuple of {@link POINTER_SLOT_COUNT}
      * entries (0 = mouse, 1-3 = touch / pen).
      */
-    private readonly slots: readonly [PointerSlot, PointerSlot, PointerSlot, PointerSlot];
+    private readonly slots: readonly [Slot, Slot, Slot, Slot];
 
     /** Maps native `pointerId` -> slot index, so up / move / cancel events can route correctly. */
-    private readonly pointerIdToSlot: Map<number, number> = new Map();
+    private readonly idToSlot: Map<number, number> = new Map();
 
     /** Accumulated wheel delta in pixels for the current frame. */
     private scrollDeltaY: number = 0;
@@ -136,10 +136,10 @@ export class PointerInput {
 
     // #region Bound Listeners
 
-    private readonly onPointerMove: (event: PointerEvent) => void;
-    private readonly onPointerDown: (event: PointerEvent) => void;
-    private readonly onPointerUp: (event: PointerEvent) => void;
-    private readonly onPointerCancel: (event: PointerEvent) => void;
+    private readonly onMove: (event: PointerEvent) => void;
+    private readonly onDown: (event: PointerEvent) => void;
+    private readonly onUp: (event: PointerEvent) => void;
+    private readonly onCancel: (event: PointerEvent) => void;
     private readonly onPointerLeave: (event: PointerEvent) => void;
     private readonly onWheel: (event: WheelEvent) => void;
     private readonly onContextMenu: (event: Event) => void;
@@ -157,10 +157,10 @@ export class PointerInput {
     constructor() {
         this.slots = [this.createEmptySlot(), this.createEmptySlot(), this.createEmptySlot(), this.createEmptySlot()];
 
-        this.onPointerMove = (event) => this.handlePointerMove(event);
-        this.onPointerDown = (event) => this.handlePointerDown(event);
-        this.onPointerUp = (event) => this.handlePointerUp(event);
-        this.onPointerCancel = (event) => this.handlePointerCancel(event);
+        this.onMove = (event) => this.handleMove(event);
+        this.onDown = (event) => this.handleDown(event);
+        this.onUp = (event) => this.handleUp(event);
+        this.onCancel = (event) => this.handleCancel(event);
         this.onPointerLeave = (event) => this.handlePointerLeave(event);
         this.onWheel = (event) => this.handleWheel(event);
         this.onContextMenu = (event) => event.preventDefault();
@@ -178,7 +178,7 @@ export class PointerInput {
      *   doesn't scroll the page when the user spins the wheel over the game
      * - `canvas.style.touchAction = 'none'` so iOS Safari doesn't intercept
      *   touches for pinch-zoom or double-tap-zoom
-     * - `contextmenu.preventDefault()` so right-click feeds `BTN_POINTER_B`
+     * - `contextmenu.preventDefault()` so right-click feeds `BTN_B`
      *   instead of popping the OS context menu
      *
      * @param canvas - Canvas element rendering the engine output.
@@ -194,10 +194,10 @@ export class PointerInput {
         canvas.style.touchAction = 'none';
         this.originalCursor = canvas.style.cursor;
 
-        canvas.addEventListener('pointermove', this.onPointerMove);
-        canvas.addEventListener('pointerdown', this.onPointerDown);
-        canvas.addEventListener('pointerup', this.onPointerUp);
-        canvas.addEventListener('pointercancel', this.onPointerCancel);
+        canvas.addEventListener('pointermove', this.onMove);
+        canvas.addEventListener('pointerdown', this.onDown);
+        canvas.addEventListener('pointerup', this.onUp);
+        canvas.addEventListener('pointercancel', this.onCancel);
         canvas.addEventListener('pointerleave', this.onPointerLeave);
         canvas.addEventListener('wheel', this.onWheel, { passive: false });
         canvas.addEventListener('contextmenu', this.onContextMenu);
@@ -214,7 +214,7 @@ export class PointerInput {
         const canvas = this.canvas;
 
         if (canvas !== null) {
-            for (const [pointerId] of this.pointerIdToSlot) {
+            for (const [pointerId] of this.idToSlot) {
                 try {
                     if (canvas.hasPointerCapture(pointerId)) {
                         canvas.releasePointerCapture(pointerId);
@@ -224,10 +224,10 @@ export class PointerInput {
                 }
             }
 
-            canvas.removeEventListener('pointermove', this.onPointerMove);
-            canvas.removeEventListener('pointerdown', this.onPointerDown);
-            canvas.removeEventListener('pointerup', this.onPointerUp);
-            canvas.removeEventListener('pointercancel', this.onPointerCancel);
+            canvas.removeEventListener('pointermove', this.onMove);
+            canvas.removeEventListener('pointerdown', this.onDown);
+            canvas.removeEventListener('pointerup', this.onUp);
+            canvas.removeEventListener('pointercancel', this.onCancel);
             canvas.removeEventListener('pointerleave', this.onPointerLeave);
             canvas.removeEventListener('wheel', this.onWheel);
             canvas.removeEventListener('contextmenu', this.onContextMenu);
@@ -246,7 +246,7 @@ export class PointerInput {
         this.originalTouchAction = null;
         this.originalCursor = null;
 
-        this.pointerIdToSlot.clear();
+        this.idToSlot.clear();
         this.scrollDeltaY = 0;
 
         for (const slot of this.slots) {
@@ -366,14 +366,14 @@ export class PointerInput {
     /**
      * Reports whether the given pointer button is held in slot `slot`.
      *
-     * For slot 0 (mouse): `BTN_POINTER_A` is left, `B` is right, `C` is middle,
+     * For slot 0 (mouse): `BTN_A` is left, `B` is right, `C` is middle,
      * `D` is back / forward (matches RetroBlit canonical, not DOM
      * `PointerEvent.button` index order).
      *
-     * For slots 1-3 (touch / pen): only `BTN_POINTER_A` is ever true while the
+     * For slots 1-3 (touch / pen): only `BTN_A` is ever true while the
      * contact is down; `B`, `C`, `D` always return `false`.
      *
-     * @param button - One of `BTN_POINTER_A..D`.
+     * @param button - One of `BTN_A..D`.
      * @param slot - Pointer slot index.
      * @returns `true` while the button remains pressed.
      */
@@ -385,13 +385,13 @@ export class PointerInput {
         }
 
         switch (button) {
-            case BTN_POINTER_A:
+            case BTN_A:
                 return s.a;
-            case BTN_POINTER_B:
+            case BTN_B:
                 return s.b;
-            case BTN_POINTER_C:
+            case BTN_C:
                 return s.c;
-            case BTN_POINTER_D:
+            case BTN_D:
                 return s.d;
             default:
                 return false;
@@ -401,7 +401,7 @@ export class PointerInput {
     /**
      * Reports whether the given pointer button transitioned to down on the current frame.
      *
-     * @param button - One of `BTN_POINTER_A..D`.
+     * @param button - One of `BTN_A..D`.
      * @param slot - Pointer slot index.
      * @returns `true` only on the frame the button transitions from up to down.
      */
@@ -413,13 +413,13 @@ export class PointerInput {
         }
 
         switch (button) {
-            case BTN_POINTER_A:
+            case BTN_A:
                 return s.a && !s.prevA;
-            case BTN_POINTER_B:
+            case BTN_B:
                 return s.b && !s.prevB;
-            case BTN_POINTER_C:
+            case BTN_C:
                 return s.c && !s.prevC;
-            case BTN_POINTER_D:
+            case BTN_D:
                 return s.d && !s.prevD;
             default:
                 return false;
@@ -429,7 +429,7 @@ export class PointerInput {
     /**
      * Reports whether the given pointer button transitioned to up on the current frame.
      *
-     * @param button - One of `BTN_POINTER_A..D`.
+     * @param button - One of `BTN_A..D`.
      * @param slot - Pointer slot index.
      * @returns `true` only on the frame the button transitions from down to up.
      */
@@ -441,13 +441,13 @@ export class PointerInput {
         }
 
         switch (button) {
-            case BTN_POINTER_A:
+            case BTN_A:
                 return !s.a && s.prevA;
-            case BTN_POINTER_B:
+            case BTN_B:
                 return !s.b && s.prevB;
-            case BTN_POINTER_C:
+            case BTN_C:
                 return !s.c && s.prevC;
-            case BTN_POINTER_D:
+            case BTN_D:
                 return !s.d && s.prevD;
             default:
                 return false;
@@ -491,7 +491,7 @@ export class PointerInput {
      *
      * @param event - DOM pointer event from the canvas.
      */
-    private handlePointerMove(event: PointerEvent): void {
+    private handleMove(event: PointerEvent): void {
         if (event.pointerType === 'mouse') {
             const slot = this.slots[0];
             const isPreviouslyActive = slot.isActive;
@@ -512,7 +512,7 @@ export class PointerInput {
             return;
         }
 
-        const slot = this.lookupSlotByPointerId(event.pointerId);
+        const slot = this.lookupSlotById(event.pointerId);
 
         if (slot === null) {
             return;
@@ -524,12 +524,12 @@ export class PointerInput {
     /**
      * Routes a `pointerdown` event. Mouse events claim slot 0 and set the
      * mapped button. Touch / pen events allocate the first free slot in
-     * 1..3 and set `BTN_POINTER_A`; events that arrive while all touch
+     * 1..3 and set `BTN_A`; events that arrive while all touch
      * slots are full are dropped silently.
      *
      * @param event - DOM pointer event from the canvas.
      */
-    private handlePointerDown(event: PointerEvent): void {
+    private handleDown(event: PointerEvent): void {
         if (event.pointerType === 'mouse') {
             const slot = this.slots[0];
             const isPreviouslyActive = slot.isActive;
@@ -552,7 +552,7 @@ export class PointerInput {
         }
 
         // Touch or pen: route to the first free slot in 1..POINTER_SLOT_COUNT - 1.
-        if (this.pointerIdToSlot.has(event.pointerId)) {
+        if (this.idToSlot.has(event.pointerId)) {
             return;
         }
 
@@ -582,7 +582,7 @@ export class PointerInput {
         // position from the previous occupant of this slot.
         slot.prevPos.copyFrom(slot.pos);
 
-        this.pointerIdToSlot.set(event.pointerId, slotIndex);
+        this.idToSlot.set(event.pointerId, slotIndex);
 
         // Capture so off-canvas drags keep delivering events to this canvas.
         this.canvas?.setPointerCapture(event.pointerId);
@@ -595,7 +595,7 @@ export class PointerInput {
      *
      * @param event - DOM pointer event from the canvas.
      */
-    private handlePointerUp(event: PointerEvent): void {
+    private handleUp(event: PointerEvent): void {
         if (event.pointerType === 'mouse') {
             const slot = this.slots[0];
 
@@ -605,13 +605,13 @@ export class PointerInput {
             return;
         }
 
-        const slotIndex = this.pointerIdToSlot.get(event.pointerId);
+        const slotIndex = this.idToSlot.get(event.pointerId);
 
         if (slotIndex === undefined) {
             return;
         }
 
-        // eslint-disable-next-line security/detect-object-injection -- slotIndex resolved from pointerIdToSlot, always in [0, POINTER_SLOT_COUNT)
+        // eslint-disable-next-line security/detect-object-injection -- slotIndex resolved from idToSlot, always in [0, POINTER_SLOT_COUNT)
         const slot = this.slots[slotIndex];
 
         if (slot !== undefined) {
@@ -628,14 +628,14 @@ export class PointerInput {
      *
      * @param event - DOM pointer event from the canvas.
      */
-    private handlePointerCancel(event: PointerEvent): void {
+    private handleCancel(event: PointerEvent): void {
         if (event.pointerType === 'mouse') {
             this.deactivateMouseSlot();
 
             return;
         }
 
-        const slotIndex = this.pointerIdToSlot.get(event.pointerId);
+        const slotIndex = this.idToSlot.get(event.pointerId);
 
         if (slotIndex === undefined) {
             return;
@@ -658,7 +658,7 @@ export class PointerInput {
             return;
         }
 
-        const slotIndex = this.pointerIdToSlot.get(event.pointerId);
+        const slotIndex = this.idToSlot.get(event.pointerId);
 
         if (slotIndex === undefined) {
             return;
@@ -696,12 +696,12 @@ export class PointerInput {
     // #region Slot Helpers
 
     /**
-     * Builds a fresh `PointerSlot` with newly allocated `Vector2i` instances
+     * Builds a fresh `Slot` with newly allocated `Vector2i` instances
      * so each slot owns its own position storage.
      *
      * @returns Slot in the empty / inactive state.
      */
-    private createEmptySlot(): PointerSlot {
+    private createEmptySlot(): Slot {
         return {
             pointerId: null,
             pointerType: null,
@@ -725,7 +725,7 @@ export class PointerInput {
      *
      * @param slot - Slot to reset in place.
      */
-    private resetSlot(slot: PointerSlot): void {
+    private resetSlot(slot: Slot): void {
         slot.pointerId = null;
         slot.pointerType = null;
         slot.isActive = false;
@@ -770,7 +770,7 @@ export class PointerInput {
      * @param slotIndex - Index of the slot to free.
      */
     private freeSlot(slotIndex: number): void {
-        // eslint-disable-next-line security/detect-object-injection -- slotIndex resolved from pointerIdToSlot, always in [0, POINTER_SLOT_COUNT)
+        // eslint-disable-next-line security/detect-object-injection -- slotIndex resolved from idToSlot, always in [0, POINTER_SLOT_COUNT)
         const slot = this.slots[slotIndex];
 
         if (slot === undefined) {
@@ -782,7 +782,7 @@ export class PointerInput {
                 this.canvas.releasePointerCapture(slot.pointerId);
             }
 
-            this.pointerIdToSlot.delete(slot.pointerId);
+            this.idToSlot.delete(slot.pointerId);
         }
 
         slot.pointerId = null;
@@ -804,7 +804,7 @@ export class PointerInput {
         const slot = this.slots[0];
 
         if (slot.pointerId !== null) {
-            this.pointerIdToSlot.delete(slot.pointerId);
+            this.idToSlot.delete(slot.pointerId);
         }
 
         slot.pointerId = null;
@@ -829,7 +829,7 @@ export class PointerInput {
      * @param button - DOM `PointerEvent.button` value.
      * @param isPressed - `true` to set the button down, `false` to release it.
      */
-    private setMouseButton(slot: PointerSlot, button: number, isPressed: boolean): void {
+    private setMouseButton(slot: Slot, button: number, isPressed: boolean): void {
         switch (button) {
             case 0:
                 slot.a = isPressed;
@@ -860,7 +860,7 @@ export class PointerInput {
      * @param clientX - DOM `clientX` from the source event.
      * @param clientY - DOM `clientY` from the source event.
      */
-    private updateSlotPosition(slot: PointerSlot, clientX: number, clientY: number): void {
+    private updateSlotPosition(slot: Slot, clientX: number, clientY: number): void {
         const canvas = this.canvas;
         const displaySize = this.displaySize;
 
@@ -897,7 +897,7 @@ export class PointerInput {
      * @param index - Slot index to look up.
      * @returns Slot at the index, or `null` for out-of-range indices.
      */
-    private getSlotOrNull(index: number): PointerSlot | null {
+    private getSlotOrNull(index: number): Slot | null {
         if (!Number.isInteger(index) || index < 0 || index >= POINTER_SLOT_COUNT) {
             return null;
         }
@@ -909,20 +909,20 @@ export class PointerInput {
     /**
      * Looks up the slot bound to a native `pointerId`, or `null` when none is bound.
      *
-     * Resolves the `pointerIdToSlot` map and the indexed slot lookup in one
+     * Resolves the `idToSlot` map and the indexed slot lookup in one
      * helper so event handlers can early-return without repeating the guards.
      *
      * @param pointerId - Native `pointerId` from a DOM pointer event.
      * @returns Slot bound to this `pointerId`, or `null` when no slot is bound.
      */
-    private lookupSlotByPointerId(pointerId: number): PointerSlot | null {
-        const index = this.pointerIdToSlot.get(pointerId);
+    private lookupSlotById(pointerId: number): Slot | null {
+        const index = this.idToSlot.get(pointerId);
 
         if (index === undefined) {
             return null;
         }
 
-        // eslint-disable-next-line security/detect-object-injection -- index originated from pointerIdToSlot, always in [0, POINTER_SLOT_COUNT)
+        // eslint-disable-next-line security/detect-object-injection -- index originated from idToSlot, always in [0, POINTER_SLOT_COUNT)
         return this.slots[index] ?? null;
     }
 

--- a/src/input/PointerInput.ts
+++ b/src/input/PointerInput.ts
@@ -76,7 +76,7 @@ interface PointerSlot {
     /** Current state of `BTN_POINTER_D` for this slot. */
     d: boolean;
 
-    /** Snapshot of `a` taken at `endFrame()`, used for pressed/released edge detection. */
+    /** Snapshot of `a` taken at `endFrame()`, used for isPressed/released edge detection. */
     prevA: boolean;
 
     /** Snapshot of `b` taken at `endFrame()`. */
@@ -494,7 +494,7 @@ export class PointerInput {
     private handlePointerMove(event: PointerEvent): void {
         if (event.pointerType === 'mouse') {
             const slot = this.slots[0];
-            const wasActive = slot.isActive;
+            const isPreviouslyActive = slot.isActive;
 
             slot.pointerId = event.pointerId;
             slot.pointerType = 'mouse';
@@ -505,7 +505,7 @@ export class PointerInput {
             // Activation: sync prevPos to the entry pos so the first frame's
             // delta is zero rather than a jump from (0, 0) (or wherever the
             // slot was previously zeroed) to the entry point.
-            if (!wasActive) {
+            if (!isPreviouslyActive) {
                 slot.prevPos.copyFrom(slot.pos);
             }
 
@@ -532,7 +532,7 @@ export class PointerInput {
     private handlePointerDown(event: PointerEvent): void {
         if (event.pointerType === 'mouse') {
             const slot = this.slots[0];
-            const wasActive = slot.isActive;
+            const isPreviouslyActive = slot.isActive;
 
             slot.pointerId = event.pointerId;
             slot.pointerType = 'mouse';
@@ -544,7 +544,7 @@ export class PointerInput {
             // Activation: sync prevPos so the first delta is zero. Without
             // this, the very first read after the mouse enters would see a
             // delta from (0, 0) to the entry point.
-            if (!wasActive) {
+            if (!isPreviouslyActive) {
                 slot.prevPos.copyFrom(slot.pos);
             }
 
@@ -818,7 +818,7 @@ export class PointerInput {
 
     /**
      * Maps a DOM `PointerEvent.button` value to the corresponding pointer
-     * button on slot 0 and sets it to `pressed`.
+     * button on slot 0 and sets it to `isPressed`.
      *
      * The mapping intentionally follows RetroBlit canonical (A=left, B=right,
      * C=middle), not the DOM index order (where 1 is middle and 2 is right).
@@ -827,22 +827,22 @@ export class PointerInput {
      *
      * @param slot - Mouse slot to update (always slot 0).
      * @param button - DOM `PointerEvent.button` value.
-     * @param pressed - `true` to set the button down, `false` to release it.
+     * @param isPressed - `true` to set the button down, `false` to release it.
      */
-    private setMouseButton(slot: PointerSlot, button: number, pressed: boolean): void {
+    private setMouseButton(slot: PointerSlot, button: number, isPressed: boolean): void {
         switch (button) {
             case 0:
-                slot.a = pressed;
+                slot.a = isPressed;
                 break;
             case 2:
-                slot.b = pressed;
+                slot.b = isPressed;
                 break;
             case 1:
-                slot.c = pressed;
+                slot.c = isPressed;
                 break;
             case 3:
             case 4:
-                slot.d = pressed;
+                slot.d = isPressed;
                 break;
             default:
                 break;

--- a/src/input/PointerInput.ts
+++ b/src/input/PointerInput.ts
@@ -56,7 +56,7 @@ interface PointerSlot {
     pointerType: 'mouse' | 'touch' | 'pen' | null;
 
     /** True when this slot represents an active pointer (mouse hovering, touch in contact). */
-    valid: boolean;
+    isActive: boolean;
 
     /** Last known position in display coordinates (mutated in place by event handlers). */
     pos: Vector2i;
@@ -335,8 +335,8 @@ export class PointerInput {
      * @param slot - Pointer slot index.
      * @returns `true` when the slot has live position data.
      */
-    public isValid(slot: number): boolean {
-        return this.getSlotOrNull(slot)?.valid ?? false;
+    public isActive(slot: number): boolean {
+        return this.getSlotOrNull(slot)?.isActive ?? false;
     }
 
     /**
@@ -380,7 +380,7 @@ export class PointerInput {
     public isButtonDown(button: number, slot: number): boolean {
         const s = this.getSlotOrNull(slot);
 
-        if (s === null || !s.valid) {
+        if (s === null || !s.isActive) {
             return false;
         }
 
@@ -494,18 +494,18 @@ export class PointerInput {
     private handlePointerMove(event: PointerEvent): void {
         if (event.pointerType === 'mouse') {
             const slot = this.slots[0];
-            const wasValid = slot.valid;
+            const wasActive = slot.isActive;
 
             slot.pointerId = event.pointerId;
             slot.pointerType = 'mouse';
-            slot.valid = true;
+            slot.isActive = true;
 
             this.updateSlotPosition(slot, event.clientX, event.clientY);
 
             // Activation: sync prevPos to the entry pos so the first frame's
             // delta is zero rather than a jump from (0, 0) (or wherever the
             // slot was previously zeroed) to the entry point.
-            if (!wasValid) {
+            if (!wasActive) {
                 slot.prevPos.copyFrom(slot.pos);
             }
 
@@ -532,11 +532,11 @@ export class PointerInput {
     private handlePointerDown(event: PointerEvent): void {
         if (event.pointerType === 'mouse') {
             const slot = this.slots[0];
-            const wasValid = slot.valid;
+            const wasActive = slot.isActive;
 
             slot.pointerId = event.pointerId;
             slot.pointerType = 'mouse';
-            slot.valid = true;
+            slot.isActive = true;
 
             this.updateSlotPosition(slot, event.clientX, event.clientY);
             this.setMouseButton(slot, event.button, true);
@@ -544,7 +544,7 @@ export class PointerInput {
             // Activation: sync prevPos so the first delta is zero. Without
             // this, the very first read after the mouse enters would see a
             // delta from (0, 0) to the entry point.
-            if (!wasValid) {
+            if (!wasActive) {
                 slot.prevPos.copyFrom(slot.pos);
             }
 
@@ -572,7 +572,7 @@ export class PointerInput {
 
         slot.pointerId = event.pointerId;
         slot.pointerType = event.pointerType === 'pen' ? 'pen' : 'touch';
-        slot.valid = true;
+        slot.isActive = true;
         slot.a = true;
 
         this.updateSlotPosition(slot, event.clientX, event.clientY);
@@ -705,7 +705,7 @@ export class PointerInput {
         return {
             pointerId: null,
             pointerType: null,
-            valid: false,
+            isActive: false,
             pos: new Vector2iImpl(0, 0),
             prevPos: new Vector2iImpl(0, 0),
             a: false,
@@ -728,7 +728,7 @@ export class PointerInput {
     private resetSlot(slot: PointerSlot): void {
         slot.pointerId = null;
         slot.pointerType = null;
-        slot.valid = false;
+        slot.isActive = false;
         slot.pos.set(0, 0);
         slot.prevPos.set(0, 0);
         slot.a = false;
@@ -787,7 +787,7 @@ export class PointerInput {
 
         slot.pointerId = null;
         slot.pointerType = null;
-        slot.valid = false;
+        slot.isActive = false;
         slot.a = false;
         slot.b = false;
         slot.c = false;
@@ -809,7 +809,7 @@ export class PointerInput {
 
         slot.pointerId = null;
         slot.pointerType = null;
-        slot.valid = false;
+        slot.isActive = false;
         slot.a = false;
         slot.b = false;
         slot.c = false;

--- a/src/overlay/Overlay.test.ts
+++ b/src/overlay/Overlay.test.ts
@@ -171,14 +171,14 @@ describe('Overlay', () => {
             1,
         );
 
-        expect(overlay.bodyVisible).toBe(true);
+        expect(overlay.isBodyVisible).toBe(true);
     });
 
     it('starts hidden by default and toggles body visibility', () => {
         const layout = createOverlayLayout(320, 240, 14);
         const overlay = createOverlay(layout, 'Test Demo');
 
-        expect(overlay.bodyVisible).toBe(false);
+        expect(overlay.isBodyVisible).toBe(false);
 
         overlay.handleToggle(
             null,
@@ -188,7 +188,7 @@ describe('Overlay', () => {
             1,
         );
 
-        expect(overlay.bodyVisible).toBe(true);
+        expect(overlay.isBodyVisible).toBe(true);
 
         overlay.handleToggle(
             null,
@@ -198,7 +198,7 @@ describe('Overlay', () => {
             2,
         );
 
-        expect(overlay.bodyVisible).toBe(false);
+        expect(overlay.isBodyVisible).toBe(false);
     });
 
     it('draws top and bottom overlay labels when body is visible', () => {
@@ -558,7 +558,7 @@ describe('Overlay', () => {
 
         const customRows = [{ leftText: 'Bounces: 11' }, { leftText: 'Position: (43, 166)' }];
         const pointer = {
-            isValid: () => true,
+            isActive: () => true,
             getPos: () => new Vector2i(swatch.x + 1, swatch.y + 1),
         };
 
@@ -823,7 +823,7 @@ describe('Overlay', () => {
             1,
         );
 
-        expect(overlay.bodyVisible).toBe(false);
+        expect(overlay.isBodyVisible).toBe(false);
     });
 
     it('resets camera for hint-only draws then restores the saved offset', () => {

--- a/src/overlay/Overlay.test.ts
+++ b/src/overlay/Overlay.test.ts
@@ -14,7 +14,7 @@ import { OVERLAY_BAR_HEIGHT, OVERLAY_ROW_GAP_PX } from './layout/constants';
 import { createOverlayLayout, overlayRightAlignedTextX } from './layout/layoutHelpers';
 import { hintBarY, paletteBandY } from './layout/layoutPlan';
 import { Overlay } from './Overlay';
-import { overlayToggleHintIconPos } from './OverlayToggleIcon';
+import { hintIconPos } from './OverlayToggleIcon';
 import { computePaletteGrid, writePaletteScrollbarRects, writePaletteSwatchTopLeft } from './palette/PaletteView';
 import {
     createMockRenderer,
@@ -31,14 +31,14 @@ import {
 // #region Helpers
 
 /** Default overlay tests use the 13 px hint bar (palette grid opt-in off). */
-const OVERLAY_PALETTE_VIEW_OFF = false;
+const OVERLAY_PALETTE_GRID_OFF = false;
 
 interface OverlayTestOptions {
     style?: { barPaletteIndex?: number; textPaletteIndex?: number; gapPaletteIndex?: number };
-    paletteView?: boolean;
+    isOverlayPaletteEnabled?: boolean;
     paletteColumns?: number;
     paletteRowsVisible?: number;
-    overlayTimingChart?: boolean;
+    isOverlayTimingChartEnabled?: boolean;
     overlayTimingChartStyle?: {
         updateBarPaletteIndex?: number;
         renderBarPaletteIndex?: number;
@@ -48,10 +48,10 @@ interface OverlayTestOptions {
     };
     overlayTimingChartHeight?: number;
     overlayTimingChartDiagnostics?: false | 'minimal' | 'rich';
-    overlayRendererDiagnosticsBar?: boolean;
-    visibleAtStart?: boolean;
-    toggleHintVisible?: boolean;
-    toggleEnabled?: boolean;
+    isOverlayRendererDiagnosticsBarEnabled?: boolean;
+    isOverlayVisibleAtStart?: boolean;
+    isOverlayToggleHintVisible?: boolean;
+    isOverlayToggleEnabled?: boolean;
     backend?: 'webgpu' | 'software';
 }
 
@@ -67,17 +67,17 @@ function createOverlay(
         60,
         options.backend ?? 'webgpu',
         options.style,
-        options.paletteView ?? OVERLAY_PALETTE_VIEW_OFF,
+        options.isOverlayPaletteEnabled ?? OVERLAY_PALETTE_GRID_OFF,
         options.paletteColumns,
         options.paletteRowsVisible,
-        options.overlayTimingChart ?? false,
+        options.isOverlayTimingChartEnabled ?? false,
         options.overlayTimingChartStyle,
         options.overlayTimingChartHeight,
         options.overlayTimingChartDiagnostics ?? false,
-        options.overlayRendererDiagnosticsBar ?? false,
-        options.visibleAtStart ?? false,
-        options.toggleHintVisible ?? true,
-        options.toggleEnabled ?? true,
+        options.isOverlayRendererDiagnosticsBarEnabled ?? false,
+        options.isOverlayVisibleAtStart ?? false,
+        options.isOverlayToggleHintVisible ?? true,
+        options.isOverlayToggleEnabled ?? true,
     );
 }
 
@@ -97,18 +97,21 @@ function buildUsageMask(indices: readonly number[], size = 256): Uint8Array {
 // #region Tests
 
 describe('Overlay', () => {
-    it('tracksPaletteUsage is false when palette grid is disabled', () => {
+    it('isTrackingPaletteUsage is false when palette grid is disabled', () => {
         const layout = createOverlayLayout(320, 240, 14);
         const overlay = createOverlay(layout, 'Test Demo');
 
-        expect(overlay.tracksPaletteUsage).toBe(false);
+        expect(overlay.isTrackingPaletteUsage).toBe(false);
     });
 
-    it('tracksPaletteUsage follows palette grid opt-in and visibility toggle', () => {
+    it('isTrackingPaletteUsage follows palette grid opt-in and visibility toggle', () => {
         const layout = createOverlayLayout(320, 240, 14);
-        const overlay = createOverlay(layout, 'Test Demo', { paletteView: true, visibleAtStart: true });
+        const overlay = createOverlay(layout, 'Test Demo', {
+            isOverlayPaletteEnabled: true,
+            isOverlayVisibleAtStart: true,
+        });
 
-        expect(overlay.tracksPaletteUsage).toBe(true);
+        expect(overlay.isTrackingPaletteUsage).toBe(true);
 
         overlay.handleToggle(
             null,
@@ -118,12 +121,15 @@ describe('Overlay', () => {
             1,
         );
 
-        expect(overlay.tracksPaletteUsage).toBe(false);
+        expect(overlay.isTrackingPaletteUsage).toBe(false);
     });
 
     it('swatch press in the toggle corner does not toggle overlay body', () => {
         const layout = createOverlayLayout(320, 240, 14);
-        const overlay = createOverlay(layout, 'Test Demo', { paletteView: true, visibleAtStart: true });
+        const overlay = createOverlay(layout, 'Test Demo', {
+            isOverlayPaletteEnabled: true,
+            isOverlayVisibleAtStart: true,
+        });
         const grid = computePaletteGrid(320);
         const paletteBandTop = paletteBandY(240, grid.totalHeight);
         const paletteBand = new Rect2i(0, paletteBandTop, 320, grid.totalHeight);
@@ -141,14 +147,14 @@ describe('Overlay', () => {
             1,
         );
 
-        expect(overlay.bodyVisible).toBe(true);
+        expect(overlay.isBodyVisible).toBe(true);
     });
 
     it('scrollbar track press blocks toggle but swatch press still copies first', () => {
         const layout = createOverlayLayout(320, 240, 14);
         const overlay = createOverlay(layout, 'Test Demo', {
-            paletteView: true,
-            visibleAtStart: true,
+            isOverlayPaletteEnabled: true,
+            isOverlayVisibleAtStart: true,
             paletteRowsVisible: 3,
         });
         const grid = computePaletteGrid(320, undefined, 256, undefined, undefined, 3);
@@ -162,7 +168,7 @@ describe('Overlay', () => {
             {
                 isButtonPressed: () => true,
                 isButtonDown: () => true,
-                isValid: () => true,
+                isActive: () => true,
                 getPos: () => new Vector2i(track.x + 1, track.y + 1),
                 getScrollDelta: () => 0,
                 consumeScrollDelta: vi.fn(),
@@ -204,7 +210,7 @@ describe('Overlay', () => {
     it('draws top and bottom overlay labels when body is visible', () => {
         const layout = createOverlayLayout(320, 240, 14);
         const topLeftLabel = 'Patterns Demo';
-        const overlay = createOverlay(layout, topLeftLabel, { visibleAtStart: true });
+        const overlay = createOverlay(layout, topLeftLabel, { isOverlayVisibleAtStart: true });
         const renderer = createMockRenderer();
 
         overlay.updateAndRender(renderer, mockFont, null, null, 0);
@@ -246,7 +252,7 @@ describe('Overlay', () => {
 
     it('uses activeBackend for the top-right label', () => {
         const layout = createOverlayLayout(320, 240, 14);
-        const overlay = createOverlay(layout, 'Demo', { backend: 'software', visibleAtStart: true });
+        const overlay = createOverlay(layout, 'Demo', { backend: 'software', isOverlayVisibleAtStart: true });
         const renderer = createMockRenderer();
 
         overlay.updateAndRender(renderer, mockFont, null, null, 0);
@@ -257,7 +263,7 @@ describe('Overlay', () => {
 
     it('uses provided frame timings and shows update-step suffix when multiple updates ran', () => {
         const layout = createOverlayLayout(320, 240, 14);
-        const overlay = createOverlay(layout, 'Demo', { visibleAtStart: true });
+        const overlay = createOverlay(layout, 'Demo', { isOverlayVisibleAtStart: true });
         const renderer = createMockRenderer();
 
         overlay.updateAndRender(renderer, mockFont, null, null, 0, undefined, {
@@ -282,7 +288,7 @@ describe('Overlay', () => {
 
     it('skips draw calls when body is hidden and the toggle hint is disabled', () => {
         const layout = createOverlayLayout(320, 240, 14);
-        const overlay = createOverlay(layout, 'Demo', { toggleHintVisible: false });
+        const overlay = createOverlay(layout, 'Demo', { isOverlayToggleHintVisible: false });
         const renderer = createMockRenderer();
 
         overlay.updateAndRender(renderer, mockFont, null, null, 0);
@@ -295,7 +301,7 @@ describe('Overlay', () => {
     it('draws hint-only path while body is hidden and toggle hint is visible', () => {
         const overlay = createOverlay(createOverlayLayout(320, 240, 14), 'Demo');
         const renderer = createMockRenderer();
-        const iconPos = overlayToggleHintIconPos(hintBarY(240));
+        const iconPos = hintIconPos(hintBarY(240));
 
         overlay.updateAndRender(renderer, mockFont, null, null, 0);
 
@@ -312,7 +318,7 @@ describe('Overlay', () => {
 
     it('does not draw the palette band while body is hidden even when palette view is enabled', () => {
         const layout = createOverlayLayout(320, 240, 14);
-        const overlay = createOverlay(layout, 'Demo', { paletteView: true });
+        const overlay = createOverlay(layout, 'Demo', { isOverlayPaletteEnabled: true });
         const renderer = createMockRenderer();
         const grid = computePaletteGrid(320, undefined, 256);
 
@@ -327,7 +333,7 @@ describe('Overlay', () => {
 
     it('resets camera for overlay draws then restores the saved offset', () => {
         const layout = createOverlayLayout(320, 240, 14);
-        const overlay = createOverlay(layout, 'Demo', { visibleAtStart: true });
+        const overlay = createOverlay(layout, 'Demo', { isOverlayVisibleAtStart: true });
         const renderer = createMockRenderer();
         const saved = new Vector2i(12, 34);
 
@@ -340,7 +346,7 @@ describe('Overlay', () => {
 
     it('uses default overlay palette indices when style is omitted', () => {
         const layout = createOverlayLayout(320, 240, 14);
-        const overlay = createOverlay(layout, 'Demo', { visibleAtStart: true });
+        const overlay = createOverlay(layout, 'Demo', { isOverlayVisibleAtStart: true });
         const renderer = createMockRenderer();
         overlay.updateAndRender(renderer, mockFont, null, null, 0);
 
@@ -354,7 +360,7 @@ describe('Overlay', () => {
         const layout = createOverlayLayout(320, 240, 14);
         const overlay = createOverlay(layout, 'Demo', {
             style: { barPaletteIndex: 8, textPaletteIndex: 9, gapPaletteIndex: 12 },
-            visibleAtStart: true,
+            isOverlayVisibleAtStart: true,
         });
         const renderer = createMockRenderer();
 
@@ -374,7 +380,7 @@ describe('Overlay', () => {
         const layout = createOverlayLayout(320, 240, 14);
         const overlay = createOverlay(layout, 'Demo', {
             style: { barPaletteIndex: 8, textPaletteIndex: 9 },
-            visibleAtStart: true,
+            isOverlayVisibleAtStart: true,
         });
         const renderer = createMockRenderer();
 
@@ -390,7 +396,7 @@ describe('Overlay', () => {
         const layout = createOverlayLayout(320, 240, 14);
         const overlay = createOverlay(layout, 'Demo', {
             style: { barPaletteIndex: 8, textPaletteIndex: 9 },
-            visibleAtStart: true,
+            isOverlayVisibleAtStart: true,
         });
         const renderer = createMockRenderer();
         overlay.updateAndRender(renderer, mockFont, null, null, 0);
@@ -406,7 +412,7 @@ describe('Overlay', () => {
         const layout = createOverlayLayout(320, 240, 14);
         const overlay = createOverlay(layout, 'Demo', {
             style: { barPaletteIndex: 2, textPaletteIndex: 3 },
-            visibleAtStart: true,
+            isOverlayVisibleAtStart: true,
         });
         const renderer = createMockRenderer();
         const customRows = [{ leftText: 'Left', barPaletteIndex: 5, textPaletteIndex: 6 }];
@@ -424,7 +430,7 @@ describe('Overlay', () => {
 
     it('draws custom rows stacked above the bottom bar with 1px gaps', () => {
         const layout = createOverlayLayout(320, 240, 14);
-        const overlay = createOverlay(layout, 'Demo', { visibleAtStart: true });
+        const overlay = createOverlay(layout, 'Demo', { isOverlayVisibleAtStart: true });
         const renderer = createMockRenderer();
         const customRows = [{ leftText: 'Position: 10, 20' }, { leftText: 'Bounces: 3', rightText: 'ok' }];
 
@@ -463,7 +469,7 @@ describe('Overlay', () => {
 
     it('skips extra custom row draws when customRows is empty', () => {
         const layout = createOverlayLayout(320, 240, 14);
-        const overlay = createOverlay(layout, 'Demo', { visibleAtStart: true });
+        const overlay = createOverlay(layout, 'Demo', { isOverlayVisibleAtStart: true });
         const renderer = createMockRenderer();
 
         overlay.updateAndRender(renderer, mockFont, null, null, 0, () => []);
@@ -483,9 +489,9 @@ describe('Overlay', () => {
         expect(getCustomRows).not.toHaveBeenCalled();
     });
 
-    it('renders palette grid when overlayPaletteView is enabled', () => {
+    it('renders palette grid when isOverlayPaletteEnabled is enabled', () => {
         const layout = createOverlayLayout(320, 240, 14);
-        const overlay = createOverlay(layout, 'Demo', { paletteView: true, visibleAtStart: true });
+        const overlay = createOverlay(layout, 'Demo', { isOverlayPaletteEnabled: true, isOverlayVisibleAtStart: true });
         const renderer = createMockRenderer();
         const palette = Palette.vga();
         const usedMask = buildUsageMask([1, 2, 3, 4, 5, 6, 7, 8]);
@@ -510,7 +516,7 @@ describe('Overlay', () => {
 
     it('preserves default hint bar height when palette view is disabled', () => {
         const layout = createOverlayLayout(320, 240, 14);
-        const overlay = createOverlay(layout, 'Demo', { visibleAtStart: true });
+        const overlay = createOverlay(layout, 'Demo', { isOverlayVisibleAtStart: true });
         const renderer = createMockRenderer();
         const palette = Palette.vga();
 
@@ -526,7 +532,7 @@ describe('Overlay', () => {
 
     it('stacks custom rows above the palette grid bottom band', () => {
         const layout = createOverlayLayout(320, 240, 14);
-        const overlay = createOverlay(layout, 'Demo', { paletteView: true, visibleAtStart: true });
+        const overlay = createOverlay(layout, 'Demo', { isOverlayPaletteEnabled: true, isOverlayVisibleAtStart: true });
         const renderer = createMockRenderer();
         const palette = Palette.vga();
         const usedMask = buildUsageMask([1, 2, 3, 4, 5, 6, 7, 8]);
@@ -544,7 +550,7 @@ describe('Overlay', () => {
 
     it('draws palette tooltip label after custom row and hint labels', () => {
         const layout = createOverlayLayout(320, 240, 14);
-        const overlay = createOverlay(layout, 'Demo', { paletteView: true, visibleAtStart: true });
+        const overlay = createOverlay(layout, 'Demo', { isOverlayPaletteEnabled: true, isOverlayVisibleAtStart: true });
         const renderer = createMockRenderer();
         const palette = Palette.vga();
         const usedMask = buildUsageMask([1, 2, 3, 4, 5, 6, 7, 8]);
@@ -607,9 +613,9 @@ describe('Overlay', () => {
     it('forwards timing chart tags to drawLabelOnTop with event palette offset', () => {
         const layout = createOverlayLayout(320, 240, 14);
         const overlay = createOverlay(layout, 'Demo', {
-            overlayTimingChart: true,
+            isOverlayTimingChartEnabled: true,
             overlayTimingChartStyle: { tagPaletteIndex: 7 },
-            visibleAtStart: true,
+            isOverlayVisibleAtStart: true,
         });
         const renderer = createMockRenderer();
 
@@ -633,14 +639,14 @@ describe('Overlay', () => {
         expect(tagCall?.[3]).toBe(6);
     });
 
-    it('draws timing chart dots when overlayTimingChart is enabled', () => {
+    it('draws timing chart dots when isOverlayTimingChartEnabled is enabled', () => {
         const layout = createOverlayLayout(320, 240, 14);
         const overlay = createOverlay(layout, 'Demo', {
             style: { barPaletteIndex: 8, textPaletteIndex: 9 },
-            overlayTimingChart: true,
+            isOverlayTimingChartEnabled: true,
             overlayTimingChartStyle: { updateBarPaletteIndex: 10, renderBarPaletteIndex: 11 },
             overlayTimingChartHeight: 36,
-            visibleAtStart: true,
+            isOverlayVisibleAtStart: true,
         });
         const renderer = createMockRenderer();
 
@@ -669,14 +675,14 @@ describe('Overlay', () => {
     it('tints timing chart dots with warning palette when frame exceeds soft budget', () => {
         const layout = createOverlayLayout(320, 240, 14);
         const overlay = createOverlay(layout, 'Demo', {
-            overlayTimingChart: true,
+            isOverlayTimingChartEnabled: true,
             overlayTimingChartStyle: {
                 updateBarPaletteIndex: 10,
                 renderBarPaletteIndex: 11,
                 warningPaletteIndex: 3,
                 errorPaletteIndex: 4,
             },
-            visibleAtStart: true,
+            isOverlayVisibleAtStart: true,
         });
         const renderer = createMockRenderer();
 
@@ -705,10 +711,10 @@ describe('Overlay', () => {
     it('does not draw overlay while hidden but keeps timing chart samples for re-show', () => {
         const layout = createOverlayLayout(320, 240, 14);
         const overlay = createOverlay(layout, 'Demo', {
-            overlayTimingChart: true,
+            isOverlayTimingChartEnabled: true,
             overlayTimingChartStyle: { updateBarPaletteIndex: 10, renderBarPaletteIndex: 11 },
-            visibleAtStart: true,
-            toggleHintVisible: false,
+            isOverlayVisibleAtStart: true,
+            isOverlayToggleHintVisible: false,
         });
         const renderer = createMockRenderer();
 
@@ -745,9 +751,9 @@ describe('Overlay', () => {
         expect(renderer.drawBarFill.mock.calls.some((call) => call[1] === 10)).toBe(true);
     });
 
-    it('does not draw timing chart dots when overlayTimingChart is disabled', () => {
+    it('does not draw timing chart dots when isOverlayTimingChartEnabled is disabled', () => {
         const layout = createOverlayLayout(320, 240, 14);
-        const overlay = createOverlay(layout, 'Demo', { visibleAtStart: true });
+        const overlay = createOverlay(layout, 'Demo', { isOverlayVisibleAtStart: true });
         const renderer = createMockRenderer();
 
         overlay.updateAndRender(renderer, mockFont, null, null, 0, undefined, {
@@ -769,10 +775,10 @@ describe('Overlay', () => {
     it('records drop severity in chart history while body is hidden', () => {
         const layout = createOverlayLayout(320, 240, 14);
         const overlay = createOverlay(layout, 'Demo', {
-            overlayTimingChart: true,
+            isOverlayTimingChartEnabled: true,
             overlayTimingChartStyle: { warningPaletteIndex: 3, errorPaletteIndex: 4 },
-            visibleAtStart: true,
-            toggleHintVisible: false,
+            isOverlayVisibleAtStart: true,
+            isOverlayToggleHintVisible: false,
         });
         const renderer = createMockRenderer();
 
@@ -809,11 +815,11 @@ describe('Overlay', () => {
         expect(renderer.drawBarFill.mock.calls.some((call) => call[1] === 3)).toBe(true);
     });
 
-    it('ignores toggle input when overlayToggleEnabled is false', () => {
+    it('ignores toggle input when isOverlayToggleEnabled is false', () => {
         const layout = createOverlayLayout(320, 240, 14);
-        const overlay = createOverlay(layout, 'Demo', { toggleEnabled: false });
+        const overlay = createOverlay(layout, 'Demo', { isOverlayToggleEnabled: false });
 
-        expect(overlay.bodyVisible).toBe(false);
+        expect(overlay.isBodyVisible).toBe(false);
 
         overlay.handleToggle(
             null,

--- a/src/overlay/Overlay.test.ts
+++ b/src/overlay/Overlay.test.ts
@@ -7,7 +7,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { Palette } from '../assets/Palette';
-import { markRenderPaletteIndexUsed } from '../core/RenderPaletteUsage';
+import { markIndexUsed } from '../core/RenderPaletteUsage';
 import { Rect2i } from '../utils/Rect2i';
 import { Vector2i } from '../utils/Vector2i';
 import { OVERLAY_BAR_HEIGHT, OVERLAY_ROW_GAP_PX } from './layout/constants';
@@ -15,7 +15,7 @@ import { createOverlayLayout, overlayRightAlignedTextX } from './layout/layoutHe
 import { hintBarY, paletteBandY } from './layout/layoutPlan';
 import { Overlay } from './Overlay';
 import { hintIconPos } from './OverlayToggleIcon';
-import { computePaletteGrid, writePaletteScrollbarRects, writePaletteSwatchTopLeft } from './palette/PaletteView';
+import { computeGrid, writeScrollbarRects, writeSwatchTopLeft } from './palette/PaletteView';
 import {
     createMockRenderer,
     customRowBarY,
@@ -31,7 +31,7 @@ import {
 // #region Helpers
 
 /** Default overlay tests use the 13 px hint bar (palette grid opt-in off). */
-const OVERLAY_PALETTE_GRID_OFF = false;
+const PALETTE_GRID_OFF = false;
 
 interface OverlayTestOptions {
     style?: { barPaletteIndex?: number; textPaletteIndex?: number; gapPaletteIndex?: number };
@@ -67,7 +67,7 @@ function createOverlay(
         60,
         options.backend ?? 'webgpu',
         options.style,
-        options.isOverlayPaletteEnabled ?? OVERLAY_PALETTE_GRID_OFF,
+        options.isOverlayPaletteEnabled ?? PALETTE_GRID_OFF,
         options.paletteColumns,
         options.paletteRowsVisible,
         options.isOverlayTimingChartEnabled ?? false,
@@ -86,7 +86,7 @@ function buildUsageMask(indices: readonly number[], size = 256): Uint8Array {
     const mask = new Uint8Array(size);
 
     for (const index of indices) {
-        markRenderPaletteIndexUsed(mask, index);
+        markIndexUsed(mask, index);
     }
 
     return mask;
@@ -130,13 +130,13 @@ describe('Overlay', () => {
             isOverlayPaletteEnabled: true,
             isOverlayVisibleAtStart: true,
         });
-        const grid = computePaletteGrid(320);
+        const grid = computeGrid(320);
         const paletteBandTop = paletteBandY(240, grid.totalHeight);
         const paletteBand = new Rect2i(0, paletteBandTop, 320, grid.totalHeight);
         const swatch = new Rect2i();
         const index = grid.cols * (grid.rows - 1);
 
-        writePaletteSwatchTopLeft(swatch, index, paletteBand, grid);
+        writeSwatchTopLeft(swatch, index, paletteBand, grid);
 
         overlay.handleFrameInput(
             {
@@ -157,12 +157,12 @@ describe('Overlay', () => {
             isOverlayVisibleAtStart: true,
             paletteRowsVisible: 3,
         });
-        const grid = computePaletteGrid(320, undefined, 256, undefined, undefined, 3);
+        const grid = computeGrid(320, undefined, 256, undefined, undefined, 3);
         const paletteBandTop = paletteBandY(240, grid.totalHeight);
         const paletteBand = new Rect2i(0, paletteBandTop, 320, grid.totalHeight);
         const track = new Rect2i();
         const thumb = new Rect2i();
-        writePaletteScrollbarRects(track, thumb, paletteBand, grid, 0, 4);
+        writeScrollbarRects(track, thumb, paletteBand, grid, 0, 4);
 
         overlay.handleFrameInput(
             {
@@ -320,7 +320,7 @@ describe('Overlay', () => {
         const layout = createOverlayLayout(320, 240, 14);
         const overlay = createOverlay(layout, 'Demo', { isOverlayPaletteEnabled: true });
         const renderer = createMockRenderer();
-        const grid = computePaletteGrid(320, undefined, 256);
+        const grid = computeGrid(320, undefined, 256);
 
         overlay.updateAndRender(renderer, mockFont, null, null, 0, undefined, undefined, Palette.vga());
 
@@ -495,7 +495,7 @@ describe('Overlay', () => {
         const renderer = createMockRenderer();
         const palette = Palette.vga();
         const usedMask = buildUsageMask([1, 2, 3, 4, 5, 6, 7, 8]);
-        const grid = computePaletteGrid(320, undefined, palette.size);
+        const grid = computeGrid(320, undefined, palette.size);
 
         overlay.updateAndRender(renderer, mockFont, null, null, 0, undefined, undefined, palette, usedMask);
 
@@ -536,7 +536,7 @@ describe('Overlay', () => {
         const renderer = createMockRenderer();
         const palette = Palette.vga();
         const usedMask = buildUsageMask([1, 2, 3, 4, 5, 6, 7, 8]);
-        const grid = computePaletteGrid(320, undefined, palette.size);
+        const grid = computeGrid(320, undefined, palette.size);
         const customRows = [{ leftText: 'Palette row' }];
 
         overlay.updateAndRender(renderer, mockFont, null, null, 0, () => customRows, undefined, palette, usedMask);
@@ -554,13 +554,13 @@ describe('Overlay', () => {
         const renderer = createMockRenderer();
         const palette = Palette.vga();
         const usedMask = buildUsageMask([1, 2, 3, 4, 5, 6, 7, 8]);
-        const grid = computePaletteGrid(320, undefined, palette.size);
+        const grid = computeGrid(320, undefined, palette.size);
         const paletteBandTop = paletteBandY(240, grid.totalHeight);
         const paletteBand = new Rect2i(0, paletteBandTop, 320, grid.totalHeight);
         const swatch = new Rect2i();
         const hoveredIndex = 7;
 
-        writePaletteSwatchTopLeft(swatch, hoveredIndex, paletteBand, grid);
+        writeSwatchTopLeft(swatch, hoveredIndex, paletteBand, grid);
 
         const customRows = [{ leftText: 'Bounces: 11' }, { leftText: 'Position: (43, 166)' }];
         const pointer = {

--- a/src/overlay/Overlay.ts
+++ b/src/overlay/Overlay.ts
@@ -22,7 +22,7 @@ import { Toggle } from './input/Toggle';
 import { buildOverlayLayoutPlan, createDefaultLayoutConfig, createOverlayLayoutPlanScratch } from './layout/layoutPlan';
 import type { OverlayLayout, OverlayLayoutConfig, OverlayLayoutPlan } from './layout/types';
 import type { OverlayRenderer } from './OverlayDrawTarget';
-import { drawOverlayToggleIcon } from './OverlayToggleIcon';
+import { toggleIcon } from './OverlayToggleIcon';
 import { PaletteInteraction } from './palette/PaletteInteraction';
 import { computePaletteGrid, DEFAULT_PALETTE_GRID, PaletteView } from './palette/PaletteView';
 import { FpsSampler } from './sampling/FpsSampler';
@@ -96,7 +96,7 @@ export class Overlay {
 
     readonly #toggle: Toggle;
 
-    readonly #toggleHintVisible: boolean;
+    readonly #isToggleHintVisible: boolean;
 
     readonly #bars: OverlayBars = new OverlayBars();
 
@@ -207,7 +207,7 @@ export class Overlay {
      * @param currentTick - Current fixed-update tick (`BT.ticks`).
      */
     assignTag(label: string | undefined, currentTick: number): void {
-        if (!this.#timingChart.enabled) {
+        if (!this.#timingChart.isEnabled) {
             return;
         }
 
@@ -219,8 +219,8 @@ export class Overlay {
      *
      * @returns `true` while metrics bars and palette grid are rendered.
      */
-    get bodyVisible(): boolean {
-        return this.#toggle.bodyVisible;
+    get isBodyVisible(): boolean {
+        return this.#toggle.isBodyVisible;
     }
 
     /**
@@ -232,7 +232,7 @@ export class Overlay {
      * @returns `true` when sprite/text palette usage scanning is needed.
      */
     get tracksPaletteUsage(): boolean {
-        return this.#paletteView.enabled && this.#toggle.bodyVisible;
+        return this.#paletteView.isEnabled && this.#toggle.isBodyVisible;
     }
 
     /**
@@ -253,7 +253,7 @@ export class Overlay {
     ): void {
         let pointerPressConsumed = false;
 
-        if (this.#paletteView.enabled && this.#toggle.bodyVisible) {
+        if (this.#paletteView.isEnabled && this.#toggle.isBodyVisible) {
             const customRows = getCustomRows?.();
             const { layoutConfig, plan } = this.#buildFramePlan(customRows?.length ?? 0, palette);
             const grid = layoutConfig.paletteGrid;
@@ -320,17 +320,17 @@ export class Overlay {
         // Chart history keeps advancing while hidden so re-show reflects demo-only timing.
         this.#sampleTiming(timing);
 
-        const bodyVisible = this.#toggle.bodyVisible;
+        const isBodyVisible = this.#toggle.isBodyVisible;
 
-        if (!bodyVisible && !this.#toggleHintVisible) {
+        if (!isBodyVisible && !this.#isToggleHintVisible) {
             return;
         }
 
-        if (bodyVisible) {
+        if (isBodyVisible) {
             this.#fps.sample();
         }
 
-        const customRows = bodyVisible ? getCustomRows?.() : undefined;
+        const customRows = isBodyVisible ? getCustomRows?.() : undefined;
         const { layoutConfig, plan } = this.#buildFramePlan(customRows?.length ?? 0, palette);
 
         this.#withOverlayCamera(renderer, () => {
@@ -339,7 +339,7 @@ export class Overlay {
                 font,
                 plan,
                 layoutConfig,
-                bodyVisible,
+                isBodyVisible,
                 customRows,
                 palette,
                 usedPaletteMask,
@@ -375,9 +375,9 @@ export class Overlay {
      * @returns Layout config for {@link buildOverlayLayoutPlan}.
      */
     #createLayoutConfig(customRowCount: number, palette: Palette | null | undefined): OverlayLayoutConfig {
-        const overlayPaletteView = this.#paletteView.enabled;
+        const isOverlayPaletteEnabled = this.#paletteView.isEnabled;
         const colorCount = palette?.size ?? 256;
-        const paletteGrid = overlayPaletteView
+        const paletteGrid = isOverlayPaletteEnabled
             ? computePaletteGrid(
                   this.#layout.displayWidth,
                   undefined,
@@ -395,8 +395,8 @@ export class Overlay {
                 this.#layout.lineHeight,
                 customRowCount,
             ),
-            overlayPaletteView,
-            timingChartEnabled: this.#timingChart.enabled,
+            isOverlayPaletteEnabled,
+            isOverlayTimingChartEnabled: this.#timingChart.isEnabled,
             timingChartHeight: this.#timingChartHeight,
             rendererDiagnosticsBarEnabled: this.#rendererDiagnosticsBarEnabled,
             ...(paletteGrid !== undefined ? { paletteGrid } : {}),
@@ -446,14 +446,14 @@ export class Overlay {
     /**
      * Draws overlay content for one frame.
      *
-     * Body panels and the footer hint bar draw only when {@link bodyVisible} is true.
+     * Body panels and the footer hint bar draw only when {@link isBodyVisible} is true.
      * The toggle hint icon always draws when this method runs (symbol only while hidden).
      *
      * @param renderer - Active renderer.
      * @param font - System bitmap font.
      * @param plan - Computed layout plan for this frame.
      * @param layoutConfig - Layout config used to build the plan.
-     * @param bodyVisible - Whether metrics bars and palette grid should draw.
+     * @param isBodyVisible - Whether metrics bars and palette grid should draw.
      * @param customRows - Optional demo rows, if any.
      * @param palette - Active demo palette.
      * @param usedPaletteMask - Per-frame palette usage mask from BTAPI.
@@ -465,7 +465,7 @@ export class Overlay {
         font: BitmapFont,
         plan: OverlayLayoutPlan,
         layoutConfig: OverlayLayoutConfig,
-        bodyVisible: boolean,
+        isBodyVisible: boolean,
         customRows: readonly OverlayRow[] | undefined,
         palette: Palette | null | undefined,
         usedPaletteMask: Uint8Array,
@@ -480,7 +480,7 @@ export class Overlay {
         let rendererDiagnosticsLabel = '';
         const paletteGrid = layoutConfig.paletteGrid ?? DEFAULT_PALETTE_GRID;
 
-        if (bodyVisible) {
+        if (isBodyVisible) {
             const updateStepSuffix = this.#timing.updateSteps > 1 ? `x${this.#timing.updateSteps}` : '';
 
             topMetricsLabel = `Present: ${this.#fps.measuredFps} FPS | Target: ${this.#targetFps} FPS | Draw Calls: ${this.#timing.drawCalls}`;
@@ -533,11 +533,11 @@ export class Overlay {
             this.#bars.drawClusterSeparators(renderer, plan, this.#idxGap, true, true);
         }
 
-        if (bodyVisible) {
+        if (isBodyVisible) {
             this.#bars.drawHintBarFill(renderer, plan, this.#idxBg);
         }
 
-        if (bodyVisible) {
+        if (isBodyVisible) {
             if (customRows !== undefined && customRows.length > 0) {
                 this.#bars.drawCustomRowLabels(renderer, font, plan, customRows, this.#barStyle);
             }
@@ -555,9 +555,9 @@ export class Overlay {
             );
         }
 
-        drawOverlayToggleIcon(renderer, plan.hintBar.y, this.#idxText, bodyVisible);
+        toggleIcon(renderer, plan.hintBar.y, this.#idxText, isBodyVisible);
 
-        if (bodyVisible) {
+        if (isBodyVisible) {
             this.#paletteInteraction.drawTooltipChrome(
                 renderer,
                 plan,

--- a/src/overlay/Overlay.ts
+++ b/src/overlay/Overlay.ts
@@ -24,7 +24,7 @@ import type { OverlayLayout, OverlayLayoutConfig, OverlayLayoutPlan } from './la
 import type { OverlayRenderer } from './OverlayDrawTarget';
 import { toggleIcon } from './OverlayToggleIcon';
 import { PaletteInteraction } from './palette/PaletteInteraction';
-import { computePaletteGrid, DEFAULT_PALETTE_GRID, PaletteView } from './palette/PaletteView';
+import { computeGrid, DEFAULT_PALETTE_GRID, PaletteView } from './palette/PaletteView';
 import { FpsSampler } from './sampling/FpsSampler';
 import { TimingSampler } from './sampling/TimingSampler';
 import { DEFAULT_TIMING_CHART_HEIGHT } from './timing-chart/constants';
@@ -275,7 +275,7 @@ export class Overlay {
             }
         }
 
-        this.#toggle.handleToggle(pointer, keyboard, currentTick, this.#layout.toggleRect, isPointerPressConsumed);
+        this.#toggle.handleInput(pointer, keyboard, currentTick, this.#layout.toggleRect, isPointerPressConsumed);
     }
 
     /**
@@ -330,7 +330,7 @@ export class Overlay {
         const customRows = isBodyVisible ? getCustomRows?.() : undefined;
         const { layoutConfig, plan } = this.#buildFramePlan(customRows?.length ?? 0, palette);
 
-        this.#withOverlayCamera(renderer, () => {
+        this.#withCamera(renderer, () => {
             this.#drawFrame(
                 renderer,
                 font,
@@ -375,7 +375,7 @@ export class Overlay {
         const isOverlayPaletteEnabled = this.#paletteView.isEnabled;
         const colorCount = palette?.size ?? 256;
         const paletteGrid = isOverlayPaletteEnabled
-            ? computePaletteGrid(
+            ? computeGrid(
                   this.#layout.displayWidth,
                   undefined,
                   colorCount,
@@ -428,7 +428,7 @@ export class Overlay {
      * @param renderer - Active renderer.
      * @param draw - Callback that issues overlay draws.
      */
-    #withOverlayCamera(renderer: OverlayRenderer, draw: () => void): void {
+    #withCamera(renderer: OverlayRenderer, draw: () => void): void {
         const savedCamera = renderer.getCameraOffset();
 
         renderer.resetCamera();

--- a/src/overlay/Overlay.ts
+++ b/src/overlay/Overlay.ts
@@ -42,7 +42,7 @@ const EMPTY_PALETTE_USAGE_MASK = new Uint8Array(0);
  * @param style - Optional configure-time overlay style.
  * @returns Resolved palette indices for overlay chrome.
  */
-function resolveOverlayStyleIndices(style?: OverlayStyle): { bg: number; gap: number; text: number } {
+function resolveStyleIndices(style?: OverlayStyle): { bg: number; gap: number; text: number } {
     const bg = style?.barPaletteIndex ?? DEFAULT_IDX_BG;
     const text = style?.textPaletteIndex ?? DEFAULT_IDX_TEXT;
 
@@ -53,20 +53,20 @@ function resolveOverlayStyleIndices(style?: OverlayStyle): { bg: number; gap: nu
  * Creates a timing chart instance and resets its ring buffer when enabled.
  *
  * @param layout - Cached display layout.
- * @param enabled - Whether the timing chart band is active.
+ * @param isEnabled - Whether the timing chart band is active.
  * @param targetFps - Configured fixed-update rate.
  * @param diagnosticsMode - Renderer diagnostic visualization mode.
  * @returns Configured {@link TimingChart} for the overlay.
  */
-function createOverlayTimingChart(
+function createTimingChart(
     layout: OverlayLayout,
-    enabled: boolean,
+    isEnabled: boolean,
     targetFps: number,
     diagnosticsMode: OverlayTimingChartDiagnosticsMode,
 ): TimingChart {
-    const chart = new TimingChart(enabled, targetFps, enabled ? diagnosticsMode : false);
+    const chart = new TimingChart(isEnabled, targetFps, isEnabled ? diagnosticsMode : false);
 
-    if (enabled) {
+    if (isEnabled) {
         chart.reset(layout.displayWidth, 0);
     }
 
@@ -77,7 +77,7 @@ function createOverlayTimingChart(
  * Screen-space overlay HUD rendered after demo content each frame.
  *
  * Internal to the engine; demos do not instantiate this class. Use
- * {@link HardwareSettings.overlayEnabled} and {@link BT.activeBackend} instead.
+ * {@link HardwareSettings.isOverlayEnabled} and {@link BT.activeBackend} instead.
  */
 export class Overlay {
     // #region Fields
@@ -104,7 +104,7 @@ export class Overlay {
 
     readonly #timingChartHeight: number;
 
-    readonly #rendererDiagnosticsBarEnabled: boolean;
+    readonly #isOverlayRendererDiagnosticsBarEnabled: boolean;
 
     readonly #timingChartStyle: TimingChartDrawStyle;
 
@@ -138,17 +138,17 @@ export class Overlay {
      * @param targetFps - Configured fixed-update rate for the target FPS line.
      * @param activeBackend - Backend started by BTAPI (`webgpu` or `software`).
      * @param style - Optional palette indices from {@link HardwareSettings.overlayStyle}.
-     * @param overlayPaletteView - When true, draws the live palette swatch grid.
+     * @param isOverlayPaletteEnabled - When true, draws the live palette swatch grid.
      * @param paletteColumns - Optional max swatches per row from {@link HardwareSettings.overlayPaletteColumns}.
-     * @param overlayPaletteRowsVisible - Optional max visible palette grid rows from {@link HardwareSettings.overlayPaletteRowsVisible}.
-     * @param overlayTimingChart - When true, draws the update/render timing chart band.
-     * @param overlayTimingChartStyle - Optional timing chart palette overrides.
-     * @param overlayTimingChartHeight - Chart band height in pixels (default 22).
-     * @param overlayTimingChartDiagnostics - Chart renderer diagnostic mode (`minimal`, `rich`, or `false`).
-     * @param overlayRendererDiagnosticsBar - When true, draws the GPU diagnostics text row.
-     * @param overlayVisibleAtStart - Initial overlay body visibility (default false).
-     * @param overlayToggleHintVisible - Draw toggle hint while body hidden (default true).
-     * @param overlayToggleEnabled - Enable Backquote and corner toggle input (default true).
+     * @param paletteRowsVisible - Optional max visible palette grid rows from {@link HardwareSettings.overlayPaletteRowsVisible}.
+     * @param isOverlayTimingChartEnabled - When true, draws the update/render timing chart band.
+     * @param timingChartStyle - Optional timing chart palette overrides.
+     * @param timingChartHeight - Chart band height in pixels (default 22).
+     * @param timingChartDiagnostics - Chart renderer diagnostic mode (`minimal`, `rich`, or `false`).
+     * @param isOverlayRendererDiagnosticsBarEnabled - When true, draws the GPU diagnostics text row.
+     * @param isOverlayVisibleAtStart - Initial overlay body visibility (default false).
+     * @param isOverlayToggleHintVisible - Draw toggle hint while body hidden (default true).
+     * @param isOverlayToggleEnabled - Enable Backquote and corner toggle input (default true).
      */
     constructor(
         layout: OverlayLayout,
@@ -156,42 +156,39 @@ export class Overlay {
         targetFps: number,
         activeBackend: Backend,
         style?: OverlayStyle,
-        overlayPaletteView = false,
+        isOverlayPaletteEnabled = false,
         paletteColumns?: number,
-        overlayPaletteRowsVisible?: number,
-        overlayTimingChart = false,
-        overlayTimingChartStyle?: OverlayTimingChartStyle,
-        overlayTimingChartHeight?: number,
-        overlayTimingChartDiagnostics: OverlayTimingChartDiagnosticsMode = false,
-        overlayRendererDiagnosticsBar = false,
-        overlayVisibleAtStart = false,
-        overlayToggleHintVisible = true,
-        overlayToggleEnabled = true,
+        paletteRowsVisible?: number,
+        isOverlayTimingChartEnabled = false,
+        timingChartStyle?: OverlayTimingChartStyle,
+        timingChartHeight?: number,
+        timingChartDiagnostics: OverlayTimingChartDiagnosticsMode = false,
+        isOverlayRendererDiagnosticsBarEnabled = false,
+        isOverlayVisibleAtStart = false,
+        isOverlayToggleHintVisible = true,
+        isOverlayToggleEnabled = true,
     ) {
         this.#layout = layout;
         this.#topLeftLabel = topLeftLabel;
         this.#targetFps = targetFps;
         this.#fps = new FpsSampler(this.#targetFps);
-        const indices = resolveOverlayStyleIndices(style);
+
+        const indices = resolveStyleIndices(style);
+
         this.#idxBg = indices.bg;
         this.#idxText = indices.text;
         this.#idxGap = indices.gap;
         this.#topRightLabel = `${activeBackend} | ${layout.displayWidth}x${layout.displayHeight}`;
-        this.#timingChartStyle = resolveTimingChartStyle(style, overlayTimingChartStyle);
-        this.#timingChartHeight = overlayTimingChartHeight ?? DEFAULT_TIMING_CHART_HEIGHT;
-        this.#timingChart = createOverlayTimingChart(
-            layout,
-            overlayTimingChart,
-            targetFps,
-            overlayTimingChartDiagnostics,
-        );
-        this.#rendererDiagnosticsBarEnabled = overlayRendererDiagnosticsBar;
-        this.#paletteView = new PaletteView(overlayPaletteView);
+        this.#timingChartStyle = resolveTimingChartStyle(style, timingChartStyle);
+        this.#timingChartHeight = timingChartHeight ?? DEFAULT_TIMING_CHART_HEIGHT;
+        this.#timingChart = createTimingChart(layout, isOverlayTimingChartEnabled, targetFps, timingChartDiagnostics);
+        this.#isOverlayRendererDiagnosticsBarEnabled = isOverlayRendererDiagnosticsBarEnabled;
+        this.#paletteView = new PaletteView(isOverlayPaletteEnabled);
         this.#paletteInteraction = new PaletteInteraction(targetFps);
         this.#paletteColumns = paletteColumns;
-        this.#paletteRowsVisible = overlayPaletteRowsVisible;
-        this.#toggle = new Toggle(overlayVisibleAtStart, overlayToggleEnabled);
-        this.#toggleHintVisible = overlayToggleHintVisible;
+        this.#paletteRowsVisible = paletteRowsVisible;
+        this.#toggle = new Toggle(isOverlayVisibleAtStart, isOverlayToggleEnabled);
+        this.#isToggleHintVisible = isOverlayToggleHintVisible;
     }
 
     // #endregion
@@ -231,7 +228,7 @@ export class Overlay {
      *
      * @returns `true` when sprite/text palette usage scanning is needed.
      */
-    get tracksPaletteUsage(): boolean {
+    get isTrackingPaletteUsage(): boolean {
         return this.#paletteView.isEnabled && this.#toggle.isBodyVisible;
     }
 
@@ -251,7 +248,7 @@ export class Overlay {
         getCustomRows?: () => readonly OverlayRow[] | undefined,
         palette?: Palette | null,
     ): void {
-        let pointerPressConsumed = false;
+        let isPointerPressConsumed = false;
 
         if (this.#paletteView.isEnabled && this.#toggle.isBodyVisible) {
             const customRows = getCustomRows?.();
@@ -262,7 +259,7 @@ export class Overlay {
             if (grid !== undefined && plan.paletteBand.height > 0) {
                 this.#paletteInteraction.syncScrollBounds(grid);
 
-                pointerPressConsumed = this.#paletteInteraction.handlePress(
+                isPointerPressConsumed = this.#paletteInteraction.handlePress(
                     pointer,
                     currentTick,
                     plan,
@@ -272,13 +269,13 @@ export class Overlay {
                     this.#layout.displayWidth,
                 );
 
-                pointerPressConsumed =
-                    this.#paletteInteraction.handleScroll(pointer, plan, grid, pointerPressConsumed) ||
-                    pointerPressConsumed;
+                isPointerPressConsumed =
+                    this.#paletteInteraction.handleScroll(pointer, plan, grid, isPointerPressConsumed) ||
+                    isPointerPressConsumed;
             }
         }
 
-        this.#toggle.handleToggle(pointer, keyboard, currentTick, this.#layout.toggleRect, pointerPressConsumed);
+        this.#toggle.handleToggle(pointer, keyboard, currentTick, this.#layout.toggleRect, isPointerPressConsumed);
     }
 
     /**
@@ -398,8 +395,8 @@ export class Overlay {
             isOverlayPaletteEnabled,
             isOverlayTimingChartEnabled: this.#timingChart.isEnabled,
             timingChartHeight: this.#timingChartHeight,
-            rendererDiagnosticsBarEnabled: this.#rendererDiagnosticsBarEnabled,
-            ...(paletteGrid !== undefined ? { paletteGrid } : {}),
+            isOverlayRendererDiagnosticsBarEnabled: this.#isOverlayRendererDiagnosticsBarEnabled,
+            ...(paletteGrid === undefined ? {} : { paletteGrid }),
         };
     }
 
@@ -489,7 +486,7 @@ export class Overlay {
                 `Frame: ${this.#timing.frameMs.toFixed(1)}ms | update(): ${this.#timing.updateMs.toFixed(1)}ms${updateStepSuffix} | ` +
                 `render(): ${this.#timing.renderMs.toFixed(1)}ms`;
 
-            if (this.#rendererDiagnosticsBarEnabled) {
+            if (this.#isOverlayRendererDiagnosticsBarEnabled) {
                 rendererDiagnosticsLabel = this.#timing.formatRendererDiagnosticsLabel();
             }
 

--- a/src/overlay/OverlayToggleIcon.test.ts
+++ b/src/overlay/OverlayToggleIcon.test.ts
@@ -3,26 +3,21 @@ import { describe, expect, it } from 'vitest';
 import { Vector2i } from '../utils/Vector2i';
 import { OVERLAY_EDGE_MARGIN_PX } from './layout/constants';
 import { hintBarY } from './layout/layoutPlan';
-import {
-    drawOverlayToggleIcon,
-    overlayToggleHintIconExclusionRect,
-    overlayToggleHintIconPos,
-    overlayToggleHintIconY,
-} from './OverlayToggleIcon';
+import { hintIconExclusionRect, hintIconPos, hintIconY, toggleIcon } from './OverlayToggleIcon';
 import { createMockRenderer } from './testFixtures';
-import { OVERLAY_TOGGLE_ICON_HEIGHT, OVERLAY_TOGGLE_ICON_MASK, OVERLAY_TOGGLE_ICON_WIDTH } from './toggleIconData';
+import { ICON_HEIGHT, ICON_MASK, ICON_WIDTH } from './toggleIconData';
 
 describe('overlayToggleHintIconPos', () => {
     it('anchors the icon at the left edge margin inside the hint bar', () => {
         const hintBarTopY = hintBarY(240);
 
-        expect(overlayToggleHintIconPos(hintBarTopY)).toEqual(new Vector2i(OVERLAY_EDGE_MARGIN_PX, 230));
-        expect(overlayToggleHintIconY(hintBarTopY)).toBe(230);
-        expect(overlayToggleHintIconExclusionRect(hintBarTopY)).toMatchObject({
+        expect(hintIconPos(hintBarTopY)).toEqual(new Vector2i(OVERLAY_EDGE_MARGIN_PX, 230));
+        expect(hintIconY(hintBarTopY)).toBe(230);
+        expect(hintIconExclusionRect(hintBarTopY)).toMatchObject({
             x: OVERLAY_EDGE_MARGIN_PX,
             y: 230,
-            width: OVERLAY_TOGGLE_ICON_WIDTH,
-            height: OVERLAY_TOGGLE_ICON_HEIGHT,
+            width: ICON_WIDTH,
+            height: ICON_HEIGHT,
         });
     });
 });
@@ -31,18 +26,18 @@ describe('drawOverlayToggleIcon', () => {
     function countMaskRuns(foregroundBit: 0 | 1): number {
         let expectedRuns = 0;
 
-        for (let row = 0; row < OVERLAY_TOGGLE_ICON_HEIGHT; row++) {
+        for (let row = 0; row < ICON_HEIGHT; row++) {
             let col = 0;
 
-            while (col < OVERLAY_TOGGLE_ICON_WIDTH) {
-                const rowOffset = row * OVERLAY_TOGGLE_ICON_WIDTH;
+            while (col < ICON_WIDTH) {
+                const rowOffset = row * ICON_WIDTH;
 
-                if (OVERLAY_TOGGLE_ICON_MASK[rowOffset + col] !== foregroundBit) {
+                if (ICON_MASK[rowOffset + col] !== foregroundBit) {
                     col++;
                     continue;
                 }
 
-                while (col < OVERLAY_TOGGLE_ICON_WIDTH && OVERLAY_TOGGLE_ICON_MASK[rowOffset + col] === foregroundBit) {
+                while (col < ICON_WIDTH && ICON_MASK[rowOffset + col] === foregroundBit) {
                     col++;
                 }
 
@@ -57,7 +52,7 @@ describe('drawOverlayToggleIcon', () => {
         const renderer = createMockRenderer();
         const hintBarTopY = hintBarY(240);
 
-        drawOverlayToggleIcon(renderer, hintBarTopY, 2);
+        toggleIcon(renderer, hintBarTopY, 2);
 
         expect(renderer.drawBarFillOnTop).toHaveBeenCalledTimes(countMaskRuns(1));
         expect(renderer.drawBarFillOnTop.rectSnapshots[0]).toMatchObject({
@@ -72,13 +67,13 @@ describe('drawOverlayToggleIcon', () => {
         const renderer = createMockRenderer();
         const hintBarTopY = hintBarY(240);
 
-        drawOverlayToggleIcon(renderer, hintBarTopY, 2, true);
+        toggleIcon(renderer, hintBarTopY, 2, true);
 
         expect(renderer.drawBarFillOnTop).toHaveBeenCalledTimes(countMaskRuns(0));
         expect(renderer.drawBarFillOnTop.rectSnapshots[0]).toMatchObject({
             x: OVERLAY_EDGE_MARGIN_PX,
             y: 230,
-            width: OVERLAY_TOGGLE_ICON_WIDTH,
+            width: ICON_WIDTH,
             height: 1,
         });
     });

--- a/src/overlay/OverlayToggleIcon.ts
+++ b/src/overlay/OverlayToggleIcon.ts
@@ -6,7 +6,7 @@ import { Rect2i } from '../utils/Rect2i';
 import { Vector2i } from '../utils/Vector2i';
 import { OVERLAY_BAR_HEIGHT, OVERLAY_EDGE_MARGIN_PX } from './layout/constants';
 import type { OverlayDrawTarget } from './OverlayDrawTarget';
-import { OVERLAY_TOGGLE_ICON_HEIGHT, OVERLAY_TOGGLE_ICON_MASK, OVERLAY_TOGGLE_ICON_WIDTH } from './toggleIconData';
+import { ICON_HEIGHT, ICON_MASK, ICON_WIDTH } from './toggleIconData';
 
 /** Reused fill rect for icon horizontal runs (one overlay draw at a time). */
 const iconDrawScratch = {
@@ -20,8 +20,8 @@ const iconDrawScratch = {
  * @param hintBarTopY - Top Y of the bottom hint bar from the layout plan.
  * @returns Icon top Y in display pixels.
  */
-export function overlayToggleHintIconY(hintBarTopY: number): number {
-    return hintBarTopY + Math.floor((OVERLAY_BAR_HEIGHT - OVERLAY_TOGGLE_ICON_HEIGHT) / 2);
+export function hintIconY(hintBarTopY: number): number {
+    return hintBarTopY + Math.floor((OVERLAY_BAR_HEIGHT - ICON_HEIGHT) / 2);
 }
 
 /**
@@ -30,8 +30,8 @@ export function overlayToggleHintIconY(hintBarTopY: number): number {
  * @param hintBarTopY - Top Y of the bottom hint bar from the layout plan.
  * @returns Icon anchor in display pixels.
  */
-export function overlayToggleHintIconPos(hintBarTopY: number): Vector2i {
-    return new Vector2i(OVERLAY_EDGE_MARGIN_PX, overlayToggleHintIconY(hintBarTopY));
+export function hintIconPos(hintBarTopY: number): Vector2i {
+    return new Vector2i(OVERLAY_EDGE_MARGIN_PX, hintIconY(hintBarTopY));
 }
 
 /**
@@ -40,17 +40,12 @@ export function overlayToggleHintIconPos(hintBarTopY: number): Vector2i {
  * @param hintBarTopY - Top Y of the bottom hint bar from the layout plan.
  * @returns Icon bounding rect in display pixels.
  */
-export function overlayToggleHintIconExclusionRect(hintBarTopY: number): Rect2i {
-    return new Rect2i(
-        OVERLAY_EDGE_MARGIN_PX,
-        overlayToggleHintIconY(hintBarTopY),
-        OVERLAY_TOGGLE_ICON_WIDTH,
-        OVERLAY_TOGGLE_ICON_HEIGHT,
-    );
+export function hintIconExclusionRect(hintBarTopY: number): Rect2i {
+    return new Rect2i(OVERLAY_EDGE_MARGIN_PX, hintIconY(hintBarTopY), ICON_WIDTH, ICON_HEIGHT);
 }
 
 /**
- * Draws the toggle hint icon from {@link OVERLAY_TOGGLE_ICON_MASK} using on-top bar fills.
+ * Draws the toggle hint icon from {@link ICON_MASK} using on-top bar fills.
  *
  * Collapses each mask row into horizontal runs to minimize draw calls. Reuses scratch rects
  * so the path stays allocation-free after warmup.
@@ -58,38 +53,40 @@ export function overlayToggleHintIconExclusionRect(hintBarTopY: number): Rect2i 
  * @param target - Overlay draw target.
  * @param hintBarTopY - Top Y of the bottom hint bar from the layout plan.
  * @param textPaletteIndex - Overlay text palette index (`OverlayStyle.textPaletteIndex`, default `2`).
- * @param inverted - When `true`, draw the complement mask so the symbol reads against the hint bar fill.
+ * @param isInverted - When `true`, draw the complement mask so the symbol reads against the hint bar fill.
  */
-export function drawOverlayToggleIcon(
+export function toggleIcon(
     target: OverlayDrawTarget,
     hintBarTopY: number,
     textPaletteIndex: number,
-    inverted = false,
+    isInverted = false,
 ): void {
-    writeOverlayToggleHintIconOrigin(iconDrawScratch.origin, hintBarTopY);
+    writeHintIconOrigin(iconDrawScratch.origin, hintBarTopY);
+
     const originX = iconDrawScratch.origin.x;
     const originY = iconDrawScratch.origin.y;
     const run = iconDrawScratch.run;
-    const foregroundBit = inverted ? 0 : 1;
+    const foregroundBit = isInverted ? 0 : 1;
 
-    for (let row = 0; row < OVERLAY_TOGGLE_ICON_HEIGHT; row++) {
+    for (let row = 0; row < ICON_HEIGHT; row++) {
         let col = 0;
 
-        while (col < OVERLAY_TOGGLE_ICON_WIDTH) {
-            const rowOffset = row * OVERLAY_TOGGLE_ICON_WIDTH;
+        while (col < ICON_WIDTH) {
+            const rowOffset = row * ICON_WIDTH;
 
-            if (OVERLAY_TOGGLE_ICON_MASK[rowOffset + col] !== foregroundBit) {
+            if (ICON_MASK[rowOffset + col] !== foregroundBit) {
                 col++;
                 continue;
             }
 
             const runStart = col;
 
-            while (col < OVERLAY_TOGGLE_ICON_WIDTH && OVERLAY_TOGGLE_ICON_MASK[rowOffset + col] === foregroundBit) {
+            while (col < ICON_WIDTH && ICON_MASK[rowOffset + col] === foregroundBit) {
                 col++;
             }
 
             run.set(originX + runStart, originY + row, col - runStart, 1);
+
             target.drawBarFillOnTop(run, textPaletteIndex);
         }
     }
@@ -101,7 +98,7 @@ export function drawOverlayToggleIcon(
  * @param target - Reusable vector mutated in place.
  * @param hintBarTopY - Top Y of the bottom hint bar from the layout plan.
  */
-function writeOverlayToggleHintIconOrigin(target: Vector2i, hintBarTopY: number): void {
+function writeHintIconOrigin(target: Vector2i, hintBarTopY: number): void {
     target.x = OVERLAY_EDGE_MARGIN_PX;
-    target.y = overlayToggleHintIconY(hintBarTopY);
+    target.y = hintIconY(hintBarTopY);
 }

--- a/src/overlay/OverlayToggleIcon.ts
+++ b/src/overlay/OverlayToggleIcon.ts
@@ -31,6 +31,17 @@ export function hintIconY(hintBarTopY: number): number {
 }
 
 /**
+ * Backward-compatible alias for {@link hintIconY}.
+ *
+ * @deprecated Deprecated since 2026-05-31. Use {@link hintIconY} instead.
+ * @param hintBarTopY - Top Y of the bottom hint bar from the layout plan.
+ * @returns Icon top Y in display pixels.
+ */
+export function overlayToggleHintIconY(hintBarTopY: number): number {
+    return hintIconY(hintBarTopY);
+}
+
+/**
  * Returns the top-left screen position for the toggle hint icon inside the hint bar.
  *
  * @param hintBarTopY - Top Y of the bottom hint bar from the layout plan.
@@ -41,6 +52,17 @@ export function hintIconPos(hintBarTopY: number): Vector2i {
 }
 
 /**
+ * Backward-compatible alias for {@link hintIconPos}.
+ *
+ * @deprecated Deprecated since 2026-05-31. Use {@link hintIconPos} instead.
+ * @param hintBarTopY - Top Y of the bottom hint bar from the layout plan.
+ * @returns Icon anchor in display pixels.
+ */
+export function overlayToggleHintIconPos(hintBarTopY: number): Vector2i {
+    return hintIconPos(hintBarTopY);
+}
+
+/**
  * Returns the screen-space rect reserved for the toggle hint icon (palette swatch exclusion).
  *
  * @param hintBarTopY - Top Y of the bottom hint bar from the layout plan.
@@ -48,6 +70,17 @@ export function hintIconPos(hintBarTopY: number): Vector2i {
  */
 export function hintIconExclusionRect(hintBarTopY: number): Rect2i {
     return new Rect2i(OVERLAY_EDGE_MARGIN_PX, hintIconY(hintBarTopY), ICON_WIDTH, ICON_HEIGHT);
+}
+
+/**
+ * Backward-compatible alias for {@link hintIconExclusionRect}.
+ *
+ * @deprecated Deprecated since 2026-05-31. Use {@link hintIconExclusionRect} instead.
+ * @param hintBarTopY - Top Y of the bottom hint bar from the layout plan.
+ * @returns Icon bounding rect in display pixels.
+ */
+export function overlayToggleHintIconExclusionRect(hintBarTopY: number): Rect2i {
+    return hintIconExclusionRect(hintBarTopY);
 }
 
 // #endregion
@@ -100,6 +133,24 @@ export function toggleIcon(
             target.drawBarFillOnTop(run, textPaletteIndex);
         }
     }
+}
+
+/**
+ * Backward-compatible alias for {@link toggleIcon}.
+ *
+ * @deprecated Deprecated since 2026-05-31. Use {@link toggleIcon} instead.
+ * @param target - Overlay draw target.
+ * @param hintBarTopY - Top Y of the bottom hint bar from the layout plan.
+ * @param textPaletteIndex - Overlay text palette index (`OverlayStyle.textPaletteIndex`, default `2`).
+ * @param inverted - Legacy parameter name forwarded to `isInverted`.
+ */
+export function drawOverlayToggleIcon(
+    target: OverlayDrawTarget,
+    hintBarTopY: number,
+    textPaletteIndex: number,
+    inverted = false,
+): void {
+    toggleIcon(target, hintBarTopY, textPaletteIndex, inverted);
 }
 
 // #endregion

--- a/src/overlay/OverlayToggleIcon.ts
+++ b/src/overlay/OverlayToggleIcon.ts
@@ -2,6 +2,8 @@
  * Draw helper for the inline overlay toggle hint bitmap icon.
  */
 
+// #region Imports and constants
+
 import { Rect2i } from '../utils/Rect2i';
 import { Vector2i } from '../utils/Vector2i';
 import { OVERLAY_BAR_HEIGHT, OVERLAY_EDGE_MARGIN_PX } from './layout/constants';
@@ -13,6 +15,10 @@ const iconDrawScratch = {
     run: new Rect2i(),
     origin: new Vector2i(),
 };
+
+// #endregion
+
+// #region Layout helpers
 
 /**
  * Computes the icon top-left Y inside the hint bar without allocating.
@@ -43,6 +49,10 @@ export function hintIconPos(hintBarTopY: number): Vector2i {
 export function hintIconExclusionRect(hintBarTopY: number): Rect2i {
     return new Rect2i(OVERLAY_EDGE_MARGIN_PX, hintIconY(hintBarTopY), ICON_WIDTH, ICON_HEIGHT);
 }
+
+// #endregion
+
+// #region Drawing
 
 /**
  * Draws the toggle hint icon from {@link ICON_MASK} using on-top bar fills.
@@ -92,6 +102,10 @@ export function toggleIcon(
     }
 }
 
+// #endregion
+
+// #region Utilities
+
 /**
  * Writes the toggle hint icon top-left origin into {@link target} without allocating.
  *
@@ -102,3 +116,5 @@ function writeHintIconOrigin(target: Vector2i, hintBarTopY: number): void {
     target.x = OVERLAY_EDGE_MARGIN_PX;
     target.y = hintIconY(hintBarTopY);
 }
+
+// #endregion

--- a/src/overlay/bars/Bars.ts
+++ b/src/overlay/bars/Bars.ts
@@ -87,21 +87,21 @@ export class OverlayBars {
      * @param target - Overlay draw target.
      * @param plan - Computed layout plan.
      * @param gapIndex - Palette index for separator fills.
-     * @param drawTop - When true, draws the separator below the top overlay cluster.
-     * @param drawBottom - When true, draws the separator above the bottom overlay cluster.
+     * @param isDrawTop - When true, draws the separator below the top overlay cluster.
+     * @param isDrawBottom - When true, draws the separator above the bottom overlay cluster.
      */
     drawClusterSeparators(
         target: OverlayDrawTarget,
         plan: OverlayLayoutPlan,
         gapIndex: number,
-        drawTop: boolean,
-        drawBottom: boolean,
+        isDrawTop: boolean,
+        isDrawBottom: boolean,
     ): void {
-        if (drawTop) {
+        if (isDrawTop) {
             target.drawBarFill(plan.topClusterSeparator, gapIndex);
         }
 
-        if (drawBottom) {
+        if (isDrawBottom) {
             target.drawBarFill(plan.bottomClusterSeparator, gapIndex);
         }
     }

--- a/src/overlay/index.ts
+++ b/src/overlay/index.ts
@@ -48,6 +48,7 @@ export {
     computeTimingChartGridLineY,
     isTimingChartGridLineAtY,
     resolveTimingChartStyle,
+    shouldDrawTimingChartGridLineY,
     timingChartBaselineY,
     timingChartFrameBudgetMs,
     writeTimingChartGridMarkers,

--- a/src/overlay/index.ts
+++ b/src/overlay/index.ts
@@ -27,7 +27,16 @@ export {
 export type { OverlayLayout, OverlayLayoutConfig, OverlayLayoutPlan } from './layout/types';
 export { Overlay } from './Overlay';
 export type { OverlayDrawTarget, OverlayRenderer } from './OverlayDrawTarget';
-export { hintIconExclusionRect, hintIconPos, hintIconY, toggleIcon } from './OverlayToggleIcon';
+export {
+    drawOverlayToggleIcon,
+    hintIconExclusionRect,
+    hintIconPos,
+    hintIconY,
+    overlayToggleHintIconExclusionRect,
+    overlayToggleHintIconPos,
+    overlayToggleHintIconY,
+    toggleIcon,
+} from './OverlayToggleIcon';
 export { PaletteInteraction } from './palette/PaletteInteraction';
 export { computeGrid, PaletteView } from './palette/PaletteView';
 export { FpsSampler } from './sampling/FpsSampler';

--- a/src/overlay/index.ts
+++ b/src/overlay/index.ts
@@ -29,7 +29,7 @@ export { Overlay } from './Overlay';
 export type { OverlayDrawTarget, OverlayRenderer } from './OverlayDrawTarget';
 export { hintIconExclusionRect, hintIconPos, hintIconY, toggleIcon } from './OverlayToggleIcon';
 export { PaletteInteraction } from './palette/PaletteInteraction';
-export { computePaletteGrid, PaletteView } from './palette/PaletteView';
+export { computeGrid, PaletteView } from './palette/PaletteView';
 export { FpsSampler } from './sampling/FpsSampler';
 export { TimingSampler } from './sampling/TimingSampler';
 export type { TimingChartDrawStyle } from './timing-chart/style';

--- a/src/overlay/index.ts
+++ b/src/overlay/index.ts
@@ -27,12 +27,7 @@ export {
 export type { OverlayLayout, OverlayLayoutConfig, OverlayLayoutPlan } from './layout/types';
 export { Overlay } from './Overlay';
 export type { OverlayDrawTarget, OverlayRenderer } from './OverlayDrawTarget';
-export {
-    drawOverlayToggleIcon,
-    overlayToggleHintIconExclusionRect,
-    overlayToggleHintIconPos,
-    overlayToggleHintIconY,
-} from './OverlayToggleIcon';
+export { hintIconExclusionRect, hintIconPos, hintIconY, toggleIcon } from './OverlayToggleIcon';
 export { PaletteInteraction } from './palette/PaletteInteraction';
 export { computePaletteGrid, PaletteView } from './palette/PaletteView';
 export { FpsSampler } from './sampling/FpsSampler';
@@ -42,8 +37,8 @@ export {
     computeTimingChartBarHeight,
     computeTimingChartDotY,
     computeTimingChartGridLineY,
+    isTimingChartGridLineAtY,
     resolveTimingChartStyle,
-    shouldDrawTimingChartGridLineY,
     timingChartBaselineY,
     timingChartFrameBudgetMs,
     writeTimingChartGridMarkers,

--- a/src/overlay/input/Toggle.test.ts
+++ b/src/overlay/input/Toggle.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { Rect2i } from '../../utils/Rect2i';
+import { Toggle } from './Toggle';
+
+describe('Toggle.handleToggle', () => {
+    it('forwards to handleInput and toggles from keyboard input', () => {
+        const toggle = new Toggle(false, true);
+        const keyboard = {
+            isKeyPressed: (key: string, _repeatRate: number | undefined, tick: number): boolean =>
+                key === 'Backquote' && tick === 5,
+        };
+
+        toggle.handleToggle(null, keyboard as never, 5, new Rect2i(0, 0, 48, 48), false);
+
+        expect(toggle.isBodyVisible).toBe(true);
+    });
+
+    it('forwards pointerPressConsumed flag to prevent pointer toggle', () => {
+        const toggle = new Toggle(false, true);
+        const pointer = {
+            isButtonPressed: (): boolean => true,
+            getPos: () => ({ x: 8, y: 8 }),
+        };
+        const keyboard = {
+            isKeyPressed: (): boolean => false,
+        };
+
+        toggle.handleToggle(pointer as never, keyboard as never, 1, new Rect2i(0, 0, 48, 48), true);
+
+        expect(toggle.isBodyVisible).toBe(false);
+    });
+});

--- a/src/overlay/input/Toggle.test.ts
+++ b/src/overlay/input/Toggle.test.ts
@@ -3,15 +3,15 @@ import { describe, expect, it } from 'vitest';
 import { Rect2i } from '../../utils/Rect2i';
 import { Toggle } from './Toggle';
 
-describe('Toggle.handleToggle', () => {
-    it('forwards to handleInput and toggles from keyboard input', () => {
+describe('Toggle.handleInput', () => {
+    it('toggles from keyboard input', () => {
         const toggle = new Toggle(false, true);
         const keyboard = {
             isKeyPressed: (key: string, _repeatRate: number | undefined, tick: number): boolean =>
                 key === 'Backquote' && tick === 5,
         };
 
-        toggle.handleToggle(null, keyboard as never, 5, new Rect2i(0, 0, 48, 48), false);
+        toggle.handleInput(null, keyboard as never, 5, new Rect2i(0, 0, 48, 48), false);
 
         expect(toggle.isBodyVisible).toBe(true);
     });
@@ -26,7 +26,7 @@ describe('Toggle.handleToggle', () => {
             isKeyPressed: (): boolean => false,
         };
 
-        toggle.handleToggle(pointer as never, keyboard as never, 1, new Rect2i(0, 0, 48, 48), true);
+        toggle.handleInput(pointer as never, keyboard as never, 1, new Rect2i(0, 0, 48, 48), true);
 
         expect(toggle.isBodyVisible).toBe(false);
     });

--- a/src/overlay/input/Toggle.ts
+++ b/src/overlay/input/Toggle.ts
@@ -11,7 +11,7 @@ import { OVERLAY_TOGGLE_KEY_CODE, POINTER_PRIMARY_BUTTON } from './constants';
 export class Toggle {
     #isBodyVisible: boolean;
 
-    readonly #isToggleEnabled: boolean;
+    readonly #isEnabled: boolean;
 
     /**
      * Creates toggle state from configure-time visibility and input flags.
@@ -21,7 +21,7 @@ export class Toggle {
      */
     constructor(isOverlayVisibleAtStart = false, isOverlayToggleEnabled = true) {
         this.#isBodyVisible = isOverlayVisibleAtStart;
-        this.#isToggleEnabled = isOverlayToggleEnabled;
+        this.#isEnabled = isOverlayToggleEnabled;
     }
 
     /**
@@ -42,14 +42,14 @@ export class Toggle {
      * @param toggleRect - Bottom-left toggle hit region.
      * @param isPointerPressConsumed - When true, skip pointer corner toggle (palette swatch handled the press).
      */
-    handleToggle(
+    handleInput(
         pointer: PointerInput | null,
         keyboard: KeyboardInput | null,
         currentTick: number,
         toggleRect: Rect2i,
         isPointerPressConsumed = false,
     ): void {
-        if (!this.#isToggleEnabled) {
+        if (!this.#isEnabled) {
             return;
         }
 

--- a/src/overlay/input/Toggle.ts
+++ b/src/overlay/input/Toggle.ts
@@ -9,7 +9,7 @@ import { OVERLAY_TOGGLE_KEY_CODE, POINTER_PRIMARY_BUTTON } from './constants';
  * Handles overlay body visibility toggle input (Backquote and corner pointer).
  */
 export class Toggle {
-    #bodyVisible: boolean;
+    #isBodyVisible: boolean;
 
     readonly #toggleEnabled: boolean;
 
@@ -29,8 +29,8 @@ export class Toggle {
      *
      * @returns `true` while metrics bars and palette grid are rendered.
      */
-    get bodyVisible(): boolean {
-        return this.#bodyVisible;
+    get isBodyVisible(): boolean {
+        return this.#isBodyVisible;
     }
 
     /**
@@ -54,7 +54,7 @@ export class Toggle {
         }
 
         if (keyboard?.isKeyPressed(OVERLAY_TOGGLE_KEY_CODE, undefined, currentTick)) {
-            this.#bodyVisible = !this.#bodyVisible;
+            this.#isBodyVisible = !this.#isBodyVisible;
 
             return;
         }
@@ -71,7 +71,7 @@ export class Toggle {
             const pos = pointer.getPos(slot);
 
             if (isPointerInOverlayToggleCorner(pos, toggleRect)) {
-                this.#bodyVisible = !this.#bodyVisible;
+                this.#isBodyVisible = !this.#isBodyVisible;
 
                 return;
             }

--- a/src/overlay/input/Toggle.ts
+++ b/src/overlay/input/Toggle.ts
@@ -77,4 +77,24 @@ export class Toggle {
             }
         }
     }
+
+    /**
+     * Backward-compatible alias for {@link handleInput}.
+     *
+     * @deprecated Deprecated since 2026-05-31. Use {@link handleInput} instead.
+     * @param pointer - Pointer subsystem, or `null` when unavailable.
+     * @param keyboard - Keyboard subsystem, or `null` when unavailable.
+     * @param currentTick - Current fixed-update tick for keyboard edge detection.
+     * @param toggleRect - Bottom-left toggle hit region.
+     * @param isPointerPressConsumed - When true, skip pointer corner toggle.
+     */
+    handleToggle(
+        pointer: PointerInput | null,
+        keyboard: KeyboardInput | null,
+        currentTick: number,
+        toggleRect: Rect2i,
+        isPointerPressConsumed = false,
+    ): void {
+        this.handleInput(pointer, keyboard, currentTick, toggleRect, isPointerPressConsumed);
+    }
 }

--- a/src/overlay/input/Toggle.ts
+++ b/src/overlay/input/Toggle.ts
@@ -11,17 +11,17 @@ import { OVERLAY_TOGGLE_KEY_CODE, POINTER_PRIMARY_BUTTON } from './constants';
 export class Toggle {
     #isBodyVisible: boolean;
 
-    readonly #toggleEnabled: boolean;
+    readonly #isToggleEnabled: boolean;
 
     /**
      * Creates toggle state from configure-time visibility and input flags.
      *
-     * @param visibleAtStart - Initial overlay body visibility from configure.
-     * @param toggleEnabled - When false, toggle input is ignored.
+     * @param isOverlayVisibleAtStart - Initial overlay body visibility from configure.
+     * @param isOverlayToggleEnabled - When false, toggle input is ignored.
      */
-    constructor(visibleAtStart = false, toggleEnabled = true) {
-        this.#bodyVisible = visibleAtStart;
-        this.#toggleEnabled = toggleEnabled;
+    constructor(isOverlayVisibleAtStart = false, isOverlayToggleEnabled = true) {
+        this.#isBodyVisible = isOverlayVisibleAtStart;
+        this.#isToggleEnabled = isOverlayToggleEnabled;
     }
 
     /**
@@ -40,16 +40,16 @@ export class Toggle {
      * @param keyboard - Keyboard subsystem, or `null` when unavailable.
      * @param currentTick - Current fixed-update tick for keyboard edge detection.
      * @param toggleRect - Bottom-left toggle hit region.
-     * @param pointerPressConsumed - When true, skip pointer corner toggle (palette swatch handled the press).
+     * @param isPointerPressConsumed - When true, skip pointer corner toggle (palette swatch handled the press).
      */
     handleToggle(
         pointer: PointerInput | null,
         keyboard: KeyboardInput | null,
         currentTick: number,
         toggleRect: Rect2i,
-        pointerPressConsumed = false,
+        isPointerPressConsumed = false,
     ): void {
-        if (!this.#toggleEnabled) {
+        if (!this.#isToggleEnabled) {
             return;
         }
 
@@ -59,7 +59,7 @@ export class Toggle {
             return;
         }
 
-        if (!pointer || pointerPressConsumed) {
+        if (!pointer || isPointerPressConsumed) {
             return;
         }
 

--- a/src/overlay/layout/layoutHelpers.ts
+++ b/src/overlay/layout/layoutHelpers.ts
@@ -35,10 +35,10 @@ export function createOverlayLayout(displayWidth: number, displayHeight: number,
  *
  * @param pos - Pointer position in display coordinates.
  * @param toggleRect - Bottom-left toggle region.
- * @returns `true` when the point is inside the rect (`Rect2i.contains` half-open bounds).
+ * @returns `true` when the point is inside the rect (`Rect2i.isContaining` half-open bounds).
  */
 export function isPointerInOverlayToggleCorner(pos: Vector2i, toggleRect: Rect2i): boolean {
-    return toggleRect.contains(pos);
+    return toggleRect.isContaining(pos);
 }
 
 /**

--- a/src/overlay/layout/layoutPlan.test.ts
+++ b/src/overlay/layout/layoutPlan.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { computePaletteGrid } from '../palette/PaletteView';
+import { computeGrid } from '../palette/PaletteView';
 import { OVERLAY_BAR_HEIGHT, OVERLAY_ROW_GAP_PX } from './constants';
 import { createOverlayLayout } from './layoutHelpers';
 import {
@@ -99,7 +99,7 @@ describe('buildOverlayLayoutPlan', () => {
     it('uses variable bottom height when palette grid is enabled', () => {
         const layout = createOverlayLayout(320, 240, 14);
         const scratch = createOverlayLayoutPlanScratch();
-        const paletteGrid = computePaletteGrid(320, 4, 256, 1);
+        const paletteGrid = computeGrid(320, 4, 256, 1);
         const config = {
             ...createDefaultLayoutConfig(320, 240, 14, 0),
             isOverlayPaletteEnabled: true,
@@ -123,7 +123,7 @@ describe('buildOverlayLayoutPlan', () => {
     it('stacks custom rows above a palette grid bottom band', () => {
         const layout = createOverlayLayout(320, 240, 14);
         const scratch = createOverlayLayoutPlanScratch();
-        const paletteGrid = computePaletteGrid(320, 4, 256, 1);
+        const paletteGrid = computeGrid(320, 4, 256, 1);
         const config = {
             ...createDefaultLayoutConfig(320, 240, 14, 1),
             isOverlayPaletteEnabled: true,
@@ -140,8 +140,8 @@ describe('buildOverlayLayoutPlan', () => {
     });
 
     it('resolveOverlayFooterHeight reserves hint bar or palette plus gap plus hint', () => {
-        const paletteGrid = computePaletteGrid(320, 4, 256, 1);
-        const cappedGrid = computePaletteGrid(320, 4, 256, 1, undefined, 3);
+        const paletteGrid = computeGrid(320, 4, 256, 1);
+        const cappedGrid = computeGrid(320, 4, 256, 1, undefined, 3);
         const hintOnlyConfig = createDefaultLayoutConfig(320, 240, 14, 0);
         const paletteConfig = {
             ...hintOnlyConfig,

--- a/src/overlay/layout/layoutPlan.test.ts
+++ b/src/overlay/layout/layoutPlan.test.ts
@@ -67,7 +67,7 @@ describe('buildOverlayLayoutPlan', () => {
         const scratch = createOverlayLayoutPlanScratch();
         const config = {
             ...createDefaultLayoutConfig(320, 240, 14, 0),
-            timingChartEnabled: true,
+            isOverlayTimingChartEnabled: true,
             timingChartHeight: 22,
         };
 
@@ -82,7 +82,7 @@ describe('buildOverlayLayoutPlan', () => {
         const scratch = createOverlayLayoutPlanScratch();
         const config = {
             ...createDefaultLayoutConfig(320, 240, 14, 0),
-            rendererDiagnosticsBarEnabled: true,
+            isOverlayRendererDiagnosticsBarEnabled: true,
         };
 
         const plan = buildOverlayLayoutPlan(config, scratch, 'webgpu | 320x240', layout.toggleRect);
@@ -102,7 +102,7 @@ describe('buildOverlayLayoutPlan', () => {
         const paletteGrid = computePaletteGrid(320, 4, 256, 1);
         const config = {
             ...createDefaultLayoutConfig(320, 240, 14, 0),
-            overlayPaletteView: true,
+            isOverlayPaletteEnabled: true,
             paletteGrid,
         };
 
@@ -126,7 +126,7 @@ describe('buildOverlayLayoutPlan', () => {
         const paletteGrid = computePaletteGrid(320, 4, 256, 1);
         const config = {
             ...createDefaultLayoutConfig(320, 240, 14, 1),
-            overlayPaletteView: true,
+            isOverlayPaletteEnabled: true,
             paletteGrid,
         };
 
@@ -145,12 +145,12 @@ describe('buildOverlayLayoutPlan', () => {
         const hintOnlyConfig = createDefaultLayoutConfig(320, 240, 14, 0);
         const paletteConfig = {
             ...hintOnlyConfig,
-            overlayPaletteView: true,
+            isOverlayPaletteEnabled: true,
             paletteGrid,
         };
         const cappedPaletteConfig = {
             ...hintOnlyConfig,
-            overlayPaletteView: true,
+            isOverlayPaletteEnabled: true,
             paletteGrid: cappedGrid,
         };
 

--- a/src/overlay/layout/layoutPlan.ts
+++ b/src/overlay/layout/layoutPlan.ts
@@ -3,7 +3,7 @@
  *
  * Computes bar rects and text anchors each frame from display size, custom row count,
  * and optional timing-chart / palette-grid feature flags (timing chart default off,
- * opt-in via {@link HardwareSettings.overlayTimingChart}).
+ * opt-in via {@link HardwareSettings.isOverlayTimingChartEnabled}).
  */
 
 import { Rect2i } from '../../utils/Rect2i';
@@ -100,9 +100,9 @@ function resolveFooterLayout(
     displayHeight: number,
 ): { paletteBandHeight: number; footerStackTopY: number; hintBarTopY: number } {
     const hintBarTopY = hintBarY(displayHeight);
-    const paletteEnabled = config.overlayPaletteView && config.paletteGrid !== undefined;
+    const isPaletteLayoutEnabled = config.isOverlayPaletteEnabled && config.paletteGrid !== undefined;
 
-    if (paletteEnabled) {
+    if (isPaletteLayoutEnabled) {
         const paletteBandHeight = config.paletteGrid.totalHeight;
 
         return {
@@ -126,7 +126,7 @@ function resolveFooterLayout(
  * @returns Footer band height in pixels.
  */
 export function resolveOverlayFooterHeight(config: OverlayLayoutConfig): number {
-    if (config.overlayPaletteView && config.paletteGrid !== undefined) {
+    if (config.isOverlayPaletteEnabled && config.paletteGrid !== undefined) {
         return config.paletteGrid.totalHeight + OVERLAY_ROW_GAP_PX + OVERLAY_BAR_HEIGHT;
     }
 
@@ -316,7 +316,7 @@ export function buildOverlayLayoutPlan(
     scratch.titleBar.height = OVERLAY_BAR_HEIGHT;
     y += OVERLAY_BAR_HEIGHT + OVERLAY_ROW_GAP_PX;
 
-    if (config.timingChartEnabled) {
+    if (config.isOverlayTimingChartEnabled) {
         const chartHeight = config.timingChartHeight > 0 ? config.timingChartHeight : DEFAULT_TIMING_CHART_HEIGHT;
 
         scratch.timingChart.x = 0;
@@ -342,7 +342,7 @@ export function buildOverlayLayoutPlan(
     scratch.timingTextBar.width = displayWidth;
     scratch.timingTextBar.height = OVERLAY_BAR_HEIGHT;
 
-    if (config.rendererDiagnosticsBarEnabled) {
+    if (config.isOverlayRendererDiagnosticsBarEnabled) {
         const diagnosticsY = y + OVERLAY_BAR_HEIGHT + OVERLAY_ROW_GAP_PX;
 
         scratch.rendererDiagnosticsBar.x = 0;
@@ -406,10 +406,10 @@ export function createDefaultLayoutConfig(
         displayHeight,
         lineHeight,
         customRowCount,
-        timingChartEnabled: false,
+        isOverlayTimingChartEnabled: false,
         timingChartHeight: DEFAULT_TIMING_CHART_HEIGHT,
-        rendererDiagnosticsBarEnabled: false,
-        overlayPaletteView: false,
+        isOverlayRendererDiagnosticsBarEnabled: false,
+        isOverlayPaletteEnabled: false,
     };
 }
 

--- a/src/overlay/layout/layoutPlan.ts
+++ b/src/overlay/layout/layoutPlan.ts
@@ -81,7 +81,7 @@ export function hintBarY(displayHeight: number): number {
  * Top Y of the palette swatch grid band stacked above the hint bar row gap.
  *
  * @param displayHeight - Logical display height in pixels.
- * @param paletteGridHeight - Total palette grid height from {@link computePaletteGrid}.
+ * @param paletteGridHeight - Total palette grid height from {@link computeGrid}.
  * @returns Palette band top Y.
  */
 export function paletteBandY(displayHeight: number, paletteGridHeight: number): number {

--- a/src/overlay/layout/types.ts
+++ b/src/overlay/layout/types.ts
@@ -30,15 +30,15 @@ export interface OverlayLayoutConfig {
 
     readonly customRowCount: number;
 
-    readonly timingChartEnabled: boolean;
+    readonly isOverlayTimingChartEnabled: boolean;
 
     readonly timingChartHeight: number;
 
-    /** Mirrors {@link HardwareSettings.overlayRendererDiagnosticsBar}. */
-    readonly rendererDiagnosticsBarEnabled: boolean;
+    /** Mirrors {@link HardwareSettings.isOverlayRendererDiagnosticsBarEnabled}. */
+    readonly isOverlayRendererDiagnosticsBarEnabled: boolean;
 
-    /** Mirrors {@link HardwareSettings.overlayPaletteView}. */
-    readonly overlayPaletteView: boolean;
+    /** Mirrors {@link HardwareSettings.isOverlayPaletteEnabled}. */
+    readonly isOverlayPaletteEnabled: boolean;
 
     readonly paletteGrid?: PaletteGridLayout;
 }

--- a/src/overlay/palette/PaletteInteraction.test.ts
+++ b/src/overlay/palette/PaletteInteraction.test.ts
@@ -13,28 +13,28 @@ import type { OverlayLayoutPlan } from '../layout/types';
 import { mockFont } from '../testFixtures';
 import {
     clampScrollRowOffset,
-    drawPaletteTooltipChrome,
-    drawPaletteTooltipLabel,
-    hitTestPaletteSwatch,
-    isPointerInPaletteScrollbarTrack,
-    layoutPaletteTooltip,
+    drawTooltipChrome,
+    drawTooltipLabel,
+    hitTestSwatch,
+    isPointerInScrollbarTrack,
+    layoutTooltip,
     maxScrollRowOffset,
     PALETTE_COPY_STATUS_SECONDS,
     PALETTE_SCROLLBAR_TRACK_WIDTH_PX,
     PaletteInteraction,
     resolveScrollRowOffsetFromTrackPointerY,
-    writePaletteIndexToClipboard,
+    writeIndexToClipboard,
 } from './PaletteInteraction';
 import {
-    computePaletteGrid,
-    computePaletteScrollbarThumbHeight,
+    computeGrid,
+    computeScrollbarThumbHeight,
     DEFAULT_PALETTE_SWATCH_SIZE,
     PALETTE_SCROLLBAR_EDGE_PADDING_PX,
     PALETTE_SCROLLBAR_MIN_THUMB_HEIGHT_PX,
     PALETTE_SWATCH_GAP_PX,
-    resolvePaletteHintExclusionRect,
-    writePaletteScrollbarRects,
-    writePaletteSwatchTopLeft,
+    resolveHintExclusionRect,
+    writeScrollbarRects,
+    writeSwatchTopLeft,
 } from './PaletteView';
 
 /** Minimal layout plan with only the palette band populated. */
@@ -46,12 +46,12 @@ function paletteOnlyPlan(paletteBand: Rect2i): OverlayLayoutPlan {
 function goldenHintExclusion(): Rect2i {
     const layout = createOverlayLayout(320, 240, 14);
 
-    return resolvePaletteHintExclusionRect(hintBarY(layout.displayHeight), layout.displayWidth);
+    return resolveHintExclusionRect(hintBarY(layout.displayHeight), layout.displayWidth);
 }
 
-describe('hitTestPaletteSwatch', () => {
+describe('hitTestSwatch', () => {
     const layout = createOverlayLayout(320, 240, 14);
-    const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 256, PALETTE_SWATCH_GAP_PX);
+    const grid = computeGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 256, PALETTE_SWATCH_GAP_PX);
     const paletteBandTop = paletteBandY(240, grid.totalHeight);
     const paletteBand = new Rect2i(0, paletteBandTop, 320, grid.totalHeight);
     const hintExclusion = goldenHintExclusion();
@@ -60,9 +60,9 @@ describe('hitTestPaletteSwatch', () => {
         const index = 42;
         const swatch = new Rect2i();
 
-        writePaletteSwatchTopLeft(swatch, index, paletteBand, grid);
+        writeSwatchTopLeft(swatch, index, paletteBand, grid);
 
-        const hit = hitTestPaletteSwatch(
+        const hit = hitTestSwatch(
             swatch.x + 1,
             swatch.y + 1,
             paletteBand,
@@ -78,22 +78,22 @@ describe('hitTestPaletteSwatch', () => {
     it('returns null in horizontal and vertical gaps between swatches', () => {
         const swatch = new Rect2i();
 
-        writePaletteSwatchTopLeft(swatch, 0, paletteBand, grid);
+        writeSwatchTopLeft(swatch, 0, paletteBand, grid);
         const gapX = swatch.x + grid.swatchSize;
 
         expect(
-            hitTestPaletteSwatch(gapX, swatch.y + 1, paletteBand, grid, 256, hintExclusion, layout.displayWidth),
+            hitTestSwatch(gapX, swatch.y + 1, paletteBand, grid, 256, hintExclusion, layout.displayWidth),
         ).toBeNull();
 
         const gapY = swatch.y + grid.swatchSize;
 
         expect(
-            hitTestPaletteSwatch(swatch.x + 1, gapY, paletteBand, grid, 256, hintExclusion, layout.displayWidth),
+            hitTestSwatch(swatch.x + 1, gapY, paletteBand, grid, 256, hintExclusion, layout.displayWidth),
         ).toBeNull();
     });
 
     it('returns null over the hint exclusion band', () => {
-        const hit = hitTestPaletteSwatch(
+        const hit = hitTestSwatch(
             hintExclusion.x + 1,
             hintExclusion.y + 1,
             paletteBand,
@@ -110,10 +110,10 @@ describe('hitTestPaletteSwatch', () => {
         const trackWidth = PALETTE_SCROLLBAR_TRACK_WIDTH_PX;
         const swatch = new Rect2i();
 
-        writePaletteSwatchTopLeft(swatch, 31, paletteBand, grid);
+        writeSwatchTopLeft(swatch, 31, paletteBand, grid);
 
         expect(
-            hitTestPaletteSwatch(
+            hitTestSwatch(
                 layout.displayWidth - 1,
                 swatch.y + 1,
                 paletteBand,
@@ -132,10 +132,10 @@ describe('hitTestPaletteSwatch', () => {
         const index = scrollRowOffset * grid.cols + 5;
         const swatch = new Rect2i();
 
-        writePaletteSwatchTopLeft(swatch, index, paletteBand, grid, scrollRowOffset);
+        writeSwatchTopLeft(swatch, index, paletteBand, grid, scrollRowOffset);
 
         expect(
-            hitTestPaletteSwatch(
+            hitTestSwatch(
                 swatch.x + 1,
                 swatch.y + 1,
                 paletteBand,
@@ -152,25 +152,17 @@ describe('hitTestPaletteSwatch', () => {
         const index = grid.cols * (grid.rows - 1);
         const swatch = new Rect2i();
 
-        writePaletteSwatchTopLeft(swatch, index, paletteBand, grid);
+        writeSwatchTopLeft(swatch, index, paletteBand, grid);
 
         expect(
-            hitTestPaletteSwatch(
-                swatch.x + 1,
-                swatch.y + 1,
-                paletteBand,
-                grid,
-                256,
-                hintExclusion,
-                layout.displayWidth,
-            ),
+            hitTestSwatch(swatch.x + 1, swatch.y + 1, paletteBand, grid, 256, hintExclusion, layout.displayWidth),
         ).toBe(index);
         expect(layout.toggleRect.isContaining(new Vector2i(swatch.x + 1, swatch.y + 1))).toBe(true);
     });
 });
 
 describe('palette scroll helpers', () => {
-    const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 256, PALETTE_SWATCH_GAP_PX, undefined, 3);
+    const grid = computeGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 256, PALETTE_SWATCH_GAP_PX, undefined, 3);
 
     it('computes maxScrollRowOffset from total and visible rows', () => {
         expect(maxScrollRowOffset(grid)).toBe(grid.rows - grid.visibleRows);
@@ -185,7 +177,7 @@ describe('palette scroll helpers', () => {
     it('sizes thumb proportionally to visible rows with a 4 px minimum', () => {
         const paletteBand = new Rect2i(0, 200, 320, grid.totalHeight);
         const trackHeight = paletteBand.height - PALETTE_SCROLLBAR_EDGE_PADDING_PX * 2;
-        const thumbHeight = computePaletteScrollbarThumbHeight(trackHeight, grid);
+        const thumbHeight = computeScrollbarThumbHeight(trackHeight, grid);
 
         expect(thumbHeight).toBeGreaterThanOrEqual(PALETTE_SCROLLBAR_MIN_THUMB_HEIGHT_PX);
         expect(thumbHeight).toBe(Math.floor((grid.visibleRows / grid.rows) * trackHeight));
@@ -199,7 +191,7 @@ describe('palette scroll helpers', () => {
         const scrollRowOffset = 3;
         const pad = PALETTE_SCROLLBAR_EDGE_PADDING_PX;
 
-        writePaletteScrollbarRects(track, thumb, paletteBand, grid, scrollRowOffset, PALETTE_SCROLLBAR_TRACK_WIDTH_PX);
+        writeScrollbarRects(track, thumb, paletteBand, grid, scrollRowOffset, PALETTE_SCROLLBAR_TRACK_WIDTH_PX);
 
         expect(track).toMatchObject({
             x: paletteBand.x + paletteBand.width - PALETTE_SCROLLBAR_TRACK_WIDTH_PX - pad,
@@ -216,8 +208,8 @@ describe('palette scroll helpers', () => {
         const topThumb = new Rect2i();
         const bottomThumb = new Rect2i();
 
-        writePaletteScrollbarRects(track, topThumb, paletteBand, grid, 0, PALETTE_SCROLLBAR_TRACK_WIDTH_PX);
-        writePaletteScrollbarRects(track, bottomThumb, paletteBand, grid, maxOffset, PALETTE_SCROLLBAR_TRACK_WIDTH_PX);
+        writeScrollbarRects(track, topThumb, paletteBand, grid, 0, PALETTE_SCROLLBAR_TRACK_WIDTH_PX);
+        writeScrollbarRects(track, bottomThumb, paletteBand, grid, maxOffset, PALETTE_SCROLLBAR_TRACK_WIDTH_PX);
 
         expect(topThumb.y).toBe(track.y);
         expect(bottomThumb.y + bottomThumb.height).toBe(track.y + track.height);
@@ -229,7 +221,7 @@ describe('palette scroll helpers', () => {
         const track = new Rect2i();
         const thumb = new Rect2i();
 
-        writePaletteScrollbarRects(track, thumb, paletteBand, grid, 0, PALETTE_SCROLLBAR_TRACK_WIDTH_PX);
+        writeScrollbarRects(track, thumb, paletteBand, grid, 0, PALETTE_SCROLLBAR_TRACK_WIDTH_PX);
 
         expect(
             resolveScrollRowOffsetFromTrackPointerY(track.y, paletteBand, grid, PALETTE_SCROLLBAR_TRACK_WIDTH_PX),
@@ -248,12 +240,12 @@ describe('palette scroll helpers', () => {
 describe('PaletteInteraction scroll', () => {
     it('advances scroll offset from wheel delta over the palette band and consumes scroll', () => {
         const interaction = new PaletteInteraction(60);
-        const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 256, PALETTE_SWATCH_GAP_PX, undefined, 3);
+        const grid = computeGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 256, PALETTE_SWATCH_GAP_PX, undefined, 3);
         const paletteBandTop = paletteBandY(240, grid.totalHeight);
         const plan = paletteOnlyPlan(new Rect2i(0, paletteBandTop, 320, grid.totalHeight));
         const swatch = new Rect2i();
 
-        writePaletteSwatchTopLeft(swatch, 0, plan.paletteBand, grid);
+        writeSwatchTopLeft(swatch, 0, plan.paletteBand, grid);
 
         const pointer = {
             isActive: () => true,
@@ -272,7 +264,7 @@ describe('PaletteInteraction scroll', () => {
 
     it('does not consume wheel delta when pointer is outside the palette band', () => {
         const interaction = new PaletteInteraction(60);
-        const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 256, PALETTE_SWATCH_GAP_PX, undefined, 3);
+        const grid = computeGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 256, PALETTE_SWATCH_GAP_PX, undefined, 3);
         const paletteBandTop = paletteBandY(240, grid.totalHeight);
         const plan = paletteOnlyPlan(new Rect2i(0, paletteBandTop, 320, grid.totalHeight));
         const pointer = {
@@ -292,13 +284,13 @@ describe('PaletteInteraction scroll', () => {
 
     it('blocks toggle when primary press starts on the scrollbar track', () => {
         const interaction = new PaletteInteraction(60);
-        const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 256, PALETTE_SWATCH_GAP_PX, undefined, 3);
+        const grid = computeGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 256, PALETTE_SWATCH_GAP_PX, undefined, 3);
         const paletteBandTop = paletteBandY(240, grid.totalHeight);
         const plan = paletteOnlyPlan(new Rect2i(0, paletteBandTop, 320, grid.totalHeight));
         const track = new Rect2i();
         const thumb = new Rect2i();
 
-        writePaletteScrollbarRects(track, thumb, plan.paletteBand, grid, 0, PALETTE_SCROLLBAR_TRACK_WIDTH_PX);
+        writeScrollbarRects(track, thumb, plan.paletteBand, grid, 0, PALETTE_SCROLLBAR_TRACK_WIDTH_PX);
 
         const consumed = interaction.handleScroll(
             {
@@ -316,7 +308,7 @@ describe('PaletteInteraction scroll', () => {
 
         expect(consumed).toBe(true);
         expect(
-            isPointerInPaletteScrollbarTrack(
+            isPointerInScrollbarTrack(
                 track.x + 1,
                 track.y + 2,
                 plan.paletteBand,
@@ -328,7 +320,7 @@ describe('PaletteInteraction scroll', () => {
     });
 });
 
-describe('layoutPaletteTooltip', () => {
+describe('layoutTooltip', () => {
     const layoutScratch = {
         body: new Rect2i(),
         swatch: new Rect2i(),
@@ -339,7 +331,7 @@ describe('layoutPaletteTooltip', () => {
         const swatch = new Rect2i(300, 180, 7, 7);
         const label = '255';
 
-        layoutPaletteTooltip(layoutScratch, swatch, label, 320, 240);
+        layoutTooltip(layoutScratch, swatch, label, 320, 240);
 
         expect(layoutScratch.body.x + layoutScratch.body.width).toBeLessThanOrEqual(320);
         expect(layoutScratch.body.x).toBeGreaterThanOrEqual(0);
@@ -349,7 +341,7 @@ describe('layoutPaletteTooltip', () => {
         const swatch = new Rect2i(0, 180, 7, 7);
         const label = '255';
 
-        layoutPaletteTooltip(layoutScratch, swatch, label, 320, 240);
+        layoutTooltip(layoutScratch, swatch, label, 320, 240);
 
         expect(layoutScratch.body.x).toBeGreaterThanOrEqual(0);
     });
@@ -357,7 +349,7 @@ describe('layoutPaletteTooltip', () => {
     it('places tooltip body above the swatch with a one-pixel gap', () => {
         const swatch = new Rect2i(40, 180, 7, 7);
 
-        layoutPaletteTooltip(layoutScratch, swatch, '12', 320, 240);
+        layoutTooltip(layoutScratch, swatch, '12', 320, 240);
 
         expect(layoutScratch.body.y + layoutScratch.body.height).toBe(swatch.y - 1);
     });
@@ -365,21 +357,21 @@ describe('layoutPaletteTooltip', () => {
     it('keeps tooltip body fully inside the display on the bottom edge', () => {
         const swatch = new Rect2i(0, 235, 7, 7);
 
-        layoutPaletteTooltip(layoutScratch, swatch, '12', 320, 240);
+        layoutTooltip(layoutScratch, swatch, '12', 320, 240);
 
         expect(layoutScratch.body.y + layoutScratch.body.height).toBeLessThanOrEqual(240);
         expect(layoutScratch.body.y).toBeGreaterThanOrEqual(0);
     });
 });
 
-describe('drawPaletteTooltipChrome', () => {
+describe('drawTooltipChrome', () => {
     it('draws tooltip body and border via drawBarFillOnTop', () => {
         const layoutScratch = {
             body: new Rect2i(),
             swatch: new Rect2i(40, 180, 7, 7),
             textPos: new Vector2i(),
         };
-        const layout = layoutPaletteTooltip(layoutScratch, layoutScratch.swatch, '42', 320, 240);
+        const layout = layoutTooltip(layoutScratch, layoutScratch.swatch, '42', 320, 240);
         const target = {
             drawBarFill: vi.fn(),
             drawBarFillOnTop: vi.fn(),
@@ -387,7 +379,7 @@ describe('drawPaletteTooltipChrome', () => {
             drawLabelOnTop: vi.fn(),
         };
 
-        drawPaletteTooltipChrome(target, layout, DEFAULT_IDX_BG, DEFAULT_IDX_TEXT);
+        drawTooltipChrome(target, layout, DEFAULT_IDX_BG, DEFAULT_IDX_TEXT);
 
         expect(target.drawBarFillOnTop).toHaveBeenCalled();
         expect(target.drawBarFill).not.toHaveBeenCalled();
@@ -395,14 +387,14 @@ describe('drawPaletteTooltipChrome', () => {
     });
 });
 
-describe('drawPaletteTooltipLabel', () => {
+describe('drawTooltipLabel', () => {
     it('draws tooltip text via drawLabelOnTop', () => {
         const layoutScratch = {
             body: new Rect2i(),
             swatch: new Rect2i(40, 180, 7, 7),
             textPos: new Vector2i(),
         };
-        const layout = layoutPaletteTooltip(layoutScratch, layoutScratch.swatch, '42', 320, 240);
+        const layout = layoutTooltip(layoutScratch, layoutScratch.swatch, '42', 320, 240);
         const target = {
             drawBarFill: vi.fn(),
             drawBarFillOnTop: vi.fn(),
@@ -410,7 +402,7 @@ describe('drawPaletteTooltipLabel', () => {
             drawLabelOnTop: vi.fn(),
         };
 
-        drawPaletteTooltipLabel(target, mockFont, layout, '42', DEFAULT_IDX_TEXT);
+        drawTooltipLabel(target, mockFont, layout, '42', DEFAULT_IDX_TEXT);
 
         expect(target.drawLabelOnTop).toHaveBeenCalled();
         expect(target.drawBarFill).not.toHaveBeenCalled();
@@ -432,7 +424,7 @@ describe('PaletteInteraction clipboard', () => {
     });
 
     it('writes plain index strings to the clipboard', async () => {
-        await writePaletteIndexToClipboard(42);
+        await writeIndexToClipboard(42);
 
         expect(navigator.clipboard.writeText).toHaveBeenCalledWith('42');
     });
@@ -440,12 +432,12 @@ describe('PaletteInteraction clipboard', () => {
     it('shows Copied N after successful press', async () => {
         const interaction = new PaletteInteraction(60);
         const layout = createOverlayLayout(320, 240, 14);
-        const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 256, PALETTE_SWATCH_GAP_PX);
+        const grid = computeGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 256, PALETTE_SWATCH_GAP_PX);
         const paletteBandTop = paletteBandY(240, grid.totalHeight);
         const plan = paletteOnlyPlan(new Rect2i(0, paletteBandTop, 320, grid.totalHeight));
         const swatch = new Rect2i();
 
-        writePaletteSwatchTopLeft(swatch, 7, plan.paletteBand, grid);
+        writeSwatchTopLeft(swatch, 7, plan.paletteBand, grid);
 
         const consumed = interaction.handlePress(
             {
@@ -512,12 +504,12 @@ describe('PaletteInteraction clipboard', () => {
 
         const interaction = new PaletteInteraction(60);
         const layout = createOverlayLayout(320, 240, 14);
-        const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 256, PALETTE_SWATCH_GAP_PX);
+        const grid = computeGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 256, PALETTE_SWATCH_GAP_PX);
         const paletteBandTop = paletteBandY(240, grid.totalHeight);
         const plan = paletteOnlyPlan(new Rect2i(0, paletteBandTop, 320, grid.totalHeight));
         const swatch = new Rect2i();
 
-        writePaletteSwatchTopLeft(swatch, 3, plan.paletteBand, grid);
+        writeSwatchTopLeft(swatch, 3, plan.paletteBand, grid);
 
         interaction.handlePress(
             {
@@ -561,12 +553,12 @@ describe('PaletteInteraction clipboard', () => {
     it('clears copy status after the configured duration', async () => {
         const interaction = new PaletteInteraction(60);
         const layout = createOverlayLayout(320, 240, 14);
-        const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 256, PALETTE_SWATCH_GAP_PX);
+        const grid = computeGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 256, PALETTE_SWATCH_GAP_PX);
         const paletteBandTop = paletteBandY(240, grid.totalHeight);
         const plan = paletteOnlyPlan(new Rect2i(0, paletteBandTop, 320, grid.totalHeight));
         const swatch = new Rect2i();
 
-        writePaletteSwatchTopLeft(swatch, 9, plan.paletteBand, grid);
+        writeSwatchTopLeft(swatch, 9, plan.paletteBand, grid);
 
         interaction.handlePress(
             {
@@ -632,12 +624,12 @@ describe('PaletteInteraction clipboard', () => {
 
         const interaction = new PaletteInteraction(60);
         const layout = createOverlayLayout(320, 240, 14);
-        const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 256, PALETTE_SWATCH_GAP_PX);
+        const grid = computeGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 256, PALETTE_SWATCH_GAP_PX);
         const paletteBandTop = paletteBandY(240, grid.totalHeight);
         const plan = paletteOnlyPlan(new Rect2i(0, paletteBandTop, 320, grid.totalHeight));
         const swatch = new Rect2i();
 
-        writePaletteSwatchTopLeft(swatch, 9, plan.paletteBand, grid);
+        writeSwatchTopLeft(swatch, 9, plan.paletteBand, grid);
 
         interaction.handlePress(
             {

--- a/src/overlay/palette/PaletteInteraction.test.ts
+++ b/src/overlay/palette/PaletteInteraction.test.ts
@@ -256,7 +256,7 @@ describe('PaletteInteraction scroll', () => {
         writePaletteSwatchTopLeft(swatch, 0, plan.paletteBand, grid);
 
         const pointer = {
-            isValid: () => true,
+            isActive: () => true,
             getPos: () => new Vector2i(swatch.x + 1, swatch.y + 1),
             getScrollDelta: () => 16,
             consumeScrollDelta: vi.fn(),
@@ -276,7 +276,7 @@ describe('PaletteInteraction scroll', () => {
         const paletteBandTop = paletteBandY(240, grid.totalHeight);
         const plan = paletteOnlyPlan(new Rect2i(0, paletteBandTop, 320, grid.totalHeight));
         const pointer = {
-            isValid: () => true,
+            isActive: () => true,
             getPos: () => new Vector2i(0, 0),
             getScrollDelta: () => 16,
             consumeScrollDelta: vi.fn(),
@@ -302,7 +302,7 @@ describe('PaletteInteraction scroll', () => {
 
         const consumed = interaction.handleScroll(
             {
-                isValid: () => true,
+                isActive: () => true,
                 getPos: () => new Vector2i(track.x + 1, track.y + 2),
                 getScrollDelta: () => 0,
                 consumeScrollDelta: vi.fn(),
@@ -597,7 +597,7 @@ describe('PaletteInteraction clipboard', () => {
 
         interaction.updateHover(
             {
-                isValid: () => true,
+                isActive: () => true,
                 getPos: () => new Vector2i(swatch.x + 1, swatch.y + 1),
             } as never,
             plan,
@@ -713,7 +713,7 @@ describe('PaletteInteraction clipboard', () => {
         interaction.tickCopyStatus(completionExpiryTick);
         interaction.updateHover(
             {
-                isValid: () => true,
+                isActive: () => true,
                 getPos: () => new Vector2i(swatch.x + 1, swatch.y + 1),
             } as never,
             plan,

--- a/src/overlay/palette/PaletteInteraction.test.ts
+++ b/src/overlay/palette/PaletteInteraction.test.ts
@@ -165,7 +165,7 @@ describe('hitTestPaletteSwatch', () => {
                 layout.displayWidth,
             ),
         ).toBe(index);
-        expect(layout.toggleRect.contains(new Vector2i(swatch.x + 1, swatch.y + 1))).toBe(true);
+        expect(layout.toggleRect.isContaining(new Vector2i(swatch.x + 1, swatch.y + 1))).toBe(true);
     });
 });
 

--- a/src/overlay/palette/PaletteInteraction.ts
+++ b/src/overlay/palette/PaletteInteraction.ts
@@ -571,7 +571,7 @@ export class PaletteInteraction {
         let togglePressConsumed = false;
 
         for (let slot = 0; slot < POINTER_SLOT_COUNT; slot++) {
-            if (!pointer.isValid(slot)) {
+            if (!pointer.isActive(slot)) {
                 if (this.#scrollDragSlot === slot) {
                     this.#scrollDragSlot = null;
                 }
@@ -627,7 +627,7 @@ export class PaletteInteraction {
         }
 
         for (let slot = 0; slot < POINTER_SLOT_COUNT; slot++) {
-            if (!pointer.isValid(slot)) {
+            if (!pointer.isActive(slot)) {
                 continue;
             }
 
@@ -785,7 +785,7 @@ export class PaletteInteraction {
         let hovered: number | null = null;
 
         for (let slot = 0; slot < POINTER_SLOT_COUNT; slot++) {
-            if (!pointer.isValid(slot)) {
+            if (!pointer.isActive(slot)) {
                 continue;
             }
 

--- a/src/overlay/palette/PaletteInteraction.ts
+++ b/src/overlay/palette/PaletteInteraction.ts
@@ -64,7 +64,7 @@ const tooltipScratch = {
  * @param hintExclusion - Region reserved for the toggle hint icon.
  * @returns `true` when the swatch should not receive hits or draws.
  */
-function swatchOverlapsHintExclusion(
+function isSwatchOverlappingWithHintExclusion(
     swatchX: number,
     swatchY: number,
     swatchSize: number,
@@ -209,7 +209,7 @@ export function hitTestPaletteSwatch(
 
     writePaletteSwatchTopLeft(swatchScratch, index, paletteBand, grid, scrollRowOffset);
 
-    if (swatchOverlapsHintExclusion(swatchScratch.x, swatchScratch.y, swatchSize, hintExclusion)) {
+    if (isSwatchOverlappingWithHintExclusion(swatchScratch.x, swatchScratch.y, swatchSize, hintExclusion)) {
         return null;
     }
 
@@ -551,14 +551,14 @@ export class PaletteInteraction {
      * @param pointer - Pointer subsystem, or `null` when unavailable.
      * @param plan - Layout plan for this frame.
      * @param grid - Palette grid layout.
-     * @param swatchPressConsumed - When true, drag scrolling is skipped this frame.
+     * @param isSwatchPressConsumed - When true, drag scrolling is skipped this frame.
      * @returns `true` when a scrollbar-track press should block the toggle corner.
      */
     handleScroll(
         pointer: PointerInput | null,
         plan: OverlayLayoutPlan,
         grid: PaletteGridLayout,
-        swatchPressConsumed: boolean,
+        isSwatchPressConsumed: boolean,
     ): boolean {
         if (plan.paletteBand.height <= 0 || grid.cols <= 0 || maxScrollRowOffset(grid) <= 0 || !pointer) {
             this.#scrollDragSlot = null;
@@ -568,7 +568,7 @@ export class PaletteInteraction {
 
         this.syncScrollBounds(grid);
 
-        let togglePressConsumed = false;
+        let isTogglePressConsumed = false;
 
         for (let slot = 0; slot < POINTER_SLOT_COUNT; slot++) {
             if (!pointer.isActive(slot)) {
@@ -595,20 +595,20 @@ export class PaletteInteraction {
                     this.#scrollDragSlot = slot;
                     this.#scrollDragStartY = pos.y;
                     this.#scrollDragStartOffset = this.#scrollRowOffset;
-                    togglePressConsumed = true;
+                    isTogglePressConsumed = true;
                 }
             }
         }
 
-        if (!swatchPressConsumed) {
-            togglePressConsumed = this.#applyScrollDrag(pointer, plan, grid) || togglePressConsumed;
+        if (!isSwatchPressConsumed) {
+            isTogglePressConsumed = this.#applyScrollDrag(pointer, plan, grid) || isTogglePressConsumed;
         } else {
             this.#scrollDragSlot = null;
         }
 
-        togglePressConsumed = this.#applyScrollWheel(pointer, plan, grid) || togglePressConsumed;
+        isTogglePressConsumed = this.#applyScrollWheel(pointer, plan, grid) || isTogglePressConsumed;
 
-        return togglePressConsumed;
+        return isTogglePressConsumed;
     }
 
     /**
@@ -658,10 +658,10 @@ export class PaletteInteraction {
      * @returns `true` when drag scrolling consumed a toggle-corner press.
      */
     #applyScrollDrag(pointer: PointerInput, plan: OverlayLayoutPlan, grid: PaletteGridLayout): boolean {
-        let togglePressConsumed = false;
+        let isTogglePressConsumed = false;
 
         for (let slot = 0; slot < POINTER_SLOT_COUNT; slot++) {
-            if (!pointer.isButtonDown(POINTER_PRIMARY_BUTTON, slot) || !pointer.isValid(slot)) {
+            if (!pointer.isButtonDown(POINTER_PRIMARY_BUTTON, slot) || !pointer.isActive(slot)) {
                 if (this.#scrollDragSlot === slot) {
                     this.#scrollDragSlot = null;
                 }
@@ -670,9 +670,9 @@ export class PaletteInteraction {
             }
 
             const pos = pointer.getPos(slot);
-            const inScrollRegion = isPointerInPaletteScrollRegion(pos.x, pos.y, plan.paletteBand);
+            const isInScrollRegion = isPointerInPaletteScrollRegion(pos.x, pos.y, plan.paletteBand);
 
-            if (!inScrollRegion && this.#scrollDragSlot !== slot) {
+            if (!isInScrollRegion && this.#scrollDragSlot !== slot) {
                 continue;
             }
 
@@ -686,7 +686,7 @@ export class PaletteInteraction {
                     this.#scrollbarTrackWidth,
                 )
             ) {
-                togglePressConsumed = true;
+                isTogglePressConsumed = true;
             }
 
             if (this.#scrollDragSlot === slot) {
@@ -716,7 +716,7 @@ export class PaletteInteraction {
                 continue;
             }
 
-            if (!inScrollRegion) {
+            if (!isInScrollRegion) {
                 continue;
             }
 
@@ -732,7 +732,7 @@ export class PaletteInteraction {
             }
         }
 
-        return togglePressConsumed;
+        return isTogglePressConsumed;
     }
 
     /**

--- a/src/overlay/palette/PaletteInteraction.ts
+++ b/src/overlay/palette/PaletteInteraction.ts
@@ -15,12 +15,12 @@ import type { OverlayLayoutPlan } from '../layout/types';
 import type { OverlayDrawTarget } from '../OverlayDrawTarget';
 import type { PaletteGridLayout } from '../types';
 import {
-    computePaletteScrollbarThumbHeight,
+    computeScrollbarThumbHeight,
     PALETTE_GRID_PADDING_PX,
     PALETTE_SCROLLBAR_EDGE_PADDING_PX,
-    resolvePaletteHintExclusionRect,
-    writePaletteScrollbarRects,
-    writePaletteSwatchTopLeft,
+    resolveHintExclusionRect,
+    writeScrollbarRects,
+    writeSwatchTopLeft,
 } from './PaletteView';
 
 // #region Constants and types
@@ -29,10 +29,10 @@ import {
 export const PALETTE_SCROLLBAR_TRACK_WIDTH_PX = 4;
 
 /** Minimum wheel delta in pixels before advancing one palette row. */
-const PALETTE_SCROLL_WHEEL_ROW_PX = 8;
+const SCROLL_WHEEL_ROW_PX = 8;
 
 /** Minimum pointer drag delta in pixels before advancing one palette row. */
-const PALETTE_SCROLL_DRAG_ROW_PX = 4;
+const SCROLL_DRAG_ROW_PX = 4;
 
 /** Duration for transient copy status tooltips in seconds. */
 export const PALETTE_COPY_STATUS_SECONDS = 0.75;
@@ -41,7 +41,7 @@ export const PALETTE_COPY_STATUS_SECONDS = 0.75;
 const TOOLTIP_GAP_ABOVE_SWATCH_PX = 1;
 
 /** Clipboard copy feedback state for palette swatch presses. */
-type PaletteCopyStatus = 'idle' | 'copied' | 'failed';
+type CopyStatus = 'idle' | 'copied' | 'failed';
 
 /** Scratch rects and points reused by tooltip layout and draw (one overlay at a time). */
 const tooltipScratch = {
@@ -89,12 +89,7 @@ function isSwatchOverlappingWithHintExclusion(
  * @param bandRight - Right edge of the hittable band (excludes scrollbar track).
  * @returns `true` when the pointer lies outside the palette band (including scrollbar track).
  */
-function isPointerOutsidePaletteBand(
-    pointerX: number,
-    pointerY: number,
-    paletteBand: Rect2i,
-    bandRight: number,
-): boolean {
+function isPointerOutsideBand(pointerX: number, pointerY: number, paletteBand: Rect2i, bandRight: number): boolean {
     return (
         pointerX < paletteBand.x ||
         pointerX >= bandRight ||
@@ -115,7 +110,7 @@ function isPointerOutsidePaletteBand(
  * @param colorCount - Active palette slot count.
  * @returns Palette index, or `null` when the point is in padding or out of range.
  */
-function resolvePaletteIndexAtBandLocal(
+function resolveIndexAtBandLocal(
     localX: number,
     localY: number,
     cols: number,
@@ -171,7 +166,7 @@ function resolvePaletteIndexAtBandLocal(
  * @param scrollbarTrackWidth - Right-edge track width excluded from hits (default {@link PALETTE_SCROLLBAR_TRACK_WIDTH_PX}).
  * @returns Palette index, or `null` when the pointer is not over a hittable swatch.
  */
-export function hitTestPaletteSwatch(
+export function hitTestSwatch(
     pointerX: number,
     pointerY: number,
     paletteBand: Rect2i,
@@ -193,13 +188,13 @@ export function hitTestPaletteSwatch(
         scrollbarTrackWidth -
         PALETTE_SCROLLBAR_EDGE_PADDING_PX;
 
-    if (isPointerOutsidePaletteBand(pointerX, pointerY, paletteBand, bandRight)) {
+    if (isPointerOutsideBand(pointerX, pointerY, paletteBand, bandRight)) {
         return null;
     }
 
     const localX = pointerX - (paletteBand.x + OVERLAY_EDGE_MARGIN_PX);
     const localY = pointerY - (paletteBand.y + PALETTE_GRID_PADDING_PX);
-    const index = resolvePaletteIndexAtBandLocal(localX, localY, cols, swatchSize, gap, scrollRowOffset, colorCount);
+    const index = resolveIndexAtBandLocal(localX, localY, cols, swatchSize, gap, scrollRowOffset, colorCount);
 
     if (index === null) {
         return null;
@@ -207,7 +202,7 @@ export function hitTestPaletteSwatch(
 
     const swatchScratch = tooltipScratch.swatch;
 
-    writePaletteSwatchTopLeft(swatchScratch, index, paletteBand, grid, scrollRowOffset);
+    writeSwatchTopLeft(swatchScratch, index, paletteBand, grid, scrollRowOffset);
 
     if (isSwatchOverlappingWithHintExclusion(swatchScratch.x, swatchScratch.y, swatchSize, hintExclusion)) {
         return null;
@@ -255,7 +250,7 @@ export function clampScrollRowOffset(offset: number, grid: PaletteGridLayout): n
  * @param paletteBand - Palette band rect from the layout plan.
  * @returns `true` when wheel or drag scrolling may apply.
  */
-function isPointerInPaletteScrollRegion(pointerX: number, pointerY: number, paletteBand: Rect2i): boolean {
+function isPointerInScrollRegion(pointerX: number, pointerY: number, paletteBand: Rect2i): boolean {
     return (
         pointerX >= paletteBand.x &&
         pointerX < paletteBand.x + paletteBand.width &&
@@ -275,7 +270,7 @@ function isPointerInPaletteScrollRegion(pointerX: number, pointerY: number, pale
  * @param trackWidth - Scrollbar track width in pixels.
  * @returns `true` when the pointer is over the track rect.
  */
-export function isPointerInPaletteScrollbarTrack(
+export function isPointerInScrollbarTrack(
     pointerX: number,
     pointerY: number,
     paletteBand: Rect2i,
@@ -286,7 +281,7 @@ export function isPointerInPaletteScrollbarTrack(
     const trackScratch = tooltipScratch.swatch;
     const thumbScratch = tooltipScratch.outlineEdge;
 
-    if (!writePaletteScrollbarRects(trackScratch, thumbScratch, paletteBand, grid, scrollRowOffset, trackWidth)) {
+    if (!writeScrollbarRects(trackScratch, thumbScratch, paletteBand, grid, scrollRowOffset, trackWidth)) {
         return false;
     }
 
@@ -322,11 +317,11 @@ export function resolveScrollRowOffsetFromTrackPointerY(
     const trackScratch = tooltipScratch.swatch;
     const thumbScratch = tooltipScratch.outlineEdge;
 
-    writePaletteScrollbarRects(trackScratch, thumbScratch, paletteBand, grid, 0, trackWidth);
+    writeScrollbarRects(trackScratch, thumbScratch, paletteBand, grid, 0, trackWidth);
 
     const trackTop = trackScratch.y;
     const trackHeight = trackScratch.height;
-    const thumbHeight = computePaletteScrollbarThumbHeight(trackHeight, grid);
+    const thumbHeight = computeScrollbarThumbHeight(trackHeight, grid);
     const scrollRange = Math.max(1, trackHeight - thumbHeight);
     const localY = pointerY - trackTop - Math.floor(thumbHeight / 2);
     const ratio = localY / scrollRange;
@@ -358,7 +353,7 @@ export interface PaletteTooltipLayout {
  * @param displayHeight - Logical display height.
  * @returns `target` for chaining.
  */
-export function layoutPaletteTooltip(
+export function layoutTooltip(
     target: PaletteTooltipLayout,
     swatchRect: Rect2i,
     label: string,
@@ -399,11 +394,11 @@ export function layoutPaletteTooltip(
  * Draws a docked palette swatch tooltip body and 1px border.
  *
  * @param target - Overlay draw target.
- * @param layout - Tooltip layout from {@link layoutPaletteTooltip}.
+ * @param layout - Tooltip layout from {@link layoutTooltip}.
  * @param barIndex - Palette index for tooltip body fill (overlay background).
  * @param textIndex - Palette index for the border stroke.
  */
-export function drawPaletteTooltipChrome(
+export function drawTooltipChrome(
     target: OverlayDrawTarget,
     layout: PaletteTooltipLayout,
     barIndex: number,
@@ -431,11 +426,11 @@ export function drawPaletteTooltipChrome(
  *
  * @param target - Overlay draw target.
  * @param font - System bitmap font.
- * @param layout - Tooltip layout from {@link layoutPaletteTooltip}.
+ * @param layout - Tooltip layout from {@link layoutTooltip}.
  * @param label - Tooltip label text.
  * @param textIndex - Palette index for label text.
  */
-export function drawPaletteTooltipLabel(
+export function drawTooltipLabel(
     target: OverlayDrawTarget,
     font: BitmapFont,
     layout: PaletteTooltipLayout,
@@ -461,7 +456,7 @@ export function drawPaletteTooltipLabel(
  * @param index - Palette slot to copy.
  * @returns Resolves on success; rejects when clipboard is unavailable or denied.
  */
-export async function writePaletteIndexToClipboard(index: number): Promise<void> {
+export async function writeIndexToClipboard(index: number): Promise<void> {
     const clipboard = globalThis.navigator?.clipboard;
 
     if (!clipboard?.writeText) {
@@ -483,7 +478,7 @@ export class PaletteInteraction {
 
     #hoveredIndex: number | null = null;
 
-    #copyStatus: PaletteCopyStatus = 'idle';
+    #copyStatus: CopyStatus = 'idle';
 
     #copyStatusIndex = -1;
 
@@ -583,7 +578,7 @@ export class PaletteInteraction {
 
             if (pointer.isButtonPressed(POINTER_PRIMARY_BUTTON, slot)) {
                 if (
-                    isPointerInPaletteScrollbarTrack(
+                    isPointerInScrollbarTrack(
                         pos.x,
                         pos.y,
                         plan.paletteBand,
@@ -633,11 +628,11 @@ export class PaletteInteraction {
 
             const pos = pointer.getPos(slot);
 
-            if (!isPointerInPaletteScrollRegion(pos.x, pos.y, plan.paletteBand)) {
+            if (!isPointerInScrollRegion(pos.x, pos.y, plan.paletteBand)) {
                 continue;
             }
 
-            const rowStep = Math.max(1, Math.trunc(Math.abs(scrollDelta) / PALETTE_SCROLL_WHEEL_ROW_PX));
+            const rowStep = Math.max(1, Math.trunc(Math.abs(scrollDelta) / SCROLL_WHEEL_ROW_PX));
             const nextOffset = this.#scrollRowOffset + (scrollDelta > 0 ? rowStep : -rowStep);
 
             this.#scrollRowOffset = clampScrollRowOffset(nextOffset, grid);
@@ -670,14 +665,14 @@ export class PaletteInteraction {
             }
 
             const pos = pointer.getPos(slot);
-            const isInScrollRegion = isPointerInPaletteScrollRegion(pos.x, pos.y, plan.paletteBand);
+            const isInScrollRegion = isPointerInScrollRegion(pos.x, pos.y, plan.paletteBand);
 
             if (!isInScrollRegion && this.#scrollDragSlot !== slot) {
                 continue;
             }
 
             if (
-                isPointerInPaletteScrollbarTrack(
+                isPointerInScrollbarTrack(
                     pos.x,
                     pos.y,
                     plan.paletteBand,
@@ -691,7 +686,7 @@ export class PaletteInteraction {
 
             if (this.#scrollDragSlot === slot) {
                 if (
-                    isPointerInPaletteScrollbarTrack(
+                    isPointerInScrollbarTrack(
                         pos.x,
                         pos.y,
                         plan.paletteBand,
@@ -708,7 +703,7 @@ export class PaletteInteraction {
                     );
                 } else {
                     const deltaY = pos.y - this.#scrollDragStartY;
-                    const rowStep = Math.trunc(deltaY / PALETTE_SCROLL_DRAG_ROW_PX);
+                    const rowStep = Math.trunc(deltaY / SCROLL_DRAG_ROW_PX);
 
                     this.#scrollRowOffset = clampScrollRowOffset(this.#scrollDragStartOffset - rowStep, grid);
                 }
@@ -725,7 +720,7 @@ export class PaletteInteraction {
             this.#scrollDragStartOffset = this.#scrollRowOffset;
 
             const deltaY = pos.y - this.#scrollDragStartY;
-            const rowStep = Math.trunc(deltaY / PALETTE_SCROLL_DRAG_ROW_PX);
+            const rowStep = Math.trunc(deltaY / SCROLL_DRAG_ROW_PX);
 
             if (rowStep !== 0) {
                 this.#scrollRowOffset = clampScrollRowOffset(this.#scrollDragStartOffset - rowStep, grid);
@@ -781,7 +776,7 @@ export class PaletteInteraction {
             return;
         }
 
-        const hintExclusion = resolvePaletteHintExclusionRect(hintBarTopY, displayWidth);
+        const hintExclusion = resolveHintExclusionRect(hintBarTopY, displayWidth);
         let hovered: number | null = null;
 
         for (let slot = 0; slot < POINTER_SLOT_COUNT; slot++) {
@@ -790,7 +785,7 @@ export class PaletteInteraction {
             }
 
             const pos = pointer.getPos(slot);
-            const hit = hitTestPaletteSwatch(
+            const hit = hitTestSwatch(
                 pos.x,
                 pos.y,
                 plan.paletteBand,
@@ -839,7 +834,7 @@ export class PaletteInteraction {
 
         this.#lastKnownTick = currentTick;
 
-        const hintExclusion = resolvePaletteHintExclusionRect(hintBarTopY, displayWidth);
+        const hintExclusion = resolveHintExclusionRect(hintBarTopY, displayWidth);
 
         for (let slot = 0; slot < POINTER_SLOT_COUNT; slot++) {
             if (!pointer.isButtonPressed(POINTER_PRIMARY_BUTTON, slot)) {
@@ -847,7 +842,7 @@ export class PaletteInteraction {
             }
 
             const pos = pointer.getPos(slot);
-            const index = hitTestPaletteSwatch(
+            const index = hitTestSwatch(
                 pos.x,
                 pos.y,
                 plan.paletteBand,
@@ -865,7 +860,7 @@ export class PaletteInteraction {
 
             void (async () => {
                 try {
-                    await writePaletteIndexToClipboard(index);
+                    await writeIndexToClipboard(index);
                     this.#setCopyStatus('copied', index, this.#lastKnownTick);
                 } catch {
                     this.#setCopyStatus('failed', index, this.#lastKnownTick);
@@ -905,9 +900,9 @@ export class PaletteInteraction {
             return null;
         }
 
-        writePaletteSwatchTopLeft(tooltipScratch.swatch, index, plan.paletteBand, grid, this.#scrollRowOffset);
+        writeSwatchTopLeft(tooltipScratch.swatch, index, plan.paletteBand, grid, this.#scrollRowOffset);
 
-        const layout = layoutPaletteTooltip(tooltipScratch, tooltipScratch.swatch, label, displayWidth, displayHeight);
+        const layout = layoutTooltip(tooltipScratch, tooltipScratch.swatch, label, displayWidth, displayHeight);
 
         return { layout, label };
     }
@@ -938,7 +933,7 @@ export class PaletteInteraction {
             return;
         }
 
-        drawPaletteTooltipChrome(target, active.layout, barIndex, textIndex);
+        drawTooltipChrome(target, active.layout, barIndex, textIndex);
     }
 
     /**
@@ -967,7 +962,7 @@ export class PaletteInteraction {
             return;
         }
 
-        drawPaletteTooltipLabel(target, font, active.layout, active.label, textIndex);
+        drawTooltipLabel(target, font, active.layout, active.label, textIndex);
     }
 
     /**
@@ -977,7 +972,7 @@ export class PaletteInteraction {
      * @param index - Palette index that was copied.
      * @param completionTick - Fixed-update tick when the clipboard write finished.
      */
-    #setCopyStatus(status: Exclude<PaletteCopyStatus, 'idle'>, index: number, completionTick: number): void {
+    #setCopyStatus(status: Exclude<CopyStatus, 'idle'>, index: number, completionTick: number): void {
         this.#copyStatus = status;
         this.#copyStatusIndex = index;
         this.#copyStatusExpiryTick = completionTick + Math.ceil(PALETTE_COPY_STATUS_SECONDS * this.#targetFps);

--- a/src/overlay/palette/PaletteView.alloc.test.ts
+++ b/src/overlay/palette/PaletteView.alloc.test.ts
@@ -7,12 +7,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Palette } from '../../assets/Palette';
-import { markRenderPaletteIndexUsed } from '../../core/RenderPaletteUsage';
+import { markIndexUsed } from '../../core/RenderPaletteUsage';
 import type * as Rect2iModule from '../../utils/Rect2i';
 import { Rect2i } from '../../utils/Rect2i';
 import { createOverlayLayout } from '../layout/layoutHelpers';
 import { hintBarY, paletteBandY } from '../layout/layoutPlan';
-import { computePaletteGrid, DEFAULT_PALETTE_SWATCH_SIZE, PaletteView } from './PaletteView';
+import { computeGrid, DEFAULT_PALETTE_SWATCH_SIZE, PaletteView } from './PaletteView';
 
 // #endregion
 
@@ -42,7 +42,7 @@ function buildUsageMask(indices: readonly number[], size = 256): Uint8Array {
     const mask = new Uint8Array(size);
 
     for (const index of indices) {
-        markRenderPaletteIndexUsed(mask, index);
+        markIndexUsed(mask, index);
     }
 
     return mask;
@@ -61,7 +61,7 @@ describe('PaletteView allocation', () => {
         const layout = createOverlayLayout(320, 240, 14);
         const palette = Palette.cga();
         const usedMask = buildUsageMask([1, 2, 3]);
-        const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, palette.size);
+        const grid = computeGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, palette.size);
         const paletteBand = new Rect2i(0, paletteBandY(240, grid.totalHeight), 320, grid.totalHeight);
         const view = new PaletteView(true);
         const renderer = { drawBarFill: vi.fn() } as never;
@@ -101,7 +101,7 @@ describe('PaletteView allocation', () => {
         const layout = createOverlayLayout(320, 240, 14);
         const palette = Palette.vga();
         const usedMask = buildUsageMask([1, 2, 3, 4, 5]);
-        const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, palette.size);
+        const grid = computeGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, palette.size);
         const paletteBand = new Rect2i(0, paletteBandY(240, grid.totalHeight), 320, grid.totalHeight);
         const view = new PaletteView(true);
         const renderer = { drawBarFill: vi.fn() } as never;

--- a/src/overlay/palette/PaletteView.bench.ts
+++ b/src/overlay/palette/PaletteView.bench.ts
@@ -3,12 +3,12 @@
 import { bench, describe } from 'vitest';
 
 import { Palette } from '../../assets/Palette';
-import { resetRenderPaletteUsage } from '../../core/RenderPaletteUsage';
+import { resetUsage } from '../../core/RenderPaletteUsage';
 import { Rect2i } from '../../utils/Rect2i';
 import { Vector2i } from '../../utils/Vector2i';
 import { createOverlayLayout } from '../layout/layoutHelpers';
 import { hintBarY } from '../layout/layoutPlan';
-import { computePaletteGrid, PaletteView } from './PaletteView';
+import { computeGrid, PaletteView } from './PaletteView';
 
 // #endregion
 
@@ -26,13 +26,13 @@ const BENCH_OPTIONS = {
 // #region Fixtures
 
 const layout16 = createOverlayLayout(320, 240, 14);
-const grid16 = computePaletteGrid(320, undefined, 16);
+const grid16 = computeGrid(320, undefined, 16);
 const palette16 = new Palette(16);
 const usedMask16 = new Uint8Array(256);
 const paletteBand16 = new Rect2i(0, 200, 320, 40);
 
 const layout256 = createOverlayLayout(320, 240, 14);
-const grid256 = computePaletteGrid(320, undefined, 256);
+const grid256 = computeGrid(320, undefined, 256);
 const palette256 = new Palette(256);
 const usedMask256 = new Uint8Array(256);
 const paletteBand256 = new Rect2i(0, 120, 320, 120);
@@ -51,7 +51,7 @@ describe('PaletteView.draw', () => {
     bench(
         '16-slot palette grid',
         () => {
-            resetRenderPaletteUsage(usedMask16);
+            resetUsage(usedMask16);
             paletteView.draw(
                 noopRenderer as never,
                 paletteBand16,
@@ -69,7 +69,7 @@ describe('PaletteView.draw', () => {
     bench(
         '256-slot palette grid',
         () => {
-            resetRenderPaletteUsage(usedMask256);
+            resetUsage(usedMask256);
             paletteView.draw(
                 noopRenderer as never,
                 paletteBand256,

--- a/src/overlay/palette/PaletteView.test.ts
+++ b/src/overlay/palette/PaletteView.test.ts
@@ -1,27 +1,27 @@
 /**
- * Unit tests for {@link computePaletteGrid} and palette swatch drawing.
+ * Unit tests for {@link computeGrid} and palette swatch drawing.
  */
 
 import { describe, expect, it, vi } from 'vitest';
 
 import { Palette } from '../../assets/Palette';
-import { markRenderPaletteIndexUsed } from '../../core/RenderPaletteUsage';
+import { markIndexUsed } from '../../core/RenderPaletteUsage';
 import { Rect2i } from '../../utils/Rect2i';
 import { DEFAULT_IDX_TEXT } from '../constants';
 import { OVERLAY_EDGE_MARGIN_PX, OVERLAY_ROW_GAP_PX } from '../layout/constants';
 import { createOverlayLayout } from '../layout/layoutHelpers';
 import { hintBarY, paletteBandY } from '../layout/layoutPlan';
 import {
-    computePaletteGrid,
+    computeGrid,
     computeUnusedSwatchMarkerRect,
     DEFAULT_PALETTE_SWATCH_SIZE,
+    gridRowStackHeight,
+    gridRowWidth,
     PALETTE_GRID_PADDING_PX,
     PALETTE_SWATCH_GAP_PX,
-    paletteGridRowStackHeight,
-    paletteGridRowWidth,
     PaletteView,
-    pickPaletteGridColumnCount,
-    resolvePaletteGridVisibleRows,
+    pickGridColumnCount,
+    resolveGridVisibleRows,
 } from './PaletteView';
 
 /** Builds a usage mask from palette slot indices for tests. */
@@ -29,7 +29,7 @@ function buildUsageMask(indices: readonly number[], size = 256): Uint8Array {
     const mask = new Uint8Array(size);
 
     for (const index of indices) {
-        markRenderPaletteIndexUsed(mask, index);
+        markIndexUsed(mask, index);
     }
 
     return mask;
@@ -68,46 +68,46 @@ function swatchTopLeft(
     };
 }
 
-describe('computePaletteGrid', () => {
+describe('computeGrid', () => {
     it('uses 32 columns and 8 rows at 320 px width for a 256-color palette', () => {
-        const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 256, PALETTE_SWATCH_GAP_PX);
+        const grid = computeGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 256, PALETTE_SWATCH_GAP_PX);
 
         expect(grid.cols).toBe(32);
         expect(grid.rows).toBe(8);
         expect(grid.swatchSize).toBe(DEFAULT_PALETTE_SWATCH_SIZE);
         expect(grid.gap).toBe(PALETTE_SWATCH_GAP_PX);
         expect(grid.totalHeight).toBe(
-            paletteGridRowStackHeight(grid.rows, grid.swatchSize, grid.gap) + PALETTE_GRID_PADDING_PX * 2,
+            gridRowStackHeight(grid.rows, grid.swatchSize, grid.gap) + PALETTE_GRID_PADDING_PX * 2,
         );
-        expect(paletteGridRowWidth(grid.cols, grid.swatchSize, grid.gap)).toBeLessThanOrEqual(320 - 6);
+        expect(gridRowWidth(grid.cols, grid.swatchSize, grid.gap)).toBeLessThanOrEqual(320 - 6);
     });
 
     it('keeps small palettes on one row when width allows', () => {
-        expect(computePaletteGrid(320, 4, 2).cols).toBe(2);
-        expect(computePaletteGrid(320, 4, 4).cols).toBe(4);
-        expect(computePaletteGrid(320, 4, 16).cols).toBe(16);
+        expect(computeGrid(320, 4, 2).cols).toBe(2);
+        expect(computeGrid(320, 4, 4).cols).toBe(4);
+        expect(computeGrid(320, 4, 16).cols).toBe(16);
     });
 
     it('halves column count when a single row no longer fits', () => {
-        const narrowWidth = paletteGridRowWidth(16, 4, 1) + OVERLAY_EDGE_MARGIN_PX * 2 - 1;
-        const grid = computePaletteGrid(narrowWidth, 4, 16, 1);
+        const narrowWidth = gridRowWidth(16, 4, 1) + OVERLAY_EDGE_MARGIN_PX * 2 - 1;
+        const grid = computeGrid(narrowWidth, 4, 16, 1);
 
         expect(grid.cols).toBe(8);
         expect(grid.rows).toBe(2);
     });
 
     it('falls back to one column when only one swatch fits horizontally', () => {
-        const grid = computePaletteGrid(10, 4, 256, 1);
+        const grid = computeGrid(10, 4, 256, 1);
 
         expect(grid.cols).toBe(1);
         expect(grid.rows).toBe(256);
         expect(grid.totalHeight).toBe(
-            paletteGridRowStackHeight(grid.rows, grid.swatchSize, grid.gap) + PALETTE_GRID_PADDING_PX * 2,
+            gridRowStackHeight(grid.rows, grid.swatchSize, grid.gap) + PALETTE_GRID_PADDING_PX * 2,
         );
     });
 
     it('returns an empty grid when color count is zero', () => {
-        expect(computePaletteGrid(320, 4, 0, 1)).toEqual({
+        expect(computeGrid(320, 4, 0, 1)).toEqual({
             cols: 0,
             rows: 0,
             visibleRows: 0,
@@ -118,49 +118,47 @@ describe('computePaletteGrid', () => {
     });
 
     it('caps visible rows and band height when overlayPaletteRowsVisible is set', () => {
-        const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 256, PALETTE_SWATCH_GAP_PX, undefined, 3);
+        const grid = computeGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 256, PALETTE_SWATCH_GAP_PX, undefined, 3);
 
         expect(grid.rows).toBe(8);
         expect(grid.visibleRows).toBe(3);
-        expect(grid.totalHeight).toBe(
-            paletteGridRowStackHeight(3, grid.swatchSize, grid.gap) + PALETTE_GRID_PADDING_PX * 2,
-        );
+        expect(grid.totalHeight).toBe(gridRowStackHeight(3, grid.swatchSize, grid.gap) + PALETTE_GRID_PADDING_PX * 2);
     });
 
     it('clamps overlayPaletteRowsVisible below 1 up to one visible row', () => {
-        const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 256, PALETTE_SWATCH_GAP_PX, undefined, 0);
+        const grid = computeGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 256, PALETTE_SWATCH_GAP_PX, undefined, 0);
 
         expect(grid.visibleRows).toBe(1);
     });
 
     it('clamps overlayPaletteRowsVisible above total rows down to total rows', () => {
-        const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 16, PALETTE_SWATCH_GAP_PX, undefined, 99);
+        const grid = computeGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 16, PALETTE_SWATCH_GAP_PX, undefined, 99);
 
         expect(grid.rows).toBe(1);
         expect(grid.visibleRows).toBe(1);
     });
 
-    it('matches pickPaletteGridColumnCount helper cases', () => {
-        expect(pickPaletteGridColumnCount(320, 4, 1, 256)).toBe(32);
-        expect(pickPaletteGridColumnCount(320, 4, 1, 32)).toBe(32);
-        expect(pickPaletteGridColumnCount(120, 4, 1, 32)).toBe(16);
+    it('matches pickGridColumnCount helper cases', () => {
+        expect(pickGridColumnCount(320, 4, 1, 256)).toBe(32);
+        expect(pickGridColumnCount(320, 4, 1, 32)).toBe(32);
+        expect(pickGridColumnCount(120, 4, 1, 32)).toBe(16);
     });
 
     it('caps column count when overlayPaletteColumns is set', () => {
-        expect(computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 16, PALETTE_SWATCH_GAP_PX, 8).cols).toBe(8);
-        expect(computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 16, PALETTE_SWATCH_GAP_PX, 8).rows).toBe(2);
-        expect(pickPaletteGridColumnCount(320, DEFAULT_PALETTE_SWATCH_SIZE, PALETTE_SWATCH_GAP_PX, 256, 8)).toBe(8);
+        expect(computeGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 16, PALETTE_SWATCH_GAP_PX, 8).cols).toBe(8);
+        expect(computeGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, 16, PALETTE_SWATCH_GAP_PX, 8).rows).toBe(2);
+        expect(pickGridColumnCount(320, DEFAULT_PALETTE_SWATCH_SIZE, PALETTE_SWATCH_GAP_PX, 256, 8)).toBe(8);
     });
 });
 
-describe('resolvePaletteGridVisibleRows', () => {
+describe('resolveGridVisibleRows', () => {
     it('ignores non-finite caps and returns all rows', () => {
-        expect(resolvePaletteGridVisibleRows(8, Number.NaN)).toBe(8);
-        expect(resolvePaletteGridVisibleRows(8, Number.POSITIVE_INFINITY)).toBe(8);
+        expect(resolveGridVisibleRows(8, Number.NaN)).toBe(8);
+        expect(resolveGridVisibleRows(8, Number.POSITIVE_INFINITY)).toBe(8);
     });
 
     it('truncates fractional caps before clamping', () => {
-        expect(resolvePaletteGridVisibleRows(8, 2.9)).toBe(2);
+        expect(resolveGridVisibleRows(8, 2.9)).toBe(2);
     });
 });
 
@@ -185,7 +183,7 @@ describe('PaletteView.draw', () => {
         const palette = Palette.cga();
         const usedMask = buildUsageMask([5]);
         const swatchSize = DEFAULT_PALETTE_SWATCH_SIZE;
-        const grid = computePaletteGrid(320, swatchSize, palette.size, 1);
+        const grid = computeGrid(320, swatchSize, palette.size, 1);
         const paletteBandTop = paletteBandY(240, grid.totalHeight);
         const view = new PaletteView(true);
         const { drawBarFill, calls } = createRectFillMock();
@@ -249,7 +247,7 @@ describe('PaletteView.draw', () => {
         const palette = Palette.cga();
         const usedMask = buildUsageMask([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
         const swatchSize = DEFAULT_PALETTE_SWATCH_SIZE;
-        const grid = computePaletteGrid(320, swatchSize, palette.size, 1);
+        const grid = computeGrid(320, swatchSize, palette.size, 1);
         const paletteBandTop = paletteBandY(240, grid.totalHeight);
         const view = new PaletteView(true);
         const { drawBarFill, calls } = createRectFillMock();
@@ -292,7 +290,7 @@ describe('PaletteView.draw', () => {
     it('keeps palette swatches above the dedicated hint bar', () => {
         const layout = createOverlayLayout(320, 240, 14);
         const palette = new Palette(256);
-        const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, palette.size, 1, 36);
+        const grid = computeGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, palette.size, 1, 36);
         const paletteBandTop = paletteBandY(240, grid.totalHeight);
         const swatchOriginY = paletteBandTop + PALETTE_GRID_PADDING_PX;
         const view = new PaletteView(true);
@@ -324,7 +322,7 @@ describe('PaletteView.draw', () => {
             renderer,
             new Rect2i(0, 201, 320, 39),
             Palette.cga(),
-            computePaletteGrid(320),
+            computeGrid(320),
             227,
             320,
             buildUsageMask([1, 2, 3]),
@@ -337,7 +335,7 @@ describe('PaletteView.draw', () => {
     it('draws only the visible row window when scroll offset is non-zero', () => {
         const layout = createOverlayLayout(320, 240, 14);
         const palette = new Palette(256);
-        const grid = computePaletteGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, palette.size, 1, undefined, 3);
+        const grid = computeGrid(320, DEFAULT_PALETTE_SWATCH_SIZE, palette.size, 1, undefined, 3);
         const scrollRowOffset = 2;
         const paletteBandTop = paletteBandY(240, grid.totalHeight);
         const view = new PaletteView(true);

--- a/src/overlay/palette/PaletteView.ts
+++ b/src/overlay/palette/PaletteView.ts
@@ -546,7 +546,7 @@ function drawPaletteScrollbar(
  * Live palette swatch renderer for the overlay bottom band.
  */
 export class PaletteView {
-    readonly #enabled: boolean;
+    readonly #isEnabled: boolean;
 
     /**
      * Creates a palette view with the given feature flag.
@@ -554,7 +554,7 @@ export class PaletteView {
      * @param enabled - When false, draw is a no-op (default matches public opt-in API).
      */
     constructor(enabled = false) {
-        this.#enabled = enabled;
+        this.#isEnabled = enabled;
     }
 
     /**
@@ -562,8 +562,8 @@ export class PaletteView {
      *
      * @returns Feature flag state.
      */
-    get enabled(): boolean {
-        return this.#enabled;
+    get isEnabled(): boolean {
+        return this.#isEnabled;
     }
 
     /**
@@ -594,7 +594,7 @@ export class PaletteView {
         scrollbarTrackWidth = 0,
         scrollbarThumbIndex = unusedMarkIndex,
     ): void {
-        if (!this.#enabled || palette === null || grid.cols <= 0) {
+        if (!this.#isEnabled || palette === null || grid.cols <= 0) {
             return;
         }
 

--- a/src/overlay/palette/PaletteView.ts
+++ b/src/overlay/palette/PaletteView.ts
@@ -63,6 +63,15 @@ export function gridRowWidth(cols: number, swatchSize: number, gap: number): num
 }
 
 /**
+ * @deprecated Deprecated since 2026-05-31. Use {@link gridRowWidth} instead.
+ * @param cols - Column count.
+ * @param swatchSize - Side length of each swatch.
+ * @param gap - Gap between swatches.
+ * @returns Row width in pixels.
+ */
+export const paletteGridRowWidth = gridRowWidth;
+
+/**
  * Computes the vertical span of the full grid.
  *
  * @param rows - Row count.
@@ -77,6 +86,15 @@ export function gridRowStackHeight(rows: number, swatchSize: number, gap: number
 
     return rows * swatchSize + (rows - 1) * gap;
 }
+
+/**
+ * @deprecated Deprecated since 2026-05-31. Use {@link gridRowStackHeight} instead.
+ * @param rows - Row count.
+ * @param swatchSize - Side length of each swatch.
+ * @param gap - Gap between swatches.
+ * @returns Grid height in pixels.
+ */
+export const paletteGridRowStackHeight = gridRowStackHeight;
 
 /**
  * Picks the widest column count that fits the display while halving from the palette size.
@@ -114,6 +132,17 @@ export function pickGridColumnCount(
 }
 
 /**
+ * @deprecated Deprecated since 2026-05-31. Use {@link pickGridColumnCount} instead.
+ * @param displayWidth - Logical display width in pixels.
+ * @param swatchSize - Side length of each swatch.
+ * @param gap - Gap between swatches.
+ * @param colorCount - Active palette slot count.
+ * @param maxColumns - Optional cap from {@link HardwareSettings.overlayPaletteColumns}.
+ * @returns Column count (at least 1).
+ */
+export const pickPaletteGridColumnCount = pickGridColumnCount;
+
+/**
  * Resolves the visible row count for a palette grid viewport.
  *
  * @param totalRows - Full palette row count.
@@ -133,6 +162,14 @@ export function resolveGridVisibleRows(totalRows: number, maxVisibleRows?: numbe
 
     return Math.min(totalRows, parsedMax);
 }
+
+/**
+ * @deprecated Deprecated since 2026-05-31. Use {@link resolveGridVisibleRows} instead.
+ * @param totalRows - Full palette row count.
+ * @param maxVisibleRows - Optional cap from {@link HardwareSettings.overlayPaletteRowsVisible}.
+ * @returns Visible rows (0 when `totalRows` is 0; otherwise clamped to `[1, totalRows]`).
+ */
+export const resolvePaletteGridVisibleRows = resolveGridVisibleRows;
 
 /**
  * Computes palette grid layout for the bottom band.
@@ -164,6 +201,18 @@ export function computeGrid(
 
     return { cols, rows, visibleRows, swatchSize, gap, totalHeight };
 }
+
+/**
+ * @deprecated Deprecated since 2026-05-31. Use {@link computeGrid} instead.
+ * @param displayWidth - Logical display width in pixels.
+ * @param swatchSize - Side length of each swatch.
+ * @param colorCount - Number of palette slots to show.
+ * @param gap - Gap between swatches.
+ * @param maxColumns - Optional cap from {@link HardwareSettings.overlayPaletteColumns}.
+ * @param maxVisibleRows - Optional cap from {@link HardwareSettings.overlayPaletteRowsVisible}.
+ * @returns Grid dimensions and viewport band height.
+ */
+export const computePaletteGrid = computeGrid;
 
 // #endregion
 
@@ -236,6 +285,14 @@ export function resolveHintExclusionRect(hintBarTopY: number, displayWidth: numb
 
     return hintExclusionCache.rect;
 }
+
+/**
+ * @deprecated Deprecated since 2026-05-31. Use {@link resolveHintExclusionRect} instead.
+ * @param hintBarTopY - Top Y of the bottom hint bar from the layout plan.
+ * @param displayWidth - Logical display width (cache key only; icon X is margin-based).
+ * @returns Exclusion rect for swatch placement and hit testing.
+ */
+export const resolvePaletteHintExclusionRect = resolveHintExclusionRect;
 
 // #endregion
 
@@ -379,6 +436,12 @@ export function writeSwatchTopLeft(
     scrollRowOffset = 0,
 ): void {
     const { cols, swatchSize, gap } = grid;
+
+    if (cols === 0) {
+        target.set(0, 0, 0, 0);
+        return;
+    }
+
     const col = index % cols;
     const row = Math.floor(index / cols) - scrollRowOffset;
     const originX = paletteBand.x + OVERLAY_EDGE_MARGIN_PX;
@@ -388,6 +451,16 @@ export function writeSwatchTopLeft(
 
     target.set(x, y, swatchSize, swatchSize);
 }
+
+/**
+ * @deprecated Deprecated since 2026-05-31. Use {@link writeSwatchTopLeft} instead.
+ * @param target - Reusable rect mutated in place.
+ * @param index - Palette slot index.
+ * @param paletteBand - Palette band rect from layout plan.
+ * @param grid - Precomputed grid layout.
+ * @param scrollRowOffset - First visible grid row (default `0`).
+ */
+export const writePaletteSwatchTopLeft = writeSwatchTopLeft;
 
 /**
  * Draws the visible palette swatch window inside the bottom band.
@@ -452,6 +525,14 @@ export function computeScrollbarThumbHeight(trackHeight: number, grid: PaletteGr
 }
 
 /**
+ * @deprecated Deprecated since 2026-05-31. Use {@link computeScrollbarThumbHeight} instead.
+ * @param trackHeight - Full palette band height in pixels.
+ * @param grid - Precomputed grid layout.
+ * @returns Thumb height in pixels, or `0` when inputs are invalid.
+ */
+export const computePaletteScrollbarThumbHeight = computeScrollbarThumbHeight;
+
+/**
  * Writes the palette scrollbar track and thumb rects for the bottom band.
  *
  * The track is inset 1 px from the palette band top, right, and bottom edges. Only the
@@ -504,6 +585,18 @@ export function writeScrollbarRects(
 
     return true;
 }
+
+/**
+ * @deprecated Deprecated since 2026-05-31. Use {@link writeScrollbarRects} instead.
+ * @param trackTarget - Reusable track rect mutated in place.
+ * @param thumbTarget - Reusable thumb rect mutated in place.
+ * @param paletteBand - Palette band rect from layout plan.
+ * @param grid - Precomputed grid layout.
+ * @param scrollRowOffset - First visible grid row.
+ * @param trackWidth - Scrollbar track width in pixels.
+ * @returns `true` when scrolling is possible and rects were written.
+ */
+export const writePaletteScrollbarRects = writeScrollbarRects;
 
 /**
  * Draws the palette scrollbar thumb inside the bottom band (no track fill).

--- a/src/overlay/palette/PaletteView.ts
+++ b/src/overlay/palette/PaletteView.ts
@@ -13,8 +13,8 @@ import { Rect2i } from '../../utils/Rect2i';
 import { OVERLAY_EDGE_MARGIN_PX } from '../layout/constants';
 import { overlayToggleHintIconX } from '../layout/layoutHelpers';
 import type { OverlayDrawTarget } from '../OverlayDrawTarget';
-import { overlayToggleHintIconY } from '../OverlayToggleIcon';
-import { OVERLAY_TOGGLE_ICON_HEIGHT, OVERLAY_TOGGLE_ICON_WIDTH } from '../toggleIconData';
+import { hintIconY } from '../OverlayToggleIcon';
+import { ICON_HEIGHT, ICON_WIDTH } from '../toggleIconData';
 import type { PaletteGridLayout } from '../types';
 
 /** Default swatch size in pixels. */
@@ -182,7 +182,7 @@ export function computePaletteGrid(
  * @param bh - Height of rect B.
  * @returns `true` when the rects overlap.
  */
-function rectsIntersect(
+function doRectsOverlap(
     ax: number,
     ay: number,
     aw: number,
@@ -204,8 +204,8 @@ function rectsIntersect(
  * @param exclusion - Region to avoid (for example the toggle hint icon).
  * @returns `true` when any part of the swatch overlaps the exclusion rect.
  */
-function swatchIntersectsRect(x: number, y: number, swatchSize: number, exclusion: Rect2i): boolean {
-    return rectsIntersect(x, y, swatchSize, swatchSize, exclusion.x, exclusion.y, exclusion.width, exclusion.height);
+function doesSwatchIntersectExclusion(x: number, y: number, swatchSize: number, exclusion: Rect2i): boolean {
+    return doRectsOverlap(x, y, swatchSize, swatchSize, exclusion.x, exclusion.y, exclusion.width, exclusion.height);
 }
 
 /** Cached hint exclusion rect; recomputed only when layout inputs change. */
@@ -232,12 +232,7 @@ export function resolvePaletteHintExclusionRect(hintBarTopY: number, displayWidt
     hintExclusionCache.hintBarTopY = hintBarTopY;
     hintExclusionCache.displayWidth = displayWidth;
 
-    hintExclusionCache.rect.set(
-        overlayToggleHintIconX(),
-        overlayToggleHintIconY(hintBarTopY),
-        OVERLAY_TOGGLE_ICON_WIDTH,
-        OVERLAY_TOGGLE_ICON_HEIGHT,
-    );
+    hintExclusionCache.rect.set(overlayToggleHintIconX(), hintIconY(hintBarTopY), ICON_WIDTH, ICON_HEIGHT);
 
     return hintExclusionCache.rect;
 }
@@ -429,7 +424,7 @@ function drawPaletteSwatchGrid(
 
         // Reserve only the toggle hint icon band; do not clip against the 48x48 toggle hit rect
         // (it overlaps many grid rows and would truncate every row below it).
-        if (swatchIntersectsRect(x, y, swatchSize, hintExclusion)) {
+        if (doesSwatchIntersectExclusion(x, y, swatchSize, hintExclusion)) {
             continue;
         }
 
@@ -551,10 +546,10 @@ export class PaletteView {
     /**
      * Creates a palette view with the given feature flag.
      *
-     * @param enabled - When false, draw is a no-op (default matches public opt-in API).
+     * @param isEnabled - When false, draw is a no-op (default matches public opt-in API).
      */
-    constructor(enabled = false) {
-        this.#isEnabled = enabled;
+    constructor(isEnabled = false) {
+        this.#isEnabled = isEnabled;
     }
 
     /**

--- a/src/overlay/palette/PaletteView.ts
+++ b/src/overlay/palette/PaletteView.ts
@@ -1,7 +1,7 @@
 /**
  * Live palette swatch grid for the overlay bottom band.
  *
- * {@link computePaletteGrid} picks adaptive column counts from the active palette
+ * {@link computeGrid} picks adaptive column counts from the active palette
  * size; {@link PaletteView.draw} renders indexed swatches with gaps and
  * transparent corner pixels.
  */
@@ -54,7 +54,7 @@ export const DEFAULT_PALETTE_GRID: PaletteGridLayout = {
  * @param gap - Gap between swatches.
  * @returns Row width in pixels.
  */
-export function paletteGridRowWidth(cols: number, swatchSize: number, gap: number): number {
+export function gridRowWidth(cols: number, swatchSize: number, gap: number): number {
     if (cols <= 0) {
         return 0;
     }
@@ -70,7 +70,7 @@ export function paletteGridRowWidth(cols: number, swatchSize: number, gap: numbe
  * @param gap - Gap between swatches.
  * @returns Grid height in pixels.
  */
-export function paletteGridRowStackHeight(rows: number, swatchSize: number, gap: number): number {
+export function gridRowStackHeight(rows: number, swatchSize: number, gap: number): number {
     if (rows <= 0) {
         return 0;
     }
@@ -88,7 +88,7 @@ export function paletteGridRowStackHeight(rows: number, swatchSize: number, gap:
  * @param maxColumns - Optional cap from {@link HardwareSettings.overlayPaletteColumns}.
  * @returns Column count (at least 1).
  */
-export function pickPaletteGridColumnCount(
+export function pickGridColumnCount(
     displayWidth: number,
     swatchSize: number,
     gap: number,
@@ -103,7 +103,7 @@ export function pickPaletteGridColumnCount(
     }
 
     while (candidate > 1) {
-        if (paletteGridRowWidth(candidate, swatchSize, gap) <= availableWidth) {
+        if (gridRowWidth(candidate, swatchSize, gap) <= availableWidth) {
             return candidate;
         }
 
@@ -120,7 +120,7 @@ export function pickPaletteGridColumnCount(
  * @param maxVisibleRows - Optional cap from {@link HardwareSettings.overlayPaletteRowsVisible}.
  * @returns Visible rows (0 when `totalRows` is 0; otherwise clamped to `[1, totalRows]`).
  */
-export function resolvePaletteGridVisibleRows(totalRows: number, maxVisibleRows?: number): number {
+export function resolveGridVisibleRows(totalRows: number, maxVisibleRows?: number): number {
     if (totalRows <= 0) {
         return 0;
     }
@@ -145,7 +145,7 @@ export function resolvePaletteGridVisibleRows(totalRows: number, maxVisibleRows?
  * @param maxVisibleRows - Optional cap from {@link HardwareSettings.overlayPaletteRowsVisible}.
  * @returns Grid dimensions and viewport band height.
  */
-export function computePaletteGrid(
+export function computeGrid(
     displayWidth: number,
     swatchSize = DEFAULT_PALETTE_SWATCH_SIZE,
     colorCount = 256,
@@ -157,10 +157,10 @@ export function computePaletteGrid(
         return { cols: 0, rows: 0, visibleRows: 0, swatchSize, gap, totalHeight: 0 };
     }
 
-    const cols = pickPaletteGridColumnCount(displayWidth, swatchSize, gap, colorCount, maxColumns);
+    const cols = pickGridColumnCount(displayWidth, swatchSize, gap, colorCount, maxColumns);
     const rows = Math.ceil(colorCount / cols);
-    const visibleRows = resolvePaletteGridVisibleRows(rows, maxVisibleRows);
-    const totalHeight = paletteGridRowStackHeight(visibleRows, swatchSize, gap) + PALETTE_GRID_PADDING_PX * 2;
+    const visibleRows = resolveGridVisibleRows(rows, maxVisibleRows);
+    const totalHeight = gridRowStackHeight(visibleRows, swatchSize, gap) + PALETTE_GRID_PADDING_PX * 2;
 
     return { cols, rows, visibleRows, swatchSize, gap, totalHeight };
 }
@@ -224,7 +224,7 @@ const hintExclusionCache = {
  * @param displayWidth - Logical display width (cache key only; icon X is margin-based).
  * @returns Exclusion rect for swatch placement and hit testing.
  */
-export function resolvePaletteHintExclusionRect(hintBarTopY: number, displayWidth: number): Rect2i {
+export function resolveHintExclusionRect(hintBarTopY: number, displayWidth: number): Rect2i {
     if (hintExclusionCache.hintBarTopY === hintBarTopY && hintExclusionCache.displayWidth === displayWidth) {
         return hintExclusionCache.rect;
     }
@@ -245,7 +245,7 @@ export function resolvePaletteHintExclusionRect(hintBarTopY: number, displayWidt
 const UNUSED_SWATCH_MARKER_SIZE = 3;
 
 /** Reused draw scratch rects for the palette grid hot loop (one overlay draw at a time). */
-const paletteGridDrawScratch = {
+const gridDrawScratch = {
     swatch: new Rect2i(),
     marker: new Rect2i(),
 };
@@ -325,7 +325,7 @@ function drawUnusedSwatch(
  * @param index - Palette slot to query.
  * @returns `true` when the slot is marked used.
  */
-function isPaletteSlotUsed(usedMask: Uint8Array, index: number): boolean {
+function isSlotUsed(usedMask: Uint8Array, index: number): boolean {
     // eslint-disable-next-line security/detect-object-injection -- index bounds checked below
     return index > 0 && index < usedMask.length && usedMask[index] === 1;
 }
@@ -343,7 +343,7 @@ function isPaletteSlotUsed(usedMask: Uint8Array, index: number): boolean {
  * @param usedMask - Per-frame usage mask from BTAPI.
  * @param unusedMarkIndex - Palette index for unused swatch marker fills.
  */
-function drawPaletteSwatch(
+function drawSwatch(
     target: OverlayDrawTarget,
     swatchScratch: Rect2i,
     markerScratch: Rect2i,
@@ -354,7 +354,7 @@ function drawPaletteSwatch(
     usedMask: Uint8Array,
     unusedMarkIndex: number,
 ): void {
-    if (isPaletteSlotUsed(usedMask, index)) {
+    if (isSlotUsed(usedMask, index)) {
         swatchScratch.set(x, y, swatchSize, swatchSize);
         target.drawBarFill(swatchScratch, index);
     } else {
@@ -371,7 +371,7 @@ function drawPaletteSwatch(
  * @param grid - Precomputed grid layout.
  * @param scrollRowOffset - First visible grid row (default `0`).
  */
-export function writePaletteSwatchTopLeft(
+export function writeSwatchTopLeft(
     target: Rect2i,
     index: number,
     paletteBand: Rect2i,
@@ -401,7 +401,7 @@ export function writePaletteSwatchTopLeft(
  * @param unusedMarkIndex - Palette index for unused swatch marker fills.
  * @param scrollRowOffset - First visible grid row (default `0`).
  */
-function drawPaletteSwatchGrid(
+function drawSwatchGrid(
     target: OverlayDrawTarget,
     paletteBand: Rect2i,
     colorCount: number,
@@ -412,13 +412,13 @@ function drawPaletteSwatchGrid(
     scrollRowOffset = 0,
 ): void {
     const { cols, visibleRows, swatchSize } = grid;
-    const swatchScratch = paletteGridDrawScratch.swatch;
-    const markerScratch = paletteGridDrawScratch.marker;
+    const swatchScratch = gridDrawScratch.swatch;
+    const markerScratch = gridDrawScratch.marker;
     const firstIndex = scrollRowOffset * cols;
     const lastIndex = Math.min(colorCount, (scrollRowOffset + visibleRows) * cols);
 
     for (let index = firstIndex; index < lastIndex; index++) {
-        writePaletteSwatchTopLeft(swatchScratch, index, paletteBand, grid, scrollRowOffset);
+        writeSwatchTopLeft(swatchScratch, index, paletteBand, grid, scrollRowOffset);
         const x = swatchScratch.x;
         const y = swatchScratch.y;
 
@@ -428,7 +428,7 @@ function drawPaletteSwatchGrid(
             continue;
         }
 
-        drawPaletteSwatch(target, swatchScratch, markerScratch, x, y, swatchSize, index, usedMask, unusedMarkIndex);
+        drawSwatch(target, swatchScratch, markerScratch, x, y, swatchSize, index, usedMask, unusedMarkIndex);
     }
 }
 
@@ -439,7 +439,7 @@ function drawPaletteSwatchGrid(
  * @param grid - Precomputed grid layout.
  * @returns Thumb height in pixels, or `0` when inputs are invalid.
  */
-export function computePaletteScrollbarThumbHeight(trackHeight: number, grid: PaletteGridLayout): number {
+export function computeScrollbarThumbHeight(trackHeight: number, grid: PaletteGridLayout): number {
     const { rows, visibleRows } = grid;
 
     if (rows <= 0 || trackHeight <= 0) {
@@ -465,7 +465,7 @@ export function computePaletteScrollbarThumbHeight(trackHeight: number, grid: Pa
  * @param trackWidth - Scrollbar track width in pixels.
  * @returns `true` when scrolling is possible and rects were written.
  */
-export function writePaletteScrollbarRects(
+export function writeScrollbarRects(
     trackTarget: Rect2i,
     thumbTarget: Rect2i,
     paletteBand: Rect2i,
@@ -496,7 +496,7 @@ export function writePaletteScrollbarRects(
 
     trackTarget.set(trackX, trackY, trackWidth, trackHeight);
 
-    const thumbHeight = computePaletteScrollbarThumbHeight(trackHeight, grid);
+    const thumbHeight = computeScrollbarThumbHeight(trackHeight, grid);
     const scrollRange = Math.max(0, trackHeight - thumbHeight);
     const thumbY = trackY + Math.floor((scrollRowOffset / maxOffset) * scrollRange);
 
@@ -515,7 +515,7 @@ export function writePaletteScrollbarRects(
  * @param trackWidth - Scrollbar track width in pixels.
  * @param thumbIndex - Palette index for the thumb fill.
  */
-function drawPaletteScrollbar(
+function drawScrollbar(
     target: OverlayDrawTarget,
     paletteBand: Rect2i,
     grid: PaletteGridLayout,
@@ -523,10 +523,10 @@ function drawPaletteScrollbar(
     trackWidth: number,
     thumbIndex: number,
 ): void {
-    const trackScratch = paletteGridDrawScratch.swatch;
-    const thumbScratch = paletteGridDrawScratch.marker;
+    const trackScratch = gridDrawScratch.swatch;
+    const thumbScratch = gridDrawScratch.marker;
 
-    if (!writePaletteScrollbarRects(trackScratch, thumbScratch, paletteBand, grid, scrollRowOffset, trackWidth)) {
+    if (!writeScrollbarRects(trackScratch, thumbScratch, paletteBand, grid, scrollRowOffset, trackWidth)) {
         return;
     }
 
@@ -593,9 +593,9 @@ export class PaletteView {
             return;
         }
 
-        const hintExclusion = resolvePaletteHintExclusionRect(hintBarTopY, displayWidth);
+        const hintExclusion = resolveHintExclusionRect(hintBarTopY, displayWidth);
 
-        drawPaletteSwatchGrid(
+        drawSwatchGrid(
             target,
             paletteBand,
             palette.size,
@@ -606,7 +606,7 @@ export class PaletteView {
             scrollRowOffset,
         );
 
-        drawPaletteScrollbar(target, paletteBand, grid, scrollRowOffset, scrollbarTrackWidth, scrollbarThumbIndex);
+        drawScrollbar(target, paletteBand, grid, scrollRowOffset, scrollbarTrackWidth, scrollbarThumbIndex);
     }
 }
 

--- a/src/overlay/timing-chart/TimingChart.ts
+++ b/src/overlay/timing-chart/TimingChart.ts
@@ -19,7 +19,7 @@ import {
     computeTimingChartDotY,
     computeTimingChartGridLineY,
     computeTimingChartPressureHeight,
-    shouldDrawTimingChartGridLineY,
+    isTimingChartGridLineAtY,
     timingChartBaselineY,
     type TimingChartDrawStyle,
     writeTimingChartGridMarkers,
@@ -87,14 +87,14 @@ export class TimingChart {
     /**
      * Creates a timing chart with the given feature flag.
      *
-     * @param enabled - When false, sample/draw are no-ops.
+     * @param isEnabled - When false, sample/draw are no-ops.
      * @param targetFps - Configured fixed-step rate for frame-budget classification.
      * @param diagnosticsMode - Renderer diagnostic visualization (`minimal`, `rich`, or `false`).
      */
-    constructor(enabled = false, targetFps = 60, diagnosticsMode: OverlayTimingChartDiagnosticsMode = false) {
-        this.#isEnabled = enabled;
+    constructor(isEnabled = false, targetFps = 60, diagnosticsMode: OverlayTimingChartDiagnosticsMode = false) {
+        this.#isEnabled = isEnabled;
         this.#targetFps = targetFps;
-        this.#diagnosticsMode = enabled ? diagnosticsMode : false;
+        this.#diagnosticsMode = isEnabled ? diagnosticsMode : false;
     }
 
     /**
@@ -259,9 +259,9 @@ export class TimingChart {
             const updateMs = this.#updateMsBuffer[bufferIndex] as number;
             const renderMs = this.#renderMsBuffer[bufferIndex] as number;
             let severity = this.#severityBuffer[bufferIndex] as number;
-            const overflow = this.#diagnosticsMode !== false && (this.#overflowBuffer[bufferIndex] as number) > 0;
+            const hasOverflow = this.#diagnosticsMode !== false && (this.#overflowBuffer[bufferIndex] as number) > 0;
 
-            if (overflow && severity < TIMING_CHART_SEVERITY_WARNING) {
+            if (hasOverflow && severity < TIMING_CHART_SEVERITY_WARNING) {
                 severity = TIMING_CHART_SEVERITY_WARNING;
             }
             /* eslint-enable security/detect-object-injection */
@@ -293,7 +293,7 @@ export class TimingChart {
                 this.#drawDot(target, x, updateMs, chartRect, style.updateBarIndex);
             }
 
-            if (overflow) {
+            if (hasOverflow) {
                 this.#drawBaselineMarker(target, x, baselineY, style.overflowBarIndex);
             }
 
@@ -416,7 +416,7 @@ export class TimingChart {
 
             const y = computeTimingChartGridLineY(ms, chartRect, TIMING_CHART_FULL_SCALE_MS);
 
-            if (y === null || !shouldDrawTimingChartGridLineY(y, chartRect) || y === lastY) {
+            if (y === null || !isTimingChartGridLineAtY(y, chartRect) || y === lastY) {
                 continue;
             }
 

--- a/src/overlay/timing-chart/TimingChart.ts
+++ b/src/overlay/timing-chart/TimingChart.ts
@@ -77,7 +77,7 @@ export class TimingChart {
     readonly #tags: TimingChartTag[] = [];
 
     /** Tick at last chart reset; used for relative tick labels. */
-    #chartStartTick = 0;
+    #startTick = 0;
 
     /** Timing samples recorded since the last chart width reset (one per overlay frame). */
     #totalSamples = 0;
@@ -159,7 +159,7 @@ export class TimingChart {
         this.#overflowBuffer = new Uint8Array(width);
         this.#primitiveVertexBuffer = new Uint32Array(width);
         this.#spriteVertexBuffer = new Uint32Array(width);
-        this.#chartStartTick = currentTick;
+        this.#startTick = currentTick;
         this.#tags.length = 0;
 
         this.assignTag(TIMING_CHART_TAG_START, currentTick);
@@ -376,7 +376,7 @@ export class TimingChart {
                 target.drawLabelOnTop(
                     font,
                     this.#tagLabelPos.clone(),
-                    formatTimingChartTagRelTick(leadTag.tick, this.#chartStartTick),
+                    formatTimingChartTagRelTick(leadTag.tick, this.#startTick),
                     paletteOffset,
                 );
             }

--- a/src/overlay/timing-chart/TimingChart.ts
+++ b/src/overlay/timing-chart/TimingChart.ts
@@ -42,7 +42,7 @@ import {
  * Scrolling update/render timing chart with a fixed-capacity ring buffer.
  */
 export class TimingChart {
-    readonly #enabled: boolean;
+    readonly #isEnabled: boolean;
 
     readonly #targetFps: number;
 
@@ -92,7 +92,7 @@ export class TimingChart {
      * @param diagnosticsMode - Renderer diagnostic visualization (`minimal`, `rich`, or `false`).
      */
     constructor(enabled = false, targetFps = 60, diagnosticsMode: OverlayTimingChartDiagnosticsMode = false) {
-        this.#enabled = enabled;
+        this.#isEnabled = enabled;
         this.#targetFps = targetFps;
         this.#diagnosticsMode = enabled ? diagnosticsMode : false;
     }
@@ -102,8 +102,8 @@ export class TimingChart {
      *
      * @returns Feature flag state.
      */
-    get enabled(): boolean {
-        return this.#enabled;
+    get isEnabled(): boolean {
+        return this.#isEnabled;
     }
 
     /**
@@ -171,7 +171,7 @@ export class TimingChart {
      * @param timing - Per-frame snapshot from BTAPI.
      */
     sample(timing: OverlayTimingSnapshot): void {
-        if (!this.#enabled || this.#bufferWidth <= 0) {
+        if (!this.#isEnabled || this.#bufferWidth <= 0) {
             return;
         }
 
@@ -222,7 +222,7 @@ export class TimingChart {
         font: BitmapFont,
         currentTick: number,
     ): void {
-        if (!this.#enabled || chartRect.width <= 0 || chartRect.height <= 0) {
+        if (!this.#isEnabled || chartRect.width <= 0 || chartRect.height <= 0) {
             return;
         }
 

--- a/src/overlay/timing-chart/style.test.ts
+++ b/src/overlay/timing-chart/style.test.ts
@@ -101,6 +101,8 @@ describe('computeTimingChartGridLineY', () => {
     it('skips top and bottom band edges for grid draw', () => {
         expect(isTimingChartGridLineAtY(chartRect22.y, chartRect22)).toBe(false);
         expect(isTimingChartGridLineAtY(baselineY, chartRect22)).toBe(false);
+        expect(isTimingChartGridLineAtY(chartRect22.y - 1, chartRect22)).toBe(false);
+        expect(isTimingChartGridLineAtY(chartRect22.y + chartRect22.height, chartRect22)).toBe(false);
         const gridLineY5 = gridY(5);
 
         expect(gridLineY5).not.toBeNull();

--- a/src/overlay/timing-chart/style.test.ts
+++ b/src/overlay/timing-chart/style.test.ts
@@ -11,8 +11,8 @@ import {
     computeTimingChartBarHeight,
     computeTimingChartDotY,
     computeTimingChartGridLineY,
+    isTimingChartGridLineAtY,
     resolveTimingChartStyle,
-    shouldDrawTimingChartGridLineY,
     timingChartBaselineY,
     timingChartFrameBudgetMs,
     writeTimingChartGridMarkers,
@@ -99,8 +99,8 @@ describe('computeTimingChartGridLineY', () => {
     });
 
     it('skips top and bottom band edges for grid draw', () => {
-        expect(shouldDrawTimingChartGridLineY(chartRect22.y, chartRect22)).toBe(false);
-        expect(shouldDrawTimingChartGridLineY(baselineY, chartRect22)).toBe(false);
+        expect(isTimingChartGridLineAtY(chartRect22.y, chartRect22)).toBe(false);
+        expect(isTimingChartGridLineAtY(baselineY, chartRect22)).toBe(false);
         const gridLineY5 = gridY(5);
 
         expect(gridLineY5).not.toBeNull();
@@ -108,7 +108,7 @@ describe('computeTimingChartGridLineY', () => {
             return;
         }
 
-        expect(shouldDrawTimingChartGridLineY(gridLineY5, chartRect22)).toBe(true);
+        expect(isTimingChartGridLineAtY(gridLineY5, chartRect22)).toBe(true);
     });
 
     it('maps frame-budget marker from targetFPS at 60 Hz', () => {

--- a/src/overlay/timing-chart/style.ts
+++ b/src/overlay/timing-chart/style.ts
@@ -184,6 +184,16 @@ export function isTimingChartGridLineAtY(y: number, chartRect: Rect2i): boolean 
 }
 
 /**
+ * Backward-compatible alias for {@link isTimingChartGridLineAtY}.
+ *
+ * @deprecated Deprecated since 2026-05-31. Use {@link isTimingChartGridLineAtY} instead.
+ * @param y - Screen Y from {@link computeTimingChartGridLineY}.
+ * @param chartRect - Chart band bounds.
+ * @returns `true` when the row is strictly inside the band and not the baseline.
+ */
+export const shouldDrawTimingChartGridLineY = isTimingChartGridLineAtY;
+
+/**
  * Frame-budget grid marker in milliseconds from configured fixed-step rate.
  *
  * @param targetFps - Configured `targetFPS` (clamped to at least 1).

--- a/src/overlay/timing-chart/style.ts
+++ b/src/overlay/timing-chart/style.ts
@@ -179,7 +179,7 @@ export function timingChartBaselineY(chartRect: Rect2i): number {
  * @param chartRect - Chart band bounds.
  * @returns `true` when the row is strictly between the band edges.
  */
-export function shouldDrawTimingChartGridLineY(y: number, chartRect: Rect2i): boolean {
+export function isTimingChartGridLineAtY(y: number, chartRect: Rect2i): boolean {
     return y !== chartRect.y && y !== timingChartBaselineY(chartRect);
 }
 

--- a/src/overlay/timing-chart/style.ts
+++ b/src/overlay/timing-chart/style.ts
@@ -177,10 +177,10 @@ export function timingChartBaselineY(chartRect: Rect2i): number {
  *
  * @param y - Screen Y from {@link computeTimingChartGridLineY}.
  * @param chartRect - Chart band bounds.
- * @returns `true` when the row is strictly between the band edges.
+ * @returns `true` when the row is strictly inside the band and not the baseline.
  */
 export function isTimingChartGridLineAtY(y: number, chartRect: Rect2i): boolean {
-    return y !== chartRect.y && y !== timingChartBaselineY(chartRect);
+    return y > chartRect.y && y < chartRect.y + chartRect.height && y !== timingChartBaselineY(chartRect);
 }
 
 /**

--- a/src/overlay/timing-chart/tags.ts
+++ b/src/overlay/timing-chart/tags.ts
@@ -210,11 +210,11 @@ export function groupTimingChartTagsByColumn(
  * Relative tick text for the tag tick row (ticks since chart reset).
  *
  * @param tagTick - Absolute tick when the tag was assigned.
- * @param chartStartTick - Tick recorded when the chart last reset.
+ * @param startTick - Tick recorded when the chart last reset.
  * @returns Relative tick string capped at {@link TIMING_CHART_TAG_REL_TICK_MAX}.
  */
-export function formatTimingChartTagRelTick(tagTick: number, chartStartTick: number): string {
-    const relTick = tagTick - chartStartTick;
+export function formatTimingChartTagRelTick(tagTick: number, startTick: number): string {
+    const relTick = tagTick - startTick;
 
     return String(Math.min(relTick, TIMING_CHART_TAG_REL_TICK_MAX));
 }

--- a/src/overlay/toggleIconData.ts
+++ b/src/overlay/toggleIconData.ts
@@ -5,15 +5,15 @@
  */
 
 /** Toggle hint icon width in pixels. */
-export const OVERLAY_TOGGLE_ICON_WIDTH = 11;
+export const ICON_WIDTH = 11;
 
 /** Toggle hint icon height in pixels. */
-export const OVERLAY_TOGGLE_ICON_HEIGHT = 7;
+export const ICON_HEIGHT = 7;
 
 /**
  * Row-major tilde toggle hint mask (`width` × `height`).
  */
-export const OVERLAY_TOGGLE_ICON_MASK: readonly number[] = [
+export const ICON_MASK: readonly number[] = [
     0,
     0,
     0,

--- a/src/render/PaletteResolveUpscalePass.ts
+++ b/src/render/PaletteResolveUpscalePass.ts
@@ -1,5 +1,5 @@
 import type { Vector2i } from '../utils/Vector2i';
-import { FULLSCREEN_VS_WGSL } from './effects/fullscreenVS';
+import { VS_WGSL } from './effects/fullscreenVS';
 import type { UpscaleFilter } from './UpscalePass';
 
 /**
@@ -49,7 +49,7 @@ export class PaletteResolveUpscalePass {
 
         const module = device.createShaderModule({
             label: 'PaletteResolveUpscalePass Shader',
-            code: FULLSCREEN_VS_WGSL + RESOLVE_FRAGMENT_WGSL,
+            code: VS_WGSL + FRAGMENT_WGSL,
         });
 
         this.pipeline = device.createRenderPipeline({
@@ -170,9 +170,9 @@ export class PaletteResolveUpscalePass {
 
 // #endregion
 
-// #region RESOLVE_FRAGMENT_WGSL
+// #region FRAGMENT_WGSL
 
-const RESOLVE_FRAGMENT_WGSL = `
+const FRAGMENT_WGSL = `
 struct Params {
     logicalSize: vec2<f32>,
     filterLinear: f32,

--- a/src/render/PostProcessChain.ts
+++ b/src/render/PostProcessChain.ts
@@ -46,10 +46,10 @@ export class PostProcessChain {
     private readonly format: GPUTextureFormat;
 
     /** Resolution of this chain's render targets in pixels. */
-    private readonly chainSize: Vector2i;
+    private readonly size: Vector2i;
 
     /** Tier this chain serves. Effects added to it must declare the same tier. */
-    private readonly chainTier: EffectTier;
+    readonly tier: EffectTier;
 
     /** Effects in execution order. */
     private effects: Effect[] = [];
@@ -88,22 +88,13 @@ export class PostProcessChain {
     constructor(device: GPUDevice, format: GPUTextureFormat, chainSize: Vector2i, tier: EffectTier) {
         this.device = device;
         this.format = format;
-        this.chainSize = chainSize.clone();
-        this.chainTier = tier;
+        this.size = chainSize.clone();
+        this.tier = tier;
     }
 
     // #endregion
 
     // #region Public API
-
-    /**
-     * Returns the tier this chain serves.
-     *
-     * @returns Tier of effects this chain holds.
-     */
-    get tier(): EffectTier {
-        return this.chainTier;
-    }
 
     /**
      * Returns `true` when at least one effect is registered.
@@ -135,9 +126,9 @@ export class PostProcessChain {
      * @throws If the effect instance is already registered.
      */
     add(effect: Effect): void {
-        if (effect.tier !== this.chainTier) {
+        if (effect.tier !== this.tier) {
             throw new Error(
-                `PostProcessChain.add: effect.tier='${effect.tier}' does not match chain tier='${this.chainTier}'.`,
+                `PostProcessChain.add: effect.tier='${effect.tier}' does not match chain tier='${this.tier}'.`,
             );
         }
 
@@ -155,7 +146,7 @@ export class PostProcessChain {
             this.allocateSecondary();
         }
 
-        effect.init(this.device, this.format, this.chainSize);
+        effect.init(this.device, this.format, this.size);
         this.effects = [...this.effects, effect];
     }
 
@@ -264,7 +255,7 @@ export class PostProcessChain {
             // eslint-disable-next-line security/detect-object-injection
             const effect = this.effects[i] as Effect;
 
-            effect.updateUniforms(deltaMs, this.chainSize);
+            effect.updateUniforms(deltaMs, this.size);
             effect.encodePass(encoder, read, write);
 
             read = write;
@@ -288,8 +279,8 @@ export class PostProcessChain {
     /** Allocates {@link texA}. */
     private allocatePrimary(): void {
         this.texA = this.device.createTexture({
-            label: `PostProcessChain[${this.chainTier}] texA`,
-            size: { width: this.chainSize.x, height: this.chainSize.y, depthOrArrayLayers: 1 },
+            label: `PostProcessChain[${this.tier}] texA`,
+            size: { width: this.size.x, height: this.size.y, depthOrArrayLayers: 1 },
             format: this.format,
             usage: OFFSCREEN_USAGE,
         });
@@ -299,8 +290,8 @@ export class PostProcessChain {
     /** Allocates {@link texB} for chains with two or more effects. */
     private allocateSecondary(): void {
         this.texB = this.device.createTexture({
-            label: `PostProcessChain[${this.chainTier}] texB`,
-            size: { width: this.chainSize.x, height: this.chainSize.y, depthOrArrayLayers: 1 },
+            label: `PostProcessChain[${this.tier}] texB`,
+            size: { width: this.size.x, height: this.size.y, depthOrArrayLayers: 1 },
             format: this.format,
             usage: OFFSCREEN_USAGE,
         });

--- a/src/render/PrimitivePipeline.ts
+++ b/src/render/PrimitivePipeline.ts
@@ -9,7 +9,7 @@ import { Vector2i } from '../utils/Vector2i';
  * Note: Axis-aligned lines are optimized to use 6 vertices total instead of
  * 6 vertices per pixel, dramatically reducing buffer requirements.
  */
-const MAX_PRIMITIVE_VERTICES = 50000;
+const MAX_VERTICES = 50000;
 
 /**
  * Number of 4-byte values per vertex: x (f32), y (f32), paletteIndex (u32).
@@ -99,7 +99,7 @@ export class PrimitivePipeline {
      * Call `init()` before encoding GPU work.
      */
     constructor() {
-        this.vertexArrayBuffer = new ArrayBuffer(MAX_PRIMITIVE_VERTICES * VERTEX_STRIDE);
+        this.vertexArrayBuffer = new ArrayBuffer(MAX_VERTICES * VERTEX_STRIDE);
         this.vertexFloats = new Float32Array(this.vertexArrayBuffer);
         this.vertexIndices = new Uint32Array(this.vertexArrayBuffer);
     }

--- a/src/render/SoftwareRenderer.ts
+++ b/src/render/SoftwareRenderer.ts
@@ -66,7 +66,7 @@ type BitmapTextCommand = {
 type DrawCommand = PrimitiveCommand | SpriteCommand | BitmapTextCommand;
 
 /** Pending `captureFrame` promise callbacks, held until the next `endFrame`. */
-type PendingCapture = {
+type Pending = {
     resolve: (blob: Blob) => void;
     reject: (reason?: unknown) => void;
 };
@@ -110,7 +110,7 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
     private readonly commands: DrawCommand[] = [];
     private readonly framePixels: Uint8ClampedArray;
     private imageData: ImageData | null = null;
-    private pendingCapture: PendingCapture | null = null;
+    private pending: Pending | null = null;
     private primitiveSubmittedVertices = 0;
     private spriteSubmittedVertices = 0;
 
@@ -238,7 +238,7 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
         }
 
         this.presentFrame();
-        this.resolvePendingCapture();
+        this.resolvePending();
         this.commands.length = 0;
     }
 
@@ -445,8 +445,8 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
      * @returns Promise that resolves with the captured frame as a PNG `Blob`.
      */
     captureFrame(): Promise<Blob> {
-        if (this.pendingCapture) {
-            this.pendingCapture.reject(
+        if (this.pending) {
+            this.pending.reject(
                 new Error(
                     'A capture is already in progress. Wait for the first captureFrame() to finish before requesting another.',
                 ),
@@ -454,7 +454,7 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
         }
 
         return new Promise<Blob>((resolve, reject) => {
-            this.pendingCapture = { resolve, reject };
+            this.pending = { resolve, reject };
         });
     }
 
@@ -893,28 +893,28 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
 
     /**
      * Resolves or rejects the pending `captureFrame` promise using `canvas.toBlob`.
-     * Clears `pendingCapture` after handling.
+     * Clears `pending` after handling.
      */
-    private resolvePendingCapture(): void {
-        if (!this.pendingCapture) {
+    private resolvePending(): void {
+        if (!this.pending) {
             return;
         }
 
         if (typeof this.canvas.toBlob !== 'function') {
-            this.pendingCapture.reject(
+            this.pending.reject(
                 new Error(
                     "Can't save this frame - your browser doesn't support canvas image export. Try Chrome or Edge.",
                 ),
             );
 
-            this.pendingCapture = null;
+            this.pending = null;
 
             return;
         }
 
-        const request = this.pendingCapture;
+        const request = this.pending;
 
-        this.pendingCapture = null;
+        this.pending = null;
         this.canvas.toBlob((blob) => {
             if (!blob) {
                 request.reject(

--- a/src/render/SpritePipeline.test.ts
+++ b/src/render/SpritePipeline.test.ts
@@ -344,7 +344,7 @@ describe('drawSprite', () => {
         const sheet = new SpriteSheet(mockImage);
 
         try {
-            // MAX_SPRITE_VERTICES = 50,000, each sprite = 6 vertices * 5 values (20 bytes)
+            // MAX_VERTICES = 50,000, each sprite = 6 vertices * 5 values (20 bytes)
             // 50,000 / 6 = ~8333 sprites max; draw more to trigger overflow
             for (let i = 0; i < 8400; i++) {
                 pipeline.drawSprite(sheet, new Rect2i(0, 0, 8, 8), new Vector2i(0, 0));

--- a/src/render/SpritePipeline.ts
+++ b/src/render/SpritePipeline.ts
@@ -8,7 +8,7 @@ import { Vector2i } from '../utils/Vector2i';
 /**
  * Maximum number of sprite vertices retained for a frame.
  */
-const MAX_SPRITE_VERTICES = 50000;
+const MAX_VERTICES = 50000;
 
 /**
  * Number of values per vertex: x (f32), y (f32), u (f32), v (f32), paletteOffset (u32).
@@ -111,7 +111,7 @@ export class SpritePipeline {
      * Call `init()` before encoding GPU work.
      */
     constructor() {
-        this.vertexArrayBuffer = new ArrayBuffer(MAX_SPRITE_VERTICES * VERTEX_STRIDE);
+        this.vertexArrayBuffer = new ArrayBuffer(MAX_VERTICES * VERTEX_STRIDE);
         this.vertexFloats = new Float32Array(this.vertexArrayBuffer);
         this.vertexUints = new Uint32Array(this.vertexArrayBuffer);
     }

--- a/src/render/UpscalePass.ts
+++ b/src/render/UpscalePass.ts
@@ -1,5 +1,5 @@
 import type { Vector2i } from '../utils/Vector2i';
-import { FULLSCREEN_VS_WGSL } from './effects/fullscreenVS';
+import { VS_WGSL } from './effects/fullscreenVS';
 
 // #region Configuration
 
@@ -82,7 +82,7 @@ export class UpscalePass {
 
         const module = device.createShaderModule({
             label: 'UpscalePass Shader',
-            code: FULLSCREEN_VS_WGSL + UPSCALE_FRAGMENT_WGSL,
+            code: VS_WGSL + FRAGMENT_WGSL,
         });
 
         this.pipeline = device.createRenderPipeline({
@@ -224,7 +224,7 @@ export class UpscalePass {
 
 // #region WGSL fragment shader
 
-const UPSCALE_FRAGMENT_WGSL = `
+const FRAGMENT_WGSL = `
 @group(0) @binding(0) var src: texture_2d<f32>;
 @group(0) @binding(1) var samp: sampler;
 

--- a/src/render/WebGpuRenderer.test.ts
+++ b/src/render/WebGpuRenderer.test.ts
@@ -925,7 +925,7 @@ describe('palette dirty-flag auto-propagation', () => {
         expect(renderer.getPalette()).not.toBe(palette);
     });
 
-    it('palette.dirty is cleared after endFrame uploads', async () => {
+    it('palette.isDirty is cleared after endFrame uploads', async () => {
         const renderer = new WebGpuRenderer(
             createMockGPUDevice(),
             createMockGPUCanvasContext(),
@@ -943,18 +943,18 @@ describe('palette dirty-flag auto-propagation', () => {
         // Dirty the palette AFTER setPalette, simulating per-frame animation.
         palette.set(1, new Color32(200, 100, 50, 255));
 
-        expect(palette.dirty).toBe(true);
+        expect(palette.isDirty).toBe(true);
 
         renderer.beginFrame();
         renderer.endFrame();
 
         // Renderer must clear the dirty flag as part of the GPU upload.
-        expect(palette.dirty).toBe(false);
+        expect(palette.isDirty).toBe(false);
 
         uninstallMockNavigatorGPU();
     });
 
-    it('palette.dirty drives upload without requiring a new paletteSet call', async () => {
+    it('palette.isDirty drives upload without requiring a new paletteSet call', async () => {
         const device = createMockGPUDevice();
         const writeBufferSpy = vi.spyOn(device.queue, 'writeBuffer');
 
@@ -977,7 +977,7 @@ describe('palette dirty-flag auto-propagation', () => {
         // Mutate palette without calling BT.paletteSet() again.
         palette.set(1, new Color32(255, 0, 128, 255));
 
-        // Second frame - must re-upload because palette.dirty is true.
+        // Second frame - must re-upload because palette.isDirty is true.
         renderer.beginFrame();
         renderer.endFrame();
 

--- a/src/render/WebGpuRenderer.test.ts
+++ b/src/render/WebGpuRenderer.test.ts
@@ -968,7 +968,7 @@ describe('palette dirty-flag auto-propagation', () => {
 
         renderer.setPalette(palette);
 
-        // First frame - initial upload due to paletteDirty.
+        // First frame - initial upload due to isPaletteDirty.
         renderer.beginFrame();
         renderer.endFrame();
 
@@ -988,7 +988,7 @@ describe('palette dirty-flag auto-propagation', () => {
         uninstallMockNavigatorGPU();
     });
 
-    it('no GPU upload happens when palette is clean and paletteDirty is false', async () => {
+    it('no GPU upload happens when palette is clean and isPaletteDirty is false', async () => {
         const device = createMockGPUDevice();
         const writeBufferSpy = vi.spyOn(device.queue, 'writeBuffer');
 

--- a/src/render/WebGpuRenderer.ts
+++ b/src/render/WebGpuRenderer.ts
@@ -78,7 +78,7 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
      * `drawingBufferSize` in `configure()`), enabling display-tier effects
      * regardless of whether the output resolution differs from the logical one.
      */
-    private readonly displayTierEnabled: boolean;
+    private readonly isDisplayTierEnabled: boolean;
 
     /** Palette index used for the frame clear color. Defaults to 0 (transparent). */
     private clearPaletteIndex: number = 0;
@@ -190,7 +190,7 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
         this.device = device;
         this.context = context;
         this.displaySize = displaySize.clone();
-        this.displayTierEnabled = outputSize !== undefined;
+        this.isDisplayTierEnabled = outputSize !== undefined;
         this.outputSize = (outputSize ?? displaySize).clone();
         this.upscaleFilterMode = upscaleFilter;
         this.primitives = new PrimitivePipeline();
@@ -369,16 +369,16 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
 
         const swapChainView = swapTexture.createView();
         const commandEncoder = this.device.createCommandEncoder({ label: 'Render Commands' });
-        const pixelActive = this.pixelChain?.isActive() ?? false;
-        const displayActive = this.displayChain?.isActive() ?? false;
-        const sceneView = this.resolveSceneView(pixelActive);
+        const isPixelChainActive = this.pixelChain?.isActive() ?? false;
+        const isDisplayChainActive = this.displayChain?.isActive() ?? false;
+        const sceneView = this.resolveSceneView(isPixelChainActive);
 
         const now = performance.now();
         const deltaMs = this.lastFrameMs === 0 ? 0 : Math.max(0, now - this.lastFrameMs);
         this.lastFrameMs = now;
 
         this.encodeScenePass(commandEncoder, sceneView);
-        this.encodePostProcess(commandEncoder, swapChainView, pixelActive, displayActive, deltaMs);
+        this.encodePostProcess(commandEncoder, swapChainView, isPixelChainActive, isDisplayChainActive, deltaMs);
         this.submitFrame(commandEncoder, swapTexture);
     }
 
@@ -629,7 +629,7 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
             throw new Error('WebGpuRenderer.addEffect: renderer not initialized.');
         }
 
-        if (effect.tier === 'display' && !this.displayTierEnabled) {
+        if (effect.tier === 'display' && !this.isDisplayTierEnabled) {
             throw new Error(
                 'WebGpuRenderer.addEffect: display-tier effects require drawingBufferSize to be set in configure().',
             );
@@ -781,18 +781,18 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
      *
      * @param encoder - Active command encoder.
      * @param swapChainView - Current swap-chain view (final destination).
-     * @param pixelActive - Whether the pixel chain has any registered effects.
-     * @param displayActive - Whether the display chain has any registered effects.
+     * @param isPixelChainActive - Whether the pixel chain has any registered effects.
+     * @param isDisplayChainActive - Whether the display chain has any registered effects.
      * @param deltaMs - Wall-clock milliseconds since the previous frame.
      */
     private encodePostProcess(
         encoder: GPUCommandEncoder,
         swapChainView: GPUTextureView,
-        pixelActive: boolean,
-        displayActive: boolean,
+        isPixelChainActive: boolean,
+        isDisplayChainActive: boolean,
         deltaMs: number,
     ): void {
-        if (pixelActive && this.pixelChain) {
+        if (isPixelChainActive && this.pixelChain) {
             this.pixelChain.encode(encoder, deltaMs, this.pixelChainDestView());
         }
 
@@ -800,12 +800,12 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
         // any display-tier RGBA effects run.
         if (this.resolvePass) {
             const resolveSrc = this.requireSceneTexView();
-            const resolveDest = displayActive ? this.requireDisplayChainInput() : swapChainView;
+            const resolveDest = isDisplayChainActive ? this.requireDisplayChainInput() : swapChainView;
 
             this.resolvePass.encode(encoder, resolveSrc, resolveDest, this.displaySize);
         }
 
-        if (displayActive && this.displayChain) {
+        if (isDisplayChainActive && this.displayChain) {
             this.displayChain.encode(encoder, deltaMs, swapChainView);
         }
     }
@@ -818,15 +818,15 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
      * @param swapTexture - Current swap-chain texture (capture source).
      */
     private submitFrame(encoder: GPUCommandEncoder, swapTexture: GPUTexture): void {
-        const capturing = this.frameCapture.hasPendingCapture();
+        const isCapturing = this.frameCapture.hasPendingCapture();
 
-        if (capturing) {
+        if (isCapturing) {
             this.frameCapture.executeCaptureInEncoder(this.device, swapTexture, encoder);
         }
 
         this.device.queue.submit([encoder.finish()]);
 
-        if (capturing) {
+        if (isCapturing) {
             void this.frameCapture.resolveCapture(this.device);
         }
 
@@ -848,11 +848,11 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
     /**
      * Picks the texture view the scene render pass should target this frame.
      *
-     * @param pixelActive - Whether the pixel chain has any registered effects.
+     * @param isPixelChainActive - Whether the pixel chain has any registered effects.
      * @returns Stable view to render the scene into.
      */
-    private resolveSceneView(pixelActive: boolean): GPUTextureView {
-        if (pixelActive && this.pixelChain) {
+    private resolveSceneView(isPixelChainActive: boolean): GPUTextureView {
+        if (isPixelChainActive && this.pixelChain) {
             return this.pixelChain.getInputView();
         }
 

--- a/src/render/WebGpuRenderer.ts
+++ b/src/render/WebGpuRenderer.ts
@@ -105,7 +105,7 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
     /**
      * True after {@link setPalette} is called, guaranteeing at least one upload
      * even when the palette was never mutated via {@link Palette.set}.
-     * Per-frame mutations are detected separately via {@link Palette.dirty}.
+     * Per-frame mutations are detected separately via {@link Palette.isDirty}.
      */
     private paletteDirty: boolean = false;
 
@@ -286,7 +286,7 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
      *
      * Stores a reference to the supplied palette - no clone is made. Subsequent
      * calls to {@link Palette.set} or {@link Palette.copyFrom} on the same object
-     * will be detected via {@link Palette.dirty} and uploaded automatically at the
+     * will be detected via {@link Palette.isDirty} and uploaded automatically at the
      * start of the next frame. {@link paletteDirty} is set to guarantee the initial
      * upload even when the palette has never been mutated through {@link Palette.set}.
      *
@@ -727,7 +727,7 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
      * since the last frame.
      */
     private flushPaletteIfDirty(): void {
-        if (this.palette && this.paletteBuffer && (this.paletteDirty || this.palette.dirty)) {
+        if (this.palette && this.paletteBuffer && (this.paletteDirty || this.palette.isDirty)) {
             this.palette.toFloat32ArrayInto(this.paletteStaging);
             this.device.queue.writeBuffer(this.paletteBuffer, 0, this.paletteStaging);
             this.paletteDirty = false;

--- a/src/render/WebGpuRenderer.ts
+++ b/src/render/WebGpuRenderer.ts
@@ -559,7 +559,7 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
      * @returns Promise resolving to a PNG Blob of the rendered frame.
      */
     captureFrame(): Promise<Blob> {
-        return this.frameCapture.requestCapture();
+        return this.frameCapture.request();
     }
 
     // #endregion
@@ -818,16 +818,16 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
      * @param swapTexture - Current swap-chain texture (capture source).
      */
     private submitFrame(encoder: GPUCommandEncoder, swapTexture: GPUTexture): void {
-        const isCapturing = this.frameCapture.hasPendingCapture();
+        const isCapturing = this.frameCapture.hasPending();
 
         if (isCapturing) {
-            this.frameCapture.executeCaptureInEncoder(this.device, swapTexture, encoder);
+            this.frameCapture.executeInEncoder(this.device, swapTexture, encoder);
         }
 
         this.device.queue.submit([encoder.finish()]);
 
         if (isCapturing) {
-            void this.frameCapture.resolveCapture(this.device);
+            void this.frameCapture.resolve(this.device);
         }
 
         // Defensive reset so the pipeline state is clean even if beginFrame() is not

--- a/src/render/WebGpuRenderer.ts
+++ b/src/render/WebGpuRenderer.ts
@@ -107,7 +107,7 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
      * even when the palette was never mutated via {@link Palette.set}.
      * Per-frame mutations are detected separately via {@link Palette.isDirty}.
      */
-    private paletteDirty: boolean = false;
+    private isPaletteDirty: boolean = false;
 
     // #endregion
 
@@ -237,7 +237,7 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
             // Mark the palette dirty so the new buffer is populated on the first
             // endFrame(), even if the palette data has not changed since the last
             // init() call (e.g. after a WebGPU device-loss recovery).
-            this.paletteDirty = true;
+            this.isPaletteDirty = true;
 
             // Primitive and sprite pipelines run at logical resolution. The
             // viewport is automatic since each pass binds a target view; only
@@ -287,14 +287,14 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
      * Stores a reference to the supplied palette - no clone is made. Subsequent
      * calls to {@link Palette.set} or {@link Palette.copyFrom} on the same object
      * will be detected via {@link Palette.isDirty} and uploaded automatically at the
-     * start of the next frame. {@link paletteDirty} is set to guarantee the initial
+     * start of the next frame. {@link isPaletteDirty} is set to guarantee the initial
      * upload even when the palette has never been mutated through {@link Palette.set}.
      *
      * @param palette - Palette to use for color lookups and GPU upload.
      */
     setPalette(palette: Palette): void {
         this.palette = palette;
-        this.paletteDirty = true;
+        this.isPaletteDirty = true;
 
         // If the new palette is smaller than the current clear index, reset to 0
         // (transparent) so resolveClearColor does not warn on every endFrame().
@@ -727,10 +727,10 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
      * since the last frame.
      */
     private flushPaletteIfDirty(): void {
-        if (this.palette && this.paletteBuffer && (this.paletteDirty || this.palette.isDirty)) {
+        if (this.palette && this.paletteBuffer && (this.isPaletteDirty || this.palette.isDirty)) {
             this.palette.toFloat32ArrayInto(this.paletteStaging);
             this.device.queue.writeBuffer(this.paletteBuffer, 0, this.paletteStaging);
-            this.paletteDirty = false;
+            this.isPaletteDirty = false;
             this.palette.clearDirty();
         }
     }

--- a/src/render/effects/FullscreenEffect.ts
+++ b/src/render/effects/FullscreenEffect.ts
@@ -1,6 +1,6 @@
 import type { Vector2i } from '../../utils/Vector2i';
 import type { Effect, EffectTier } from './Effect';
-import { FULLSCREEN_VS_WGSL } from './fullscreenVS';
+import { VS_WGSL } from './fullscreenVS';
 
 /**
  * Sampler magnification/minification mode used by a fullscreen effect.
@@ -88,7 +88,7 @@ export abstract class FullscreenEffect implements Effect {
 
         const module = device.createShaderModule({
             label: `${this.label} Shader`,
-            code: FULLSCREEN_VS_WGSL + this.fragmentShader,
+            code: VS_WGSL + this.fragmentShader,
         });
 
         this.pipeline = device.createRenderPipeline({

--- a/src/render/effects/FullscreenPixelEffect.ts
+++ b/src/render/effects/FullscreenPixelEffect.ts
@@ -1,6 +1,6 @@
 import type { Vector2i } from '../../utils/Vector2i';
 import type { Effect } from './Effect';
-import { FULLSCREEN_VS_WGSL } from './fullscreenVS';
+import { VS_WGSL } from './fullscreenVS';
 
 // #region FullscreenPixelEffect
 
@@ -56,7 +56,7 @@ export abstract class FullscreenPixelEffect implements Effect {
         const fragment = format === 'r8uint' ? this.fragmentShaderUint : this.fragmentShaderRgba;
         const module = device.createShaderModule({
             label: `${this.label} Shader`,
-            code: FULLSCREEN_VS_WGSL + fragment,
+            code: VS_WGSL + fragment,
         });
 
         this.pipeline = device.createRenderPipeline({

--- a/src/render/effects/display/BarrelDistortion.ts
+++ b/src/render/effects/display/BarrelDistortion.ts
@@ -30,7 +30,7 @@ export class BarrelDistortion extends FullscreenEffect {
     /** vec2 resolution + curvature + 1 padding f32 = 16 bytes. */
     protected readonly uniformBytes = 16;
 
-    protected readonly fragmentShader = BARREL_FRAGMENT_WGSL;
+    protected readonly fragmentShader = FRAGMENT_WGSL;
 
     /**
      * Writes resolution and curvature into the uniform block.
@@ -51,7 +51,7 @@ export class BarrelDistortion extends FullscreenEffect {
     }
 }
 
-const BARREL_FRAGMENT_WGSL = `
+const FRAGMENT_WGSL = `
 struct Params {
     resolution: vec2<f32>,
     curvature: f32,

--- a/src/render/effects/display/Bloom.ts
+++ b/src/render/effects/display/Bloom.ts
@@ -32,7 +32,7 @@ export class Bloom extends FullscreenEffect {
     /** vec2 resolution + spread + glow = 16 bytes. */
     protected readonly uniformBytes = 16;
 
-    protected readonly fragmentShader = BLOOM_FRAGMENT_WGSL;
+    protected readonly fragmentShader = FRAGMENT_WGSL;
 
     /**
      * Writes resolution, spread, and glow into the uniform block.
@@ -53,7 +53,7 @@ export class Bloom extends FullscreenEffect {
     }
 }
 
-const BLOOM_FRAGMENT_WGSL = `
+const FRAGMENT_WGSL = `
 struct Params {
     resolution: vec2<f32>,
     spread: f32,

--- a/src/render/effects/display/ChromaticAberration.ts
+++ b/src/render/effects/display/ChromaticAberration.ts
@@ -23,7 +23,7 @@ export class ChromaticAberration extends FullscreenEffect {
     /** vec2 resolution + aberration + 1 pad = 16 bytes. */
     protected readonly uniformBytes = 16;
 
-    protected readonly fragmentShader = AB_FRAGMENT_WGSL;
+    protected readonly fragmentShader = FRAGMENT_WGSL;
 
     /**
      * Writes resolution and aberration offset into the uniform block.
@@ -44,7 +44,7 @@ export class ChromaticAberration extends FullscreenEffect {
     }
 }
 
-const AB_FRAGMENT_WGSL = `
+const FRAGMENT_WGSL = `
 struct Params {
     resolution: vec2<f32>,
     aberration: f32,

--- a/src/render/effects/display/Flicker.ts
+++ b/src/render/effects/display/Flicker.ts
@@ -26,7 +26,7 @@ export class Flicker extends FullscreenEffect {
     /** vec2 resolution + amount + 1 pad = 16 bytes. */
     protected readonly uniformBytes = 16;
 
-    protected readonly fragmentShader = FLICKER_FRAGMENT_WGSL;
+    protected readonly fragmentShader = FRAGMENT_WGSL;
 
     /**
      * Writes resolution and brightness amount into the uniform block.
@@ -47,7 +47,7 @@ export class Flicker extends FullscreenEffect {
     }
 }
 
-const FLICKER_FRAGMENT_WGSL = `
+const FRAGMENT_WGSL = `
 struct Params {
     resolution: vec2<f32>,
     amount: f32,

--- a/src/render/effects/display/Interference.ts
+++ b/src/render/effects/display/Interference.ts
@@ -28,7 +28,7 @@ export class Interference extends FullscreenEffect {
     /** vec2 resolution + amount + time = 16 bytes. */
     protected readonly uniformBytes = 16;
 
-    protected readonly fragmentShader = INTERFERENCE_FRAGMENT_WGSL;
+    protected readonly fragmentShader = FRAGMENT_WGSL;
 
     /**
      * Writes resolution, amount, and time into the uniform block.
@@ -49,7 +49,7 @@ export class Interference extends FullscreenEffect {
     }
 }
 
-const INTERFERENCE_FRAGMENT_WGSL = `
+const FRAGMENT_WGSL = `
 struct Params {
     resolution: vec2<f32>,
     amount: f32,

--- a/src/render/effects/display/Noise.ts
+++ b/src/render/effects/display/Noise.ts
@@ -24,7 +24,7 @@ export class Noise extends FullscreenEffect {
     /** vec2 resolution + amount + time = 16 bytes. */
     protected readonly uniformBytes = 16;
 
-    protected readonly fragmentShader = NOISE_FRAGMENT_WGSL;
+    protected readonly fragmentShader = FRAGMENT_WGSL;
 
     /**
      * Writes resolution, amount, and time into the uniform block.
@@ -45,7 +45,7 @@ export class Noise extends FullscreenEffect {
     }
 }
 
-const NOISE_FRAGMENT_WGSL = `
+const FRAGMENT_WGSL = `
 struct Params {
     resolution: vec2<f32>,
     amount: f32,

--- a/src/render/effects/display/RGBMask.ts
+++ b/src/render/effects/display/RGBMask.ts
@@ -28,7 +28,7 @@ export class RGBMask extends FullscreenEffect {
     /** vec2 resolution + intensity + size + border + 1 pad = 32 bytes. */
     protected readonly uniformBytes = 32;
 
-    protected readonly fragmentShader = MASK_FRAGMENT_WGSL;
+    protected readonly fragmentShader = FRAGMENT_WGSL;
 
     /**
      * Writes resolution, intensity, size, and border into the uniform block.
@@ -52,7 +52,7 @@ export class RGBMask extends FullscreenEffect {
     }
 }
 
-const MASK_FRAGMENT_WGSL = `
+const FRAGMENT_WGSL = `
 struct Params {
     resolution: vec2<f32>,
     intensity: f32,

--- a/src/render/effects/display/RollLine.ts
+++ b/src/render/effects/display/RollLine.ts
@@ -25,7 +25,7 @@ export class RollLine extends FullscreenEffect {
     /** vec2 resolution + amount + speed + time + 1 pad = 32 bytes. */
     protected readonly uniformBytes = 32;
 
-    protected readonly fragmentShader = ROLL_FRAGMENT_WGSL;
+    protected readonly fragmentShader = FRAGMENT_WGSL;
 
     /**
      * Writes resolution, amount, speed, and time into the uniform block.
@@ -48,7 +48,7 @@ export class RollLine extends FullscreenEffect {
     }
 }
 
-const ROLL_FRAGMENT_WGSL = `
+const FRAGMENT_WGSL = `
 struct Params {
     resolution: vec2<f32>,
     amount: f32,

--- a/src/render/effects/display/Scanlines.ts
+++ b/src/render/effects/display/Scanlines.ts
@@ -37,7 +37,7 @@ export class Scanlines extends FullscreenEffect {
     /** amount + strength + density + _pad = 4 floats / 16 bytes. */
     protected readonly uniformBytes = 16;
 
-    protected readonly fragmentShader = SCANLINES_FRAGMENT_WGSL;
+    protected readonly fragmentShader = FRAGMENT_WGSL;
 
     /**
      * Writes amount, strength, and density into the uniform block.
@@ -60,7 +60,7 @@ export class Scanlines extends FullscreenEffect {
     }
 }
 
-const SCANLINES_FRAGMENT_WGSL = `
+const FRAGMENT_WGSL = `
 struct Params {
     amount: f32,
     strength: f32,

--- a/src/render/effects/display/Vignette.ts
+++ b/src/render/effects/display/Vignette.ts
@@ -22,7 +22,7 @@ export class Vignette extends FullscreenEffect {
     /** vec2 resolution + amount + 1 pad = 16 bytes. */
     protected readonly uniformBytes = 16;
 
-    protected readonly fragmentShader = VIGNETTE_FRAGMENT_WGSL;
+    protected readonly fragmentShader = FRAGMENT_WGSL;
 
     /**
      * Writes resolution and amount into the uniform block.
@@ -43,7 +43,7 @@ export class Vignette extends FullscreenEffect {
     }
 }
 
-const VIGNETTE_FRAGMENT_WGSL = `
+const FRAGMENT_WGSL = `
 struct Params {
     resolution: vec2<f32>,
     amount: f32,

--- a/src/render/effects/fullscreenVS.ts
+++ b/src/render/effects/fullscreenVS.ts
@@ -15,7 +15,7 @@
  *
  * Draw with `pass.draw(3, 1, 0, 0)`.
  */
-export const FULLSCREEN_VS_WGSL = `
+export const VS_WGSL = `
 struct VsOut {
     @builtin(position) pos: vec4<f32>,
     @location(0) uv: vec2<f32>,

--- a/src/render/effects/pixel/PixelGlitch.ts
+++ b/src/render/effects/pixel/PixelGlitch.ts
@@ -14,9 +14,9 @@ export class PixelGlitch extends FullscreenPixelEffect {
     /** vec2 resolution + intensity + bandHeight + seed + 3 pads = 32 bytes. */
     protected readonly uniformBytes = 32;
 
-    protected readonly fragmentShaderRgba = RGBA_UNSUPPORTED_WGSL;
+    protected readonly fragmentShaderRgba = UNSUPPORTED_WGSL;
 
-    protected readonly fragmentShaderUint = GLITCH_FRAGMENT_UINT_WGSL;
+    protected readonly fragmentShaderUint = FRAGMENT_UINT_WGSL;
 
     /**
      * Glitch strength in `[0, 1]`. Drives both the per-band shift magnitude
@@ -58,7 +58,7 @@ export class PixelGlitch extends FullscreenPixelEffect {
 }
 
 /** Unused RGBA path retained only so {@link FullscreenPixelEffect} can compile both branches. */
-const RGBA_UNSUPPORTED_WGSL = `
+const UNSUPPORTED_WGSL = `
 struct Params {
     resolution: vec2<f32>,
     intensity: f32,
@@ -79,7 +79,7 @@ fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
 }
 `;
 
-const GLITCH_FRAGMENT_UINT_WGSL = `
+const FRAGMENT_UINT_WGSL = `
 struct Params {
     resolution: vec2<f32>,
     intensity: f32,

--- a/src/render/effects/pixel/PixelMosaic.ts
+++ b/src/render/effects/pixel/PixelMosaic.ts
@@ -14,9 +14,9 @@ export class PixelMosaic extends FullscreenPixelEffect {
     /** vec2 resolution + blockSize + 1 pad = 16 bytes. */
     protected readonly uniformBytes = 16;
 
-    protected readonly fragmentShaderRgba = RGBA_UNSUPPORTED_WGSL;
+    protected readonly fragmentShaderRgba = UNSUPPORTED_WGSL;
 
-    protected readonly fragmentShaderUint = MOSAIC_FRAGMENT_UINT_WGSL;
+    protected readonly fragmentShaderUint = FRAGMENT_UINT_WGSL;
 
     /**
      * Block side length in source pixels. `1` is a no-op; `2` halves
@@ -44,7 +44,7 @@ export class PixelMosaic extends FullscreenPixelEffect {
     }
 }
 
-const RGBA_UNSUPPORTED_WGSL = `
+const UNSUPPORTED_WGSL = `
 struct Params {
     resolution: vec2<f32>,
     blockSize: f32,
@@ -61,7 +61,7 @@ fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
 }
 `;
 
-const MOSAIC_FRAGMENT_UINT_WGSL = `
+const FRAGMENT_UINT_WGSL = `
 struct Params {
     resolution: vec2<f32>,
     blockSize: f32,

--- a/src/utils/AssetLimits.test.ts
+++ b/src/utils/AssetLimits.test.ts
@@ -9,18 +9,18 @@ import {
     MAX_BTFONT_EMBEDDED_TEXTURE_BYTES,
     MAX_BTFONT_JSON_BYTES,
     MAX_GLYPH_COUNT,
-    validateAssetDimensions,
     validateBtfontEmbeddedTextureUri,
     validateBtfontGlyphData,
     validateBtfontGlyphDataPreAtlas,
     validateBtfontJsonByteSize,
+    validateDimensions,
     validateGlyphCount,
     validateIndexedPixelInput,
 } from './AssetLimits';
 import { Rect2i } from './Rect2i';
 
 describe('AssetLimits', () => {
-    describe('validateAssetDimensions', () => {
+    describe('validateDimensions', () => {
         const cases: Array<{ name: string; width: number; height: number }> = [
             { name: 'zero width', width: 0, height: 16 },
             { name: 'negative height', width: 16, height: -1 },
@@ -33,16 +33,16 @@ describe('AssetLimits', () => {
 
         for (const testCase of cases) {
             it(`rejects ${testCase.name}`, () => {
-                expect(validateAssetDimensions('sprite sheet', testCase.width, testCase.height)).not.toBeNull();
+                expect(validateDimensions('sprite sheet', testCase.width, testCase.height)).not.toBeNull();
             });
         }
 
         it('accepts valid dimensions', () => {
-            expect(validateAssetDimensions('sprite sheet', 256, 256)).toBeNull();
+            expect(validateDimensions('sprite sheet', 256, 256)).toBeNull();
         });
 
         it('rejects total area separately from per-axis limits', () => {
-            const error = validateAssetDimensions('sprite sheet', 4096, 4097);
+            const error = validateDimensions('sprite sheet', 4096, 4097);
 
             expect(error).toContain(MAX_ASSET_PIXELS.toLocaleString('en-US'));
         });

--- a/src/utils/AssetLimits.ts
+++ b/src/utils/AssetLimits.ts
@@ -100,6 +100,18 @@ export function formatSize(width: number, height: number): string {
 }
 
 /**
+ * Backward-compatible alias for {@link formatSize}.
+ *
+ * @deprecated Deprecated since 2026-05-31. Use {@link formatSize} instead.
+ * @param width - Width in pixels.
+ * @param height - Height in pixels.
+ * @returns Size formatted as `WIDTHxHEIGHT`.
+ */
+export function formatAssetSize(width: number, height: number): string {
+    return formatSize(width, height);
+}
+
+/**
  * Computes a safe pixel count when width and height are valid asset dimensions.
  *
  * @param width - Width in pixels.
@@ -180,6 +192,19 @@ export function validateDimensions(context: string, width: number, height: numbe
 }
 
 /**
+ * Backward-compatible alias for {@link validateDimensions}.
+ *
+ * @deprecated Deprecated since 2026-05-31. Use {@link validateDimensions} instead.
+ * @param context - Asset label used in error text (for example `'sprite sheet'`).
+ * @param width - Width in pixels.
+ * @param height - Height in pixels.
+ * @returns A user-facing error message when invalid, otherwise `null`.
+ */
+export function validateAssetDimensions(context: string, width: number, height: number): string | null {
+    return validateDimensions(context, width, height);
+}
+
+/**
  * Validates decoded image dimensions and throws when they exceed engine limits.
  *
  * @param context - Asset label used in error text.
@@ -193,6 +218,19 @@ export function assertDimensions(context: string, width: number, height: number)
     if (error) {
         throw new AssetLimitError(error);
     }
+}
+
+/**
+ * Backward-compatible alias for {@link assertDimensions}.
+ *
+ * @deprecated Deprecated since 2026-05-31. Use {@link assertDimensions} instead.
+ * @param context - Asset label used in error text.
+ * @param width - Width in pixels.
+ * @param height - Height in pixels.
+ * @throws {@link AssetLimitError} when the dimensions are invalid.
+ */
+export function assertAssetDimensions(context: string, width: number, height: number): void {
+    assertDimensions(context, width, height);
 }
 
 /**

--- a/src/utils/AssetLimits.ts
+++ b/src/utils/AssetLimits.ts
@@ -95,7 +95,7 @@ export interface BtfontGlyphData {
  * @param height - Height in pixels.
  * @returns Size formatted as `WIDTHxHEIGHT`.
  */
-export function formatAssetSize(width: number, height: number): string {
+export function formatSize(width: number, height: number): string {
     return `${width}x${height}`;
 }
 
@@ -156,15 +156,15 @@ function isIntegerMetric(value: number): boolean {
  * @param height - Height in pixels.
  * @returns A user-facing error message when invalid, otherwise `null`.
  */
-export function validateAssetDimensions(context: string, width: number, height: number): string | null {
+export function validateDimensions(context: string, width: number, height: number): string | null {
     if (!isPositiveIntegerDimension(width) || !isPositiveIntegerDimension(height)) {
-        return assetDimensionInvalidError(context, formatAssetSize(width, height));
+        return assetDimensionInvalidError(context, formatSize(width, height));
     }
 
     if (width > ASSET_DIMENSION_LIMITS.maxWidth || height > ASSET_DIMENSION_LIMITS.maxHeight) {
         return assetDimensionTooLargeError(
             context,
-            formatAssetSize(width, height),
+            formatSize(width, height),
             ASSET_DIMENSION_LIMITS.maxWidth,
             ASSET_DIMENSION_LIMITS.maxHeight,
         );
@@ -173,11 +173,7 @@ export function validateAssetDimensions(context: string, width: number, height: 
     const area = width * height;
 
     if (!Number.isSafeInteger(area) || area > ASSET_DIMENSION_LIMITS.maxPixels) {
-        return assetDimensionAreaTooLargeError(
-            context,
-            formatAssetSize(width, height),
-            ASSET_DIMENSION_LIMITS.maxPixels,
-        );
+        return assetDimensionAreaTooLargeError(context, formatSize(width, height), ASSET_DIMENSION_LIMITS.maxPixels);
     }
 
     return null;
@@ -191,8 +187,8 @@ export function validateAssetDimensions(context: string, width: number, height: 
  * @param height - Height in pixels.
  * @throws {@link AssetLimitError} when the dimensions are invalid.
  */
-export function assertAssetDimensions(context: string, width: number, height: number): void {
-    const error = validateAssetDimensions(context, width, height);
+export function assertDimensions(context: string, width: number, height: number): void {
+    const error = validateDimensions(context, width, height);
 
     if (error) {
         throw new AssetLimitError(error);
@@ -207,7 +203,7 @@ export function assertAssetDimensions(context: string, width: number, height: nu
  * @throws {@link AssetLimitError} when the image dimensions are invalid.
  */
 export function assertImageElementWithinLimits(context: string, image: HTMLImageElement): void {
-    assertAssetDimensions(context, image.width, image.height);
+    assertDimensions(context, image.width, image.height);
 }
 
 /**
@@ -219,7 +215,7 @@ export function assertImageElementWithinLimits(context: string, image: HTMLImage
  * @returns A user-facing error message when invalid, otherwise `null`.
  */
 export function validateIndexedPixelInput(width: number, height: number, pixelLength?: number): string | null {
-    const dimensionError = validateAssetDimensions('indexed sprite sheet', width, height);
+    const dimensionError = validateDimensions('indexed sprite sheet', width, height);
 
     if (dimensionError) {
         return dimensionError;
@@ -228,7 +224,7 @@ export function validateIndexedPixelInput(width: number, height: number, pixelLe
     const expectedLength = computeSafePixelArea(width, height);
 
     if (expectedLength === null) {
-        return assetIndexedPixelOverflowError(formatAssetSize(width, height));
+        return assetIndexedPixelOverflowError(formatSize(width, height));
     }
 
     if (pixelLength !== undefined && pixelLength !== expectedLength) {

--- a/src/utils/Bootstrap.test.ts
+++ b/src/utils/Bootstrap.test.ts
@@ -73,13 +73,13 @@ describe('bootstrap', () => {
         teardownDOM();
     });
 
-    // #region waitForDOMReady
+    // #region isWaitingForDOMReady
 
-    describe('waitForDOMReady', () => {
-        it('should skip DOM waiting when waitForDOMReady is false', async () => {
+    describe('isWaitingForDOMReady', () => {
+        it('should skip DOM waiting when isWaitingForDOMReady is false', async () => {
             setupDOM();
 
-            const result = await bootstrap(MockDemo, { waitForDOMReady: false });
+            const result = await bootstrap(MockDemo, { isWaitingForDOMReady: false });
 
             expect(result).toBe(true);
         });
@@ -89,7 +89,7 @@ describe('bootstrap', () => {
 
             setupDOM();
 
-            const bootstrapPromise = bootstrap(MockDemo, { waitForDOMReady: true });
+            const bootstrapPromise = bootstrap(MockDemo, { isWaitingForDOMReady: true });
 
             Object.defineProperty(document, 'readyState', { value: 'complete', writable: true, configurable: true });
 
@@ -103,7 +103,7 @@ describe('bootstrap', () => {
         it('should proceed immediately when the readyState is complete', async () => {
             setupDOM();
 
-            const result = await bootstrap(MockDemo, { waitForDOMReady: true });
+            const result = await bootstrap(MockDemo, { isWaitingForDOMReady: true });
 
             expect(result).toBe(true);
         });
@@ -119,7 +119,7 @@ describe('bootstrap', () => {
 
             // No navigator.gpu installed. BTAPI.init is mocked to return true (set in beforeEach).
             const onError = vi.fn();
-            const result = await bootstrap(MockDemo, { waitForDOMReady: false, onError });
+            const result = await bootstrap(MockDemo, { isWaitingForDOMReady: false, onError });
 
             // Bootstrap no longer hard-stops on missing WebGPU; BTAPI handles backend selection.
             expect(result).toBe(true);
@@ -143,8 +143,8 @@ describe('bootstrap', () => {
             const onError = vi.fn();
 
             const result = await bootstrap(MockDemo, {
-                waitForDOMReady: false,
-                canvasId: 'nonexistent-canvas',
+                isWaitingForDOMReady: false,
+                canvasID: 'nonexistent-canvas',
                 onError,
             });
 
@@ -176,7 +176,7 @@ describe('bootstrap', () => {
 
             const onError = vi.fn();
             const result = await bootstrap(BrokenDemo as unknown as new () => IBlitTechDemo, {
-                waitForDOMReady: false,
+                isWaitingForDOMReady: false,
                 onError,
             });
 
@@ -196,7 +196,7 @@ describe('bootstrap', () => {
             vi.spyOn(BTAPI.instance, 'init').mockResolvedValue(false);
 
             const onError = vi.fn();
-            const result = await bootstrap(MockDemo, { waitForDOMReady: false, onError });
+            const result = await bootstrap(MockDemo, { isWaitingForDOMReady: false, onError });
 
             expect(result).toBe(false);
             expect(onError).toHaveBeenCalledOnce();
@@ -208,7 +208,7 @@ describe('bootstrap', () => {
             vi.spyOn(BTAPI.instance, 'init').mockRejectedValue(new Error('Init exploded'));
 
             const onError = vi.fn();
-            const result = await bootstrap(MockDemo, { waitForDOMReady: false, onError });
+            const result = await bootstrap(MockDemo, { isWaitingForDOMReady: false, onError });
 
             expect(result).toBe(false);
             expect(onError).toHaveBeenCalledOnce();
@@ -218,7 +218,7 @@ describe('bootstrap', () => {
             setupDOM();
 
             const onSuccess = vi.fn();
-            const result = await bootstrap(MockDemo, { waitForDOMReady: false, onSuccess });
+            const result = await bootstrap(MockDemo, { isWaitingForDOMReady: false, onSuccess });
 
             expect(result).toBe(true);
             expect(onSuccess).toHaveBeenCalledOnce();
@@ -229,7 +229,7 @@ describe('bootstrap', () => {
 
             const focusSpy = vi.spyOn(canvas, 'focus');
 
-            await bootstrap(MockDemo, { waitForDOMReady: false });
+            await bootstrap(MockDemo, { isWaitingForDOMReady: false });
 
             expect(canvas.tabIndex).toBe(0);
             expect(focusSpy).toHaveBeenCalled();
@@ -238,7 +238,7 @@ describe('bootstrap', () => {
         it('should use default canvas and container IDs when not specified', async () => {
             setupDOM();
 
-            const result = await bootstrap(MockDemo, { waitForDOMReady: false });
+            const result = await bootstrap(MockDemo, { isWaitingForDOMReady: false });
 
             expect(result).toBe(true);
         });
@@ -257,9 +257,9 @@ describe('bootstrap', () => {
             document.body.appendChild(canvas);
 
             const result = await bootstrap(MockDemo, {
-                waitForDOMReady: false,
-                canvasId: 'custom-canvas',
-                containerId: 'custom-container',
+                isWaitingForDOMReady: false,
+                canvasID: 'custom-canvas',
+                containerID: 'custom-container',
             });
 
             expect(result).toBe(true);
@@ -279,7 +279,7 @@ describe('bootstrap', () => {
             });
 
             const onError = vi.fn();
-            const result = await bootstrap(MockDemo, { waitForDOMReady: false, onError });
+            const result = await bootstrap(MockDemo, { isWaitingForDOMReady: false, onError });
 
             expect(result).toBe(false);
             expect(onError).toHaveBeenCalledOnce();

--- a/src/utils/Bootstrap.ts
+++ b/src/utils/Bootstrap.ts
@@ -21,13 +21,13 @@ export interface BootstrapOptions {
      * Canvas element ID to use.
      * Default: 'blit-tech-canvas'
      */
-    canvasId?: string;
+    canvasID?: string;
 
     /**
      * Container element ID for error display.
      * Default: 'canvas-container'
      */
-    containerId?: string;
+    containerID?: string;
 
     /** Custom callback on successful initialization. */
     onSuccess?: () => void;
@@ -39,7 +39,7 @@ export interface BootstrapOptions {
      * Whether to automatically handle DOM ready state.
      * Default: true
      */
-    waitForDOMReady?: boolean;
+    isWaitingForDOMReady?: boolean;
 }
 
 /**
@@ -78,7 +78,7 @@ async function waitForDOM(): Promise<void> {
  * @param title - Error title for display.
  * @param message - Error message for display.
  * @param error - The Error object.
- * @param containerId - Container ID for error display.
+ * @param containerID - Container ID for error display.
  * @param onError - Optional error callback.
  * @returns BootstrapResult indicating failure.
  */
@@ -86,10 +86,10 @@ function handleBootstrapError(
     title: string,
     message: ErrorContent,
     error: Error,
-    containerId: string,
+    containerID: string,
     onError?: (error: Error) => void,
 ): BootstrapResult {
-    displayError(title, message, containerId);
+    displayError(title, message, containerID);
     onError?.(error);
     return { success: false, error };
 }
@@ -97,17 +97,17 @@ function handleBootstrapError(
 /**
  * Validates the canvas element and returns it.
  *
- * @param canvasId - Canvas element ID.
- * @param containerId - Container ID for error display.
+ * @param canvasID - Canvas element ID.
+ * @param containerID - Container ID for error display.
  * @param onError - Optional error callback.
  * @returns Canvas element or null with error handling.
  */
 function validateCanvas(
-    canvasId: string,
-    containerId: string,
+    canvasID: string,
+    containerID: string,
     onError?: (error: Error) => void,
 ): { canvas: HTMLCanvasElement | null; result: BootstrapResult } {
-    const canvas = getCanvas(canvasId);
+    const canvas = getCanvas(canvasID);
     let result: BootstrapResult;
 
     if (canvas) {
@@ -115,9 +115,9 @@ function validateCanvas(
     } else {
         result = handleBootstrapError(
             'Canvas Error',
-            CANVAS_NOT_FOUND_MESSAGE(canvasId),
-            new Error(`Canvas element '${canvasId}' not found`),
-            containerId,
+            CANVAS_NOT_FOUND_MESSAGE(canvasID),
+            new Error(`Canvas element '${canvasID}' not found`),
+            containerID,
             onError,
         );
     }
@@ -130,7 +130,7 @@ function validateCanvas(
  *
  * @param DemoClass - Demo class constructor.
  * @param canvas - Canvas element.
- * @param containerId - Container ID for error display.
+ * @param containerID - Container ID for error display.
  * @param onSuccess - Optional success callback.
  * @param onError - Optional error callback.
  * @returns BootstrapResult with success status.
@@ -138,7 +138,7 @@ function validateCanvas(
 async function initDemo(
     DemoClass: DemoConstructor,
     canvas: HTMLCanvasElement,
-    containerId: string,
+    containerID: string,
     onSuccess?: () => void,
     onError?: (error: Error) => void,
 ): Promise<BootstrapResult> {
@@ -149,7 +149,7 @@ async function initDemo(
             'Demo Setup Error',
             'Your Demo class is missing update() or render(). Add both methods so the engine knows what to run each frame.',
             new Error('Demo class is missing update() or render()'),
-            containerId,
+            containerID,
             onError,
         );
     }
@@ -182,7 +182,7 @@ async function initDemo(
             'Initialization Failed',
             displayMessage,
             initError ?? new Error('Engine initialization failed'),
-            containerId,
+            containerID,
             onError,
         );
     }
@@ -213,8 +213,8 @@ async function initDemo(
  * @example
  * // With custom options.
  * bootstrap(MyDemo, {
- *     canvasId: 'custom-canvas',
- *     containerId: 'custom-container',
+ *     canvasID: 'custom-canvas',
+ *     containerID: 'custom-container',
  *     onSuccess: () => console.log('Demo started!'),
  *     onError: (err) => analytics.trackError(err),
  * });
@@ -228,22 +228,22 @@ async function initDemo(
  */
 export async function bootstrap(DemoClass: DemoConstructor, options: BootstrapOptions = {}): Promise<boolean> {
     const {
-        canvasId = DEFAULT_CANVAS_ID,
-        containerId = DEFAULT_CONTAINER_ID,
+        canvasID = DEFAULT_CANVAS_ID,
+        containerID = DEFAULT_CONTAINER_ID,
         onSuccess,
         onError,
-        waitForDOMReady = true,
+        isWaitingForDOMReady = true,
     } = options;
 
     let success: boolean;
 
     // Wait for DOM if needed.
-    if (waitForDOMReady) {
+    if (isWaitingForDOMReady) {
         await waitForDOM();
     }
 
     try {
-        const { canvas, result: canvasResult } = validateCanvas(canvasId, containerId, onError);
+        const { canvas, result: canvasResult } = validateCanvas(canvasID, containerID, onError);
 
         success = canvasResult.success;
 
@@ -256,7 +256,7 @@ export async function bootstrap(DemoClass: DemoConstructor, options: BootstrapOp
                 canvas.focus();
             }
 
-            const initResult = await initDemo(DemoClass, canvas, containerId, onSuccess, onError);
+            const initResult = await initDemo(DemoClass, canvas, containerID, onSuccess, onError);
 
             success = initResult.success;
         }
@@ -272,7 +272,7 @@ export async function bootstrap(DemoClass: DemoConstructor, options: BootstrapOp
                 code: error.message,
             },
             error,
-            containerId,
+            containerID,
             onError,
         );
 

--- a/src/utils/Bootstrap.ts
+++ b/src/utils/Bootstrap.ts
@@ -50,7 +50,7 @@ export type DemoConstructor = new () => IBlitTechDemo;
 /**
  * Internal result type for bootstrap steps.
  */
-interface BootstrapResult {
+interface Result {
     success: boolean;
     error?: Error;
 }
@@ -80,15 +80,15 @@ async function waitForDOM(): Promise<void> {
  * @param error - The Error object.
  * @param containerID - Container ID for error display.
  * @param onError - Optional error callback.
- * @returns BootstrapResult indicating failure.
+ * @returns Result indicating failure.
  */
-function handleBootstrapError(
+function handleError(
     title: string,
     message: ErrorContent,
     error: Error,
     containerID: string,
     onError?: (error: Error) => void,
-): BootstrapResult {
+): Result {
     displayError(title, message, containerID);
     onError?.(error);
     return { success: false, error };
@@ -106,14 +106,14 @@ function validateCanvas(
     canvasID: string,
     containerID: string,
     onError?: (error: Error) => void,
-): { canvas: HTMLCanvasElement | null; result: BootstrapResult } {
+): { canvas: HTMLCanvasElement | null; result: Result } {
     const canvas = getCanvas(canvasID);
-    let result: BootstrapResult;
+    let result: Result;
 
     if (canvas) {
         result = { success: true };
     } else {
-        result = handleBootstrapError(
+        result = handleError(
             'Canvas Error',
             CANVAS_NOT_FOUND_MESSAGE(canvasID),
             new Error(`Canvas element '${canvasID}' not found`),
@@ -133,7 +133,7 @@ function validateCanvas(
  * @param containerID - Container ID for error display.
  * @param onSuccess - Optional success callback.
  * @param onError - Optional error callback.
- * @returns BootstrapResult with success status.
+ * @returns Result with success status.
  */
 async function initDemo(
     DemoClass: DemoConstructor,
@@ -141,11 +141,11 @@ async function initDemo(
     containerID: string,
     onSuccess?: () => void,
     onError?: (error: Error) => void,
-): Promise<BootstrapResult> {
+): Promise<Result> {
     const demo = new DemoClass();
 
     if (typeof demo.update !== 'function' || typeof demo.render !== 'function') {
-        return handleBootstrapError(
+        return handleError(
             'Demo Setup Error',
             'Your Demo class is missing update() or render(). Add both methods so the engine knows what to run each frame.',
             new Error('Demo class is missing update() or render()'),
@@ -165,7 +165,7 @@ async function initDemo(
         initialized = false;
     }
 
-    let result: BootstrapResult;
+    let result: Result;
 
     if (initialized) {
         console.log('[BT] Demo started successfully');
@@ -178,7 +178,7 @@ async function initDemo(
             ? { text: INIT_FAILED_MESSAGE, code: initError.message }
             : INIT_FAILED_MESSAGE;
 
-        result = handleBootstrapError(
+        result = handleError(
             'Initialization Failed',
             displayMessage,
             initError ?? new Error('Engine initialization failed'),
@@ -265,7 +265,7 @@ export async function bootstrap(DemoClass: DemoConstructor, options: BootstrapOp
 
         console.error('[BT] Bootstrap error:', error);
 
-        handleBootstrapError(
+        handleError(
             'Unexpected Error',
             {
                 text: 'An unexpected error occurred during initialization:',

--- a/src/utils/Bootstrap.ts
+++ b/src/utils/Bootstrap.ts
@@ -24,10 +24,20 @@ export interface BootstrapOptions {
     canvasID?: string;
 
     /**
+     * @deprecated Deprecated since 2026-05-31. Use `canvasID` instead.
+     */
+    canvasId?: string;
+
+    /**
      * Container element ID for error display.
      * Default: 'canvas-container'
      */
     containerID?: string;
+
+    /**
+     * @deprecated Deprecated since 2026-05-31. Use `containerID` instead.
+     */
+    containerId?: string;
 
     /** Custom callback on successful initialization. */
     onSuccess?: () => void;
@@ -40,6 +50,11 @@ export interface BootstrapOptions {
      * Default: true
      */
     isWaitingForDOMReady?: boolean;
+
+    /**
+     * @deprecated Deprecated since 2026-05-31. Use `isWaitingForDOMReady` instead.
+     */
+    waitForDOMReady?: boolean;
 }
 
 /**
@@ -228,12 +243,18 @@ async function initDemo(
  */
 export async function bootstrap(DemoClass: DemoConstructor, options: BootstrapOptions = {}): Promise<boolean> {
     const {
-        canvasID = DEFAULT_CANVAS_ID,
-        containerID = DEFAULT_CONTAINER_ID,
+        canvasID: providedCanvasID,
+        canvasId,
+        containerID: providedContainerID,
+        containerId,
         onSuccess,
         onError,
-        isWaitingForDOMReady = true,
+        isWaitingForDOMReady: providedIsWaitingForDOMReady,
+        waitForDOMReady,
     } = options;
+    const canvasID = providedCanvasID ?? canvasId ?? DEFAULT_CANVAS_ID;
+    const containerID = providedContainerID ?? containerId ?? DEFAULT_CONTAINER_ID;
+    const isWaitingForDOMReady = providedIsWaitingForDOMReady ?? waitForDOMReady ?? true;
 
     let success: boolean;
 

--- a/src/utils/BootstrapHelpers.ts
+++ b/src/utils/BootstrapHelpers.ts
@@ -63,7 +63,7 @@ function appendTextWithLineBreaks(element: HTMLElement, text: string): void {
  *
  * @param title - Error heading text displayed prominently.
  * @param content - Error message content (string or object with optional code formatting).
- * @param containerId - ID of the container element. Default: 'canvas-container'
+ * @param containerID - ID of the container element. Default: 'canvas-container'
  *
  * @example
  * displayError(
@@ -77,8 +77,8 @@ function appendTextWithLineBreaks(element: HTMLElement, text: string): void {
  *     { text: 'An error occurred:', code: error.message }
  * );
  */
-export function displayError(title: string, content: ErrorContent, containerId: string = DEFAULT_CONTAINER_ID): void {
-    const container = document.getElementById(containerId);
+export function displayError(title: string, content: ErrorContent, containerID: string = DEFAULT_CONTAINER_ID): void {
+    const container = document.getElementById(containerID);
 
     if (container) {
         // Create error elements using DOM methods for safety.
@@ -148,7 +148,7 @@ export function displayError(title: string, content: ErrorContent, containerId: 
  * Retrieves a canvas element from the DOM by ID.
  * Validates that the element exists and is a canvas element.
  *
- * @param canvasId - ID of the canvas element. Default: 'blit-tech-canvas'
+ * @param canvasID - ID of the canvas element. Default: 'blit-tech-canvas'
  * @returns The canvas element if found and valid, null otherwise.
  *
  * @example
@@ -158,14 +158,14 @@ export function displayError(title: string, content: ErrorContent, containerId: 
  *     return;
  * }
  */
-export function getCanvas(canvasId: string = DEFAULT_CANVAS_ID): HTMLCanvasElement | null {
-    const element = document.getElementById(canvasId);
+export function getCanvas(canvasID: string = DEFAULT_CANVAS_ID): HTMLCanvasElement | null {
+    const element = document.getElementById(canvasID);
     let canvas: HTMLCanvasElement | null = null;
 
     if (!element) {
-        console.error(`[BT] Canvas element with id '${canvasId}' not found`);
+        console.error(`[BT] Canvas element with id '${canvasID}' not found`);
     } else if (!(element instanceof HTMLCanvasElement)) {
-        console.error(`[BT] Element with id '${canvasId}' is not a canvas element`);
+        console.error(`[BT] Element with id '${canvasID}' is not a canvas element`);
     } else {
         canvas = element;
     }

--- a/src/utils/CameraUtils.test.ts
+++ b/src/utils/CameraUtils.test.ts
@@ -11,7 +11,7 @@ describe('clampCameraToWorld', () => {
 
         const clamped = clampCameraToWorld(camera, world, view);
 
-        expect(clamped.equalsXY(320, 240)).toBe(true);
+        expect(clamped.isEqualXY(320, 240)).toBe(true);
     });
 
     it('clamps negative camera coordinates to zero', () => {
@@ -21,7 +21,7 @@ describe('clampCameraToWorld', () => {
 
         const clamped = clampCameraToWorld(camera, world, view);
 
-        expect(clamped.equalsXY(0, 0)).toBe(true);
+        expect(clamped.isEqualXY(0, 0)).toBe(true);
     });
 
     it('pins axis to zero when world is smaller than viewport', () => {
@@ -31,6 +31,6 @@ describe('clampCameraToWorld', () => {
 
         const clamped = clampCameraToWorld(camera, world, view);
 
-        expect(clamped.equalsXY(0, 0)).toBe(true);
+        expect(clamped.isEqualXY(0, 0)).toBe(true);
     });
 });

--- a/src/utils/Color32.bench.ts
+++ b/src/utils/Color32.bench.ts
@@ -220,9 +220,9 @@ describe('Color32 comparison benchmarks', () => {
     const right = Color32.fromRGBAUnchecked(BASE_R, BASE_G, BASE_B, BASE_A);
 
     bench(
-        'equals()',
+        'isEqual()',
         () => {
-            left.equals(right);
+            left.isEqual(right);
         },
         BENCH_OPTIONS,
     );

--- a/src/utils/Color32.test.ts
+++ b/src/utils/Color32.test.ts
@@ -200,14 +200,14 @@ describe('static color getters', () => {
 
 describe('named color registry', () => {
     it('resolves required CSS level 1 names', () => {
-        expect(Color32.resolveNamedColor('black')?.equals(Color32.black)).toBe(true);
-        expect(Color32.resolveNamedColor('white')?.equals(Color32.white)).toBe(true);
-        expect(Color32.resolveNamedColor('red')?.equals(Color32.red)).toBe(true);
-        expect(Color32.resolveNamedColor('green')?.equals(Color32.green)).toBe(true);
-        expect(Color32.resolveNamedColor('blue')?.equals(Color32.blue)).toBe(true);
-        expect(Color32.resolveNamedColor('yellow')?.equals(Color32.yellow)).toBe(true);
-        expect(Color32.resolveNamedColor('cyan')?.equals(Color32.cyan)).toBe(true);
-        expect(Color32.resolveNamedColor('magenta')?.equals(Color32.magenta)).toBe(true);
+        expect(Color32.resolveNamedColor('black')?.isEqual(Color32.black)).toBe(true);
+        expect(Color32.resolveNamedColor('white')?.isEqual(Color32.white)).toBe(true);
+        expect(Color32.resolveNamedColor('red')?.isEqual(Color32.red)).toBe(true);
+        expect(Color32.resolveNamedColor('green')?.isEqual(Color32.green)).toBe(true);
+        expect(Color32.resolveNamedColor('blue')?.isEqual(Color32.blue)).toBe(true);
+        expect(Color32.resolveNamedColor('yellow')?.isEqual(Color32.yellow)).toBe(true);
+        expect(Color32.resolveNamedColor('cyan')?.isEqual(Color32.cyan)).toBe(true);
+        expect(Color32.resolveNamedColor('magenta')?.isEqual(Color32.magenta)).toBe(true);
     });
 
     it('resolves gray and grey to the same singleton', () => {
@@ -216,19 +216,19 @@ describe('named color registry', () => {
 
         expect(gray).toBeDefined();
         expect(gray).toBe(grey);
-        expect(gray?.equals(Color32.gray(128))).toBe(true);
+        expect(gray?.isEqual(Color32.gray(128))).toBe(true);
     });
 
     it('resolves common extra names', () => {
-        expect(Color32.resolveNamedColor('cornflowerblue')?.equals(Color32.fromRGBAUnchecked(100, 149, 237, 255))).toBe(
-            true,
-        );
-        expect(Color32.resolveNamedColor('tomato')?.equals(Color32.fromRGBAUnchecked(255, 99, 71, 255))).toBe(true);
+        expect(
+            Color32.resolveNamedColor('cornflowerblue')?.isEqual(Color32.fromRGBAUnchecked(100, 149, 237, 255)),
+        ).toBe(true);
+        expect(Color32.resolveNamedColor('tomato')?.isEqual(Color32.fromRGBAUnchecked(255, 99, 71, 255))).toBe(true);
     });
 
     it('normalizes lookup names with trim + lowercase', () => {
         const color = Color32.resolveNamedColor('  CoRnFlOwErBlUe  ');
-        expect(color?.equals(Color32.fromRGBAUnchecked(100, 149, 237, 255))).toBe(true);
+        expect(color?.isEqual(Color32.fromRGBAUnchecked(100, 149, 237, 255))).toBe(true);
     });
 
     it('returns same instance on repeated lookups', () => {
@@ -252,7 +252,7 @@ describe('named color registry', () => {
             const resolved = Color32.resolveNamedColor('mycustomcolor');
             expect(resolved).toBeDefined();
             expect(resolved).not.toBe(source);
-            expect(resolved?.equals(source)).toBe(true);
+            expect(resolved?.isEqual(source)).toBe(true);
             expect(Object.isFrozen(resolved)).toBe(true);
         } finally {
             Color32.unregisterColor('mycustomcolor');
@@ -277,7 +277,7 @@ describe('named color registry', () => {
             Color32.updateColor('  UpdatableColor  ', updatedSource);
 
             const resolved = Color32.resolveNamedColor('updatablecolor');
-            expect(resolved?.equals(updatedSource)).toBe(true);
+            expect(resolved?.isEqual(updatedSource)).toBe(true);
             expect(resolved).not.toBe(updatedSource);
             expect(Object.isFrozen(resolved)).toBe(true);
         } finally {
@@ -305,8 +305,8 @@ describe('named color registry', () => {
 
             expect(gray).toBeDefined();
             expect(grey).toBeDefined();
-            expect(gray?.equals(new Color32(200, 200, 200, 255))).toBe(true);
-            expect(grey?.equals(new Color32(200, 200, 200, 255))).toBe(true);
+            expect(gray?.isEqual(new Color32(200, 200, 200, 255))).toBe(true);
+            expect(grey?.isEqual(new Color32(200, 200, 200, 255))).toBe(true);
             expect(gray).toBe(grey);
             expect(Object.isFrozen(gray)).toBe(true);
         } finally {
@@ -676,26 +676,26 @@ describe('toString', () => {
 
 // #region Comparison
 
-describe('equals', () => {
+describe('isEqual', () => {
     it('returns true for identical colors', () => {
         const a = new Color32(10, 20, 30, 40);
         const b = new Color32(10, 20, 30, 40);
 
-        expect(a.equals(b)).toBe(true);
+        expect(a.isEqual(b)).toBe(true);
     });
 
     it('returns false for different colors', () => {
         const a = new Color32(10, 20, 30, 40);
         const b = new Color32(10, 20, 30, 41);
 
-        expect(a.equals(b)).toBe(false);
+        expect(a.isEqual(b)).toBe(false);
     });
 
     it('returns false for null or undefined', () => {
         const a = new Color32(10, 20, 30, 40);
 
-        expect(a.equals(null as unknown as Color32)).toBe(false);
-        expect(a.equals(undefined as unknown as Color32)).toBe(false);
+        expect(a.isEqual(null as unknown as Color32)).toBe(false);
+        expect(a.isEqual(undefined as unknown as Color32)).toBe(false);
     });
 });
 
@@ -845,7 +845,7 @@ describe('Color32.lerp (static)', () => {
         const b = new Color32(200, 100, 50, 254);
 
         for (const t of [0, 0.25, 0.5, 0.75, 1, -1, 2]) {
-            expect(Color32.lerp(a, b, t).equals(a.lerp(b, t))).toBe(true);
+            expect(Color32.lerp(a, b, t).isEqual(a.lerp(b, t))).toBe(true);
         }
     });
 

--- a/src/utils/Color32.ts
+++ b/src/utils/Color32.ts
@@ -57,7 +57,7 @@ export class Color32 {
     private static readonly _magenta: Color32 = Object.freeze(Color32.fromRGBAUnchecked(255, 0, 255, 255));
 
     /** Internal named-color registry used by string color resolution. */
-    private static readonly namedColors: Map<string, Color32> = Color32.createNamedColorMap();
+    private static readonly namedColors: Map<string, Color32> = Color32.createNamedMap();
 
     // #endregion
 
@@ -818,7 +818,7 @@ export class Color32 {
      *
      * @returns Map of normalized names to frozen singleton Color32 values.
      */
-    private static createNamedColorMap(): Map<string, Color32> {
+    private static createNamedMap(): Map<string, Color32> {
         const map = new Map<string, Color32>();
         const define = (name: string, r: number, g: number, b: number, a: number = 255): void => {
             map.set(name, Object.freeze(Color32.fromRGBAUnchecked(r, g, b, a)));

--- a/src/utils/Color32.ts
+++ b/src/utils/Color32.ts
@@ -555,7 +555,7 @@ export class Color32 {
      * @param other - Color to compare with.
      * @returns True if all RGBA channels are identical.
      */
-    equals(other: Color32): boolean {
+    isEqual(other: Color32): boolean {
         // Simple comparison with early exit on the first mismatch.
         // Modern JS engines optimize this well.
         return (

--- a/src/utils/Color32.ts
+++ b/src/utils/Color32.ts
@@ -568,6 +568,17 @@ export class Color32 {
         );
     }
 
+    /**
+     * Backward-compatible alias for {@link isEqual}.
+     *
+     * @deprecated Deprecated since 2026-05-31. Use {@link isEqual} instead.
+     * @param other - Color to compare with.
+     * @returns True if all RGBA channels are identical.
+     */
+    equals(other: Color32): boolean {
+        return this.isEqual(other);
+    }
+
     // #endregion
 
     // #region Modification Methods

--- a/src/utils/FrameCapture.test.ts
+++ b/src/utils/FrameCapture.test.ts
@@ -147,34 +147,34 @@ describe('FrameCapture', () => {
     it('should start with no pending capture', () => {
         const capture = new FrameCapture();
 
-        expect(capture.hasPendingCapture()).toBe(false);
+        expect(capture.hasPending()).toBe(false);
     });
 
-    it('should set a pending flag after requestCapture', () => {
+    it('should set a pending flag after request', () => {
         const capture = new FrameCapture();
 
         // Don't await - just queue the request.
-        void capture.requestCapture();
+        void capture.request();
 
-        expect(capture.hasPendingCapture()).toBe(true);
+        expect(capture.hasPending()).toBe(true);
     });
 
     it('should reject the previous capture when a new one is requested', async () => {
         const capture = new FrameCapture();
 
-        const firstCapture = capture.requestCapture();
+        const firstCapture = capture.request();
 
-        void capture.requestCapture();
+        void capture.request();
 
         await expect(firstCapture).rejects.toThrow('superseded');
     });
 
-    it('should clear the pending flag after resolveCapture', async () => {
+    it('should clear the pending flag after resolve', async () => {
         const capture = new FrameCapture();
 
-        void capture.requestCapture();
+        void capture.request();
 
-        expect(capture.hasPendingCapture()).toBe(true);
+        expect(capture.hasPending()).toBe(true);
 
         const device = createMockGPUDevice();
         const texture = createMockGPUTexture(4, 4);
@@ -183,17 +183,17 @@ describe('FrameCapture', () => {
         // Add copyTextureToBuffer to mock encoder.
         (encoder as unknown as Record<string, unknown>).copyTextureToBuffer = vi.fn();
 
-        capture.executeCaptureInEncoder(device, texture, encoder as unknown as GPUCommandEncoder);
+        capture.executeInEncoder(device, texture, encoder as unknown as GPUCommandEncoder);
 
-        await capture.resolveCapture(device);
+        await capture.resolve(device);
 
-        expect(capture.hasPendingCapture()).toBe(false);
+        expect(capture.hasPending()).toBe(false);
     });
 
-    it('should call copyTextureToBuffer in executeCaptureInEncoder', () => {
+    it('should call copyTextureToBuffer in executeInEncoder', () => {
         const capture = new FrameCapture();
 
-        void capture.requestCapture();
+        void capture.request();
 
         const device = createMockGPUDevice();
         const texture = createMockGPUTexture(320, 240);
@@ -203,7 +203,7 @@ describe('FrameCapture', () => {
             copyTextureToBuffer: copyFn,
         } as unknown as GPUCommandEncoder;
 
-        capture.executeCaptureInEncoder(device, texture, encoder);
+        capture.executeInEncoder(device, texture, encoder);
 
         expect(copyFn).toHaveBeenCalledOnce();
 
@@ -215,7 +215,7 @@ describe('FrameCapture', () => {
 
     it('should resolve with a Blob on successful capture', async () => {
         const capture = new FrameCapture();
-        const capturePromise = capture.requestCapture();
+        const capturePromise = capture.request();
 
         const device = createMockGPUDevice();
         const texture = createMockGPUTexture(4, 4);
@@ -224,9 +224,9 @@ describe('FrameCapture', () => {
             copyTextureToBuffer: vi.fn(),
         } as unknown as GPUCommandEncoder;
 
-        capture.executeCaptureInEncoder(device, texture, encoder);
+        capture.executeInEncoder(device, texture, encoder);
 
-        await capture.resolveCapture(device);
+        await capture.resolve(device);
 
         const result = await capturePromise;
 
@@ -236,7 +236,7 @@ describe('FrameCapture', () => {
 
     it('should swizzle BGRA pixels to RGBA during resolve', async () => {
         const capture = new FrameCapture();
-        const capturePromise = capture.requestCapture();
+        const capturePromise = capture.request();
 
         const device = createMockGPUDevice();
         const bgraTexture = { ...createMockGPUTexture(4, 4), format: 'bgra8unorm' } as unknown as GPUTexture;
@@ -273,7 +273,7 @@ describe('FrameCapture', () => {
             copyTextureToBuffer: vi.fn(),
         } as unknown as GPUCommandEncoder;
 
-        capture.executeCaptureInEncoder(device, bgraTexture, encoder);
+        capture.executeInEncoder(device, bgraTexture, encoder);
 
         // Capture the pixel data passed to ImageData to verify swizzle.
         let capturedPixels: Uint8ClampedArray | null = null;
@@ -304,10 +304,10 @@ describe('FrameCapture', () => {
             },
         );
 
-        await capture.resolveCapture(device);
+        await capture.resolve(device);
         await capturePromise;
 
-        expect(capture.hasPendingCapture()).toBe(false);
+        expect(capture.hasPending()).toBe(false);
         expect(capturedPixels).not.toBeNull();
 
         // After swizzle, first pixel of each row should be RGBA = [30, 20, 10, 255].
@@ -328,11 +328,11 @@ describe('FrameCapture', () => {
         vi.unstubAllGlobals();
     });
 
-    it('should not throw when resolveCapture is called without pending capture', async () => {
+    it('should not throw when resolve is called without pending capture', async () => {
         const capture = new FrameCapture();
         const device = createMockGPUDevice();
 
-        await expect(capture.resolveCapture(device)).resolves.toBeUndefined();
+        await expect(capture.resolve(device)).resolves.toBeUndefined();
     });
 });
 

--- a/src/utils/FrameCapture.ts
+++ b/src/utils/FrameCapture.ts
@@ -18,10 +18,10 @@ const BYTES_PER_PIXEL = 4;
 // #region Pending Capture State
 
 /** Promise resolve callback for a pending frame capture. */
-type CaptureResolve = (blob: Blob) => void;
+type Resolve = (blob: Blob) => void;
 
 /** Promise reject callback for a pending frame capture. */
-type CaptureReject = (reason: Error) => void;
+type Reject = (reason: Error) => void;
 
 // #endregion
 
@@ -109,25 +109,25 @@ export async function pixelBufferToPNG(
 /**
  * Manages single-frame capture from the WebGPU rendering pipeline.
  *
- * A capture request is queued via {@link requestCapture}, executed during the
- * next render pass via {@link executeCaptureInEncoder}, and resolved
- * asynchronously in {@link resolveCapture}.
+ * A capture request is queued via {@link request}, executed during the
+ * next render pass via {@link executeInEncoder}, and resolved
+ * asynchronously in {@link resolve}.
  */
 export class FrameCapture {
     /** Resolve callback for the pending capture. */
-    private pendingResolve: CaptureResolve | null = null;
+    private pendingResolve: Resolve | null = null;
 
     /** Reject callback for the pending capture. */
-    private pendingReject: CaptureReject | null = null;
+    private pendingReject: Reject | null = null;
 
     /** Staging buffer for GPU-to-CPU readback. */
     private stagingBuffer: GPUBuffer | null = null;
 
     /** Width of the captured frame. */
-    private captureWidth = 0;
+    private width = 0;
 
     /** Height of the captured frame. */
-    private captureHeight = 0;
+    private height = 0;
 
     /** Padded bytes per row used in the staging buffer. */
     private paddedBytesPerRow = 0;
@@ -140,7 +140,7 @@ export class FrameCapture {
      *
      * @returns True if a capture request is pending.
      */
-    hasPendingCapture(): boolean {
+    hasPending(): boolean {
         return this.pendingResolve !== null;
     }
 
@@ -150,7 +150,7 @@ export class FrameCapture {
      *
      * @returns Promise resolving to the captured PNG Blob.
      */
-    requestCapture(): Promise<Blob> {
+    request(): Promise<Blob> {
         if (this.pendingResolve) {
             this.pendingReject?.(new Error('[FrameCapture] Capture superseded by a new request'));
 
@@ -171,13 +171,13 @@ export class FrameCapture {
      * @param texture - The rendered canvas texture to capture.
      * @param commandEncoder - Active command encoder to add the copy command to.
      */
-    executeCaptureInEncoder(device: GPUDevice, texture: GPUTexture, commandEncoder: GPUCommandEncoder): void {
-        this.captureWidth = texture.width;
-        this.captureHeight = texture.height;
-        this.paddedBytesPerRow = alignedBytesPerRow(this.captureWidth);
+    executeInEncoder(device: GPUDevice, texture: GPUTexture, commandEncoder: GPUCommandEncoder): void {
+        this.width = texture.width;
+        this.height = texture.height;
+        this.paddedBytesPerRow = alignedBytesPerRow(this.width);
         this.isBGRA = texture.format === 'bgra8unorm';
 
-        const bufferSize = this.paddedBytesPerRow * this.captureHeight;
+        const bufferSize = this.paddedBytesPerRow * this.height;
 
         this.stagingBuffer = device.createBuffer({
             label: 'Frame Capture Staging',
@@ -187,8 +187,8 @@ export class FrameCapture {
 
         commandEncoder.copyTextureToBuffer(
             { texture },
-            { buffer: this.stagingBuffer, bytesPerRow: this.paddedBytesPerRow, rowsPerImage: this.captureHeight },
-            { width: this.captureWidth, height: this.captureHeight },
+            { buffer: this.stagingBuffer, bytesPerRow: this.paddedBytesPerRow, rowsPerImage: this.height },
+            { width: this.width, height: this.height },
         );
     }
 
@@ -197,7 +197,7 @@ export class FrameCapture {
      *
      * @param device - WebGPU device (used for onSubmittedWorkDone).
      */
-    async resolveCapture(device: GPUDevice): Promise<void> {
+    async resolve(device: GPUDevice): Promise<void> {
         const resolve = this.pendingResolve;
         const reject = this.pendingReject;
         const buffer = this.stagingBuffer;
@@ -216,13 +216,7 @@ export class FrameCapture {
             await buffer.mapAsync(GPUMapMode.READ);
 
             const data = buffer.getMappedRange();
-            const blob = await pixelBufferToPNG(
-                data,
-                this.captureWidth,
-                this.captureHeight,
-                this.paddedBytesPerRow,
-                this.isBGRA,
-            );
+            const blob = await pixelBufferToPNG(data, this.width, this.height, this.paddedBytesPerRow, this.isBGRA);
 
             buffer.unmap();
             buffer.destroy();

--- a/src/utils/Rect2i.bench.ts
+++ b/src/utils/Rect2i.bench.ts
@@ -60,17 +60,17 @@ describe('Rect2i collision benchmarks', () => {
     const overlapping = Rect2i.fromValuesUnchecked(30, 36, 20, 18);
 
     bench(
-        'contains(Vector2i)',
+        'isContaining(Vector2i)',
         () => {
-            rect.contains(point);
+            rect.isContaining(point);
         },
         BENCH_OPTIONS,
     );
 
     bench(
-        'containsXY()',
+        'isContainingXY()',
         () => {
-            rect.containsXY(24, 32);
+            rect.isContainingXY(24, 32);
         },
         BENCH_OPTIONS,
     );

--- a/src/utils/Rect2i.bench.ts
+++ b/src/utils/Rect2i.bench.ts
@@ -76,9 +76,9 @@ describe('Rect2i collision benchmarks', () => {
     );
 
     bench(
-        'intersects(Rect2i)',
+        'isIntersecting(Rect2i)',
         () => {
-            rect.intersects(overlapping);
+            rect.isIntersecting(overlapping);
         },
         BENCH_OPTIONS,
     );

--- a/src/utils/Rect2i.test.ts
+++ b/src/utils/Rect2i.test.ts
@@ -382,32 +382,32 @@ describe('Rect2i', () => {
 
     // #region Intersection Tests
 
-    describe('contains', () => {
+    describe('isContaining', () => {
         it('should return true for a point inside', () => {
             const r = new Rect2i(0, 0, 100, 100);
 
-            expect(r.contains(new Vector2i(50, 50))).toBe(true);
+            expect(r.isContaining(new Vector2i(50, 50))).toBe(true);
         });
 
         it('should return true for a point on the min edge (inclusive)', () => {
             const r = new Rect2i(10, 20, 100, 100);
 
-            expect(r.contains(new Vector2i(10, 20))).toBe(true);
+            expect(r.isContaining(new Vector2i(10, 20))).toBe(true);
         });
 
         it('should return false for a point on the max edge (exclusive)', () => {
             const r = new Rect2i(10, 20, 100, 100);
 
-            expect(r.contains(new Vector2i(110, 120))).toBe(false);
-            expect(r.contains(new Vector2i(110, 50))).toBe(false);
-            expect(r.contains(new Vector2i(50, 120))).toBe(false);
+            expect(r.isContaining(new Vector2i(110, 120))).toBe(false);
+            expect(r.isContaining(new Vector2i(110, 50))).toBe(false);
+            expect(r.isContaining(new Vector2i(50, 120))).toBe(false);
         });
 
         it('should return false for a point outside', () => {
             const r = new Rect2i(10, 20, 100, 100);
 
-            expect(r.contains(new Vector2i(0, 0))).toBe(false);
-            expect(r.contains(new Vector2i(200, 200))).toBe(false);
+            expect(r.isContaining(new Vector2i(0, 0))).toBe(false);
+            expect(r.isContaining(new Vector2i(200, 200))).toBe(false);
         });
     });
 
@@ -415,25 +415,25 @@ describe('Rect2i', () => {
         it('should return true for a point inside', () => {
             const r = new Rect2i(0, 0, 100, 100);
 
-            expect(r.containsXY(50, 50)).toBe(true);
+            expect(r.isContainingXY(50, 50)).toBe(true);
         });
 
         it('should return true for min edge (inclusive)', () => {
             const r = new Rect2i(10, 20, 100, 100);
 
-            expect(r.containsXY(10, 20)).toBe(true);
+            expect(r.isContainingXY(10, 20)).toBe(true);
         });
 
         it('should return false for max edge (exclusive)', () => {
             const r = new Rect2i(10, 20, 100, 100);
 
-            expect(r.containsXY(110, 120)).toBe(false);
+            expect(r.isContainingXY(110, 120)).toBe(false);
         });
 
         it('should return false for a point outside', () => {
             const r = new Rect2i(10, 20, 100, 100);
 
-            expect(r.containsXY(0, 0)).toBe(false);
+            expect(r.isContainingXY(0, 0)).toBe(false);
         });
     });
 

--- a/src/utils/Rect2i.test.ts
+++ b/src/utils/Rect2i.test.ts
@@ -501,12 +501,12 @@ describe('Rect2i', () => {
         });
     });
 
-    describe('intersectionTo', () => {
+    describe('intersectTo', () => {
         it('should write intersection to output rect and return true', () => {
             const a = new Rect2i(0, 0, 100, 100);
             const b = new Rect2i(50, 50, 100, 100);
             const out = new Rect2i();
-            const result = a.intersectionTo(b, out);
+            const result = a.intersectTo(b, out);
 
             expect(result).toBe(true);
             expect(out.x).toBe(50);
@@ -519,7 +519,7 @@ describe('Rect2i', () => {
             const a = new Rect2i(0, 0, 10, 10);
             const b = new Rect2i(20, 20, 10, 10);
             const out = new Rect2i(99, 99, 99, 99);
-            const result = a.intersectionTo(b, out);
+            const result = a.intersectTo(b, out);
 
             expect(result).toBe(false);
             expect(out.x).toBe(99);

--- a/src/utils/Rect2i.test.ts
+++ b/src/utils/Rect2i.test.ts
@@ -437,35 +437,35 @@ describe('Rect2i', () => {
         });
     });
 
-    describe('intersects', () => {
+    describe('isIntersecting', () => {
         it('should return true for overlapping rects', () => {
             const a = new Rect2i(0, 0, 100, 100);
             const b = new Rect2i(50, 50, 100, 100);
 
-            expect(a.intersects(b)).toBe(true);
-            expect(b.intersects(a)).toBe(true);
+            expect(a.isIntersecting(b)).toBe(true);
+            expect(b.isIntersecting(a)).toBe(true);
         });
 
         it('should return false for adjacent rects (no overlap)', () => {
             const a = new Rect2i(0, 0, 100, 100);
             const b = new Rect2i(100, 0, 100, 100);
 
-            expect(a.intersects(b)).toBe(false);
+            expect(a.isIntersecting(b)).toBe(false);
         });
 
         it('should return true when one rect is fully inside another', () => {
             const outer = new Rect2i(0, 0, 100, 100);
             const inner = new Rect2i(20, 20, 10, 10);
 
-            expect(outer.intersects(inner)).toBe(true);
-            expect(inner.intersects(outer)).toBe(true);
+            expect(outer.isIntersecting(inner)).toBe(true);
+            expect(inner.isIntersecting(outer)).toBe(true);
         });
 
         it('should return false for non-overlapping rects', () => {
             const a = new Rect2i(0, 0, 10, 10);
             const b = new Rect2i(50, 50, 10, 10);
 
-            expect(a.intersects(b)).toBe(false);
+            expect(a.isIntersecting(b)).toBe(false);
         });
     });
 

--- a/src/utils/Rect2i.test.ts
+++ b/src/utils/Rect2i.test.ts
@@ -574,21 +574,21 @@ describe('Rect2i', () => {
 
     // #region Utility
 
-    describe('equals', () => {
+    describe('isEqual', () => {
         it('should return true for identical rects', () => {
             const a = new Rect2i(10, 20, 30, 40);
             const b = new Rect2i(10, 20, 30, 40);
 
-            expect(a.equals(b)).toBe(true);
+            expect(a.isEqual(b)).toBe(true);
         });
 
         it('should return false when any component differs', () => {
             const base = new Rect2i(10, 20, 30, 40);
 
-            expect(base.equals(new Rect2i(99, 20, 30, 40))).toBe(false);
-            expect(base.equals(new Rect2i(10, 99, 30, 40))).toBe(false);
-            expect(base.equals(new Rect2i(10, 20, 99, 40))).toBe(false);
-            expect(base.equals(new Rect2i(10, 20, 30, 99))).toBe(false);
+            expect(base.isEqual(new Rect2i(99, 20, 30, 40))).toBe(false);
+            expect(base.isEqual(new Rect2i(10, 99, 30, 40))).toBe(false);
+            expect(base.isEqual(new Rect2i(10, 20, 99, 40))).toBe(false);
+            expect(base.isEqual(new Rect2i(10, 20, 30, 99))).toBe(false);
         });
     });
 

--- a/src/utils/Rect2i.ts
+++ b/src/utils/Rect2i.ts
@@ -399,7 +399,7 @@ export class Rect2i {
      * @param out - Rectangle to write the result to.
      * @returns True if intersection exists (out is valid), false otherwise (out unchanged).
      */
-    intersectionTo(other: Rect2i, out: Rect2i): boolean {
+    intersectTo(other: Rect2i, out: Rect2i): boolean {
         if (!this.isIntersecting(other)) {
             return false;
         }

--- a/src/utils/Rect2i.ts
+++ b/src/utils/Rect2i.ts
@@ -340,7 +340,7 @@ export class Rect2i {
      * @param point - Point to test.
      * @returns True if point is inside the rectangle.
      */
-    contains(point: Vector2i): boolean {
+    isContaining(point: Vector2i): boolean {
         return (
             point.x >= this.x && point.x < this.x + this.width && point.y >= this.y && point.y < this.y + this.height
         );
@@ -353,7 +353,7 @@ export class Rect2i {
      * @param py - Y coordinate to test.
      * @returns True if point is inside the rectangle.
      */
-    containsXY(px: number, py: number): boolean {
+    isContainingXY(px: number, py: number): boolean {
         return px >= this.x && px < this.x + this.width && py >= this.y && py < this.y + this.height;
     }
 

--- a/src/utils/Rect2i.ts
+++ b/src/utils/Rect2i.ts
@@ -347,6 +347,17 @@ export class Rect2i {
     }
 
     /**
+     * Backward-compatible alias for {@link isContaining}.
+     *
+     * @deprecated Deprecated since 2026-05-31. Use {@link isContaining} instead.
+     * @param point - Point to test.
+     * @returns True if point is inside the rectangle.
+     */
+    contains(point: Vector2i): boolean {
+        return this.isContaining(point);
+    }
+
+    /**
      * Tests raw coordinates against this rectangle without allocating a vector.
      *
      * @param px - X coordinate to test.
@@ -355,6 +366,18 @@ export class Rect2i {
      */
     isContainingXY(px: number, py: number): boolean {
         return px >= this.x && px < this.x + this.width && py >= this.y && py < this.y + this.height;
+    }
+
+    /**
+     * Backward-compatible alias for {@link isContainingXY}.
+     *
+     * @deprecated Deprecated since 2026-05-31. Use {@link isContainingXY} instead.
+     * @param px - X coordinate to test.
+     * @param py - Y coordinate to test.
+     * @returns True if point is inside the rectangle.
+     */
+    containsXY(px: number, py: number): boolean {
+        return this.isContainingXY(px, py);
     }
 
     /**
@@ -370,6 +393,17 @@ export class Rect2i {
             other.y >= this.y + this.height ||
             other.y + other.height <= this.y
         );
+    }
+
+    /**
+     * Backward-compatible alias for {@link isIntersecting}.
+     *
+     * @deprecated Deprecated since 2026-05-31. Use {@link isIntersecting} instead.
+     * @param other - Rectangle to test against.
+     * @returns True if rectangles overlap.
+     */
+    intersects(other: Rect2i): boolean {
+        return this.isIntersecting(other);
     }
 
     /**
@@ -413,6 +447,18 @@ export class Rect2i {
         out.height = Math.min(this.y + this.height, other.y + other.height) - y1;
 
         return true;
+    }
+
+    /**
+     * Backward-compatible alias for {@link intersectTo}.
+     *
+     * @deprecated Deprecated since 2026-05-31. Use {@link intersectTo} instead.
+     * @param other - Rectangle to intersect with.
+     * @param out - Rectangle to write the result to.
+     * @returns True if intersection exists (out is valid), false otherwise (out unchanged).
+     */
+    intersectionTo(other: Rect2i, out: Rect2i): boolean {
+        return this.intersectTo(other, out);
     }
 
     /**
@@ -480,6 +526,17 @@ export class Rect2i {
      */
     isEqual(other: Rect2i): boolean {
         return this.x === other.x && this.y === other.y && this.width === other.width && this.height === other.height;
+    }
+
+    /**
+     * Backward-compatible alias for {@link isEqual}.
+     *
+     * @deprecated Deprecated since 2026-05-31. Use {@link isEqual} instead.
+     * @param other - Rectangle to compare with.
+     * @returns True if position and size are identical.
+     */
+    equals(other: Rect2i): boolean {
+        return this.isEqual(other);
     }
 
     /**

--- a/src/utils/Rect2i.ts
+++ b/src/utils/Rect2i.ts
@@ -478,7 +478,7 @@ export class Rect2i {
      * @param other - Rectangle to compare with.
      * @returns True if position and size are identical.
      */
-    equals(other: Rect2i): boolean {
+    isEqual(other: Rect2i): boolean {
         return this.x === other.x && this.y === other.y && this.width === other.width && this.height === other.height;
     }
 

--- a/src/utils/Rect2i.ts
+++ b/src/utils/Rect2i.ts
@@ -363,7 +363,7 @@ export class Rect2i {
      * @param other - Rectangle to test against.
      * @returns True if rectangles overlap.
      */
-    intersects(other: Rect2i): boolean {
+    isIntersecting(other: Rect2i): boolean {
         return !(
             other.x >= this.x + this.width ||
             other.x + other.width <= this.x ||
@@ -379,7 +379,7 @@ export class Rect2i {
      * @returns New rectangle representing the overlap, or null if no overlap.
      */
     intersection(other: Rect2i): Rect2i | null {
-        if (!this.intersects(other)) {
+        if (!this.isIntersecting(other)) {
             return null;
         }
 
@@ -400,7 +400,7 @@ export class Rect2i {
      * @returns True if intersection exists (out is valid), false otherwise (out unchanged).
      */
     intersectionTo(other: Rect2i, out: Rect2i): boolean {
-        if (!this.intersects(other)) {
+        if (!this.isIntersecting(other)) {
             return false;
         }
 
@@ -422,8 +422,8 @@ export class Rect2i {
      *
      * Note: Creates a new Vector2i. Use intersectionDepthTo() in hot paths.
      *
-     * Assumes this rectangle already intersects {@link other}. Call
-     * {@link intersects} first; if they don't overlap, the returned depths
+     * Assumes this rectangle already isIntersecting {@link other}. Call
+     * {@link isIntersecting} first; if they don't overlap, the returned depths
      * may be zero or negative and aren't meaningful for resolution.
      *
      * @param other - Rectangle to measure overlap with.
@@ -447,8 +447,8 @@ export class Rect2i {
      * Calculates intersection depth and writes to an existing vector.
      * Zero allocation alternative to intersectionDepth().
      *
-     * Assumes this rectangle already intersects {@link other}. Call
-     * {@link intersects} first; if they don't overlap, the returned depths
+     * Assumes this rectangle already isIntersecting {@link other}. Call
+     * {@link isIntersecting} first; if they don't overlap, the returned depths
      * may be zero or negative and aren't meaningful for resolution.
      *
      * @param other - Rectangle to measure overlap with.

--- a/src/utils/RenderLimits.test.ts
+++ b/src/utils/RenderLimits.test.ts
@@ -6,8 +6,8 @@ import {
     type RenderDimensionField,
     RenderDimensionLimitError,
     type RenderDimensionSettings,
-    validateRenderDimension,
-    validateRenderDimensions,
+    validateDimension,
+    validateDimensions,
     validateWebGPUTextureDimension,
 } from './RenderLimits';
 import { Vector2i } from './Vector2i';
@@ -44,7 +44,7 @@ function makeSettings(field: RenderDimensionField, size: Vector2i): RenderDimens
 // #endregion
 
 describe('RenderLimits', () => {
-    describe('validateRenderDimensions', () => {
+    describe('validateDimensions', () => {
         const fields: RenderDimensionField[] = ['displaySize', 'drawingBufferSize', 'maxCanvasSize'];
         const cases: Array<{ name: string; size: Vector2i }> = [
             { name: 'zero', size: rawSize(0, 240) },
@@ -60,7 +60,7 @@ describe('RenderLimits', () => {
         for (const field of fields) {
             for (const testCase of cases) {
                 it(`rejects ${testCase.name} ${field}`, () => {
-                    const error = validateRenderDimensions(makeSettings(field, testCase.size));
+                    const error = validateDimensions(makeSettings(field, testCase.size));
 
                     expect(error).toContain(field);
                 });
@@ -69,7 +69,7 @@ describe('RenderLimits', () => {
 
         it('accepts the default render dimensions', () => {
             expect(
-                validateRenderDimensions({
+                validateDimensions({
                     displaySize: new Vector2i(320, 240),
                     drawingBufferSize: new Vector2i(640, 480),
                     maxCanvasSize: new Vector2i(960, 720),
@@ -79,14 +79,14 @@ describe('RenderLimits', () => {
 
         it('accepts omitted optional canvas dimensions', () => {
             expect(
-                validateRenderDimensions({
+                validateDimensions({
                     displaySize: new Vector2i(320, 240),
                 }),
             ).toBeNull();
         });
 
         it('rejects total area separately from per-axis limits', () => {
-            const error = validateRenderDimensions({
+            const error = validateDimensions({
                 displaySize: rawSize(4096, 4097),
             });
 
@@ -94,7 +94,7 @@ describe('RenderLimits', () => {
         });
 
         it('rejects 8192x8192 when per-axis limits pass but total area exceeds cap', () => {
-            const error = validateRenderDimensions({
+            const error = validateDimensions({
                 displaySize: rawSize(MAX_RENDER_DIMENSION, MAX_RENDER_DIMENSION),
             });
 
@@ -104,7 +104,7 @@ describe('RenderLimits', () => {
 
         it('accepts dimensions at the per-axis maximum with area within cap', () => {
             expect(
-                validateRenderDimensions({
+                validateDimensions({
                     displaySize: rawSize(MAX_RENDER_DIMENSION, 2048),
                 }),
             ).toBeNull();
@@ -112,7 +112,7 @@ describe('RenderLimits', () => {
 
         it('accepts dimensions at the total pixel area maximum', () => {
             expect(
-                validateRenderDimensions({
+                validateDimensions({
                     displaySize: rawSize(4096, 4096),
                 }),
             ).toBeNull();
@@ -120,20 +120,20 @@ describe('RenderLimits', () => {
 
         it('accepts dimensions at the per-axis maximum on a single axis', () => {
             expect(
-                validateRenderDimensions({
+                validateDimensions({
                     displaySize: rawSize(MAX_RENDER_DIMENSION, 1),
                 }),
             ).toBeNull();
         });
     });
 
-    describe('validateRenderDimension', () => {
+    describe('validateDimension', () => {
         it('returns null for a valid size at engine limits', () => {
-            expect(validateRenderDimension('displaySize', new Vector2i(4096, 4096))).toBeNull();
+            expect(validateDimension('displaySize', new Vector2i(4096, 4096))).toBeNull();
         });
 
         it('returns a field-specific message for invalid sizes', () => {
-            const error = validateRenderDimension('drawingBufferSize', rawSize(0, 480));
+            const error = validateDimension('drawingBufferSize', rawSize(0, 480));
 
             expect(error).toContain('drawingBufferSize');
         });

--- a/src/utils/RenderLimits.ts
+++ b/src/utils/RenderLimits.ts
@@ -80,7 +80,7 @@ function formatSize(size: Vector2i | undefined | null): string {
  * @param size - Size value to validate.
  * @returns A user-facing error message when invalid, otherwise `null`.
  */
-export function validateRenderDimension(field: RenderDimensionField, size: Vector2i | undefined | null): string | null {
+export function validateDimension(field: RenderDimensionField, size: Vector2i | undefined | null): string | null {
     const x = size?.x;
     const y = size?.y;
 
@@ -119,21 +119,21 @@ export function validateRenderDimension(field: RenderDimensionField, size: Vecto
  * @param settings - Hardware settings returned by `configure()` or defaults.
  * @returns A user-facing error message when invalid, otherwise `null`.
  */
-export function validateRenderDimensions(settings: RenderDimensionSettings): string | null {
-    const logicalError = validateRenderDimension('displaySize', settings.displaySize);
+export function validateDimensions(settings: RenderDimensionSettings): string | null {
+    const logicalError = validateDimension('displaySize', settings.displaySize);
     if (logicalError) {
         return logicalError;
     }
 
     if (settings.drawingBufferSize !== undefined) {
-        const maxCanvasError = validateRenderDimension('drawingBufferSize', settings.drawingBufferSize);
+        const maxCanvasError = validateDimension('drawingBufferSize', settings.drawingBufferSize);
         if (maxCanvasError) {
             return maxCanvasError;
         }
     }
 
     if (settings.maxCanvasSize !== undefined) {
-        const maxCanvasError = validateRenderDimension('maxCanvasSize', settings.maxCanvasSize);
+        const maxCanvasError = validateDimension('maxCanvasSize', settings.maxCanvasSize);
         if (maxCanvasError) {
             return maxCanvasError;
         }

--- a/src/utils/Timer.test.ts
+++ b/src/utils/Timer.test.ts
@@ -25,23 +25,23 @@ describe('Timer', () => {
         });
     });
 
-    describe('tick', () => {
+    describe('shouldFire', () => {
         it('returns false before interval, true at interval, then resets baseline', () => {
             vi.spyOn(BTAPI.instance, 'getTicks').mockReturnValue(0);
             const timer = new Timer(5);
 
-            expect(timer.tick(4)).toBe(false);
-            expect(timer.tick(5)).toBe(true);
-            expect(timer.tick(9)).toBe(false);
-            expect(timer.tick(10)).toBe(true);
+            expect(timer.shouldFire(4)).toBe(false);
+            expect(timer.shouldFire(5)).toBe(true);
+            expect(timer.shouldFire(9)).toBe(false);
+            expect(timer.shouldFire(10)).toBe(true);
         });
 
         it('fires once per call when large gaps pass', () => {
             vi.spyOn(BTAPI.instance, 'getTicks').mockReturnValue(0);
             const timer = new Timer(5);
 
-            expect(timer.tick(20)).toBe(true);
-            expect(timer.tick(20)).toBe(false);
+            expect(timer.shouldFire(20)).toBe(true);
+            expect(timer.shouldFire(20)).toBe(false);
             expect(timer.elapsedTicks(23)).toBe(3);
         });
 
@@ -51,20 +51,20 @@ describe('Timer', () => {
             const timer = new Timer(3);
 
             spy.mockReturnValue(2);
-            expect(timer.tick()).toBe(false);
+            expect(timer.shouldFire()).toBe(false);
 
             spy.mockReturnValue(3);
-            expect(timer.tick()).toBe(true);
+            expect(timer.shouldFire()).toBe(true);
         });
 
         it('does not lock when current tick rewinds shallowly', () => {
             vi.spyOn(BTAPI.instance, 'getTicks').mockReturnValue(0);
             const timer = new Timer(5);
 
-            expect(timer.tick(5)).toBe(true);
+            expect(timer.shouldFire(5)).toBe(true);
             expect(timer.elapsedTicks(3)).toBe(0);
             expect(timer.remainingTicks(3)).toBe(5);
-            expect(timer.tick(10)).toBe(true);
+            expect(timer.shouldFire(10)).toBe(true);
         });
 
         it('resets baseline and does not lock after a hard tick rewind', () => {
@@ -72,14 +72,14 @@ describe('Timer', () => {
             const timer = new Timer(5);
 
             // Advance well past the interval so lastFiredTick is 1000.
-            expect(timer.tick(1000)).toBe(true);
+            expect(timer.shouldFire(1000)).toBe(true);
 
             // Hard rewind to 0 - without the guard the timer would lock until tick 1005.
-            expect(timer.tick(0)).toBe(false); // rewind detected, baseline reset to 0
+            expect(timer.shouldFire(0)).toBe(false); // rewind detected, baseline reset to 0
 
             // Should now fire exactly intervalTicks later.
-            expect(timer.tick(4)).toBe(false);
-            expect(timer.tick(5)).toBe(true);
+            expect(timer.shouldFire(4)).toBe(false);
+            expect(timer.shouldFire(5)).toBe(true);
         });
     });
 

--- a/src/utils/Timer.test.ts
+++ b/src/utils/Timer.test.ts
@@ -25,23 +25,23 @@ describe('Timer', () => {
         });
     });
 
-    describe('shouldFire', () => {
+    describe('fireIfElapsed', () => {
         it('returns false before interval, true at interval, then resets baseline', () => {
             vi.spyOn(BTAPI.instance, 'getTicks').mockReturnValue(0);
             const timer = new Timer(5);
 
-            expect(timer.shouldFire(4)).toBe(false);
-            expect(timer.shouldFire(5)).toBe(true);
-            expect(timer.shouldFire(9)).toBe(false);
-            expect(timer.shouldFire(10)).toBe(true);
+            expect(timer.fireIfElapsed(4)).toBe(false);
+            expect(timer.fireIfElapsed(5)).toBe(true);
+            expect(timer.fireIfElapsed(9)).toBe(false);
+            expect(timer.fireIfElapsed(10)).toBe(true);
         });
 
         it('fires once per call when large gaps pass', () => {
             vi.spyOn(BTAPI.instance, 'getTicks').mockReturnValue(0);
             const timer = new Timer(5);
 
-            expect(timer.shouldFire(20)).toBe(true);
-            expect(timer.shouldFire(20)).toBe(false);
+            expect(timer.fireIfElapsed(20)).toBe(true);
+            expect(timer.fireIfElapsed(20)).toBe(false);
             expect(timer.elapsedTicks(23)).toBe(3);
         });
 
@@ -51,20 +51,20 @@ describe('Timer', () => {
             const timer = new Timer(3);
 
             spy.mockReturnValue(2);
-            expect(timer.shouldFire()).toBe(false);
+            expect(timer.fireIfElapsed()).toBe(false);
 
             spy.mockReturnValue(3);
-            expect(timer.shouldFire()).toBe(true);
+            expect(timer.fireIfElapsed()).toBe(true);
         });
 
         it('does not lock when current tick rewinds shallowly', () => {
             vi.spyOn(BTAPI.instance, 'getTicks').mockReturnValue(0);
             const timer = new Timer(5);
 
-            expect(timer.shouldFire(5)).toBe(true);
+            expect(timer.fireIfElapsed(5)).toBe(true);
             expect(timer.elapsedTicks(3)).toBe(0);
             expect(timer.remainingTicks(3)).toBe(5);
-            expect(timer.shouldFire(10)).toBe(true);
+            expect(timer.fireIfElapsed(10)).toBe(true);
         });
 
         it('resets baseline and does not lock after a hard tick rewind', () => {
@@ -72,14 +72,14 @@ describe('Timer', () => {
             const timer = new Timer(5);
 
             // Advance well past the interval so lastFiredTick is 1000.
-            expect(timer.shouldFire(1000)).toBe(true);
+            expect(timer.fireIfElapsed(1000)).toBe(true);
 
             // Hard rewind to 0 - without the guard the timer would lock until tick 1005.
-            expect(timer.shouldFire(0)).toBe(false); // rewind detected, baseline reset to 0
+            expect(timer.fireIfElapsed(0)).toBe(false); // rewind detected, baseline reset to 0
 
             // Should now fire exactly intervalTicks later.
-            expect(timer.shouldFire(4)).toBe(false);
-            expect(timer.shouldFire(5)).toBe(true);
+            expect(timer.fireIfElapsed(4)).toBe(false);
+            expect(timer.fireIfElapsed(5)).toBe(true);
         });
     });
 

--- a/src/utils/Timer.ts
+++ b/src/utils/Timer.ts
@@ -37,7 +37,7 @@ export class Timer {
      * @param currentTick - Tick to evaluate against; defaults to engine tick counter.
      * @returns True when at least `intervalTicks` have elapsed since the last fire/reset.
      */
-    public tick(currentTick: number = BTAPI.instance.getTicks()): boolean {
+    public shouldFire(currentTick: number = BTAPI.instance.getTicks()): boolean {
         if (currentTick < this.lastFiredTick) {
             this.lastFiredTick = currentTick;
             return false;

--- a/src/utils/Timer.ts
+++ b/src/utils/Timer.ts
@@ -52,6 +52,17 @@ export class Timer {
     }
 
     /**
+     * Backward-compatible alias for {@link fireIfElapsed}.
+     *
+     * @deprecated Deprecated since 2026-05-31. Use {@link fireIfElapsed} instead.
+     * @param currentTick - Tick to evaluate against; defaults to engine tick counter.
+     * @returns True when at least `intervalTicks` have elapsed since the last fire/reset.
+     */
+    public tick(currentTick: number = BTAPI.instance.getTicks()): boolean {
+        return this.fireIfElapsed(currentTick);
+    }
+
+    /**
      * Resets the timer baseline to a tick value.
      *
      * @param currentTick - Tick to reset against; defaults to engine tick counter.

--- a/src/utils/Timer.ts
+++ b/src/utils/Timer.ts
@@ -37,7 +37,7 @@ export class Timer {
      * @param currentTick - Tick to evaluate against; defaults to engine tick counter.
      * @returns True when at least `intervalTicks` have elapsed since the last fire/reset.
      */
-    public shouldFire(currentTick: number = BTAPI.instance.getTicks()): boolean {
+    public fireIfElapsed(currentTick: number = BTAPI.instance.getTicks()): boolean {
         if (currentTick < this.lastFiredTick) {
             this.lastFiredTick = currentTick;
             return false;

--- a/src/utils/Vector2i.bench.ts
+++ b/src/utils/Vector2i.bench.ts
@@ -289,17 +289,17 @@ describe('Vector2i comparison benchmarks', () => {
     const zero = new Vector2i();
 
     bench(
-        'equals()',
+        'isEqual()',
         () => {
-            left.equals(equal);
+            left.isEqual(equal);
         },
         BENCH_OPTIONS,
     );
 
     bench(
-        'equalsXY()',
+        'isEqualXY()',
         () => {
-            left.equalsXY(BASE_X, BASE_Y);
+            left.isEqualXY(BASE_X, BASE_Y);
         },
         BENCH_OPTIONS,
     );

--- a/src/utils/Vector2i.test.ts
+++ b/src/utils/Vector2i.test.ts
@@ -1542,59 +1542,59 @@ describe('Vector2i', () => {
     // #region Comparison
 
     describe('Comparison', () => {
-        describe('equals', () => {
+        describe('isEqual', () => {
             it('should return true for equal vectors', () => {
                 const a = new Vector2i(3, 5);
                 const b = new Vector2i(3, 5);
 
-                expect(a.equals(b)).toBe(true);
+                expect(a.isEqual(b)).toBe(true);
             });
 
             it('should return false for different x', () => {
                 const a = new Vector2i(3, 5);
                 const b = new Vector2i(4, 5);
 
-                expect(a.equals(b)).toBe(false);
+                expect(a.isEqual(b)).toBe(false);
             });
 
             it('should return false for different y', () => {
                 const a = new Vector2i(3, 5);
                 const b = new Vector2i(3, 6);
 
-                expect(a.equals(b)).toBe(false);
+                expect(a.isEqual(b)).toBe(false);
             });
 
             it('should return true for two zero vectors', () => {
                 const a = new Vector2i(0, 0);
                 const b = new Vector2i(0, 0);
 
-                expect(a.equals(b)).toBe(true);
+                expect(a.isEqual(b)).toBe(true);
             });
         });
 
-        describe('equalsXY', () => {
+        describe('isEqualXY', () => {
             it('should return true for matching coordinates', () => {
                 const v = new Vector2i(3, 5);
 
-                expect(v.equalsXY(3, 5)).toBe(true);
+                expect(v.isEqualXY(3, 5)).toBe(true);
             });
 
             it('should return false for non-matching coordinates', () => {
                 const v = new Vector2i(3, 5);
 
-                expect(v.equalsXY(4, 5)).toBe(false);
+                expect(v.isEqualXY(4, 5)).toBe(false);
             });
 
             it('should truncate float arguments before comparing', () => {
                 const v = new Vector2i(3, 5);
 
-                expect(v.equalsXY(3.9, 5.1)).toBe(true);
+                expect(v.isEqualXY(3.9, 5.1)).toBe(true);
             });
 
             it('should handle negative truncation correctly', () => {
                 const v = new Vector2i(-2, -5);
 
-                expect(v.equalsXY(-2.3, -5.8)).toBe(true);
+                expect(v.isEqualXY(-2.3, -5.8)).toBe(true);
             });
         });
 

--- a/src/utils/Vector2i.ts
+++ b/src/utils/Vector2i.ts
@@ -1034,6 +1034,17 @@ export class Vector2i {
     }
 
     /**
+     * Backward-compatible alias for {@link isEqual}.
+     *
+     * @deprecated Deprecated since 2026-05-31. Use {@link isEqual} instead.
+     * @param other - Vector to compare with.
+     * @returns True if both x and y components are equal.
+     */
+    equals(other: Vector2i): boolean {
+        return this.isEqual(other);
+    }
+
+    /**
      * Checks if this vector equals raw coordinates.
      * Avoids creating a temporary Vector2i for comparison.
      *

--- a/src/utils/Vector2i.ts
+++ b/src/utils/Vector2i.ts
@@ -1029,7 +1029,7 @@ export class Vector2i {
      * @param other - Vector to compare with.
      * @returns True if both x and y components are equal.
      */
-    equals(other: Vector2i): boolean {
+    isEqual(other: Vector2i): boolean {
         return this.x === other.x && this.y === other.y;
     }
 
@@ -1041,7 +1041,7 @@ export class Vector2i {
      * @param y - Y coordinate to compare.
      * @returns True if components match the given coordinates.
      */
-    equalsXY(x: number, y: number): boolean {
+    isEqualXY(x: number, y: number): boolean {
         return this.x === (x | 0) && this.y === (y | 0);
     }
 

--- a/src/utils/errorMessages.ts
+++ b/src/utils/errorMessages.ts
@@ -10,11 +10,11 @@
 /**
  * Returns the canvas-not-found error message for the given canvas element ID.
  *
- * @param canvasId - The canvas element ID that was searched for.
+ * @param canvasID - The canvas element ID that was searched for.
  * @returns User-facing error string.
  */
-export function CANVAS_NOT_FOUND_MESSAGE(canvasId: string): string {
-    return `Can't find the canvas on the page. Make sure your HTML has a <canvas id='${canvasId}'> element.`;
+export function CANVAS_NOT_FOUND_MESSAGE(canvasID: string): string {
+    return `Can't find the canvas on the page. Make sure your HTML has a <canvas id='${canvasID}'> element.`;
 }
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
Large API cleanup and renaming pass across core utilities, input facades, overlay/palette subsystems, renderer internals, documentation, and tests. Primary goals: normalize boolean/query/config flag naming to is*/has* forms, standardize predicate/comparison method names (isEqual/isContaining/isIntersecting/etc.), and introduce backward-compatible deprecated aliases where appropriate. Many tests, docs, and internal helpers were updated to match the new names.

## Changes

### Core utilities & timing
- Timer.tick → Timer.fireIfElapsed; tick() retained as deprecated alias. Tests updated.
- Predicate/comparison APIs renamed to is* forms:
  - Vector2i.equals / equalsXY → isEqual / isEqualXY (equals retained as deprecated alias)
  - Rect2i.contains / containsXY / intersects / intersectionTo / equals → isContaining / isContainingXY / isIntersecting / intersectTo / isEqual (deprecated aliases retained)
  - Color32.equals → isEqual (equals retained as deprecated alias)

### Palette & palette effects
- Palette internals and API:
  - _dirty → _isDirty, getter dirty → isDirty; mutation and reset paths updated.
  - Palette size/constants: VALID_PALETTE_SIZES → VALID_SIZES, GPU_PALETTE_SIZE → GPU_SIZE.
  - Palette JSON type: PaletteJSON → Serialized; toJSON/fromJSON updated.
- PaletteEffect constructors parameter names simplified (source/target). Tests updated to use isEqual/isDirty.

### Input facade (BT) and input subsystems
- BT facade renamed to is* forms:
  - BT.isPointerActive, BT.isDown, BT.isPressed, BT.isReleased, BT.isGamepadConnected, BT.isKeyDown, BT.isKeyPressed, BT.isKeyReleased. Legacy names kept as deprecated aliases.
- PointerInput: slot valid → isActive, public PointerInput.isValid → isActive; internal renames (idToSlot, Slot type), listener/handler renames; tests updated.
- GamepadInput: per-player connected → isConnected; poll/read refactors, queries use isConnected; tests updated.
- KeyboardInput: method refactors and naming aligned to isKeyPressed and local variable renames.

### Overlay, toggle, timing chart, palette view/interaction
- Overlay API and constructor/config flags renamed:
  - Overlay.bodyVisible → isBodyVisible
  - Overlay.tracksPaletteUsage → isTrackingPaletteUsage
  - Constructor/config flags: isOverlayPaletteEnabled, isOverlayTimingChartEnabled, isOverlayRendererDiagnosticsBarEnabled, isOverlayVisibleAtStart, isOverlayToggleHintVisible, isOverlayToggleEnabled
- Toggle: bodyVisible → isBodyVisible; constructor params renamed; handleInput added, handleToggle retained as deprecated alias; pointer flag param renamed to isPointerPressConsumed.
- TimingChart: enabled → isEnabled (getter + constructor param); internal startTick rename.
- PaletteView and PaletteInteraction: enabled → isEnabled; palette-grid/scroll/hint helpers generalized and renamed (computeGrid, writeSwatchTopLeft, writeScrollbarRects, resolveHintExclusionRect, hitTestSwatch, drawTooltipChrome/Label, writeIndexToClipboard, isPointerInScrollbarTrack). Deprecated palette-specific aliases retained. Pointer gating switched to pointer.isActive. Tests updated.

### Renderer & render helpers
- WebGpuRenderer internal flags and variables renamed to is*-prefixed forms (isPaletteDirty, isDisplayTierEnabled, isCapturing); palette flush now uploads when (isPaletteDirty || palette.isDirty); encode/submit variables renamed to isPixelChainActive/isDisplayChainActive; capture uses frameCapture.request().
- Shader/constant renames across effects and passes: FULLSCREEN_VS_WGSL → VS_WGSL, many fragment constants consolidated to FRAGMENT_WGSL/FRAGMENT_UINT_WGSL/UNSUPPORTED_WGSL; MAX_SPRITE_VERTICES → MAX_VERTICES; shader composition adjusted but behavior preserved.

### Assets & sprite sheet
- SpriteSheet.isIndexized → isIndexed (deprecated alias retained); indexed-pixel paths, markIndexUsed usage, and dimension assertions updated. Tests updated.

### Frame capture, bootstrap & misc utilities
- FrameCapture API renamed:
  - hasPendingCapture/requestCapture/executeCaptureInEncoder/resolveCapture → hasPending/request/executeInEncoder/resolve; internal fields renamed accordingly. Tests updated.
- Bootstrap options renamed:
  - canvasId/containerId → canvasID/containerID
  - waitForDOMReady → isWaitingForDOMReady
  - Deprecated aliases kept; helpers and error messages updated.
- Dimension/asset validation helpers renamed and consolidated:
  - validateAssetDimensions/validateRenderDimensions → validateDimensions (and validateDimension); formatAssetSize → formatSize; assertAssetDimensions → assertDimensions; deprecated aliases retained.
- RenderPaletteUsage helpers renamed:
  - resetRenderPaletteUsage/markRenderPaletteIndexUsed/collectUsedRenderPaletteIndices → resetUsage/markIndexUsed/collectUsedIndices with deprecated aliases preserved.

### Tests, docs & conventions
- Dozens of tests updated across the codebase to use the new API names (input, overlay, palette, renderer, utils, benches).
- Documentation and guides updated: docs/*, README.md, CLAUDE.md, developer-experience-guide, new docs/deprecations.md (deprecation timeline). Internal linting/rules updated (.claude/.cursor) to codify boolean naming and internal-scoped naming conventions.
- New docs entry: "Internal FrameCapture flow reference" and deprecation timeline with guidance for pruning aliases.

## Public/API surface impact
- New or renamed public members (non-exhaustive):
  - Timer.fireIfElapsed
  - Palette.isDirty, Palette.Serialized JSON type
  - Color32.isEqual
  - Vector2i.isEqual / isEqualXY
  - Rect2i.isContaining / isContainingXY / isIntersecting / intersectTo / isEqual
  - SpriteSheet.isIndexed (with deprecated isIndexized alias)
  - BT.* is* methods (isPointerActive, isDown, isPressed, isReleased, isGamepadConnected, isKeyDown, isKeyPressed, isKeyReleased)
  - PointerInput.isActive
  - Overlay.isBodyVisible → isBodyVisible, Overlay constructor option renames to isOverlay*
  - Toggle.isBodyVisible, Toggle.handleInput
  - TimingChart.isEnabled
  - PaletteView.isEnabled and many exported grid/scroll/hint helpers (computeGrid, computeScrollbarThumbHeight, writeScrollbarRects, writeSwatchTopLeft, resolveHintExclusionRect, hitTestSwatch, drawTooltipChrome/Label, writeIndexToClipboard)
  - RenderPaletteUsage: USAGE_CAPACITY, resetUsage, markIndexUsed, collectUsedIndices (deprecated aliases kept)
  - FrameCapture: hasPending, request, executeInEncoder, resolve
  - BootstrapOptions: canvasID, containerID, isWaitingForDOMReady (deprecated aliases retained)
  - WebGPUContext exported Result type (was WebGPUContextResult)
  - RenderLimits/AssetLimits helpers renamed to validateDimension(s)/formatSize/assertDimensions and deprecated aliases kept
- Widespread deprecated aliases were added to preserve backward compatibility; consumers should migrate to the new names.

## Risk & review notes
- High surface-area refactor: many public and internal identifiers renamed across subsystems. Review focus:
  - Correctness of deprecated aliases (they must forward reliably).
  - Preservation of behavioral semantics in edge cases (Timer baseline/rewind behavior, input repeat/edge semantics, palette dirty propagation and GPU upload gating, frame-capture lifecycle and promise supersession, pointer-slot reuse/resync behavior).
  - Documentation and examples aligned with new names (Bootstrap, README, docs/*).
  - Tests updated consistently; verify no remaining references to removed names in public/consumer-facing docs or examples.
- Estimated review effort: Medium–High depending on depth; pay particular attention to input, overlay/palette, and frame-capture areas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->