### PR TITLE
docs: sync Claude and Cursor skills with current project state

### DIFF
--- a/.claude/rules/bt-api-getters.md
+++ b/.claude/rules/bt-api-getters.md
@@ -10,14 +10,14 @@ Quick rules when changing `src/BlitTech.ts` or demos:
 
 ## Getter lists
 
-| Category                                         | Members                                                                        |
-| ------------------------------------------------ | ------------------------------------------------------------------------------ |
-| Configure-time (mirror `HardwareSettings` names) | `displaySize`, `drawingBufferSize`, `targetFPS`                                |
-| Derived                                          | `outputSize` (`drawingBufferSize ?? displaySize`; no `HardwareSettings` field) |
-| Configure-time (backend)                         | `requestedBackend` (mirrors `HardwareSettings.backend`)                        |
-| Loop timing                                      | `deltaSeconds`, `timeSeconds`, `ticks`                                         |
-| Runtime state                                    | `activeBackend`, `camera`, `palette`                                           |
-| Per-frame input                                  | `pointerScrollDelta`, `inputString`, `gamepadCount`                            |
+| Category                                         | Members                                                                         |
+| ------------------------------------------------ | ------------------------------------------------------------------------------- |
+| Configure-time (mirror `HardwareSettings` names) | `displaySize`, `drawingBufferSize`, `targetFPS`                                 |
+| Derived                                          | `outputSize` (`drawingBufferSize ?? displaySize`; no `HardwareSettings` field)  |
+| Configure-time (backend)                         | `requestedBackend` (mirrors `HardwareSettings.backend`; **`null` before init**) |
+| Loop timing                                      | `deltaSeconds`, `timeSeconds`, `ticks`                                          |
+| Runtime state                                    | `activeBackend`, `camera`, `palette` (`activeBackend` **`null` before init**)   |
+| Per-frame input                                  | `pointerScrollDelta`, `inputString`, `gamepadCount`                             |
 
 `Vector2i` getters return a clone per read. `activeBackend` is what actually started after fallback, not
 `configure().backend`. `palette` is a live reference - mutating slots affects rendering on the next frame.
