### PR TITLE
docs(rules): add TypeScript file structure agent rules

### DIFF
--- a/.claude/rules/ts-file-structure.md
+++ b/.claude/rules/ts-file-structure.md
@@ -1,0 +1,26 @@
+# TypeScript file structure
+
+Canonical reference: [CLAUDE.md](../../CLAUDE.md) (**TypeScript file structure**).
+
+When adding or moving code in `src/`. Class member order is **enforced** by `perfectionist/sort-classes` (auto-fix with
+`pnpm run lint:fix`); it uses `type: 'unsorted'`, enforcing only the group order below and preserving the hand-tuned
+order within each group. **Never use `// #region` / `// #endregion`.**
+
+**File layout:** module JSDoc → imports (`import type`, sorted by `simple-import-sort`) → leading module members (config
+constants, validators, type aliases) → the primary class/interface/function → trailing module members (WGSL /
+template-literal constants and pure helpers, exported before private).
+
+**Class member order:**
+
+1. Static fields (cached singletons, registries).
+2. Instance fields — public → protected → private; `readonly` grouped; one JSDoc + blank line per field.
+3. Constructor (parameter-properties carry inline JSDoc).
+4. Accessors — static getters, then instance getters/setters.
+5. Static methods — public before private.
+6. Instance methods — public → protected → private; private helpers last.
+
+**Cross-cutting:** deprecated aliases sit next to their canonical member; cluster method families (new-allocating →
+`*To` → `*InPlace` → queries → `clone`/`toString`); one blank line between members; JSDoc on every member including
+private; named exports only.
+
+Cursor: `.cursor/rules/ts-file-structure.mdc` (glob-scoped to `src/**/*.ts` in this repo).

--- a/.cursor/rules/ts-file-structure.mdc
+++ b/.cursor/rules/ts-file-structure.mdc
@@ -1,0 +1,45 @@
+---
+description: TypeScript file layout and class member order for src/ (no region markers)
+globs: { src/**/*.ts }
+alwaysApply: false
+---
+
+# TypeScript file structure
+
+When adding or moving code in library TypeScript (`src/`). **Class member order is enforced by
+`perfectionist/sort-classes`** (auto-fix with `pnpm run lint:fix`); it uses `type: 'unsorted'`, so it enforces only the
+**group order** below and keeps the hand-tuned order **within** each group. Follow this layout. **Never use `// #region`
+/ `// #endregion`.** Region markers are banned everywhere.
+
+## File layout (top to bottom)
+
+1. **Module JSDoc** — `/** … */` describing the file's purpose.
+2. **Imports** — `import type` for type-only imports; inline `type` in mixed imports. Order is auto-fixed by
+   `pnpm run lint:fix` (`simple-import-sort`).
+3. **Leading module members** — config/input constants (`MAX_VERTICES`, `INV_255`), validators/lookup tables, and type
+   aliases (`type EffectTier`, `type Resolve`). Module-level init loops live here too.
+4. **Primary export** — the class / interface / function the file is named for.
+5. **Trailing module members** — large WGSL/template-literal constants (`const FRAGMENT_WGSL`) and pure helper functions
+   **after** the class. Exported helpers before private ones.
+
+## Class member order
+
+1. **Static fields** — cached singletons (`_zero`, `_white`), registries (`namedColors`).
+2. **Instance fields** — public → protected → private (`#field` / `private`). Group `readonly` together. One JSDoc and a
+   blank line per field (no packed field blocks).
+3. **Constructor** — parameter-properties carry inline `/** … */` JSDoc.
+4. **Accessors** — static getters first, then instance getters/setters.
+5. **Static methods** — public before private.
+6. **Instance methods** — public → protected → private. Private helpers (`cleanup`, `getOrCreateBindGroup`) last.
+
+## Cross-cutting
+
+- Keep a **deprecated alias adjacent to its canonical member** (`equals` after `isEqual`; `handleToggle` after
+  `handleInput`).
+- Cluster method families deliberately: new-allocating (`add`) → `*To` zero-alloc → `*InPlace` → queries (`isEqual`) →
+  `clone` / `toString` last.
+- One blank line between members; a blank line before `return` and between logical blocks inside method bodies.
+- JSDoc on every member, including private ones. Named exports only; no default exports.
+
+Full policy: `CLAUDE.md` (**TypeScript file structure**), `docs/developer-experience-guide.md` (File structure and
+member order).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ Before writing new code, reviewing existing code, or preflighting, check here fi
 | What test mock do I need for GPU code?                     | `src/__test__/webgpu-mock.ts`                                                                                                                                                                                                |
 | Declaration tooling / TS version alignment?                | `docs/tooling.md`, `docs/developer-experience-guide.md`, `scripts/check-declaration-tooling.mjs`                                                                                                                             |
 | Should this private name repeat the class/file?            | **Internal scoped naming** below; `docs/developer-experience-guide.md` (Naming conventions)                                                                                                                                  |
