### PR TITLE
chore: cleanup assets

### DIFF
--- a/src/__test__/setup.ts
+++ b/src/__test__/setup.ts
@@ -17,9 +17,7 @@ function installGlobalIfMissing(name: string, value: unknown): void {
     /* eslint-enable security/detect-object-injection */
 }
 
-/**
- * Provide WebGPU constants that don't exist in Node.js.
- */
+/** Provide WebGPU constants that don't exist in Node.js. */
 installGlobalIfMissing('GPUBufferUsage', {
     MAP_READ: 0x0001,
     MAP_WRITE: 0x0002,
@@ -33,17 +31,13 @@ installGlobalIfMissing('GPUBufferUsage', {
     QUERY_RESOLVE: 0x0200,
 });
 
-/**
- * Provide GPUMapMode constants that don't exist in Node.js.
- */
+/** Provide GPUMapMode constants that don't exist in Node.js. */
 installGlobalIfMissing('GPUMapMode', {
     READ: 0x0001,
     WRITE: 0x0002,
 });
 
-/**
- * Provide GPUTextureUsage constants that don't exist in Node.js.
- */
+/** Provide GPUTextureUsage constants that don't exist in Node.js. */
 installGlobalIfMissing('GPUTextureUsage', {
     COPY_SRC: 0x01,
     COPY_DST: 0x02,

--- a/src/__test__/setup.ts
+++ b/src/__test__/setup.ts
@@ -1,63 +1,101 @@
 // Global test setup for blit-tech.
 // Imported by vitest.config.ts setupFiles.
 
-// Provide WebGPU constants that don't exist in Node.js.
-if (typeof GPUBufferUsage === 'undefined') {
-    (globalThis as unknown as Record<string, unknown>).GPUBufferUsage = {
-        MAP_READ: 0x0001,
-        MAP_WRITE: 0x0002,
-        COPY_SRC: 0x0004,
-        COPY_DST: 0x0008,
-        INDEX: 0x0010,
-        VERTEX: 0x0020,
-        UNIFORM: 0x0040,
-        STORAGE: 0x0080,
-        INDIRECT: 0x0100,
-        QUERY_RESOLVE: 0x0200,
-    };
+type GlobalRecord = Record<string, unknown>;
+
+/**
+ * Installs a global stub when the name is missing in the test environment.
+ *
+ * @param name Global property name.
+ * @param value Stub value to assign.
+ */
+function installGlobalIfMissing(name: string, value: unknown): void {
+    /* eslint-disable security/detect-object-injection -- test setup installs known global stubs by name */
+    if (typeof (globalThis as GlobalRecord)[name] === 'undefined') {
+        (globalThis as unknown as GlobalRecord)[name] = value;
+    }
+    /* eslint-enable security/detect-object-injection */
 }
 
-if (typeof GPUMapMode === 'undefined') {
-    (globalThis as unknown as Record<string, unknown>).GPUMapMode = {
-        READ: 0x0001,
-        WRITE: 0x0002,
-    };
-}
+/**
+ * Provide WebGPU constants that don't exist in Node.js.
+ */
+installGlobalIfMissing('GPUBufferUsage', {
+    MAP_READ: 0x0001,
+    MAP_WRITE: 0x0002,
+    COPY_SRC: 0x0004,
+    COPY_DST: 0x0008,
+    INDEX: 0x0010,
+    VERTEX: 0x0020,
+    UNIFORM: 0x0040,
+    STORAGE: 0x0080,
+    INDIRECT: 0x0100,
+    QUERY_RESOLVE: 0x0200,
+});
 
-if (typeof GPUTextureUsage === 'undefined') {
-    (globalThis as unknown as Record<string, unknown>).GPUTextureUsage = {
-        COPY_SRC: 0x01,
-        COPY_DST: 0x02,
-        TEXTURE_BINDING: 0x04,
-        STORAGE_BINDING: 0x08,
-        RENDER_ATTACHMENT: 0x10,
-    };
-}
+/**
+ * Provide GPUMapMode constants that don't exist in Node.js.
+ */
+installGlobalIfMissing('GPUMapMode', {
+    READ: 0x0001,
+    WRITE: 0x0002,
+});
 
-// The fallback OffscreenCanvas returns zero-filled RGBA bytes from getImageData().
-// Zero-alpha pixels map to the transparent sentinel (index 0) in SpriteSheet.indexize().
-// Tests that need specific opaque pixel colors must stub OffscreenCanvas themselves
-// (e.g. via vi.stubGlobal('OffscreenCanvas', ...)) before calling indexize().
-if (typeof OffscreenCanvas === 'undefined') {
-    (globalThis as unknown as Record<string, unknown>).OffscreenCanvas = class {
+/**
+ * Provide GPUTextureUsage constants that don't exist in Node.js.
+ */
+installGlobalIfMissing('GPUTextureUsage', {
+    COPY_SRC: 0x01,
+    COPY_DST: 0x02,
+    TEXTURE_BINDING: 0x04,
+    STORAGE_BINDING: 0x08,
+    RENDER_ATTACHMENT: 0x10,
+});
+
+/**
+ * The fallback OffscreenCanvas returns zero-filled RGBA bytes from getImageData().
+ * Zero-alpha pixels map to the transparent sentinel (index 0) in SpriteSheet.indexize().
+ *
+ * Tests that need specific opaque pixel colors must stub OffscreenCanvas themselves
+ * (e.g. via vi.stubGlobal('OffscreenCanvas', ...)) before calling indexize().
+ */
+installGlobalIfMissing(
+    'OffscreenCanvas',
+    class {
+        /** The width of the canvas. */
         public readonly width: number;
+
+        /** The height of the canvas. */
         public readonly height: number;
 
+        /**
+         * Creates a new OffscreenCanvas stub with the specified width and height.
+         *
+         * @param width The width of the canvas.
+         * @param height The height of the canvas.
+         */
         constructor(width: number, height: number) {
             this.width = width;
             this.height = height;
         }
 
+        /**
+         * Returns a mock context for the canvas.
+         *
+         * @param _contextId The context ID (ignored).
+         */
         getContext(_contextId: string) {
             const w = this.width;
             const h = this.height;
+
             return {
                 drawImage: () => {},
                 imageSmoothingEnabled: false,
                 getImageData: (_x: number, _y: number, _w: number, _h: number) => ({
+                    // 4 = bytes per RGBA pixel returned by OffscreenCanvas getImageData().
                     data: new Uint8ClampedArray(w * h * 4),
                 }),
             };
         }
-    };
-}
+    },
+);

--- a/src/__test__/webgpu-mock.ts
+++ b/src/__test__/webgpu-mock.ts
@@ -3,6 +3,94 @@
  * Provides stub objects that track calls without requiring a real GPU.
  */
 
+// #region Constants
+
+/** Default width and height for mock textures when a descriptor omits dimensions. */
+const DEFAULT_SIZE_PX = 256;
+
+/**
+ * Palette uniform byte size: 256 palette indices x vec4(f32) x 4 bytes.
+ * Matches {@link WebGpuRenderer} palette buffer layout.
+ */
+const INDEX_COUNT = 256;
+const RGBA_COMPONENT_COUNT = 4;
+const BYTES_PER_FLOAT32 = 4;
+const BUFFER_BYTE_SIZE = INDEX_COUNT * RGBA_COMPONENT_COUNT * BYTES_PER_FLOAT32;
+
+// #endregion
+
+// #region Helpers
+
+/**
+ * Options for creating a mock GPUBuffer stub.
+ */
+type MockBufferOptions = {
+    /**
+     * Buffer size in bytes.
+     */
+    size: number;
+
+    /**
+     * Buffer usage flags.
+     */
+    usage: GPUBufferUsageFlags;
+
+    /**
+     * Buffer label.
+     */
+    label: string;
+};
+
+/**
+ * Creates a mock GPUBuffer stub with the shared map/unmap shape used across mocks.
+ *
+ * @param options Buffer size, usage flags, and label.
+ * @param options.size Buffer size in bytes.
+ * @param options.usage Buffer usage flags.
+ * @param options.label Buffer label.
+ * @returns Mock GPUBuffer stub.
+ */
+function createMockGPUBufferStub({ size, usage, label }: MockBufferOptions): GPUBuffer {
+    return {
+        size,
+        usage,
+        label,
+        mapAsync: () => Promise.resolve(),
+        getMappedRange: () => new ArrayBuffer(size),
+        unmap: () => {},
+        destroy: () => {},
+    } as unknown as GPUBuffer;
+}
+
+/**
+ * Resolves mock texture width and height from a WebGPU texture descriptor size field.
+ *
+ * @param size Descriptor size (scalar, tuple, or extent dict).
+ * @returns Width and height in pixels.
+ */
+function resolveMockTextureSize(size: GPUTextureDescriptor['size']): { width: number; height: number } {
+    if (typeof size === 'number') {
+        return { width: size, height: size };
+    }
+
+    // Resolve array size as width/height, defaulting to DEFAULT_SIZE_PX if undefined.
+    if (Array.isArray(size)) {
+        return {
+            width: size[0] ?? DEFAULT_SIZE_PX,
+            height: size[1] ?? DEFAULT_SIZE_PX,
+        };
+    }
+
+    const extent = size as GPUExtent3DDict;
+
+    return {
+        width: extent.width,
+        height: extent.height ?? DEFAULT_SIZE_PX,
+    };
+}
+
+// #endregion
+
 // #region GPUTexture
 
 /**
@@ -13,7 +101,11 @@
  * @param label - Texture label.
  * @returns Mock GPUTexture stub.
  */
-export function createMockGPUTexture(width = 256, height = 256, label = 'MockTexture'): GPUTexture {
+export function createMockGPUTexture(
+    width = DEFAULT_SIZE_PX,
+    height = DEFAULT_SIZE_PX,
+    label = 'MockTexture',
+): GPUTexture {
     return {
         width,
         height,
@@ -65,42 +157,73 @@ export function createMockGPUDevice(): GPUDevice {
     } as unknown as GPURenderPipeline;
 
     return {
+        /**
+         * Creates a mock GPUShaderModule stub.
+         *
+         * @returns Mock GPUShaderModule stub.
+         */
         createShaderModule: () => ({ label: 'MockShaderModule' }) as unknown as GPUShaderModule,
+
+        /**
+         * Creates a mock GPURenderPipeline stub.
+         *
+         * @returns Mock GPURenderPipeline stub.
+         */
         createRenderPipeline: () => mockPipeline,
+
+        /**
+         * Creates a mock GPUBuffer stub.
+         *
+         * @param desc Buffer descriptor.
+         * @returns Mock GPUBuffer stub.
+         */
         createBuffer: (desc: GPUBufferDescriptor) =>
-            ({
+            createMockGPUBufferStub({
                 size: desc.size,
                 usage: desc.usage,
                 label: desc.label ?? 'MockBuffer',
-                mapAsync: () => Promise.resolve(),
-                getMappedRange: () => new ArrayBuffer(desc.size),
-                unmap: () => {},
-                destroy: () => {},
-            }) as unknown as GPUBuffer,
-        createBindGroup: () => ({ label: 'MockBindGroup' }) as unknown as GPUBindGroup,
-        createSampler: () => ({ label: 'MockSampler' }) as unknown as GPUSampler,
-        createTexture: (desc: GPUTextureDescriptor) => {
-            let width: number;
-            let height: number;
+            }),
 
-            if (typeof desc.size === 'number') {
-                width = desc.size;
-                height = desc.size;
-            } else if (Array.isArray(desc.size)) {
-                width = desc.size[0] ?? 256;
-                height = desc.size[1] ?? 256;
-            } else {
-                width = (desc.size as GPUExtent3DDict).width;
-                height = (desc.size as GPUExtent3DDict).height ?? 256;
-            }
+        /**
+         * Creates a mock GPUBindGroup stub.
+         *
+         * @returns Mock GPUBindGroup stub.
+         */
+        createBindGroup: () => ({ label: 'MockBindGroup' }) as unknown as GPUBindGroup,
+
+        /**
+         * Creates a mock GPUSampler stub.
+         *
+         * @returns Mock GPUSampler stub.
+         */
+        createSampler: () => ({ label: 'MockSampler' }) as unknown as GPUSampler,
+
+        /**
+         * Creates a mock GPUTexture stub.
+         *
+         * @param desc Texture descriptor.
+         * @returns Mock GPUTexture stub.
+         */
+        createTexture: (desc: GPUTextureDescriptor) => {
+            const { width, height } = resolveMockTextureSize(desc.size);
 
             return createMockGPUTexture(width, height, desc.label ?? 'MockTexture');
         },
+
+        /**
+         * Creates a mock GPUCommandEncoder stub.
+         *
+         * @returns Mock GPUCommandEncoder stub.
+         */
         createCommandEncoder: () => ({
             beginRenderPass: () => createMockRenderPassEncoder(),
             finish: () => ({ label: 'MockCommandBuffer' }) as unknown as GPUCommandBuffer,
             label: 'MockCommandEncoder',
         }),
+
+        /**
+         * Queue for submitting GPU commands.
+         */
         queue: {
             writeBuffer: () => {}, // uniform/vertex buffer uploads
             writeTexture: () => {}, // r8uint indexed texture uploads
@@ -109,10 +232,30 @@ export function createMockGPUDevice(): GPUDevice {
             onSubmittedWorkDone: () => Promise.resolve(), // GPU work completion signal
             label: 'MockQueue',
         },
+
+        /**
+         * Set of supported features.
+         */
         features: new Set(),
+
+        /**
+         * Supported limits.
+         */
         limits: {} as GPUSupportedLimits,
+
+        /**
+         * Promise that resolves when the device is lost.
+         */
         lost: Promise.resolve({ reason: undefined, message: '' } as unknown as GPUDeviceLostInfo),
+
+        /**
+         * Destroys the device.
+         */
         destroy: () => {},
+
+        /**
+         * Label for the device.
+         */
         label: 'MockDevice',
     } as unknown as GPUDevice;
 }
@@ -145,15 +288,11 @@ export function createMockGPUCanvasContext(): GPUCanvasContext {
  * @returns Mock GPUBuffer stub.
  */
 export function createMockPaletteBuffer(): GPUBuffer {
-    return {
-        size: 256 * 4 * 4,
+    return createMockGPUBufferStub({
+        size: BUFFER_BYTE_SIZE,
         usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
         label: 'Mock Palette Buffer',
-        mapAsync: () => Promise.resolve(),
-        getMappedRange: () => new ArrayBuffer(256 * 4 * 4),
-        unmap: () => {},
-        destroy: () => {},
-    } as unknown as GPUBuffer;
+    });
 }
 
 // #endregion
@@ -172,6 +311,7 @@ export function installMockNavigatorGPU(): void {
             limits: {} as GPUSupportedLimits,
             info: { vendor: 'mock', architecture: 'mock', device: 'mock', description: 'Mock GPU' },
         }),
+
         getPreferredCanvasFormat: () => 'bgra8unorm' as GPUTextureFormat,
     };
 
@@ -191,6 +331,7 @@ export function installMockNavigatorGPU(): void {
 export function uninstallMockNavigatorGPU(): void {
     if ('navigator' in globalThis) {
         const nav = globalThis.navigator as unknown as Record<string, unknown>;
+
         delete nav.gpu;
     }
 }

--- a/src/__test__/webgpu-mock.ts
+++ b/src/__test__/webgpu-mock.ts
@@ -21,23 +21,15 @@ const BUFFER_BYTE_SIZE = INDEX_COUNT * RGBA_COMPONENT_COUNT * BYTES_PER_FLOAT32;
 
 // #region Helpers
 
-/**
- * Options for creating a mock GPUBuffer stub.
- */
+/** Options for creating a mock GPUBuffer stub. */
 type MockBufferOptions = {
-    /**
-     * Buffer size in bytes.
-     */
+    /** Buffer size in bytes. */
     size: number;
 
-    /**
-     * Buffer usage flags.
-     */
+    /** Buffer usage flags. */
     usage: GPUBufferUsageFlags;
 
-    /**
-     * Buffer label.
-     */
+    /** Buffer label. */
     label: string;
 };
 
@@ -221,9 +213,7 @@ export function createMockGPUDevice(): GPUDevice {
             label: 'MockCommandEncoder',
         }),
 
-        /**
-         * Queue for submitting GPU commands.
-         */
+        /** Queue for submitting GPU commands. */
         queue: {
             writeBuffer: () => {}, // uniform/vertex buffer uploads
             writeTexture: () => {}, // r8uint indexed texture uploads
@@ -233,29 +223,19 @@ export function createMockGPUDevice(): GPUDevice {
             label: 'MockQueue',
         },
 
-        /**
-         * Set of supported features.
-         */
+        /** Set of supported features. */
         features: new Set(),
 
-        /**
-         * Supported limits.
-         */
+        /** Supported limits. */
         limits: {} as GPUSupportedLimits,
 
-        /**
-         * Promise that resolves when the device is lost.
-         */
+        /** Promise that resolves when the device is lost. */
         lost: Promise.resolve({ reason: undefined, message: '' } as unknown as GPUDeviceLostInfo),
 
-        /**
-         * Destroys the device.
-         */
+        /** Destroys the device. */
         destroy: () => {},
 
-        /**
-         * Label for the device.
-         */
+        /** Label for the device. */
         label: 'MockDevice',
     } as unknown as GPUDevice;
 }

--- a/src/assets/AssetLoader.ts
+++ b/src/assets/AssetLoader.ts
@@ -18,6 +18,12 @@ const loadedImages = new Map<string, HTMLImageElement>();
  */
 const loadingPromises = new Map<string, Promise<HTMLImageElement>>();
 
+/**
+ * Raster image file extensions accepted by {@link AssetLoader.loadImage}.
+ * Allocated once at module load; checked inside {@link buildExtensionHint}.
+ */
+const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp']);
+
 // #endregion
 
 // #region URL Hint Helpers
@@ -83,12 +89,8 @@ function buildExtensionHint(extension: string): string | null {
         return "This looks like a font file. For images, use a file that ends with '.png'.";
     }
 
-    // Raster image file extensions that are valid targets for {@link AssetLoader.loadImage}.
-    // Constructed once at module load to avoid a per-call allocation in {@link buildExtensionHint}.
-    const imageExtensions = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp']);
-
     // File extensions recognized as raster image formats.
-    if (extension === '' || imageExtensions.has(extension)) {
+    if (extension === '' || IMAGE_EXTENSIONS.has(extension)) {
         return null;
     }
 

--- a/src/assets/AssetLoader.ts
+++ b/src/assets/AssetLoader.ts
@@ -20,7 +20,7 @@ const loadingPromises = new Map<string, Promise<HTMLImageElement>>();
 
 // #endregion
 
-// #region Error Helpers
+// #region URL Hint Helpers
 
 /**
  * Returns whether a URL is absolute or uses a special browser scheme.
@@ -30,12 +30,69 @@ const loadingPromises = new Map<string, Promise<HTMLImageElement>>();
  */
 function isExplicitUrl(url: string): boolean {
     const lowerUrl = url.toLowerCase();
-    return (
-        lowerUrl.startsWith('//') ||
-        lowerUrl.includes('://') ||
-        lowerUrl.startsWith('data:') ||
-        lowerUrl.startsWith('blob:')
-    );
+
+    // URL scheme prefixes that identify an absolute or special-scheme URL.
+    // Checked after the `://` shortcut in {@link isExplicitUrl}.
+    const specialSchemePrefixes = ['//', 'data:', 'blob:'] as const;
+
+    // Lowercase scheme prefixes treated as explicit browser locations (after `://` check).
+    return lowerUrl.includes('://') || specialSchemePrefixes.some((prefix) => lowerUrl.startsWith(prefix));
+}
+
+/**
+ * Returns whether a URL already points at an explicit location: an absolute URL,
+ * a special browser scheme, or a rooted/relative (`/`, `./`) path. When this is
+ * false, the caller suggests an `images/` location.
+ *
+ * @param url - Path or URL to inspect.
+ * @returns True when the URL needs no `images/` prefix hint.
+ */
+function hasExplicitLocation(url: string): boolean {
+    // Path prefixes that already point at an explicit location,
+    // so no `images/` directory hint is appended in error messages.
+    const rootedPathPrefixes = ['/', './'] as const;
+
+    // URL prefixes that already point at an explicit location, so no `images/` hint is needed.
+    return isExplicitUrl(url) || rootedPathPrefixes.some((prefix) => url.startsWith(prefix));
+}
+
+/**
+ * Extracts the lowercase file extension (including the dot) from a URL,
+ * ignoring any query string or fragment.
+ *
+ * @param url - Path or URL to inspect.
+ * @returns Extension like `.png`, or an empty string when none is present.
+ */
+function extractExtension(url: string): string {
+    const path = url.split(/[?#]/)[0] ?? url;
+    const fileName = path.slice(path.lastIndexOf('/') + 1);
+    const dotIndex = fileName.lastIndexOf('.');
+
+    return dotIndex >= 0 ? fileName.slice(dotIndex).toLowerCase() : '';
+}
+
+/**
+ * Builds the extension-specific hint for a failing image URL.
+ *
+ * @param extension - Lowercase extension including the dot (or empty string).
+ * @returns Hint text, or null when the extension warrants no hint.
+ */
+function buildExtensionHint(extension: string): string | null {
+    // Extension that triggers a font-specific hint when used on an image load path.
+    if (extension === '.btfont') {
+        return "This looks like a font file. For images, use a file that ends with '.png'.";
+    }
+
+    // Raster image file extensions that are valid targets for {@link AssetLoader.loadImage}.
+    // Constructed once at module load to avoid a per-call allocation in {@link buildExtensionHint}.
+    const imageExtensions = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp']);
+
+    // File extensions recognized as raster image formats.
+    if (extension === '' || imageExtensions.has(extension)) {
+        return null;
+    }
+
+    return `The extension '${extension}' does not look like an image file. Did you mean '.png'?`;
 }
 
 /**
@@ -45,34 +102,75 @@ function isExplicitUrl(url: string): boolean {
  * @returns Extra hint text (or empty string when no hint applies).
  */
 function buildImageHints(url: string): string {
-    const hints: string[] = [];
-
-    if (!isExplicitUrl(url) && !url.startsWith('/') && !url.startsWith('./')) {
-        hints.push(`Did you mean '/images/${url}' or './images/${url}'?`);
-    }
-
-    const queryIndex = url.indexOf('?');
-    const hashIndex = url.indexOf('#');
-    let cleanUrl = url;
-    const cutIndex = queryIndex === -1 ? hashIndex : hashIndex === -1 ? queryIndex : Math.min(queryIndex, hashIndex);
-
-    if (cutIndex !== -1) {
-        cleanUrl = url.slice(0, cutIndex);
-    }
-
-    const slashIndex = cleanUrl.lastIndexOf('/');
-    const fileName = slashIndex >= 0 ? cleanUrl.slice(slashIndex + 1) : cleanUrl;
-    const dotIndex = fileName.lastIndexOf('.');
-    const extension = dotIndex >= 0 ? fileName.slice(dotIndex).toLowerCase() : '';
-    const knownImageExtensions = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp']);
-
-    if (extension === '.btfont') {
-        hints.push("This looks like a font file. For images, use a file that ends with '.png'.");
-    } else if (extension !== '' && !knownImageExtensions.has(extension)) {
-        hints.push(`The extension '${extension}' does not look like an image file. Did you mean '.png'?`);
-    }
+    const pathHint = hasExplicitLocation(url) ? null : `Did you mean '/images/${url}' or './images/${url}'?`;
+    const hints = [pathHint, buildExtensionHint(extractExtension(url))].filter((hint): hint is string => hint !== null);
 
     return hints.length > 0 ? ` ${hints.join(' ')}` : '';
+}
+
+// #endregion
+
+// #region Load Pipeline
+
+/**
+ * Builds the rejection error for a failed browser image load.
+ *
+ * @param url - Path or URL that failed to load.
+ * @returns Error with path, extension, and location hints.
+ */
+function buildImageNotFoundError(url: string): Error {
+    return new Error(
+        `Can't find the image '${url}'. Make sure it's in your project folder and the path is correct. ` +
+            'Check for typos, wrong letter casing, or a missing file extension.' +
+            buildImageHints(url),
+    );
+}
+
+/**
+ * Removes an in-flight entry so a later request can retry the same URL.
+ *
+ * @param url - Path or URL whose pending load should be cleared.
+ */
+function clearInFlight(url: string): void {
+    loadingPromises.delete(url);
+}
+
+/**
+ * Starts a browser image load and registers the in-flight promise.
+ *
+ * @param url - Path or URL to load.
+ * @returns Promise that resolves to the loaded image element.
+ */
+function startLoading(url: string): Promise<HTMLImageElement> {
+    const promise = new Promise<HTMLImageElement>((resolve, reject) => {
+        const img = new Image();
+
+        img.onload = () => {
+            clearInFlight(url);
+
+            try {
+                assertImageElementWithinLimits('image', img);
+
+                loadedImages.set(url, img);
+
+                resolve(img);
+            } catch (error) {
+                reject(error);
+            }
+        };
+
+        img.onerror = () => {
+            clearInFlight(url);
+
+            reject(buildImageNotFoundError(url));
+        };
+
+        img.src = url;
+    });
+
+    loadingPromises.set(url, promise);
+
+    return promise;
 }
 
 // #endregion
@@ -100,55 +198,7 @@ export class AssetLoader {
      * @throws Error if the image cannot be loaded.
      */
     static async loadImage(url: string): Promise<HTMLImageElement> {
-        // Return cached image if available.
-        const cachedImage = loadedImages.get(url);
-
-        if (cachedImage) {
-            return cachedImage;
-        }
-
-        // Return existing promise if already loading.
-        const existingPromise = loadingPromises.get(url);
-
-        if (existingPromise) {
-            return existingPromise;
-        }
-
-        // Start loading.
-        const promise = new Promise<HTMLImageElement>((resolve, reject) => {
-            const img = new Image();
-
-            img.onload = () => {
-                try {
-                    assertImageElementWithinLimits('image', img);
-                } catch (error) {
-                    loadingPromises.delete(url);
-                    reject(error);
-                    return;
-                }
-
-                loadedImages.set(url, img);
-                loadingPromises.delete(url);
-                resolve(img);
-            };
-
-            img.onerror = () => {
-                loadingPromises.delete(url);
-                reject(
-                    new Error(
-                        `Can't find the image '${url}'. Make sure it's in your project folder and the path is correct. ` +
-                            'Check for typos, wrong letter casing, or a missing file extension.' +
-                            buildImageHints(url),
-                    ),
-                );
-            };
-
-            img.src = url;
-        });
-
-        loadingPromises.set(url, promise);
-
-        return promise;
+        return loadedImages.get(url) ?? loadingPromises.get(url) ?? (await startLoading(url));
     }
 
     /**

--- a/src/assets/BitmapFont.ts
+++ b/src/assets/BitmapFont.ts
@@ -99,20 +99,50 @@ export interface TextSize {
 
 // #region Constants
 
-/**
- * Maximum number of cached string-width measurements retained at once.
- *
- * The cache uses insertion order and evicts the oldest entry when it reaches
- * this limit.
- */
-const MAX_MEASURE_CACHE_SIZE = 256;
-
-/**
- * Size of the direct lookup table used for ASCII glyphs (`0-127`).
- */
+/** Size of the direct lookup table used for ASCII glyphs (`0-127`). */
 const ASCII_CACHE_SIZE = 128;
 
 // #endregion
+
+/**
+ * Returns whether a value is a non-null plain object (not an array).
+ * Used to validate `FileData.glyphs` and individual glyph entries before reading their fields.
+ *
+ * @param value - The value to check.
+ * @returns `true` if the value is a non-null plain object, `false` otherwise.
+ */
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+/**
+ * Creates an empty ASCII glyph lookup table pre-filled with `null`.
+ *
+ * @returns A new array of `Glyph | null` with `ASCII_CACHE_SIZE` elements, all initialized to `null`.
+ */
+function createAsciiGlyphTable(): (Glyph | null)[] {
+    return new Array<Glyph | null>(ASCII_CACHE_SIZE).fill(null);
+}
+
+/**
+ * Writes a single-byte glyph into the ASCII fast-path table when the key is in range.
+ *
+ * @param asciiGlyphs - Pre-sized lookup table for codes `0-127`.
+ * @param char - Glyph map key from the `.btfont` file.
+ * @param glyph - Runtime glyph metadata to store.
+ */
+function populateAsciiGlyph(asciiGlyphs: (Glyph | null)[], char: string, glyph: Glyph): void {
+    if (char.length !== 1) {
+        return;
+    }
+
+    const code = char.charCodeAt(0);
+
+    if (code < ASCII_CACHE_SIZE) {
+        // eslint-disable-next-line security/detect-object-injection -- Index is bounds-checked above
+        asciiGlyphs[code] = glyph;
+    }
+}
 
 /**
  * Bitmap font backed by a sprite-sheet texture atlas.
@@ -228,17 +258,10 @@ export class BitmapFont {
         lineHeight: number,
         baseline: number,
     ): BitmapFont {
-        const asciiGlyphs: (Glyph | null)[] = new Array<Glyph | null>(ASCII_CACHE_SIZE).fill(null);
+        const asciiGlyphs = createAsciiGlyphTable();
 
         for (const [char, glyph] of glyphs) {
-            if (char.length === 1) {
-                const code = char.charCodeAt(0);
-
-                if (code < ASCII_CACHE_SIZE) {
-                    // eslint-disable-next-line security/detect-object-injection -- Index is bounds-checked above
-                    asciiGlyphs[code] = glyph;
-                }
-            }
+            populateAsciiGlyph(asciiGlyphs, char, glyph);
         }
 
         return new BitmapFont(spriteSheet, glyphs, asciiGlyphs, name, size, lineHeight, baseline);
@@ -276,11 +299,24 @@ export class BitmapFont {
         const atlasHeight = spriteSheet.height;
 
         const { glyphs, asciiGlyphs } = BitmapFont.buildGlyphsFromEntries(glyphEntries, atlasWidth, atlasHeight);
-        const size = BitmapFont.resolvePositiveMetric(data.size, 12);
+
+        // Default font size in points when the `.btfont` descriptor omits or invalidates `size`.
+        const defaultFontSizePt = 12;
+
+        const size = BitmapFont.resolvePositiveMetric(data.size, defaultFontSizePt);
+
         const lineHeight = BitmapFont.resolvePositiveMetric(data.lineHeight, size);
         const baseline = BitmapFont.resolvePositiveMetric(data.baseline, size);
 
-        return new BitmapFont(spriteSheet, glyphs, asciiGlyphs, data.name || 'Unknown', size, lineHeight, baseline);
+        return new BitmapFont(
+            spriteSheet,
+            glyphs,
+            asciiGlyphs,
+            data.name || 'Unknown', // display name used when the `.btfont` descriptor omits `name`
+            size,
+            lineHeight,
+            baseline,
+        );
     }
 
     // #region Loading Helpers
@@ -293,13 +329,31 @@ export class BitmapFont {
      * @returns Safe positive metric for {@link BitmapFont} construction.
      */
     private static resolvePositiveMetric(value: unknown, fallback: number): number {
-        const parsed = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : Number.NaN;
+        const parsed = BitmapFont.parseMetricValue(value);
 
         if (Number.isFinite(parsed) && parsed > 0) {
             return parsed;
         }
 
         return fallback;
+    }
+
+    /**
+     * Coerces a raw `.btfont` metric field to a number.
+     *
+     * @param value - Raw JSON value for `size`, `lineHeight`, or `baseline`.
+     * @returns Parsed number, or `NaN` when the value cannot be coerced.
+     */
+    private static parseMetricValue(value: unknown): number {
+        if (typeof value === 'number') {
+            return value;
+        }
+
+        if (typeof value === 'string') {
+            return Number(value);
+        }
+
+        return Number.NaN;
     }
 
     /**
@@ -325,23 +379,11 @@ export class BitmapFont {
         try {
             data = JSON.parse(jsonText) as FileData;
         } catch {
-            throw new Error(
-                `The font file '${url}' is broken or not a valid .btfont file. Check that it's the right file.` +
-                    BitmapFont.buildExtensionHint(url, '.btfont'),
-            );
+            throw BitmapFont.buildBrokenFileError(url);
         }
 
-        if (
-            typeof data.texture !== 'string' ||
-            data.texture.length === 0 ||
-            data.glyphs === null ||
-            typeof data.glyphs !== 'object' ||
-            Array.isArray(data.glyphs)
-        ) {
-            throw new Error(
-                `The font file '${url}' is broken or not a valid .btfont file. Check that it's the right file.` +
-                    BitmapFont.buildExtensionHint(url, '.btfont'),
-            );
+        if (!BitmapFont.isValidFileData(data)) {
+            throw BitmapFont.buildBrokenFileError(url);
         }
 
         const glyphEntries = Object.entries(data.glyphs);
@@ -361,13 +403,53 @@ export class BitmapFont {
     }
 
     /**
+     * Returns a consistent "broken or invalid .btfont" error with an extension hint appended.
+     *
+     * Used by both the JSON parse failure and the structural validation failure paths in
+     * {@link parseBtfontFile} to ensure identical messaging.
+     *
+     * @param url - Path to the `.btfont` file (used in the error message and hint).
+     * @returns Error ready to throw.
+     */
+    private static buildBrokenFileError(url: string): Error {
+        return new Error(
+            `The font file '${url}' is broken or not a valid .btfont file. Check that it's the right file.` +
+                BitmapFont.buildExtensionHint(url, '.btfont'),
+        );
+    }
+
+    /**
+     * Returns whether parsed `.btfont` JSON has the required top-level fields.
+     *
+     * @param data - Parsed font descriptor.
+     * @returns Whether the data is valid.
+     */
+    private static isValidFileData(data: FileData): boolean {
+        if (typeof data.texture !== 'string' || data.texture.length === 0) {
+            return false;
+        }
+
+        return isPlainRecord(data.glyphs);
+    }
+
+    /**
+     * Returns whether a glyph entry is a plain object suitable for validation.
+     *
+     * @param glyphData - Raw glyph entry from the parsed font file.
+     * @returns Whether the glyph data is a valid object.
+     */
+    private static isGlyphEntryObject(glyphData: unknown): glyphData is GlyphData {
+        return isPlainRecord(glyphData);
+    }
+
+    /**
      * Validates glyph entries before the font atlas image is decoded.
      *
      * @param glyphEntries - Glyph map entries from the parsed font file.
      */
     private static validateGlyphEntriesPreAtlas(glyphEntries: Array<[string, GlyphData]>): void {
         for (const [char, glyphData] of glyphEntries) {
-            if (glyphData === null || typeof glyphData !== 'object' || Array.isArray(glyphData)) {
+            if (!BitmapFont.isGlyphEntryObject(glyphData)) {
                 throw new AssetLimitError(btfontGlyphEntryNotObjectError(BitmapFont.formatGlyphCharLabel(char)));
             }
 
@@ -393,7 +475,7 @@ export class BitmapFont {
         atlasHeight: number,
     ): { glyphs: Map<string, Glyph>; asciiGlyphs: (Glyph | null)[] } {
         const glyphs = new Map<string, Glyph>();
-        const asciiGlyphs: (Glyph | null)[] = new Array<Glyph | null>(ASCII_CACHE_SIZE).fill(null);
+        const asciiGlyphs = createAsciiGlyphTable();
 
         for (const [char, glyphData] of glyphEntries) {
             const glyphError = validateBtfontGlyphAtlasBounds(
@@ -416,14 +498,7 @@ export class BitmapFont {
 
             glyphs.set(char, glyph);
 
-            if (char.length === 1) {
-                const code = char.charCodeAt(0);
-
-                if (code < ASCII_CACHE_SIZE) {
-                    // eslint-disable-next-line security/detect-object-injection -- Index is bounds-checked above
-                    asciiGlyphs[code] = glyph;
-                }
-            }
+            populateAsciiGlyph(asciiGlyphs, char, glyph);
         }
 
         return { glyphs, asciiGlyphs };
@@ -437,14 +512,11 @@ export class BitmapFont {
      * @returns Loaded texture image for the font atlas.
      */
     private static loadTexture(texture: string, url: string): Promise<HTMLImageElement> {
-        // Embedded PNG data URIs are validated in parseBtfontFile before decode.
-        if (texture.toLowerCase().startsWith(BTFONT_EMBEDDED_TEXTURE_PREFIX)) {
-            return BitmapFont.loadImage(texture);
-        }
-
-        // Otherwise, resolve the path relative to the font file.
-        const baseUrl = url.substring(0, url.lastIndexOf('/') + 1);
-        const textureUrl = baseUrl + texture;
+        // Embedded PNG data URIs are validated in parseBtfontFile before decode;
+        // relative paths are resolved against the .btfont file's directory.
+        const textureUrl = texture.toLowerCase().startsWith(BTFONT_EMBEDDED_TEXTURE_PREFIX)
+            ? texture
+            : url.substring(0, url.lastIndexOf('/') + 1) + texture;
 
         return BitmapFont.loadImage(textureUrl);
     }
@@ -485,7 +557,7 @@ export class BitmapFont {
      * @returns Hint text or an empty string.
      */
     private static buildPathHint(url: string, folderName: string): string {
-        if (BitmapFont.isExplicitUrl(url) || url.startsWith('/') || url.startsWith('./')) {
+        if (BitmapFont.hasExplicitLocation(url)) {
             return '';
         }
 
@@ -500,13 +572,7 @@ export class BitmapFont {
      * @returns Hint text or an empty string.
      */
     private static buildExtensionHint(url: string, expectedExtension: string): string {
-        const slashIndex = url.lastIndexOf('/');
-        const rawFileName = slashIndex >= 0 ? url.slice(slashIndex + 1) : url;
-        const queryIndex = rawFileName.indexOf('?');
-        const hashIndex = rawFileName.indexOf('#');
-        const cutIndex =
-            queryIndex === -1 ? hashIndex : hashIndex === -1 ? queryIndex : Math.min(queryIndex, hashIndex);
-        const fileName = cutIndex === -1 ? rawFileName : rawFileName.slice(0, cutIndex);
+        const fileName = url.slice(url.lastIndexOf('/') + 1).split(/[?#]/)[0] ?? url;
         const dotIndex = fileName.lastIndexOf('.');
         const extension = dotIndex >= 0 ? fileName.slice(dotIndex).toLowerCase() : '';
 
@@ -527,7 +593,13 @@ export class BitmapFont {
         if (char.length === 1) {
             const code = char.charCodeAt(0);
 
-            if (code < 32 || code === 127) {
+            // Control character boundary codes used when formatting glyph validation error labels.
+            // Code points at or below `controlCharBoundary`, or equal to `asciiDelCode`,
+            // are rendered as `U+XXXX` escape sequences rather than literal characters.
+            const controlCharBoundary = 31;
+            const asciiDelCode = 127;
+
+            if (code <= controlCharBoundary || code === asciiDelCode) {
                 return `U+${code.toString(16).toUpperCase().padStart(4, '0')}`;
             }
         }
@@ -543,12 +615,23 @@ export class BitmapFont {
      */
     private static isExplicitUrl(url: string): boolean {
         const lowerUrl = url.toLowerCase();
-        return (
-            lowerUrl.startsWith('//') ||
-            lowerUrl.includes('://') ||
-            lowerUrl.startsWith('data:') ||
-            lowerUrl.startsWith('blob:')
-        );
+
+        if (lowerUrl.includes('://')) {
+            return true;
+        }
+
+        return ['//', 'data:', 'blob:'].some((prefix) => lowerUrl.startsWith(prefix));
+    }
+
+    /**
+     * Returns whether the URL already specifies an absolute or explicit location.
+     *
+     * @param url - URL to inspect.
+     * @returns True when the URL has an explicit location.
+     */
+    private static hasExplicitLocation(url: string): boolean {
+        // '/', './' = Relative path prefixes that do not need a folder hint during load errors.
+        return BitmapFont.isExplicitUrl(url) || (['/', './'] as const).some((prefix) => url.startsWith(prefix));
     }
 
     // #endregion
@@ -575,13 +658,17 @@ export class BitmapFont {
 
                 resolve(image);
             };
-            image.onerror = () =>
-                reject(
+            image.onerror = () => {
+                // Maximum characters shown from a texture source string in load-failure messages.
+                const maxErrorURLDisplayChars = 50;
+
+                return reject(
                     new Error(
-                        `Can't find the font texture image '${src.substring(0, 50)}'. ` +
+                        `Can't find the font texture image '${src.substring(0, maxErrorURLDisplayChars)}'. ` +
                             'Check for typos, wrong letter casing, or a missing file extension.',
                     ),
                 );
+            };
 
             image.src = src;
         });
@@ -689,7 +776,12 @@ export class BitmapFont {
         }
 
         // Cache the result with FIFO eviction when full.
-        if (this.measureCache.size >= MAX_MEASURE_CACHE_SIZE) {
+
+        // Maximum number of cached string-width measurements retained at once.
+        // The cache uses FIFO eviction (insertion order) when this limit is reached.
+        const measureCacheMaxSize = 256;
+
+        if (this.measureCache.size >= measureCacheMaxSize) {
             // Remove oldest inserted entry (first key in Map insertion order).
             const firstKey = this.measureCache.keys().next().value;
 
@@ -748,7 +840,7 @@ export class BitmapFont {
 
             if (code < ASCII_CACHE_SIZE) {
                 // eslint-disable-next-line security/detect-object-injection -- Index is bounds-checked above
-                return (this.asciiGlyphs[code] ?? null) !== null;
+                return this.asciiGlyphs[code] != null;
             }
         }
 

--- a/src/assets/Palette.ts
+++ b/src/assets/Palette.ts
@@ -16,14 +16,19 @@ import {
 import { HUD_SLOTS } from './palettes/hudData';
 import { C64_HEX, CGA_HEX, GAMEBOY_HEX, NES_HEX, PICO8_HEX, VGA_HEX } from './palettes/presetData';
 
-/** Supported palette sizes exposed by the public API. */
-const VALID_SIZES = [2, 4, 16, 32, 64, 128, 256] as const;
-
 /** Uniform-buffer slot count used by the renderer regardless of active palette size. */
 const GPU_SIZE = 256;
 
 /** Number of normalized floats stored per palette color in GPU upload buffers. */
 const GPU_FLOATS_PER_COLOR = 4;
+
+/**
+ * Number of bytes per palette color in packed RGB byte arrays.
+ *
+ * Used by {@link Palette.fromUint8Array} and {@link Palette.toUint8Array}.
+ * Alpha is excluded from the packed format; it is always inferred as fully opaque.
+ */
+const RGB_BYTES_PER_COLOR = 3;
 
 /**
  * JSON-serializable palette payload.
@@ -44,7 +49,10 @@ type Serialized = {
  * @returns `true` when the size is supported.
  */
 function isValidSize(size: number): boolean {
-    return VALID_SIZES.includes(size as (typeof VALID_SIZES)[number]);
+    // Supported palette sizes exposed by the public API.
+    const validSizes = [2, 4, 16, 32, 64, 128, 256] as const;
+
+    return validSizes.includes(size as (typeof validSizes)[number]);
 }
 
 /**
@@ -163,13 +171,7 @@ export class Palette {
         validateSize(size);
 
         this.size = size;
-        this.colors = new Array<Color32>(size);
-        this.colors[0] = Color32.transparent;
-
-        for (let i = 1; i < size; i++) {
-            // eslint-disable-next-line security/detect-object-injection -- Constructor initializes all indices from 1 to size - 1
-            this.colors[i] = Color32.black.clone();
-        }
+        this.colors = [Color32.transparent, ...Array.from({ length: size - 1 }, () => Color32.black.clone())];
     }
 
     /**
@@ -216,23 +218,26 @@ export class Palette {
      * @throws Error if the byte length or palette size is invalid.
      */
     public static fromUint8Array(data: Uint8Array, size?: number): Palette {
-        if (data.length % 3 !== 0) {
+        if (data.length % RGB_BYTES_PER_COLOR !== 0) {
             throw new Error(`Palette byte array length ${data.length} is not divisible by 3`);
         }
 
-        const inferredSize = data.length / 3;
+        const inferredSize = data.length / RGB_BYTES_PER_COLOR;
         const resolvedSize = size ?? inferredSize;
 
         validateSize(resolvedSize);
 
-        if (data.length !== resolvedSize * 3) {
+        if (data.length !== resolvedSize * RGB_BYTES_PER_COLOR) {
             throw new Error(`Palette byte array length ${data.length} does not match palette size ${resolvedSize}`);
         }
 
         const palette = new Palette(resolvedSize);
 
         for (let i = 1; i < resolvedSize; i++) {
-            const offset = i * 3;
+            const offset = i * RGB_BYTES_PER_COLOR;
+
+            // Fully opaque alpha value applied when deserializing RGB-only byte arrays.
+            const opaqueAlpha = 255;
 
             palette.set(
                 i,
@@ -240,7 +245,7 @@ export class Palette {
                     readByte(data, offset),
                     readByte(data, offset + 1),
                     readByte(data, offset + 2),
-                    255,
+                    opaqueAlpha,
                 ),
             );
         }
@@ -333,10 +338,8 @@ export class Palette {
             throw new Error(hudRangeError(startSlot, HUD_SLOTS.length, this.size));
         }
 
-        let offset = 0;
-
-        for (const { hex, name } of HUD_SLOTS) {
-            const slot = startSlot + offset++;
+        for (const [i, { hex, name }] of HUD_SLOTS.entries()) {
+            const slot = startSlot + i;
 
             this.set(slot, Color32.fromHex(hex));
             this.setNamed(name, slot);
@@ -415,6 +418,7 @@ export class Palette {
      */
     public setNamed(name: string, index: number): void {
         this.assertIndexInRange(index);
+
         this.namedIndices.set(name, index);
     }
 
@@ -481,23 +485,12 @@ export class Palette {
 
         this.colors[0] = Color32.transparent;
 
-        for (let i = 1; i < copyCount; i++) {
+        for (let i = 1; i < this.size; i++) {
             // eslint-disable-next-line security/detect-object-injection -- Loop bounds restrict i to valid initialized source and destination indices
-            this.colors[i] = other.colorAt(i).clone();
+            this.colors[i] = i < copyCount ? other.colorAt(i).clone() : Color32.transparent.clone();
         }
 
-        for (let i = copyCount; i < this.size; i++) {
-            // eslint-disable-next-line security/detect-object-injection -- Loop bounds restrict i to valid destination indices
-            this.colors[i] = Color32.transparent.clone();
-        }
-
-        this.namedIndices.clear();
-
-        for (const [name, index] of other.namedIndices.entries()) {
-            if (index < this.size) {
-                this.namedIndices.set(name, index);
-            }
-        }
+        this.copyNamedIndices(other);
 
         this._isDirty = true;
     }
@@ -559,19 +552,7 @@ export class Palette {
      * @returns Byte array with `size * 3` entries.
      */
     public toUint8Array(): Uint8Array {
-        const bytes = new Uint8Array(this.size * 3);
-
-        for (let i = 0; i < this.size; i++) {
-            const color = this.colorAt(i);
-            const offset = i * 3;
-
-            // eslint-disable-next-line security/detect-object-injection -- Offset is computed within the allocated Uint8Array bounds
-            bytes[offset] = color.r;
-            bytes[offset + 1] = color.g;
-            bytes[offset + 2] = color.b;
-        }
-
-        return bytes;
+        return new Uint8Array(this.colors.flatMap((color) => [color.r, color.g, color.b]));
     }
 
     /**
@@ -611,13 +592,7 @@ export class Palette {
      * @returns Matching palette index, or `-1` when no exact match exists.
      */
     public findColor(color: Color32): number {
-        for (let i = 0; i < this.size; i++) {
-            if (this.colorAt(i).isEqual(color)) {
-                return i;
-            }
-        }
-
-        return -1;
+        return this.colors.findIndex((c) => c.isEqual(color));
     }
 
     /**
@@ -627,6 +602,24 @@ export class Palette {
      */
     public toString(): string {
         return `Palette(size=${this.size}, colors=${this.size}, names=${this.namedIndices.size})`;
+    }
+
+    /**
+     * Copies named index aliases from another palette into this one.
+     *
+     * Aliases that reference an index outside this palette's size are ignored.
+     * Clears the current named index map before copying.
+     *
+     * @param from - Source palette to copy named indices from.
+     */
+    private copyNamedIndices(from: Palette): void {
+        this.namedIndices.clear();
+
+        for (const [name, index] of from.namedIndices.entries()) {
+            if (index < this.size) {
+                this.namedIndices.set(name, index);
+            }
+        }
     }
 
     /**

--- a/src/assets/PaletteEffect.ts
+++ b/src/assets/PaletteEffect.ts
@@ -9,7 +9,7 @@
  * callback, after `demo.render()` but before `Renderer.endFrame()`.
  */
 
-import { Color32 } from '../utils/Color32';
+import { clampUnit, Color32 } from '../utils/Color32';
 import type { EasingFunction } from '../utils/Easing';
 import { applyEasing } from '../utils/Easing';
 import type { Palette } from './Palette';
@@ -45,8 +45,13 @@ export interface PaletteEffect {
  * {@link GameLoop} callback signatures remain unchanged.
  */
 export class PaletteEffectManager {
+    /** Active effects managed by this instance. */
     private effects: PaletteEffect[] = [];
+
+    /** Last wall-clock time in milliseconds, used to compute delta time. */
     private lastTime = 0;
+
+    /** Clock function returning milliseconds. */
     private readonly timeProvider: () => number;
 
     /**
@@ -139,7 +144,10 @@ export class PaletteEffectManager {
  * temporary {@link Color32} to avoid per-frame allocations.
  */
 export class CycleEffect implements PaletteEffect {
+    /** Accumulator for tracking the cycling progress. */
     private accumulator = 0;
+
+    /** Temporary {@link Color32} used for color calculations. */
     private readonly temp = new Color32(0, 0, 0, 0);
 
     /**
@@ -150,31 +158,60 @@ export class CycleEffect implements PaletteEffect {
      * @param speed - Steps per second. Positive = forward, negative = backward.
      */
     constructor(
+        /** First palette index in the cycling range (inclusive). */
         private readonly start: number,
+
+        /** Last palette index in the cycling range (inclusive). */
         private readonly end: number,
+
+        /** Steps per second. Positive = forward, negative = backward. */
         private readonly speed: number,
     ) {}
 
+    /**
+     * Advances the effect by one frame.
+     *
+     * @param palette - Active palette to modify.
+     * @param deltaMs - Wall-clock milliseconds since the last frame.
+     * @returns `true` to keep running, `false` to remove from the manager.
+     */
     update(palette: Palette, deltaMs: number): boolean {
         if (this.speed === 0 || this.start >= this.end) {
             return true;
         }
 
-        this.accumulator += (this.speed * deltaMs) / 1000;
+        // Milliseconds per second for delta-to-rate conversion in time-based effects.
+        const msPerSecond = 1_000;
 
-        // Forward rotation: shift entries toward lower indices, wrap last to first.
+        this.accumulator += (this.speed * deltaMs) / msPerSecond;
+        this.applyForwardSteps(palette);
+        this.applyBackwardSteps(palette);
+
+        return true; // Runs indefinitely.
+    }
+
+    /**
+     * Drains the forward accumulator, rotating entries toward lower indices one step at a time.
+     *
+     * @param palette - Palette whose entries are rotated.
+     */
+    private applyForwardSteps(palette: Palette): void {
         while (this.accumulator >= 1) {
             this.accumulator -= 1;
             this.rotateForward(palette);
         }
+    }
 
-        // Backward rotation: shift entries toward higher indices, wrap first to last.
+    /**
+     * Drains the backward accumulator, rotating entries toward higher indices one step at a time.
+     *
+     * @param palette - Palette whose entries are rotated.
+     */
+    private applyBackwardSteps(palette: Palette): void {
         while (this.accumulator <= -1) {
             this.accumulator += 1;
             this.rotateBackward(palette);
         }
-
-        return true; // Runs indefinitely.
     }
 
     /**
@@ -210,6 +247,102 @@ export class CycleEffect implements PaletteEffect {
 
 // #endregion
 
+// #region Fade Helpers
+
+/**
+ * Snapshots a contiguous palette index range into a new array.
+ *
+ * @param source - Palette to read from.
+ * @param start - First index (inclusive).
+ * @param end - Last index (inclusive).
+ * @returns Cloned colors for each index in the range.
+ */
+function snapshotPaletteRange(source: Palette, start: number, end: number): Color32[] {
+    return Array.from({ length: end - start + 1 }, (_, index) => source.get(start + index));
+}
+
+/**
+ * Computes normalized and eased fade progress for the current elapsed time.
+ *
+ * @param elapsed - Elapsed fade time in milliseconds.
+ * @param durationMs - Total fade duration in milliseconds.
+ * @param easing - Easing curve to apply.
+ * @returns Normalized `t`, eased factor, and whether the fade is still running.
+ */
+function computeFadeProgress(
+    elapsed: number,
+    durationMs: number,
+    easing: EasingFunction,
+): { t: number; easedT: number; isRunning: boolean } {
+    const rawT = durationMs <= 0 ? 1 : elapsed / durationMs;
+    const t = clampUnit(rawT);
+    const easedT = applyEasing(t, easing);
+
+    return { t, easedT, isRunning: t < 1 };
+}
+
+/**
+ * Applies one fade step to a single palette entry.
+ *
+ * @param palette - Active palette to modify.
+ * @param index - Palette index to update.
+ * @param snap - Snapshot color at fade start.
+ * @param tgt - Target color at fade end.
+ * @param t - Normalized progress in [0, 1].
+ * @param easedT - Eased progress factor.
+ */
+function applyFadeEntry(palette: Palette, index: number, snap: Color32, tgt: Color32, t: number, easedT: number): void {
+    if (t >= 1) {
+        palette.getRef(index).copyFrom(tgt);
+    } else {
+        palette.getRef(index).copyFrom(snap).lerpInPlace(tgt, easedT);
+    }
+}
+
+/**
+ * Applies one fade step to a contiguous sub-range of palette entries.
+ *
+ * Both {@link FadeEffect} and {@link FadeRangeEffect} use this helper.
+ * Snapshot arrays use zero-based local indices; `offset` maps them to palette
+ * indices: `snapshot[i - offset]` corresponds to palette entry `i`.
+ *
+ * @param palette - Active palette to modify.
+ * @param snapshot - Snapshot colors indexed from `0`.
+ * @param targets - Target colors indexed from `0`.
+ * @param from - First palette index to update (inclusive).
+ * @param to - Last palette index to update (inclusive).
+ * @param offset - Value subtracted from a palette index to get the snapshot array index.
+ * @param t - Normalized progress in [0, 1].
+ * @param easedT - Eased progress factor.
+ */
+function applyFadeToRange(
+    palette: Palette,
+    snapshot: Color32[],
+    targets: Color32[],
+    from: number,
+    to: number,
+    offset: number,
+    t: number,
+    easedT: number,
+): void {
+    for (let i = from; i <= to; i++) {
+        const localIdx = i - offset;
+
+        // eslint-disable-next-line security/detect-object-injection -- localIdx derived from loop bounds
+        const snap = snapshot[localIdx];
+        // eslint-disable-next-line security/detect-object-injection -- localIdx derived from loop bounds
+        const tgt = targets[localIdx];
+
+        if (!snap || !tgt) {
+            continue;
+        }
+
+        applyFadeEntry(palette, i, snap, tgt, t, easedT);
+    }
+}
+
+// #endregion
+
 // #region FadeEffect
 
 /**
@@ -222,9 +355,16 @@ export class CycleEffect implements PaletteEffect {
  * Auto-removes when the fade completes.
  */
 export class FadeEffect implements PaletteEffect {
+    /** Accumulated elapsed time in milliseconds. */
     private elapsed = 0;
+
+    /** Snapshot of the starting palette colors. */
     private readonly snapshotColors: Color32[];
+
+    /** Target palette colors to fade toward. */
     private readonly targetColors: Color32[];
+
+    /** Number of palette entries being faded. */
     private readonly size: number;
 
     /**
@@ -243,48 +383,26 @@ export class FadeEffect implements PaletteEffect {
     ) {
         this.size = source.size;
 
-        // Snapshot source colors once (one-time allocation).
-        this.snapshotColors = [];
-
-        for (let i = 0; i < this.size; i++) {
-            this.snapshotColors.push(source.get(i));
-        }
-
-        // Cache target colors to avoid repeated cloning.
-        this.targetColors = [];
-
-        for (let i = 0; i < target.size; i++) {
-            this.targetColors.push(target.get(i));
-        }
+        this.snapshotColors = snapshotPaletteRange(source, 0, this.size - 1);
+        this.targetColors = snapshotPaletteRange(target, 0, target.size - 1);
     }
 
+    /**
+     * Advances the effect by one frame.
+     *
+     * @param palette - Active palette to modify.
+     * @param deltaMs - Wall-clock milliseconds since the last frame.
+     * @returns `true` to keep running, `false` to remove from the manager.
+     */
     update(palette: Palette, deltaMs: number): boolean {
         this.elapsed += deltaMs;
 
-        const rawT = this.durationMs <= 0 ? 1 : this.elapsed / this.durationMs;
-        const t = rawT < 0 ? 0 : rawT > 1 ? 1 : rawT;
-        const easedT = applyEasing(t, this.easing);
-
+        const { t, easedT, isRunning } = computeFadeProgress(this.elapsed, this.durationMs, this.easing);
         const count = Math.min(this.size, palette.size);
 
-        for (let i = 1; i < count; i++) {
-            // eslint-disable-next-line security/detect-object-injection -- Loop index within validated bounds
-            const snap = this.snapshotColors[i];
-            // eslint-disable-next-line security/detect-object-injection -- Loop index within validated bounds
-            const tgt = this.targetColors[i];
+        applyFadeToRange(palette, this.snapshotColors, this.targetColors, 1, count - 1, 0, t, easedT);
 
-            if (!snap || !tgt) {
-                continue;
-            }
-
-            if (t >= 1) {
-                palette.getRef(i).copyFrom(tgt);
-            } else {
-                palette.getRef(i).copyFrom(snap).lerpInPlace(tgt, easedT);
-            }
-        }
-
-        return t < 1;
+        return isRunning;
     }
 }
 
@@ -299,8 +417,13 @@ export class FadeEffect implements PaletteEffect {
  * Auto-removes when the fade completes.
  */
 export class FadeRangeEffect implements PaletteEffect {
+    /** Accumulated elapsed time in milliseconds. */
     private elapsed = 0;
+
+    /** Snapshot of the starting palette colors. */
     private readonly snapshotColors: Color32[];
+
+    /** Target palette colors to fade toward. */
     private readonly targetColors: Color32[];
 
     /**
@@ -321,47 +444,25 @@ export class FadeRangeEffect implements PaletteEffect {
         private readonly durationMs: number,
         private readonly easing: EasingFunction = 'linear',
     ) {
-        // Snapshot only the range we care about.
-        this.snapshotColors = [];
-
-        for (let i = start; i <= end; i++) {
-            this.snapshotColors.push(source.get(i));
-        }
-
-        this.targetColors = [];
-
-        for (let i = start; i <= end; i++) {
-            this.targetColors.push(target.get(i));
-        }
+        this.snapshotColors = snapshotPaletteRange(source, start, end);
+        this.targetColors = snapshotPaletteRange(target, start, end);
     }
 
+    /**
+     * Advances the effect by one frame.
+     *
+     * @param palette - Active palette to modify.
+     * @param deltaMs - Wall-clock milliseconds since the last frame.
+     * @returns `true` to keep running, `false` to remove from the manager.
+     */
     update(palette: Palette, deltaMs: number): boolean {
         this.elapsed += deltaMs;
 
-        const rawT = this.durationMs <= 0 ? 1 : this.elapsed / this.durationMs;
-        const t = rawT < 0 ? 0 : rawT > 1 ? 1 : rawT;
-        const easedT = applyEasing(t, this.easing);
+        const { t, easedT, isRunning } = computeFadeProgress(this.elapsed, this.durationMs, this.easing);
 
-        for (let i = this.start; i <= this.end; i++) {
-            const localIdx = i - this.start;
+        applyFadeToRange(palette, this.snapshotColors, this.targetColors, this.start, this.end, this.start, t, easedT);
 
-            // eslint-disable-next-line security/detect-object-injection -- localIdx derived from loop bounds
-            const snap = this.snapshotColors[localIdx];
-            // eslint-disable-next-line security/detect-object-injection -- localIdx derived from loop bounds
-            const tgt = this.targetColors[localIdx];
-
-            if (!snap || !tgt) {
-                continue;
-            }
-
-            if (t >= 1) {
-                palette.getRef(i).copyFrom(tgt);
-            } else {
-                palette.getRef(i).copyFrom(snap).lerpInPlace(tgt, easedT);
-            }
-        }
-
-        return t < 1;
+        return isRunning;
     }
 }
 
@@ -377,7 +478,10 @@ export class FadeRangeEffect implements PaletteEffect {
  * restores the snapshot and auto-removes.
  */
 export class FlashEffect implements PaletteEffect {
+    /** Accumulated elapsed time in milliseconds. */
     private elapsed = 0;
+
+    /** Snapshot of palette colors before flash. */
     private snapshotColors: Color32[] | null = null;
 
     /**
@@ -391,14 +495,17 @@ export class FlashEffect implements PaletteEffect {
         private readonly durationMs: number,
     ) {}
 
+    /**
+     * Advances the effect by one frame.
+     *
+     * @param palette - Active palette to modify.
+     * @param deltaMs - Wall-clock milliseconds since the last frame.
+     * @returns `true` to keep running, `false` to remove from the manager.
+     */
     update(palette: Palette, deltaMs: number): boolean {
         // First frame: snapshot and apply flash.
         if (this.snapshotColors === null) {
-            this.snapshotColors = [];
-
-            for (let i = 0; i < palette.size; i++) {
-                this.snapshotColors.push(palette.get(i));
-            }
+            this.snapshotColors = snapshotPaletteRange(palette, 0, palette.size - 1);
 
             for (let i = 1; i < palette.size; i++) {
                 palette.getRef(i).copyFrom(this.color);

--- a/src/assets/SpriteSheet.ts
+++ b/src/assets/SpriteSheet.ts
@@ -7,8 +7,73 @@ import { Vector2i } from '../utils/Vector2i';
 import { AssetLoader } from './AssetLoader';
 import type { Palette } from './Palette';
 
+/** Number of slots in a palette; matches the 8-bit palette index range. */
+const PALETTE_SLOT_COUNT = 256;
+
 /** Reused per-call bitmask of sheet indices seen while scanning a source rect. */
-const markIndicesInRectScratch = new Uint8Array(256);
+const MARK_INDICES_IN_RECT_SCRATCH = new Uint8Array(PALETTE_SLOT_COUNT);
+
+/** RGBA byte stride per pixel when reading decoded image data. */
+const RGBA_BYTES_PER_PIXEL = 4;
+
+/** Depth or array-layer count for a 2-D GPU texture descriptor. */
+const TEXTURE_LAYER_COUNT = 1;
+
+/**
+ * Maps retained RGBA bytes to palette indices for one sprite sheet.
+ *
+ * @param w - Image width in pixels.
+ * @param h - Image height in pixels.
+ * @param rgba - RGBA byte buffer (`w * h * 4` bytes).
+ * @param palette - Active palette used for color lookup.
+ * @param imageSrc - Source label for error messages.
+ * @returns Palette index per pixel (`w * h` bytes).
+ */
+function mapRgbaPixelsToIndexed(
+    w: number,
+    h: number,
+    rgba: Uint8Array,
+    palette: Palette,
+    imageSrc: string,
+): Uint8Array<ArrayBuffer> {
+    const indexed = new Uint8Array(w * h);
+    const pixelCount = w * h;
+
+    for (let i = 0; i < pixelCount; i++) {
+        const base = i * RGBA_BYTES_PER_PIXEL;
+        const a = rgba[base + 3];
+
+        if (a === 0) {
+            // Index 0 is the transparent sentinel - the shader discards any pixel with rawIndex == 0.
+            // eslint-disable-next-line security/detect-object-injection
+            indexed[i] = 0;
+            continue;
+        }
+
+        // eslint-disable-next-line security/detect-object-injection
+        const r = rgba[base] ?? 0;
+        const g = rgba[base + 1] ?? 0;
+        const b = rgba[base + 2] ?? 0;
+        const color = new Color32(r, g, b, 255);
+        const index = palette.findColor(color);
+
+        if (index === -1) {
+            const hex =
+                '#' +
+                r.toString(16).padStart(2, '0') +
+                g.toString(16).padStart(2, '0') +
+                b.toString(16).padStart(2, '0');
+            const x = i % w;
+            const y = Math.floor(i / w);
+            throw new Error(spriteColorNotInPaletteError(x, y, imageSrc, hex));
+        }
+
+        // eslint-disable-next-line security/detect-object-injection
+        indexed[i] = index;
+    }
+
+    return indexed;
+}
 
 /**
  * Result object returned by {@link SpriteSheet.loadIndexed}.
@@ -199,17 +264,12 @@ export class SpriteSheet {
         const w = image.width;
         const h = image.height;
 
-        const canvas = new OffscreenCanvas(w, h);
-        const ctx = canvas.getContext('2d') as OffscreenCanvasRenderingContext2D;
-        ctx.imageSmoothingEnabled = false;
-        ctx.drawImage(image, 0, 0);
-
-        const { data } = ctx.getImageData(0, 0, w, h);
+        const data = SpriteSheet.readRgbaPixels(image, w, h);
 
         const seen = new Set<number>();
         const collected: Color32[] = [];
 
-        for (let i = 0; i < data.length; i += 4) {
+        for (let i = 0; i < data.length; i += RGBA_BYTES_PER_PIXEL) {
             const a = data[i + 3] ?? 0;
 
             if (a === 0) {
@@ -235,9 +295,7 @@ export class SpriteSheet {
         const sortMode = options?.sort ?? 'luminance';
 
         if (sortMode === 'luminance') {
-            collected.sort((c1, c2) => {
-                return c1.luminance - c2.luminance;
-            });
+            collected.sort((c1, c2) => c1.luminance - c2.luminance);
         }
 
         // Validate the full destination range up front so a mid-loop palette.set()
@@ -317,61 +375,14 @@ export class SpriteSheet {
         }
 
         assertImageElementWithinLimits('sprite sheet', this.image);
+
         const w = this.size.x;
         const h = this.size.y;
 
-        const canvas = new OffscreenCanvas(w, h);
-        const ctx = canvas.getContext('2d') as OffscreenCanvasRenderingContext2D;
-        ctx.imageSmoothingEnabled = false;
-        ctx.drawImage(this.image, 0, 0);
+        this.rgbaPixels = SpriteSheet.readRgbaPixels(this.image, w, h);
+        this.indexedPixels = mapRgbaPixelsToIndexed(w, h, this.rgbaPixels, palette, this.sourceName);
 
-        const imageData = ctx.getImageData(0, 0, w, h);
-        this.rgbaPixels = new Uint8Array(imageData.data.buffer.slice(0));
-
-        const indexed = new Uint8Array(w * h);
-        const rgba = this.rgbaPixels;
-
-        for (let i = 0; i < w * h; i++) {
-            const base = i * 4;
-            const a = rgba[base + 3];
-
-            if (a === 0) {
-                // Index 0 is the transparent sentinel - the shader discards any pixel with rawIndex == 0.
-                // eslint-disable-next-line security/detect-object-injection
-                indexed[i] = 0;
-                continue;
-            }
-
-            // eslint-disable-next-line security/detect-object-injection
-            const r = rgba[base] ?? 0;
-            const g = rgba[base + 1] ?? 0;
-            const b = rgba[base + 2] ?? 0;
-            const color = new Color32(r, g, b, 255);
-            const index = palette.findColor(color);
-
-            if (index === -1) {
-                const hex =
-                    '#' +
-                    r.toString(16).padStart(2, '0') +
-                    g.toString(16).padStart(2, '0') +
-                    b.toString(16).padStart(2, '0');
-                const x = i % w;
-                const y = Math.floor(i / w);
-                const src = this.image.src ? `'${this.image.src}'` : '(unnamed)';
-                throw new Error(spriteColorNotInPaletteError(x, y, src, hex));
-            }
-
-            // eslint-disable-next-line security/detect-object-injection
-            indexed[i] = index;
-        }
-
-        this.indexedPixels = indexed;
-
-        // Invalidate any existing texture so getTexture() re-creates as r8uint.
-        if (this.texture) {
-            this.texture.destroy();
-            this.texture = null;
-        }
+        this.invalidateTexture();
     }
 
     /**
@@ -426,50 +437,9 @@ export class SpriteSheet {
 
         const w = this.size.x;
         const h = this.size.y;
-        const indexed = new Uint8Array(w * h);
-        const rgba = this.rgbaPixels;
+        this.indexedPixels = mapRgbaPixelsToIndexed(w, h, this.rgbaPixels, palette, this.sourceName);
 
-        for (let i = 0; i < w * h; i++) {
-            const base = i * 4;
-            const a = rgba[base + 3];
-
-            if (a === 0) {
-                // Index 0 is the transparent sentinel - the shader discards any pixel with rawIndex == 0.
-                // eslint-disable-next-line security/detect-object-injection
-                indexed[i] = 0;
-                continue;
-            }
-
-            // eslint-disable-next-line security/detect-object-injection
-            const r = rgba[base] ?? 0;
-            const g = rgba[base + 1] ?? 0;
-            const b = rgba[base + 2] ?? 0;
-            const color = new Color32(r, g, b, 255);
-            const index = palette.findColor(color);
-
-            if (index === -1) {
-                const hex =
-                    '#' +
-                    r.toString(16).padStart(2, '0') +
-                    g.toString(16).padStart(2, '0') +
-                    b.toString(16).padStart(2, '0');
-                const x = i % w;
-                const y = Math.floor(i / w);
-                const src = this.image.src ? `'${this.image.src}'` : '(unnamed)';
-                throw new Error(spriteColorNotInPaletteError(x, y, src, hex));
-            }
-
-            // eslint-disable-next-line security/detect-object-injection
-            indexed[i] = index;
-        }
-
-        this.indexedPixels = indexed;
-
-        // Invalidate GPU texture; it will be re-created as r8uint on next getTexture().
-        if (this.texture) {
-            this.texture.destroy();
-            this.texture = null;
-        }
+        this.invalidateTexture();
     }
 
     /**
@@ -529,7 +499,7 @@ export class SpriteSheet {
         const startY = Math.max(0, srcRect.y);
         const endX = Math.min(this.size.x, srcRect.x + srcRect.width);
         const endY = Math.min(this.size.y, srcRect.y + srcRect.height);
-        const seenSheetIndices = markIndicesInRectScratch;
+        const seenSheetIndices = MARK_INDICES_IN_RECT_SCRATCH;
 
         seenSheetIndices.fill(0);
 
@@ -612,10 +582,12 @@ export class SpriteSheet {
      * @returns GPU texture ready for rendering.
      */
     getTexture(device: GPUDevice): GPUTexture {
-        if (this.indexedPixels !== null && this.texture === null) {
-            this.createIndexedTexture(device);
-        } else if (this.texture === null) {
-            this.createTexture(device);
+        if (this.texture === null) {
+            if (this.indexedPixels !== null) {
+                this.createIndexedTexture(device);
+            } else {
+                this.createTexture(device);
+            }
         }
 
         // Safe assertion: createTexture / createIndexedTexture always initializes this.texture.
@@ -654,10 +626,7 @@ export class SpriteSheet {
      * the GPU texture from the original image.
      */
     destroy(): void {
-        if (this.texture) {
-            this.texture.destroy();
-            this.texture = null;
-        }
+        this.invalidateTexture();
 
         if (this.imageBitmap) {
             this.imageBitmap.close();
@@ -686,9 +655,10 @@ export class SpriteSheet {
         }
 
         assertDimensions('sprite sheet texture', this.size.x, this.size.y);
+
         this.texture = device.createTexture({
             label: 'Sprite Sheet Texture',
-            size: [this.size.x, this.size.y, 1],
+            size: [this.size.x, this.size.y, TEXTURE_LAYER_COUNT],
             format: 'rgba8unorm',
             usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
         });
@@ -715,9 +685,12 @@ export class SpriteSheet {
      */
     private createIndexedTexture(device: GPUDevice): void {
         assertDimensions('sprite sheet texture', this.size.x, this.size.y);
+
+        const extent = [this.size.x, this.size.y, TEXTURE_LAYER_COUNT];
+
         this.texture = device.createTexture({
             label: 'Sprite Sheet Indexed Texture',
-            size: [this.size.x, this.size.y, 1],
+            size: extent,
             format: 'r8uint',
             usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST,
         });
@@ -727,8 +700,54 @@ export class SpriteSheet {
             { texture: this.texture },
             this.indexedPixels as Uint8Array<ArrayBuffer>,
             { bytesPerRow: this.size.x },
-            [this.size.x, this.size.y, 1],
+            extent,
         );
+    }
+
+    // #endregion
+
+    // #region Private Helpers
+
+    /**
+     * Decodes an image's pixels via an off-screen canvas and returns a flat
+     * RGBA byte buffer. Shared by `indexize` and `loadColorsIntoPalette`.
+     *
+     * @param image - Source HTML image element.
+     * @param w - Image width in pixels.
+     * @param h - Image height in pixels.
+     * @returns Flat RGBA byte array (`w * h * RGBA_BYTES_PER_PIXEL` bytes).
+     */
+    private static readRgbaPixels(image: HTMLImageElement, w: number, h: number): Uint8Array<ArrayBuffer> {
+        const canvas = new OffscreenCanvas(w, h);
+        const ctx = canvas.getContext('2d') as OffscreenCanvasRenderingContext2D;
+
+        ctx.imageSmoothingEnabled = false;
+        ctx.drawImage(image, 0, 0);
+
+        return new Uint8Array(ctx.getImageData(0, 0, w, h).data.buffer.slice(0)) as Uint8Array<ArrayBuffer>;
+    }
+
+    /**
+     * Returns a display label for the source image, used in error messages.
+     *
+     * @returns Quoted image `src` when available, or `(unnamed)` for sheets
+     *   created from raw indexed data.
+     */
+    private get sourceName(): string {
+        return this.image?.src ? `'${this.image.src}'` : '(unnamed)';
+    }
+
+    /**
+     * Destroys and clears the cached GPU texture if one is currently held.
+     *
+     * Called before re-creating the texture with a different format (after
+     * `indexize` or `reindexize`) and by `destroy` during full teardown.
+     */
+    private invalidateTexture(): void {
+        if (this.texture) {
+            this.texture.destroy();
+            this.texture = null;
+        }
     }
 
     // #endregion

--- a/src/assets/SystemFont.ts
+++ b/src/assets/SystemFont.ts
@@ -1,7 +1,7 @@
 /**
  * Built-in 6x14 system font for {@link BT.systemPrint}.
  *
- * Expands the embedded glyph bitmaps from {@link systemFontData} into a
+ * Expands the embedded glyph bitmaps from system font data into a
  * palette-indexed texture atlas and wraps the result in a {@link BitmapFont}.
  * The font is fully synchronous to create - no `fetch()`, no image decode.
  *
@@ -48,6 +48,27 @@ const ATLAS_HEIGHT = ATLAS_ROWS * SYSTEM_FONT_GLYPH_HEIGHT;
 // #region Atlas Builder
 
 /**
+ * Writes one glyph's pixel rows into the flat palette-indexed atlas array.
+ * Bit 7 of each bitmap byte is the leftmost pixel.
+ * A set bit maps to palette index 1 (foreground); a clear bit maps to 0 (transparent).
+ *
+ * @param bitmapOffset - Offset into the glyph bitmap data.
+ * @param baseX - X-coordinate of the glyph's top-left corner in the atlas.
+ * @param baseY - Y-coordinate of the glyph's top-left corner in the atlas.
+ * @param pixels - Output pixel buffer to write into.
+ */
+function writeGlyphPixels(bitmapOffset: number, baseX: number, baseY: number, pixels: Uint8Array<ArrayBuffer>): void {
+    for (let y = 0; y < SYSTEM_FONT_GLYPH_HEIGHT; y++) {
+        // Safe: length validated in buildAtlasPixels guarantees bitmapOffset + y is in bounds.
+        const rowByte = SYSTEM_FONT_BITMAPS[bitmapOffset + y] as number;
+
+        for (let x = 0; x < SYSTEM_FONT_GLYPH_WIDTH; x++) {
+            pixels[(baseY + y) * ATLAS_WIDTH + (baseX + x)] = (rowByte >> (7 - x)) & 1;
+        }
+    }
+}
+
+/**
  * Expands bit-pattern glyph data into a flat palette-indexed pixel array.
  *
  * Each set bit becomes palette index `1` (foreground); each clear bit becomes
@@ -70,23 +91,13 @@ function buildAtlasPixels(): Uint8Array<ArrayBuffer> {
     for (let i = 0; i < SYSTEM_FONT_GLYPH_COUNT; i++) {
         const col = i % ATLAS_COLUMNS;
         const row = Math.floor(i / ATLAS_COLUMNS);
-        const baseX = col * SYSTEM_FONT_GLYPH_WIDTH;
-        const baseY = row * SYSTEM_FONT_GLYPH_HEIGHT;
-        const bitmapOffset = i * SYSTEM_FONT_BYTES_PER_GLYPH;
 
-        for (let y = 0; y < SYSTEM_FONT_GLYPH_HEIGHT; y++) {
-            // Safe: length validated above guarantees bitmapOffset + y is in bounds.
-            const rowByte = SYSTEM_FONT_BITMAPS[bitmapOffset + y] as number;
-
-            for (let x = 0; x < SYSTEM_FONT_GLYPH_WIDTH; x++) {
-                // Bit 7 is leftmost pixel.
-                const bit = (rowByte >> (7 - x)) & 1;
-                const px = baseX + x;
-                const py = baseY + y;
-
-                pixels[py * ATLAS_WIDTH + px] = bit;
-            }
-        }
+        writeGlyphPixels(
+            i * SYSTEM_FONT_BYTES_PER_GLYPH,
+            col * SYSTEM_FONT_GLYPH_WIDTH,
+            row * SYSTEM_FONT_GLYPH_HEIGHT,
+            pixels,
+        );
     }
 
     return pixels;
@@ -98,29 +109,26 @@ function buildAtlasPixels(): Uint8Array<ArrayBuffer> {
  * @returns Map of single-character strings to their {@link Glyph} metadata.
  */
 function buildGlyphMap(): Map<string, Glyph> {
-    const glyphs = new Map<string, Glyph>();
+    return new Map(
+        Array.from({ length: SYSTEM_FONT_GLYPH_COUNT }, (_, i) => {
+            const col = i % ATLAS_COLUMNS;
+            const row = Math.floor(i / ATLAS_COLUMNS);
 
-    for (let i = 0; i < SYSTEM_FONT_GLYPH_COUNT; i++) {
-        const charCode = SYSTEM_FONT_FIRST_CHAR + i;
-        const col = i % ATLAS_COLUMNS;
-        const row = Math.floor(i / ATLAS_COLUMNS);
+            const glyph: Glyph = {
+                rect: new Rect2i(
+                    col * SYSTEM_FONT_GLYPH_WIDTH,
+                    row * SYSTEM_FONT_GLYPH_HEIGHT,
+                    SYSTEM_FONT_GLYPH_WIDTH,
+                    SYSTEM_FONT_GLYPH_HEIGHT,
+                ),
+                offsetX: 0,
+                offsetY: 0,
+                advance: SYSTEM_FONT_GLYPH_WIDTH,
+            };
 
-        const glyph: Glyph = {
-            rect: new Rect2i(
-                col * SYSTEM_FONT_GLYPH_WIDTH,
-                row * SYSTEM_FONT_GLYPH_HEIGHT,
-                SYSTEM_FONT_GLYPH_WIDTH,
-                SYSTEM_FONT_GLYPH_HEIGHT,
-            ),
-            offsetX: 0,
-            offsetY: 0,
-            advance: SYSTEM_FONT_GLYPH_WIDTH,
-        };
-
-        glyphs.set(String.fromCharCode(charCode), glyph);
-    }
-
-    return glyphs;
+            return [String.fromCharCode(SYSTEM_FONT_FIRST_CHAR + i), glyph] as [string, Glyph];
+        }),
+    );
 }
 
 // #endregion

--- a/src/assets/palettes/presetData.ts
+++ b/src/assets/palettes/presetData.ts
@@ -6,19 +6,10 @@
  * palette index `1`.
  */
 
-const HEX_DIGITS = '0123456789abcdef';
+// #region Hex Conversion
 
-/**
- * Converts an 8-bit channel value to a two-digit lowercase hex string.
- *
- * @param value - Byte value to convert.
- * @returns Two-character lowercase hex string.
- */
-function byteToHex(value: number): string {
-    const byte = value & 0xff;
-
-    return `${HEX_DIGITS[(byte >> 4) & 0xf]}${HEX_DIGITS[byte & 0xf]}`;
-}
+/** Masks an 8-bit channel before hex formatting. */
+const BYTE_MASK = 0xff;
 
 /**
  * Formats three RGB bytes into a compact `RRGGBB` hex string.
@@ -29,80 +20,57 @@ function byteToHex(value: number): string {
  * @returns RGB color string without a leading `#`.
  */
 function rgbToHex(r: number, g: number, b: number): string {
-    return `${byteToHex(r)}${byteToHex(g)}${byteToHex(b)}`;
+    return [r, g, b].map((channel) => (channel & BYTE_MASK).toString(16).padStart(2, '0')).join('');
 }
 
-/**
- * Builds the default VGA 256-color table.
- *
- * The data includes the classic 16-color base palette, the 6x6x6 color cube,
- * and the grayscale ramp used by standard VGA palettes.
- *
- * @returns VGA palette data as `RRGGBB` hex strings.
- */
-function buildVgaHex(): string[] {
-    const hex: string[] = [
-        '000000',
-        '800000',
-        '008000',
-        '808000',
-        '000080',
-        '800080',
-        '008080',
-        'c0c0c0',
-        '808080',
-        'ff0000',
-        '00ff00',
-        'ffff00',
-        '0000ff',
-        'ff00ff',
-        '00ffff',
-        'ffffff',
-    ];
+// #endregion
 
-    const cubeSteps = [0, 95, 135, 175, 215, 255];
+// #region VGA Palette
 
-    for (const r of cubeSteps) {
-        for (const g of cubeSteps) {
-            for (const b of cubeSteps) {
-                hex.push(rgbToHex(r, g, b));
-            }
-        }
-    }
+/** Classic VGA 16-color base entries (indices 0-15). */
+const VGA_BASE_HEX = [
+    '000000',
+    '800000',
+    '008000',
+    '808000',
+    '000080',
+    '800080',
+    '008080',
+    'c0c0c0',
+    '808080',
+    'ff0000',
+    '00ff00',
+    'ffff00',
+    '0000ff',
+    'ff00ff',
+    '00ffff',
+    'ffffff',
+] as const;
 
-    for (let i = 0; i < 24; i++) {
-        const level = 8 + i * 10;
+/** VGA 6-level per-channel steps for the 216-entry color cube (indices 16-231). */
+const VGA_CUBE_CHANNEL_LEVELS = [0, 95, 135, 175, 215, 255] as const;
 
-        hex.push(rgbToHex(level, level, level));
-    }
+/** VGA grayscale ramp parameters (indices 232-255). */
+const VGA_GRAYSCALE_ENTRY_COUNT = 24;
+const VGA_GRAYSCALE_LEVEL_STEP = 10;
+const VGA_GRAYSCALE_START_LEVEL = 8;
 
-    return hex;
-}
+const VGA_CUBE_HEX = VGA_CUBE_CHANNEL_LEVELS.flatMap((r) =>
+    VGA_CUBE_CHANNEL_LEVELS.flatMap((g) => VGA_CUBE_CHANNEL_LEVELS.map((b) => rgbToHex(r, g, b))),
+);
+
+const VGA_GRAYSCALE_HEX = Array.from({ length: VGA_GRAYSCALE_ENTRY_COUNT }, (_, index) => {
+    const level = VGA_GRAYSCALE_START_LEVEL + index * VGA_GRAYSCALE_LEVEL_STEP;
+
+    return rgbToHex(level, level, level);
+});
 
 /** Default VGA 256-color preset data. */
-export const VGA_HEX = buildVgaHex();
+export const VGA_HEX = [...VGA_BASE_HEX, ...VGA_CUBE_HEX, ...VGA_GRAYSCALE_HEX];
 
-/** Classic CGA 16-color preset data. */
-// cspell:disable
-export const CGA_HEX = [
-    '000000',
-    '0000aa',
-    '00aa00',
-    '00aaaa',
-    'aa0000',
-    'aa00aa',
-    'aa5500',
-    'aaaaaa',
-    '555555',
-    '5555ff',
-    '55ff55',
-    '55ffff',
-    'ff5555',
-    'ff55ff',
-    'ffff55',
-    'ffffff',
-];
-// cspell:enable
+// #endregion
+
+// #region Static Presets
 
 /** Commodore 64 16-color preset data. */
 // cspell:disable
@@ -126,31 +94,31 @@ export const C64_HEX = [
 ];
 // cspell:enable
 
+/** Classic CGA 16-color preset data. */
+// cspell:disable
+export const CGA_HEX = [
+    '000000',
+    '0000aa',
+    '00aa00',
+    '00aaaa',
+    'aa0000',
+    'aa00aa',
+    'aa5500',
+    'aaaaaa',
+    '555555',
+    '5555ff',
+    '55ff55',
+    '55ffff',
+    'ff5555',
+    'ff55ff',
+    'ffff55',
+    'ffffff',
+];
+// cspell:enable
+
 /** Four-shade Game Boy preset data. */
 // cspell:disable
 export const GAMEBOY_HEX = ['0f380f', '306230', '8bac0f', '9bbc0f'];
-// cspell:enable
-
-/** PICO-8 16-color preset data. */
-// cspell:disable
-export const PICO8_HEX = [
-    '000000',
-    '1d2b53',
-    '7e2553',
-    '008751',
-    'ab5236',
-    '5f574f',
-    'c2c3c7',
-    'fff1e8',
-    'ff004d',
-    'ffa300',
-    'ffec27',
-    '00e436',
-    '29adff',
-    '83769c',
-    'ff77a8',
-    'ffccaa',
-];
 // cspell:enable
 
 /** NES 64-slot preset data. */
@@ -214,3 +182,27 @@ export const NES_HEX = [
     'fce0a8',
 ];
 // cspell:enable
+
+/** PICO-8 16-color preset data. */
+// cspell:disable
+export const PICO8_HEX = [
+    '000000',
+    '1d2b53',
+    '7e2553',
+    '008751',
+    'ab5236',
+    '5f574f',
+    'c2c3c7',
+    'fff1e8',
+    'ff004d',
+    'ffa300',
+    'ffec27',
+    '00e436',
+    '29adff',
+    '83769c',
+    'ff77a8',
+    'ffccaa',
+];
+// cspell:enable
+
+// #endregion

--- a/src/utils/Color32.ts
+++ b/src/utils/Color32.ts
@@ -638,8 +638,7 @@ export class Color32 {
      * @returns New color blended between this and other.
      */
     lerp(other: Color32, t: number): Color32 {
-        // Clamp t to [0, 1] ranges using branchless-style ternary (avoids Math.max/min calls).
-        const tc = t < 0 ? 0 : t > 1 ? 1 : t;
+        const tc = clampUnit(t);
 
         // Optimized lerp: use formula a * (1-t) + b * t to reduce operations.
         const oneMinusT = 1 - tc;
@@ -661,7 +660,7 @@ export class Color32 {
      * @returns This color instance for chaining.
      */
     lerpInPlace(other: Color32, t: number): this {
-        const tc = t < 0 ? 0 : t > 1 ? 1 : t;
+        const tc = clampUnit(t);
 
         const oneMinusT = 1 - tc;
 
@@ -925,6 +924,16 @@ export function clampByte(n: number): number {
     // Bitwise operations: if n < 0, use 0; if n > 255, use 255; else truncate n.
     // This is faster than Math.max(0, Math.min(255, n)) | 0.
     return n < 0 ? 0 : n > 255 ? 255 : n | 0;
+}
+
+/**
+ * Clamps a unit interpolation factor to the closed interval [0, 1].
+ *
+ * @param t - Raw interpolation factor.
+ * @returns Clamped factor in range 0-1.
+ */
+export function clampUnit(t: number): number {
+    return t < 0 ? 0 : t > 1 ? 1 : t;
 }
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This pull request performs a broad codebase cleanup and refactor focused on test helpers and WebGPU mocks, asset loading, palette management and effects, sprite-sheet processing, font/system-font generation, and palette preset data. The changes introduce shared helpers, remove duplication, improve clarity, tighten validation and error messages, and consolidate test-time stubs — mostly preserving external APIs and behavior.

## Changes

### src/__test__/setup.ts
- Added a reusable installGlobalIfMissing helper and a typed GlobalRecord; consolidated repeated global-install checks.
- Uses the helper to install WebGPU constant objects (GPUBufferUsage, GPUMapMode, GPUTextureUsage) and an OffscreenCanvas fallback that returns zero-filled RGBA from getImageData().
- Preserves existing OffscreenCanvas mock behavior while reducing duplication.
- Lines changed: +69/-37

### src/__test__/webgpu-mock.ts
- Extracted shared helpers: createMockGPUBufferStub and resolveMockTextureSize.
- Introduced sizing/constants (DEFAULT_SIZE_PX, BUFFER_BYTE_SIZE) and updated createMockGPUTexture, createMockGPUDevice, and createMockPaletteBuffer to use them (replacing hard-coded sizes and inline buffer construction).
- Minor whitespace adjustments in navigator GPU install/uninstall helpers.
- Function default params updated to use DEFAULT_SIZE_PX.
- Lines changed: +148/-27

### src/assets/AssetLoader.ts
- Extracted URL-hint and error-message generation into helpers (special-scheme detection, extension extraction, extension-specific hints, combined hint text).
- Introduced startLoading(url) to manage request lifecycle, in-flight registry, validation, caching, and enriched error messages.
- Simplified loadImage to prefer cache, then in-flight promise, then startLoading; public API unchanged.
- Lines changed: +130/-78

### src/assets/BitmapFont.ts
- Added ASCII glyph helpers (createAsciiGlyphTable, populateAsciiGlyph) and plain-object guards (isPlainRecord).
- Centralized metric parsing via parseMetricValue/resolvePositiveMetric and added defaultFontSizePt.
- Restructured .btfont JSON parsing/validation with buildBrokenFileError, isValidFileData, and isGlyphEntryObject.
- Refactored texture handling, error messaging, and measurement-caching cosmetics.
- Lines changed: +164/-72

### src/assets/Palette.ts
- Introduced RGB_BYTES_PER_COLOR constant and moved valid size data to a module-local array.
- Streamlined construction (transparent head + cloned black entries), serialization/deserialization, and copy logic; added private copyNamedIndices helper.
- toUint8Array, fromUint8Array, findColor, copyFrom, and applyHUD refactored to use the new constant and helpers.
- Lines changed: +47/-54

### src/assets/PaletteEffect.ts
- Added shared fade utilities (snapshotPaletteRange, computeFadeProgress) and range/entry applicators.
- Refactored FadeEffect, FadeRangeEffect, CycleEffect, and FlashEffect to use shared helpers and clearer time/step handling; imports updated to include clampUnit.
- Lines changed: +186/-79

### src/assets/SpriteSheet.ts
- Extracted RGBA→palette-index conversion into mapRgbaPixelsToIndexed and related constants (palette slot count, RGBA stride, etc.).
- Added readRgbaPixels, sourceName, and centralized invalidateTexture to remove duplicated canvas/texture lifecycle code.
- Reworked indexize() and reindexize() to use shared helpers and centralized invalidation; texture creation uses TEXTURE_LAYER_COUNT.
- Lines changed: +136/-117

### src/assets/SystemFont.ts
- Introduced writeGlyphPixels helper and refactored buildAtlasPixels to use it.
- Rewrote buildGlyphMap to construct the glyph map more declaratively.
- No exported API signature changes.
- Lines changed: +49/-41

### src/assets/palettes/presetData.ts
- Replaced byteToHex approach with BYTE_MASK-based rgbToHex and zero-padding formatting.
- Converted VGA palette builder to a declarative construction using VGA_BASE_HEX, VGA_CUBE_CHANNEL_LEVELS, VGA_CUBE_HEX, and VGA_GRAYSCALE_HEX; VGA_HEX now exported as a concatenation of constants (behaviorally unchanged).
- Reorganized static preset layout.
- Lines changed: +93/-101

### src/utils/Color32.ts
- Added exported clampUnit(t: number): number and refactored Color32.lerp / lerpInPlace to use it.
- Lines changed: +12/-3

## Impact
- Only one exported API addition: clampUnit in src/utils/Color32.ts.
- Otherwise, no public TypeScript declarations or external API signatures were changed across the modified modules.
- Primary effects are internal: reduced duplication, centralized helpers, clearer validation and error messages, and behavior-preserving refactors.
- Larger diffs (SpriteSheet, BitmapFont, PaletteEffect, presetData) merit focused review to confirm behavior parity, especially around texture sizing, palette serialization/deserialization, and VGA palette construction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->