### PR TITLE
refactor(assets): use single return in AssetLoader.buildExtensionHint

### DIFF
--- a/src/assets/AssetLoader.test.ts
+++ b/src/assets/AssetLoader.test.ts
@@ -1,3 +1,5 @@
+// noinspection MagicNumberJS
+
 /**
  * Unit tests for {@link AssetLoader}.
  *

--- a/src/assets/AssetLoader.ts
+++ b/src/assets/AssetLoader.ts
@@ -84,17 +84,15 @@ function extractExtension(url: string): string {
  * @returns Hint text, or null when the extension warrants no hint.
  */
 function buildExtensionHint(extension: string): string | null {
-    // Extension that triggers a font-specific hint when used on an image load path.
+    let hint: string | null = null;
+
     if (extension === '.btfont') {
-        return "This looks like a font file. For images, use a file that ends with '.png'.";
+        hint = "This looks like a font file. For images, use a file that ends with '.png'.";
+    } else if (extension !== '' && !IMAGE_EXTENSIONS.has(extension)) {
+        hint = `The extension '${extension}' does not look like an image file. Did you mean '.png'?`;
     }
 
-    // File extensions recognized as raster image formats.
-    if (extension === '' || IMAGE_EXTENSIONS.has(extension)) {
-        return null;
-    }
-
-    return `The extension '${extension}' does not look like an image file. Did you mean '.png'?`;
+    return hint;
 }
 
 /**


### PR DESCRIPTION
Assign hint text in branches and return once so extension error hints stay unchanged but match the single-exit style used elsewhere in assets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

### AssetLoader.ts

Refactored the `buildExtensionHint` function to use a single return statement instead of early returns. The function now initializes a `hint` variable to `null` and assigns hint text conditionally within branches before returning at the end. This preserves the existing hint messages and behavior while adopting the single-exit code style used elsewhere in the assets module.

### AssetLoader.test.ts

Added a JetBrains IDE inspection suppression comment (`// noinspection MagicNumberJS`) at the top of the test file to silence the magic numbers lint rule.

## Impact

Low-risk refactoring with no functional changes or test modifications. The extension error hints remain identical in all cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->