+| Where do I put a new field/method in a `.ts` file?         | **TypeScript file structure** below; `.cursor/rules/ts-file-structure.mdc`; `docs/developer-experience-guide.md` (File structure and member order)                                                                           |
 | What agent skills are available for this project?          | `.agents/skills/` (Zed) and `.claude/skills/` (Claude Code) — `bt-preflight`, `bt-review`, `bt-pr`, `bt-format`, `bt-perf`, `bt-test`, `bt-release`, `bt-spellcheck`, `bt-security-run`, `bt-deep-review`, `bt-quick-format` |
 
 ## Architecture
@@ -256,6 +257,50 @@ or drive breaking changes through consumers for naming-only cleanup.
 - JSDoc required for public APIs
 - When implementing changes, always update JSDoc and inline comments alongside the code. Never leave stale comments that
   describe old behavior.
+
+## TypeScript file structure
+
+Applies to library TypeScript in `src/`. **Class member order is enforced by `perfectionist/sort-classes`** (and import
+order by `simple-import-sort`); the rule is auto-fixable with `pnpm run lint:fix`. It uses `type: 'unsorted'`, so it
+enforces only the **group order** below and preserves the hand-tuned order **within** each group (e.g. logical method
+families stay as written). Match this layout when adding or moving code. **Never use `// #region` / `// #endregion`** —
+region markers are banned everywhere.
+
+### File layout (top to bottom)
+
+1. **Module JSDoc** — a `/** … */` block describing the file's purpose.
+2. **Imports** — `import type` for type-only imports; inline `type` modifiers inside mixed imports
+   (`import { type Backend, defaultConfig } from …`). Ordering is auto-fixed by `pnpm run lint:fix`
+   (`simple-import-sort`).
+3. **Leading module members** — constants that act as configuration or inputs (`MAX_VERTICES`, `INV_255`),
+   validators/lookup tables (`HEX_TOKEN_PATTERN`, `HEX_TABLE`), and type aliases (`type EffectTier`, `type Resolve`).
+   Module-level init loops (e.g. filling a lookup table) live here too.
+4. **Primary export** — the class / interface / function the file is named for.
+5. **Trailing module members** — large WGSL/template-literal constants (`const FRAGMENT_WGSL`) and pure helper functions
+   placed **after** the class. Exported helpers come before private ones.
+
+### Class member order
+
+1. **Static fields** — cached singletons (`_zero`, `_white`), registries (`namedColors`).
+2. **Instance fields** — public, then protected, then private (`#field` or `private`). Group `readonly` together. Each
+   field gets its own JSDoc and is separated by a blank line (no packed field blocks).
+3. **Constructor** — parameter-properties carry inline `/** … */` JSDoc.
+4. **Accessors** — static getters first, then instance getters/setters.
+5. **Static methods** — public before private.
+6. **Instance methods** — public, then protected, then private. Private helpers (`cleanup`, `getOrCreateBindGroup`) come
+   last.
+
+### Cross-cutting
+
+- Keep a **deprecated alias next to its canonical member** (`equals` after `isEqual`; `handleToggle` after
+  `handleInput`).
+- Cluster related instance-method families in a deliberate sub-order: new-allocating methods (`add`, `sub`) → `*To`
+  zero-alloc variants → `*InPlace` variants → queries (`isEqual`, `isZero`) → `clone` / `toString` last.
+- One blank line between members; a blank line before `return` and between logical blocks inside method bodies.
+- JSDoc on every member, including private fields and methods.
+- Named exports only; no default exports.
+
+See `docs/developer-experience-guide.md` (File structure and member order) and `.cursor/rules/ts-file-structure.mdc`.
 
 ## Commands
 

