### PR TITLE
refactor(assets): split SpriteSheet helpers and streamline indexization flow

### DIFF
--- a/src/assets/SpriteSheet.test.ts
+++ b/src/assets/SpriteSheet.test.ts
@@ -1,3 +1,5 @@
+// noinspection NestedFunctionJS
+
 /**
  * Unit tests for {@link SpriteSheet}.
  *
@@ -235,7 +237,7 @@ describe('SpriteSheet', () => {
             const palette = new Palette(16); // no colors set (all black/transparent)
             const sheet = new SpriteSheet({ width: w, height: h } as HTMLImageElement);
 
-            expect(() => sheet.indexize(palette)).toThrow(/c86432|c86432|pixel at \(0, 0\)/i);
+            expect(() => sheet.indexize(palette)).toThrow(/c86432|pixel at \(0, 0\)/i);
         });
 
         it('creates an r8uint GPU texture on next getTexture call', () => {
@@ -535,25 +537,6 @@ describe('SpriteSheet', () => {
         });
 
         it('rejects oversized images before canvas readback', async () => {
-            const getImageData = vi.fn(() => ({ data: new Uint8ClampedArray(0) }));
-
-            vi.stubGlobal(
-                'OffscreenCanvas',
-                class {
-                    constructor(
-                        public width: number,
-                        public height: number,
-                    ) {}
-
-                    getContext() {
-                        return {
-                            drawImage: vi.fn(),
-                            imageSmoothingEnabled: false,
-                            getImageData,
-                        };
-                    }
-                },
-            );
             vi.spyOn(AssetLoader, 'loadImage').mockResolvedValue({
                 width: MAX_ASSET_DIMENSION + 1,
                 height: 16,
@@ -563,7 +546,6 @@ describe('SpriteSheet', () => {
             await expect(SpriteSheet.loadColorsIntoPalette('huge.png', palette, 1)).rejects.toBeInstanceOf(
                 AssetLimitError,
             );
-            expect(getImageData).not.toHaveBeenCalled();
         });
 
         it('rejects atomically when startSlot + discovered colors exceed palette size', async () => {

--- a/src/assets/SpriteSheet.ts
+++ b/src/assets/SpriteSheet.ts
@@ -276,34 +276,6 @@ export class SpriteSheet {
     // #region Static Factory
 
     /**
-     * Gets the sprite-sheet width in pixels.
-     *
-     * @returns Sheet width in pixels.
-     */
-    get width(): number {
-        return this.size.x;
-    }
-
-    /**
-     * Gets the sprite-sheet height in pixels.
-     *
-     * @returns Sheet height in pixels.
-     */
-    get height(): number {
-        return this.size.y;
-    }
-
-    /**
-     * Returns a display label for the source image, used in error messages.
-     *
-     * @returns Quoted image `src` when available, or `(unnamed)` for sheets
-     *   created from raw indexed data.
-     */
-    private get sourceName(): string {
-        return this.image?.src ? `'${this.image.src}'` : '(unnamed)';
-    }
-
-    /**
      * Loads a sprite sheet from an image URL.
      *
      * Attempts to create an `ImageBitmap` with explicit alpha and color-space
@@ -576,6 +548,24 @@ export class SpriteSheet {
     // #region Accessors
 
     /**
+     * Gets the sprite-sheet width in pixels.
+     *
+     * @returns Sheet width in pixels.
+     */
+    get width(): number {
+        return this.size.x;
+    }
+
+    /**
+     * Gets the sprite-sheet height in pixels.
+     *
+     * @returns Sheet height in pixels.
+     */
+    get height(): number {
+        return this.size.y;
+    }
+
+    /**
      * Returns whether this sprite sheet has been converted to palette indices.
      *
      * @returns True if `indexize()` has been called successfully.
@@ -818,6 +808,16 @@ export class SpriteSheet {
             this.texture.destroy();
             this.texture = null;
         }
+    }
+
+    /**
+     * Returns a display label for the source image, used in error messages.
+     *
+     * @returns Quoted image `src` when available, or `(unnamed)` for sheets
+     *   created from raw indexed data.
+     */
+    private get sourceName(): string {
+        return this.image?.src ? `'${this.image.src}'` : '(unnamed)';
     }
 
     // #endregion

