### PR TITLE
refactor(assets): streamline BitmapFont control flow and JSON validation

### DIFF
--- a/src/assets/BitmapFont.bench.ts
+++ b/src/assets/BitmapFont.bench.ts
@@ -1,4 +1,5 @@
 // #region Imports
+// noinspection MagicNumberJS
 
 import { bench, describe } from 'vitest';
 
@@ -14,6 +15,9 @@ import { SpriteSheet } from './SpriteSheet';
 const ASCII_CACHE_SIZE = 128;
 const CACHE_HALF_FULL = 128;
 const CACHE_FULL = 256;
+const PRINTABLE_ASCII_START = 32;
+const PRINTABLE_ASCII_END = 126;
+const BENCH_UNICODE_CHARS = ['é', 'Ω', 'Ж', '中'] as const;
 const BENCH_OPTIONS = {
     iterations: 500,
     time: 100,
@@ -75,23 +79,38 @@ function createBenchmarkFont(): BitmapFont {
     const glyphs = new Map<string, Glyph>();
     const asciiGlyphs = new Array<Glyph | null>(ASCII_CACHE_SIZE).fill(null);
     const sheet = new SpriteSheet({ width: 256, height: 256 } as HTMLImageElement);
+    const printableCount = PRINTABLE_ASCII_END - PRINTABLE_ASCII_START + 1;
 
-    for (let code = 32; code <= 126; code++) {
-        const glyph = createGlyph(6 + (code % 4), (code - 32) * 2, 0);
-        const char = String.fromCharCode(code);
+    for (let index = 0; index < printableCount + BENCH_UNICODE_CHARS.length; index++) {
+        let char: string | undefined;
+        let glyph: Glyph;
+        let asciiCode: number | undefined;
 
-        glyphs.set(char, glyph);
-        // eslint-disable-next-line security/detect-object-injection -- Index is an integer constrained to the ASCII table bounds above
-        asciiGlyphs[code] = glyph;
+        if (index < printableCount) {
+            asciiCode = PRINTABLE_ASCII_START + index;
+            char = String.fromCharCode(asciiCode);
+            glyph = createGlyph(6 + (asciiCode % 4), index * 2, 0);
+        } else {
+            const unicodeIndex = index - printableCount;
+
+            // eslint-disable-next-line security/detect-object-injection -- unicodeIndex is bounded by BENCH_UNICODE_CHARS.length
+            char = BENCH_UNICODE_CHARS[unicodeIndex];
+            glyph = createGlyph(9 + unicodeIndex, unicodeIndex * 8, 16);
+        }
+
+        if (char !== undefined) {
+            glyphs.set(char, glyph);
+        }
+
+        if (asciiCode !== undefined) {
+            // eslint-disable-next-line security/detect-object-injection -- asciiCode is bounded to printable ASCII
+            asciiGlyphs[asciiCode] = glyph;
+        }
     }
 
-    for (const [index, char] of ['é', 'Ω', 'Ж', '中'].entries()) {
-        glyphs.set(char, createGlyph(9 + index, index * 8, 16));
-    }
+    const ctor = BitmapFont as unknown as BitmapFontCtor;
 
-    const Ctor = BitmapFont as unknown as BitmapFontCtor;
-
-    return new Ctor(sheet, glyphs, asciiGlyphs, 'BenchFont', 12, 14, 10);
+    return new ctor(sheet, glyphs, asciiGlyphs, 'BenchFont', 12, 14, 10);
 }
 
 /**

--- a/src/assets/BitmapFont.test.ts
+++ b/src/assets/BitmapFont.test.ts
@@ -542,6 +542,23 @@ describe('BitmapFont', () => {
             expect(f.baseline).toBe(12);
         });
 
+        it('should use Unknown when name is a non-string value', async () => {
+            vi.stubGlobal(
+                'fetch',
+                vi.fn().mockResolvedValue(
+                    mockFontFetchResponse({
+                        name: 42,
+                        texture: 'data:image/png;base64,aGVsbG8=',
+                        glyphs: { A: { x: 0, y: 0, w: 8, h: 12, ox: 0, oy: 0, adv: 9 } },
+                    }),
+                ),
+            );
+
+            const f = await BitmapFont.load('bad-name.btfont');
+
+            expect(f.name).toBe('Unknown');
+        });
+
         it('should fall back when size, lineHeight, and baseline are invalid', async () => {
             vi.stubGlobal(
                 'fetch',

--- a/src/assets/BitmapFont.test.ts
+++ b/src/assets/BitmapFont.test.ts
@@ -1,3 +1,5 @@
+// noinspection MagicNumberJS
+
 /**
  * Unit tests for {@link BitmapFont}.
  *

--- a/src/assets/BitmapFont.ts
+++ b/src/assets/BitmapFont.ts
@@ -310,7 +310,7 @@ export class BitmapFont {
             spriteSheet,
             glyphs,
             asciiGlyphs,
-            data.name || 'Unknown', // display name used when the `.btfont` descriptor omits `name`
+            BitmapFont.resolveDisplayName(data.name),
             size,
             lineHeight,
             baseline,
@@ -318,6 +318,22 @@ export class BitmapFont {
     }
 
     // #region Loading Helpers
+
+    /**
+     * Coerces a `.btfont` display `name` field to a non-empty string.
+     *
+     * @param value - Raw JSON value for `name`.
+     * @returns Trimmed name when `value` is a non-empty string; otherwise `'Unknown'`.
+     */
+    private static resolveDisplayName(value: unknown): string {
+        let name = 'Unknown';
+
+        if (typeof value === 'string' && value.length > 0) {
+            name = value;
+        }
+
+        return name;
+    }
 
     /**
      * Coerces a `.btfont` metadata field to a positive finite number.

--- a/src/assets/BitmapFont.ts
+++ b/src/assets/BitmapFont.ts
@@ -132,15 +132,13 @@ function createAsciiGlyphTable(): (Glyph | null)[] {
  * @param glyph - Runtime glyph metadata to store.
  */
 function populateAsciiGlyph(asciiGlyphs: (Glyph | null)[], char: string, glyph: Glyph): void {
-    if (char.length !== 1) {
-        return;
-    }
+    if (char.length === 1) {
+        const code = char.charCodeAt(0);
 
-    const code = char.charCodeAt(0);
-
-    if (code < ASCII_CACHE_SIZE) {
-        // eslint-disable-next-line security/detect-object-injection -- Index is bounds-checked above
-        asciiGlyphs[code] = glyph;
+        if (code < ASCII_CACHE_SIZE) {
+            // eslint-disable-next-line security/detect-object-injection -- Index is bounds-checked above
+            asciiGlyphs[code] = glyph;
+        }
     }
 }
 
@@ -330,12 +328,13 @@ export class BitmapFont {
      */
     private static resolvePositiveMetric(value: unknown, fallback: number): number {
         const parsed = BitmapFont.parseMetricValue(value);
+        let metric = fallback;
 
         if (Number.isFinite(parsed) && parsed > 0) {
-            return parsed;
+            metric = parsed;
         }
 
-        return fallback;
+        return metric;
     }
 
     /**
@@ -345,15 +344,15 @@ export class BitmapFont {
      * @returns Parsed number, or `NaN` when the value cannot be coerced.
      */
     private static parseMetricValue(value: unknown): number {
+        let parsed = Number.NaN;
+
         if (typeof value === 'number') {
-            return value;
+            parsed = value;
+        } else if (typeof value === 'string') {
+            parsed = Number(value);
         }
 
-        if (typeof value === 'string') {
-            return Number(value);
-        }
-
-        return Number.NaN;
+        return parsed;
     }
 
     /**
@@ -374,18 +373,19 @@ export class BitmapFont {
             throw new AssetLimitError(jsonSizeError);
         }
 
-        let data: FileData;
+        let parsed: unknown;
 
         try {
-            data = JSON.parse(jsonText) as FileData;
+            parsed = JSON.parse(jsonText);
         } catch {
             throw BitmapFont.buildBrokenFileError(url);
         }
 
-        if (!BitmapFont.isValidFileData(data)) {
+        if (!BitmapFont.isValidFileData(parsed)) {
             throw BitmapFont.buildBrokenFileError(url);
         }
 
+        const data = parsed;
         const glyphEntries = Object.entries(data.glyphs);
         const glyphCountError = validateGlyphCount(glyphEntries.length);
 
@@ -424,12 +424,19 @@ export class BitmapFont {
      * @param data - Parsed font descriptor.
      * @returns Whether the data is valid.
      */
-    private static isValidFileData(data: FileData): boolean {
-        if (typeof data.texture !== 'string' || data.texture.length === 0) {
-            return false;
+    private static isValidFileData(data: unknown): data is FileData {
+        let valid = false;
+
+        if (typeof data === 'object' && data !== null) {
+            const record = data as Record<string, unknown>;
+            const texture = record.texture;
+
+            if (typeof texture === 'string' && texture.length > 0 && isPlainRecord(record.glyphs)) {
+                valid = true;
+            }
         }
 
-        return isPlainRecord(data.glyphs);
+        return valid;
     }
 
     /**
@@ -557,11 +564,13 @@ export class BitmapFont {
      * @returns Hint text or an empty string.
      */
     private static buildPathHint(url: string, folderName: string): string {
-        if (BitmapFont.hasExplicitLocation(url)) {
-            return '';
+        let hint = '';
+
+        if (!BitmapFont.hasExplicitLocation(url)) {
+            hint = `Did you mean '/${folderName}/${url}' or './${folderName}/${url}'?`;
         }
 
-        return `Did you mean '/${folderName}/${url}' or './${folderName}/${url}'?`;
+        return hint;
     }
 
     /**
@@ -575,12 +584,13 @@ export class BitmapFont {
         const fileName = url.slice(url.lastIndexOf('/') + 1).split(/[?#]/)[0] ?? url;
         const dotIndex = fileName.lastIndexOf('.');
         const extension = dotIndex >= 0 ? fileName.slice(dotIndex).toLowerCase() : '';
+        let hint = '';
 
-        if (extension === '' || extension === expectedExtension) {
-            return '';
+        if (extension !== '' && extension !== expectedExtension) {
+            hint = `The extension '${extension}' looks wrong for this file. Did you mean '${expectedExtension}'?`;
         }
 
-        return `The extension '${extension}' looks wrong for this file. Did you mean '${expectedExtension}'?`;
+        return hint;
     }
 
     /**
@@ -590,6 +600,8 @@ export class BitmapFont {
      * @returns Printable label or a Unicode code point for control characters.
      */
     private static formatGlyphCharLabel(char: string): string {
+        let label = char;
+
         if (char.length === 1) {
             const code = char.charCodeAt(0);
 
@@ -600,11 +612,11 @@ export class BitmapFont {
             const asciiDelCode = 127;
 
             if (code <= controlCharBoundary || code === asciiDelCode) {
-                return `U+${code.toString(16).toUpperCase().padStart(4, '0')}`;
+                label = `U+${code.toString(16).toUpperCase().padStart(4, '0')}`;
             }
         }
 
-        return char;
+        return label;
     }
 
     /**
@@ -615,12 +627,13 @@ export class BitmapFont {
      */
     private static isExplicitUrl(url: string): boolean {
         const lowerUrl = url.toLowerCase();
+        let explicit = lowerUrl.includes('://');
 
-        if (lowerUrl.includes('://')) {
-            return true;
+        if (!explicit) {
+            explicit = ['//', 'data:', 'blob:'].some((prefix) => lowerUrl.startsWith(prefix));
         }
 
-        return ['//', 'data:', 'blob:'].some((prefix) => lowerUrl.startsWith(prefix));
+        return explicit;
     }
 
     /**
@@ -649,14 +662,19 @@ export class BitmapFont {
             const image = new Image();
 
             image.onload = () => {
+                let loadError: unknown;
+
                 try {
                     assertImageElementWithinLimits('font texture', image);
                 } catch (error) {
-                    reject(error);
-                    return;
+                    loadError = error;
                 }
 
-                resolve(image);
+                if (loadError === undefined) {
+                    resolve(image);
+                } else {
+                    reject(loadError);
+                }
             };
             image.onerror = () => {
                 // Maximum characters shown from a texture source string in load-failure messages.
@@ -684,18 +702,23 @@ export class BitmapFont {
      * @returns Glyph metadata, or `null` when the font does not contain the character.
      */
     getGlyph(char: string): Glyph | null {
+        let glyph: Glyph | null = null;
+
         // Fast path for ASCII characters.
         if (char.length === 1) {
             const code = char.charCodeAt(0);
 
             if (code < ASCII_CACHE_SIZE) {
                 // eslint-disable-next-line security/detect-object-injection -- Index is bounds-checked above
-                return this.asciiGlyphs[code] ?? null;
+                glyph = this.asciiGlyphs[code] ?? null;
             }
         }
 
-        // Fallback for Unicode characters.
-        return this.glyphs.get(char) ?? null;
+        if (glyph === null) {
+            glyph = this.glyphs.get(char) ?? null;
+        }
+
+        return glyph;
     }
 
     /**
@@ -708,14 +731,16 @@ export class BitmapFont {
      * @returns Glyph metadata, or `null` when no glyph exists for the code.
      */
     getGlyphByCode(charCode: number): Glyph | null {
-        // Fast path for ASCII.
+        let glyph: Glyph | null;
+
         if (charCode < ASCII_CACHE_SIZE) {
             // eslint-disable-next-line security/detect-object-injection -- Index is bounds-checked above
-            return this.asciiGlyphs[charCode] ?? null;
+            glyph = this.asciiGlyphs[charCode] ?? null;
+        } else {
+            glyph = this.glyphs.get(String.fromCharCode(charCode)) ?? null;
         }
 
-        // Fallback for Unicode - convert code to character.
-        return this.glyphs.get(String.fromCharCode(charCode)) ?? null;
+        return glyph;
     }
 
     /**
@@ -741,56 +766,52 @@ export class BitmapFont {
      * @returns Total width in pixels.
      */
     measureText(text: string): number {
-        // Check the cache first.
         const cached = this.measureCache.get(text);
+        let width = cached ?? 0;
 
-        if (cached !== undefined) {
-            return cached;
-        }
+        if (cached === undefined) {
+            const len = text.length;
 
-        // Calculate width using optimized loop.
-        let width = 0;
-        const len = text.length;
+            for (let i = 0; i < len; i++) {
+                const code = text.charCodeAt(i);
+                let glyph: Glyph | null = null;
 
-        for (let i = 0; i < len; i++) {
-            const code = text.charCodeAt(i);
-            let glyph: Glyph | null = null;
+                // Fast path for ASCII characters.
+                if (code < ASCII_CACHE_SIZE) {
+                    // eslint-disable-next-line security/detect-object-injection -- Index is bounds-checked above
+                    glyph = this.asciiGlyphs[code] ?? null;
+                } else {
+                    // Unicode fallback - index is guaranteed valid within loop bounds.
+                    // eslint-disable-next-line security/detect-object-injection -- Index is within loop bounds
+                    const char = text[i];
 
-            // Fast path for ASCII characters.
-            if (code < ASCII_CACHE_SIZE) {
-                // eslint-disable-next-line security/detect-object-injection -- Index is bounds-checked above
-                glyph = this.asciiGlyphs[code] ?? null;
-            } else {
-                // Unicode fallback - index is guaranteed valid within loop bounds.
-                // eslint-disable-next-line security/detect-object-injection -- Index is within loop bounds
-                const char = text[i];
+                    if (char !== undefined) {
+                        glyph = this.glyphs.get(char) ?? null;
+                    }
+                }
 
-                if (char !== undefined) {
-                    glyph = this.glyphs.get(char) ?? null;
+                if (glyph) {
+                    width += glyph.advance;
                 }
             }
 
-            if (glyph) {
-                width += glyph.advance;
+            // Cache the result with FIFO eviction when full.
+
+            // Maximum number of cached string-width measurements retained at once.
+            // The cache uses FIFO eviction (insertion order) when this limit is reached.
+            const measureCacheMaxSize = 256;
+
+            if (this.measureCache.size >= measureCacheMaxSize) {
+                // Remove oldest inserted entry (first key in Map insertion order).
+                const firstKey = this.measureCache.keys().next().value;
+
+                if (firstKey !== undefined) {
+                    this.measureCache.delete(firstKey);
+                }
             }
+
+            this.measureCache.set(text, width);
         }
-
-        // Cache the result with FIFO eviction when full.
-
-        // Maximum number of cached string-width measurements retained at once.
-        // The cache uses FIFO eviction (insertion order) when this limit is reached.
-        const measureCacheMaxSize = 256;
-
-        if (this.measureCache.size >= measureCacheMaxSize) {
-            // Remove oldest inserted entry (first key in Map insertion order).
-            const firstKey = this.measureCache.keys().next().value;
-
-            if (firstKey !== undefined) {
-                this.measureCache.delete(firstKey);
-            }
-        }
-
-        this.measureCache.set(text, width);
 
         return width;
     }
@@ -834,17 +855,22 @@ export class BitmapFont {
      * @returns `true` if the font can render the character.
      */
     hasGlyph(char: string): boolean {
-        // Fast path for ASCII.
+        let found: boolean;
+
         if (char.length === 1) {
             const code = char.charCodeAt(0);
 
             if (code < ASCII_CACHE_SIZE) {
                 // eslint-disable-next-line security/detect-object-injection -- Index is bounds-checked above
-                return this.asciiGlyphs[code] != null;
+                found = this.asciiGlyphs[code] != null;
+            } else {
+                found = this.glyphs.has(char);
             }
+        } else {
+            found = this.glyphs.has(char);
         }
 
-        return this.glyphs.has(char);
+        return found;
     }
 
     /**


### PR DESCRIPTION
Use single-return paths across load helpers, glyph lookup, and measurement. Parse .btfont JSON as unknown and narrow with a runtime FileData guard so texture and glyphs are validated correctly. Merge benchmark glyph seeding into one loop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR refactors BitmapFont-related code to improve control flow consistency, strengthen .btfont JSON validation, and streamline benchmark glyph generation. It introduces single-return control flow across loaders and helpers, tightens runtime validation for parsed JSON, and consolidates benchmark glyph seeding.

## Changes

### BitmapFont.ts (Primary Changes)
- Control flow refactoring: Rewrote multiple private helpers to use local variables and a single return instead of early returns. Affected helpers include buildPathHint, buildExtensionHint, formatGlyphCharLabel (now assigns label and formats control chars/DEL as U+XXXX), isExplicitUrl, loadImage (captures/propagates assertImageElementWithinLimits errors), getGlyph, getGlyphByCode, measureText (retains ASCII fast-path and FIFO cache but recomputes only on cache miss), hasGlyph, and populateAsciiGlyph (inverted the single-character guard).
- Display name & metric coercion:
  - Added resolveDisplayName to derive the font display name (mirrors metric coercion behavior).
  - resolvePositiveMetric now accumulates into a local metric initialized from fallback; parseMetricValue initializes parsed to NaN before returning.
  - Commit fixes coercion of invalid .btfont name values: non-string or empty name fields are coerced to "Unknown" (test added).
- JSON parsing hardening:
  - parseBtfontFile parses JSON into unknown, then narrows with isValidFileData type guard before treating it as FileData.
  - isValidFileData changed to a proper unknown→FileData type guard that explicitly checks non-null object shape, requires texture to be a non-empty string, and glyphs to be a plain record.
  - Both JSON parse failures and validation failures now throw the same “broken or not valid .btfont” error via buildBrokenFileError.
- Logic preservation: No exported/public signatures changed; measurement caching and ASCII/Unicode lookup semantics preserved.

### BitmapFont.bench.ts
- Parameterized printable ASCII range with new start/end constants and added a fixed Unicode character list constant.
- Consolidated glyph generation: merged ASCII and Unicode glyph seeding into a single indexed loop inside createBenchmarkFont (reduces separate loops).
- Added an IDE inspection suppression comment.

### BitmapFont.test.ts
- Added a unit test verifying that when font metadata name is non-string, BitmapFont.load sets name to "Unknown".
- Added an IDE inspection suppression comment.

## Impact
- Improves code readability and consistency by enforcing single-return control flow in helpers.
- Strengthens runtime validation for .btfont files, improving error detection and consistency.
- Slight benchmark setup simplification by consolidating glyph seeding.
- No breaking changes to public API signatures or overall functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->