### PR TITLE
refactor(renderer): normalize GPU acronym casing to uppercase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ sprites, and bitmap text resolve color through the active `Palette` before final
 src/
   BlitTech.ts              # Public API (BT namespace exports)
   core/
-    BTAPI.ts               # Internal singleton managing subsystems (lazy-loads WebGpuRenderer on WebGPU init)
+    BTAPI.ts               # Internal singleton managing subsystems (lazy-loads WebGPURenderer on WebGPU init)
     IBlitTechDemo.ts       # Demo interface + HardwareSettings
     GameLoop.ts            # Fixed-timestep game loop
     WebGPUContext.ts       # WebGPU adapter/device/context setup
@@ -70,7 +70,7 @@ src/
     input/                 # Toggle
   render/
     IRenderer.ts           # Backend-agnostic renderer contract (interface)
-    WebGpuRenderer.ts      # WebGPU concrete renderer implementing IRenderer
+    WebGPURenderer.ts      # WebGPU concrete renderer implementing IRenderer
     SoftwareRenderer.ts    # Canvas 2D software fallback implementing IRenderer
     PrimitivePipeline.ts   # Batched geometry writing palette indices (pixels, lines, rects)
     SpritePipeline.ts      # Batched textured quads (sprites, bitmap text)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -30,13 +30,13 @@ and `vi` for browser API stubs. Tests that need a full DOM (Bootstrap, Bootstrap
 - **BitmapFont** - glyph lookup, text measurement (Node + vi stubs)
 - **BootstrapHelpers** - WebGPU support detection, canvas lookup (happy-dom)
 - **Bootstrap** - full bootstrap lifecycle, including `?backend=software` WebGPU-skip path (happy-dom)
-- **WebGpuRenderer** - frame lifecycle, camera, pipeline delegation (Node + GPU mocks)
+- **WebGPURenderer** - frame lifecycle, camera, pipeline delegation (Node + GPU mocks)
 - **SoftwareRenderer** - frame lifecycle, palette enforcement, camera offsets, indexed sprite blits, bitmap text,
   `captureFrame()` semantics, and unsupported-effects assertions (Node + 2D canvas mocks)
 - **PrimitivePipeline** - vertex buffer math, line algorithm (Node + GPU mocks)
 - **SpritePipeline** - texture batching, UV coordinates (Node + GPU mocks)
 - **WebGPUContext** - initialization with mock adapter/device (Node + GPU mocks)
-- **BTAPI** - singleton coordinator; lazy-loads `WebGpuRenderer` after WebGPU init succeeds; includes software-mode
+- **BTAPI** - singleton coordinator; lazy-loads `WebGPURenderer` after WebGPU init succeeds; includes software-mode
   init, `?backend=software` URL override, `BT.requestedBackend` vs `BT.activeBackend` after WebGPU fallback,
   `captureFrame()` in software mode, and overlay render path (Node + GPU mocks + 2D canvas mocks)
 - **Overlay** - colocated tests under `src/overlay/*.test.ts`: label parsing, layout helpers, `layoutPlan` golden Y

--- a/src/__test__/webgpu-mock.ts
+++ b/src/__test__/webgpu-mock.ts
@@ -8,7 +8,7 @@ const DEFAULT_SIZE_PX = 256;
 
 /**
  * Palette uniform byte size: 256 palette indices x vec4(f32) x 4 bytes.
- * Matches {@link WebGpuRenderer} palette buffer layout.
+ * Matches {@link WebGPURenderer} palette buffer layout.
  */
 const INDEX_COUNT = 256;
 const RGBA_COMPONENT_COUNT = 4;