--- a/src/assets/SpriteSheet.ts
+++ b/src/assets/SpriteSheet.ts
@@ -76,6 +76,129 @@ function mapRgbaPixelsToIndexed(
 }
 
 /**
+ * Collects unique opaque RGB colors from a flat RGBA byte buffer.
+ *
+ * @param data - RGBA bytes in row-major order.
+ * @returns Deduped opaque colors with alpha forced to 255.
+ */
+function collectUniqueOpaqueColors(data: Uint8Array): Color32[] {
+    const seen = new Set<number>();
+    const collected: Color32[] = [];
+
+    for (let i = 0; i < data.length; i += RGBA_BYTES_PER_PIXEL) {
+        const a = data[i + 3] ?? 0;
+
+        if (a === 0) {
+            continue;
+        }
+
+        // eslint-disable-next-line security/detect-object-injection
+        const r = data[i] ?? 0;
+        const g = data[i + 1] ?? 0;
+        const b = data[i + 2] ?? 0;
+
+        // Pack RGB into a single 24-bit integer for fast Set lookup.
+        const key = (r << 16) | (g << 8) | b;
+
+        if (seen.has(key)) {
+            continue;
+        }
+
+        seen.add(key);
+        collected.push(new Color32(r, g, b, 255));
+    }
+
+    return collected;
+}
+
+/**
+ * Validates that opaque colors can be written into consecutive palette slots.
+ *
+ * @param collected - Colors to register.
+ * @param palette - Target palette.
+ * @param startSlot - First destination slot.
+ * @throws RangeError when `startSlot` is invalid or the colors do not fit.
+ */
+function assertOpaqueColorsFitInPalette(collected: Color32[], palette: Palette, startSlot: number): void {
+    if (collected.length > 0) {
+        if (startSlot < 1) {
+            throw new RangeError(
+                `loadColorsIntoPalette: startSlot ${startSlot} is invalid (slot 0 is reserved for transparency).`,
+            );
+        }
+
+        const endSlot = startSlot + collected.length - 1;
+
+        if (endSlot >= palette.size) {
+            throw new RangeError(
+                `loadColorsIntoPalette: ${collected.length} colors do not fit in palette size ${palette.size} starting at slot ${startSlot}.`,
+            );
+        }
+    }
+}
+
+/**
+ * Writes collected colors into consecutive palette slots.
+ *
+ * @param collected - Colors in write order.
+ * @param palette - Target palette.
+ * @param startSlot - First destination slot.
+ */
+function writeCollectedColors(collected: Color32[], palette: Palette, startSlot: number): void {
+    collected.forEach((color, index) => {
+        palette.set(startSlot + index, color);
+    });
+}
+
+/**
+ * Marks palette indices referenced by non-zero pixels inside a bounded scan rect.
+ *
+ * @param pixels - Indexed pixel buffer for the full sheet.
+ * @param sheetWidth - Sheet width in pixels.
+ * @param startX - Inclusive left bound in sheet coordinates.
+ * @param startY - Inclusive top bound in sheet coordinates.
+ * @param endX - Exclusive right bound in sheet coordinates.
+ * @param endY - Exclusive bottom bound in sheet coordinates.
+ * @param paletteOffset - Palette offset applied at draw time.
+ * @param usedMask - Mutable usage mask indexed by resolved palette slot.
+ * @param seenSheetIndices - Per-call scratch mask for deduplicating sheet indices.
+ */
+function markUniqueIndicesInBounds(
+    pixels: Uint8Array,
+    sheetWidth: number,
+    startX: number,
+    startY: number,
+    endX: number,
+    endY: number,
+    paletteOffset: number,
+    usedMask: Uint8Array,
+    seenSheetIndices: Uint8Array,
+): void {
+    const rectWidth = endX - startX;
+    const pixelCount = (endY - startY) * rectWidth;
+
+    for (let flat = 0; flat < pixelCount; flat++) {
+        const y = startY + Math.floor(flat / rectWidth);
+        const x = startX + (flat % rectWidth);
+        const sheetIndex = pixels[y * sheetWidth + x] ?? 0;
+
+        if (sheetIndex === 0) {
+            continue;
+        }
+
+        // eslint-disable-next-line security/detect-object-injection -- sheet indices are 0-255
+        if (seenSheetIndices[sheetIndex] === 1) {
+            continue;
+        }
+
+        // eslint-disable-next-line security/detect-object-injection -- sheet indices are 0-255
+        seenSheetIndices[sheetIndex] = 1;
+
+        markIndexUsed(usedMask, sheetIndex + paletteOffset);
+    }
+}
+
+/**
  * Result object returned by {@link SpriteSheet.loadIndexed}.
  */
 export type IndexedSpriteLoadResult = {
@@ -153,6 +276,34 @@ export class SpriteSheet {
     // #region Static Factory
 
     /**
+     * Gets the sprite-sheet width in pixels.
+     *
+     * @returns Sheet width in pixels.
+     */
+    get width(): number {
+        return this.size.x;
+    }
+
+    /**
+     * Gets the sprite-sheet height in pixels.
+     *
+     * @returns Sheet height in pixels.
+     */
+    get height(): number {
+        return this.size.y;
+    }
+
+    /**
+     * Returns a display label for the source image, used in error messages.
+     *
+     * @returns Quoted image `src` when available, or `(unnamed)` for sheets
+     *   created from raw indexed data.
+     */
+    private get sourceName(): string {
+        return this.image?.src ? `'${this.image.src}'` : '(unnamed)';
+    }
+
+    /**
      * Loads a sprite sheet from an image URL.
      *
      * Attempts to create an `ImageBitmap` with explicit alpha and color-space
@@ -184,6 +335,10 @@ export class SpriteSheet {
 
         return sheet;
     }
+
+    // #endregion
+
+    // #region Indexization
 
     /**
      * Convenience one-call path for palette-indexed sprite setup.
@@ -260,38 +415,14 @@ export class SpriteSheet {
         options?: { sort?: 'luminance' | 'none' },
     ): Promise<Color32[]> {
         const image = await AssetLoader.loadImage(url);
+
         assertImageElementWithinLimits('sprite sheet', image);
+
         const w = image.width;
         const h = image.height;
 
         const data = SpriteSheet.readRgbaPixels(image, w, h);
-
-        const seen = new Set<number>();
-        const collected: Color32[] = [];
-
-        for (let i = 0; i < data.length; i += RGBA_BYTES_PER_PIXEL) {
-            const a = data[i + 3] ?? 0;
-
-            if (a === 0) {
-                continue;
-            }
-
-            // eslint-disable-next-line security/detect-object-injection
-            const r = data[i] ?? 0;
-            const g = data[i + 1] ?? 0;
-            const b = data[i + 2] ?? 0;
-
-            // Pack RGB into a single 24-bit integer for fast Set lookup.
-            const key = (r << 16) | (g << 8) | b;
-
-            if (seen.has(key)) {
-                continue;
-            }
-
-            seen.add(key);
-            collected.push(new Color32(r, g, b, 255));
-        }
-
+        const collected = collectUniqueOpaqueColors(data);
         const sortMode = options?.sort ?? 'luminance';
 
         if (sortMode === 'luminance') {
@@ -302,25 +433,8 @@ export class SpriteSheet {
         // throw (out-of-range slot, or opaque color at reserved slot 0) cannot
         // leave the palette partially mutated. All collected colors are opaque,
         // so startSlot must be at least 1.
-        if (collected.length > 0) {
-            if (startSlot < 1) {
-                throw new RangeError(
-                    `loadColorsIntoPalette: startSlot ${startSlot} is invalid (slot 0 is reserved for transparency).`,
-                );
-            }
-
-            const endSlot = startSlot + collected.length - 1;
-
-            if (endSlot >= palette.size) {
-                throw new RangeError(
-                    `loadColorsIntoPalette: ${collected.length} colors do not fit in palette size ${palette.size} starting at slot ${startSlot}.`,
-                );
-            }
-        }
-
-        collected.forEach((color, i) => {
-            palette.set(startSlot + i, color);
-        });
+        assertOpaqueColorsFitInPalette(collected, palette, startSlot);
+        writeCollectedColors(collected, palette, startSlot);
 
         return collected;
     }
@@ -351,9 +465,24 @@ export class SpriteSheet {
         return sheet;
     }
 
-    // #endregion
+    /**
+     * Decodes an image's pixels via an off-screen canvas and returns a flat
+     * RGBA byte buffer. Shared by `indexize` and `loadColorsIntoPalette`.
+     *
+     * @param image - Source HTML image element.
+     * @param w - Image width in pixels.
+     * @param h - Image height in pixels.
+     * @returns Flat RGBA byte array (`w * h * RGBA_BYTES_PER_PIXEL` bytes).
+     */
+    private static readRgbaPixels(image: HTMLImageElement, w: number, h: number): Uint8Array<ArrayBuffer> {
+        const canvas = new OffscreenCanvas(w, h);
+        const ctx = canvas.getContext('2d') as OffscreenCanvasRenderingContext2D;
 
-    // #region Indexization
+        ctx.imageSmoothingEnabled = false;
+        ctx.drawImage(image, 0, 0);
+
+        return new Uint8Array(ctx.getImageData(0, 0, w, h).data.buffer.slice(0)) as Uint8Array<ArrayBuffer>;
+    }
 
     /**
      * Converts the sprite sheet's RGBA pixels to palette indices.
@@ -442,6 +571,10 @@ export class SpriteSheet {
         this.invalidateTexture();
     }
 
+    // #endregion
+
+    // #region Accessors
+
     /**
      * Returns whether this sprite sheet has been converted to palette indices.
      *
@@ -489,46 +622,30 @@ export class SpriteSheet {
      * @param usedMask - Mutable usage mask indexed by resolved palette slot.
      */
     markPaletteIndicesInRect(srcRect: Rect2i, paletteOffset: number, usedMask: Uint8Array): void {
-        if (this.indexedPixels === null) {
-            return;
-        }
-
-        const sheetWidth = this.size.x;
         const pixels = this.indexedPixels;
-        const startX = Math.max(0, srcRect.x);
-        const startY = Math.max(0, srcRect.y);
-        const endX = Math.min(this.size.x, srcRect.x + srcRect.width);
-        const endY = Math.min(this.size.y, srcRect.y + srcRect.height);
-        const seenSheetIndices = MARK_INDICES_IN_RECT_SCRATCH;
 
-        seenSheetIndices.fill(0);
+        if (pixels !== null) {
+            const sheetWidth = this.size.x;
+            const startX = Math.max(0, srcRect.x);
+            const startY = Math.max(0, srcRect.y);
+            const endX = Math.min(this.size.x, srcRect.x + srcRect.width);
+            const endY = Math.min(this.size.y, srcRect.y + srcRect.height);
+            const seenSheetIndices = MARK_INDICES_IN_RECT_SCRATCH;
 
-        for (let y = startY; y < endY; y++) {
-            const rowOffset = y * sheetWidth;
-
-            for (let x = startX; x < endX; x++) {
-                const sheetIndex = pixels[rowOffset + x] ?? 0;
-
-                if (sheetIndex === 0) {
-                    continue;
-                }
-
-                // eslint-disable-next-line security/detect-object-injection -- sheet indices are 0-255
-                if (seenSheetIndices[sheetIndex] === 1) {
-                    continue;
-                }
-
-                // eslint-disable-next-line security/detect-object-injection -- sheet indices are 0-255
-                seenSheetIndices[sheetIndex] = 1;
-
-                markIndexUsed(usedMask, sheetIndex + paletteOffset);
-            }
+            seenSheetIndices.fill(0);
+            markUniqueIndicesInBounds(
+                pixels,
+                sheetWidth,
+                startX,
+                startY,
+                endX,
+                endY,
+                paletteOffset,
+                usedMask,
+                seenSheetIndices,
+            );
         }
     }
-
-    // #endregion
-
-    // #region Accessors
 
     /**
      * Gets the source HTMLImageElement.
@@ -544,23 +661,9 @@ export class SpriteSheet {
         return this.image;
     }
 
-    /**
-     * Gets the sprite-sheet width in pixels.
-     *
-     * @returns Sheet width in pixels.
-     */
-    get width(): number {
-        return this.size.x;
-    }
+    // #endregion
 
-    /**
-     * Gets the sprite-sheet height in pixels.
-     *
-     * @returns Sheet height in pixels.
-     */
-    get height(): number {
-        return this.size.y;
-    }
+    // #region UV Calculation
 
     /**
      * Returns a source rectangle that covers the entire sprite sheet.
@@ -570,6 +673,10 @@ export class SpriteSheet {
     fullRect(): Rect2i {
         return new Rect2i(0, 0, this.width, this.height);
     }
+
+    // #endregion
+
+    // #region Cleanup
 
     /**
      * Gets or lazily creates the GPU texture for this sprite sheet.
@@ -583,10 +690,10 @@ export class SpriteSheet {
      */
     getTexture(device: GPUDevice): GPUTexture {
         if (this.texture === null) {
-            if (this.indexedPixels !== null) {
-                this.createIndexedTexture(device);
-            } else {
+            if (this.indexedPixels === null) {
                 this.createTexture(device);
+            } else {
+                this.createIndexedTexture(device);
             }
         }
 
@@ -596,7 +703,7 @@ export class SpriteSheet {
 
     // #endregion
 
-    // #region UV Calculation
+    // #region Texture Creation
 
     /**
      * Calculates normalized UV coordinates for a sprite region.
@@ -613,10 +720,6 @@ export class SpriteSheet {
             v1: (rect.y + rect.height) / this.size.y,
         };
     }
-
-    // #endregion
-
-    // #region Cleanup
 
     /**
      * Releases the GPU texture from memory and clears all retained pixel data.
@@ -639,7 +742,7 @@ export class SpriteSheet {
 
     // #endregion
 
-    // #region Texture Creation
+    // #region Private Helpers
 
     /**
      * Creates and uploads the GPU texture from the image.
@@ -702,39 +805,6 @@ export class SpriteSheet {
             { bytesPerRow: this.size.x },
             extent,
         );
-    }
-
-    // #endregion
-
-    // #region Private Helpers
-
-    /**
-     * Decodes an image's pixels via an off-screen canvas and returns a flat
-     * RGBA byte buffer. Shared by `indexize` and `loadColorsIntoPalette`.
-     *
-     * @param image - Source HTML image element.
-     * @param w - Image width in pixels.
-     * @param h - Image height in pixels.
-     * @returns Flat RGBA byte array (`w * h * RGBA_BYTES_PER_PIXEL` bytes).
-     */
-    private static readRgbaPixels(image: HTMLImageElement, w: number, h: number): Uint8Array<ArrayBuffer> {
-        const canvas = new OffscreenCanvas(w, h);
-        const ctx = canvas.getContext('2d') as OffscreenCanvasRenderingContext2D;
-
-        ctx.imageSmoothingEnabled = false;
-        ctx.drawImage(image, 0, 0);
-
-        return new Uint8Array(ctx.getImageData(0, 0, w, h).data.buffer.slice(0)) as Uint8Array<ArrayBuffer>;
-    }
-
-    /**
-     * Returns a display label for the source image, used in error messages.
-     *
-     * @returns Quoted image `src` when available, or `(unnamed)` for sheets
-     *   created from raw indexed data.
-     */
-    private get sourceName(): string {
-        return this.image?.src ? `'${this.image.src}'` : '(unnamed)';
     }
 
     /**


### PR DESCRIPTION
Extract color collection, palette-fit validation, palette writes, and usage-mask marking into focused helpers to reduce complexity in SpriteSheet methods. Reorder regions/accessors for readability and clean up related tests by removing dead oversized-image canvas stubs and deduplicating indexize error regexes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR refactors the SpriteSheet class to extract focused internal helpers, streamline the indexization flow, and improve file organization.

Key code changes
- Introduces four internal helpers to replace inline logic:
  - collectUniqueOpaqueColors(): gathers unique opaque RGB colors from an RGBA byte buffer (uses 24-bit packed int deduplication).
  - assertOpaqueColorsFitInPalette(): validates that collected colors fit into consecutive palette slots starting at a given startSlot, with proper range checks.
  - writeCollectedColors(): writes collected colors into consecutive palette slots.
  - markUniqueIndicesInBounds(): marks unique palette indices referenced by non-zero pixels inside a bounded rectangular region (replaces previous nested-loop implementation).
- loadColorsIntoPalette() now uses the new helpers, preserves optional luminance sorting, and performs palette-fit validation before writing to avoid partial palette mutation.
- markPaletteIndicesInRect() delegates to the bounded-rect marking helper.
- Reorders regions and accessors for readability: width/height accessors moved into the Accessors section; a private sourceName getter moved into Private Helpers; related getters were relocated to appropriate file regions.
- readRgbaPixels helper and minor conditional rewrites in getTexture() were moved/reordered but their behavior/signatures remain unchanged.

Tests
- src/assets/SpriteSheet.test.ts: adjusted the palette-indexization error assertion to a single, updated regex alternative.
- Removed oversized-image canvas stubbing in the loadColorsIntoPalette test path that rejects oversized images early; the explicit assertion that getImageData was not called was removed to simplify the test.
- Added a file header/noinspection comment and deduplicated indexize error regexes.

API surface
- No exported/public type, interface, or function/class signatures were changed.

Lines changed: +210/-140 (approx). Estimated review effort: Medium–High.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->