### PR TITLE
chore(tests): refactor visual test specs

### DIFF
--- a/tests/visual/camera.spec.ts
+++ b/tests/visual/camera.spec.ts
@@ -1,3 +1,5 @@
+// noinspection DuplicatedCode
+
 import { expect, test } from './coverage-fixture';
 
 const GPU_PRESENT_DELAY = Number(process.env.GPU_PRESENT_DELAY ?? 100);

--- a/tests/visual/coverage-fixture.ts
+++ b/tests/visual/coverage-fixture.ts
@@ -1,3 +1,5 @@
+// noinspection DuplicatedCode
+
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';

--- a/tests/visual/fixtures/camera.html
+++ b/tests/visual/fixtures/camera.html
@@ -55,7 +55,7 @@
                     palette.set(colorBlue, Color32.blue);
                     palette.set(colorYellow, Color32.yellow);
                     palette.set(colorCyan, Color32.cyan);
-                    palette.set(8, Color32.white);
+                    palette.set(colorWhite, Color32.white);
 
                     BT.paletteSet(palette);
 

--- a/tests/visual/fixtures/camera.html
+++ b/tests/visual/fixtures/camera.html
@@ -1,98 +1,107 @@
+<!--suppress MagicNumberJS -->
+
 <!doctype html>
+
 <html lang="en">