--- a/docs/developer-experience-guide.md
+++ b/docs/developer-experience-guide.md
@@ -124,6 +124,8 @@ AI-assisted commits add a trailer: `Co-Authored-By: Claude <noreply@anthropic.co
 **Linting:**
 
 - ESLint with perfectionist, jsdoc, security, and promise plugins
+- `perfectionist/sort-classes` enforces class member order (see **File structure and member order**);
+  `simple-import-sort` enforces import/export order
 - `pnpm run lint` to check; `pnpm run lint:fix` to auto-fix
 
 **Naming conventions:**
@@ -163,6 +165,26 @@ AI-assisted commits add a trailer: `Co-Authored-By: Claude <noreply@anthropic.co
   `KeyboardInput.isKeyDown`, `GamepadInput.isButtonDown`). Do **not** embed a second `Is` in the identifier
   (`isKeyPressed` — grep: `\bis[A-Za-z]+Is[A-Z]`).
 - Identifier acronyms use both capitals: `canvasID`, `containerID` (not `canvasId`).
+
+**File structure and member order:**
+
+Class member order is enforced by `perfectionist/sort-classes` (and import order by `simple-import-sort`); run
+`pnpm run lint:fix` to auto-fix. The rule uses `type: 'unsorted'`, so it enforces only the **group order** below and
+preserves the hand-tuned order **within** each group (logical method families stay as written). Match this layout when
+adding or moving code. **Never use `// #region` / `// #endregion`** — region markers are banned.
+
+- **File layout (top to bottom):** module JSDoc → imports (`import type`, sorted) → leading module members (config/input
+  constants, validators, lookup tables, type aliases) → the primary class/interface/function → trailing module members
+  (WGSL / template-literal constants such as `FRAGMENT_WGSL`, and pure helper functions placed after the class; exported
+  helpers before private ones).
+- **Class member order:** (1) static fields (cached singletons, registries); (2) instance fields, public → protected →
+  private, `readonly` grouped, one JSDoc + blank line per field; (3) constructor (parameter-properties carry inline
+  JSDoc); (4) accessors — static getters, then instance getters/setters; (5) static methods, public before private; (6)
+  instance methods, public → protected → private, private helpers last.
+- **Cross-cutting:** keep a deprecated alias next to its canonical member (`equals` after `isEqual`); cluster method
+  families (new-allocating → `*To` zero-alloc → `*InPlace` → queries → `clone`/`toString`); one blank line between
+  members and before `return`; JSDoc on every member including private. See [CLAUDE.md](../CLAUDE.md) (**TypeScript file
+  structure**).
 
 ---
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -76,6 +76,59 @@ export default [
             'simple-import-sort/imports': 'error',
             'simple-import-sort/exports': 'error',
 
+            // Class member ordering (matches docs/developer-experience-guide.md "File structure and
+            // member order" and CLAUDE.md "TypeScript file structure"). type: 'unsorted' enforces the
+            // group order only and preserves the hand-tuned order within each group.
+            'perfectionist/sort-classes': [
+                'error',
+                {
+                    type: 'unsorted',
+                    groups: [
+                        'index-signature',
+                        // 1. Static fields (cached singletons, registries)
+                        [
+                            'static-property',
+                            'protected-static-property',
+                            'private-static-property',
+                            'static-accessor-property',
+                        ],
+                        'static-block',
+                        // 2. Instance fields: public -> protected -> private
+                        ['property', 'accessor-property'],
+                        ['protected-property', 'protected-accessor-property'],
+                        ['private-property', 'private-accessor-property'],
+                        // 3. Constructor
+                        'constructor',
+                        // 4. Accessors: static getters/setters, then instance getters/setters
+                        [
+                            'static-get-method',
+                            'static-set-method',
+                            'protected-static-get-method',
+                            'protected-static-set-method',
+                            'private-static-get-method',
+                            'private-static-set-method',
+                        ],
+                        [
+                            'get-method',
+                            'set-method',
+                            'protected-get-method',
+                            'protected-set-method',
+                            'private-get-method',
+                            'private-set-method',
+                        ],
+                        // 5. Static methods: public -> protected -> private
+                        ['static-method', 'static-function-property'],
+                        ['protected-static-method', 'protected-static-function-property'],
+                        ['private-static-method', 'private-static-function-property'],
+                        // 6. Instance methods: public -> protected -> private
+                        ['method', 'function-property'],
+                        ['protected-method', 'protected-function-property'],
+                        ['private-method', 'private-function-property'],
+                        'unknown',
+                    ],
+                },
+            ],
+
             // JSDoc rules
             'jsdoc/check-alignment': 'warn',
             'jsdoc/check-param-names': 'warn',


### PR DESCRIPTION
Add Cursor glob-scoped rule and Claude Code rule documenting src/ file layout, class member order (perfectionist/sort-classes groups), and the ban on // #region markers. Mirrors CLAUDE.md and developer-experience-guide policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR adds comprehensive TypeScript file structure documentation and enforcement rules to the repository. It introduces agent-specific rule files (Cursor and Claude), updates developer documentation, and configures ESLint to enforce class member ordering.

## Changes

### New Files
- **`.cursor/rules/ts-file-structure.mdc`** (45 lines added): Cursor glob-scoped rule defining enforced TypeScript file layout and class member ordering for files under `src/**/*.ts`. Specifies top-to-bottom module structure (JSDoc → imports → leading members → primary export → trailing members), bans `// `#region`` markers, and documents required class member grouping.

- **`.claude/rules/ts-file-structure.md`** (26 lines added): Claude Code rule mirroring the Cursor rule content, documenting repository's TypeScript file structure and coding conventions with the same specifications for module layout and class member ordering.

### Updated Files
- **`CLAUDE.md`** (45 lines added): Added entry to "Where to Find Information" table referencing TypeScript file structure guidance, plus new detailed section describing required ordering/layout rules for library TypeScript files, including `perfectionist/sort-classes` and `simple-import-sort` enforcement, and documentation of `// `#region`` marker ban.

- **`docs/developer-experience-guide.md`** (22 lines added): Added/expanded guidance under linting section documenting `perfectionist/sort-classes` and `simple-import-sort` rules, plus new "File structure and member order" section describing enforced file layout, class member ordering rules, and cross-cutting formatting constraints.

- **`eslint.config.js`** (53 lines added): Added `perfectionist/sort-classes` ESLint rule for TypeScript files set to `error` with explicit sequence of class member groups (index signatures, static fields/accessors/blocks, instance fields, constructor, accessors, methods ordered by visibility and static/instance).

## Key Rules Enforced
- Class members must follow strict ordering: static fields → instance fields → constructor → accessors → static methods → instance methods
- Files must use top-to-bottom structure: JSDoc → imports → leading members → primary export → trailing helpers
- `// `#region`` and `// `#endregion`` markers are banned
- JSDoc required for all members (including private ones)
- Related method families must be grouped together
- Deprecated aliases must be placed near canonical members
- Named exports preferred with blank-line separation between sections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->