@@ -45,4 +45,4 @@ Not `is*`: `Timer.fireIfElapsed()`, `remove(): boolean`, `init(): Promise<boolea
 - Use a derived getter when the value is computed from configure fields (`outputSize`); do not add a matching field
 - Use a runtime-descriptive name when no configure field exists (`activeBackend`, not `renderer`)
 
-Cursor: `.cursor/rules/bt-api-getters.mdc` and `.cursor/rules/internal-scoped-naming.mdc` (always applied in this repo).
+Cursor: `.cursor/rules/bt-api-getters.mdc` (always applied in this repo).

--- a/.claude/skills/bt-deep-review/SKILL.md
+++ b/.claude/skills/bt-deep-review/SKILL.md
@@ -25,7 +25,7 @@ pushing significant changes or creating pull requests.
 
 2. **Run preflight checks**
 
-- Execute `pnpm run preflight` (format, lint, typecheck, spellcheck, knip, test:unit)
+- Execute `pnpm run preflight` (format, lint, typecheck, spellcheck, knip, docs:links, test:unit, test:declarations)
 - If any check fails, report issues and stop
 - All automated checks must pass before AI review
 
@@ -83,6 +83,9 @@ pushing significant changes or creating pull requests.
 - [PASS/FAIL] Type check
 - [PASS/FAIL] Spell check
 - [PASS/FAIL] Unused exports (knip)
+- [PASS/FAIL] Markdown links (docs:links)
+- [PASS/FAIL] Unit tests (test:unit)
+- [PASS/FAIL] Declaration tooling (test:declarations)
 - [PASS/FAIL] Security audit
 
 ### Code Review Findings

--- a/.claude/skills/bt-format/SKILL.md
+++ b/.claude/skills/bt-format/SKILL.md
@@ -18,8 +18,9 @@ Format all code files using the project's formatters and verify results.
 1. **Run formatters**
 
 - Execute `pnpm run format` which runs:
-  - Biome for TypeScript/JavaScript/JSON/CSS
-  - Prettier for Markdown/YAML
+  - Biome for TypeScript/JavaScript/JSON/JSONC/CSS (`.ts`, `.tsx`, `.js`, `.jsx`, `.cjs`, `.mjs`, `.json`, `.jsonc`,
+    `.css`)
+  - Prettier for Markdown/YAML/Cursor rules (`.md`, `.mdx`, `.mdc`, `.yml`, `.yaml`)
 
 2. **Show what changed**
 
@@ -33,11 +34,11 @@ Format all code files using the project's formatters and verify results.
 
 ## Formatter Configuration
 
-| File Types                             | Tool     | Config               |
-| -------------------------------------- | -------- | -------------------- |
-| `.ts`, `.tsx`, `.js`, `.json`          | Biome    | `biome.json`         |
-| `.css`                                 | Biome    | `biome.json`         |
-| `.md`, `.mdx`, `.mdc`, `.yml`, `.yaml` | Prettier | `prettier.config.js` |
+| File Types                                                      | Tool     | Config               |
+| --------------------------------------------------------------- | -------- | -------------------- |
+| `.ts`, `.tsx`, `.js`, `.jsx`, `.cjs`, `.mjs`, `.json`, `.jsonc` | Biome    | `biome.json`         |
+| `.css`                                                          | Biome    | `biome.json`         |
+| `.md`, `.mdx`, `.mdc`, `.yml`, `.yaml`                          | Prettier | `prettier.config.js` |
 
 ## Formatting Rules
 

--- a/.claude/skills/bt-preflight/SKILL.md
+++ b/.claude/skills/bt-preflight/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: bt-preflight
-description: Run all quality checks (format, lint, typecheck, spellcheck, knip) before committing.
+description:
+  Run all quality checks (format, lint, typecheck, spellcheck, knip, docs:links, test:unit, test:declarations) before
+  committing.
 ---
 
 # Preflight Checks
@@ -28,8 +30,9 @@ Run comprehensive quality checks before committing or pushing code.
   - `typecheck` - Validate TypeScript types
   - `spellcheck` - Check spelling in code and docs
   - `knip` - Find unused exports and dependencies
-  - `docs:links` - Verify Markdown links (README, docs/, skills)
+  - `docs:links` - Verify Markdown links (all repo-root `*.md` / `*.mdx`)
   - `test:unit` - Run all unit tests
+  - `test:declarations` - Declaration tooling log checker tests
 
 2. **Report results**
 

--- a/.claude/skills/bt-quick-format/SKILL.md
+++ b/.claude/skills/bt-quick-format/SKILL.md
@@ -19,8 +19,8 @@ verification steps for maximum speed.
 1. **Run formatters**
 
 - Execute `pnpm run format` which runs:
-  - Biome for TypeScript/JavaScript/JSON/CSS
-  - Prettier for Markdown/YAML
+  - Biome for TypeScript/JavaScript/JSON/JSONC/CSS
+  - Prettier for Markdown/YAML/Cursor rules (`.md`, `.mdx`, `.mdc`, `.yml`, `.yaml`)
 
 2. **Brief confirmation**
 

--- a/.claude/skills/bt-spellcheck/SKILL.md
+++ b/.claude/skills/bt-spellcheck/SKILL.md
@@ -17,7 +17,7 @@ Run the project-wide spellcheck, then fix all reported errors.
 
 1. **Run spellcheck**
 
-- Execute `pnpm run spellcheck` to check all `*.{ts,md,mdx}` files
+- Execute `pnpm run spellcheck` to check `src/**/*.{ts,md,mdx}`, `docs/**/*.{ts,md,mdx}`, and `README.md`
 - Capture the full error output
 
 2. **Analyze each error** For every word flagged by cspell, determine if it is:
@@ -53,5 +53,5 @@ Run the project-wide spellcheck, then fix all reported errors.
 
 ## Notes
 
-- Files checked: `*.{ts,md,mdx}`
+- Files checked: `src/**/*.{ts,md,mdx}`, `docs/**/*.{ts,md,mdx}`, `README.md` (see `package.json` `spellcheck` script)
 - Compound words are allowed (`allowCompoundWords: true`)

--- a/.cursor/hooks/format-and-check.sh
+++ b/.cursor/hooks/format-and-check.sh
@@ -68,7 +68,7 @@ case "$NORMALIZED_TARGET" in
 esac
 
 case "$NORMALIZED_TARGET" in
-*.md | *.mdx | *.yml | *.yaml)
+*.md | *.mdx | *.mdc | *.yml | *.yaml)
     (cd "$REPO_ROOT" && $RUNNER prettier --write "$NORMALIZED_TARGET" >/dev/null 2>&1) || true
     ;;
 esac

--- a/.cursor/rules/bt-api-getters.mdc
+++ b/.cursor/rules/bt-api-getters.mdc
@@ -14,9 +14,9 @@ Zero-argument **read-only** values on `BT`:
 - **Configure-time** (use same names as `HardwareSettings`): `displaySize`, `drawingBufferSize`, `targetFPS`
 - **Derived:** `outputSize` (`drawingBufferSize ?? displaySize`; no `HardwareSettings` field)
 - **Configure-time (backend):** `requestedBackend` mirrors resolved `HardwareSettings.backend` (includes
-  `?backend=software`)
+  `?backend=software`); **`null` before `BT.init()`**
 - **Loop:** `deltaSeconds`, `timeSeconds`, `ticks`
-- **Runtime:** `activeBackend`, `camera`, `palette`
+- **Runtime:** `activeBackend`, `camera`, `palette` — `activeBackend` is **`null` before init or on failure**
 - **Per-frame input:** `pointerScrollDelta`, `inputString`, `gamepadCount`
 
 Good: `BT.displaySize.y`, `BT.targetFPS`, `BT.ticks % 180`
@@ -25,12 +25,22 @@ Bad: `BT.displaySize()`, `BT.fps()`, `BT.getActiveBackend()` (removed; use prope
 
 ## Keep as methods
 
-- Mutations and draws: `cameraSet`, `paletteSet`, `drawSprite`, `effectAdd`, …
+- **Lifecycle / mutations:** `init`, `ticksReset`, `cameraSet`, `cameraReset`, `paletteSet`, `paletteCreate`,
+  `showCursor`, `hideCursor`, `spritesRefresh`, `assignTag`, `inputMap`, `inputMapReset`
+- **Palette effects:** `paletteCycle`, `paletteFade`, `paletteFadeRange`, `paletteFlash`, `paletteSwap`,
+  `paletteClearEffects`
+- **Post-process:** `effectAdd`, `effectRemove`, `effectClear`; preset namespace **`BT.preset`** (`crtPipBoy`, `amber`,
+  `green`)
+- **Drawing / clearing:** `clear`, `clearRect`, `drawPixel`, `drawLine`, `drawRect`, `drawRectFill`, `drawSprite`,
+  `systemPrint`, `printFont` (4th arg is optional **`paletteOffset`**, not `Color32`)
 - Any **parameter**: `pointerPos(0)`, `isDown(BT.BTN_A)`, `cameraClamp(...)`
 - **Boolean queries with parameters** (Tier A; always methods on `BT`): `isPointerActive(0)`, `isDown(...)`,
   `isPressed(...)`, `isReleased(...)`, `isKeyDown(...)`, `isKeyPressed(...)`, `isKeyReleased(...)`
 - **Side-effect booleans** (Tier C): `Timer.fireIfElapsed()` — not `is*` because the call advances state
 - **Async**: `captureFrame`, `downloadFrame`
+
+**Deprecated aliases** still on `BT` (do not use in new code): see `docs/deprecations.md` (`pointerPosValid`,
+`buttonDown`, `keyDown`, …).
 
 ## Boolean naming (three tiers)
 
@@ -58,7 +68,7 @@ Bad: `BT.displaySize()`, `BT.fps()`, `BT.getActiveBackend()` (removed; use prope
 2. Takes args or mutates → **method**
 3. Mirrors configure? → **same field name** as `HardwareSettings` (exception: derived getters like `outputSize` have no
    field)
-4. Update `docs/api-*.md`, `CLAUDE.md`, demos if public
+4. Update `docs/api-*.md`, `CLAUDE.md`, demos if public; overlay behavior also updates `docs/overlay.md`
 
 See `CLAUDE.md` section **BT API: getters vs methods**, **Boolean naming**, **Internal scoped naming**, and
 `docs/api-core.md`.

--- a/.cursor/rules/claude-canonical.mdc
+++ b/.cursor/rules/claude-canonical.mdc
@@ -8,6 +8,8 @@ alwaysApply: true
 - Treat `/Users/vancura/Repos/_BLIT_TECH_/blit-tech/CLAUDE.md` as canonical for implementation in this repo.
 - Follow its API conventions (especially BT getters vs methods), architecture map, command set, internal scoped naming,
   and docs-update rules.
+- Subsystem guides: `docs/overlay.md` (engine HUD), `docs/api-*.md` (public API), `docs/deprecations.md` (aliases).
+- Cursor-specific policy lives in `.cursor/rules/*.mdc` and `.cursor/hooks/`; condensed mirrors in `.claude/rules/`.
 - Do not invent alternate conventions when `CLAUDE.md` provides project-specific direction.
 - Public API or behavior changes must include matching docs updates in `docs/` as described in `CLAUDE.md`.
 - Keep performance-first and strict TypeScript standards from `CLAUDE.md` (no `any`, use type-only imports, integer

--- a/.cursor/rules/docs-sync-required.mdc
+++ b/.cursor/rules/docs-sync-required.mdc
@@ -1,6 +1,6 @@
 ---
 description: Require docs updates for API and behavior changes
-globs: { src/**/*.ts, docs/**/*.md, README.md, CLAUDE.md }
+globs: { src/**/*.ts, docs/**/*.md, README.md, CLAUDE.md, .claude/skills/**/SKILL.md, .cursor/rules/*.mdc }
 alwaysApply: false
 ---
 
@@ -8,7 +8,11 @@ alwaysApply: false
 
 - Documentation is part of the implementation, not a follow-up task.
 - When public API changes, update relevant `docs/api-*.md` and related examples in the same change.
-- When runtime behavior changes, update affected guides under `docs/`.
-- When architecture or subsystem structure changes, update `CLAUDE.md` architecture sections.
+- When runtime behavior changes, update affected guides under `docs/` (including `docs/overlay.md` for overlay subsystem
+  changes).
+- When architecture or subsystem structure changes, update `CLAUDE.md` architecture sections and the **Where to Find
+  Information** table when paths change.
+- When `pnpm run` scripts or preflight steps change, update `.claude/skills/*/SKILL.md` and any affected
+  `.cursor/rules/*.mdc` cross-references.
 - Update `README.md` only when quick start, prerequisites, feature list, or compatibility is affected.
 - If no docs update is needed, state why explicitly in the final response.

--- a/.cursor/rules/rtk-and-pnpm.mdc
+++ b/.cursor/rules/rtk-and-pnpm.mdc
@@ -6,7 +6,10 @@ alwaysApply: true
 # RTK and pnpm
 
 - Package scripts: **`pnpm run <script>`** only (e.g. `pnpm run preflight`). Bare `pnpm preflight` skips RTK rewrite.
+- **`pnpm run preflight`** runs: `format:check`, `lint`, `typecheck`, `spellcheck`, `knip`, `docs:links`, `test:unit`,
+  `test:declarations`.
 - Built-ins without `run`: `pnpm install`, `pnpm audit`, `pnpm exec`, `pnpm add`, `pnpm --filter …`.
-- Cursor: `preToolUse` → `rtk hook cursor` on Shell (see `.cursor/hooks.json`).
+- Cursor: `preToolUse` → `rtk hook cursor` on Shell; `afterFileEdit` → `.cursor/hooks/format-and-check.sh` (see
+  `.cursor/hooks.json`).
 - Prefer shell + RTK (`rtk read`, `rtk grep`, `git`, `pnpm run …`) over native Read/Grep for exploration.
 - Full policy: `~/.claude/RTK.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Before writing new code, reviewing existing code, or preflighting, check here fi
 | How does a subsystem work internally?                      | The relevant `src/core/` or `src/render/` file                                                                                                                                                                               |
 | What does a demo implement?                                | `src/core/IBlitTechDemo.ts` (interface + HardwareSettings)                                                                                                                                                                   |
 | How does palette usage tracking work for the overlay grid? | `src/core/RenderPaletteUsage.ts`, `src/overlay/palette/PaletteView.ts`                                                                                                                                                       |
-| How does the overlay work?                                 | `src/overlay/` (orchestrator + `layout/layoutPlan.ts`), `docs/api-core.md` (Overlay), `HardwareSettings.isOverlayEnabled`                                                                                                    |
+| How does the overlay work?                                 | `docs/overlay.md`, `src/overlay/` (orchestrator + `layout/layoutPlan.ts`), `docs/api-core.md` (HardwareSettings overlay flags), `HardwareSettings.isOverlayEnabled`                                                          |
 | What palette/sprite setup pattern is correct?              | `docs/palette-guide.md`, then `docs/api-assets.md`                                                                                                                                                                           |
 | What are the render/asset dimension limits?                | `src/utils/RenderLimits.ts` (constants), `src/utils/AssetLimits.ts` (asset + glyph limits), `docs/api-assets.md` (asset size limits table), `docs/api-core.md` (HardwareSettings dimension constraints)                      |
 | Which preset has which exact color values?                 | `docs/palette-presets.md`                                                                                                                                                                                                    |
@@ -34,7 +34,7 @@ Before writing new code, reviewing existing code, or preflighting, check here fi
 | Dependency security policy / CI audit gate?                | `docs/security/dependency-policy.md`, `docs/security/audit-exceptions.md`                                                                                                                                                    |
 | What is the benchmark threshold?                           | `ci.yml` benchmark job (`--threshold 25` flag), not docs                                                                                                                                                                     |
 | What error message style should I use?                     | `docs/voice.md`, then `src/utils/errorMessages.ts`                                                                                                                                                                           |
-| Is this API exported publicly?                             | `src/BlitTech.ts` export block (lines 1460-1501)                                                                                                                                                                             |
+| Is this API exported publicly?                             | `src/BlitTech.ts` export block (lines 1563-1610)                                                                                                                                                                             |
 | What test mock do I need for GPU code?                     | `src/__test__/webgpu-mock.ts`                                                                                                                                                                                                |
 | Declaration tooling / TS version alignment?                | `docs/tooling.md`, `docs/developer-experience-guide.md`, `scripts/check-declaration-tooling.mjs`                                                                                                                             |
 | Should this private name repeat the class/file?            | **Internal scoped naming** below; `docs/developer-experience-guide.md` (Naming conventions)                                                                                                                                  |
@@ -45,11 +45,16 @@ Before writing new code, reviewing existing code, or preflighting, check here fi
 
 All engine functionality is accessed through the static `BT` namespace. The architecture is palette-first: primitives,
 sprites, and bitmap text resolve color through the active `Palette` before final RGBA output. Demos implement the
-`IBlitTechDemo` interface (`configure?`, `init`, `update`, `render`).
+`IBlitTechDemo` interface (`configure?`, `init`, `update`, `render`, optional `overlayRows?`).
+
+The file tree below is **illustrative, not exhaustive** — it highlights notable subsystems and entry points. Colocated
+`*.test.ts` / `*.bench.ts` files and small module-local `constants.ts` / `types.ts` helpers are omitted for readability.
 
 ```text
 src/
-  BlitTech.ts              # Public API (BT namespace exports)
+  BlitTech.ts              # Public API (BT namespace + export block for classes, helpers, presets)
+  docs/
+    consumer-doc-imports.test.ts # Guards README/docs import paths against BlitTech.ts exports
   core/
     BTAPI.ts               # Internal singleton managing subsystems (lazy-loads WebGPURenderer on WebGPU init)
     IBlitTechDemo.ts       # Demo interface + HardwareSettings
@@ -61,10 +66,13 @@ src/
     OverlayDrawTarget.ts   # Internal draw port (drawBarFill / drawLabel); not on IRenderer or BT
     OverlayToggleIcon.ts   # Bottom-left bitmap toggle hint icon draw + anchor/exclusion helpers
     toggleIconData.ts      # Inline row-major mask data for the toggle hint icon
-    index.ts               # Barrel exports for BTAPI and unit tests
+    constants.ts           # Overlay layout and style constants
+    labels.ts              # Overlay label strings and formatting helpers
+    types.ts               # OverlayRow and related types
+    index.ts               # Overlay subsystem public exports for BTAPI and unit tests
     layout/                # layoutPlan, layoutHelpers, layout types/constants
     bars/                  # OverlayBars (Bars.ts)
-    timing-chart/          # TimingChart, style, constants
+    timing-chart/          # TimingChart, severity, style, tags, constants
     palette/               # PaletteView, PaletteInteraction (swatch hover tooltip, clipboard copy, scroll)
     sampling/              # FpsSampler, TimingSampler
     input/                 # Toggle
@@ -81,16 +89,20 @@ src/
       Effect.ts            # Effect interface + EffectTier
       FullscreenEffect.ts  # Base class for typical fullscreen effects
       FullscreenPixelEffect.ts # Pixel-tier base (logical r8uint chain)
+      fullscreenVS.ts      # Shared fullscreen vertex shader module
       pixel/               # Pixel-tier effects (PixelGlitch, PixelMosaic)
-      display/             # Display-tier effects (BarrelDistortion, Scanlines, ...)
-      presets/             # Pre-configured stacks (crtPipBoy, amber, green)
+      display/             # Display-tier effects (BarrelDistortion, Bloom, ChromaticAberration, Flicker,
+                             # Interference, Noise, RGBMask, RollLine, Scanlines, Vignette)
+      presets/             # Pre-configured stacks (crtPipBoy, amber, green) + index.ts barrel
   assets/
     AssetLoader.ts         # Image loading with caching
     SpriteSheet.ts         # GPU texture wrapper (+ loadIndexed convenience path)
     BitmapFont.ts          # Bitmap font system (.btfont)
+    SystemFont.ts          # Built-in system font factory (createSystemFont; used by BT.systemPrint)
+    fonts/systemFontData.ts # Glyph bitmap data backing SystemFont
     Palette.ts             # 256-entry indexed color palette
     PaletteEffect.ts       # Palette effect system (cycle, fade, flash, swap)
-    palettes/              # Built-in preset palette data (VGA, CGA, C64, etc.) + HUD UI preset (hudData.ts)
+    palettes/              # Built-in preset palette data (presetData.ts, hudData.ts)
   input/
     PointerInput.ts        # DOM-backed pointer / mouse / touch / pen tracker (4 slots)
     KeyboardInput.ts       # KeyboardEvent.code state, edges, tick repeat, beforeinput text
@@ -101,13 +113,14 @@ src/
     BootstrapHelpers.ts    # Canvas lookup and error display utilities
     CameraUtils.ts         # Camera clamp helper (world/view bounds)
     CanvasLayoutStyles.ts  # Canvas layout CSS custom properties helper
-    RenderLimits.ts        # Render dimension validation and max-size constants (8192px / 16M px)
+    RenderLimits.ts        # Render dimension validation (8192 px per axis; 16,777,216 total pixels)
     AssetLimits.ts         # Asset dimension validation, btfont/glyph limits, sprite-blit clipping
     Vector2i.ts            # Integer 2D vector
     Rect2i.ts              # Integer rectangle
     Color32.ts             # 32-bit RGBA color
     Easing.ts              # Easing functions for palette effects
     FrameCapture.ts        # GPU readback + PNG export
+    Timer.ts               # Elapsed-time helper (exported; Timer.fireIfElapsed)
   __test__/
     webgpu-mock.ts         # WebGPU mock factories for tests
     setup.ts               # Vitest global setup (GPU constants)
@@ -171,25 +184,39 @@ and async work. Do not add new zero-argument `BT.foo()` functions when a getter 
 
 ### Use getters (property access, no `()`)
 
-| Category                                                         | Members                                             | Notes                                                                                                       |
-| ---------------------------------------------------------------- | --------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| **Configure-time** (mirror {@link HardwareSettings} field names) | `displaySize`, `drawingBufferSize`, `targetFPS`     | Clone per read for `Vector2i` getters.                                                                      |
-| **Derived**                                                      | `outputSize`                                        | Effective drawing buffer (`drawingBufferSize ?? displaySize`). No `HardwareSettings` field; clone per read. |
-| **Loop timing**                                                  | `deltaSeconds`, `timeSeconds`, `ticks`              | `targetFPS` is configured rate, not measured FPS.                                                           |
-| **Configure-time (backend)**                                     | `requestedBackend`                                  | Mirrors resolved `HardwareSettings.backend` after merge and `?backend=software`; defaults to `'webgpu'`.    |
-| **Runtime state**                                                | `activeBackend`, `camera`, `palette`                | `activeBackend` is what actually started (after fallback). `palette` is a live reference.                   |
-| **Per-frame input**                                              | `pointerScrollDelta`, `inputString`, `gamepadCount` | Read once per frame when needed.                                                                            |
+| Category                                                         | Members                                             | Notes                                                                                                                       |
+| ---------------------------------------------------------------- | --------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| **Configure-time** (mirror {@link HardwareSettings} field names) | `displaySize`, `drawingBufferSize`, `targetFPS`     | Clone per read for `Vector2i` getters.                                                                                      |
+| **Derived**                                                      | `outputSize`                                        | Effective drawing buffer (`drawingBufferSize ?? displaySize`). No `HardwareSettings` field; clone per read.                 |
+| **Loop timing**                                                  | `deltaSeconds`, `timeSeconds`, `ticks`              | `targetFPS` is configured rate, not measured FPS.                                                                           |
+| **Configure-time (backend)**                                     | `requestedBackend`                                  | Mirrors resolved `HardwareSettings.backend` after merge and `?backend=software`; `null` before init.                        |
+| **Runtime state**                                                | `activeBackend`, `camera`, `palette`                | `activeBackend` is what actually started (after fallback); `null` before init or on failure. `palette` is a live reference. |
+| **Per-frame input**                                              | `pointerScrollDelta`, `inputString`, `gamepadCount` | Read once per frame when needed.                                                                                            |
 
 Examples: `BT.displaySize.y`, `BT.targetFPS`, `BT.ticks % 60`, `if (BT.activeBackend === 'software')`.
 
 ### Use methods (call with `()`)
 
-- **Lifecycle / mutations:** `init`, `ticksReset`, `cameraSet`, `cameraReset`, `paletteSet`, `hideCursor`, all
-  draw/clear/effect APIs.
+- **Lifecycle / mutations:** `init`, `ticksReset`, `cameraSet`, `cameraReset`, `paletteSet`, `paletteCreate`,
+  `showCursor`, `hideCursor`, `spritesRefresh`, `assignTag`, `inputMap`, `inputMapReset`.
+- **Palette effects:** `paletteCycle`, `paletteFade`, `paletteFadeRange`, `paletteFlash`, `paletteSwap`,
+  `paletteClearEffects`.
+- **Post-process:** `effectAdd`, `effectRemove`, `effectClear`; preset namespace `BT.preset` (`crtPipBoy`, `amber`,
+  `green`).
+- **Drawing / clearing:** `clear`, `clearRect`, `drawPixel`, `drawLine`, `drawRect`, `drawRectFill`, `drawSprite`,
+  `systemPrint`, `printFont`.
 - **Parameterized queries:** `pointerPos(index?)`, `pointerDelta`, `isPointerActive`, `isDown`, `isPressed`,
   `isReleased`, `getAxis`, `isGamepadConnected`, `isKeyDown`, `isKeyPressed`, `isKeyReleased`.
 - **Utilities with arguments:** `cameraClamp(camera, worldSize, viewSize?)`, `systemPrintMeasure(text)`.
 - **Async:** `captureFrame`, `downloadFrame`.
+
+**Deprecated aliases still on `BT` (see `docs/deprecations.md`):** `pointerPosValid`, `buttonDown`, `buttonPressed`,
+`buttonReleased`, `gamepadConnected`, `keyDown`, `keyPressed`, `keyReleased`.
+
+**Top-level package exports** (outside the `BT` namespace): `bootstrap`, `defaultConfig`, `mergeHardwareSettings`,
+`applyEasing`, `clampCameraToWorld`, `displayError`, `getCanvas`, `Timer`, effect classes (`BarrelDistortion`, `Bloom`,
+…), preset functions (`crtPipBoy`, `amber`, `green`), core types (`Vector2i`, `Rect2i`, `Color32`, `Palette`, …), and
+`IndexedSpriteLoadResult`.
 
 ### Naming when adding getters
 
@@ -313,7 +340,7 @@ pnpm run format:check       # Check formatting (Biome + Prettier)
 pnpm run typecheck          # TypeScript type checking
 pnpm run spellcheck         # cspell check
 pnpm run knip               # Find unused exports/deps
-pnpm run docs:links         # Check Markdown links (README, docs/, skills)
+pnpm run docs:links         # Check Markdown links (all repo-root *.md / *.mdx)
 pnpm run preflight          # All checks (format + lint + typecheck + spellcheck + knip + docs:links + test:unit + test:declarations)
 ```
 
@@ -360,8 +387,9 @@ Use it when implementing or changing:
 Run `pnpm run test:visual:update` to regenerate baselines after an intentional visual change. Snapshots live in
 `tests/visual/__snapshots__/`.
 
-The suite covers: camera, fonts, mixed (primitives + sprites), post-process (baseline/CRT/CRT+bloom), primitives, and
-sprites.
+The suite covers: camera, fonts, mixed (primitives + sprites), primitives, sprites, and post-process (baseline, CRT,
+CRT+bloom, and individual display/pixel effects such as Vignette, Scanlines, Bloom, PixelGlitch, ChromaticAberration,
+BarrelDistortion, upscale passes, and more).
 
 **WebGPU mocks:** Use `src/__test__/webgpu-mock.ts` for tests needing GPUDevice, GPUTexture, etc. See
 [docs/testing.md](docs/testing.md) for full details.
@@ -370,8 +398,8 @@ sprites.
 
 - **DOM environment directive**: Add `// @vitest-environment happy-dom` at the top of any test file that touches DOM
   APIs. Without it, the test runs in Node and DOM APIs are undefined.
-- **happy-dom Image.onload does not fire for data URIs**: AssetLoader image-loading tests are marked `.todo` for this
-  reason. Do not attempt to unit-test asset loading via data URIs in happy-dom.
+- **AssetLoader image tests**: The suite stubs `Image` with `vi` rather than relying on happy-dom data-URI `onload`
+  behavior (which is unreliable in happy-dom).
 - **Vector2i `-0` vs `0`**: JavaScript can produce `-0` when negating vectors. Use `result.x + 0` to coerce in
   assertions where sign is meaningless.
 
@@ -406,8 +434,9 @@ Claude Code reusable skill:
 - Conventional Commits format: `<type>(<scope>): <description>`
 - All commits require DCO sign-off (`git commit -s`)
 - AI-assisted commits include `Co-Authored-By: Claude <noreply@anthropic.com>` trailer
-- Types: feat, fix, refactor, docs, test, chore, perf, ci
-- Scopes: renderer, camera, assets, api, utils, examples, ci, docs
+- Types: feat, fix, refactor, docs, test, chore, perf, ci, style, build, revert (commitlint-enforced)
+- Scopes: renderer, camera, assets, api, utils, examples, ci, docs (convention only; commitlint does not enforce a scope
+  enum)
 
 ## Working with Claude
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ Before writing new code, reviewing existing code, or preflighting, check here fi
 | Declaration tooling / TS version alignment?                | `docs/tooling.md`, `docs/developer-experience-guide.md`, `scripts/check-declaration-tooling.mjs`                                                                                                                             |
 | Should this private name repeat the class/file?            | **Internal scoped naming** below; `docs/developer-experience-guide.md` (Naming conventions)                                                                                                                                  |
 | Where do I put a new field/method in a `.ts` file?         | **TypeScript file structure** below; `.cursor/rules/ts-file-structure.mdc`; `docs/developer-experience-guide.md` (File structure and member order)                                                                           |
+| Where are Cursor agent rules and hooks?                    | `.cursor/rules/*.mdc` (always-applied + glob-scoped); `.cursor/hooks.json`; condensed mirrors in `.claude/rules/`; see [Developer Experience](docs/developer-experience-guide.md#cursor)                                     |
 | What agent skills are available for this project?          | `.agents/skills/` (Zed) and `.claude/skills/` (Claude Code) — `bt-preflight`, `bt-review`, `bt-pr`, `bt-format`, `bt-perf`, `bt-test`, `bt-release`, `bt-spellcheck`, `bt-security-run`, `bt-deep-review`, `bt-quick-format` |
 
 ## Architecture


### PR DESCRIPTION
Update CLAUDE.md architecture map to reflect new files added since the
last sync: SystemFont, Timer, fullscreenVS, overlay constants/labels/
types, and consumer-doc-imports test guard. Expand the BT API methods
list with grouped categories and add deprecated aliases and top-level
package exports sections. Correct requestedBackend/activeBackend
descriptions (null before init) and update BlitTech.ts export block
line numbers (1563-1610).

Update bt-preflight, bt-deep-review, bt-format, bt-quick-format, and
bt-spellcheck skills to match the full preflight suite (docs:links and
test:declarations now included) and accurate formatter file-type
coverage (adds .jsx, .cjs, .mjs, .jsonc, .mdc).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Documentation Sync and Architecture Updates

This PR comprehensively updates documentation to reflect the current project state, focusing on BT API conventions, skill definitions, and internal architecture references.

### Main Documentation Updates

**CLAUDE.md** was expanded with:
- Enhanced architecture file tree including granular `src/overlay/` and effects/assets/utils module listings
- Updated API conventions section with expanded getter/method categorization
- Revised deprecated-alias and top-level export lists
- New dedicated `pnpm run docs:links` command documentation
- Additional effect coverage notes for visual regression tests
- Expanded Git/commitlint conventions with refined commit types and scope formatting

### BT API Documentation

**bt-api-getters rules** (both `.claude/rules/` and `.cursor/rules/` versions) now explicitly clarify:
- `requestedBackend` and `activeBackend` are `null` before initialization
- `requestedBackend` mirrors resolved backend configuration
- Runtime properties (`activeBackend`, `camera`, `palette`) are active-state values
- Expanded method-only categories (lifecycle mutations, palette/effects, drawing/clearing, parameterized APIs, etc.)
- Added reference to `docs/deprecations.md` for deprecated aliases
- New checklist note requiring overlay documentation updates

### Skill Documentation Updates

All preflight-related skills were aligned to include the full preflight suite:
- **bt-preflight**: Now documents `docs:links`, `test:unit`, and `test:declarations` verification
- **bt-deep-review**: Updated to run broader `pnpm run preflight` with docs and test coverage, expanded checklist
- **bt-format** and **bt-quick-format**: Extended formatter coverage to include `.jsx`, `.cjs`, `.mjs`, `.jsonc`, `.mdc` with explicit Biome/Prettier tool mapping
- **bt-spellcheck**: Refined to document the narrower target set (`src/**`, `docs/**`, `README.md`)

### Cursor Rules Updates

**docs-sync-required.mdc** broadened to apply to additional file types and now requires documentation updates for overlay subsystem changes, CLAUDE.md architecture updates, and skill/rule cross-reference synchronization.

**claude-canonical.mdc** added explicit references to subsystem documentation (`docs/overlay.md`, `docs/api-*.md`, `docs/deprecations.md`) and clarified Cursor policy sourcing.

**rtk-and-pnpm.mdc** updated to require `pnpm run <script>` syntax with explicit documentation of the preflight sequence and expanded hook mapping to include `preToolUse` and `afterFileEdit` specifications.

### Build and Hook Updates

**format-and-check.sh** extended Prettier coverage to include `*.mdc` files alongside existing Markdown and YAML patterns.

All changes are documentation-only with no alterations to exported or public code entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->