-
-<head>
-    <meta charset="UTF-8" />
-    <title>Visual Test: Camera</title>
-    <style>
-        body { margin: 0; background: #000; }
-        canvas { image-rendering: pixelated; }
-    </style>
-</head>
-
-<body>
-    <div id="canvas-container">
-        <canvas height="240" id="blit-tech-canvas" width="320"></canvas>
-    </div>
-
-    <script type="module">
-        import { bootstrap, BT, Color32, Palette, Rect2i, Vector2i } from 'blit-tech';
-
-        window.__RENDER_COMPLETE__ = false;
-        window.__INIT_FAILED__ = false;
-
-        // Palette indices for this test.
-        const BLACK = 1;
-        const RED = 2;
-        const GREEN = 3;
-        const BLUE = 4;
-        const YELLOW = 5;
-        const CYAN = 6;
-        const WHITE = 8;
-
-        class CameraTest {
-            configure() {
-                return {
-                    displaySize: new Vector2i(320, 240),
-                    targetFPS: 60,
-                };
+    <head>
+        <meta charset="UTF-8" />
+        <title>Visual Test: Camera</title>
+        <style>
+            body {
+                margin: 0;
+                background: #000;
             }
 
-            async init() {
-                const palette = new Palette(16);
-                palette.set(BLACK, Color32.black);
-                palette.set(RED, Color32.red);
-                palette.set(GREEN, Color32.green);
-                palette.set(BLUE, Color32.blue);
-                palette.set(YELLOW, Color32.yellow);
-                palette.set(CYAN, Color32.cyan);
-                palette.set(8, Color32.white);
-                BT.paletteSet(palette);
+            canvas {
+                image-rendering: pixelated;
+            }
+        </style>
+    </head>
 
-                return true;
+    <body>
+        <div id="canvas-container">
+            <canvas height="240" id="blit-tech-canvas" width="320"></canvas>
+        </div>
+
+        <script type="module">
+            import { bootstrap, BT, Color32, Palette, Rect2i, Vector2i } from 'blit-tech';
+
+            window.__RENDER_COMPLETE__ = false;
+            window.__INIT_FAILED__ = false;
+
+            // Palette indices for this test.
+            const colorBlack = 1;
+            const colorRed = 2;
+            const colorGreen = 3;
+            const colorBlue = 4;
+            const colorYellow = 5;
+            const colorCyan = 6;
+            const colorWhite = 8;
+
+            class CameraTest {
+                configure() {
+                    return {
+                        displaySize: new Vector2i(320, 240),
+                        targetFPS: 60,
+                    };
+                }
+
+                async init() {
+                    const palette = new Palette(16);
+
+                    palette.set(colorBlack, Color32.black);
+                    palette.set(colorRed, Color32.red);
+                    palette.set(colorGreen, Color32.green);
+                    palette.set(colorBlue, Color32.blue);
+                    palette.set(colorYellow, Color32.yellow);
+                    palette.set(colorCyan, Color32.cyan);
+                    palette.set(8, Color32.white);
+
+                    BT.paletteSet(palette);
+
+                    return true;
+                }
+
+                update() {}
+
+                render() {
+                    BT.clear(colorBlack);
+
+                    // Apply camera offset: shift everything left by 50px and up by 30px.
+                    BT.cameraSet(new Vector2i(50, 30));
+
+                    // Draw a grid of colored rectangles at known world positions.
+                    // With camera (50, 30), a rect at world (60, 40) appears at screen (10, 10).
+                    BT.drawRectFill(new Rect2i(60, 40, 20, 20), colorRed);
+
+                    // World (110, 40) -> screen (60, 10).
+                    BT.drawRectFill(new Rect2i(110, 40, 20, 20), colorGreen);
+
+                    // World (60, 90) -> screen (10, 60).
+                    BT.drawRectFill(new Rect2i(60, 90, 20, 20), colorBlue);
+
+                    // World (110, 90) -> screen (60, 60).
+                    BT.drawRectFill(new Rect2i(110, 90, 20, 20), colorYellow);
+
+                    // Draw a line crossing the viewport.
+                    // World (50, 30) -> screen (0, 0) to world (370, 270) -> screen (320, 240).
+                    BT.drawLine(new Vector2i(50, 30), new Vector2i(370, 270), colorWhite);
+
+                    // Draw a rect outline at the edge of the viewport.
+                    BT.drawRect(new Rect2i(55, 35, 260, 200), colorCyan);
+
+                    // Reset camera after drawing.
+                    BT.cameraReset();
+
+                    window.__RENDER_COMPLETE__ = true;
+                }
             }
 
-            update() {}
-
-            render() {
-                BT.clear(BLACK);
-
-                // Apply camera offset: shift everything left by 50px and up by 30px.
-                BT.cameraSet(new Vector2i(50, 30));
-
-                // Draw a grid of colored rectangles at known world positions.
-                // With camera (50, 30), a rect at world (60, 40) appears at screen (10, 10).
-                BT.drawRectFill(new Rect2i(60, 40, 20, 20), RED);
-
-                // World (110, 40) -> screen (60, 10).
-                BT.drawRectFill(new Rect2i(110, 40, 20, 20), GREEN);
-
-                // World (60, 90) -> screen (10, 60).
-                BT.drawRectFill(new Rect2i(60, 90, 20, 20), BLUE);
-
-                // World (110, 90) -> screen (60, 60).
-                BT.drawRectFill(new Rect2i(110, 90, 20, 20), YELLOW);
-
-                // Draw a line crossing the viewport.
-                // World (50, 30) -> screen (0, 0) to world (370, 270) -> screen (320, 240).
-                BT.drawLine(new Vector2i(50, 30), new Vector2i(370, 270), WHITE);
-
-                // Draw a rect outline at the edge of the viewport.
-                BT.drawRect(new Rect2i(55, 35, 260, 200), CYAN);
-
-                // Reset camera after drawing.
-                BT.cameraReset();
-
-                window.__RENDER_COMPLETE__ = true;
-            }
-        }
-
-        bootstrap(CameraTest, {
-            onError: () => {
-                window.__INIT_FAILED__ = true;
-            },
-        });
-    </script>
-</body>
-
+            bootstrap(CameraTest, {
+                onError: () => {
+                    window.__INIT_FAILED__ = true;
+                },
+            });
+        </script>
+    </body>
 </html>

--- a/tests/visual/fixtures/fonts.html
+++ b/tests/visual/fixtures/fonts.html
@@ -1,80 +1,89 @@
+<!--suppress MagicNumberJS -->
+
 <!doctype html>
+
 <html lang="en">
-
-<head>
-    <meta charset="UTF-8" />
-    <title>Visual Test: Bitmap Fonts</title>
-    <style>
-        body { margin: 0; background: #000; }
-        canvas { image-rendering: pixelated; }
-    </style>
-</head>
-
-<body>
-    <div id="canvas-container">
-        <canvas height="240" id="blit-tech-canvas" width="320"></canvas>
-    </div>
-
-    <script type="module">
-        import { bootstrap, BT, Color32, Palette, Vector2i } from 'blit-tech';
-
-        window.__RENDER_COMPLETE__ = false;
-        window.__INIT_FAILED__ = false;
-
-        // Palette indices.
-        const BLACK = 1;
-        const RED = 2;
-        const GREEN = 3;
-        const YELLOW = 5;
-        const CYAN = 6;
-        const WHITE = 8;
-
-        class FontsTest {
-            configure() {
-                return {
-                    displaySize: new Vector2i(320, 240),
-                    targetFPS: 60,
-                };
+    <head>
+        <meta charset="UTF-8" />
+        <title>Visual Test: Bitmap Fonts</title>
+        <style>
+            body {
+                margin: 0;
+                background: #000;
             }
 
-            async init() {
-                const palette = new Palette(16);
-                palette.set(BLACK, Color32.black);
-                palette.set(RED, Color32.red);
-                palette.set(GREEN, Color32.green);
-                palette.set(4, Color32.blue);
-                palette.set(YELLOW, Color32.yellow);
-                palette.set(CYAN, Color32.cyan);
-                palette.set(7, Color32.magenta);
-                palette.set(WHITE, Color32.white);
-                BT.paletteSet(palette);
+            canvas {
+                image-rendering: pixelated;
+            }
+        </style>
+    </head>
 
-                return true;
+    <body>
+        <div id="canvas-container">
+            <canvas height="240" id="blit-tech-canvas" width="320"></canvas>
+        </div>
+
+        <script type="module">
+            import { bootstrap, BT, Color32, Palette, Vector2i } from 'blit-tech';
+
+            window.__RENDER_COMPLETE__ = false;
+            window.__INIT_FAILED__ = false;
+
+            // Palette indices.
+            const colorBlack = 1;
+            const colorRed = 2;
+            const colorGreen = 3;
+            const colorYellow = 5;
+            const colorCyan = 6;
+            const colorWhite = 8;
+
+            class FontsTest {
+                configure() {
+                    return {
+                        displaySize: new Vector2i(320, 240),
+                        targetFPS: 60,
+                    };
+                }
+
+                async init() {
+                    const palette = new Palette(16);
+
+                    palette.set(colorBlack, Color32.black);
+                    palette.set(colorRed, Color32.red);
+                    palette.set(colorGreen, Color32.green);
+                    palette.set(4, Color32.blue);
+                    palette.set(colorYellow, Color32.yellow);
+                    palette.set(colorCyan, Color32.cyan);
+                    palette.set(7, Color32.magenta);
+                    palette.set(colorWhite, Color32.white);
+
+                    BT.paletteSet(palette);
+
+                    return true;
+                }
+
+                update() {}
+
+                render() {
+                    BT.clear(colorBlack);
+
+                    // Use placeholder text rendering (drawText via PrimitivePipeline).
+                    // Each character is rendered as a 6x8 colored block.
+                    BT.systemPrint(new Vector2i(10, 10), colorWhite, 'Hello World');
+                    BT.systemPrint(new Vector2i(10, 30), colorRed, 'Red Text');
+                    BT.systemPrint(new Vector2i(10, 50), colorGreen, 'Green Text');
+                    BT.systemPrint(new Vector2i(10, 70), colorCyan, 'ABCDEFGHIJ');
+                    BT.systemPrint(new Vector2i(10, 90), colorYellow, '0123456789');
+
+                    window.__RENDER_COMPLETE__ = true;
+                }
             }
 
-            update() {}
-
-            render() {
-                BT.clear(BLACK);
-
-                // Use placeholder text rendering (drawText via PrimitivePipeline).
-                // Each character is rendered as a 6x8 colored block.
-                BT.systemPrint(new Vector2i(10, 10), WHITE, 'Hello World');
-                BT.systemPrint(new Vector2i(10, 30), RED, 'Red Text');
-                BT.systemPrint(new Vector2i(10, 50), GREEN, 'Green Text');
-                BT.systemPrint(new Vector2i(10, 70), CYAN, 'ABCDEFGHIJ');
-                BT.systemPrint(new Vector2i(10, 90), YELLOW, '0123456789');
-
-                window.__RENDER_COMPLETE__ = true;
-            }
-        }
-
-        bootstrap(FontsTest, {
-            onError: () => {
-                window.__INIT_FAILED__ = true;
-            },
-        });
-    </script>
-</body>
-
+            bootstrap(FontsTest, {
+                onError: () => {
+                    window.__INIT_FAILED__ = true;
+                },
+            });
+        </script>
+    </body>
 </html>

--- a/tests/visual/fixtures/mixed.html
+++ b/tests/visual/fixtures/mixed.html
@@ -1,147 +1,155 @@
+<!--suppress MagicNumberJS, FunctionWithMultipleLoopsJS -->
+
 <!doctype html>
+
 <html lang="en">
-
-<head>
-    <meta charset="UTF-8" />
-    <title>Visual Test: Mixed Rendering</title>
-    <style>
-        body { margin: 0; background: #000; }
-        canvas { image-rendering: pixelated; }
-    </style>
-</head>
-
-<body>
-    <div id="canvas-container">
-        <canvas height="240" id="blit-tech-canvas" width="320"></canvas>
-    </div>
-
-    <script type="module">
-        import { bootstrap, BT, Color32, Palette, Rect2i, SpriteSheet, Vector2i } from 'blit-tech';
-
-        window.__RENDER_COMPLETE__ = false;
-        window.__INIT_FAILED__ = false;
-
-        // Palette indices for this test.
-        const BG_COLOR = 9;
-        const DARK_RED = 10;
-        const GREEN    = 3;
-        const YELLOW   = 5;
-        const CYAN     = 6;
-        const WHITE    = 8;
-        const GRAY     = 11;
-
-        // Create a 2-color 8x8 sprite sheet: top 4 rows white, bottom 4 rows gray.
-        // Both colors must match palette entries so indexize() can convert them.
-        function createSpriteImage() {
-            const c = document.createElement('canvas');
-            c.width = 8;
-            c.height = 8;
-            const ctx = c.getContext('2d');
-
-            ctx.fillStyle = '#ffffff';
-            ctx.fillRect(0, 0, 8, 4);
-
-            ctx.fillStyle = '#888888';
-            ctx.fillRect(0, 4, 8, 4);
-
-            const img = new Image();
-
-            return new Promise((resolve) => {
-                img.onload = () => resolve(img);
-                img.src = c.toDataURL();
-            });
-        }
-
-        class MixedTest {
-            spriteSheet = null;
-
-            configure() {
-                return {
-                    displaySize: new Vector2i(320, 240),
-                    targetFPS: 60,
-                };
+    <head>
+        <meta charset="UTF-8" />
+        <title>Visual Test: Mixed Rendering</title>
+        <style>
+            body {
+                margin: 0;
+                background: #000;
             }
 
-            async init() {
-                const palette = new Palette(16);
-                palette.set(1,        new Color32(0,   0,   0,   255));
-                palette.set(2,        new Color32(255, 0,   0,   255));
-                palette.set(GREEN,    new Color32(0,   255, 0,   255));
-                palette.set(4,        new Color32(0,   0,   255, 255));
-                palette.set(YELLOW,   new Color32(255, 255, 0,   255));
-                palette.set(CYAN,     new Color32(0,   255, 255, 255));
-                palette.set(7,        new Color32(255, 0,   255, 255));
-                palette.set(WHITE,    new Color32(255, 255, 255, 255));
-                palette.set(BG_COLOR, new Color32(32,  32,  64,  255));
-                palette.set(DARK_RED, new Color32(128, 0,   0,   255));
-                palette.set(GRAY,     new Color32(136, 136, 136, 255));
-                BT.paletteSet(palette);
+            canvas {
+                image-rendering: pixelated;
+            }
+        </style>
+    </head>
 
-                const img = await createSpriteImage();
-                this.spriteSheet = new SpriteSheet(img);
+    <body>
+        <div id="canvas-container">
+            <canvas height="240" id="blit-tech-canvas" width="320"></canvas>
+        </div>
 
-                // Convert RGBA pixels to palette indices against the active palette.
-                this.spriteSheet.indexize(palette);
+        <script type="module">
+            import { bootstrap, BT, Color32, Palette, Rect2i, SpriteSheet, Vector2i } from 'blit-tech';
 
-                return true;
+            window.__RENDER_COMPLETE__ = false;
+            window.__INIT_FAILED__ = false;
+
+            // Palette indices for this test.
+            const colorBG = 9;
+            const colorDarkRed = 10;
+            const colorGreen = 3;
+            const colorYellow = 5;
+            const colorCyan = 6;
+            const colorWhite = 8;
+            const colorGray = 11;
+
+            // Create a 2-color 8x8 sprite sheet: top 4 rows white, bottom 4 rows gray.
+            // Both colors must match palette entries so indexize() can convert them.
+            function createSpriteImage() {
+                const c = document.createElement('canvas');
+
+                c.width = 8;
+                c.height = 8;
+
+                const ctx = c.getContext('2d');
+
+                ctx.fillStyle = '#ffffff';
+                ctx.fillRect(0, 0, 8, 4);
+
+                ctx.fillStyle = '#888888';
+                ctx.fillRect(0, 4, 8, 4);
+
+                const img = new Image();
+
+                return new Promise((resolve) => {
+                    img.onload = () => resolve(img);
+                    img.src = c.toDataURL();
+                });
             }
 
-            update() {}
+            class MixedTest {
+                spriteSheet = null;
 
-            render() {
-                BT.clear(BG_COLOR);
-
-                // Draw primitives first (these render in the primitives pipeline).
-
-                // Dark red filled rect as background block.
-                BT.drawRectFill(new Rect2i(10, 10, 100, 80), DARK_RED);
-
-                // Green rect outline around it.
-                BT.drawRect(new Rect2i(8, 8, 104, 84), GREEN);
-
-                // Yellow horizontal line.
-                BT.drawLine(new Vector2i(10, 100), new Vector2i(110, 100), YELLOW);
-
-                // White diagonal line.
-                BT.drawLine(new Vector2i(120, 10), new Vector2i(180, 70), WHITE);
-
-                // Cyan pixels.
-                for (let i = 0; i < 10; i++) {
-                    BT.drawPixel(new Vector2i(130 + i * 5, 80), CYAN);
+                configure() {
+                    return {
+                        displaySize: new Vector2i(320, 240),
+                        targetFPS: 60,
+                    };
                 }
 
-                // Placeholder text.
-                BT.systemPrint(new Vector2i(10, 110), WHITE, 'Mixed Test');
+                async init() {
+                    const palette = new Palette(16);
 
-                // Draw sprites on top (sprite pipeline renders after primitives).
-                const sheet = this.spriteSheet;
-                if (sheet) {
-                    // Sprite at (20, 20) - overlaps the dark red filled rect.
-                    BT.drawSprite(sheet, new Rect2i(0, 0, 8, 8), new Vector2i(20, 20));
+                    palette.set(1, new Color32(0, 0, 0, 255));
+                    palette.set(2, new Color32(255, 0, 0, 255));
+                    palette.set(colorGreen, new Color32(0, 255, 0, 255));
+                    palette.set(4, new Color32(0, 0, 255, 255));
+                    palette.set(colorYellow, new Color32(255, 255, 0, 255));
+                    palette.set(colorCyan, new Color32(0, 255, 255, 255));
+                    palette.set(7, new Color32(255, 0, 255, 255));
+                    palette.set(colorWhite, new Color32(255, 255, 255, 255));
+                    palette.set(colorBG, new Color32(32, 32, 64, 255));
+                    palette.set(colorDarkRed, new Color32(128, 0, 0, 255));
+                    palette.set(colorGray, new Color32(136, 136, 136, 255));
 
-                    // Row of sprites.
-                    for (let i = 0; i < 8; i++) {
-                        BT.drawSprite(
-                            sheet,
-                            new Rect2i(0, 0, 8, 8),
-                            new Vector2i(10 + i * 10, 130),
-                        );
+                    BT.paletteSet(palette);
+
+                    const img = await createSpriteImage();
+                    this.spriteSheet = new SpriteSheet(img);
+
+                    // Convert RGBA pixels to palette indices against the active palette.
+                    this.spriteSheet.indexize(palette);
+
+                    return true;
+                }
+
+                update() {}
+
+                render() {
+                    BT.clear(colorBG);
+
+                    // Draw primitives first (these render in the primitives pipeline).
+
+                    // Dark red filled rect as background block.
+                    BT.drawRectFill(new Rect2i(10, 10, 100, 80), colorDarkRed);
+
+                    // Green rect outline around it.
+                    BT.drawRect(new Rect2i(8, 8, 104, 84), colorGreen);
+
+                    // Yellow horizontal line.
+                    BT.drawLine(new Vector2i(10, 100), new Vector2i(110, 100), colorYellow);
+
+                    // White diagonal line.
+                    BT.drawLine(new Vector2i(120, 10), new Vector2i(180, 70), colorWhite);
+
+                    // Cyan pixels.
+                    for (let i = 0; i < 10; i++) {
+                        BT.drawPixel(new Vector2i(130 + i * 5, 80), colorCyan);
                     }
 
-                    // Sprite with paletteOffset=2: white (8) shifts to index 10 (dark red),
-                    // gray (11) shifts to index 13 (unused = black).
-                    BT.drawSprite(sheet, new Rect2i(0, 0, 8, 8), new Vector2i(50, 20), 2);
+                    // Placeholder text.
+                    BT.systemPrint(new Vector2i(10, 110), colorWhite, 'Mixed Test');
+
+                    // Draw sprites on top (sprite pipeline renders after primitives).
+                    const sheet = this.spriteSheet;
+                    if (sheet) {
+                        // Sprite at (20, 20) - overlaps the dark red filled rect.
+                        BT.drawSprite(sheet, new Rect2i(0, 0, 8, 8), new Vector2i(20, 20));
+
+                        // Row of sprites.
+                        for (let i = 0; i < 8; i++) {
+                            BT.drawSprite(sheet, new Rect2i(0, 0, 8, 8), new Vector2i(10 + i * 10, 130));
+                        }
+
+                        // Sprite with paletteOffset=2: white (8) shifts to index 10 (dark red),
+                        // gray (11) shifts to index 13 (unused = black).
+                        BT.drawSprite(sheet, new Rect2i(0, 0, 8, 8), new Vector2i(50, 20), 2);
+                    }
+
+                    window.__RENDER_COMPLETE__ = true;
                 }
-
-                window.__RENDER_COMPLETE__ = true;
             }
-        }
 
-        bootstrap(MixedTest, {
-            onError: () => {
-                window.__INIT_FAILED__ = true;
-            },
-        });
-    </script>
-</body>
+            bootstrap(MixedTest, {
+                onError: () => {
+                    window.__INIT_FAILED__ = true;
+                },
+            });
+        </script>
+    </body>
 </html>

--- a/tests/visual/fixtures/post-process.html
+++ b/tests/visual/fixtures/post-process.html
@@ -1,190 +1,261 @@
+<!--suppress FunctionWithMultipleLoopsJS, MagicNumberJS, BlockStatementJS -->
+
 <!doctype html>
+
 <html lang="en">
-
-<head>
-    <meta charset="UTF-8" />
-    <title>Visual Test: Post-Process</title>
-    <style>
-        body { margin: 0; background: #000; }
-        canvas { image-rendering: pixelated; }
-    </style>
-</head>
-
-<body>
-    <div id="canvas-container">
-        <canvas id="blit-tech-canvas"></canvas>
-    </div>
-
-    <script type="module">
-        import {
-            BarrelDistortion,
-            Bloom,
-            bootstrap,
-            BT,
-            ChromaticAberration,
-            Color32,
-            crtPipBoy,
-            Palette,
-            PixelGlitch,
-            Rect2i,
-            RGBMask,
-            Scanlines,
-            Vector2i,
-            Vignette,
-        } from 'blit-tech';
-
-        // Effect mode is selected via the URL hash so a single fixture covers
-        // many snapshot variants.
-        const mode = (window.location.hash || '#baseline').replace('#', '');
-
-        // Modes that need a display-tier output buffer - anything testing a
-        // display effect or the upscale pass needs drawingBufferSize set.
-        const NEEDS_DISPLAY = new Set([
-            'barrel',
-            'scanlines',
-            'mask',
-            'vignette',
-            'aberration',
-            'bloom',
-            'crt-pipboy',
-            'stacked',
-            'upscale-nearest',
-            'upscale-linear',
-        ]);
-
-        window.__RENDER_COMPLETE__ = false;
-        window.__INIT_FAILED__ = false;
-        window.__FIXTURE_MODE__ = mode;
-
-        // Palette indices for this test.
-        const BLACK = 1;
-        const RED = 2;
-        const GREEN = 3;
-        const BLUE = 4;
-        const YELLOW = 5;
-        const CYAN = 6;
-        const MAGENTA = 7;
-        const WHITE = 8;
-
-        class PostProcessTest {
-            configure() {
-                const cfg = {
-                    displaySize: new Vector2i(320, 240),
-                    targetFPS: 60,
-                };
-                if (NEEDS_DISPLAY.has(mode)) {
-                    cfg.drawingBufferSize = new Vector2i(1280, 960);
-                    cfg.outputUpscaleFilter = mode === 'upscale-linear' ? 'linear' : 'nearest';
-                }
-                return cfg;
+    <head>
+        <meta charset="UTF-8" />
+        <title>Visual Test: Post-Process</title>
+        <style>
+            body {
+                margin: 0;
+                background: #000;
             }
 
-            async init() {
-                const palette = new Palette(16);
-                palette.set(BLACK, Color32.black);
-                palette.set(RED, Color32.red);
-                palette.set(GREEN, Color32.green);
-                palette.set(BLUE, Color32.blue);
-                palette.set(YELLOW, Color32.yellow);
-                palette.set(CYAN, Color32.cyan);
-                palette.set(MAGENTA, Color32.magenta);
-                palette.set(WHITE, Color32.white);
-                BT.paletteSet(palette);
+            canvas {
+                image-rendering: pixelated;
+            }
+        </style>
+    </head>
 
-                switch (mode) {
-                    case 'pixel-glitch': {
-                        const fx = new PixelGlitch();
-                        fx.intensity = 0.5;
-                        fx.bandHeight = 6;
-                        fx.seed = 42;
-                        BT.effectAdd(fx);
-                        break;
+    <body>
+        <div id="canvas-container">
+            <canvas id="blit-tech-canvas"></canvas>
+        </div>
+
+        <script type="module">
+            import {
+                BarrelDistortion,
+                Bloom,
+                bootstrap,
+                BT,
+                ChromaticAberration,
+                Color32,
+                crtPipBoy,
+                Palette,
+                PixelGlitch,
+                Rect2i,
+                RGBMask,
+                Scanlines,
+                Vector2i,
+                Vignette,
+            } from 'blit-tech';
+
+            // Effect mode is selected via the URL hash so a single fixture covers
+            // many snapshot variants.
+            const mode = (window.location.hash || '#baseline').replace('#', '');
+
+            // Modes that need a display-tier output buffer - anything testing a
+            // display effect or the upscale pass needs drawingBufferSize set.
+            const needsDisplay = new Set([
+                'barrel',
+                'scanlines',
+                'mask',
+                'vignette',
+                'aberration',
+                'bloom',
+                'crt-pipboy',
+                'stacked',
+                'upscale-nearest',
+                'upscale-linear',
+            ]);
+
+            window.__RENDER_COMPLETE__ = false;
+            window.__INIT_FAILED__ = false;
+            window.__FIXTURE_MODE__ = mode;
+
+            // Palette indices for this test.
+            const colorBlack = 1;
+            const colorRed = 2;
+            const colorGreen = 3;
+            const colorBlue = 4;
+            const colorYellow = 5;
+            const colorCyan = 6;
+            const colorMagenta = 7;
+            const colorWhite = 8;
+
+            class PostProcessTest {
+                configure() {
+                    const cfg = {
+                        displaySize: new Vector2i(320, 240),
+                        targetFPS: 60,
+                    };
+
+                    if (needsDisplay.has(mode)) {
+                        cfg.drawingBufferSize = new Vector2i(1280, 960);
+                        cfg.outputUpscaleFilter = mode === 'upscale-linear' ? 'linear' : 'nearest';
                     }
-                    case 'barrel': {
-                        const fx = new BarrelDistortion();
-                        fx.curvature = 0.05;
-                        BT.effectAdd(fx);
-                        break;
-                    }
-                    case 'scanlines': {
-                        BT.effectAdd(new Scanlines());
-                        break;
-                    }
-                    case 'mask': {
-                        BT.effectAdd(new RGBMask());
-                        break;
-                    }
-                    case 'vignette': {
-                        BT.effectAdd(new Vignette());
-                        break;
-                    }
-                    case 'aberration': {
-                        const fx = new ChromaticAberration();
-                        fx.aberration = 2;
-                        BT.effectAdd(fx);
-                        break;
-                    }
-                    case 'bloom': {
-                        BT.effectAdd(new Bloom());
-                        break;
-                    }
-                    case 'crt-pipboy': {
-                        for (const fx of crtPipBoy()) {
-                            // Pin animation uniforms for determinism.
-                            if ('time' in fx) fx.time = 0;
-                            BT.effectAdd(fx);
-                        }
-                        break;
-                    }
-                    case 'stacked': {
-                        const glitch = new PixelGlitch();
-                        glitch.intensity = 0.4;
-                        glitch.bandHeight = 6;
-                        glitch.seed = 17;
-                        BT.effectAdd(glitch);
-                        for (const fx of crtPipBoy()) {
-                            if ('time' in fx) fx.time = 0;
-                            BT.effectAdd(fx);
-                        }
-                        break;
-                    }
-                    // baseline, upscale-nearest, upscale-linear: no effects
-                    default:
-                        break;
+
+                    return cfg;
                 }
 
-                return true;
+                async init() {
+                    const palette = new Palette(16);
+
+                    palette.set(colorBlack, Color32.black);
+                    palette.set(colorRed, Color32.red);
+                    palette.set(colorGreen, Color32.green);
+                    palette.set(colorBlue, Color32.blue);
+                    palette.set(colorYellow, Color32.yellow);
+                    palette.set(colorCyan, Color32.cyan);
+                    palette.set(colorMagenta, Color32.magenta);
+                    palette.set(colorWhite, Color32.white);
+
+                    BT.paletteSet(palette);
+
+                    switch (mode) {
+                        case 'pixel-glitch': {
+                            this.applyPixelGlitchEffect();
+                            break;
+                        }
+
+                        case 'barrel': {
+                            this.applyBarrelEffect();
+                            break;
+                        }
+
+                        case 'scanlines': {
+                            this.applyScanlinesEffect();
+                            break;
+                        }
+
+                        case 'mask': {
+                            this.applyMaskEffect();
+                            break;
+                        }
+
+                        case 'vignette': {
+                            this.applyVignetteEffect();
+                            break;
+                        }
+
+                        case 'aberration': {
+                            this.applyAberrationEffect();
+                            break;
+                        }
+
+                        case 'bloom': {
+                            this.applyBloomEffect();
+                            break;
+                        }
+
+                        case 'crt-pipboy': {
+                            this.applyCRTPipBoyEffect();
+                            break;
+                        }
+
+                        case 'stacked': {
+                            this.applyStackedEffect();
+                            break;
+                        }
+
+                        // Baseline, upscale-nearest, upscale-linear: no effects.
+                        default:
+                            break;
+                    }
+
+                    return true;
+                }
+
+                applyStackedEffect() {
+                    const glitch = new PixelGlitch();
+
+                    glitch.intensity = 0.4;
+                    glitch.bandHeight = 6;
+                    glitch.seed = 17;
+
+                    BT.effectAdd(glitch);
+
+                    for (const fx of crtPipBoy()) {
+                        if ('time' in fx) {
+                            fx.time = 0;
+                        }
+
+                        BT.effectAdd(fx);
+                    }
+                }
+
+                applyCRTPipBoyEffect() {
+                    for (const fx of crtPipBoy()) {
+                        // Pin animation uniforms for determinism.
+                        if ('time' in fx) {
+                            fx.time = 0;
+                        }
+
+                        BT.effectAdd(fx);
+                    }
+                }
+
+                applyPixelGlitchEffect() {
+                    const fx = new PixelGlitch();
+
+                    fx.intensity = 0.5;
+                    fx.bandHeight = 6;
+                    fx.seed = 42;
+
+                    BT.effectAdd(fx);
+                }
+
+                applyBarrelEffect() {
+                    const fx = new BarrelDistortion();
+
+                    fx.curvature = 0.05;
+
+                    BT.effectAdd(fx);
+                }
+
+                applyScanlinesEffect() {
+                    BT.effectAdd(new Scanlines());
+                }
+
+                applyMaskEffect() {
+                    BT.effectAdd(new RGBMask());
+                }
+
+                applyVignetteEffect() {
+                    BT.effectAdd(new Vignette());
+                }
+
+                applyAberrationEffect() {
+                    const fx = new ChromaticAberration();
+
+                    fx.aberration = 2;
+
+                    BT.effectAdd(fx);
+                }
+
+                applyBloomEffect() {
+                    BT.effectAdd(new Bloom());
+                }
+
+                update() {}
+
+                render() {
+                    BT.clear(colorBlack);
+
+                    // Wide bright bands stress scanlines, mask, and aberration.
+                    BT.drawRectFill(new Rect2i(20, 20, 280, 30), colorGreen);
+                    BT.drawRectFill(new Rect2i(20, 60, 280, 30), colorCyan);
+                    BT.drawRectFill(new Rect2i(20, 100, 280, 30), colorMagenta);
+                    BT.drawRectFill(new Rect2i(20, 140, 280, 30), colorYellow);
+                    BT.drawRectFill(new Rect2i(20, 180, 280, 30), colorWhite);
+
+                    // High-contrast outline highlights vignette and curvature.
+                    BT.drawRect(new Rect2i(5, 5, 310, 230), colorWhite);
+
+                    // Diagonal cross to expose chromatic aberration and barrel curve.
+                    BT.drawLine(new Vector2i(0, 0), new Vector2i(319, 239), colorRed);
+                    BT.drawLine(new Vector2i(319, 0), new Vector2i(0, 239), colorBlue);
+
+                    window.__RENDER_COMPLETE__ = true;
+                }
             }
 
-            update() {}
-
-            render() {
-                BT.clear(BLACK);
-
-                // Wide bright bands stress scanlines, mask, and aberration.
-                BT.drawRectFill(new Rect2i(20, 20, 280, 30), GREEN);
-                BT.drawRectFill(new Rect2i(20, 60, 280, 30), CYAN);
-                BT.drawRectFill(new Rect2i(20, 100, 280, 30), MAGENTA);
-                BT.drawRectFill(new Rect2i(20, 140, 280, 30), YELLOW);
-                BT.drawRectFill(new Rect2i(20, 180, 280, 30), WHITE);
-
-                // High-contrast outline highlights vignette and curvature.
-                BT.drawRect(new Rect2i(5, 5, 310, 230), WHITE);
-
-                // Diagonal cross to expose chromatic aberration and barrel curve.
-                BT.drawLine(new Vector2i(0, 0), new Vector2i(319, 239), RED);
-                BT.drawLine(new Vector2i(319, 0), new Vector2i(0, 239), BLUE);
-
-                window.__RENDER_COMPLETE__ = true;
-            }
-        }
-
-        bootstrap(PostProcessTest, {
-            onError: () => {
-                window.__INIT_FAILED__ = true;
-            },
-        });
-    </script>
-</body>
-
+            bootstrap(PostProcessTest, {
+                onError: () => {
+                    window.__INIT_FAILED__ = true;
+                },
+            });
+        </script>
+    </body>
 </html>

--- a/tests/visual/fixtures/primitives.html
+++ b/tests/visual/fixtures/primitives.html
@@ -1,94 +1,103 @@
+<!--suppress MagicNumberJS -->
+
 <!doctype html>
+
 <html lang="en">
-
-<head>
-    <meta charset="UTF-8" />
-    <title>Visual Test: Primitives</title>
-    <style>
-        body { margin: 0; background: #000; }
-        canvas { image-rendering: pixelated; }
-    </style>
-</head>
-
-<body>
-    <div id="canvas-container">
-        <canvas height="240" id="blit-tech-canvas" width="320"></canvas>
-    </div>
-
-    <script type="module">
-        import { bootstrap, BT, Color32, Palette, Rect2i, Vector2i } from 'blit-tech';
-
-        // Signal test readiness regardless of success/failure.
-        window.__RENDER_COMPLETE__ = false;
-        window.__INIT_FAILED__ = false;
-
-        // Palette indices for this test.
-        const BLACK = 1;
-        const RED = 2;
-        const GREEN = 3;
-        const BLUE = 4;
-        const YELLOW = 5;
-        const CYAN = 6;
-        const WHITE = 8;
-
-        class PrimitivesTest {
-            configure() {
-                return {
-                    displaySize: new Vector2i(320, 240),
-                    targetFPS: 60,
-                };
+    <head>
+        <meta charset="UTF-8" />
+        <title>Visual Test: Primitives</title>
+        <style>
+            body {
+                margin: 0;
+                background: #000;
             }
 
-            async init() {
-                // Create and activate a test palette.
-                const palette = new Palette(16);
-                palette.set(BLACK, Color32.black);
-                palette.set(RED, Color32.red);
-                palette.set(GREEN, Color32.green);
-                palette.set(BLUE, Color32.blue);
-                palette.set(YELLOW, Color32.yellow);
-                palette.set(CYAN, Color32.cyan);
-                palette.set(8, Color32.white);
-                BT.paletteSet(palette);
+            canvas {
+                image-rendering: pixelated;
+            }
+        </style>
+    </head>
 
-                return true;
+    <body>
+        <div id="canvas-container">
+            <canvas height="240" id="blit-tech-canvas" width="320"></canvas>
+        </div>
+
+        <script type="module">
+            import { bootstrap, BT, Color32, Palette, Rect2i, Vector2i } from 'blit-tech';
+
+            // Signal test readiness regardless of success/failure.
+            window.__RENDER_COMPLETE__ = false;
+            window.__INIT_FAILED__ = false;
+
+            // Palette indices for this test.
+            const colorBlack = 1;
+            const colorRed = 2;
+            const colorGreen = 3;
+            const colorBlue = 4;
+            const colorYellow = 5;
+            const colorCyan = 6;
+            const colorWhite = 8;
+
+            class PrimitivesTest {
+                configure() {
+                    return {
+                        displaySize: new Vector2i(320, 240),
+                        targetFPS: 60,
+                    };
+                }
+
+                async init() {
+                    // Create and activate a test palette.
+                    const palette = new Palette(16);
+
+                    palette.set(colorBlack, Color32.black);
+                    palette.set(colorRed, Color32.red);
+                    palette.set(colorGreen, Color32.green);
+                    palette.set(colorBlue, Color32.blue);
+                    palette.set(colorYellow, Color32.yellow);
+                    palette.set(colorCyan, Color32.cyan);
+                    palette.set(8, Color32.white);
+
+                    BT.paletteSet(palette);
+
+                    return true;
+                }
+
+                update() {}
+
+                render() {
+                    BT.clear(colorBlack);
+
+                    // Draw known patterns for visual regression.
+                    // Red pixel at (10, 10).
+                    BT.drawPixel(new Vector2i(10, 10), colorRed);
+
+                    // Green horizontal line from (20, 20) to (100, 20).
+                    BT.drawLine(new Vector2i(20, 20), new Vector2i(100, 20), colorGreen);
+
+                    // Blue vertical line from (120, 10) to (120, 100).
+                    BT.drawLine(new Vector2i(120, 10), new Vector2i(120, 100), colorBlue);
+
+                    // Yellow filled rect at (140, 10, 40, 30).
+                    BT.drawRectFill(new Rect2i(140, 10, 40, 30), colorYellow);
+
+                    // Cyan rect outline at (200, 10, 50, 40).
+                    BT.drawRect(new Rect2i(200, 10, 50, 40), colorCyan);
+
+                    // White diagonal line.
+                    BT.drawLine(new Vector2i(10, 50), new Vector2i(60, 100), colorWhite);
+
+                    // Signal render complete.
+                    window.__RENDER_COMPLETE__ = true;
+                }
             }
 
-            update() {}
-
-            render() {
-                BT.clear(BLACK);
-
-                // Draw known patterns for visual regression.
-                // Red pixel at (10, 10).
-                BT.drawPixel(new Vector2i(10, 10), RED);
-
-                // Green horizontal line from (20, 20) to (100, 20).
-                BT.drawLine(new Vector2i(20, 20), new Vector2i(100, 20), GREEN);
-
-                // Blue vertical line from (120, 10) to (120, 100).
-                BT.drawLine(new Vector2i(120, 10), new Vector2i(120, 100), BLUE);
-
-                // Yellow filled rect at (140, 10, 40, 30).
-                BT.drawRectFill(new Rect2i(140, 10, 40, 30), YELLOW);
-
-                // Cyan rect outline at (200, 10, 50, 40).
-                BT.drawRect(new Rect2i(200, 10, 50, 40), CYAN);
-
-                // White diagonal line.
-                BT.drawLine(new Vector2i(10, 50), new Vector2i(60, 100), WHITE);
-
-                // Signal render complete.
-                window.__RENDER_COMPLETE__ = true;
-            }
-        }
-
-        bootstrap(PrimitivesTest, {
-            onError: () => {
-                window.__INIT_FAILED__ = true;
-            },
-        });
-    </script>
-</body>
-
+            bootstrap(PrimitivesTest, {
+                onError: () => {
+                    window.__INIT_FAILED__ = true;
+                },
+            });
+        </script>
+    </body>
 </html>

--- a/tests/visual/fixtures/primitives.html
+++ b/tests/visual/fixtures/primitives.html
@@ -57,7 +57,7 @@
                     palette.set(colorBlue, Color32.blue);
                     palette.set(colorYellow, Color32.yellow);
                     palette.set(colorCyan, Color32.cyan);
-                    palette.set(8, Color32.white);
+                    palette.set(colorWhite, Color32.white);
 
                     BT.paletteSet(palette);
 

--- a/tests/visual/fixtures/sprites.html
+++ b/tests/visual/fixtures/sprites.html
@@ -1,138 +1,153 @@
+<!--suppress MagicNumberJS -->
+
 <!doctype html>
+
 <html lang="en">
-
-<head>
-    <meta charset="UTF-8" />
-    <title>Visual Test: Sprites</title>
-    <style>
-        body { margin: 0; background: #000; }
-        canvas { image-rendering: pixelated; }
-    </style>
-</head>
-
-<body>
-    <div id="canvas-container">
-        <canvas height="240" id="blit-tech-canvas" width="320"></canvas>
-    </div>
-
-    <script type="module">
-        import { bootstrap, BT, Color32, Palette, Rect2i, SpriteSheet, Vector2i } from 'blit-tech';
-
-        // Signal test readiness regardless of success/failure.
-        window.__RENDER_COMPLETE__ = false;
-        window.__INIT_FAILED__ = false;
-
-        // Palette indices.
-        const BLACK  = 1;
-        const RED    = 2;
-        const GREEN  = 3;
-        const BLUE   = 4;
-        const YELLOW = 5;
-
-        // Create a minimal 16x16 sprite sheet from a canvas.
-        // 4 tiles of 8x8: red (top-left), green (top-right), blue (bottom-left), yellow (bottom-right).
-        // The colors used here must match the palette entries set in init().
-        function createSpriteImage() {
-            const c = document.createElement('canvas');
-            c.width = 16;
-            c.height = 16;
-            const ctx = c.getContext('2d');
-
-            // Top-left 8x8: red
-            ctx.fillStyle = '#ff0000';
-            ctx.fillRect(0, 0, 8, 8);
-
-            // Top-right 8x8: green
-            ctx.fillStyle = '#00ff00';
-            ctx.fillRect(8, 0, 8, 8);
-
-            // Bottom-left 8x8: blue
-            ctx.fillStyle = '#0000ff';
-            ctx.fillRect(0, 8, 8, 8);
-
-            // Bottom-right 8x8: yellow
-            ctx.fillStyle = '#ffff00';
-            ctx.fillRect(8, 8, 8, 8);
-
-            const img = new Image();
-
-            return new Promise((resolve) => {
-                img.onload = () => resolve(img);
-                img.src = c.toDataURL();
-            });
-        }
-
-        class SpritesTest {
-            spriteSheet = null;
-
-            configure() {
-                return {
-                    displaySize: new Vector2i(320, 240),
-                    targetFPS: 60,
-                };
+    <head>
+        <meta charset="UTF-8" />
+        <title>Visual Test: Sprites</title>
+        <style>
+            body {
+                margin: 0;
+                background: #000;
             }
 
-            async init() {
-                const palette = new Palette(16);
-                palette.set(BLACK,  new Color32(0,   0,   0,   255));
-                palette.set(RED,    new Color32(255, 0,   0,   255));
-                palette.set(GREEN,  new Color32(0,   255, 0,   255));
-                palette.set(BLUE,   new Color32(0,   0,   255, 255));
-                palette.set(YELLOW, new Color32(255, 255, 0,   255));
-                BT.paletteSet(palette);
+            canvas {
+                image-rendering: pixelated;
+            }
+        </style>
+    </head>
 
-                const img = await createSpriteImage();
-                this.spriteSheet = new SpriteSheet(img);
+    <body>
+        <div id="canvas-container">
+            <canvas height="240" id="blit-tech-canvas" width="320"></canvas>
+        </div>
 
-                // Convert RGBA pixels to palette indices.
-                this.spriteSheet.indexize(palette);
+        <script type="module">
+            import { bootstrap, BT, Color32, Palette, Rect2i, SpriteSheet, Vector2i } from 'blit-tech';
 
-                return true;
+            // Signal test readiness regardless of success/failure.
+            window.__RENDER_COMPLETE__ = false;
+            window.__INIT_FAILED__ = false;
+
+            // Palette indices.
+            const colorBlack = 1;
+            const colorRed = 2;
+            const colorGreen = 3;
+            const colorBlue = 4;
+            const colorYellow = 5;
+
+            // Create a minimal 16x16 sprite sheet from a canvas.
+            // 4 tiles of 8x8: red (top-left), green (top-right), blue (bottom-left), yellow (bottom-right).
+            // The colors used here must match the palette entries set in init().
+            function createSpriteImage() {
+                const c = document.createElement('canvas');
+
+                c.width = 16;
+                c.height = 16;
+
+                const ctx = c.getContext('2d');
+
+                // Top-left 8x8: red
+                ctx.fillStyle = '#ff0000';
+                ctx.fillRect(0, 0, 8, 8);
+
+                // Top-right 8x8: green
+                ctx.fillStyle = '#00ff00';
+                ctx.fillRect(8, 0, 8, 8);
+
+                // Bottom-left 8x8: blue
+                ctx.fillStyle = '#0000ff';
+                ctx.fillRect(0, 8, 8, 8);
+
+                // Bottom-right 8x8: yellow
+                ctx.fillStyle = '#ffff00';
+                ctx.fillRect(8, 8, 8, 8);
+
+                const img = new Image();
+
+                return new Promise((resolve) => {
+                    img.onload = () => resolve(img);
+                    img.src = c.toDataURL();
+                });
             }
 
-            update() {}
+            class SpritesTest {
+                spriteSheet = null;
 
-            render() {
-                BT.clear(BLACK);
-
-                const sheet = this.spriteSheet;
-                if (!sheet) return;
-
-                // Draw red tile at (10, 10) - paletteOffset 0 (original colors).
-                BT.drawSprite(sheet, new Rect2i(0, 0, 8, 8), new Vector2i(10, 10));
-
-                // Draw green tile at (30, 10) - paletteOffset 0.
-                BT.drawSprite(sheet, new Rect2i(8, 0, 8, 8), new Vector2i(30, 10));
-
-                // Draw blue tile at (50, 10) - paletteOffset 0.
-                BT.drawSprite(sheet, new Rect2i(0, 8, 8, 8), new Vector2i(50, 10));
-
-                // Draw yellow tile at (70, 10) - paletteOffset 0.
-                BT.drawSprite(sheet, new Rect2i(8, 8, 8, 8), new Vector2i(70, 10));
-
-                // Draw red tile at (10, 30) with paletteOffset 2 (shifts index 2 -> 4 = blue).
-                BT.drawSprite(sheet, new Rect2i(0, 0, 8, 8), new Vector2i(10, 30), 2);
-
-                // Draw multiple tiles in a row (batch test).
-                for (let i = 0; i < 4; i++) {
-                    BT.drawSprite(
-                        sheet,
-                        new Rect2i((i % 2) * 8, Math.floor(i / 2) * 8, 8, 8),
-                        new Vector2i(10 + i * 12, 50),
-                    );
+                configure() {
+                    return {
+                        displaySize: new Vector2i(320, 240),
+                        targetFPS: 60,
+                    };
                 }
 
-                // Signal render complete.
-                window.__RENDER_COMPLETE__ = true;
+                async init() {
+                    const palette = new Palette(16);
+
+                    palette.set(colorBlack, new Color32(0, 0, 0, 255));
+                    palette.set(colorRed, new Color32(255, 0, 0, 255));
+                    palette.set(colorGreen, new Color32(0, 255, 0, 255));
+                    palette.set(colorBlue, new Color32(0, 0, 255, 255));
+                    palette.set(colorYellow, new Color32(255, 255, 0, 255));
+
+                    BT.paletteSet(palette);
+
+                    const img = await createSpriteImage();
+
+                    this.spriteSheet = new SpriteSheet(img);
+
+                    // Convert RGBA pixels to palette indices.
+                    this.spriteSheet.indexize(palette);
+
+                    return true;
+                }
+
+                update() {}
+
+                render() {
+                    BT.clear(colorBlack);
+
+                    const sheet = this.spriteSheet;
+
+                    if (!sheet) {
+                        return;
+                    }
+
+                    // Draw red tile at (10, 10) - paletteOffset 0 (original colors).
+                    BT.drawSprite(sheet, new Rect2i(0, 0, 8, 8), new Vector2i(10, 10));
+
+                    // Draw green tile at (30, 10) - paletteOffset 0.
+                    BT.drawSprite(sheet, new Rect2i(8, 0, 8, 8), new Vector2i(30, 10));
+
+                    // Draw blue tile at (50, 10) - paletteOffset 0.
+                    BT.drawSprite(sheet, new Rect2i(0, 8, 8, 8), new Vector2i(50, 10));
+
+                    // Draw yellow tile at (70, 10) - paletteOffset 0.
+                    BT.drawSprite(sheet, new Rect2i(8, 8, 8, 8), new Vector2i(70, 10));
+
+                    // Draw red tile at (10, 30) with paletteOffset 2 (shifts index 2 -> 4 = blue).
+                    BT.drawSprite(sheet, new Rect2i(0, 0, 8, 8), new Vector2i(10, 30), 2);
+
+                    // Draw multiple tiles in a row (batch test).
+                    for (let i = 0; i < 4; i++) {
+                        BT.drawSprite(
+                            sheet,
+                            new Rect2i((i % 2) * 8, Math.floor(i / 2) * 8, 8, 8),
+                            new Vector2i(10 + i * 12, 50),
+                        );
+                    }
+
+                    // Signal render complete.
+                    window.__RENDER_COMPLETE__ = true;
+                }
             }
-        }
 
-        bootstrap(SpritesTest, {
-            onError: () => {
-                window.__INIT_FAILED__ = true;
-            },
-        });
-    </script>
-</body>
-
+            bootstrap(SpritesTest, {
+                onError: () => {
+                    window.__INIT_FAILED__ = true;
+                },
+            });
+        </script>
+    </body>
 </html>

--- a/tests/visual/fonts.spec.ts
+++ b/tests/visual/fonts.spec.ts
@@ -1,3 +1,5 @@
+// noinspection DuplicatedCode
+
 import { expect, test } from './coverage-fixture';
 
 const GPU_PRESENT_DELAY = Number(process.env.GPU_PRESENT_DELAY ?? 100);

--- a/tests/visual/mixed.spec.ts
+++ b/tests/visual/mixed.spec.ts
@@ -1,3 +1,5 @@
+// noinspection DuplicatedCode
+
 import { expect, test } from './coverage-fixture';
 
 const GPU_PRESENT_DELAY = Number(process.env.GPU_PRESENT_DELAY ?? 100);

--- a/tests/visual/post-process.spec.ts
+++ b/tests/visual/post-process.spec.ts
@@ -1,3 +1,5 @@
+// noinspection DuplicatedCode
+
 import type { Page } from '@playwright/test';
 
 import { expect, test } from './coverage-fixture';

--- a/tests/visual/primitives.spec.ts
+++ b/tests/visual/primitives.spec.ts
@@ -1,3 +1,5 @@
+// noinspection DuplicatedCode
+
 import { expect, test } from './coverage-fixture';
 
 // Delay after render-complete signal before taking a screenshot, to allow the

--- a/tests/visual/sprites.spec.ts
+++ b/tests/visual/sprites.spec.ts
@@ -1,3 +1,5 @@
+// noinspection DuplicatedCode
+
 import { expect, test } from './coverage-fixture';
 
 const GPU_PRESENT_DELAY = Number(process.env.GPU_PRESENT_DELAY ?? 100);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes Overview

This pull request refactors the visual test specifications and fixtures, focusing on code organization, naming consistency, and linting improvements.

## Spec Files

Added `// noinspection DuplicatedCode` comments to the following test specification files:
- `tests/visual/camera.spec.ts`
- `tests/visual/fonts.spec.ts`
- `tests/visual/mixed.spec.ts`
- `tests/visual/post-process.spec.ts`
- `tests/visual/primitives.spec.ts`
- `tests/visual/sprites.spec.ts`

Also added a similar comment to `tests/visual/coverage-fixture.ts`.

## HTML Fixtures - Constant Naming Refactor

All visual fixture HTML files now use consistent camelCase naming for palette index constants:
- `BLACK/RED/GREEN/BLUE/YELLOW/CYAN/MAGENTA/WHITE` → `colorBlack/colorRed/colorGreen/colorBlue/colorYellow/colorCyan/colorMagenta/colorWhite`
- Updated in: `camera.html`, `fonts.html`, `mixed.html`, `primitives.html`, `sprites.html`, `post-process.html`

Additionally, HTML fixtures received formatting updates including:
- Reorganized HTML/CSS layout for readability
- Added lint-suppression comments (e.g., `<!--suppress MagicNumberJS -->`)
- Adjusted whitespace and line wrapping

Test rendering logic and behavior remain unchanged.

## Post-Process Fixture Refactoring

The `post-process.html` fixture received more substantial changes:
- Extracted effect setup logic from the `init()` switch statement into dedicated instance methods:
  - `applyStackedEffect()`
  - `applyCRTPipBoyEffect()`
  - `applyPixelGlitchEffect()`
  - `applyBarrelEffect()`
  - `applyScanlinesEffect()`
  - `applyMaskEffect()`
  - `applyVignetteEffect()`
  - `applyAberrationEffect()`
  - `applyBloomEffect()`
- Renamed the display-buffer eligibility set from `NEEDS_DISPLAY` to `needsDisplay`
- Applied the same constant naming refactor (uppercase to camelCase) for palette colors

The `configure()` and `render()` methods preserve original functionality while using the refactored helper methods and renamed constants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->