--- a/src/core/BTAPI.test.ts
+++ b/src/core/BTAPI.test.ts
@@ -1223,7 +1223,7 @@ describe('BTAPI', () => {
 
         it('calls getFrameDiagnostics when isOverlayTimingChartEnabled is enabled', async () => {
             const diagnosticsSpy = vi.spyOn(
-                (await import('../render/WebGpuRenderer')).WebGpuRenderer.prototype,
+                (await import('../render/WebGPURenderer')).WebGPURenderer.prototype,
                 'getFrameDiagnostics',
             );
             const demo: IBlitTechDemo = {
@@ -1244,7 +1244,7 @@ describe('BTAPI', () => {
 
         it('does not call getFrameDiagnostics when isOverlayTimingChartEnabled is disabled', async () => {
             const diagnosticsSpy = vi.spyOn(
-                (await import('../render/WebGpuRenderer')).WebGpuRenderer.prototype,
+                (await import('../render/WebGPURenderer')).WebGPURenderer.prototype,
                 'getFrameDiagnostics',
             );
             const demo: IBlitTechDemo = {
@@ -1266,7 +1266,7 @@ describe('BTAPI', () => {
 
         it('calls getFrameDiagnostics when isOverlayRendererDiagnosticsBarEnabled is enabled without chart', async () => {
             const diagnosticsSpy = vi.spyOn(
-                (await import('../render/WebGpuRenderer')).WebGpuRenderer.prototype,
+                (await import('../render/WebGPURenderer')).WebGPURenderer.prototype,
                 'getFrameDiagnostics',
             );
             const demo: IBlitTechDemo = {
@@ -1295,7 +1295,7 @@ describe('BTAPI', () => {
             };
 
             vi.spyOn(
-                (await import('../render/WebGpuRenderer')).WebGpuRenderer.prototype,
+                (await import('../render/WebGPURenderer')).WebGPURenderer.prototype,
                 'getFrameDiagnostics',
             ).mockReturnValue(mockDiagnostics);
 

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -1110,9 +1110,9 @@ export class BTAPI {
 
                 // Lazy-load WebGPU renderer code so browsers without WebGPU globals
                 // (e.g. Firefox on Linux) can still start with the software backend.
-                const { WebGpuRenderer } = await import('../render/WebGpuRenderer');
+                const { WebGPURenderer } = await import('../render/WebGPURenderer');
 
-                this.renderer = new WebGpuRenderer(
+                this.renderer = new WebGPURenderer(
                     webGPUResult.device,
                     webGPUResult.context,
                     hw.displaySize,

--- a/src/overlay/OverlayDrawTarget.ts
+++ b/src/overlay/OverlayDrawTarget.ts
@@ -6,7 +6,7 @@ import type { Vector2i } from '../utils/Vector2i';
 /**
  * Internal draw port for the engine overlay HUD.
  *
- * Not part of the public {@link BT} API. {@link WebGpuRenderer} and
+ * Not part of the public {@link BT} API. {@link WebGPURenderer} and
  * {@link SoftwareRenderer} implement this alongside {@link IRenderer}.
  */
 export interface OverlayDrawTarget {

--- a/src/render/WebGPURenderer.test.ts
+++ b/src/render/WebGPURenderer.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for {@link WebGpuRenderer}.
+ * Unit tests for {@link WebGPURenderer}.
  *
  * Exercises the engine's WebGPU render coordinator:
  * - constructor behavior and pre-initialization safety
@@ -31,10 +31,10 @@ import { Vector2i } from '../utils/Vector2i';
 import type { Effect } from './effects/Effect';
 import type { PrimitivePipeline } from './PrimitivePipeline';
 import type { SpritePipeline } from './SpritePipeline';
-import { WebGpuRenderer } from './WebGpuRenderer';
+import { WebGPURenderer } from './WebGPURenderer';
 
-/** Internal pipeline batches on {@link WebGpuRenderer} (compile-time private, runtime-accessible). */
-type WebGpuRendererPipelineAccess = {
+/** Internal pipeline batches on {@link WebGPURenderer} (compile-time private, runtime-accessible). */
+type WebGPURendererPipelineAccess = {
     primitives: PrimitivePipeline;
     overlayPrimitives: PrimitivePipeline;
     overlayTopPrimitives: PrimitivePipeline;
@@ -46,11 +46,11 @@ type WebGpuRendererPipelineAccess = {
 /**
  * Returns the six scene-pass pipeline batches for encode-order and routing tests.
  *
- * @param renderer - Initialized {@link WebGpuRenderer}.
+ * @param renderer - Initialized {@link WebGPURenderer}.
  * @returns Primitive, sprite, overlay, and overlay-top pipeline instances.
  */
-function getRendererPipelines(renderer: WebGpuRenderer): WebGpuRendererPipelineAccess {
-    return renderer as unknown as WebGpuRendererPipelineAccess;
+function getRendererPipelines(renderer: WebGPURenderer): WebGPURendererPipelineAccess {
+    return renderer as unknown as WebGPURendererPipelineAccess;
 }
 
 /** Creates a small 16-color test palette with known color assignments. */
@@ -69,21 +69,21 @@ function createTestPalette(): Palette {
     return palette;
 }
 
-describe('WebGpuRenderer constructor', () => {
+describe('WebGPURenderer constructor', () => {
     it('creates an instance with mock objects', () => {
         const device = createMockGPUDevice();
         const context = createMockGPUCanvasContext();
         const displaySize = new Vector2i(320, 240);
-        const renderer = new WebGpuRenderer(device, context, displaySize);
+        const renderer = new WebGPURenderer(device, context, displaySize);
 
         expect(renderer).toBeDefined();
-        expect(renderer).toBeInstanceOf(WebGpuRenderer);
+        expect(renderer).toBeInstanceOf(WebGPURenderer);
     });
 });
 
 describe('pre-initialization methods', () => {
     it('setClearColor does not throw', () => {
-        const renderer = new WebGpuRenderer(
+        const renderer = new WebGPURenderer(
             createMockGPUDevice(),
             createMockGPUCanvasContext(),
             new Vector2i(320, 240),
@@ -95,7 +95,7 @@ describe('pre-initialization methods', () => {
     });
 
     it('setCameraOffset does not throw', () => {
-        const renderer = new WebGpuRenderer(
+        const renderer = new WebGPURenderer(
             createMockGPUDevice(),
             createMockGPUCanvasContext(),
             new Vector2i(320, 240),
@@ -107,7 +107,7 @@ describe('pre-initialization methods', () => {
     });
 
     it('getCameraOffset returns a zero vector initially', () => {
-        const renderer = new WebGpuRenderer(
+        const renderer = new WebGPURenderer(
             createMockGPUDevice(),
             createMockGPUCanvasContext(),
             new Vector2i(320, 240),
@@ -119,7 +119,7 @@ describe('pre-initialization methods', () => {
     });
 
     it('resetCamera sets camera back to zero', () => {
-        const renderer = new WebGpuRenderer(
+        const renderer = new WebGPURenderer(
             createMockGPUDevice(),
             createMockGPUCanvasContext(),
             new Vector2i(320, 240),
@@ -135,7 +135,7 @@ describe('pre-initialization methods', () => {
     });
 
     it('beginFrame throws without active palette', () => {
-        const renderer = new WebGpuRenderer(
+        const renderer = new WebGPURenderer(
             createMockGPUDevice(),
             createMockGPUCanvasContext(),
             new Vector2i(320, 240),
@@ -147,7 +147,7 @@ describe('pre-initialization methods', () => {
     });
 
     it('beginFrame succeeds with active palette', () => {
-        const renderer = new WebGpuRenderer(
+        const renderer = new WebGPURenderer(
             createMockGPUDevice(),
             createMockGPUCanvasContext(),
             new Vector2i(320, 240),
@@ -163,7 +163,7 @@ describe('pre-initialization methods', () => {
 
 describe('camera operations', () => {
     it('getCameraOffset returns a copy, not the internal reference', () => {
-        const renderer = new WebGpuRenderer(
+        const renderer = new WebGPURenderer(
             createMockGPUDevice(),
             createMockGPUCanvasContext(),
             new Vector2i(320, 240),
@@ -186,7 +186,7 @@ describe('camera operations', () => {
     });
 
     it('setCameraOffset stores the offset correctly', () => {
-        const renderer = new WebGpuRenderer(
+        const renderer = new WebGPURenderer(
             createMockGPUDevice(),
             createMockGPUCanvasContext(),
             new Vector2i(320, 240),
@@ -201,7 +201,7 @@ describe('camera operations', () => {
     });
 
     it('setCameraOffset clones the input vector', () => {
-        const renderer = new WebGpuRenderer(
+        const renderer = new WebGPURenderer(
             createMockGPUDevice(),
             createMockGPUCanvasContext(),
             new Vector2i(320, 240),
@@ -222,7 +222,7 @@ describe('camera operations', () => {
 
 describe('palette enforcement', () => {
     it('setPalette stores and returns palette', () => {
-        const renderer = new WebGpuRenderer(
+        const renderer = new WebGPURenderer(
             createMockGPUDevice(),
             createMockGPUCanvasContext(),
             new Vector2i(320, 240),
@@ -241,7 +241,7 @@ describe('palette enforcement', () => {
     });
 
     it('getPalette returns null when no palette is set', () => {
-        const renderer = new WebGpuRenderer(
+        const renderer = new WebGPURenderer(
             createMockGPUDevice(),
             createMockGPUCanvasContext(),
             new Vector2i(320, 240),
@@ -255,7 +255,7 @@ describe('with initialized renderer', () => {
     const device = createMockGPUDevice();
     const context = createMockGPUCanvasContext();
     const displaySize = new Vector2i(320, 240);
-    const renderer = new WebGpuRenderer(device, context, displaySize);
+    const renderer = new WebGPURenderer(device, context, displaySize);
 
     beforeAll(async () => {
         installMockNavigatorGPU();
@@ -272,7 +272,7 @@ describe('with initialized renderer', () => {
     });
 
     it('init returns true on success', async () => {
-        const r = new WebGpuRenderer(device, context, displaySize);
+        const r = new WebGPURenderer(device, context, displaySize);
         const result = await r.init();
 
         expect(result).toBe(true);
@@ -564,7 +564,7 @@ describe('with initialized renderer', () => {
 
 describe('resolveClearColor fallbacks', () => {
     it('returns black (no throw) when no palette is set', async () => {
-        const r = new WebGpuRenderer(createMockGPUDevice(), createMockGPUCanvasContext(), new Vector2i(320, 240));
+        const r = new WebGPURenderer(createMockGPUDevice(), createMockGPUCanvasContext(), new Vector2i(320, 240));
 
         installMockNavigatorGPU();
 
@@ -577,7 +577,7 @@ describe('resolveClearColor fallbacks', () => {
     });
 
     it('returns black (no throw) when palette.get throws', async () => {
-        const r = new WebGpuRenderer(createMockGPUDevice(), createMockGPUCanvasContext(), new Vector2i(320, 240));
+        const r = new WebGPURenderer(createMockGPUDevice(), createMockGPUCanvasContext(), new Vector2i(320, 240));
 
         installMockNavigatorGPU();
 
@@ -612,7 +612,7 @@ describe('frame capture', () => {
         });
 
         const context = createMockGPUCanvasContext();
-        const renderer = new WebGpuRenderer(device, context, new Vector2i(4, 4));
+        const renderer = new WebGPURenderer(device, context, new Vector2i(4, 4));
 
         installMockNavigatorGPU();
 
@@ -671,7 +671,7 @@ describe('frame capture', () => {
         });
 
         const context = createMockGPUCanvasContext();
-        const renderer = new WebGpuRenderer(device, context, new Vector2i(4, 4));
+        const renderer = new WebGPURenderer(device, context, new Vector2i(4, 4));
 
         installMockNavigatorGPU();
 
@@ -732,7 +732,7 @@ describe('frame capture', () => {
         });
 
         const context = createMockGPUCanvasContext();
-        const renderer = new WebGpuRenderer(device, context, new Vector2i(320, 240));
+        const renderer = new WebGPURenderer(device, context, new Vector2i(320, 240));
 
         installMockNavigatorGPU();
 
@@ -759,7 +759,7 @@ describe('endFrame error paths', () => {
             },
         } as unknown as GPUCanvasContext;
 
-        const renderer = new WebGpuRenderer(device, throwingContext, new Vector2i(320, 240));
+        const renderer = new WebGPURenderer(device, throwingContext, new Vector2i(320, 240));
 
         installMockNavigatorGPU();
 
@@ -803,7 +803,7 @@ describe('endFrame error paths', () => {
             }),
         } as unknown as GPUCanvasContext;
 
-        const renderer = new WebGpuRenderer(device, zeroTextureContext, new Vector2i(320, 240));
+        const renderer = new WebGPURenderer(device, zeroTextureContext, new Vector2i(320, 240));
 
         installMockNavigatorGPU();
 
@@ -837,7 +837,7 @@ describe('init error paths', () => {
             },
         } as unknown as GPUDevice;
 
-        const renderer = new WebGpuRenderer(throwingDevice, createMockGPUCanvasContext(), new Vector2i(320, 240));
+        const renderer = new WebGPURenderer(throwingDevice, createMockGPUCanvasContext(), new Vector2i(320, 240));
 
         installMockNavigatorGPU();
 
@@ -858,7 +858,7 @@ describe('init error paths', () => {
 
 describe('palette dirty-flag auto-propagation', () => {
     it('setPalette stores a reference, not a clone', () => {
-        const renderer = new WebGpuRenderer(
+        const renderer = new WebGPURenderer(
             createMockGPUDevice(),
             createMockGPUCanvasContext(),
             new Vector2i(320, 240),
@@ -875,7 +875,7 @@ describe('palette dirty-flag auto-propagation', () => {
     });
 
     it('getPalette still returns a clone, not the internal reference', () => {
-        const renderer = new WebGpuRenderer(
+        const renderer = new WebGPURenderer(
             createMockGPUDevice(),
             createMockGPUCanvasContext(),
             new Vector2i(320, 240),
@@ -888,7 +888,7 @@ describe('palette dirty-flag auto-propagation', () => {
     });
 
     it('palette.isDirty is cleared after endFrame uploads', async () => {
-        const renderer = new WebGpuRenderer(
+        const renderer = new WebGPURenderer(
             createMockGPUDevice(),
             createMockGPUCanvasContext(),
             new Vector2i(320, 240),
@@ -920,7 +920,7 @@ describe('palette dirty-flag auto-propagation', () => {
         const device = createMockGPUDevice();
         const writeBufferSpy = vi.spyOn(device.queue, 'writeBuffer');
 
-        const renderer = new WebGpuRenderer(device, createMockGPUCanvasContext(), new Vector2i(320, 240));
+        const renderer = new WebGPURenderer(device, createMockGPUCanvasContext(), new Vector2i(320, 240));
 
         installMockNavigatorGPU();
 
@@ -954,7 +954,7 @@ describe('palette dirty-flag auto-propagation', () => {
         const device = createMockGPUDevice();
         const writeBufferSpy = vi.spyOn(device.queue, 'writeBuffer');
 
-        const renderer = new WebGpuRenderer(device, createMockGPUCanvasContext(), new Vector2i(320, 240));
+        const renderer = new WebGPURenderer(device, createMockGPUCanvasContext(), new Vector2i(320, 240));
 
         installMockNavigatorGPU();
 
@@ -1019,25 +1019,25 @@ describe('post-process effects', () => {
     }
 
     it('addEffect throws before init', () => {
-        const r = new WebGpuRenderer(createMockGPUDevice(), createMockGPUCanvasContext(), new Vector2i(320, 240));
+        const r = new WebGPURenderer(createMockGPUDevice(), createMockGPUCanvasContext(), new Vector2i(320, 240));
 
         expect(() => r.addEffect(createStubEffect())).toThrow(/not initialized/);
     });
 
     it('removeEffect throws before init', () => {
-        const r = new WebGpuRenderer(createMockGPUDevice(), createMockGPUCanvasContext(), new Vector2i(320, 240));
+        const r = new WebGPURenderer(createMockGPUDevice(), createMockGPUCanvasContext(), new Vector2i(320, 240));
 
         expect(() => r.removeEffect(createStubEffect())).toThrow(/not initialized/);
     });
 
     it('clearEffects throws before init', () => {
-        const r = new WebGpuRenderer(createMockGPUDevice(), createMockGPUCanvasContext(), new Vector2i(320, 240));
+        const r = new WebGPURenderer(createMockGPUDevice(), createMockGPUCanvasContext(), new Vector2i(320, 240));
 
         expect(() => r.clearEffects()).toThrow(/not initialized/);
     });
 
     it('addEffect / clearEffects work after init', async () => {
-        const r = new WebGpuRenderer(createMockGPUDevice(), createMockGPUCanvasContext(), new Vector2i(320, 240));
+        const r = new WebGPURenderer(createMockGPUDevice(), createMockGPUCanvasContext(), new Vector2i(320, 240));
 
         await r.init();
 
@@ -1064,7 +1064,7 @@ describe('post-process effects', () => {
             return encoder;
         });
 
-        const r = new WebGpuRenderer(device, createMockGPUCanvasContext(), new Vector2i(320, 240));
+        const r = new WebGPURenderer(device, createMockGPUCanvasContext(), new Vector2i(320, 240));
 
         await r.init();
         r.setPalette(createTestPalette());
@@ -1078,7 +1078,7 @@ describe('post-process effects', () => {
 
     it('endFrame drives chain.encode for each registered effect', async () => {
         const device = createMockGPUDevice();
-        const r = new WebGpuRenderer(device, createMockGPUCanvasContext(), new Vector2i(320, 240));
+        const r = new WebGPURenderer(device, createMockGPUCanvasContext(), new Vector2i(320, 240));
 
         await r.init();
         r.setPalette(createTestPalette());
@@ -1101,7 +1101,7 @@ describe('post-process effects', () => {
 
     it('endFrame drives every effect when multiple are stacked', async () => {
         const device = createMockGPUDevice();
-        const r = new WebGpuRenderer(device, createMockGPUCanvasContext(), new Vector2i(320, 240));
+        const r = new WebGPURenderer(device, createMockGPUCanvasContext(), new Vector2i(320, 240));
 
         await r.init();
         r.setPalette(createTestPalette());
@@ -1144,7 +1144,7 @@ describe('post-process effects', () => {
             getCurrentTexture: () => swapTexture,
         } as unknown as GPUCanvasContext;
 
-        const r = new WebGpuRenderer(device, context, new Vector2i(320, 240));
+        const r = new WebGPURenderer(device, context, new Vector2i(320, 240));
 
         await r.init();
         r.setPalette(createTestPalette());
@@ -1198,7 +1198,7 @@ describe('post-process effects', () => {
             getCurrentTexture: () => swapTexture,
         } as unknown as GPUCanvasContext;
 
-        const r = new WebGpuRenderer(device, context, new Vector2i(320, 240));
+        const r = new WebGPURenderer(device, context, new Vector2i(320, 240));
 
         await r.init();
         r.setPalette(createTestPalette());

--- a/src/render/WebGPURenderer.test.ts
+++ b/src/render/WebGPURenderer.test.ts
@@ -34,7 +34,7 @@ import type { SpritePipeline } from './SpritePipeline';
 import { WebGPURenderer } from './WebGPURenderer';
 
 /** Internal pipeline batches on {@link WebGPURenderer} (compile-time private, runtime-accessible). */
-type WebGPURendererPipelineAccess = {
+type PipelineAccess = {
     primitives: PrimitivePipeline;
     overlayPrimitives: PrimitivePipeline;
     overlayTopPrimitives: PrimitivePipeline;
@@ -49,8 +49,8 @@ type WebGPURendererPipelineAccess = {
  * @param renderer - Initialized {@link WebGPURenderer}.
  * @returns Primitive, sprite, overlay, and overlay-top pipeline instances.
  */
-function getRendererPipelines(renderer: WebGPURenderer): WebGPURendererPipelineAccess {
-    return renderer as unknown as WebGPURendererPipelineAccess;
+function getRendererPipelines(renderer: WebGPURenderer): PipelineAccess {
+    return renderer as unknown as PipelineAccess;
 }
 
 /** Creates a small 16-color test palette with known color assignments. */

--- a/src/render/WebGPURenderer.ts
+++ b/src/render/WebGPURenderer.ts
@@ -33,7 +33,7 @@ const LOGICAL_TARGET_FORMAT: GPUTextureFormat = 'r8uint';
 /**
  * WebGPU renderer implementing {@link IRenderer}.
  *
- * `WebGpuRenderer` owns frame begin/end, clear color, camera state, palette
+ * `WebGPURenderer` owns frame begin/end, clear color, camera state, palette
  * buffer, frame capture, and the two-tier post-process pipeline. Actual draw
  * batching is delegated to {@link PrimitivePipeline} and {@link SpritePipeline}.
  *
@@ -50,7 +50,7 @@ const LOGICAL_TARGET_FORMAT: GPUTextureFormat = 'r8uint';
  * exists only after palette resolve/upscale, so display-tier effects remain
  * unchanged while the obsolete logical RGBA path is removed.
  */
-export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
+export class WebGPURenderer implements IRenderer, OverlayDrawTarget {
     /** WebGPU device for GPU operations. */
     private readonly device: GPUDevice;
 
@@ -248,7 +248,7 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
 
             return true;
         } catch (error) {
-            console.error('[WebGpuRenderer] Initialization failed:', error);
+            console.error('[WebGPURenderer] Initialization failed:', error);
 
             return false;
         }
@@ -575,12 +575,12 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
      */
     addEffect(effect: Effect): void {
         if (!this.pixelChain || !this.displayChain) {
-            throw new Error('WebGpuRenderer.addEffect: renderer not initialized.');
+            throw new Error('WebGPURenderer.addEffect: renderer not initialized.');
         }
 
         if (effect.tier === 'display' && !this.isDisplayTierEnabled) {
             throw new Error(
-                'WebGpuRenderer.addEffect: display-tier effects require drawingBufferSize to be set in configure().',
+                'WebGPURenderer.addEffect: display-tier effects require drawingBufferSize to be set in configure().',
             );
         }
 
@@ -602,7 +602,7 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
      */
     removeEffect(effect: Effect): void {
         if (!this.pixelChain || !this.displayChain) {
-            throw new Error('WebGpuRenderer.removeEffect: renderer not initialized.');
+            throw new Error('WebGPURenderer.removeEffect: renderer not initialized.');
         }
 
         const [primary, fallback] =
@@ -620,7 +620,7 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
      */
     clearEffects(): void {
         if (!this.pixelChain || !this.displayChain) {
-            throw new Error('WebGpuRenderer.clearEffects: renderer not initialized.');
+            throw new Error('WebGPURenderer.clearEffects: renderer not initialized.');
         }
 
         this.pixelChain.clear();
@@ -639,7 +639,7 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
         try {
             swapTexture = this.context.getCurrentTexture();
         } catch (error) {
-            console.error('[WebGpuRenderer] Failed to get current texture:', error);
+            console.error('[WebGPURenderer] Failed to get current texture:', error);
 
             this.primitives.reset();
             this.overlayPrimitives.reset();
@@ -652,7 +652,7 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
         }
 
         if (swapTexture.width === 0 || swapTexture.height === 0) {
-            console.warn('[WebGpuRenderer] Texture has zero dimensions, skipping frame');
+            console.warn('[WebGPURenderer] Texture has zero dimensions, skipping frame');
 
             this.primitives.reset();
             this.overlayPrimitives.reset();
@@ -842,7 +842,7 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
         const chain = this.displayChain;
 
         if (!chain?.isActive()) {
-            throw new Error('WebGpuRenderer.requireDisplayChainInput: display chain inactive.');
+            throw new Error('WebGPURenderer.requireDisplayChainInput: display chain inactive.');
         }
 
         return chain.getInputView();
@@ -872,7 +872,7 @@ export class WebGpuRenderer implements IRenderer, OverlayDrawTarget {
 
         if (this.clearPaletteIndex < 0 || this.clearPaletteIndex >= this.palette.size) {
             console.warn(
-                '[WebGpuRenderer] resolveClearPaletteIndex: clearPaletteIndex out of range, falling back to 0.',
+                '[WebGPURenderer] resolveClearPaletteIndex: clearPaletteIndex out of range, falling back to 0.',
             );
             return 0;
         }

--- a/src/render/effects/FullscreenPixelEffect.ts
+++ b/src/render/effects/FullscreenPixelEffect.ts
@@ -45,7 +45,7 @@ export abstract class FullscreenPixelEffect implements Effect {
             );
         }
 
-        this.disposeGpuState();
+        this.disposeGPUState();
 
         this.device = device;
         this.attachmentFormat = format;
@@ -134,7 +134,7 @@ export abstract class FullscreenPixelEffect implements Effect {
      * Destroys GPU buffers and pipelines owned by this effect.
      */
     dispose(): void {
-        this.disposeGpuState();
+        this.disposeGPUState();
     }
 
     /** Populates {@link uniformData} before GPU upload. */
@@ -143,7 +143,7 @@ export abstract class FullscreenPixelEffect implements Effect {
     /**
      * Drops GPU handles so the effect can be re-initialized with a different chain format.
      */
-    private disposeGpuState(): void {
+    private disposeGPUState(): void {
         this.uniformBuffer?.destroy();
         this.uniformBuffer = null;
         this.pipeline = null;

--- a/src/utils/RenderLimits.ts
+++ b/src/utils/RenderLimits.ts
@@ -1,6 +1,6 @@
 import {
     renderDimensionAreaTooLargeError,
-    renderDimensionGpuLimitError,
+    renderDimensionGPULimitError,
     renderDimensionInvalidError,
     renderDimensionTooLargeError,
 } from './errorMessages';
@@ -155,7 +155,7 @@ export function validateWebGPUTextureDimension(
     }
 
     if (size.x > maxTextureDimension2D || size.y > maxTextureDimension2D) {
-        return renderDimensionGpuLimitError(field, formatSize(size), maxTextureDimension2D);
+        return renderDimensionGPULimitError(field, formatSize(size), maxTextureDimension2D);
     }
 
     return null;

--- a/src/utils/errorMessages.test.ts
+++ b/src/utils/errorMessages.test.ts
@@ -22,7 +22,7 @@ import {
     paletteIndexNegativeError,
     paletteIndexOutOfRangeError,
     renderDimensionAreaTooLargeError,
-    renderDimensionGpuLimitError,
+    renderDimensionGPULimitError,
     renderDimensionInvalidError,
     renderDimensionTooLargeError,
     spriteColorNotInPaletteError,
@@ -127,9 +127,9 @@ describe('errorMessages', () => {
         });
     });
 
-    describe('renderDimensionGpuLimitError', () => {
+    describe('renderDimensionGPULimitError', () => {
         it('includes the field name, size, and graphics-card limit', () => {
-            const message = renderDimensionGpuLimitError('drawingBufferSize', '2048x1024', 1024);
+            const message = renderDimensionGPULimitError('drawingBufferSize', '2048x1024', 1024);
 
             expect(message).toContain('drawingBufferSize');
             expect(message).toContain('2048x1024');

--- a/src/utils/errorMessages.ts
+++ b/src/utils/errorMessages.ts
@@ -101,7 +101,7 @@ export function renderDimensionAreaTooLargeError(field: string, size: string, ma
  * @param maxTextureDimension2D - WebGPU adapter/device texture dimension limit.
  * @returns User-facing error string.
  */
-export function renderDimensionGpuLimitError(field: string, size: string, maxTextureDimension2D: number): string {
+export function renderDimensionGPULimitError(field: string, size: string, maxTextureDimension2D: number): string {
     return (
         `${field} is too large for this graphics card (got ${size}). ` +
         `Use a width and height of ${maxTextureDimension2D} pixels or fewer`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR normalizes the casing of the "GPU" acronym across the codebase, replacing mixed-case identifiers (`WebGpuRenderer`, `disposeGpuState`, `renderDimensionGpuLimitError`, etc.) with uppercase `GPU` variants (`WebGPURenderer`, `disposeGPUState`, `renderDimensionGPULimitError`). Changes touch source, tests, and documentation; behavior is unchanged.

## Changes by Category

### Class Rename: WebGpuRenderer → WebGPURenderer
- Renamed exported renderer class in src/render/WebGPURenderer.ts and updated all internal references, error/warning messages, and JSDoc to use WebGPURenderer.
- BTAPI lazy-load now imports ../render/WebGPURenderer and constructs WebGPURenderer.

### Exported Function Rename: renderDimensionGpuLimitError → renderDimensionGPULimitError
- Renamed exported function in src/utils/errorMessages.ts to renderDimensionGPULimitError and updated callers in src/utils/RenderLimits.ts and tests.

### GPU State Cleanup Rename: disposeGpuState → disposeGPUState
- In src/render/effects/FullscreenPixelEffect.ts renamed the private helper and its call sites to disposeGPUState().

### Tests
- Updated tests to match renamed symbols:
  - src/render/WebGPURenderer.test.ts (migrated references to WebGPURenderer)
  - src/core/BTAPI.test.ts (spies/mocks target WebGPURenderer.prototype)
  - src/utils/errorMessages.test.ts (uses renderDimensionGPULimitError)
  - src/__test__/webgpu-mock.ts (JSDoc reference)
- No behavioral test changes beyond identifier updates.

### Documentation and JSDoc
- Updated architecture and testing docs: CLAUDE.md and docs/testing.md now reference WebGPURenderer.
- JSDoc cross-references updated (e.g., src/overlay/OverlayDrawTarget.ts).

## Impact

- Public API changes (renamed exports):
  - Class: WebGpuRenderer → WebGPURenderer
  - Function: renderDimensionGpuLimitError → renderDimensionGPULimitError
- No runtime logic changes; this is a casing/identifier normalization refactor. Tests and docs have been updated to reflect the renames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->