### PR TITLE
refactor: remove banned #region section markers project-wide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,7 +256,6 @@ or drive breaking changes through consumers for naming-only cleanup.
 - JSDoc required for public APIs
 - When implementing changes, always update JSDoc and inline comments alongside the code. Never leave stale comments that
   describe old behavior.
-- Use `// #region` / `// #endregion` for sections in files >100 lines
 
 ## Commands
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -136,7 +136,6 @@ describe('MyClass', () => {
 Conventions:
 
 - Use `describe`/`it` (not `test`)
-- Use `// #region` / `// #endregion` for files over ~100 lines
 - Follow source code style (4-space indent, single quotes, semicolons)
 - No emoji in test descriptions
 - No JSDoc required in test files

--- a/scripts/convert-bmfont.mjs
+++ b/scripts/convert-bmfont.mjs
@@ -9,8 +9,6 @@
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join, relative, resolve, sep } from 'node:path';
 
-// #region Helper Functions
-
 /**
  * Extracts the value of a specified attribute from an XML tag.
  *
@@ -24,10 +22,6 @@ function parseXmlAttribute(tag, attr) {
 
     return match ? match[1] : null;
 }
-
-// #endregion
-
-// #region XML Parsing Functions
 
 /**
  * Parses the `<info>` XML tag from the provided font file data and extracts the font name and size.
@@ -94,10 +88,6 @@ function parseCommonTag(xmlData, fontSize) {
     return { lineHeight, baseline };
 }
 
-// #endregion
-
-// #region Asset Loading Functions
-
 /**
  * Parses the <page> tag in the provided XML data to extract the texture filename.
  * Multipage BMFonts aren't supported and will cause an error.
@@ -133,10 +123,6 @@ function parsePageTag(xmlData) {
 
     return textureFilename;
 }
-
-// #endregion
-
-// #region Texture Processing Functions
 
 /**
  * Generates and returns the appropriate texture value based on the specified options.
@@ -208,10 +194,6 @@ function getTextureValue(embedTexture, textureFilename, fntDir, outputPath) {
 
     return textureValue;
 }
-
-// #endregion
-
-// #region Glyph Parsing Functions
 
 /**
  * Parses glyph data from a given XML tag and updates the glyph object with the corresponding character's properties.
@@ -316,10 +298,6 @@ function parseGlyphs(xmlData) {
     return { glyphs, glyphCount };
 }
 
-// #endregion
-
-// #region Output Functions
-
 /**
  * Writes the given font data to a file and logs the conversion details.
  *
@@ -342,10 +320,6 @@ function writeOutput(outputPath, btfont, fontName, fontSize, lineHeight, baselin
     console.log(`  Baseline: ${baseline}px`);
     console.log(`  Glyphs: ${glyphCount}`);
 }
-
-// #endregion
-
-// #region Conversion Logic
 
 /**
  * Converts a BMFont `.fnt` file to a `.btfont` format file.
@@ -389,10 +363,6 @@ function convertBMFont(fntPath, outputPath, embedTexture = false) {
     // Write the output.
     writeOutput(outputPath, btfont, fontName, fontSize, lineHeight, baseline, glyphCount);
 }
-
-// #endregion
-
-// #region Main Entry Point
 
 /**
  * Main function that serves as the entry point for the BMFont to .btfont converter.
@@ -470,5 +440,3 @@ Examples:
 }
 
 main();
-
-// #endregion

--- a/scripts/convert-system-font.mjs
+++ b/scripts/convert-system-font.mjs
@@ -23,8 +23,6 @@ import { fileURLToPath } from 'node:url';
 
 import { PNG } from 'pngjs';
 
-// #region Constants
-
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = resolve(__dirname, '..');
 const DEFAULT_INPUT = join(PROJECT_ROOT, 'assets/system-font.png');
@@ -40,10 +38,6 @@ const FIRST_CHAR = 32;
 const LAST_CHAR = 126;
 const GLYPH_COUNT = LAST_CHAR - FIRST_CHAR + 1; // 95
 const ON_THRESHOLD = 128; // Red channel >= this means "on".
-
-// #endregion
-
-// #region PNG Reading
 
 /**
  * Reads the PNG and extracts bit patterns for all 95 glyphs.
@@ -90,10 +84,6 @@ function extractBitmaps(inputPath) {
 
     return bitmaps;
 }
-
-// #endregion
-
-// #region TypeScript Generation
 
 /**
  * Returns the printable label for a character code.
@@ -148,8 +138,6 @@ function generateTypeScript(bitmaps) {
     lines.push(' * This font data is in the public domain.');
     lines.push(' */');
     lines.push('');
-    lines.push('// #region Bitmap Data');
-    lines.push('');
     lines.push('// prettier-ignore');
     lines.push('export const SYSTEM_FONT_BITMAPS: readonly number[] = [');
 
@@ -164,10 +152,6 @@ function generateTypeScript(bitmaps) {
     }
 
     lines.push('];');
-    lines.push('');
-    lines.push('// #endregion');
-    lines.push('');
-    lines.push('// #region Constants');
     lines.push('');
     lines.push('/** First character code in the bitmap array. */');
 
@@ -187,15 +171,9 @@ function generateTypeScript(bitmaps) {
     lines.push('');
     lines.push('/** Number of bytes per glyph (one byte per row). */');
     lines.push('export const SYSTEM_FONT_BYTES_PER_GLYPH = 14;');
-    lines.push('');
-    lines.push('// #endregion');
 
     return lines.join('\n');
 }
-
-// #endregion
-
-// #region Main
 
 function main() {
     const args = process.argv.slice(2);
@@ -233,5 +211,3 @@ Options:
 }
 
 main();
-
-// #endregion

--- a/scripts/export-system-font.mjs
+++ b/scripts/export-system-font.mjs
@@ -20,8 +20,6 @@ import { fileURLToPath } from 'node:url';
 
 import { PNG } from 'pngjs';
 
-// #region Constants
-
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = resolve(__dirname, '..');
 const FONT_DATA_PATH = join(PROJECT_ROOT, 'src/assets/fonts/systemFontData.ts');
@@ -36,10 +34,6 @@ const ATLAS_HEIGHT = ATLAS_ROWS * GLYPH_HEIGHT; // 84
 const FIRST_CHAR = 32;
 const LAST_CHAR = 126;
 const GLYPH_COUNT = LAST_CHAR - FIRST_CHAR + 1; // 95
-
-// #endregion
-
-// #region Bit-Pattern Extraction
 
 /**
  * Parses the SYSTEM_FONT_BITMAPS array from the TypeScript source file.
@@ -81,10 +75,6 @@ function parseBitmapData() {
 
     return matches.map((hex) => parseInt(hex, 16));
 }
-
-// #endregion
-
-// #region PNG Generation
 
 /**
  * Builds a 96x84 RGBA PNG from the bit-pattern data.
@@ -138,10 +128,6 @@ function buildPNG(bitmaps) {
     return PNG.sync.write(png);
 }
 
-// #endregion
-
-// #region Main
-
 function main() {
     const args = process.argv.slice(2);
 
@@ -178,5 +164,3 @@ Options:
 }
 
 main();
-
-// #endregion

--- a/src/BlitTech.test.ts
+++ b/src/BlitTech.test.ts
@@ -17,8 +17,6 @@ import { BTAPI } from './core/BTAPI';
 import type { FaceButtonCode } from './input/defaultKeyboardMap';
 import { DEFAULT_CONTAINER_ID } from './utils/BootstrapHelpers';
 
-// #region Helpers
-
 const mockHardwareSettings = (displaySize = new Vector2i(320, 240), targetFPS = 60): HardwareSettings => ({
     displaySize,
     targetFPS,
@@ -53,10 +51,6 @@ async function withErrorContainer(callback: () => void | Promise<void>): Promise
         clearErrorContainer();
     }
 }
-
-// #endregion
-
-// #region BT.init
 
 describe('BT.init', () => {
     beforeEach(() => {
@@ -95,10 +89,6 @@ describe('BT.init', () => {
     });
 });
 
-// #endregion
-
-// #region BT.displaySize
-
 describe('BT.displaySize', () => {
     beforeEach(() => {
         vi.restoreAllMocks();
@@ -122,10 +112,6 @@ describe('BT.displaySize', () => {
         expect(size.y).toBe(480);
     });
 });
-
-// #endregion
-
-// #region BT.drawingBufferSize / BT.outputSize
 
 describe('BT.drawingBufferSize', () => {
     beforeEach(() => {
@@ -219,10 +205,6 @@ describe('BT.outputSize', () => {
     });
 });
 
-// #endregion
-
-// #region BT.targetFPS
-
 describe('BT.targetFPS', () => {
     beforeEach(() => {
         vi.restoreAllMocks();
@@ -242,10 +224,6 @@ describe('BT.targetFPS', () => {
         expect(BT.targetFPS).toBe(30);
     });
 });
-
-// #endregion
-
-// #region BT.deltaSeconds / BT.timeSeconds
 
 describe('BT.deltaSeconds', () => {
     beforeEach(() => {
@@ -322,10 +300,6 @@ describe('BT.timeSeconds', () => {
     });
 });
 
-// #endregion
-
-// #region BT.ticks / BT.ticksReset
-
 describe('BT.ticks', () => {
     beforeEach(() => {
         vi.restoreAllMocks();
@@ -365,10 +339,6 @@ describe('BT.assignTag', () => {
         expect(spy).toHaveBeenCalledWith('Milestone');
     });
 });
-
-// #endregion
-
-// #region BT.paletteCreate / BT.paletteSet / BT.palette
 
 describe('BT.paletteCreate', () => {
     it('creates a palette with the requested size', () => {
@@ -432,10 +402,6 @@ describe('BT.palette', () => {
     });
 });
 
-// #endregion
-
-// #region BT.clear / BT.clearRect
-
 describe('BT.clear', () => {
     beforeEach(() => {
         vi.restoreAllMocks();
@@ -466,10 +432,6 @@ describe('BT.clearRect', () => {
         expect(spy).toHaveBeenCalledWith(rect, 1);
     });
 });
-
-// #endregion
-
-// #region BT.drawPixel / BT.drawLine / BT.drawRect / BT.drawRectFill
 
 describe('BT.drawPixel', () => {
     beforeEach(() => {
@@ -553,10 +515,6 @@ describe('BT.drawRectFill', () => {
     });
 });
 
-// #endregion
-
-// #region BT.cameraSet / BT.camera / BT.cameraClamp / BT.cameraReset
-
 describe('BT.cameraSet', () => {
     beforeEach(() => {
         vi.restoreAllMocks();
@@ -632,10 +590,6 @@ describe('BT.cameraReset', () => {
         expect(spy).toHaveBeenCalledOnce();
     });
 });
-
-// #endregion
-
-// #region BT.isDown / BT.isPressed / BT.isReleased
 
 describe('BT.isDown', () => {
     beforeEach(() => {
@@ -809,10 +763,6 @@ describe('BT.isReleased', () => {
     });
 });
 
-// #endregion
-
-// #region BT.inputMap / BT.inputMapReset
-
 describe('BT.inputMap / BT.inputMapReset', () => {
     beforeEach(() => {
         vi.restoreAllMocks();
@@ -898,10 +848,6 @@ describe('BT.inputMap / BT.inputMapReset', () => {
         expect(isDown).toHaveBeenCalledWith([]);
     });
 });
-
-// #endregion
-
-// #region BT pointer queries
 
 describe('BT.pointerPos', () => {
     afterEach(() => {
@@ -1001,10 +947,6 @@ describe('BT.pointerScrollDelta', () => {
     });
 });
 
-// #endregion
-
-// #region Pointer button constants
-
 describe('Pointer button constants', () => {
     it('exposes BTN_POINTER_A..D as bit flags', () => {
         expect(BT.BTN_POINTER_A).toBe(1 << 12);
@@ -1013,10 +955,6 @@ describe('Pointer button constants', () => {
         expect(BT.BTN_POINTER_D).toBe(1 << 15);
     });
 });
-
-// #endregion
-
-// #region BT gamepad constants and APIs / BT.isKeyDown / BT.isKeyPressed / BT.isKeyReleased
 
 describe('BT gamepad constants and APIs', () => {
     afterEach(() => {
@@ -1096,10 +1034,6 @@ describe('BT.isKeyReleased', () => {
     });
 });
 
-// #endregion
-
-// #region BT.systemPrint / BT.systemPrintMeasure / BT.printFont
-
 describe('BT.systemPrint', () => {
     beforeEach(() => {
         vi.restoreAllMocks();
@@ -1177,10 +1111,6 @@ describe('BT.printFont', () => {
     });
 });
 
-// #endregion
-
-// #region BT.captureFrame / BT.downloadFrame
-
 describe('BT.captureFrame', () => {
     beforeEach(() => {
         vi.restoreAllMocks();
@@ -1245,10 +1175,6 @@ describe('BT.downloadFrame', () => {
         expect(mockAnchor.download).toBe('blit-tech-capture.png');
     });
 });
-
-// #endregion
-
-// #region BT.drawSprite
 
 describe('BT.drawSprite', () => {
     const mockImage = { width: 64, height: 64 } as HTMLImageElement;
@@ -1320,10 +1246,6 @@ describe('BT.drawSprite', () => {
         });
     });
 });
-
-// #endregion
-
-// #region BT.effectAdd / BT.effectRemove / BT.effectClear
 
 describe('BT.effectAdd / BT.effectRemove / BT.effectClear', () => {
     function makeStubEffect() {
@@ -1452,10 +1374,6 @@ describe('BT.effectAdd / BT.effectRemove / BT.effectClear', () => {
     });
 });
 
-// #endregion
-
-// #region BT.requestedBackend
-
 describe('BT.requestedBackend', () => {
     beforeEach(() => {
         vi.restoreAllMocks();
@@ -1487,10 +1405,6 @@ describe('BT.requestedBackend', () => {
     });
 });
 
-// #endregion
-
-// #region BT.activeBackend
-
 describe('BT.activeBackend', () => {
     beforeEach(() => {
         vi.restoreAllMocks();
@@ -1517,5 +1431,3 @@ describe('BT.activeBackend', () => {
         expect(BT.activeBackend).toBe('software');
     });
 });
-
-// #endregion

--- a/src/BlitTech.ts
+++ b/src/BlitTech.ts
@@ -238,12 +238,8 @@ function pointerFlagToPointerCode(pointerFlag: number): number | null {
     }
 }
 
-// #region Public API
-
 /** Main Blit-Tech API namespace used by runtime demos. */
 export const BT = {
-    // #region Constants - Sprite Transform Flags
-
     /** Horizontal flip flag for sprite rendering. */
     FLIP_H: 1,
 
@@ -258,10 +254,6 @@ export const BT = {
 
     /** Rotate 270° clockwise flag for sprite rendering. */
     ROT_270_CW: 1 << 4,
-
-    // #endregion
-
-    // #region Constants - Button Codes
 
     /** Up button bit flag. */
     BTN_UP: 1 << 0,
@@ -381,10 +373,6 @@ export const BT = {
      */
     DEFAULT_KEYBOARD_PLAYER2,
 
-    // #endregion
-
-    // #region Initialization
-
     /**
      * Initializes the engine against a demo instance and target canvas.
      *
@@ -401,10 +389,6 @@ export const BT = {
     init: async (demo: IBlitTechDemo, canvas: HTMLCanvasElement): Promise<boolean> => {
         return await BTAPI.instance.init(demo, canvas);
     },
-
-    // #endregion
-
-    // #region Hardware Information
 
     /**
      * Active logical render resolution in pixels.
@@ -615,10 +599,6 @@ export const BT = {
         return palette;
     },
 
-    // #endregion
-
-    // #region Palette Effects API
-
     /**
      * Starts rotating a range of palette entries at a constant speed.
      *
@@ -711,10 +691,6 @@ export const BT = {
         BTAPI.instance.paletteClearEffects();
     },
 
-    // #endregion
-
-    // #region Post-Process Effects API
-
     /**
      * Appends a fullscreen post-processing effect to whichever chain matches
      * its declared {@link Effect.tier}.
@@ -778,10 +754,6 @@ export const BT = {
      */
     preset: { crtPipBoy, amber, green },
 
-    // #endregion
-
-    // #region Rendering API - Clear Operations
-
     /**
      * Sets the frame clear color using a palette index.
      *
@@ -807,10 +779,6 @@ export const BT = {
             BTAPI.instance.clearRect(rect, paletteIndex);
         });
     },
-
-    // #endregion
-
-    // #region Rendering API - Primitives
 
     /**
      * Draws a single pixel.
@@ -888,10 +856,6 @@ export const BT = {
         });
     },
 
-    // #endregion
-
-    // #region Camera API
-
     /**
      * Sets the global camera offset applied to subsequent draw calls.
      *
@@ -931,10 +895,6 @@ export const BT = {
     cameraReset: (): void => {
         BTAPI.instance.resetCamera();
     },
-
-    // #endregion
-
-    // #region Input API - Pointer
 
     /**
      * Returns the position of the pointer in the given slot, in display coordinates.
@@ -1025,10 +985,6 @@ export const BT = {
     showCursor: (): void => {
         BTAPI.instance.getPointer()?.showCursor();
     },
-
-    // #endregion
-
-    // #region Input API - Buttons
 
     /**
      * Checks whether a button is currently held.
@@ -1341,10 +1297,6 @@ export const BT = {
         return BTAPI.instance.getGamepad()?.connectedCount() ?? 0;
     },
 
-    // #endregion
-
-    // #region Input API - Keyboard
-
     /**
      * Checks whether a keyboard key is currently held.
      *
@@ -1429,10 +1381,6 @@ export const BT = {
         return BTAPI.instance.getKeyboard()?.getInputString() ?? '';
     },
 
-    // #endregion
-
-    // #region Text Rendering API
-
     /**
      * Draws text using the built-in 6x14 system font.
      *
@@ -1494,10 +1442,6 @@ export const BT = {
         });
     },
 
-    // #endregion
-
-    // #region Frame Capture API
-
     /**
      * Captures the next rendered frame as a PNG blob.
      *
@@ -1537,10 +1481,6 @@ export const BT = {
 
         URL.revokeObjectURL(url);
     },
-
-    // #endregion
-
-    // #region Rendering API - Sprites
 
     /**
      * Draws a sprite region from an indexed sprite sheet.
@@ -1618,13 +1558,7 @@ export const BT = {
     spritesRefresh: (): void => {
         BTAPI.instance.spritesRefresh();
     },
-
-    // #endregion
 };
-
-// #endregion
-
-// #region Exports
 
 export {
     amber,
@@ -1674,5 +1608,3 @@ export type {
     TextSize,
 };
 export type { IndexedSpriteLoadResult };
-
-// #endregion

--- a/src/__test__/webgpu-mock.ts
+++ b/src/__test__/webgpu-mock.ts
@@ -3,8 +3,6 @@
  * Provides stub objects that track calls without requiring a real GPU.
  */
 
-// #region Constants
-
 /** Default width and height for mock textures when a descriptor omits dimensions. */
 const DEFAULT_SIZE_PX = 256;
 
@@ -16,10 +14,6 @@ const INDEX_COUNT = 256;
 const RGBA_COMPONENT_COUNT = 4;
 const BYTES_PER_FLOAT32 = 4;
 const BUFFER_BYTE_SIZE = INDEX_COUNT * RGBA_COMPONENT_COUNT * BYTES_PER_FLOAT32;
-
-// #endregion
-
-// #region Helpers
 
 /** Options for creating a mock GPUBuffer stub. */
 type MockBufferOptions = {
@@ -81,10 +75,6 @@ function resolveMockTextureSize(size: GPUTextureDescriptor['size']): { width: nu
     };
 }
 
-// #endregion
-
-// #region GPUTexture
-
 /**
  * Creates a mock GPUTexture.
  *
@@ -113,10 +103,6 @@ export function createMockGPUTexture(
     } as unknown as GPUTexture;
 }
 
-// #endregion
-
-// #region GPURenderPassEncoder
-
 /**
  * Creates a mock GPURenderPassEncoder that records calls.
  *
@@ -132,10 +118,6 @@ export function createMockRenderPassEncoder(): GPURenderPassEncoder {
         label: 'MockRenderPass',
     } as unknown as GPURenderPassEncoder;
 }
-
-// #endregion
-
-// #region GPUDevice
 
 /**
  * Creates a mock GPUDevice with stub methods.
@@ -240,10 +222,6 @@ export function createMockGPUDevice(): GPUDevice {
     } as unknown as GPUDevice;
 }
 
-// #endregion
-
-// #region GPUCanvasContext
-
 /**
  * Creates a mock GPUCanvasContext.
  *
@@ -256,10 +234,6 @@ export function createMockGPUCanvasContext(): GPUCanvasContext {
         canvas: {} as HTMLCanvasElement,
     } as unknown as GPUCanvasContext;
 }
-
-// #endregion
-
-// #region Palette Buffer
 
 /**
  * Creates a mock GPUBuffer matching the real 4096-byte palette uniform layout.
@@ -274,10 +248,6 @@ export function createMockPaletteBuffer(): GPUBuffer {
         label: 'Mock Palette Buffer',
     });
 }
-
-// #endregion
-
-// #region Navigator GPU
 
 /**
  * Installs a mock navigator.gpu on globalThis for tests.
@@ -315,5 +285,3 @@ export function uninstallMockNavigatorGPU(): void {
         delete nav.gpu;
     }
 }
-
-// #endregion

--- a/src/assets/AssetLoader.test.ts
+++ b/src/assets/AssetLoader.test.ts
@@ -24,8 +24,6 @@ afterEach(() => {
 });
 
 describe('AssetLoader', () => {
-    // #region Cache Management
-
     describe('cache management', () => {
         it('should report isLoaded as false for an unloaded URL', () => {
             expect(AssetLoader.isLoaded('never-loaded.png')).toBe(false);
@@ -70,10 +68,6 @@ describe('AssetLoader', () => {
             }
         });
     });
-
-    // #endregion
-
-    // #region Image Loading
 
     describe('image loading', () => {
         let createCount = 0;
@@ -143,10 +137,6 @@ describe('AssetLoader', () => {
             expect(createCount).toBe(1);
         });
     });
-
-    // #endregion
-
-    // #region Error Handling
 
     describe('error handling', () => {
         beforeEach(() => {
@@ -240,6 +230,4 @@ describe('AssetLoader', () => {
             );
         });
     });
-
-    // #endregion
 });

--- a/src/assets/AssetLoader.ts
+++ b/src/assets/AssetLoader.ts
@@ -1,7 +1,5 @@
 import { assertImageElementWithinLimits } from '../utils/AssetLimits';
 
-// #region Module State
-
 /**
  * Successfully loaded images keyed by request URL.
  *
@@ -23,10 +21,6 @@ const loadingPromises = new Map<string, Promise<HTMLImageElement>>();
  * Allocated once at module load; checked inside {@link buildExtensionHint}.
  */
 const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp']);
-
-// #endregion
-
-// #region URL Hint Helpers
 
 /**
  * Returns whether a URL is absolute or uses a special browser scheme.
@@ -108,10 +102,6 @@ function buildImageHints(url: string): string {
     return hints.length > 0 ? ` ${hints.join(' ')}` : '';
 }
 
-// #endregion
-
-// #region Load Pipeline
-
 /**
  * Builds the rejection error for a failed browser image load.
  *
@@ -173,8 +163,6 @@ function startLoading(url: string): Promise<HTMLImageElement> {
     return promise;
 }
 
-// #endregion
-
 /**
  * Shared image-loading utility for runtime asset code.
  *
@@ -185,8 +173,6 @@ function startLoading(url: string): Promise<HTMLImageElement> {
  * - exposes cache inspection and reset helpers for engine code and tests
  */
 export class AssetLoader {
-    // #region Image loading
-
     /**
      * Loads an image and caches the resolved element by URL.
      *
@@ -211,10 +197,6 @@ export class AssetLoader {
     static async loadImages(urls: string[]): Promise<HTMLImageElement[]> {
         return Promise.all(urls.map((url) => AssetLoader.loadImage(url)));
     }
-
-    // #endregion
-
-    // #region Cache Management
 
     /**
      * Checks if an image is already loaded and cached.
@@ -246,6 +228,4 @@ export class AssetLoader {
         loadedImages.clear();
         loadingPromises.clear();
     }
-
-    // #endregion
 }

--- a/src/assets/BitmapFont.bench.ts
+++ b/src/assets/BitmapFont.bench.ts
@@ -1,4 +1,3 @@
-// #region Imports
 // noinspection MagicNumberJS
 
 import { bench, describe } from 'vitest';
@@ -7,10 +6,6 @@ import { Rect2i } from '../utils/Rect2i';
 import type { Glyph } from './BitmapFont';
 import { BitmapFont } from './BitmapFont';
 import { SpriteSheet } from './SpriteSheet';
-
-// #endregion
-
-// #region Constants
 
 const ASCII_CACHE_SIZE = 128;
 const CACHE_HALF_FULL = 128;
@@ -24,10 +19,6 @@ const BENCH_OPTIONS = {
     warmupTime: 25,
     warmupIterations: 50,
 };
-
-// #endregion
-
-// #region Helper Types
 
 /**
  * Constructor shape used to instantiate `BitmapFont` with synthetic data.
@@ -48,10 +39,6 @@ type BitmapFontCtor = new (
 type BitmapFontCacheView = {
     measureCache: Map<string, number>;
 };
-
-// #endregion
-
-// #region Helper Functions
 
 /**
  * Creates synthetic glyph metadata for benchmark-only font construction.
@@ -159,10 +146,6 @@ function createUniqueTexts(length: number, count: number): string[] {
     return texts;
 }
 
-// #endregion
-
-// #region Bench Registration
-
 /**
  * Registers a benchmark for cache-miss text measurement at a fixed text length.
  *
@@ -223,10 +206,6 @@ function benchMeasureTextSize(name: string, text: string): void {
         BENCH_OPTIONS,
     );
 }
-
-// #endregion
-
-// #region Benchmark Suites
 
 describe('BitmapFont glyph lookup benchmarks', () => {
     const font = createBenchmarkFont();
@@ -292,5 +271,3 @@ describe('BitmapFont cache fill level benchmarks', () => {
         );
     }
 });
-
-// #endregion

--- a/src/assets/BitmapFont.test.ts
+++ b/src/assets/BitmapFont.test.ts
@@ -27,8 +27,6 @@ import { Rect2i } from '../utils/Rect2i';
 import { BitmapFont } from './BitmapFont';
 import { SpriteSheet } from './SpriteSheet';
 
-// #region Test Fixtures
-
 type GlyphData = { x: number; y: number; w: number; h: number; ox: number; oy: number; adv: number };
 type FontData = {
     name: string;
@@ -118,10 +116,6 @@ const MOCK_FONT_DATA: FontData = {
     },
 };
 
-// #endregion
-
-// #region BitmapFont Tests
-
 describe('BitmapFont', () => {
     let font: BitmapFont;
 
@@ -206,8 +200,6 @@ describe('BitmapFont', () => {
         expect(font.measureText('A')).toBe(9);
     });
 
-    // #region Additional accessors
-
     it('should return the correct glyphCount', () => {
         expect(font.glyphCount).toBe(3);
     });
@@ -274,10 +266,6 @@ describe('BitmapFont', () => {
     it('should return 0 width for a character not in the font (measureText)', () => {
         expect(font.measureText('\u0100')).toBe(0);
     });
-
-    // #endregion
-
-    // #region load error cases
 
     describe('load error cases', () => {
         it('should throw when fetch returns a non-ok response', async () => {
@@ -518,10 +506,6 @@ describe('BitmapFont', () => {
         });
     });
 
-    // #endregion
-
-    // #region Default metadata fallbacks
-
     describe('default metadata fallbacks', () => {
         it('should use defaults when name, size, lineHeight, baseline are missing', async () => {
             vi.stubGlobal(
@@ -603,10 +587,6 @@ describe('BitmapFont', () => {
         });
     });
 
-    // #endregion
-
-    // #region Edge cases
-
     describe('edge cases', () => {
         it('should return 0 for measureText with empty string', () => {
             expect(font.measureText('')).toBe(0);
@@ -630,10 +610,6 @@ describe('BitmapFont', () => {
             expect(size2.width).toBe(17);
         });
     });
-
-    // #endregion
-
-    // #region createFromGlyphs
 
     describe('createFromGlyphs', () => {
         it('creates a font with correct metadata', () => {
@@ -683,8 +659,4 @@ describe('BitmapFont', () => {
             expect(font.measureText('Hi')).toBe(14); // 8 + 6
         });
     });
-
-    // #endregion
 });
-
-// #endregion

--- a/src/assets/BitmapFont.ts
+++ b/src/assets/BitmapFont.ts
@@ -12,8 +12,6 @@ import { btfontGlyphEntryNotObjectError } from '../utils/errorMessages';
 import { Rect2i } from '../utils/Rect2i';
 import { SpriteSheet } from './SpriteSheet';
 
-// #region Type Definitions
-
 /**
  * Runtime glyph metadata used by the renderer.
  */
@@ -95,14 +93,8 @@ export interface TextSize {
     height: number;
 }
 
-// #endregion
-
-// #region Constants
-
 /** Size of the direct lookup table used for ASCII glyphs (`0-127`). */
 const ASCII_CACHE_SIZE = 128;
-
-// #endregion
 
 /**
  * Returns whether a value is a non-null plain object (not an array).
@@ -152,8 +144,6 @@ function populateAsciiGlyph(asciiGlyphs: (Glyph | null)[], char: string, glyph: 
  * - providing the underlying {@link SpriteSheet} used for rendering glyph quads
  */
 export class BitmapFont {
-    // #region Module State
-
     /** Font display name. */
     public readonly name: string;
 
@@ -180,10 +170,6 @@ export class BitmapFont {
 
     /** Reusable result object for measureTextSize to avoid allocations. */
     private readonly textSizeResult: TextSize = { width: 0, height: 0 };
-
-    // #endregion
-
-    // #region Constructor
 
     /**
      * Creates a BitmapFont instance.
@@ -215,10 +201,6 @@ export class BitmapFont {
         this.baseline = baseline;
     }
 
-    // #endregion
-
-    // #region Metadata
-
     /**
      * Returns the total number of glyphs loaded into the font.
      *
@@ -227,10 +209,6 @@ export class BitmapFont {
     get glyphCount(): number {
         return this.glyphs.size;
     }
-
-    // #endregion
-
-    // #region Static Factories
 
     /**
      * Creates a bitmap font synchronously from pre-built glyph data.
@@ -264,10 +242,6 @@ export class BitmapFont {
 
         return new BitmapFont(spriteSheet, glyphs, asciiGlyphs, name, size, lineHeight, baseline);
     }
-
-    // #endregion
-
-    // #region Loading
 
     /**
      * Loads a bitmap font from a `.btfont` JSON file.
@@ -316,8 +290,6 @@ export class BitmapFont {
             baseline,
         );
     }
-
-    // #region Loading Helpers
 
     /**
      * Coerces a `.btfont` display `name` field to a non-empty string.
@@ -663,10 +635,6 @@ export class BitmapFont {
         return BitmapFont.isExplicitUrl(url) || (['/', './'] as const).some((prefix) => url.startsWith(prefix));
     }
 
-    // #endregion
-
-    // #region Glyph Access
-
     /**
      * Loads an image from a URL or data URI.
      *
@@ -767,10 +735,6 @@ export class BitmapFont {
     getSpriteSheet(): SpriteSheet {
         return this.spriteSheet;
     }
-
-    // #endregion
-
-    // #region Text Measurement
 
     /**
      * Measures the horizontal pixel width of a text string.
@@ -898,6 +862,4 @@ export class BitmapFont {
     clearMeasureCache(): void {
         this.measureCache.clear();
     }
-
-    // #endregion
 }

--- a/src/assets/Palette.test.ts
+++ b/src/assets/Palette.test.ts
@@ -12,8 +12,6 @@ import { describe, expect, it } from 'vitest';
 import { Color32 } from '../utils/Color32';
 import { Palette } from './Palette';
 
-// #region Palette
-
 describe('Palette', () => {
     /** Verifies that every supported indexed palette size constructs cleanly. */
     it('constructs all valid palette sizes', () => {
@@ -256,10 +254,6 @@ describe('Palette', () => {
     });
 });
 
-// #endregion
-
-// #region Palette dirty flag
-
 describe('Palette dirty flag', () => {
     it('starts clean after construction', () => {
         expect(new Palette(16).isDirty).toBe(false);
@@ -323,10 +317,6 @@ describe('Palette dirty flag', () => {
         expect(palette.isDirty).toBe(true);
     });
 });
-
-// #endregion
-
-// #region applyHUD
 
 describe('applyHUD', () => {
     it('fills slots 1-6 with canonical HUD colors at default startSlot', () => {
@@ -439,5 +429,3 @@ describe('applyHUD', () => {
         expect(palette.isDirty).toBe(true);
     });
 });
-
-// #endregion

--- a/src/assets/PaletteEffect.bench.ts
+++ b/src/assets/PaletteEffect.bench.ts
@@ -1,14 +1,8 @@
-// #region Imports
-
 import { bench, describe } from 'vitest';
 
 import { Color32 } from '../utils/Color32';
 import { Palette } from './Palette';
 import { CycleEffect, FadeEffect, PaletteEffectManager, paletteSwap } from './PaletteEffect';
-
-// #endregion
-
-// #region Constants
 
 const BENCH_OPTIONS = {
     iterations: 500,
@@ -18,10 +12,6 @@ const BENCH_OPTIONS = {
 };
 
 const PALETTE_SIZE = 256;
-
-// #endregion
-
-// #region Helpers
 
 /**
  * Creates a palette with distinct colors for benchmarking.
@@ -54,10 +44,6 @@ function makeTimeClock(): { now: () => number; advance: (ms: number) => void } {
     };
 }
 
-// #endregion
-
-// #region CycleEffect Benchmarks
-
 describe('CycleEffect benchmarks', () => {
     const palette = makePalette();
     const effect = new CycleEffect(1, 31, 60);
@@ -84,10 +70,6 @@ describe('CycleEffect large range benchmarks', () => {
     );
 });
 
-// #endregion
-
-// #region FadeEffect Benchmarks
-
 describe('FadeEffect benchmarks', () => {
     const source = makePalette();
     const target = makePalette();
@@ -108,10 +90,6 @@ describe('FadeEffect benchmarks', () => {
     );
 });
 
-// #endregion
-
-// #region paletteSwap Benchmarks
-
 describe('paletteSwap benchmarks', () => {
     const palette = makePalette();
 
@@ -123,10 +101,6 @@ describe('paletteSwap benchmarks', () => {
         BENCH_OPTIONS,
     );
 });
-
-// #endregion
-
-// #region PaletteEffectManager Benchmarks
 
 describe('PaletteEffectManager benchmarks', () => {
     const clock = makeTimeClock();
@@ -162,5 +136,3 @@ describe('PaletteEffectManager empty benchmarks', () => {
         BENCH_OPTIONS,
     );
 });
-
-// #endregion

--- a/src/assets/PaletteEffect.test.ts
+++ b/src/assets/PaletteEffect.test.ts
@@ -11,8 +11,6 @@ import {
     paletteSwap,
 } from './PaletteEffect';
 
-// #region Helpers
-
 /** Creates a 16-entry palette with distinct colors for testing. */
 function makeTestPalette(): Palette {
     const p = new Palette(16);
@@ -54,10 +52,6 @@ function makeTimeClock() {
         },
     };
 }
-
-// #endregion
-
-// #region PaletteEffectManager
 
 describe('PaletteEffectManager', () => {
     it('starts with zero active effects', () => {
@@ -206,10 +200,6 @@ describe('PaletteEffectManager', () => {
     });
 });
 
-// #endregion
-
-// #region CycleEffect
-
 describe('CycleEffect', () => {
     it('rotates entries forward', () => {
         const palette = makeTestPalette();
@@ -303,10 +293,6 @@ describe('CycleEffect', () => {
         expect(palette.getRef(5).isEqual(original5)).toBe(true);
     });
 });
-
-// #endregion
-
-// #region FadeEffect
 
 describe('FadeEffect', () => {
     it('reaches exact target values at completion', () => {
@@ -406,10 +392,6 @@ describe('FadeEffect', () => {
     });
 });
 
-// #endregion
-
-// #region FadeRangeEffect
-
 describe('FadeRangeEffect', () => {
     it('only affects specified range', () => {
         const source = makeTestPalette();
@@ -466,10 +448,6 @@ describe('FadeRangeEffect', () => {
     });
 });
 
-// #endregion
-
-// #region FlashEffect
-
 describe('FlashEffect', () => {
     it('sets all non-zero entries to flash color', () => {
         const palette = makeTestPalette();
@@ -523,10 +501,6 @@ describe('FlashEffect', () => {
     });
 });
 
-// #endregion
-
-// #region paletteSwap
-
 describe('paletteSwap', () => {
     it('exchanges two palette entries', () => {
         const palette = makeTestPalette();
@@ -559,5 +533,3 @@ describe('paletteSwap', () => {
         expect(palette.isDirty).toBe(false);
     });
 });
-
-// #endregion

--- a/src/assets/PaletteEffect.ts
+++ b/src/assets/PaletteEffect.ts
@@ -14,8 +14,6 @@ import type { EasingFunction } from '../utils/Easing';
 import { applyEasing } from '../utils/Easing';
 import type { Palette } from './Palette';
 
-// #region Types
-
 /**
  * A single palette effect that runs over time.
  *
@@ -33,10 +31,6 @@ export interface PaletteEffect {
      */
     update(palette: Palette, deltaMs: number): boolean;
 }
-
-// #endregion
-
-// #region PaletteEffectManager
 
 /**
  * Manages active palette effects and updates them each frame.
@@ -127,10 +121,6 @@ export class PaletteEffectManager {
         this.effects.length = 0;
     }
 }
-
-// #endregion
-
-// #region CycleEffect
 
 /**
  * Rotates a range of palette entries at a constant speed.
@@ -241,10 +231,6 @@ export class CycleEffect implements PaletteEffect {
     }
 }
 
-// #endregion
-
-// #region Fade Helpers
-
 /**
  * Snapshots a contiguous palette index range into a new array.
  *
@@ -337,10 +323,6 @@ function applyFadeToRange(
     }
 }
 
-// #endregion
-
-// #region FadeEffect
-
 /**
  * Smoothly interpolates all palette entries toward a target palette over time.
  *
@@ -402,10 +384,6 @@ export class FadeEffect implements PaletteEffect {
     }
 }
 
-// #endregion
-
-// #region FadeRangeEffect
-
 /**
  * Fades only a subset of palette indices toward a target palette.
  *
@@ -462,10 +440,6 @@ export class FadeRangeEffect implements PaletteEffect {
     }
 }
 
-// #endregion
-
-// #region Flash Helpers
-
 /**
  * Copies `color` into every palette slot except the transparent sentinel at index 0.
  *
@@ -494,10 +468,6 @@ function restoreNonZeroSlots(palette: Palette, snapshot: Color32[]): void {
         }
     }
 }
-
-// #endregion
-
-// #region FlashEffect
 
 /**
  * Temporarily sets all palette entries to a single color, then restores.
@@ -551,10 +521,6 @@ export class FlashEffect implements PaletteEffect {
     }
 }
 
-// #endregion
-
-// #region Standalone Functions
-
 /**
  * Instantly exchanges two palette entries.
  *
@@ -581,5 +547,3 @@ export function paletteSwap(palette: Palette, indexA: number, indexB: number): v
         palette.markDirty();
     }
 }
-
-// #endregion

--- a/src/assets/SpriteSheet.bench.ts
+++ b/src/assets/SpriteSheet.bench.ts
@@ -1,14 +1,8 @@
-// #region Imports
-
 import { bench, describe } from 'vitest';
 
 import { resetUsage } from '../core/RenderPaletteUsage';
 import { Rect2i } from '../utils/Rect2i';
 import { SpriteSheet } from './SpriteSheet';
-
-// #endregion
-
-// #region Constants
 
 const BENCH_OPTIONS = {
     iterations: 200,
@@ -22,10 +16,6 @@ const GLYPH_RECT = new Rect2i(0, 0, 8, 8);
 
 /** 64x64 sprite rect. */
 const SPRITE_RECT = new Rect2i(0, 0, 64, 64);
-
-// #endregion
-
-// #region Fixtures
 
 /**
  * Builds an indexized sheet filled with cycling non-zero palette indices.
@@ -48,8 +38,6 @@ function makeBenchSheet(width: number, height: number): SpriteSheet {
 const glyphSheet = makeBenchSheet(8, 8);
 const spriteSheet = makeBenchSheet(64, 64);
 const usageMask = new Uint8Array(256);
-
-// #endregion
 
 describe('SpriteSheet.markPaletteIndicesInRect', () => {
     bench(

--- a/src/assets/SpriteSheet.test.ts
+++ b/src/assets/SpriteSheet.test.ts
@@ -27,8 +27,6 @@ import { AssetLoader } from './AssetLoader';
 import { Palette } from './Palette';
 import { SpriteSheet } from './SpriteSheet';
 
-// #region OffscreenCanvas Test Helpers
-
 /**
  * Returns a minimal OffscreenCanvas mock whose getImageData yields the supplied
  * pixel buffer. Use vi.stubGlobal to install it for a single test.
@@ -48,12 +46,8 @@ function makeOffscreenCanvasMock(pixelData: Uint8ClampedArray, w: number, h: num
     };
 }
 
-// #endregion
-
 describe('SpriteSheet', () => {
     const mockImage = { width: 256, height: 256 } as HTMLImageElement;
-
-    // #region UV Calculation
 
     describe('getUVs', () => {
         it('should return (0, 0, 1, 1) for a full-size rect', () => {
@@ -76,10 +70,6 @@ describe('SpriteSheet', () => {
             expect(uvs.v1).toBe(48 / 256);
         });
     });
-
-    // #endregion
-
-    // #region Size
 
     describe('size', () => {
         it('should reflect the image dimensions', () => {
@@ -105,10 +95,6 @@ describe('SpriteSheet', () => {
         });
     });
 
-    // #endregion
-
-    // #region Texture Management
-
     describe('getTexture', () => {
         it('should return a texture object from a mock device', () => {
             const sheet = new SpriteSheet(mockImage);
@@ -128,10 +114,6 @@ describe('SpriteSheet', () => {
             expect(second).toBe(first);
         });
     });
-
-    // #endregion
-
-    // #region Destroy
 
     describe('destroy', () => {
         it('should allow creating a new texture after destroy', () => {
@@ -162,20 +144,12 @@ describe('SpriteSheet', () => {
         });
     });
 
-    // #endregion
-
-    // #region getImage
-
     describe('getImage', () => {
         it('should return the source HTMLImageElement', () => {
             const sheet = new SpriteSheet(mockImage);
             expect(sheet.getImage()).toBe(mockImage);
         });
     });
-
-    // #endregion
-
-    // #region Indexization
 
     describe('isIndexed', () => {
         it('returns false before indexize is called', () => {
@@ -308,10 +282,6 @@ describe('SpriteSheet', () => {
         });
     });
 
-    // #endregion
-
-    // #region load
-
     describe('load', () => {
         afterEach(() => {
             vi.restoreAllMocks();
@@ -382,10 +352,6 @@ describe('SpriteSheet', () => {
         });
     });
 
-    // #endregion
-
-    // #region loadIndexed
-
     describe('loadIndexed', () => {
         afterEach(() => {
             vi.restoreAllMocks();
@@ -428,10 +394,6 @@ describe('SpriteSheet', () => {
             expect(loadColorsSpy).toHaveBeenCalledWith('hero.png', palette, 4, { sort: 'none' });
         });
     });
-
-    // #endregion
-
-    // #region loadColorsIntoPalette
 
     describe('loadColorsIntoPalette', () => {
         afterEach(() => {
@@ -573,10 +535,6 @@ describe('SpriteSheet', () => {
         });
     });
 
-    // #endregion
-
-    // #region fromIndexedPixels
-
     describe('fromIndexedPixels', () => {
         it('creates a sheet with correct dimensions', () => {
             const pixels = new Uint8Array(16 * 16) as Uint8Array<ArrayBuffer>;
@@ -652,10 +610,6 @@ describe('SpriteSheet', () => {
         });
     });
 
-    // #endregion
-
-    // #region getIndexedPixels
-
     describe('getIndexedPixels', () => {
         it('returns contents equal to the pixels passed to fromIndexedPixels', () => {
             const pixels = new Uint8Array([
@@ -686,10 +640,6 @@ describe('SpriteSheet', () => {
             );
         });
     });
-
-    // #endregion
-
-    // #region Palette usage marking
 
     describe('markPaletteIndicesInRect', () => {
         it('marks resolved palette slots for unique non-zero sheet indices in the rect', () => {
@@ -753,6 +703,4 @@ describe('SpriteSheet', () => {
             expect(collectUsedIndices(mask, 16, scratch)).toEqual([]);
         });
     });
-
-    // #endregion
 });

--- a/src/assets/SpriteSheet.ts
+++ b/src/assets/SpriteSheet.ts
@@ -226,8 +226,6 @@ export type IndexedSpriteLoadResult = {
  * reloading the image.
  */
 export class SpriteSheet {
-    // #region Module State
-
     /** Sprite sheet dimensions in pixels. */
     public readonly size: Vector2i;
 
@@ -245,10 +243,6 @@ export class SpriteSheet {
 
     /** Palette index per pixel (set by indexize, uploaded as r8uint texture). */
     private indexedPixels: Uint8Array<ArrayBuffer> | null = null;
-
-    // #endregion
-
-    // #region Constructor
 
     /**
      * Creates a sprite sheet from a loaded image.
@@ -270,10 +264,6 @@ export class SpriteSheet {
             throw new Error('Either an image or explicit size must be provided.');
         }
     }
-
-    // #endregion
-
-    // #region Static Factory
 
     /**
      * Loads a sprite sheet from an image URL.
@@ -307,10 +297,6 @@ export class SpriteSheet {
 
         return sheet;
     }
-
-    // #endregion
-
-    // #region Indexization
 
     /**
      * Convenience one-call path for palette-indexed sprite setup.
@@ -543,10 +529,6 @@ export class SpriteSheet {
         this.invalidateTexture();
     }
 
-    // #endregion
-
-    // #region Accessors
-
     /**
      * Gets the sprite-sheet width in pixels.
      *
@@ -651,10 +633,6 @@ export class SpriteSheet {
         return this.image;
     }
 
-    // #endregion
-
-    // #region UV Calculation
-
     /**
      * Returns a source rectangle that covers the entire sprite sheet.
      *
@@ -663,10 +641,6 @@ export class SpriteSheet {
     fullRect(): Rect2i {
         return new Rect2i(0, 0, this.width, this.height);
     }
-
-    // #endregion
-
-    // #region Cleanup
 
     /**
      * Gets or lazily creates the GPU texture for this sprite sheet.
@@ -690,10 +664,6 @@ export class SpriteSheet {
         // Safe assertion: createTexture / createIndexedTexture always initializes this.texture.
         return this.texture as GPUTexture;
     }
-
-    // #endregion
-
-    // #region Texture Creation
 
     /**
      * Calculates normalized UV coordinates for a sprite region.
@@ -729,10 +699,6 @@ export class SpriteSheet {
         this.rgbaPixels = null;
         this.indexedPixels = null;
     }
-
-    // #endregion
-
-    // #region Private Helpers
 
     /**
      * Creates and uploads the GPU texture from the image.
@@ -819,6 +785,4 @@ export class SpriteSheet {
     private get sourceName(): string {
         return this.image?.src ? `'${this.image.src}'` : '(unnamed)';
     }
-
-    // #endregion
 }

--- a/src/assets/SystemFont.bench.ts
+++ b/src/assets/SystemFont.bench.ts
@@ -7,15 +7,9 @@
  * - Text measurement throughput
  */
 
-// #region Imports
-
 import { bench, describe } from 'vitest';
 
 import { createSystemFont } from './SystemFont';
-
-// #endregion
-
-// #region Constants
 
 const BENCH_OPTIONS = {
     iterations: 500,
@@ -27,10 +21,6 @@ const BENCH_OPTIONS = {
 const SHORT_TEXT = 'Hello, World!';
 const LONG_TEXT = 'The quick brown fox jumps over the lazy dog. 0123456789 ~!@#$%^&*()';
 
-// #endregion
-
-// #region Creation Benchmarks
-
 describe('SystemFont creation', () => {
     bench(
         'createSystemFont()',
@@ -40,10 +30,6 @@ describe('SystemFont creation', () => {
         BENCH_OPTIONS,
     );
 });
-
-// #endregion
-
-// #region Glyph Lookup Benchmarks
 
 describe('SystemFont glyph lookup', () => {
     const font = createSystemFont();
@@ -74,10 +60,6 @@ describe('SystemFont glyph lookup', () => {
         BENCH_OPTIONS,
     );
 });
-
-// #endregion
-
-// #region Text Measurement Benchmarks
 
 describe('SystemFont text measurement', () => {
     const font = createSystemFont();
@@ -116,5 +98,3 @@ describe('SystemFont text measurement', () => {
         BENCH_OPTIONS,
     );
 });
-
-// #endregion

--- a/src/assets/SystemFont.test.ts
+++ b/src/assets/SystemFont.test.ts
@@ -23,8 +23,6 @@ import {
 import { Palette } from './Palette';
 import { createSystemFont } from './SystemFont';
 
-// #region Factory
-
 describe('createSystemFont', () => {
     it('returns a BitmapFont instance', () => {
         const font = createSystemFont();
@@ -61,10 +59,6 @@ describe('createSystemFont', () => {
         }
     });
 });
-
-// #endregion
-
-// #region Glyph Access
 
 describe('system font glyph access', () => {
     it('returns glyph for space character', () => {
@@ -108,10 +102,6 @@ describe('system font glyph access', () => {
     });
 });
 
-// #endregion
-
-// #region Text Measurement
-
 describe('system font text measurement', () => {
     it('measures text width correctly', () => {
         const font = createSystemFont();
@@ -135,10 +125,6 @@ describe('system font text measurement', () => {
         expect(size.height).toBe(SYSTEM_FONT_GLYPH_HEIGHT);
     });
 });
-
-// #endregion
-
-// #region Sprite Sheet
 
 describe('system font sprite sheet', () => {
     it('produces an indexized sprite sheet', () => {
@@ -180,5 +166,3 @@ describe('system font sprite sheet', () => {
         expect(() => sheet.getImage()).toThrow('not available for sheets created from raw indexed data');
     });
 });
-
-// #endregion

--- a/src/assets/SystemFont.ts
+++ b/src/assets/SystemFont.ts
@@ -29,8 +29,6 @@ import {
 } from './fonts/systemFontData';
 import { SpriteSheet } from './SpriteSheet';
 
-// #region Constants
-
 /** Number of glyph columns in the texture atlas. */
 const ATLAS_COLUMNS = 16;
 
@@ -42,10 +40,6 @@ const ATLAS_WIDTH = ATLAS_COLUMNS * SYSTEM_FONT_GLYPH_WIDTH;
 
 /** Atlas height in pixels. */
 const ATLAS_HEIGHT = ATLAS_ROWS * SYSTEM_FONT_GLYPH_HEIGHT;
-
-// #endregion
-
-// #region Atlas Builder
 
 /**
  * Writes one glyph's pixel rows into the flat palette-indexed atlas array.
@@ -134,10 +128,6 @@ function buildGlyphMap(): Map<string, Glyph> {
     );
 }
 
-// #endregion
-
-// #region Public API
-
 /**
  * Creates the built-in 6x14 system font.
  *
@@ -162,5 +152,3 @@ export function createSystemFont(): BitmapFont {
         SYSTEM_FONT_GLYPH_HEIGHT,
     );
 }
-
-// #endregion

--- a/src/assets/fonts/systemFontData.ts
+++ b/src/assets/fonts/systemFontData.ts
@@ -18,8 +18,6 @@
  * This font data is in the public domain.
  */
 
-// #region Bitmap Data
-
 // prettier-ignore
 export const SYSTEM_FONT_BITMAPS: readonly number[] = [
     // Space (32)
@@ -214,10 +212,6 @@ export const SYSTEM_FONT_BITMAPS: readonly number[] = [
     0x00, 0x00, 0x40, 0xa8, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 ];
 
-// #endregion
-
-// #region Constants
-
 /** First character code in the bitmap array. */
 export const SYSTEM_FONT_FIRST_CHAR = 32;
 
@@ -235,5 +229,3 @@ export const SYSTEM_FONT_GLYPH_HEIGHT = 14;
 
 /** Number of bytes per glyph (one byte per row). */
 export const SYSTEM_FONT_BYTES_PER_GLYPH = 14;
-
-// #endregion

--- a/src/assets/palettes/presetData.ts
+++ b/src/assets/palettes/presetData.ts
@@ -6,8 +6,6 @@
  * palette index `1`.
  */
 
-// #region Hex Conversion
-
 /** Masks an 8-bit channel before hex formatting. */
 const BYTE_MASK = 0xff;
 
@@ -22,10 +20,6 @@ const BYTE_MASK = 0xff;
 function rgbToHex(r: number, g: number, b: number): string {
     return [r, g, b].map((channel) => (channel & BYTE_MASK).toString(16).padStart(2, '0')).join('');
 }
-
-// #endregion
-
-// #region VGA Palette
 
 /** Classic VGA 16-color base entries (indices 0-15). */
 const VGA_BASE_HEX = [
@@ -67,10 +61,6 @@ const VGA_GRAYSCALE_HEX = Array.from({ length: VGA_GRAYSCALE_ENTRY_COUNT }, (_, 
 
 /** Default VGA 256-color preset data. */
 export const VGA_HEX = [...VGA_BASE_HEX, ...VGA_CUBE_HEX, ...VGA_GRAYSCALE_HEX];
-
-// #endregion
-
-// #region Static Presets
 
 /** Commodore 64 16-color preset data. */
 // cspell:disable
@@ -204,5 +194,3 @@ export const PICO8_HEX = [
     'ffccaa',
 ];
 // cspell:enable
-
-// #endregion

--- a/src/core/BTAPI.test.ts
+++ b/src/core/BTAPI.test.ts
@@ -46,8 +46,6 @@ import { BTAPI } from './BTAPI';
 import type { IBlitTechDemo, OverlayRow } from './IBlitTechDemo';
 import { collectUsedIndices } from './RenderPaletteUsage';
 
-// #region Helpers
-
 function resetSingleton(): void {
     // BTAPI._instance is private; the cast is intentional - there is no public
     // reset API, and this is the least-invasive way to isolate singleton state
@@ -129,8 +127,6 @@ function makeOffscreenCanvas2dContext(): OffscreenCanvas2DMock {
     };
 }
 
-// #endregion
-
 describe('BTAPI', () => {
     beforeEach(() => {
         resetSingleton();
@@ -148,8 +144,6 @@ describe('BTAPI', () => {
 
         vi.unstubAllGlobals();
     });
-
-    // #region Version constants
 
     describe('version constants', () => {
         it('should expose VERSION_MAJOR as a number', () => {
@@ -173,10 +167,6 @@ describe('BTAPI', () => {
         });
     });
 
-    // #endregion
-
-    // #region Singleton
-
     describe('singleton', () => {
         it('should return the same instance on multiple accesses', () => {
             const a = BTAPI.instance;
@@ -195,10 +185,6 @@ describe('BTAPI', () => {
             expect(a).not.toBe(b);
         });
     });
-
-    // #endregion
-
-    // #region Pre-init null-state accessors
 
     describe('pre-initialization accessors', () => {
         it('getTicks should return 0 before init', () => {
@@ -252,10 +238,6 @@ describe('BTAPI', () => {
             expect(offset.y).toBe(0);
         });
     });
-
-    // #endregion
-
-    // #region Pre-init no-ops
 
     describe('pre-initialization drawing no-ops', () => {
         it('stop should not throw before init', () => {
@@ -359,10 +341,6 @@ describe('BTAPI', () => {
             expect(BTAPI.instance.getPalette()).toBe(palette);
         });
     });
-
-    // #endregion
-
-    // #region init()
 
     describe('init', () => {
         it('should return false for NaN targetFPS', async () => {
@@ -1145,10 +1123,6 @@ describe('BTAPI', () => {
         });
     });
 
-    // #endregion
-
-    // #region Timing chart tags
-
     describe('assignTag', () => {
         it('forwards tags to Overlay when the timing chart is enabled', async () => {
             const assignSpy = vi.spyOn(Overlay.prototype, 'assignTag');
@@ -1189,10 +1163,6 @@ describe('BTAPI', () => {
             expect(assignSpy).not.toHaveBeenCalled();
         });
     });
-
-    // #endregion
-
-    // #region Renderer diagnostics
 
     describe('renderer diagnostics in overlay timing snapshot', () => {
         /**
@@ -1346,10 +1316,6 @@ describe('BTAPI', () => {
             expect(secondTiming).toMatchObject(mockDiagnostics);
         });
     });
-
-    // #endregion
-
-    // #region Palette usage tracking
 
     describe('palette usage tracking', () => {
         function getOverlay(): Overlay | null {
@@ -1752,10 +1718,6 @@ describe('BTAPI', () => {
         });
     });
 
-    // #endregion
-
-    // #region assertPaletteIndex
-
     describe('assertPaletteIndex', () => {
         it('throws when index is negative (no palette set)', () => {
             expect(() => BTAPI.instance.drawPixel(new Vector2i(0, 0), -1)).toThrow('0 or higher');
@@ -1769,10 +1731,6 @@ describe('BTAPI', () => {
             expect(() => BTAPI.instance.drawPixel(new Vector2i(0, 0), 20)).toThrow('The color number 20 is too big');
         });
     });
-
-    // #endregion
-
-    // #region Post-Process Effects API
 
     describe('post-process effects', () => {
         function makeStubEffect(): Effect {
@@ -1829,6 +1787,4 @@ describe('BTAPI', () => {
             expect(removeSpy).toHaveBeenCalledWith(effect);
         });
     });
-
-    // #endregion
 });

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -51,8 +51,6 @@ import { initWebGPU } from './WebGPUContext';
  * It is a singleton; access it through `BTAPI.instance`.
  */
 export class BTAPI {
-    // #region Version Constants
-
     /**
      * Major semantic-version component.
      */
@@ -64,26 +62,14 @@ export class BTAPI {
     /** Patch version number. */
     public static readonly VERSION_PATCH = 0;
 
-    // #endregion
-
-    // #region Module State - Demo Instance
-
     /** Current demo instance implementing IBlitTechDemo. */
     private demo: IBlitTechDemo | null = null;
-
-    // #endregion
-
-    // #region Module State - Hardware Settings
 
     /** Hardware configuration settings from the demo. */
     private hwSettings: HardwareSettings | null = null;
 
     /** WebGPU device for GPU operations. */
     private device: GPUDevice | null = null;
-
-    // #endregion
-
-    // #region Module State - WebGPU Resources
 
     /** WebGPU canvas context for presenting frames. */
     private context: GPUCanvasContext | null = null;
@@ -108,10 +94,6 @@ export class BTAPI {
 
     /** Registry of all sprite sheets that have been passed to drawSprite, for spritesRefresh. */
     private readonly spriteSheets: Set<SpriteSheet> = new Set();
-
-    // #endregion
-
-    // #region Module State - Subsystems
 
     /** Game loop managing fixed-timestep updates and variable-rate rendering. */
     private loop: GameLoop | null = null;
@@ -187,10 +169,6 @@ export class BTAPI {
     // TODO: Additional subsystems for future implementation:
     // AudioManager, AssetManager
 
-    // #endregion
-
-    // #region Singleton / Constructor
-
     /**
      * Private constructor to enforce singleton access via `BTAPI.instance`.
      */
@@ -198,10 +176,6 @@ export class BTAPI {
 
     /** Singleton instance of BTAPI. */
     private static _instance: BTAPI | null = null;
-
-    // #endregion
-
-    // #region Singleton Access
 
     /**
      * Gets the lazily created singleton instance.
@@ -215,10 +189,6 @@ export class BTAPI {
 
         return BTAPI._instance;
     }
-
-    // #endregion
-
-    // #region Initialization
 
     /**
      * Initializes the engine for a demo and starts the main loop on success.
@@ -536,10 +506,6 @@ export class BTAPI {
         this.overlay?.assignTag(label, this.getTicks());
     }
 
-    // #endregion
-
-    // #region Demo State Accessors
-
     /**
      * Gets the hardware settings used for the active demo (from `configure()` or
      * {@link defaultConfig}).
@@ -567,10 +533,6 @@ export class BTAPI {
     public getContext(): GPUCanvasContext | null {
         return this.context;
     }
-
-    // #endregion
-
-    // #region WebGPU Resource Accessors
 
     /**
      * Gets the canvas bound during initialization.
@@ -646,10 +608,6 @@ export class BTAPI {
         return this.gamepad;
     }
 
-    // #endregion
-
-    // #region Rendering API - Palette
-
     /**
      * Gets the active engine palette.
      *
@@ -679,10 +637,6 @@ export class BTAPI {
         this.palette = palette;
         this.renderer?.setPalette(palette);
     }
-
-    // #endregion
-
-    // #region Rendering API - Clear Operations
 
     /**
      * Sets the background clear color for each frame using a palette index.
@@ -742,10 +696,6 @@ export class BTAPI {
 
         this.renderer?.drawLine(p0, p1, paletteIndex);
     }
-
-    // #endregion
-
-    // #region Rendering API - Primitives
 
     /**
      * Draws a rectangle outline (unfilled).
@@ -861,10 +811,6 @@ export class BTAPI {
         this.renderer?.drawBitmapText(font, pos, text, paletteOffset);
     }
 
-    // #endregion
-
-    // #region Rendering API - Sprites
-
     /**
      * Re-indexizes all tracked sprite sheets against the current active palette.
      *
@@ -898,10 +844,6 @@ export class BTAPI {
         console.log(`[BT] Refreshed ${refreshed} sprite sheet(s) against current palette`);
     }
 
-    // #endregion
-
-    // #region Frame Capture API
-
     /**
      * Captures the next rendered frame as a PNG blob.
      * The capture occurs on the next completed render cycle.
@@ -916,10 +858,6 @@ export class BTAPI {
 
         return this.renderer.captureFrame();
     }
-
-    // #endregion
-
-    // #region Camera API
 
     /**
      * Sets the camera offset for scrolling effects.
@@ -946,10 +884,6 @@ export class BTAPI {
     public resetCamera(): void {
         this.renderer?.resetCamera();
     }
-
-    // #endregion
-
-    // #region Palette Effects API
 
     /**
      * Starts rotating a range of palette entries at a constant speed.
@@ -1057,10 +991,6 @@ export class BTAPI {
         this.paletteEffects.clear();
     }
 
-    // #endregion
-
-    // #region Post-Process Effects API
-
     /**
      * Appends a fullscreen post-processing effect to the chain.
      *
@@ -1108,10 +1038,6 @@ export class BTAPI {
 
         this.renderer.clearEffects();
     }
-
-    // #endregion
-
-    // #region Private - Initialization Helpers
 
     /**
      * Constructs and initializes the renderer for the active hardware settings.
@@ -1305,10 +1231,6 @@ export class BTAPI {
         }
     }
 
-    // #endregion
-
-    // #region Private Helpers
-
     /**
      * Records dropped-frame severity for the timing chart and optionally logs a warning.
      *
@@ -1478,6 +1400,4 @@ export class BTAPI {
             throw new Error(paletteIndexOutOfRangeError(index, this.palette.size));
         }
     }
-
-    // #endregion
 }

--- a/src/core/GameLoop.test.ts
+++ b/src/core/GameLoop.test.ts
@@ -19,8 +19,6 @@ import type { FrameDropEvent } from './GameLoop';
 import { GameLoop } from './GameLoop';
 
 describe('GameLoop', () => {
-    // #region Constructor
-
     describe('constructor', () => {
         it('should accept a valid positive update interval', () => {
             const loop = new GameLoop(16.67, vi.fn(), vi.fn());
@@ -49,10 +47,6 @@ describe('GameLoop', () => {
         });
     });
 
-    // #endregion
-
-    // #region Public Methods
-
     describe('getTicks', () => {
         it('should return 0 initially', () => {
             const loop = new GameLoop(16.67, vi.fn(), vi.fn());
@@ -80,10 +74,6 @@ describe('GameLoop', () => {
             expect(() => loop.stop()).not.toThrow();
         });
     });
-
-    // #endregion
-
-    // #region start
 
     describe('start', () => {
         beforeEach(() => {
@@ -114,10 +104,6 @@ describe('GameLoop', () => {
             expect((requestAnimationFrame as ReturnType<typeof vi.fn>).mock.calls.length).toBe(callsBefore);
         });
     });
-
-    // #endregion
-
-    // #region start (RAF flush)
 
     describe('start (RAF flush)', () => {
         afterEach(() => {
@@ -151,10 +137,6 @@ describe('GameLoop', () => {
             expect(rafCallbacks).toHaveLength(3);
         });
     });
-
-    // #endregion
-
-    // #region tick (private)
 
     describe('tick (via type cast)', () => {
         type PrivateLoop = {
@@ -243,10 +225,6 @@ describe('GameLoop', () => {
             expect(requestAnimationFrame).toHaveBeenCalled();
         });
     });
-
-    // #endregion
-
-    // #region Frame-drop detection
 
     describe('frame-drop detection', () => {
         type PrivateLoop = {
@@ -455,6 +433,4 @@ describe('GameLoop', () => {
             expect(() => p.tick(100)).not.toThrow();
         });
     });
-
-    // #endregion
 });

--- a/src/core/GameLoop.ts
+++ b/src/core/GameLoop.ts
@@ -1,5 +1,3 @@
-// #region Types
-
 /**
  * Information passed to a {@link GameLoop} dropped-frame callback.
  *
@@ -38,10 +36,6 @@ export interface FrameDropEvent {
  */
 export type FrameDropCallback = (event: FrameDropEvent) => void;
 
-// #endregion
-
-// #region GameLoop Class
-
 /**
  * Fixed-timestep game loop with variable-rate rendering.
  *
@@ -61,8 +55,6 @@ export type FrameDropCallback = (event: FrameDropEvent) => void;
  * filter out tab-switch pauses), the supplied callback is invoked.
  */
 export class GameLoop {
-    // #region Constants
-
     /** Maximum update steps per frame to prevent spiral-of-death after long pauses. */
     private static readonly MAX_STEPS = 8;
 
@@ -87,10 +79,6 @@ export class GameLoop {
      * rAF callbacks may fire with unusual cadence.
      */
     private static readonly BASELINE_WARMUP_SAMPLES = 8;
-
-    // #endregion
-
-    // #region State
 
     /** Whether the loop is currently running. */
     private isRunning: boolean = false;
@@ -130,10 +118,6 @@ export class GameLoop {
     /** Number of valid samples in {@link recentDeltas}; saturates at BASELINE_WINDOW. */
     private deltaCount: number = 0;
 
-    // #endregion
-
-    // #region Constructor
-
     /**
      * Creates a new GameLoop.
      *
@@ -153,10 +137,6 @@ export class GameLoop {
         this.onRender = onRender;
         this.onFrameDrop = onFrameDrop ?? null;
     }
-
-    // #endregion
-
-    // #region Public Methods
 
     /**
      * Starts the loop.
@@ -204,10 +184,6 @@ export class GameLoop {
     public resetTicks(): void {
         this.ticks = 0;
     }
-
-    // #endregion
-
-    // #region Private Loop
 
     /**
      * Processes one animation frame.
@@ -324,8 +300,4 @@ export class GameLoop {
             expectedInterval: baseline,
         });
     }
-
-    // #endregion
 }
-
-// #endregion

--- a/src/core/IBlitTechDemo.ts
+++ b/src/core/IBlitTechDemo.ts
@@ -1,8 +1,6 @@
 import { DEFAULT_MAX_CANVAS_SIZE } from '../utils/CanvasLayoutStyles';
 import { Vector2i } from '../utils/Vector2i';
 
-// #region Type Definitions
-
 /**
  * Magnification filter used by the upscale pass between the pixel chain
  * (logical resolution) and the display chain (output resolution).
@@ -409,10 +407,6 @@ export interface IBlitTechDemo {
      */
     overlayRows?(): readonly OverlayRow[] | undefined;
 }
-
-// #endregion
-
-// #region Helper Functions
 
 /**
  * Creates a fresh default hardware configuration for quick demos.
@@ -949,5 +943,3 @@ export function needsOverlayRendererDiagnostics(settings: HardwareSettings): boo
         settings.isOverlayRendererDiagnosticsBarEnabled === true
     );
 }
-
-// #endregion

--- a/src/core/WebGPUContext.test.ts
+++ b/src/core/WebGPUContext.test.ts
@@ -24,8 +24,6 @@ import { RenderDimensionLimitError } from '../utils/RenderLimits';
 import { Vector2i } from '../utils/Vector2i';
 import { initWebGPU } from './WebGPUContext';
 
-// #region Helpers
-
 function createMockCanvas(webgpuContext: unknown = createMockGPUCanvasContext()): HTMLCanvasElement {
     return {
         width: 0,
@@ -35,16 +33,12 @@ function createMockCanvas(webgpuContext: unknown = createMockGPUCanvasContext())
     } as unknown as HTMLCanvasElement;
 }
 
-// #endregion
-
 describe('initWebGPU', () => {
     const displaySize = new Vector2i(320, 240);
 
     afterEach(() => {
         uninstallMockNavigatorGPU();
     });
-
-    // #region No WebGPU support
 
     it('should return null when navigator.gpu is absent', async () => {
         // Use Object.defineProperty to install a navigator without .gpu - direct
@@ -60,10 +54,6 @@ describe('initWebGPU', () => {
 
         expect(result).toBeNull();
     });
-
-    // #endregion
-
-    // #region Adapter failures
 
     it('should throw with WEBGPU_ADAPTER_MESSAGE when requestAdapter returns null', async () => {
         Object.defineProperty(globalThis, 'navigator', {
@@ -105,10 +95,6 @@ describe('initWebGPU', () => {
         await expect(initWebGPU(canvas, displaySize)).rejects.toThrow(WEBGPU_DEVICE_MESSAGE);
     });
 
-    // #endregion
-
-    // #region Context failures
-
     it('should return null when canvas.getContext returns null', async () => {
         installMockNavigatorGPU();
 
@@ -117,10 +103,6 @@ describe('initWebGPU', () => {
 
         expect(result).toBeNull();
     });
-
-    // #endregion
-
-    // #region Dimension limits
 
     it('throws RenderDimensionLimitError when displaySize exceeds adapter texture limit', async () => {
         const requestDevice = vi.fn(async () => createMockGPUDevice());
@@ -207,10 +189,6 @@ describe('initWebGPU', () => {
         expect(canvas.height).toBe(1024);
     });
 
-    // #endregion
-
-    // #region Success paths
-
     it('should return device and context on success', async () => {
         installMockNavigatorGPU();
 
@@ -245,6 +223,4 @@ describe('initWebGPU', () => {
         expect(canvas.width).toBe(640);
         expect(canvas.height).toBe(480);
     });
-
-    // #endregion
 });

--- a/src/core/WebGPUContext.ts
+++ b/src/core/WebGPUContext.ts
@@ -2,8 +2,6 @@ import { WEBGPU_ADAPTER_MESSAGE, WEBGPU_DEVICE_MESSAGE } from '../utils/errorMes
 import { RenderDimensionLimitError, validateWebGPUTextureDimension } from '../utils/RenderLimits';
 import type { Vector2i } from '../utils/Vector2i';
 
-// #region Types
-
 /**
  * Result returned when WebGPU canvas initialization succeeds.
  */
@@ -17,10 +15,6 @@ export interface Result {
     /** WebGPU drawing-buffer size in pixels (`configuredDrawingBufferSize ?? displaySize`). */
     drawingBufferSize: Vector2i;
 }
-
-// #endregion
-
-// #region WebGPU Initialization
 
 /**
  * Initializes the WebGPU adapter, device, and canvas context for a canvas.
@@ -145,5 +139,3 @@ export async function initWebGPU(
 
     return { device, context, drawingBufferSize: drawingBufferSize.clone() };
 }
-
-// #endregion

--- a/src/input/GamepadInput.ts
+++ b/src/input/GamepadInput.ts
@@ -6,8 +6,6 @@
  */
 /* eslint-disable security/detect-object-injection */
 
-// #region Constants
-
 /** Maximum supported local gamepad players. */
 export const GAMEPAD_PLAYER_COUNT = 4;
 
@@ -74,10 +72,6 @@ const VALID_AXIS_INDICES = [
     AXIS_TRIGGER_R,
 ] as const;
 
-// #endregion
-
-// #region Raw gamepad reads
-
 /**
  * Reads and clamps a raw stick axis to `[-1, 1]`.
  *
@@ -131,10 +125,6 @@ function isButtonDown(pad: Gamepad, index: number): boolean {
     return button.pressed || button.value >= 0.5;
 }
 
-// #endregion
-
-// #region Types
-
 /**
  * Per-player gamepad snapshot used for current and previous frame state.
  */
@@ -146,10 +136,6 @@ interface PlayerSnapshot {
     /** Snapshot axis values in `AXIS_*` order. */
     axes: readonly [number, number, number, number, number, number];
 }
-
-// #endregion
-
-// #region GamepadInput
 
 /**
  * Polling-based gamepad input tracker with per-frame previous-state snapshots.
@@ -456,8 +442,6 @@ export class GamepadInput {
         return count;
     }
 
-    // #region Private
-
     /**
      * Creates an empty disconnected player snapshot.
      *
@@ -720,8 +704,4 @@ export class GamepadInput {
             this.firstPressTick[i]?.clear();
         }
     }
-
-    // #endregion
 }
-
-// #endregion

--- a/src/input/KeyboardInput.ts
+++ b/src/input/KeyboardInput.ts
@@ -3,8 +3,6 @@
  * and text accumulation via `beforeinput` (`inputString`).
  */
 
-// #region Types
-
 /** Options supplied when attaching to the canvas. */
 export interface KeyboardAttachOptions {
     /**
@@ -13,10 +11,6 @@ export interface KeyboardAttachOptions {
      */
     getTicks: () => number;
 }
-
-// #endregion
-
-// #region KeyboardInput
 
 /**
  * Tracks held keys using `KeyboardEvent.code`, snapshots once per frame for
@@ -257,8 +251,6 @@ export class KeyboardInput {
         return codes.some((c) => this.prevHeld.has(c));
     }
 
-    // #region Private
-
     /**
      * Minimum `firstPressTick` among codes that are still held (OR-button repeat).
      *
@@ -368,8 +360,4 @@ export class KeyboardInput {
             return;
         }
     }
-
-    // #endregion
 }
-
-// #endregion

--- a/src/input/PointerInput.test.ts
+++ b/src/input/PointerInput.test.ts
@@ -99,8 +99,6 @@ describe('PointerInput', () => {
         canvas.remove();
     });
 
-    // #region Construction
-
     describe('construction', () => {
         it('initializes all slots as inactive', () => {
             const fresh = new PointerInput();
@@ -112,10 +110,6 @@ describe('PointerInput', () => {
             expect(fresh.getScrollDelta()).toBe(0);
         });
     });
-
-    // #endregion
-
-    // #region Lifecycle
 
     describe('attach / detach', () => {
         it('sets canvas.style.touchAction to "none" on attach', () => {
@@ -260,10 +254,6 @@ describe('PointerInput', () => {
         });
     });
 
-    // #endregion
-
-    // #region Mouse Slot 0
-
     describe('mouse routing (slot 0)', () => {
         it('routes mouse pointerdown button 0 to slot 0 with BTN_POINTER_A held', () => {
             canvas.dispatchEvent(
@@ -404,10 +394,6 @@ describe('PointerInput', () => {
             expect(input.isActive(0)).toBe(false);
         });
     });
-
-    // #endregion
-
-    // #region Touch Slot Allocation
 
     describe('touch slot allocation', () => {
         it('routes three sequential touches to slots 1, 2, 3 in arrival order', () => {
@@ -638,10 +624,6 @@ describe('PointerInput', () => {
         });
     });
 
-    // #endregion
-
-    // #region Coordinate Conversion
-
     describe('coordinate conversion', () => {
         it('maps clientX/clientY to display coordinates via getBoundingClientRect', () => {
             // rect = { left:10, top:20, width:640, height:480 }
@@ -679,10 +661,6 @@ describe('PointerInput', () => {
             c.remove();
         });
     });
-
-    // #endregion
-
-    // #region Per-Frame State
 
     // The lifecycle model: each rAF tick is "events arrive (between ticks) ->
     // update / render read state -> endFrame snapshots current as prev". The
@@ -1044,10 +1022,6 @@ describe('PointerInput', () => {
         });
     });
 
-    // #endregion
-
-    // #region Wheel
-
     describe('wheel handling', () => {
         it('uses raw deltaY for deltaMode 0 (PIXEL)', () => {
             canvas.dispatchEvent(new WheelEvent('wheel', { deltaY: 5, deltaMode: 0, bubbles: true, cancelable: true }));
@@ -1088,10 +1062,6 @@ describe('PointerInput', () => {
         });
     });
 
-    // #endregion
-
-    // #region Context Menu
-
     describe('context menu suppression', () => {
         it('calls preventDefault on contextmenu events', () => {
             const event = new Event('contextmenu', { bubbles: true, cancelable: true });
@@ -1102,10 +1072,6 @@ describe('PointerInput', () => {
             expect(preventDefault).toHaveBeenCalled();
         });
     });
-
-    // #endregion
-
-    // #region Safe Defaults
 
     describe('out-of-range slot index', () => {
         it.each([-1, POINTER_SLOT_COUNT, 99, 1.5, Number.NaN])('returns safe defaults for slot %s', (slot) => {
@@ -1138,6 +1104,4 @@ describe('PointerInput', () => {
             expect(input.isButtonReleased(99, 0)).toBe(false);
         });
     });
-
-    // #endregion
 });

--- a/src/input/PointerInput.ts
+++ b/src/input/PointerInput.ts
@@ -18,8 +18,6 @@
 import type { Vector2i } from '../utils/Vector2i';
 import { Vector2i as Vector2iImpl } from '../utils/Vector2i';
 
-// #region Constants
-
 /** Maximum number of simultaneously tracked pointers (slot 0 = mouse, 1-3 = touch / pen). */
 export const POINTER_SLOT_COUNT = 4;
 
@@ -37,10 +35,6 @@ const BTN_C = 22;
 
 /** Auxiliary pointer button code (mouse back / forward). Maps to `BT.BTN_POINTER_D`. */
 const BTN_D = 23;
-
-// #endregion
-
-// #region Types
 
 /**
  * Internal per-slot pointer state.
@@ -89,10 +83,6 @@ interface Slot {
     prevD: boolean;
 }
 
-// #endregion
-
-// #region PointerInput Class
-
 /**
  * DOM-backed pointer input tracker.
  *
@@ -106,8 +96,6 @@ interface Slot {
  * out-of-range queries return safe defaults rather than throwing.
  */
 export class PointerInput {
-    // #region State
-
     /**
      * Per-slot pointer state. Fixed-length tuple of {@link POINTER_SLOT_COUNT}
      * entries (0 = mouse, 1-3 = touch / pen).
@@ -132,10 +120,6 @@ export class PointerInput {
     /** Captured `canvas.style.cursor` value, restored by {@link detach}. */
     private originalCursor: string | null = null;
 
-    // #endregion
-
-    // #region Bound Listeners
-
     private readonly onMove: (event: PointerEvent) => void;
     private readonly onDown: (event: PointerEvent) => void;
     private readonly onUp: (event: PointerEvent) => void;
@@ -143,10 +127,6 @@ export class PointerInput {
     private readonly onPointerLeave: (event: PointerEvent) => void;
     private readonly onWheel: (event: WheelEvent) => void;
     private readonly onContextMenu: (event: Event) => void;
-
-    // #endregion
-
-    // #region Constructor
 
     /**
      * Creates a `PointerInput` with all slots inactive.
@@ -165,10 +145,6 @@ export class PointerInput {
         this.onWheel = (event) => this.handleWheel(event);
         this.onContextMenu = (event) => event.preventDefault();
     }
-
-    // #endregion
-
-    // #region Lifecycle
 
     /**
      * Attaches DOM listeners to the canvas and stores the logical display size.
@@ -283,10 +259,6 @@ export class PointerInput {
 
         this.scrollDeltaY = 0;
     }
-
-    // #endregion
-
-    // #region Public Queries
 
     /**
      * Returns the position of the pointer in slot `slot` in display coordinates.
@@ -454,10 +426,6 @@ export class PointerInput {
         }
     }
 
-    // #endregion
-
-    // #region Cursor
-
     /**
      * Hides the native OS cursor while the pointer is over the canvas.
      *
@@ -479,10 +447,6 @@ export class PointerInput {
             this.canvas.style.cursor = this.originalCursor ?? '';
         }
     }
-
-    // #endregion
-
-    // #region Event Handlers
 
     /**
      * Routes a `pointermove` event: updates slot 0 for mouse, or the slot
@@ -690,10 +654,6 @@ export class PointerInput {
 
         this.scrollDeltaY += pixels;
     }
-
-    // #endregion
-
-    // #region Slot Helpers
 
     /**
      * Builds a fresh `Slot` with newly allocated `Vector2i` instances
@@ -925,8 +885,4 @@ export class PointerInput {
         // eslint-disable-next-line security/detect-object-injection -- index originated from idToSlot, always in [0, POINTER_SLOT_COUNT)
         return this.slots[index] ?? null;
     }
-
-    // #endregion
 }
-
-// #endregion

--- a/src/overlay/Overlay.test.ts
+++ b/src/overlay/Overlay.test.ts
@@ -2,8 +2,6 @@
  * Integration tests for {@link Overlay} draw layout and toggle behavior.
  */
 
-// #region Imports
-
 import { describe, expect, it, vi } from 'vitest';
 
 import { Palette } from '../assets/Palette';
@@ -25,10 +23,6 @@ import {
     OVERLAY_EDGE_MARGIN_PX,
     OVERLAY_TOP_TEXT_Y,
 } from './testFixtures';
-
-// #endregion
-
-// #region Helpers
 
 /** Default overlay tests use the 13 px hint bar (palette grid opt-in off). */
 const PALETTE_GRID_OFF = false;
@@ -91,10 +85,6 @@ function buildUsageMask(indices: readonly number[], size = 256): Uint8Array {
 
     return mask;
 }
-
-// #endregion
-
-// #region Tests
 
 describe('Overlay', () => {
     it('isTrackingPaletteUsage is false when palette grid is disabled', () => {
@@ -845,5 +835,3 @@ describe('Overlay', () => {
         expect(renderer.setCameraOffset).toHaveBeenCalledWith(saved);
     });
 });
-
-// #endregion

--- a/src/overlay/Overlay.ts
+++ b/src/overlay/Overlay.ts
@@ -80,8 +80,6 @@ function createTimingChart(
  * {@link HardwareSettings.isOverlayEnabled} and {@link BT.activeBackend} instead.
  */
 export class Overlay {
-    // #region Fields
-
     readonly #layout: OverlayLayout;
 
     readonly #topLeftLabel: string;
@@ -125,10 +123,6 @@ export class Overlay {
     #idxText = DEFAULT_IDX_TEXT;
 
     #idxGap = DEFAULT_IDX_BG;
-
-    // #endregion
-
-    // #region Constructor
 
     /**
      * Creates an overlay with fixed layout and text strings.
@@ -190,10 +184,6 @@ export class Overlay {
         this.#toggle = new Toggle(isOverlayVisibleAtStart, isOverlayToggleEnabled);
         this.#isToggleHintVisible = isOverlayToggleHintVisible;
     }
-
-    // #endregion
-
-    // #region Public API
 
     /**
      * Records a timing-chart event tag at the current tick.
@@ -345,10 +335,6 @@ export class Overlay {
             );
         });
     }
-
-    // #endregion
-
-    // #region Private helpers
 
     /**
      * Records timing samples when a snapshot is provided.
@@ -576,6 +562,4 @@ export class Overlay {
             );
         }
     }
-
-    // #endregion
 }

--- a/src/overlay/OverlayToggleIcon.ts
+++ b/src/overlay/OverlayToggleIcon.ts
@@ -2,8 +2,6 @@
  * Draw helper for the inline overlay toggle hint bitmap icon.
  */
 
-// #region Imports and constants
-
 import { Rect2i } from '../utils/Rect2i';
 import { Vector2i } from '../utils/Vector2i';
 import { OVERLAY_BAR_HEIGHT, OVERLAY_EDGE_MARGIN_PX } from './layout/constants';
@@ -15,10 +13,6 @@ const iconDrawScratch = {
     run: new Rect2i(),
     origin: new Vector2i(),
 };
-
-// #endregion
-
-// #region Layout helpers
 
 /**
  * Computes the icon top-left Y inside the hint bar without allocating.
@@ -82,10 +76,6 @@ export function hintIconExclusionRect(hintBarTopY: number): Rect2i {
 export function overlayToggleHintIconExclusionRect(hintBarTopY: number): Rect2i {
     return hintIconExclusionRect(hintBarTopY);
 }
-
-// #endregion
-
-// #region Drawing
 
 /**
  * Draws the toggle hint icon from {@link ICON_MASK} using on-top bar fills.
@@ -153,10 +143,6 @@ export function drawOverlayToggleIcon(
     toggleIcon(target, hintBarTopY, textPaletteIndex, inverted);
 }
 
-// #endregion
-
-// #region Utilities
-
 /**
  * Writes the toggle hint icon top-left origin into {@link target} without allocating.
  *
@@ -167,5 +153,3 @@ function writeHintIconOrigin(target: Vector2i, hintBarTopY: number): void {
     target.x = OVERLAY_EDGE_MARGIN_PX;
     target.y = hintIconY(hintBarTopY);
 }
-
-// #endregion

--- a/src/overlay/bars/Bars.ts
+++ b/src/overlay/bars/Bars.ts
@@ -1,5 +1,3 @@
-// #region Imports
-
 import type { BitmapFont } from '../../assets/BitmapFont';
 import type { OverlayRow } from '../../core/IBlitTechDemo';
 import { Rect2i } from '../../utils/Rect2i';
@@ -9,33 +7,21 @@ import { overlayBitmapTextPaletteOffset, overlayRightAlignedTextX } from '../lay
 import type { OverlayLayoutPlan } from '../layout/types';
 import type { OverlayDrawTarget } from '../OverlayDrawTarget';
 
-// #endregion
-
-// #region Types
-
 /** Default bar and text palette indices for overlay drawing. */
 export interface OverlayBarStyle {
     readonly barIndex: number;
     readonly textIndex: number;
 }
 
-// #endregion
-
 /**
  * Draws fixed and custom overlay bars and labels from a layout plan.
  */
 export class OverlayBars {
-    // #region Private fields
-
     readonly #customLeftPos: Vector2i[] = [];
 
     readonly #customRightPos: Vector2i[] = [];
 
     readonly #hintSeparatorRect = new Rect2i(0, 0, 0, OVERLAY_ROW_GAP_PX);
-
-    // #endregion
-
-    // #region Private helpers
 
     /**
      * Ensures the custom-row scratch pool has at least `count` entries.
@@ -48,10 +34,6 @@ export class OverlayBars {
             this.#customRightPos.push(new Vector2i(0, 0));
         }
     }
-
-    // #endregion
-
-    // #region Draw methods
 
     /**
      * Draws 1 px row gaps between stacked overlay bands.
@@ -274,6 +256,4 @@ export class OverlayBars {
         }
         /* eslint-enable security/detect-object-injection */
     }
-
-    // #endregion
 }

--- a/src/overlay/layout/layoutPlan.test.ts
+++ b/src/overlay/layout/layoutPlan.test.ts
@@ -1,5 +1,3 @@
-// #region Imports
-
 import { describe, expect, it } from 'vitest';
 
 import { computeGrid } from '../palette/PaletteView';
@@ -13,10 +11,6 @@ import {
     paletteBandY,
     resolveOverlayFooterHeight,
 } from './layoutPlan';
-
-// #endregion
-
-// #region Tests
 
 describe('buildOverlayLayoutPlan', () => {
     it('matches legacy fixed layout for 320x240 with no custom rows', () => {
@@ -164,5 +158,3 @@ describe('buildOverlayLayoutPlan', () => {
         expect(cappedGrid.totalHeight).toBeLessThan(paletteGrid.totalHeight);
     });
 });
-
-// #endregion

--- a/src/overlay/layout/layoutPlan.ts
+++ b/src/overlay/layout/layoutPlan.ts
@@ -13,8 +13,6 @@ import { OVERLAY_BAR_HEIGHT, OVERLAY_EDGE_MARGIN_PX, OVERLAY_ROW_GAP_PX, OVERLAY
 import { overlayRightAlignedTextX } from './layoutHelpers';
 import type { OverlayLayoutConfig, OverlayLayoutPlan } from './types';
 
-// #region Scratch type
-
 /** Mutable scratch object reused by {@link buildOverlayLayoutPlan}. */
 export interface OverlayLayoutPlanScratch {
     titleBar: Rect2i;
@@ -62,10 +60,6 @@ export function createOverlayLayoutPlanScratch(): OverlayLayoutPlanScratch {
         bottomClusterSeparator: new Rect2i(0, 0, 0, OVERLAY_ROW_GAP_PX),
     };
 }
-
-// #endregion
-
-// #region Geometry helpers
 
 /**
  * Top Y of the bottom hint bar (13 px strip at the display bottom edge).
@@ -257,10 +251,6 @@ function populateGapLayout(scratch: OverlayLayoutPlanScratch, config: OverlayLay
     scratch.bottomClusterSeparator.height = OVERLAY_ROW_GAP_PX;
 }
 
-// #endregion
-
-// #region Layout planner
-
 /**
  * Builds or updates a layout plan from configuration (top-down stack).
  *
@@ -382,10 +372,6 @@ export function buildOverlayLayoutPlan(
     return scratch;
 }
 
-// #endregion
-
-// #region Config factory
-
 /**
  * Default layout config with chart and palette features disabled.
  *
@@ -412,5 +398,3 @@ export function createDefaultLayoutConfig(
         isOverlayPaletteEnabled: false,
     };
 }
-
-// #endregion

--- a/src/overlay/palette/PaletteInteraction.ts
+++ b/src/overlay/palette/PaletteInteraction.ts
@@ -23,8 +23,6 @@ import {
     writeSwatchTopLeft,
 } from './PaletteView';
 
-// #region Constants and types
-
 /** Reserved width on the right edge of the palette band excluded from swatch hits (scrollbar). */
 export const PALETTE_SCROLLBAR_TRACK_WIDTH_PX = 4;
 
@@ -50,10 +48,6 @@ const tooltipScratch = {
     outlineEdge: new Rect2i(),
     textPos: new Vector2i(),
 };
-
-// #endregion
-
-// #region Helpers
 
 /**
  * Returns whether a palette slot at the given swatch origin overlaps the hint exclusion rect.
@@ -330,10 +324,6 @@ export function resolveScrollRowOffsetFromTrackPointerY(
     return clampScrollRowOffset(offset, grid);
 }
 
-// #endregion
-
-// #region Tooltip
-
 /** Layout output for a docked palette swatch tooltip. */
 export interface PaletteTooltipLayout {
     /** Tooltip label body in display coordinates. */
@@ -446,10 +436,6 @@ export function drawTooltipLabel(
     target.drawLabelOnTop(font, layout.textPos, label, textPaletteOffset);
 }
 
-// #endregion
-
-// #region Clipboard
-
 /**
  * Writes palette index text to the clipboard when the API is available.
  *
@@ -465,10 +451,6 @@ export async function writeIndexToClipboard(index: number): Promise<void> {
 
     await clipboard.writeText(String(index));
 }
-
-// #endregion
-
-// #region Interaction
 
 /**
  * Handles palette swatch hover, copy-on-press, and tooltip rendering for the overlay.
@@ -1007,5 +989,3 @@ export class PaletteInteraction {
         return this.#tooltipLabel;
     }
 }
-
-// #endregion

--- a/src/overlay/palette/PaletteView.alloc.test.ts
+++ b/src/overlay/palette/PaletteView.alloc.test.ts
@@ -2,8 +2,6 @@
  * Allocation regression tests for {@link PaletteView} draw hot path.
  */
 
-// #region Imports
-
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Palette } from '../../assets/Palette';
@@ -13,10 +11,6 @@ import { Rect2i } from '../../utils/Rect2i';
 import { createOverlayLayout } from '../layout/layoutHelpers';
 import { hintBarY, paletteBandY } from '../layout/layoutPlan';
 import { computeGrid, DEFAULT_PALETTE_SWATCH_SIZE, PaletteView } from './PaletteView';
-
-// #endregion
-
-// #region Mock setup
 
 const { rect2iAllocStats } = vi.hoisted(() => ({ rect2iAllocStats: { count: 0 } }));
 
@@ -33,10 +27,6 @@ vi.mock('../../utils/Rect2i', async (importOriginal) => {
     return { ...mod, Rect2i: CountingRect2i };
 });
 
-// #endregion
-
-// #region Helpers
-
 /** Builds a usage mask from palette slot indices for tests. */
 function buildUsageMask(indices: readonly number[], size = 256): Uint8Array {
     const mask = new Uint8Array(size);
@@ -47,10 +37,6 @@ function buildUsageMask(indices: readonly number[], size = 256): Uint8Array {
 
     return mask;
 }
-
-// #endregion
-
-// #region Tests
 
 describe('PaletteView allocation', () => {
     beforeEach(() => {
@@ -137,5 +123,3 @@ describe('PaletteView allocation', () => {
         expect(rect2iAllocStats.count).toBe(afterWarmup);
     });
 });
-
-// #endregion

--- a/src/overlay/palette/PaletteView.bench.ts
+++ b/src/overlay/palette/PaletteView.bench.ts
@@ -1,5 +1,3 @@
-// #region Imports
-
 import { bench, describe } from 'vitest';
 
 import { Palette } from '../../assets/Palette';
@@ -10,20 +8,12 @@ import { createOverlayLayout } from '../layout/layoutHelpers';
 import { hintBarY } from '../layout/layoutPlan';
 import { computeGrid, PaletteView } from './PaletteView';
 
-// #endregion
-
-// #region Constants
-
 const BENCH_OPTIONS = {
     iterations: 100,
     time: 100,
     warmupTime: 25,
     warmupIterations: 25,
 };
-
-// #endregion
-
-// #region Fixtures
 
 const layout16 = createOverlayLayout(320, 240, 14);
 const grid16 = computeGrid(320, undefined, 16);
@@ -44,8 +34,6 @@ const noopRenderer = {
     getCameraOffset: () => new Vector2i(0, 0),
     resetCamera: () => {},
 };
-
-// #endregion
 
 describe('PaletteView.draw', () => {
     bench(

--- a/src/overlay/palette/PaletteView.ts
+++ b/src/overlay/palette/PaletteView.ts
@@ -6,8 +6,6 @@
  * transparent corner pixels.
  */
 
-// #region Imports and constants
-
 import type { Palette } from '../../assets/Palette';
 import { Rect2i } from '../../utils/Rect2i';
 import { OVERLAY_EDGE_MARGIN_PX } from '../layout/constants';
@@ -41,10 +39,6 @@ export const DEFAULT_PALETTE_GRID: PaletteGridLayout = {
     gap: 0,
     totalHeight: 0,
 };
-
-// #endregion
-
-// #region Grid math
 
 /**
  * Computes the horizontal span of one grid row.
@@ -214,10 +208,6 @@ export function computeGrid(
  */
 export const computePaletteGrid = computeGrid;
 
-// #endregion
-
-// #region Rect helpers
-
 /**
  * Returns whether two axis-aligned rects overlap (zero allocation).
  *
@@ -293,10 +283,6 @@ export function resolveHintExclusionRect(hintBarTopY: number, displayWidth: numb
  * @returns Exclusion rect for swatch placement and hit testing.
  */
 export const resolvePaletteHintExclusionRect = resolveHintExclusionRect;
-
-// #endregion
-
-// #region Marker and draw helpers
 
 /** Preferred side length for the filled marker drawn inside unused swatches. */
 const UNUSED_SWATCH_MARKER_SIZE = 3;
@@ -626,10 +612,6 @@ function drawScrollbar(
     target.drawBarFill(thumbScratch, thumbIndex);
 }
 
-// #endregion
-
-// #region PaletteView
-
 /**
  * Live palette swatch renderer for the overlay bottom band.
  */
@@ -702,5 +684,3 @@ export class PaletteView {
         drawScrollbar(target, paletteBand, grid, scrollRowOffset, scrollbarTrackWidth, scrollbarThumbIndex);
     }
 }
-
-// #endregion

--- a/src/overlay/timing-chart/TimingChart.test.ts
+++ b/src/overlay/timing-chart/TimingChart.test.ts
@@ -40,8 +40,6 @@ function drawChart(
     chart.draw(renderer, chartRect, defaultStyle, mockFont, currentTick);
 }
 
-// #region computeTimingChartBarHeight tests
-
 describe('computeTimingChartBarHeight', () => {
     it('maps ms proportionally to chart height and clamps at band bounds', () => {
         expect(computeTimingChartBarHeight(0, 22, TIMING_CHART_FULL_SCALE_MS)).toBe(0);
@@ -50,10 +48,6 @@ describe('computeTimingChartBarHeight', () => {
         expect(computeTimingChartBarHeight(32, 22, TIMING_CHART_FULL_SCALE_MS)).toBe(22);
     });
 });
-
-// #endregion
-
-// #region TimingChart tests
 
 describe('TimingChart', () => {
     it('does not draw when disabled', () => {
@@ -687,5 +681,3 @@ describe('TimingChart', () => {
         expect(pressureDots.length).toBeGreaterThanOrEqual(2);
     });
 });
-
-// #endregion

--- a/src/render/IRenderer.ts
+++ b/src/render/IRenderer.ts
@@ -20,18 +20,12 @@ import type { Effect } from './effects/Effect';
  * 3. Palette must be set via {@link setPalette} before the first {@link beginFrame}.
  */
 export interface IRenderer {
-    // #region Initialization
-
     /**
      * Initializes GPU or canvas resources for rendering.
      *
      * @returns `true` when resources are ready; `false` on failure.
      */
     init(): Promise<boolean>;
-
-    // #endregion
-
-    // #region Palette
 
     /**
      * Sets the active palette used for all color lookups this frame and beyond.
@@ -46,10 +40,6 @@ export interface IRenderer {
      * @returns Clone of the active palette, or `null`.
      */
     getPalette(): Palette | null;
-
-    // #endregion
-
-    // #region Frame Management
 
     /**
      * Begins a new frame. Resets per-frame draw batches.
@@ -79,10 +69,6 @@ export interface IRenderer {
      * @returns Diagnostic counters for the current frame.
      */
     getFrameDiagnostics(): OverlayRendererDiagnostics;
-
-    // #endregion
-
-    // #region Drawing - Primitives
 
     /**
      * Draws a filled rectangle.
@@ -125,10 +111,6 @@ export interface IRenderer {
      */
     clearRect(rect: Rect2i, paletteIndex: number): void;
 
-    // #endregion
-
-    // #region Drawing - Sprites
-
     /**
      * Draws a sprite region from an indexed sprite sheet.
      *
@@ -149,20 +131,12 @@ export interface IRenderer {
      */
     drawBitmapText(font: BitmapFont, pos: Vector2i, text: string, paletteOffset?: number): void;
 
-    // #endregion
-
-    // #region Frame Capture
-
     /**
      * Captures the next rendered frame as a PNG blob.
      *
      * @returns Promise resolving to a PNG Blob after the next {@link endFrame}.
      */
     captureFrame(): Promise<Blob>;
-
-    // #endregion
-
-    // #region Camera
 
     /**
      * Sets the camera offset for scrolling.
@@ -182,10 +156,6 @@ export interface IRenderer {
      * Resets the camera offset to the origin (0, 0).
      */
     resetCamera(): void;
-
-    // #endregion
-
-    // #region Post-Process Effects
 
     /**
      * Appends a fullscreen post-processing effect.
@@ -207,6 +177,4 @@ export interface IRenderer {
      * Removes every registered post-processing effect.
      */
     clearEffects(): void;
-
-    // #endregion
 }

--- a/src/render/PaletteResolveUpscalePass.ts
+++ b/src/render/PaletteResolveUpscalePass.ts
@@ -9,8 +9,10 @@ import type { UpscaleFilter } from './UpscalePass';
  * Replaces {@link UpscalePass} for logical-index framebuffers: palette lookup happens here,
  * after the pixel-tier chain.
  */
-// #region PaletteResolveUpscalePass
 
+/**
+ *
+ */
 export class PaletteResolveUpscalePass {
     private device: GPUDevice | null = null;
     private pipeline: GPURenderPipeline | null = null;
@@ -168,10 +170,6 @@ export class PaletteResolveUpscalePass {
     }
 }
 
-// #endregion
-
-// #region FRAGMENT_WGSL
-
 const FRAGMENT_WGSL = `
 struct Params {
     logicalSize: vec2<f32>,
@@ -238,5 +236,3 @@ fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
     return vec4<f32>(pm.rgb / pm.a, pm.a);
 }
 `;
-
-// #endregion

--- a/src/render/PostProcessChain.test.ts
+++ b/src/render/PostProcessChain.test.ts
@@ -25,8 +25,6 @@ import { Vector2i } from '../utils/Vector2i';
 import type { Effect, EffectTier } from './effects/Effect';
 import { PostProcessChain } from './PostProcessChain';
 
-// #region Test Helpers
-
 const FORMAT: GPUTextureFormat = 'bgra8unorm';
 const DISPLAY_SIZE = new Vector2i(320, 240);
 
@@ -61,10 +59,6 @@ function createStubEffect(tier: EffectTier = 'pixel'): Effect & { calls: CallLog
     return stub;
 }
 
-// #endregion
-
-// #region Mock setup
-
 beforeAll(() => {
     installMockNavigatorGPU();
 });
@@ -72,10 +66,6 @@ beforeAll(() => {
 afterAll(() => {
     uninstallMockNavigatorGPU();
 });
-
-// #endregion
-
-// #region Constructor
 
 describe('PostProcessChain constructor', () => {
     it('does not allocate GPU textures', () => {
@@ -102,10 +92,6 @@ describe('PostProcessChain constructor', () => {
         expect(display.tier).toBe('display');
     });
 });
-
-// #endregion
-
-// #region Add / Remove / Clear
 
 describe('add()', () => {
     it('initializes the effect with the chain device, format, and chain size', () => {
@@ -309,10 +295,6 @@ describe('clear()', () => {
     });
 });
 
-// #endregion
-
-// #region Input view
-
 describe('getInputView()', () => {
     it('throws before any effect has been added', () => {
         const chain = new PostProcessChain(createMockGPUDevice(), FORMAT, DISPLAY_SIZE, 'pixel');
@@ -331,10 +313,6 @@ describe('getInputView()', () => {
         expect(a).toBe(b);
     });
 });
-
-// #endregion
-
-// #region Encode
 
 describe('encode()', () => {
     function makeDestView(): GPUTextureView {
@@ -480,10 +458,6 @@ describe('encode()', () => {
     });
 });
 
-// #endregion
-
-// #region Dispose
-
 describe('dispose()', () => {
     it('destroys every effect and offscreen texture', () => {
         const device = createMockGPUDevice();
@@ -506,5 +480,3 @@ describe('dispose()', () => {
         expect(chain.isActive()).toBe(false);
     });
 });
-
-// #endregion

--- a/src/render/PostProcessChain.ts
+++ b/src/render/PostProcessChain.ts
@@ -1,8 +1,6 @@
 import type { Vector2i } from '../utils/Vector2i';
 import type { Effect, EffectTier } from './effects/Effect';
 
-// #region Configuration
-
 /**
  * Texture usage flags for offscreen color targets.
  *
@@ -10,8 +8,6 @@ import type { Effect, EffectTier } from './effects/Effect';
  * `TEXTURE_BINDING` allows post-process effects to sample from it.
  */
 const OFFSCREEN_USAGE = GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING;
-
-// #endregion
 
 /**
  * Stackable post-processing effect chain that runs at a single resolution tier.
@@ -37,8 +33,6 @@ const OFFSCREEN_USAGE = GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXT
  * Effect ordering is the order of {@link add} calls.
  */
 export class PostProcessChain {
-    // #region State
-
     /** WebGPU device used for resource creation. */
     private readonly device: GPUDevice;
 
@@ -69,10 +63,6 @@ export class PostProcessChain {
     /** Cached view for {@link texB}, regenerated when the texture is recreated. */
     private texBView: GPUTextureView | null = null;
 
-    // #endregion
-
-    // #region Constructor
-
     /**
      * Creates a chain bound to a device, swap-chain format, render resolution,
      * and tier.
@@ -91,10 +81,6 @@ export class PostProcessChain {
         this.size = chainSize.clone();
         this.tier = tier;
     }
-
-    // #endregion
-
-    // #region Public API
 
     /**
      * Returns `true` when at least one effect is registered.
@@ -272,10 +258,6 @@ export class PostProcessChain {
         this.clear();
     }
 
-    // #endregion
-
-    // #region Private Helpers
-
     /** Allocates {@link texA}. */
     private allocatePrimary(): void {
         this.texA = this.device.createTexture({
@@ -323,6 +305,4 @@ export class PostProcessChain {
         this.texAView = null;
         this.texBView = null;
     }
-
-    // #endregion
 }

--- a/src/render/PrimitivePipeline.test.ts
+++ b/src/render/PrimitivePipeline.test.ts
@@ -25,8 +25,6 @@ import { Rect2i } from '../utils/Rect2i';
 import { Vector2i } from '../utils/Vector2i';
 import { PrimitivePipeline } from './PrimitivePipeline';
 
-// #region Constructor
-
 describe('PrimitivePipeline constructor', () => {
     it('creates an instance without error', () => {
         const pipeline = new PrimitivePipeline();
@@ -35,10 +33,6 @@ describe('PrimitivePipeline constructor', () => {
         expect(pipeline).toBeInstanceOf(PrimitivePipeline);
     });
 });
-
-// #endregion
-
-// #region Pre-initialization Safety
 
 describe('pre-initialization safety', () => {
     it('reset() can be called multiple times safely', () => {
@@ -141,10 +135,6 @@ describe('pre-initialization safety', () => {
         }).not.toThrow();
     });
 });
-
-// #endregion
-
-// #region Initialized Pipeline
 
 describe('with initialized pipeline', () => {
     const device = createMockGPUDevice();
@@ -253,10 +243,6 @@ describe('with initialized pipeline', () => {
         pipeline.setCameraOffset(Vector2i.zero());
     });
 });
-
-// #endregion
-
-// #region Vertex Count Verification
 
 describe('vertex count verification', () => {
     const device = createMockGPUDevice();
@@ -464,5 +450,3 @@ describe('vertex count verification', () => {
         expect(pipeline.getFrameSubmittedVertices()).toBe(6);
     });
 });
-
-// #endregion

--- a/src/render/PrimitivePipeline.ts
+++ b/src/render/PrimitivePipeline.ts
@@ -1,8 +1,6 @@
 import { Rect2i } from '../utils/Rect2i';
 import { Vector2i } from '../utils/Vector2i';
 
-// #region Configuration
-
 /**
  * Maximum number of primitive vertices retained for a frame.
  *
@@ -21,8 +19,6 @@ const VALUES_PER_VERTEX = 3;
  */
 const VERTEX_STRIDE = VALUES_PER_VERTEX * 4;
 
-// #endregion
-
 /**
  * Batched WebGPU pipeline for palette-indexed primitives.
  *
@@ -35,8 +31,6 @@ const VERTEX_STRIDE = VALUES_PER_VERTEX * 4;
  * prior RGBA behavior.
  */
 export class PrimitivePipeline {
-    // #region State
-
     /** WebGPU device, set during init(). */
     private device: GPUDevice | null = null;
 
@@ -70,10 +64,6 @@ export class PrimitivePipeline {
     /** Camera offset applied to all drawing operations. */
     private cameraOffset: Vector2i = Vector2i.zero();
 
-    // #endregion
-
-    // #region Batching State
-
     /** Primitive batches recorded after each early flush. */
     private batches: Array<{ vertexStart: number; vertexCount: number }> = [];
 
@@ -83,16 +73,8 @@ export class PrimitivePipeline {
     /** Overflow events recorded this frame (dropped pixels or vertices). */
     private overflowCount: number = 0;
 
-    // #endregion
-
-    // #region Reusable Objects
-
     /** Pre-allocated rect to avoid per-call allocations in hot paths. */
     private readonly tempRect: Rect2i = new Rect2i(0, 0, 0, 0);
-
-    // #endregion
-
-    // #region Constructor
 
     /**
      * Creates an empty primitive pipeline.
@@ -103,10 +85,6 @@ export class PrimitivePipeline {
         this.vertexFloats = new Float32Array(this.vertexArrayBuffer);
         this.vertexIndices = new Uint32Array(this.vertexArrayBuffer);
     }
-
-    // #endregion
-
-    // #region Initialization
 
     /**
      * Initializes the GPU pipeline state and backing buffers.
@@ -126,10 +104,6 @@ export class PrimitivePipeline {
         await this.createPipeline(displaySize, paletteBuffer, targetFormat);
     }
 
-    // #endregion
-
-    // #region Camera
-
     /**
      * Sets the camera offset applied to all drawing operations.
      *
@@ -138,10 +112,6 @@ export class PrimitivePipeline {
     setCameraOffset(offset: Vector2i): void {
         this.cameraOffset = offset;
     }
-
-    // #endregion
-
-    // #region Drawing
 
     /**
      * Draws a filled rectangle using two triangles.
@@ -327,10 +297,6 @@ export class PrimitivePipeline {
         }
     }
 
-    // #endregion
-
-    // #region Frame Rendering
-
     /**
      * Clears per-frame batching state.
      */
@@ -481,10 +447,6 @@ export class PrimitivePipeline {
         });
     }
 
-    // #endregion
-
-    // #region Private Helpers
-
     /**
      * Draws a diagonal line using Bresenham's line algorithm.
      * Produces pixel-perfect lines without antialiasing by emitting 1x1 quads
@@ -615,6 +577,4 @@ export class PrimitivePipeline {
         this.totalVertices += this.vertexCount;
         this.vertexCount = 0;
     }
-
-    // #endregion
 }

--- a/src/render/SoftwareRenderer.test.ts
+++ b/src/render/SoftwareRenderer.test.ts
@@ -9,8 +9,6 @@ import { Vector2i } from '../utils/Vector2i';
 import type { Effect } from './effects/Effect';
 import { SoftwareRenderer } from './SoftwareRenderer';
 
-// #region Types and helpers
-
 type MockContext = {
     imageSmoothingEnabled: boolean;
     createImageData: (w: number, h: number) => ImageData;
@@ -85,11 +83,7 @@ function hashPixels(imageData: ImageData): number {
     return hash >>> 0;
 }
 
-// #endregion
-
 describe('SoftwareRenderer', () => {
-    // #region Setup
-
     beforeEach(() => {
         vi.clearAllMocks();
         context.lastImageData = null;
@@ -111,10 +105,6 @@ describe('SoftwareRenderer', () => {
         vi.unstubAllGlobals();
     });
 
-    // #endregion
-
-    // #region Basic lifecycle
-
     it('requires palette before beginFrame', async () => {
         const canvas = {
             width: 0,
@@ -128,10 +118,6 @@ describe('SoftwareRenderer', () => {
 
         expect(() => renderer.beginFrame()).toThrow('No palette set yet. Call BT.paletteSet');
     });
-
-    // #endregion
-
-    // #region Rendering behaviors
 
     it('renders primitives with camera offset applied', async () => {
         const canvas = {
@@ -330,10 +316,6 @@ describe('SoftwareRenderer', () => {
         expect(() => renderer.clearEffects()).toThrow("doesn't support fullscreen effects");
     });
 
-    // #endregion
-
-    // #region Capture behavior
-
     it('resolves captureFrame on next endFrame', async () => {
         const toBlob = vi.fn((callback: (blob: Blob | null) => void) =>
             callback(new Blob(['png'], { type: 'image/png' })),
@@ -422,10 +404,6 @@ describe('SoftwareRenderer', () => {
         await expect(capture).rejects.toThrow('something went wrong exporting the canvas image');
     });
 
-    // #endregion
-
-    // #region Determinism
-
     it('produces deterministic output for the same command sequence', async () => {
         const canvas = {
             width: 0,
@@ -487,6 +465,4 @@ describe('SoftwareRenderer', () => {
 
         renderer.endFrame();
     });
-
-    // #endregion
 });

--- a/src/render/SoftwareRenderer.ts
+++ b/src/render/SoftwareRenderer.ts
@@ -11,8 +11,6 @@ import { Vector2i } from '../utils/Vector2i';
 import type { Effect } from './effects/Effect';
 import type { IRenderer } from './IRenderer';
 
-// #region Type Definitions
-
 /** A queued filled-rectangle or outline-rectangle draw command. */
 type RectCommand = {
     kind: 'rectFill' | 'rect';
@@ -74,8 +72,6 @@ type Pending = {
 /** Alias for either the offscreen or on-screen 2D rendering context variant. */
 type Canvas2D = OffscreenCanvasRenderingContext2D | CanvasRenderingContext2D;
 
-// #endregion
-
 /**
  * Canvas-2D software fallback renderer implementing {@link IRenderer}.
  *
@@ -84,17 +80,11 @@ type Canvas2D = OffscreenCanvasRenderingContext2D | CanvasRenderingContext2D;
  * target canvas with optional nearest-neighbor upscaling.
  */
 export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
-    // #region Constants
-
     private static readonly EFFECTS_UNSUPPORTED_MESSAGE =
         "The software renderer doesn't support fullscreen effects. To use post-process effects, set backend to 'webgpu' in configure().";
 
     /** Vertices emitted for one filled rect or sprite quad (matches WebGPU batching). */
     private static readonly QUAD_VERTEX_COUNT = 6;
-
-    // #endregion
-
-    // #region State
 
     private readonly canvas: HTMLCanvasElement;
     private readonly displaySize: Vector2i;
@@ -114,10 +104,6 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
     private primitiveSubmittedVertices = 0;
     private spriteSubmittedVertices = 0;
 
-    // #endregion
-
-    // #region Constructor
-
     /**
      * Creates a software renderer bound to the given canvas.
      *
@@ -131,10 +117,6 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
         this.outputSize = (outputSize ?? displaySize).clone();
         this.framePixels = new Uint8ClampedArray(this.displaySize.x * this.displaySize.y * 4);
     }
-
-    // #endregion
-
-    // #region Initialization
 
     /**
      * Initializes the 2D canvas contexts and backing image buffer.
@@ -171,10 +153,6 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
         return true;
     }
 
-    // #endregion
-
-    // #region Palette
-
     /**
      * Sets the active palette used for all color lookups during rendering.
      *
@@ -196,10 +174,6 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
     getPalette(): Palette | null {
         return this.palette?.clone() ?? null;
     }
-
-    // #endregion
-
-    // #region Frame Management
 
     /**
      * Marks the start of a new frame and clears the draw-command queue.
@@ -258,10 +232,6 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
             spriteSubmittedVertices: this.spriteSubmittedVertices,
         };
     }
-
-    // #endregion
-
-    // #region Drawing - Primitives
 
     /**
      * Queues a filled rectangle draw command.
@@ -364,10 +334,6 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
         this.drawRectFill(rect, paletteIndex);
     }
 
-    // #endregion
-
-    // #region Drawing - Sprites
-
     /**
      * Queues a sprite blit from a source sheet rectangle to a destination position.
      *
@@ -434,10 +400,6 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
         this.drawLabel(font, pos, text, paletteOffset);
     }
 
-    // #endregion
-
-    // #region Frame Capture
-
     /**
      * Returns a promise that resolves with a PNG Blob on the next `endFrame` call.
      * Any previously pending capture is rejected before the new one is registered.
@@ -457,10 +419,6 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
             this.pending = { resolve, reject };
         });
     }
-
-    // #endregion
-
-    // #region Camera
 
     /**
      * Sets the camera scroll offset applied to all subsequent draw commands.
@@ -485,10 +443,6 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
         this.cameraOffset = Vector2i.zero();
     }
 
-    // #endregion
-
-    // #region Effects
-
     /**
      * Not supported - always throws.
      *
@@ -511,10 +465,6 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
     clearEffects(): void {
         throw new Error(SoftwareRenderer.EFFECTS_UNSUPPORTED_MESSAGE);
     }
-
-    // #endregion
-
-    // #region Private Helpers
 
     /**
      * Creates an `OffscreenCanvas` when available, falling back to an off-DOM `<canvas>`.
@@ -928,10 +878,6 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
         }, 'image/png');
     }
 
-    // #endregion
-
-    // #region Diagnostic estimation
-
     /**
      * Estimates primitive vertices for a line using the same rules as {@link PrimitivePipeline.drawLine}.
      *
@@ -1030,6 +976,4 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
 
         return steps;
     }
-
-    // #endregion
 }

--- a/src/render/SpritePipeline.test.ts
+++ b/src/render/SpritePipeline.test.ts
@@ -27,8 +27,6 @@ import { Rect2i } from '../utils/Rect2i';
 import { Vector2i } from '../utils/Vector2i';
 import { SpritePipeline } from './SpritePipeline';
 
-// #region Constructor
-
 describe('SpritePipeline constructor', () => {
     it('creates an instance without error', () => {
         const pipeline = new SpritePipeline();
@@ -37,10 +35,6 @@ describe('SpritePipeline constructor', () => {
         expect(pipeline).toBeInstanceOf(SpritePipeline);
     });
 });
-
-// #endregion
-
-// #region Pre-initialization Safety
 
 describe('pre-initialization safety', () => {
     it('reset() can be called multiple times safely', () => {
@@ -69,10 +63,6 @@ describe('pre-initialization safety', () => {
         }).not.toThrow();
     });
 });
-
-// #endregion
-
-// #region Initialized Pipeline
 
 describe('with initialized pipeline', () => {
     const device = createMockGPUDevice();
@@ -136,10 +126,6 @@ describe('with initialized pipeline', () => {
         pipeline.setCameraOffset(Vector2i.zero());
     });
 });
-
-// #endregion
-
-// #region Sprite Drawing
 
 describe('drawSprite', () => {
     const device = createMockGPUDevice();
@@ -398,10 +384,6 @@ describe('drawSprite', () => {
     });
 });
 
-// #endregion
-
-// #region drawBitmapText
-
 describe('drawBitmapText', () => {
     const device = createMockGPUDevice();
     const pipeline = new SpritePipeline();
@@ -535,5 +517,3 @@ describe('drawBitmapText', () => {
         }).not.toThrow();
     });
 });
-
-// #endregion

--- a/src/render/SpritePipeline.ts
+++ b/src/render/SpritePipeline.ts
@@ -3,8 +3,6 @@ import type { SpriteSheet } from '../assets/SpriteSheet';
 import type { Rect2i } from '../utils/Rect2i';
 import { Vector2i } from '../utils/Vector2i';
 
-// #region Configuration
-
 /**
  * Maximum number of sprite vertices retained for a frame.
  */
@@ -20,8 +18,6 @@ const VALUES_PER_VERTEX = 5;
  */
 const VERTEX_STRIDE = 20;
 
-// #endregion
-
 /**
  * Batched WebGPU pipeline for indexed-palette sprite rendering.
  *
@@ -35,8 +31,6 @@ const VERTEX_STRIDE = 20;
  * draw call per texture batch in `encodePass()`.
  */
 export class SpritePipeline {
-    // #region State
-
     /** WebGPU device, set during init(). */
     private device: GPUDevice | null = null;
 
@@ -70,10 +64,6 @@ export class SpritePipeline {
     /** Camera offset applied to all drawing operations. */
     private cameraOffset: Vector2i = Vector2i.zero();
 
-    // #endregion
-
-    // #region Batching State
-
     /** Currently bound texture for sprite rendering. */
     private currentTexture: GPUTexture | null = null;
 
@@ -92,19 +82,11 @@ export class SpritePipeline {
     /** Overflow events recorded this frame (dropped quads). */
     private overflowCount: number = 0;
 
-    // #endregion
-
-    // #region Reusable Objects
-
     /** Pre-allocated vector for character positions in drawBitmapText. */
     private readonly tempVec: Vector2i = new Vector2i(0, 0);
 
     /** Pre-allocated vector for sprite size in drawSprite. */
     private readonly tempSize: Vector2i = new Vector2i(0, 0);
-
-    // #endregion
-
-    // #region Constructor
 
     /**
      * Creates an empty sprite pipeline.
@@ -115,10 +97,6 @@ export class SpritePipeline {
         this.vertexFloats = new Float32Array(this.vertexArrayBuffer);
         this.vertexUints = new Uint32Array(this.vertexArrayBuffer);
     }
-
-    // #endregion
-
-    // #region Initialization
 
     /**
      * Initializes the GPU pipeline state and vertex buffer.
@@ -140,10 +118,6 @@ export class SpritePipeline {
         await this.createPipeline(displaySize, targetFormat);
     }
 
-    // #endregion
-
-    // #region Camera
-
     /**
      * Sets the camera offset applied to all drawing operations.
      *
@@ -152,10 +126,6 @@ export class SpritePipeline {
     setCameraOffset(offset: Vector2i): void {
         this.cameraOffset = offset;
     }
-
-    // #endregion
-
-    // #region Drawing
 
     /**
      * Draws a sprite region from an indexed sprite sheet.
@@ -238,10 +208,6 @@ export class SpritePipeline {
             renderPass.draw(batch.vertexCount, 1, batch.vertexStart, 0);
         }
     }
-
-    // #endregion
-
-    // #region Frame Rendering
 
     /**
      * Clears all per-frame batching state.
@@ -401,10 +367,6 @@ export class SpritePipeline {
         });
     }
 
-    // #endregion
-
-    // #region Private Helpers
-
     /**
      * Draws a textured quad (two triangles) to the screen.
      * Handles texture switching and keeps quad emission atomic so partial quads
@@ -553,6 +515,4 @@ export class SpritePipeline {
 
         return bindGroup;
     }
-
-    // #endregion
 }

--- a/src/render/UpscalePass.test.ts
+++ b/src/render/UpscalePass.test.ts
@@ -11,8 +11,6 @@ import { createMockGPUDevice, installMockNavigatorGPU, uninstallMockNavigatorGPU
 import { Vector2i } from '../utils/Vector2i';
 import { UpscalePass } from './UpscalePass';
 
-// #region Test Helpers
-
 const FORMAT: GPUTextureFormat = 'bgra8unorm';
 
 beforeAll(() => {
@@ -22,10 +20,6 @@ beforeAll(() => {
 afterAll(() => {
     uninstallMockNavigatorGPU();
 });
-
-// #endregion
-
-// #region init()
 
 describe('UpscalePass.init', () => {
     it('creates a render pipeline and a sampler', () => {
@@ -71,10 +65,6 @@ describe('UpscalePass.init', () => {
         expect(desc?.addressModeV).toBe('clamp-to-edge');
     });
 });
-
-// #endregion
-
-// #region encode()
 
 describe('UpscalePass.encode', () => {
     it('throws when called before init', () => {
@@ -143,10 +133,6 @@ describe('UpscalePass.encode', () => {
     });
 });
 
-// #endregion
-
-// #region createOutputTexture()
-
 describe('UpscalePass.createOutputTexture', () => {
     it('creates a texture with the requested size and format', () => {
         const device = createMockGPUDevice();
@@ -175,10 +161,6 @@ describe('UpscalePass.createOutputTexture', () => {
     });
 });
 
-// #endregion
-
-// #region dispose()
-
 describe('UpscalePass.dispose', () => {
     it('clears references and is safe to call without init', () => {
         const pass = new UpscalePass();
@@ -200,5 +182,3 @@ describe('UpscalePass.dispose', () => {
         ).toThrow(/not initialized/);
     });
 });
-
-// #endregion

--- a/src/render/UpscalePass.ts
+++ b/src/render/UpscalePass.ts
@@ -1,8 +1,6 @@
 import type { Vector2i } from '../utils/Vector2i';
 import { VS_WGSL } from './effects/fullscreenVS';
 
-// #region Configuration
-
 /**
  * Texture usage flags for the upscale pass output.
  *
@@ -11,8 +9,6 @@ import { VS_WGSL } from './effects/fullscreenVS';
  * texture-binding usages.
  */
 const OUTPUT_USAGE = GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING;
-
-// #endregion
 
 /**
  * Upscale filter applied between the pixel chain (logical resolution) and the
@@ -37,8 +33,6 @@ export type UpscaleFilter = 'nearest' | 'linear';
  * supplies views every frame.
  */
 export class UpscalePass {
-    // #region GPU State
-
     private device: GPUDevice | null = null;
     private pipeline: GPURenderPipeline | null = null;
     private bindGroupLayout: GPUBindGroupLayout | null = null;
@@ -52,10 +46,6 @@ export class UpscalePass {
      * lifetime of the pixel chain, so a `WeakMap` is safe.
      */
     private readonly bindGroups = new WeakMap<GPUTextureView, GPUBindGroup>();
-
-    // #endregion
-
-    // #region Lifecycle
 
     /**
      * Returns the filter mode this pass was initialized with.
@@ -151,10 +141,6 @@ export class UpscalePass {
         this.device = null;
     }
 
-    // #endregion
-
-    // #region Helpers - texture allocation
-
     /**
      * Allocates a texture for the upscale pass output at the supplied size and
      * format.
@@ -182,10 +168,6 @@ export class UpscalePass {
             usage: OUTPUT_USAGE,
         });
     }
-
-    // #endregion
-
-    // #region Private Helpers
 
     /**
      * Returns the bind group for the supplied source view, creating one on
@@ -218,11 +200,7 @@ export class UpscalePass {
 
         return bindGroup;
     }
-
-    // #endregion
 }
-
-// #region WGSL fragment shader
 
 const FRAGMENT_WGSL = `
 @group(0) @binding(0) var src: texture_2d<f32>;
@@ -233,5 +211,3 @@ fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
     return textureSample(src, samp, in.uv);
 }
 `;
-
-// #endregion

--- a/src/render/WebGpuRenderer.test.ts
+++ b/src/render/WebGpuRenderer.test.ts
@@ -33,8 +33,6 @@ import type { PrimitivePipeline } from './PrimitivePipeline';
 import type { SpritePipeline } from './SpritePipeline';
 import { WebGpuRenderer } from './WebGpuRenderer';
 
-// #region Test Helpers
-
 /** Internal pipeline batches on {@link WebGpuRenderer} (compile-time private, runtime-accessible). */
 type WebGpuRendererPipelineAccess = {
     primitives: PrimitivePipeline;
@@ -71,10 +69,6 @@ function createTestPalette(): Palette {
     return palette;
 }
 
-// #endregion
-
-// #region Constructor
-
 describe('WebGpuRenderer constructor', () => {
     it('creates an instance with mock objects', () => {
         const device = createMockGPUDevice();
@@ -86,10 +80,6 @@ describe('WebGpuRenderer constructor', () => {
         expect(renderer).toBeInstanceOf(WebGpuRenderer);
     });
 });
-
-// #endregion
-
-// #region Pre-initialization Methods
 
 describe('pre-initialization methods', () => {
     it('setClearColor does not throw', () => {
@@ -171,10 +161,6 @@ describe('pre-initialization methods', () => {
     });
 });
 
-// #endregion
-
-// #region Camera API
-
 describe('camera operations', () => {
     it('getCameraOffset returns a copy, not the internal reference', () => {
         const renderer = new WebGpuRenderer(
@@ -234,10 +220,6 @@ describe('camera operations', () => {
     });
 });
 
-// #endregion
-
-// #region Palette Enforcement
-
 describe('palette enforcement', () => {
     it('setPalette stores and returns palette', () => {
         const renderer = new WebGpuRenderer(
@@ -268,10 +250,6 @@ describe('palette enforcement', () => {
         expect(renderer.getPalette()).toBeNull();
     });
 });
-
-// #endregion
-
-// #region Initialized Renderer
 
 describe('with initialized renderer', () => {
     const device = createMockGPUDevice();
@@ -584,10 +562,6 @@ describe('with initialized renderer', () => {
     });
 });
 
-// #endregion
-
-// #region resolveClearColor Fallbacks
-
 describe('resolveClearColor fallbacks', () => {
     it('returns black (no throw) when no palette is set', async () => {
         const r = new WebGpuRenderer(createMockGPUDevice(), createMockGPUCanvasContext(), new Vector2i(320, 240));
@@ -622,10 +596,6 @@ describe('resolveClearColor fallbacks', () => {
         uninstallMockNavigatorGPU();
     });
 });
-
-// #endregion
-
-// #region Frame Capture API
 
 describe('frame capture', () => {
     it('captureFrame returns a promise', async () => {
@@ -778,10 +748,6 @@ describe('frame capture', () => {
     });
 });
 
-// #endregion
-
-// #region Error Paths
-
 describe('endFrame error paths', () => {
     it('recovers gracefully when getCurrentTexture throws', async () => {
         const device = createMockGPUDevice();
@@ -889,10 +855,6 @@ describe('init error paths', () => {
         }
     });
 });
-
-// #endregion
-
-// #region Palette dirty-flag auto-propagation
 
 describe('palette dirty-flag auto-propagation', () => {
     it('setPalette stores a reference, not a clone', () => {
@@ -1019,10 +981,6 @@ describe('palette dirty-flag auto-propagation', () => {
         uninstallMockNavigatorGPU();
     });
 });
-
-// #endregion
-
-// #region Post-Process Effects API
 
 describe('post-process effects', () => {
     // Install/uninstall via beforeEach/afterEach so an assertion failure in any
@@ -1259,5 +1217,3 @@ describe('post-process effects', () => {
         expect(beginRenderPassCalls).toHaveLength(2);
     });
 });
-
-// #endregion

--- a/src/render/WebGpuRenderer.ts
+++ b/src/render/WebGpuRenderer.ts
@@ -15,8 +15,6 @@ import { PrimitivePipeline } from './PrimitivePipeline';
 import { SpritePipeline } from './SpritePipeline';
 import type { UpscaleFilter } from './UpscalePass';
 
-// #region Configuration
-
 /**
  * GPU palette uniform buffer size: 256 entries x 4 floats x 4 bytes = 4096 bytes.
  */
@@ -32,8 +30,6 @@ const SCENE_TARGET_USAGE = GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.T
 
 /** Logical scene + pixel chain format (palette index in the red channel). */
 const LOGICAL_TARGET_FORMAT: GPUTextureFormat = 'r8uint';
-
-// #endregion
 
 /**
  * WebGPU renderer implementing {@link IRenderer}.
@@ -89,10 +85,6 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
     /** Frame capture manager for PNG export. */
     private readonly frameCapture = new FrameCapture();
 
-    // #endregion
-
-    // #region Palette State
-
     /** Active palette for color lookups and GPU upload. */
     private palette: Palette | null = null;
 
@@ -108,10 +100,6 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
      * Per-frame mutations are detected separately via {@link Palette.isDirty}.
      */
     private isPaletteDirty: boolean = false;
-
-    // #endregion
-
-    // #region Pipelines
 
     /** Pipeline for palette-indexed geometry (pixels, lines, rectangles). */
     private readonly primitives: PrimitivePipeline;
@@ -164,10 +152,6 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
      */
     private lastFrameMs: number = 0;
 
-    // #endregion
-
-    // #region Constructor
-
     /**
      * Creates a renderer bound to an initialized device and canvas context.
      *
@@ -200,10 +184,6 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
         this.overlaySprites = new SpritePipeline();
         this.overlayTopSprites = new SpritePipeline();
     }
-
-    // #endregion
-
-    // #region Initialization
 
     /**
      * Initializes the underlying render pipelines and GPU resources.
@@ -277,10 +257,6 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
         }
     }
 
-    // #endregion
-
-    // #region Palette
-
     /**
      * Sets the active palette used for rendering.
      *
@@ -317,10 +293,6 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
     getPalette(): Palette | null {
         return this.palette?.clone() ?? null;
     }
-
-    // #endregion
-
-    // #region Frame Management
 
     /**
      * Begins a new frame by clearing all per-frame batching state.
@@ -418,10 +390,6 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
         };
     }
 
-    // #endregion
-
-    // #region Rendering API - Primitives
-
     /**
      * Draws a filled rectangle using two triangles.
      *
@@ -494,10 +462,6 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
         this.primitives.clearRect(rect, paletteIndex);
     }
 
-    // #endregion
-
-    // #region Rendering API - Sprites
-
     /**
      * Draws a sprite region from an indexed sprite sheet.
      *
@@ -547,10 +511,6 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
         this.overlayTopSprites.drawBitmapText(font, pos, text, paletteOffset);
     }
 
-    // #endregion
-
-    // #region Frame Capture API
-
     /**
      * Captures the next rendered frame as a PNG blob.
      * The capture happens on the next `endFrame()` call.
@@ -561,10 +521,6 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
     captureFrame(): Promise<Blob> {
         return this.frameCapture.request();
     }
-
-    // #endregion
-
-    // #region Camera API
 
     /**
      * Sets the camera offset for scrolling.
@@ -606,10 +562,6 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
         this.overlaySprites.setCameraOffset(this.cameraOffset);
         this.overlayTopSprites.setCameraOffset(this.cameraOffset);
     }
-
-    // #endregion
-
-    // #region Post-Process Effects API
 
     /**
      * Appends a fullscreen post-processing effect to the chain matching its
@@ -677,10 +629,6 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
         this.pixelChain.clear();
         this.displayChain.clear();
     }
-
-    // #endregion
-
-    // #region Private - frame encoding
 
     /**
      * Tries to acquire the swap-chain texture and validate its dimensions.
@@ -841,10 +789,6 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
         this.overlayTopSprites.reset();
     }
 
-    // #endregion
-
-    // #region Private Helpers
-
     /**
      * Picks the texture view the scene render pass should target this frame.
      *
@@ -907,10 +851,6 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
         return chain.getInputView();
     }
 
-    // #endregion
-
-    // #region Private - drawing
-
     /**
      * Fast-path pixel draw using raw integer coordinates.
      * Avoids Vector2i unpacking overhead when coordinates are already available as numbers.
@@ -942,6 +882,4 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
 
         return this.clearPaletteIndex;
     }
-
-    // #endregion
 }

--- a/src/render/effects/FullscreenEffect.ts
+++ b/src/render/effects/FullscreenEffect.ts
@@ -50,7 +50,6 @@ export abstract class FullscreenEffect implements Effect {
     protected abstract readonly fragmentShader: string;
     protected device: GPUDevice | null = null;
 
-    // #region GPU State
     protected pipeline: GPURenderPipeline | null = null;
     protected uniformBuffer: GPUBuffer | null = null;
     protected sampler: GPUSampler | null = null;
@@ -116,10 +115,6 @@ export abstract class FullscreenEffect implements Effect {
         });
     }
 
-    // #endregion
-
-    // #region Effect lifecycle
-
     /**
      * Calls {@link writeUniforms} then uploads the uniform block to the GPU.
      *
@@ -184,10 +179,6 @@ export abstract class FullscreenEffect implements Effect {
     /** Writes the per-frame uniform values into {@link uniformData}. */
     protected abstract writeUniforms(deltaMs: number, sourceSize: Vector2i): void;
 
-    // #endregion
-
-    // #region Private Helpers
-
     /**
      * Returns the bind group for the supplied source view, creating one on
      * first use and caching by view identity.
@@ -220,6 +211,4 @@ export abstract class FullscreenEffect implements Effect {
 
         return bindGroup;
     }
-
-    // #endregion
 }

--- a/src/render/effects/FullscreenPixelEffect.ts
+++ b/src/render/effects/FullscreenPixelEffect.ts
@@ -2,8 +2,6 @@ import type { Vector2i } from '../../utils/Vector2i';
 import type { Effect } from './Effect';
 import { VS_WGSL } from './fullscreenVS';
 
-// #region FullscreenPixelEffect
-
 /**
  * Base class for pixel-tier fullscreen effects supporting both RGBA (`texture_2d<f32>`)
  * and palette-native (`texture_2d<u32>` / `r8uint` attachments) chains.
@@ -199,5 +197,3 @@ export abstract class FullscreenPixelEffect implements Effect {
         return bindGroup;
     }
 }
-
-// #endregion

--- a/src/utils/AssetLimits.ts
+++ b/src/utils/AssetLimits.ts
@@ -19,8 +19,6 @@ import {
 import type { Rect2i } from './Rect2i';
 import { MAX_RENDER_DIMENSION, MAX_RENDER_PIXELS } from './RenderLimits';
 
-// #region Constants
-
 /** Maximum decoded asset width or height on either axis before CPU/GPU allocation. */
 export const MAX_ASSET_DIMENSION = MAX_RENDER_DIMENSION;
 
@@ -48,10 +46,6 @@ export const MAX_GLYPH_COUNT = 8192;
 
 /** Maximum pixels iterated for a single software sprite blit (`width * height`). */
 export const MAX_SPRITE_BLIT_PIXELS = MAX_ASSET_PIXELS;
-
-// #endregion
-
-// #region Types
 
 /** Error type for asset-dimension failures surfaced through public load APIs. */
 export class AssetLimitError extends Error {
@@ -83,10 +77,6 @@ export interface BtfontGlyphData {
     /** Horizontal advance width. */
     adv: number;
 }
-
-// #endregion
-
-// #region Helpers
 
 /**
  * Formats width and height for error messages.
@@ -155,10 +145,6 @@ function isPositiveIntegerDimension(value: number): boolean {
 function isIntegerMetric(value: number): boolean {
     return typeof value === 'number' && Number.isFinite(value) && Number.isInteger(value);
 }
-
-// #endregion
-
-// #region Validation
 
 /**
  * Validates decoded image or indexed-buffer dimensions before allocation.
@@ -523,5 +509,3 @@ export function clipSpriteSourceRect(
 
     return { x: x0, y: y0, width, height };
 }
-
-// #endregion

--- a/src/utils/Bootstrap.test.ts
+++ b/src/utils/Bootstrap.test.ts
@@ -22,8 +22,6 @@ import type { IBlitTechDemo } from '../core/IBlitTechDemo';
 import { bootstrap } from './Bootstrap';
 import { DEFAULT_CANVAS_ID, DEFAULT_CONTAINER_ID } from './BootstrapHelpers';
 
-// #region Test Demo
-
 class MockDemo implements IBlitTechDemo {
     async init() {
         return true;
@@ -33,10 +31,6 @@ class MockDemo implements IBlitTechDemo {
 
     render() {}
 }
-
-// #endregion
-
-// #region Helpers
 
 function setupDOM(): { canvas: HTMLCanvasElement; container: HTMLDivElement } {
     const container = document.createElement('div');
@@ -60,8 +54,6 @@ function teardownDOM(): void {
     }
 }
 
-// #endregion
-
 describe('bootstrap', () => {
     beforeEach(() => {
         vi.spyOn(BTAPI.instance, 'init').mockResolvedValue(true);
@@ -72,8 +64,6 @@ describe('bootstrap', () => {
         vi.restoreAllMocks();
         teardownDOM();
     });
-
-    // #region isWaitingForDOMReady
 
     describe('isWaitingForDOMReady', () => {
         it('should skip DOM waiting when isWaitingForDOMReady is false', async () => {
@@ -109,10 +99,6 @@ describe('bootstrap', () => {
         });
     });
 
-    // #endregion
-
-    // #region Backend fallback
-
     describe('backend fallback', () => {
         it('should proceed to engine init when WebGPU is not supported, letting BTAPI handle fallback', async () => {
             setupDOM();
@@ -126,10 +112,6 @@ describe('bootstrap', () => {
             expect(onError).not.toHaveBeenCalled();
         });
     });
-
-    // #endregion
-
-    // #region Canvas validation
 
     describe('canvas validation', () => {
         it('should return false and call onError when canvas is not found', async () => {
@@ -152,10 +134,6 @@ describe('bootstrap', () => {
             expect(onError).toHaveBeenCalledOnce();
         });
     });
-
-    // #endregion
-
-    // #region Engine initialization
 
     describe('engine initialization', () => {
         it('should return false and call onError when demo is missing render/update', async () => {
@@ -266,10 +244,6 @@ describe('bootstrap', () => {
         });
     });
 
-    // #endregion
-
-    // #region Unexpected errors
-
     describe('unexpected errors', () => {
         it('should return false when BTAPI.init throws synchronously', async () => {
             setupDOM();
@@ -285,6 +259,4 @@ describe('bootstrap', () => {
             expect(onError).toHaveBeenCalledOnce();
         });
     });
-
-    // #endregion
 });

--- a/src/utils/Bootstrap.ts
+++ b/src/utils/Bootstrap.ts
@@ -11,8 +11,6 @@ import type { ErrorContent } from './BootstrapHelpers';
 import { DEFAULT_CANVAS_ID, DEFAULT_CONTAINER_ID, displayError, getCanvas } from './BootstrapHelpers';
 import { CANVAS_NOT_FOUND_MESSAGE, INIT_FAILED_MESSAGE } from './errorMessages';
 
-// #region Types
-
 /**
  * Options for the bootstrap function.
  */
@@ -69,10 +67,6 @@ interface Result {
     success: boolean;
     error?: Error;
 }
-
-// #endregion
-
-// #region Helper Functions
 
 /**
  * Waits for DOM to be ready if it's still loading.
@@ -205,10 +199,6 @@ async function initDemo(
     return result;
 }
 
-// #endregion
-
-// #region Bootstrap Function
-
 /**
  * One-liner bootstrap function for Blit-Tech demos.
  * Handles canvas retrieval and engine initialization. Backend selection
@@ -302,5 +292,3 @@ export async function bootstrap(DemoClass: DemoConstructor, options: BootstrapOp
 
     return success;
 }
-
-// #endregion

--- a/src/utils/BootstrapHelpers.test.ts
+++ b/src/utils/BootstrapHelpers.test.ts
@@ -4,8 +4,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { DEFAULT_CANVAS_ID, DEFAULT_CONTAINER_ID, displayError, getCanvas } from './BootstrapHelpers';
 
-// #region Constants
-
 describe('BootstrapHelpers', () => {
     describe('Constants', () => {
         it('should have DEFAULT_CANVAS_ID equal to blit-tech-canvas', () => {
@@ -16,10 +14,6 @@ describe('BootstrapHelpers', () => {
             expect(DEFAULT_CONTAINER_ID).toBe('canvas-container');
         });
     });
-
-    // #endregion
-
-    // #region getCanvas
 
     describe('getCanvas', () => {
         it('should return null for a missing element', () => {
@@ -54,10 +48,6 @@ describe('BootstrapHelpers', () => {
             }
         });
     });
-
-    // #endregion
-
-    // #region displayError
 
     describe('displayError', () => {
         beforeEach(() => {
@@ -101,6 +91,4 @@ describe('BootstrapHelpers', () => {
             consoleSpy.mockRestore();
         });
     });
-
-    // #endregion
 });

--- a/src/utils/BootstrapHelpers.ts
+++ b/src/utils/BootstrapHelpers.ts
@@ -4,17 +4,11 @@
  * Canvas lookup and error display utilities used by the bootstrap function.
  */
 
-// #region Constants
-
 /** Default canvas element ID. */
 export const DEFAULT_CANVAS_ID = 'blit-tech-canvas';
 
 /** Default container element ID for error display. */
 export const DEFAULT_CONTAINER_ID = 'canvas-container';
-
-// #endregion
-
-// #region Types
 
 /**
  * Content that can be displayed in an error message.
@@ -26,10 +20,6 @@ export type ErrorContent =
           text: string;
           code?: string;
       };
-
-// #endregion
-
-// #region Internal Helpers
 
 /**
  * Appends text to an element, converting newline characters to `<br>` elements.
@@ -49,10 +39,6 @@ function appendTextWithLineBreaks(element: HTMLElement, text: string): void {
         }
     });
 }
-
-// #endregion
-
-// #region Exported Helpers
 
 /**
  * Displays an error message in the page UI.
@@ -173,4 +159,3 @@ export function getCanvas(canvasID: string = DEFAULT_CANVAS_ID): HTMLCanvasEleme
     return canvas;
 }
 
-// #endregion

--- a/src/utils/CanvasLayoutStyles.ts
+++ b/src/utils/CanvasLayoutStyles.ts
@@ -1,14 +1,8 @@
 import { DEFAULT_CONTAINER_ID } from './BootstrapHelpers';
 import type { Vector2i } from './Vector2i';
 
-// #region Constants
-
 /** Default cap for on-screen canvas CSS size (demos layout uses these as max bounds). */
 export const DEFAULT_MAX_CANVAS_SIZE = { x: 960, y: 720 } as const;
-
-// #endregion
-
-// #region Types
 
 /** Inputs for {@link applyCanvasLayoutStyles}. */
 export interface CanvasLayoutStyleOptions {
@@ -19,10 +13,6 @@ export interface CanvasLayoutStyleOptions {
     /** Maximum on-screen canvas size in CSS pixels (letterboxing still applies below this). */
     maxCanvasSize: Vector2i;
 }
-
-// #endregion
-
-// #region Exported Helpers
 
 /**
  * Resolves the layout root element for CSS custom property injection.
@@ -67,5 +57,3 @@ export function applyCanvasLayoutStyles(canvas: HTMLCanvasElement, options: Canv
     canvas.style.width = '';
     canvas.style.height = '';
 }
-
-// #endregion

--- a/src/utils/Color32.bench.ts
+++ b/src/utils/Color32.bench.ts
@@ -1,12 +1,6 @@
-// #region Imports
-
 import { bench, describe } from 'vitest';
 
 import { clampByte, Color32 } from './Color32';
-
-// #endregion
-
-// #region Constants
 
 const BASE_R = 64;
 const BASE_G = 128;
@@ -23,10 +17,6 @@ const BENCH_OPTIONS = {
     warmupIterations: 50,
 };
 
-// #endregion
-
-// #region Helper Functions
-
 /**
  * Restores a mutable color to a known baseline before in-place benchmarks.
  *
@@ -42,10 +32,6 @@ function resetColor(color: Color32, r: number, g: number, b: number, a: number):
     color.b = b;
     color.a = a;
 }
-
-// #endregion
-
-// #region Benchmark Suites
 
 describe('Color32 creation benchmarks', () => {
     bench(
@@ -284,5 +270,3 @@ describe('Color32 mutation benchmarks', () => {
         BENCH_OPTIONS,
     );
 });
-
-// #endregion

--- a/src/utils/Color32.test.ts
+++ b/src/utils/Color32.test.ts
@@ -10,8 +10,6 @@ import { describe, expect, it } from 'vitest';
 
 import { clampByte, Color32, INV_255 } from './Color32';
 
-// #region clampByte
-
 describe('clampByte', () => {
     it('passes through values in valid range', () => {
         expect(clampByte(0)).toBe(0);
@@ -35,10 +33,6 @@ describe('clampByte', () => {
         expect(clampByte(254.999)).toBe(254);
     });
 });
-
-// #endregion
-
-// #region Constructor
 
 describe('Color32 constructor', () => {
     it('defaults to white (255, 255, 255, 255)', () => {
@@ -68,10 +62,6 @@ describe('Color32 constructor', () => {
         expect(c.a).toBe(128);
     });
 });
-
-// #endregion
-
-// #region Static Color Getters
 
 describe('static color getters', () => {
     it('white returns (255, 255, 255, 255)', () => {
@@ -336,10 +326,6 @@ describe('named color registry', () => {
     });
 });
 
-// #endregion
-
-// #region Static Factory Methods
-
 describe('fromRGBAUnchecked', () => {
     it('creates color without clamping', () => {
         const c = Color32.fromRGBAUnchecked(100, 150, 200, 250);
@@ -521,10 +507,6 @@ describe('fromHSL', () => {
     });
 });
 
-// #endregion
-
-// #region Conversion Methods
-
 describe('toFloat32Array', () => {
     it('returns 4-element Float32Array with values in [0, 1]', () => {
         const c = new Color32(255, 0, 128, 255);
@@ -672,10 +654,6 @@ describe('toString', () => {
     });
 });
 
-// #endregion
-
-// #region Comparison
-
 describe('isEqual', () => {
     it('returns true for identical colors', () => {
         const a = new Color32(10, 20, 30, 40);
@@ -698,10 +676,6 @@ describe('isEqual', () => {
         expect(a.isEqual(undefined as unknown as Color32)).toBe(false);
     });
 });
-
-// #endregion
-
-// #region Modification
 
 describe('clone', () => {
     it('creates an independent copy', () => {
@@ -792,10 +766,6 @@ describe('invert', () => {
         expect(doubleInv.a).toBe(180);
     });
 });
-
-// #endregion
-
-// #region Blending
 
 describe('lerp', () => {
     it('returns this color at t=0', () => {
@@ -1028,10 +998,6 @@ describe('premultiplyAlpha', () => {
     });
 });
 
-// #endregion
-
-// #region Mutation
-
 describe('setRGBA', () => {
     it('sets all channels with clamping and returns this', () => {
         const c = new Color32(0, 0, 0, 0);
@@ -1103,10 +1069,6 @@ describe('copyFrom', () => {
     });
 });
 
-// #endregion
-
-// #region Utility
-
 describe('luminance', () => {
     it('returns 255 for white', () => {
         const c = new Color32(255, 255, 255, 255);
@@ -1143,5 +1105,3 @@ describe('INV_255 constant', () => {
         expect(INV_255).toBeCloseTo(1 / 255, 10);
     });
 });
-
-// #endregion

--- a/src/utils/Color32.ts
+++ b/src/utils/Color32.ts
@@ -5,8 +5,6 @@
  * and a mix of allocation-free and convenience APIs for renderer code.
  */
 
-// #region Constants
-
 /** Reciprocal of 255 used for fast byte-to-float normalization. */
 export const INV_255 = 1 / 255;
 
@@ -21,14 +19,8 @@ for (let i = 0; i < 256; i++) {
     HEX_TABLE[i] = i.toString(16).padStart(2, '0');
 }
 
-// #endregion
-
-// #region Color32 Class
-
 /** Mutable 32-bit RGBA color value with 8-bit channels. */
 export class Color32 {
-    // #region Static Color Constants
-
     /** The cached singleton for white color. */
     private static readonly _white: Color32 = Object.freeze(Color32.fromRGBAUnchecked(255, 255, 255, 255));
 
@@ -59,10 +51,6 @@ export class Color32 {
     /** Internal named-color registry used by string color resolution. */
     private static readonly namedColors: Map<string, Color32> = Color32.createNamedMap();
 
-    // #endregion
-
-    // #region Instance Properties
-
     /** Red channel (0-255). */
     public r: number;
 
@@ -74,10 +62,6 @@ export class Color32 {
 
     /** Alpha channel (0-255). */
     public a: number;
-
-    // #endregion
-
-    // #region Constructor
 
     /**
      * Creates a clamped 8-bit RGBA color.
@@ -94,10 +78,6 @@ export class Color32 {
         this.b = clampByte(b);
         this.a = clampByte(a);
     }
-
-    // #endregion
-
-    // #region Static Color Getters
 
     /**
      * Pure white color (255, 255, 255, 255).
@@ -288,10 +268,6 @@ export class Color32 {
         return Color32.namedColors.get(normalizedName);
     }
 
-    // #endregion
-
-    // #region Static Factory Methods
-
     /**
      * Creates a color without clamping or validation.
      *
@@ -450,10 +426,6 @@ export class Color32 {
         return new Color32(Math.floor(r * 255), Math.floor(g * 255), Math.floor(b * 255), a);
     }
 
-    // #endregion
-
-    // #region Conversion Methods
-
     /**
      * Converts color to Float32Array for WebGPU uniform buffers.
      * Values are normalized to the 0.0-1.0 range.
@@ -545,10 +517,6 @@ export class Color32 {
         return `Color32(${this.r}, ${this.g}, ${this.b}, ${this.a})`;
     }
 
-    // #endregion
-
-    // #region Comparison Methods
-
     /**
      * Checks if this color equals another (all channels match).
      *
@@ -578,10 +546,6 @@ export class Color32 {
     equals(other: Color32): boolean {
         return this.isEqual(other);
     }
-
-    // #endregion
-
-    // #region Modification Methods
 
     /**
      * Creates an independent copy of this color.
@@ -624,10 +588,6 @@ export class Color32 {
     invert(): Color32 {
         return Color32.fromRGBAUnchecked(255 - this.r, 255 - this.g, 255 - this.b, this.a);
     }
-
-    // #endregion
-
-    // #region Blending Methods
 
     /**
      * Linearly interpolates between this color and another.
@@ -748,10 +708,6 @@ export class Color32 {
         );
     }
 
-    // #endregion
-
-    // #region Mutation Methods
-
     /**
      * Sets all RGBA channels at once, with validation.
      * Use this to reuse a Color32 instance instead of creating a new one.
@@ -807,10 +763,6 @@ export class Color32 {
 
         return this;
     }
-
-    // #endregion
-
-    // #region Utility Methods
 
     /**
      * Perceived (Rec. 601) luminance of this color, ignoring alpha.
@@ -902,15 +854,7 @@ export class Color32 {
     private static freezeSingleton(color: Color32): Color32 {
         return Object.freeze(Color32.fromRGBAUnchecked(color.r, color.g, color.b, color.a));
     }
-
-    // #endregion
-
-    // #endregion
 }
-
-// #endregion
-
-// #region Helper Functions
 
 /**
  * Clamps a number to the 0-255 byte range and truncates to integer.
@@ -964,5 +908,3 @@ function parseHexToken(hex: string, start: number, length: number): number {
 
     return parseInt(token, 16);
 }
-
-// #endregion

--- a/src/utils/Easing.ts
+++ b/src/utils/Easing.ts
@@ -5,14 +5,8 @@
  * Used by palette fade effects to control interpolation curves.
  */
 
-// #region Types
-
 /** Supported easing function identifiers. */
 export type EasingFunction = 'linear' | 'ease-in' | 'ease-out' | 'ease-in-out';
-
-// #endregion
-
-// #region Public API
 
 /**
  * Applies an easing curve to a normalized time value.
@@ -37,5 +31,3 @@ export function applyEasing(t: number, easing: EasingFunction): number {
         }
     }
 }
-
-// #endregion

--- a/src/utils/FrameCapture.test.ts
+++ b/src/utils/FrameCapture.test.ts
@@ -11,8 +11,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createMockGPUDevice, createMockGPUTexture } from '../__test__/webgpu-mock';
 import { alignedBytesPerRow, FrameCapture, swizzleBGRAtoRGBA } from './FrameCapture';
 
-// #region Browser API Mocks
-
 /**
  * Installs browser-only globals (ImageData, OffscreenCanvas) that don't exist in Node.js.
  * Call in beforeEach for tests that exercise the full capture-to-PNG flow.
@@ -49,10 +47,6 @@ function installBrowserMocks(): void {
     );
 }
 
-// #endregion
-
-// #region alignedBytesPerRow
-
 describe('alignedBytesPerRow', () => {
     it('should return 256 for widths up to 64 pixels', () => {
         // 64 * 4 = 256, which is already aligned.
@@ -79,10 +73,6 @@ describe('alignedBytesPerRow', () => {
         expect(alignedBytesPerRow(256)).toBe(1024);
     });
 });
-
-// #endregion
-
-// #region swizzleBGRAtoRGBA
 
 describe('swizzleBGRAtoRGBA', () => {
     it('should swap B and R channels', () => {
@@ -130,10 +120,6 @@ describe('swizzleBGRAtoRGBA', () => {
         expect(data.length).toBe(0);
     });
 });
-
-// #endregion
-
-// #region FrameCapture
 
 describe('FrameCapture', () => {
     beforeEach(() => {
@@ -335,5 +321,3 @@ describe('FrameCapture', () => {
         await expect(capture.resolve(device)).resolves.toBeUndefined();
     });
 });
-
-// #endregion

--- a/src/utils/FrameCapture.ts
+++ b/src/utils/FrameCapture.ts
@@ -5,27 +5,17 @@
  * browser-side PNG encoding.
  */
 
-// #region Constants
-
 /** WebGPU row alignment requirement (bytes per row must be a multiple of 256). */
 const BYTES_PER_ROW_ALIGNMENT = 256;
 
 /** Bytes per pixel for RGBA/BGRA pixel data. */
 const BYTES_PER_PIXEL = 4;
 
-// #endregion
-
-// #region Pending Capture State
-
 /** Promise resolve callback for a pending frame capture. */
 type Resolve = (blob: Blob) => void;
 
 /** Promise reject callback for a pending frame capture. */
 type Reject = (reason: Error) => void;
-
-// #endregion
-
-// #region Helper Functions
 
 /**
  * Calculates the WebGPU-aligned byte size per row for a given image width.
@@ -101,10 +91,6 @@ export async function pixelBufferToPNG(
 
     return await offscreen.convertToBlob({ type: 'image/png' });
 }
-
-// #endregion
-
-// #region FrameCapture Class
 
 /**
  * Manages single-frame capture from the WebGPU rendering pipeline.
@@ -238,5 +224,3 @@ export class FrameCapture {
         }
     }
 }
-
-// #endregion

--- a/src/utils/Rect2i.bench.ts
+++ b/src/utils/Rect2i.bench.ts
@@ -1,13 +1,7 @@
-// #region Imports
-
 import { bench, describe } from 'vitest';
 
 import { Rect2i } from './Rect2i';
 import { Vector2i } from './Vector2i';
-
-// #endregion
-
-// #region Constants
 
 const BASE_X = 10;
 const BASE_Y = 20;
@@ -20,10 +14,6 @@ const BENCH_OPTIONS = {
     warmupTime: 25,
     warmupIterations: 50,
 };
-
-// #endregion
-
-// #region Benchmark Suites
 
 describe('Rect2i creation benchmarks', () => {
     const source = Rect2i.fromValuesUnchecked(BASE_X, BASE_Y, BASE_WIDTH, BASE_HEIGHT);
@@ -108,5 +98,3 @@ describe('Rect2i property access benchmarks', () => {
         BENCH_OPTIONS,
     );
 });
-
-// #endregion

--- a/src/utils/Rect2i.test.ts
+++ b/src/utils/Rect2i.test.ts
@@ -11,8 +11,6 @@ import { describe, expect, it } from 'vitest';
 import { Rect2i } from './Rect2i';
 import { Vector2i } from './Vector2i';
 
-// #region Constructor
-
 describe('Rect2i', () => {
     describe('constructor', () => {
         it('should default to (0, 0, 0, 0)', () => {
@@ -51,10 +49,6 @@ describe('Rect2i', () => {
             expect(r.height).toBe(-4);
         });
     });
-
-    // #endregion
-
-    // #region Raw Value Getters
 
     describe('right', () => {
         it('should return x + width', () => {
@@ -123,10 +117,6 @@ describe('Rect2i', () => {
             expect(r.centerY).toBe(20);
         });
     });
-
-    // #endregion
-
-    // #region Computed Properties
 
     describe('min', () => {
         it('should return Vector2i(x, y)', () => {
@@ -268,10 +258,6 @@ describe('Rect2i', () => {
         });
     });
 
-    // #endregion
-
-    // #region Zero-Allocation Output Methods
-
     describe('minTo', () => {
         it('should write min to the output vector', () => {
             const r = new Rect2i(5, 10, 100, 200);
@@ -377,10 +363,6 @@ describe('Rect2i', () => {
             expect(r.sizeTo(out)).toBe(out);
         });
     });
-
-    // #endregion
-
-    // #region Intersection Tests
 
     describe('isContaining', () => {
         it('should return true for a point inside', () => {
@@ -570,10 +552,6 @@ describe('Rect2i', () => {
         });
     });
 
-    // #endregion
-
-    // #region Utility
-
     describe('isEqual', () => {
         it('should return true for identical rects', () => {
             const a = new Rect2i(10, 20, 30, 40);
@@ -652,10 +630,6 @@ describe('Rect2i', () => {
             expect(r.toString()).toBe('Rect2i(0, 0, 0, 0)');
         });
     });
-
-    // #endregion
-
-    // #region In-Place Mutation Methods
 
     describe('set', () => {
         it('should set all components', () => {
@@ -873,10 +847,6 @@ describe('Rect2i', () => {
         });
     });
 
-    // #endregion
-
-    // #region Static Constructors
-
     describe('zero', () => {
         it('should return a rect at (0, 0, 0, 0)', () => {
             const r = Rect2i.zero();
@@ -1032,6 +1002,4 @@ describe('Rect2i', () => {
             expect(r.bottom).toBe(60);
         });
     });
-
-    // #endregion
 });

--- a/src/utils/Rect2i.ts
+++ b/src/utils/Rect2i.ts
@@ -9,14 +9,8 @@ import { Vector2i } from './Vector2i';
  * hot-path efficiency.
  */
 export class Rect2i {
-    // #region Cached Static Rectangles
-
     /** The cached singleton for zero rectangle. */
     private static readonly _zero: Rect2i = Object.freeze(Rect2i.fromValuesUnchecked(0, 0, 0, 0));
-
-    // #endregion
-
-    // #region Constructor
 
     /**
      * Creates an integer rectangle, truncating all inputs toward zero.
@@ -45,10 +39,6 @@ export class Rect2i {
         this.width = width | 0;
         this.height = height | 0;
     }
-
-    // #endregion
-
-    // #region Raw Value Getters (Zero Allocation)
 
     /**
      * Gets the exclusive right edge (`x + width`).
@@ -81,10 +71,6 @@ export class Rect2i {
     get centerY(): number {
         return (this.y + this.height / 2) | 0;
     }
-
-    // #endregion
-
-    // #region Computed Properties
 
     /**
      * Gets the top-left corner as a new vector.
@@ -145,10 +131,6 @@ export class Rect2i {
         this.width = value.x | 0;
         this.height = value.y | 0;
     }
-
-    // #endregion
-
-    // #region Static Factory Methods
 
     /**
      * Returns a zero-sized rectangle at origin.
@@ -255,10 +237,6 @@ export class Rect2i {
         return r;
     }
 
-    // #endregion
-
-    // #region Zero-Allocation Output Methods
-
     /**
      * Writes the top-left corner (min) to an existing vector.
      * Zero allocation alternative to the min getter.
@@ -328,10 +306,6 @@ export class Rect2i {
 
         return out;
     }
-
-    // #endregion
-
-    // #region Intersection Tests
 
     /**
      * Tests if a point lies within this rectangle.
@@ -514,10 +488,6 @@ export class Rect2i {
         return out;
     }
 
-    // #endregion
-
-    // #region Utility Methods
-
     /**
      * Checks if this rectangle equals another (all components match).
      *
@@ -573,10 +543,6 @@ export class Rect2i {
     toString(): string {
         return `Rect2i(${this.x}, ${this.y}, ${this.width}, ${this.height})`;
     }
-
-    // #endregion
-
-    // #region In-Place Mutation Methods
 
     /**
      * Sets all components of this rectangle.
@@ -709,6 +675,4 @@ export class Rect2i {
 
         return this;
     }
-
-    // #endregion
 }

--- a/src/utils/RenderLimits.test.ts
+++ b/src/utils/RenderLimits.test.ts
@@ -12,8 +12,6 @@ import {
 } from './RenderLimits';
 import { Vector2i } from './Vector2i';
 
-// #region Helpers
-
 function rawSize(x: number, y: number): Vector2i {
     return { x, y } as Vector2i;
 }
@@ -40,8 +38,6 @@ function makeSettings(field: RenderDimensionField, size: Vector2i): RenderDimens
             };
     }
 }
-
-// #endregion
 
 describe('RenderLimits', () => {
     describe('validateDimensions', () => {

--- a/src/utils/RenderLimits.ts
+++ b/src/utils/RenderLimits.ts
@@ -6,8 +6,6 @@ import {
 } from './errorMessages';
 import type { Vector2i } from './Vector2i';
 
-// #region Constants
-
 /** Maximum render dimension accepted on either axis before renderer allocation. */
 export const MAX_RENDER_DIMENSION = 8192;
 
@@ -20,10 +18,6 @@ export const RENDER_DIMENSION_LIMITS = {
     maxHeight: MAX_RENDER_DIMENSION,
     maxPixels: MAX_RENDER_PIXELS,
 } as const;
-
-// #endregion
-
-// #region Types
 
 /** Hardware settings fields that carry render or canvas dimensions. */
 export type RenderDimensionField = 'displaySize' | 'drawingBufferSize' | 'maxCanvasSize';
@@ -50,10 +44,6 @@ export interface RenderDimensionSettings {
     /** Optional maximum on-screen canvas CSS size in pixels. */
     maxCanvasSize?: Vector2i;
 }
-
-// #endregion
-
-// #region Helpers
 
 /**
  * Formats a render dimension for error messages.
@@ -170,5 +160,3 @@ export function validateWebGPUTextureDimension(
 
     return null;
 }
-
-// #endregion

--- a/src/utils/Vector2i.bench.ts
+++ b/src/utils/Vector2i.bench.ts
@@ -1,12 +1,6 @@
-// #region Imports
-
 import { bench, describe } from 'vitest';
 
 import { Vector2i } from './Vector2i';
-
-// #endregion
-
-// #region Constants
 
 const BASE_X = 17;
 const BASE_Y = 23;
@@ -24,10 +18,6 @@ const BENCH_OPTIONS = {
     warmupIterations: 50,
 };
 
-// #endregion
-
-// #region Helper Functions
-
 /**
  * Restores a mutable vector to a known baseline before in-place benchmarks.
  *
@@ -39,10 +29,6 @@ function resetVector(vector: Vector2i, x: number, y: number): void {
     vector.x = x;
     vector.y = y;
 }
-
-// #endregion
-
-// #region Benchmark Suites
 
 describe('Vector2i creation and copy benchmarks', () => {
     const source = Vector2i.fromXYUnchecked(BASE_X, BASE_Y);
@@ -312,5 +298,3 @@ describe('Vector2i comparison benchmarks', () => {
         BENCH_OPTIONS,
     );
 });
-
-// #endregion

--- a/src/utils/Vector2i.test.ts
+++ b/src/utils/Vector2i.test.ts
@@ -10,8 +10,6 @@ import { describe, expect, it } from 'vitest';
 
 import { Vector2i } from './Vector2i';
 
-// #region Constructor
-
 describe('Vector2i', () => {
     describe('Constructor', () => {
         it('should default to (0, 0)', () => {
@@ -57,10 +55,6 @@ describe('Vector2i', () => {
         });
     });
 
-    // #endregion
-
-    // #region Property Aliases
-
     describe('Property Aliases', () => {
         it('should return x as width', () => {
             const v = new Vector2i(42, 99);
@@ -104,10 +98,6 @@ describe('Vector2i', () => {
             expect(v.y).toBe(200);
         });
     });
-
-    // #endregion
-
-    // #region Static Singletons
 
     describe('Static Singletons', () => {
         it('should return (0, 0) for zero()', () => {
@@ -183,10 +173,6 @@ describe('Vector2i', () => {
             expect(Object.isFrozen(Vector2i.right())).toBe(true);
         });
     });
-
-    // #endregion
-
-    // #region Arithmetic
 
     describe('Arithmetic', () => {
         describe('add', () => {
@@ -667,10 +653,6 @@ describe('Vector2i', () => {
         });
     });
 
-    // #endregion
-
-    // #region Zero-Allocation Output ("To" methods)
-
     describe('Zero-Allocation Output ("To" methods)', () => {
         describe('addTo', () => {
             it('should write the sum to the output vector', () => {
@@ -911,10 +893,6 @@ describe('Vector2i', () => {
             });
         });
     });
-
-    // #endregion
-
-    // #region In-Place Mutations
 
     describe('In-Place Mutations', () => {
         describe('addInPlace', () => {
@@ -1274,10 +1252,6 @@ describe('Vector2i', () => {
         });
     });
 
-    // #endregion
-
-    // #region Distance
-
     describe('Distance', () => {
         describe('magnitude', () => {
             it('should return 5 for (3, 4)', () => {
@@ -1489,10 +1463,6 @@ describe('Vector2i', () => {
         });
     });
 
-    // #endregion
-
-    // #region Normalization
-
     describe('Normalization', () => {
         describe('normalized', () => {
             it('should return zero vector for zero input', () => {
@@ -1536,10 +1506,6 @@ describe('Vector2i', () => {
             });
         });
     });
-
-    // #endregion
-
-    // #region Comparison
 
     describe('Comparison', () => {
         describe('isEqual', () => {
@@ -1625,10 +1591,6 @@ describe('Vector2i', () => {
         });
     });
 
-    // #endregion
-
-    // #region Utility
-
     describe('Utility', () => {
         describe('clone', () => {
             it('should create an independent copy', () => {
@@ -1676,10 +1638,6 @@ describe('Vector2i', () => {
             });
         });
     });
-
-    // #endregion
-
-    // #region Static Factories
 
     describe('Static Factories', () => {
         describe('fromXYUnchecked', () => {
@@ -1894,6 +1852,4 @@ describe('Vector2i', () => {
             });
         });
     });
-
-    // #endregion
 });

--- a/src/utils/Vector2i.ts
+++ b/src/utils/Vector2i.ts
@@ -6,8 +6,6 @@
  * convenience methods that return new vectors.
  */
 export class Vector2i {
-    // #region Cached Static Vectors
-
     /** The cached singleton for zero vector. */
     private static readonly _zero: Vector2i = Object.freeze(Vector2i.fromXYUnchecked(0, 0));
 
@@ -25,10 +23,6 @@ export class Vector2i {
 
     /** The cached singleton for the right direction. */
     private static readonly _right: Vector2i = Object.freeze(Vector2i.fromXYUnchecked(1, 0));
-
-    // #endregion
-
-    // #region Constructor
 
     /**
      * Creates an integer 2D vector, truncating inputs toward zero.
@@ -48,10 +42,6 @@ export class Vector2i {
         this.x = x | 0;
         this.y = y | 0;
     }
-
-    // #endregion
-
-    // #region Property Aliases
 
     /**
      * Alias for `x` when treating the vector as a size.
@@ -86,10 +76,6 @@ export class Vector2i {
     set height(value: number) {
         this.y = value | 0;
     }
-
-    // #endregion
-
-    // #region Vector Operations
 
     /**
      * Returns a zero vector (0, 0).
@@ -304,10 +290,6 @@ export class Vector2i {
         return Vector2i.fromXYUnchecked(this.x - (x | 0), this.y - (y | 0));
     }
 
-    // #endregion
-
-    // #region Instance Arithmetic Methods
-
     /**
      * Multiplies both components by a scalar and returns a new vector.
      *
@@ -419,10 +401,6 @@ export class Vector2i {
     dot(other: Vector2i): number {
         return this.x * other.x + this.y * other.y;
     }
-
-    // #endregion
-
-    // #region Geometric Operations and Write-To-Out Methods
 
     /**
      * Calculates the 2D cross-product (perpendicular dot product).
@@ -609,10 +587,6 @@ export class Vector2i {
 
         return out;
     }
-
-    // #endregion
-
-    // #region In-Place Mutation Methods
 
     /**
      * Adds another vector to this one in place.
@@ -832,10 +806,6 @@ export class Vector2i {
         return this;
     }
 
-    // #endregion
-
-    // #region Setters and Scalar Geometry
-
     /**
      * Sets both components of this vector.
      * Modifies this vector directly for maximum performance.
@@ -877,10 +847,6 @@ export class Vector2i {
     magnitude(): number {
         return Math.sqrt(this.x * this.x + this.y * this.y);
     }
-
-    // #endregion
-
-    // #region Distance Methods
 
     /**
      * Calculates the squared magnitude (avoids the sqrt for performance).
@@ -995,10 +961,6 @@ export class Vector2i {
         return Math.max(Math.abs((x | 0) - this.x), Math.abs((y | 0) - this.y));
     }
 
-    // #endregion
-
-    // #region Comparison and Utility
-
     /**
      * Returns a direction vector pointing in the same direction.
      * Components are rounded to the nearest integer, producing one of 8 cardinal/diagonal
@@ -1085,6 +1047,4 @@ export class Vector2i {
     toString(): string {
         return `(${this.x}, ${this.y})`;
     }
-
-    // #endregion
 }

--- a/src/utils/errorMessages.ts
+++ b/src/utils/errorMessages.ts
@@ -52,8 +52,6 @@ export const WEBGPU_DEVICE_MESSAGE =
 export const OVERLAY_NO_BACKEND =
     "Couldn't start the overlay because the rendering backend isn't ready yet. Try initializing the engine before creating the overlay.";
 
-// #region Runtime - Render configuration
-
 /**
  * Returns the error message for a render dimension that is not a positive whole-number pixel size.
  *
@@ -109,10 +107,6 @@ export function renderDimensionGpuLimitError(field: string, size: string, maxTex
         `Use a width and height of ${maxTextureDimension2D} pixels or fewer`
     );
 }
-
-// #endregion
-
-// #region Runtime - Assets
 
 /**
  * Returns the error message for an asset whose width or height is not a positive whole number.
@@ -401,10 +395,6 @@ export function btfontGlyphAreaTooLargeError(charLabel: string): string {
     return `The '${charLabel}' glyph covers too many pixels to render safely. Use a smaller glyph rectangle`;
 }
 
-// #endregion
-
-// #region Runtime - Palette
-
 /**
  * Returns the "no active palette" error message used whenever a palette must
  * be set before an operation can proceed.
@@ -462,10 +452,6 @@ export function hudRangeError(startSlot: number, count: number, size: number): s
     );
 }
 
-// #endregion
-
-// #region Runtime - Sprites
-
 /**
  * Returns the error message for a sprite pixel whose color is absent from the
  * active palette.
@@ -495,5 +481,3 @@ export function spriteNotIndexizedError(): string {
         ' or call sheet.indexize(palette) after BT.paletteSet.'
     );
 }
-
-// #endregion


### PR DESCRIPTION
Strip // #region and // #endregion from src/, scripts/, tests, and benchmarks. Drop stale guidance in CLAUDE.md and docs/testing.md that still recommended region markers for long files.