### PR TITLE
refactor(assets): flatten SystemFont glyph pixel loop

### DIFF
--- a/src/assets/SystemFont.ts
+++ b/src/assets/SystemFont.ts
@@ -58,13 +58,16 @@ const ATLAS_HEIGHT = ATLAS_ROWS * SYSTEM_FONT_GLYPH_HEIGHT;
  * @param pixels - Output pixel buffer to write into.
  */
 function writeGlyphPixels(bitmapOffset: number, baseX: number, baseY: number, pixels: Uint8Array<ArrayBuffer>): void {
-    for (let y = 0; y < SYSTEM_FONT_GLYPH_HEIGHT; y++) {
+    const pixelCount = SYSTEM_FONT_GLYPH_HEIGHT * SYSTEM_FONT_GLYPH_WIDTH;
+
+    for (let flat = 0; flat < pixelCount; flat++) {
+        const y = Math.floor(flat / SYSTEM_FONT_GLYPH_WIDTH);
+        const x = flat % SYSTEM_FONT_GLYPH_WIDTH;
+
         // Safe: length validated in buildAtlasPixels guarantees bitmapOffset + y is in bounds.
         const rowByte = SYSTEM_FONT_BITMAPS[bitmapOffset + y] as number;
 
-        for (let x = 0; x < SYSTEM_FONT_GLYPH_WIDTH; x++) {
-            pixels[(baseY + y) * ATLAS_WIDTH + (baseX + x)] = (rowByte >> (7 - x)) & 1;
-        }
+        pixels[(baseY + y) * ATLAS_WIDTH + (baseX + x)] = (rowByte >> (7 - x)) & 1;
     }
 }
 


### PR DESCRIPTION
Replace nested x/y loops in writeGlyphPixels with a single flat index loop while preserving atlas write semantics and bitmap bit decoding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

The `writeGlyphPixels` function in `src/assets/SystemFont.ts` was refactored to use a single flattened loop instead of nested x/y loops. The change introduces:

- A `pixelCount` constant that represents the total pixels per glyph (`SYSTEM_FONT_GLYPH_HEIGHT * SYSTEM_FONT_GLYPH_WIDTH`)
- A single loop over the flat pixel index (`for (let flat = 0; flat < pixelCount; flat++)`)
- Per-pixel coordinate computation using division and modulo operations (`y = Math.floor(flat / SYSTEM_FONT_GLYPH_WIDTH)` and `x = flat % SYSTEM_FONT_GLYPH_WIDTH`)
- A bounds-safety comment documenting that the bitmap offset access is validated by the `buildAtlasPixels` function

The atlas write semantics and bitmap bit decoding remain unchanged; only the loop structure was simplified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->