### PR TITLE
docs: add overlay guide and correct accuracy across all docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,9 @@ Signed-off-by: Your Name <your.email@example.com>
 - `build` - Build system or dependencies
 - `ci` - CI configuration
 - `chore` - Other changes
+- `revert` - Revert a previous commit
+
+Suggested scopes are **conventions only** — commitlint does not enforce a scope enum.
 
 ### Suggested Scopes
 
@@ -147,12 +150,14 @@ pnpm run preflight
 
 This runs:
 
-- Code formatting checks
+- Code formatting checks (`format:check`)
 - Linting
 - TypeScript type checks
 - Spell checking
 - Unused export and dependency checks (knip)
-- Unit tests
+- Markdown link check (`docs:links`)
+- Unit tests (`test:unit`)
+- Declaration tooling tests (`test:declarations`)
 
 ### Available Commands
 
@@ -165,6 +170,11 @@ pnpm run format:check     # Check formatting
 pnpm run typecheck        # Run TypeScript checks
 pnpm run spellcheck       # Check spelling
 pnpm run knip             # Find unused exports and dependencies
+pnpm run docs:links       # Check Markdown links
+pnpm run test:unit        # Run unit tests
+pnpm run test:declarations # Declaration tooling checker tests
+pnpm run test:visual      # Playwright visual regression (local; not in preflight)
+pnpm run bench            # CPU benchmarks (Vitest bench)
 pnpm run preflight        # Run all quality checks
 ```
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ See [API: Core](docs/api-core.md) for `bootstrap()` options.
 | Guide                                                | What it covers                                         |
 | ---------------------------------------------------- | ------------------------------------------------------ |
 | [API: Core](docs/api-core.md)                        | bootstrap, game loop, camera, Timer, core types        |
+| [Overlay Guide](docs/overlay.md)                     | engine HUD subsystem, toggle, custom rows, layout      |
 | [API: Rendering](docs/api-rendering.md)              | primitives, sprites, text, post-process, frame capture |
 | [API: Palette](docs/api-palette.md)                  | palette setup, presets, effects, serialization         |
 | [API: Assets](docs/api-assets.md)                    | sprite sheets, bitmap fonts, asset loading             |

--- a/docs/api-assets.md
+++ b/docs/api-assets.md
@@ -38,6 +38,9 @@ soon as the browser reports decoded dimensions.
 ```ts
 import { AssetLoader } from 'blit-tech';
 
+// Load a single image (cached by URL)
+const image = await AssetLoader.loadImage('sprites.png');
+
 // Load multiple images in parallel
 const images = await AssetLoader.loadImages(['sprites.png', 'tiles.png']);
 
@@ -121,18 +124,26 @@ BT.drawSprite(sheet, srcRect, pos, 16); // render in "blue team" color range
 
 ## Bitmap Fonts
 
-Load `.btfont` files for proportional, palette-indexed bitmap fonts.
+Load `.btfont` files for proportional, palette-indexed bitmap fonts. After loading, register colors in the palette and
+indexize the font's internal sprite sheet before drawing (same pattern as manual sprite setup).
 
 ```ts
-import { BitmapFont } from 'blit-tech';
+import { BitmapFont, Palette } from 'blit-tech';
 
+const palette = new Palette(256);
 const font = await BitmapFont.load('fonts/MyFont.btfont');
+font.getSpriteSheet().indexize(palette);
+BT.paletteSet(palette);
+
 BT.printFont(font, new Vector2i(10, 10), 'Hello!');
-BT.printFont(font, new Vector2i(10, 10), 'Hello!', paletteOffset); // tinted variant
+BT.printFont(font, new Vector2i(10, 10), 'Hello!', paletteOffset); // per-draw index shift
 ```
 
-The font's internal sprite sheet is indexized automatically when loaded. Font rendering goes through the same sprite
-pipeline as `BT.drawSprite()` and is auto-batched.
+Font rendering goes through the same sprite pipeline as `BT.drawSprite()` and is auto-batched.
+
+**SpriteSheet helpers** (after indexize): `isIndexed()`, `getIndexedPixels()` (defensive copy for software renderer),
+`reindexize(palette)` when palette layout changes. `SpriteSheet.loadIndexed()` returns `IndexedSpriteLoadResult`
+(`{ sheet, srcRect, colors }`).
 
 See [Bitmap Fonts Guide](bitmap-fonts.md) for the `.btfont` format specification and the BMFont conversion workflow
 (`pnpm run convert-font`).
@@ -148,10 +159,11 @@ BT.systemPrint(new Vector2i(10, 10), paletteIndex, 'Score: 100');
 BT.systemPrintMeasure('Score: 100'); // → Vector2i (pixel width, height)
 ```
 
-Use `BT.systemPrint()` for demo-specific HUD panels and labels. The engine draws a default overlay (present FPS, target
-FPS, draw calls, frame/update()/render() timings, backend, resolution, demo title) after each `render()` when
-`isOverlayEnabled` is true; see [API: Core - Overlay](api-core.md#overlay). For styled variable-width text, use a bitmap
-font instead.
+Use `BT.systemPrint()` for demo-specific HUD panels and labels. Call `palette.applyHUD()` at init so overlay and demo
+HUD share the same label/header/dim slot conventions — see [API: Palette](api-palette.md) and
+[Palette Presets — HUD](palette-presets.md#hud-preset-paletteapplyhud). The engine draws its own overlay (present FPS,
+target FPS, draw calls, frame/update()/render() timings, backend, resolution, demo title) after each `render()` when
+`isOverlayEnabled` is true; see [Overlay Guide](overlay.md). For styled variable-width text, use a bitmap font instead.
 
 ---
 

--- a/docs/api-core.md
+++ b/docs/api-core.md
@@ -44,6 +44,9 @@ const canvas = getCanvas('my-canvas'); // returns null on missing element
 displayError('Init Failed', 'WebGPU unavailable.', 'my-container');
 ```
 
+`bootstrap()` applies canvas layout CSS custom properties via `CanvasLayoutStyles` (logical size, CSS cap, pixelated
+scaling). Custom hosts can reuse the same helper when not using `bootstrap()`.
+
 ---
 
 ## Initialization
@@ -430,6 +433,41 @@ BT.cameraReset(); // set back to (0, 0)
 const clamped = BT.cameraClamp(desired, worldSize);
 // Optional third argument overrides the viewport size (default: BT.displaySize):
 const clamped = BT.cameraClamp(desired, worldSize, new Vector2i(160, 120));
+```
+
+Standalone helper (same math as `BT.cameraClamp`):
+
+```ts
+import { clampCameraToWorld } from 'blit-tech';
+
+const clamped = clampCameraToWorld(desired, worldSize, viewSize);
+```
+
+---
+
+## Default configuration
+
+Import `defaultConfig` and `mergeHardwareSettings` when building custom configure flows outside `bootstrap()`:
+
+```ts
+import { defaultConfig, mergeHardwareSettings } from 'blit-tech';
+
+const settings = mergeHardwareSettings(defaultConfig(), { targetFPS: 30 });
+```
+
+`defaultConfig()` returns a full `HardwareSettings` object (`320×240` logical, `640×480` drawing buffer, overlay
+enabled, WebGPU backend, and other defaults documented in the table above).
+
+---
+
+## Easing helper
+
+Palette fade effects accept an `EasingFunction`. Use `applyEasing` to evaluate named curves:
+
+```ts
+import { applyEasing } from 'blit-tech';
+
+const t = applyEasing('ease-in-out', 0.5); // 0..1 progress → eased value
 ```
 
 ---

--- a/docs/api-palette.md
+++ b/docs/api-palette.md
@@ -145,6 +145,8 @@ const restored = Palette.fromJSON(json);
 
 // Raw byte arrays (RGB triplets, no alpha channel)
 const bytes = palette.toUint8Array(); // Uint8Array, 3 bytes per slot
+const floats = palette.toFloat32Array(); // Float32Array, 4 floats per slot (RGBA 0..1)
+palette.toFloat32ArrayInto(out); // zero-allocation variant into existing buffer
 const p = Palette.fromUint8Array(bytes); // auto-detect size
 const p = Palette.fromUint8Array(bytes, 16); // explicit size
 
@@ -160,8 +162,9 @@ const slot = palette.findColor(color); // → index, or -1 if not found
 ## Palette Effects
 
 Animated effects run automatically each frame in the engine's end-of-frame pass (after `demo.render()`, before the GPU
-upload). Multiple effects can run simultaneously on different palette ranges and will not conflict. Effects process via
-the `isDirty` flag - no polling needed.
+upload). Multiple effects can run simultaneously on different palette ranges and will not conflict. The public
+`Palette.isDirty` getter reflects whether slots changed since the last GPU upload — effects set this flag; no polling
+needed.
 
 ```ts
 // Cycle a range of slots (water, fire, plasma)

--- a/docs/api-rendering.md
+++ b/docs/api-rendering.md
@@ -137,6 +137,10 @@ BT.effectClear(); // remove all from both chains
 for (const fx of BT.preset.crtPipBoy()) BT.effectAdd(fx);
 for (const fx of BT.preset.amber()) BT.effectAdd(fx);
 for (const fx of BT.preset.green()) BT.effectAdd(fx);
+
+// Equivalent standalone imports also work:
+import { crtPipBoy, amber, green } from 'blit-tech';
+for (const fx of crtPipBoy()) BT.effectAdd(fx);
 ```
 
 **Built-in effects:**
@@ -168,20 +172,10 @@ await BT.downloadFrame();
 await BT.downloadFrame('screenshot-001.png'); // custom filename
 ```
 
-### Internal `FrameCapture` flow reference
+### Internal implementation note
 
-`BT.captureFrame()` uses `FrameCapture` internally. The capture lifecycle is:
-
-1. `FrameCapture.request()` - queue one capture
-2. `FrameCapture.executeInEncoder(device, texture, commandEncoder)` - record GPU copy in the frame encoder
-3. `FrameCapture.resolve(device)` - wait for submit completion, map readback, encode PNG
-
-Reference methods:
-
-- `FrameCapture.hasPending()`
-- `FrameCapture.request()`
-- `FrameCapture.executeInEncoder(device, texture, commandEncoder)`
-- `FrameCapture.resolve(device)`
+`BT.captureFrame()` uses the internal `FrameCapture` class (`src/utils/FrameCapture.ts`), which is **not** exported from
+`'blit-tech'`. Demos should use `BT.captureFrame()` and `BT.downloadFrame()` only.
 
 ---
 

--- a/docs/bitmap-fonts.md
+++ b/docs/bitmap-fonts.md
@@ -36,16 +36,21 @@ For proportional fonts, Unicode support, or custom aesthetics, load a `.btfont` 
 ## Quick Start
 
 ```ts
-import { BitmapFont, BT, Color32, Vector2i } from 'blit-tech';
+import { BitmapFont, BT, Palette, Vector2i } from 'blit-tech';
 
-// Load a font
+// Load a font and register its colors in the palette
+const palette = new Palette(256);
 const font = await BitmapFont.load('fonts/MyFont.btfont');
+font.getSpriteSheet().indexize(palette); // required before draw
+BT.paletteSet(palette);
 
-// Render text
-BT.printFont(font, new Vector2i(10, 10), 'Hello World!', Color32.white);
+// Render text (optional 4th arg is paletteOffset, not a Color32)
+BT.printFont(font, new Vector2i(10, 10), 'Hello World!');
+BT.printFont(font, new Vector2i(10, 30), 'Team B', 16); // shift glyph indices by 16
 
 // Measure text width
 const width = font.measureText('Hello');
+const size = font.measureTextSize('Hello'); // { width, height } (TextSize)
 
 // Access font properties
 console.log(font.name); // "MyFont"
@@ -243,7 +248,8 @@ If you prefer to convert manually:
 
 3. **Export with padding** between characters to prevent bleeding artifacts.
 
-4. **Use white glyphs** on a transparent background - colors are applied at render time via tinting.
+4. **Use white glyphs** on a transparent background — palette slots are assigned at indexize time; recolor at draw time
+   via `paletteOffset` on `BT.printFont()`, not RGBA tinting.
 
 5. **Include common symbols** beyond ASCII: `×`, `÷`, `·`, `-`, `…`, etc.
 
@@ -267,19 +273,22 @@ class BitmapFont {
   getGlyph(char: string): Glyph | null;
   measureText(text: string): number;
   measureTextSize(text: string): { width: number; height: number };
+  measureTextSizeInto(text: string, out: { width: number; height: number }): void;
   hasGlyph(char: string): boolean;
   getSpriteSheet(): SpriteSheet;
 }
 ```
 
+Exported type `TextSize` is `{ width: number; height: number }`.
+
 ### BT.printFont()
 
 ```ts
 BT.printFont(
-  font: BitmapFont,    // The loaded font
-  pos: Vector2i,       // Position (top-left corner)
-  text: string,        // Text to render
-  color?: Color32      // Tint color (default: white)
+  font: BitmapFont,       // The loaded font (sprite sheet must be indexized)
+  pos: Vector2i,          // Position (top-left corner)
+  text: string,           // Text to render
+  paletteOffset?: number // Per-draw index shift (default 0); not a Color32
 ): void;
 ```
 
@@ -292,7 +301,7 @@ const lines = ['Line 1', 'Line 2', 'Line 3'];
 let y = 10;
 
 for (const line of lines) {
-  BT.printFont(font, new Vector2i(10, y), line, Color32.white);
+  BT.printFont(font, new Vector2i(10, y), line);
   y += font.lineHeight;
 }
 ```
@@ -305,19 +314,18 @@ const textWidth = font.measureText(text);
 const screenWidth = BT.displaySize.x;
 const x = Math.floor((screenWidth - textWidth) / 2);
 
-BT.printFont(font, new Vector2i(x, 10), text, Color32.white);
+BT.printFont(font, new Vector2i(x, 10), text);
 ```
 
-### Rainbow Text Effect
+### Per-character palette offsets
 
 ```ts
 let x = 10;
 for (let i = 0; i < text.length; i++) {
-  const hue = (i * 30 + animTime * 100) % 360;
-  const color = hslToRgb(hue, 100, 60);
   const char = text[i];
+  const offset = i % 2 === 0 ? 0 : 16; // alternate palette ranges
 
-  BT.printFont(font, new Vector2i(x, 10), char, color);
+  BT.printFont(font, new Vector2i(x, 10), char, offset);
 
   const glyph = font.getGlyph(char);
   x += glyph ? glyph.advance : font.size;

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -54,3 +54,6 @@ These aliases were introduced to preserve backward compatibility after the API n
 
 - Search for `@deprecated Deprecated since 2026-05-31` in `src/`.
 - Remove aliases only after confirming downstream demos/apps have migrated.
+
+**Scope:** This tracker lists **public** compatibility aliases only. Internal deprecated helpers (overlay layout
+functions, `RenderPaletteUsage` re-exports, etc.) are omitted — search `@deprecated` in `src/` for the full set.

--- a/docs/developer-experience-guide.md
+++ b/docs/developer-experience-guide.md
@@ -23,40 +23,42 @@ See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow. Key
 These commands apply when building or maintaining **blit-tech** from a repository checkout (not when consuming the npm
 package).
 
-| Command                            | Description                                                                          |
-| ---------------------------------- | ------------------------------------------------------------------------------------ |
-| `pnpm run build`                   | Build the library for npm distribution                                               |
-| `pnpm run lint`                    | Run ESLint                                                                           |
-| `pnpm run lint:fix`                | Run ESLint with auto-fix                                                             |
-| `pnpm run format`                  | Format all code (Biome + Prettier)                                                   |
-| `pnpm run format:check`            | Check all formatting without changes                                                 |
-| `pnpm run format:biome`            | Format TS/JS/JSON/CSS only (Biome)                                                   |
-| `pnpm run format:prettier`         | Format Markdown/YAML/HTML/HBS (Prettier)                                             |
-| `pnpm run typecheck`               | Run TypeScript type checking                                                         |
-| `pnpm run spellcheck`              | Check spelling in source files                                                       |
-| `pnpm run test`                    | Run all unit tests (alias for `test:unit`)                                           |
-| `pnpm run test:unit`               | Run all unit tests                                                                   |
-| `pnpm run test:unit:watch`         | Run unit tests in watch mode                                                         |
-| `pnpm run test:unit:coverage`      | Run unit tests with coverage report (80% threshold)                                  |
-| `pnpm run test:visual`             | Playwright visual regression tests (requires Chrome with WebGPU)                     |
-| `pnpm run test:visual:update`      | Update visual test baseline screenshots                                              |
-| `pnpm run test:visual:coverage`    | Run visual tests with Istanbul coverage report                                       |
-| `pnpm run bench`                   | Run Tier 1 CPU benchmarks (Vitest bench)                                             |
-| `pnpm run bench:json`              | Run Tier 1 benchmarks and write `benchmark-results.json`                             |
-| `pnpm run preflight`               | Run all quality checks (format, lint, typecheck, spellcheck, knip, docs:links, test) |
-| `pnpm run docs:links`              | Check Markdown links in README, docs/, and `.claude/` skills                         |
-| `pnpm run knip`                    | Find unused exports and dependencies                                                 |
-| `pnpm run knip:fix`                | Auto-fix unused exports and dependencies                                             |
-| `pnpm run clean`                   | Remove dist and cache directories                                                    |
-| `pnpm run release`                 | Build library and publish to npm                                                     |
-| `pnpm run convert-font`            | Convert BMFont to .btfont format                                                     |
-| `pnpm run system-font:export`      | Export system font data to PNG atlas (`assets/system-font.png`)                      |
-| `pnpm run system-font:convert`     | Regenerate `systemFontData.ts` from edited PNG atlas                                 |
-| `pnpm run security:audit`          | Run dependency security audit (all deps, moderate+; matches CI)                      |
-| `pnpm run security:audit:prod`     | Run production-only dependency audit (moderate+)                                     |
-| `pnpm run security:audit:fix`      | Run dependency security audit and auto-fix                                           |
-| `pnpm run security:mcp-preflight`  | MCP health/auth preflight and governance scan (requires `-- --mcps-dir`)             |
-| `pnpm run test:security-preflight` | Unit tests for MCP preflight script                                                  |
+| Command                             | Description                                                                                     |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `pnpm run build`                    | Build the library for npm distribution                                                          |
+| `pnpm run lint`                     | Run ESLint                                                                                      |
+| `pnpm run lint:fix`                 | Run ESLint with auto-fix                                                                        |
+| `pnpm run format`                   | Format all code (Biome + Prettier)                                                              |
+| `pnpm run format:check`             | Check all formatting without changes                                                            |
+| `pnpm run format:biome`             | Format TS/JS/JSON/CSS only (Biome)                                                              |
+| `pnpm run format:prettier`          | Format Markdown/YAML/HTML/HBS (Prettier)                                                        |
+| `pnpm run typecheck`                | Run TypeScript type checking                                                                    |
+| `pnpm run spellcheck`               | Check spelling in source files                                                                  |
+| `pnpm run test`                     | Run all unit tests (alias for `test:unit`)                                                      |
+| `pnpm run test:unit`                | Run all unit tests                                                                              |
+| `pnpm run test:unit:watch`          | Run unit tests in watch mode                                                                    |
+| `pnpm run test:unit:coverage`       | Run unit tests with coverage report (80% threshold)                                             |
+| `pnpm run test:declarations`        | Declaration tooling log checker (Node test)                                                     |
+| `pnpm run build:check-declarations` | Build and run declaration tooling check on build log                                            |
+| `pnpm run test:visual`              | Playwright visual regression tests (requires Chrome with WebGPU)                                |
+| `pnpm run test:visual:update`       | Update visual test baseline screenshots                                                         |
+| `pnpm run test:visual:coverage`     | Run visual tests with Istanbul coverage report                                                  |
+| `pnpm run bench`                    | Run CPU benchmarks — Tier 4 (Vitest bench; see [Testing](testing.md))                           |
+| `pnpm run bench:json`               | Run Tier 4 benchmarks and write `benchmark-results.json`                                        |
+| `pnpm run preflight`                | All checks: format, lint, typecheck, spellcheck, knip, docs:links, test:unit, test:declarations |
+| `pnpm run docs:links`               | Check Markdown links in all repo-root `*.md` / `*.mdx` files                                    |
+| `pnpm run knip`                     | Find unused exports and dependencies                                                            |
+| `pnpm run knip:fix`                 | Auto-fix unused exports and dependencies                                                        |
+| `pnpm run clean`                    | Remove dist and cache directories                                                               |
+| `pnpm run release`                  | Build library and publish to npm                                                                |
+| `pnpm run convert-font`             | Convert BMFont to .btfont format                                                                |
+| `pnpm run system-font:export`       | Export system font data to PNG atlas (`assets/system-font.png`)                                 |
+| `pnpm run system-font:convert`      | Regenerate `systemFontData.ts` from edited PNG atlas                                            |
+| `pnpm run security:audit`           | Run dependency security audit (all deps, moderate+; matches CI)                                 |
+| `pnpm run security:audit:prod`      | Run production-only dependency audit (moderate+)                                                |
+| `pnpm run security:audit:fix`       | Run dependency security audit and auto-fix                                                      |
+| `pnpm run security:mcp-preflight`   | MCP health/auth preflight and governance scan (requires `-- --mcps-dir`)                        |
+| `pnpm run test:security-preflight`  | Unit tests for MCP preflight script                                                             |
 
 Dependency audit severity policy and CI gate: [dependency-policy.md](security/dependency-policy.md). Temporary
 exceptions: [audit-exceptions.md](security/audit-exceptions.md).
@@ -68,6 +70,7 @@ exceptions: [audit-exceptions.md](security/audit-exceptions.md).
 | Guide                                                       | What it covers                                         |
 | ----------------------------------------------------------- | ------------------------------------------------------ |
 | [API: Core](api-core.md)                                    | bootstrap, init, game loop, camera, Timer, core types  |
+| [Overlay Guide](overlay.md)                                 | engine HUD subsystem, toggle, custom rows, layout      |
 | [API: Rendering](api-rendering.md)                          | primitives, sprites, text, post-process, frame capture |
 | [API: Palette](api-palette.md)                              | palette setup, presets, effects, serialization         |
 | [Palette Guide](palette-guide.md)                           | palette-first workflow, offsets, effects, performance  |
@@ -105,8 +108,11 @@ Format: `<type>(<scope>): <description>`
 | `chore`    | Build, config, tooling                      |
 | `perf`     | Performance improvement                     |
 | `ci`       | CI / workflow changes                       |
+| `style`    | Formatting, no code change                  |
+| `build`    | Build system or external dependencies       |
+| `revert`   | Revert a previous commit                    |
 
-**Scopes:** `renderer`, `camera`, `assets`, `api`, `utils`, `examples`, `ci`, `docs`
+**Scopes:** `renderer`, `camera`, `assets`, `api`, `utils`, `examples`, `ci`, `docs` (convention only; not enforced)
 
 AI-assisted commits add a trailer: `Co-Authored-By: Claude <noreply@anthropic.com>`
 
@@ -118,7 +124,7 @@ AI-assisted commits add a trailer: `Co-Authored-By: Claude <noreply@anthropic.co
 
 - 4-space indent, 120-character line width
 - Single quotes, always semicolons, always trailing commas
-- Biome formats TypeScript/JavaScript; Prettier formats Markdown/YAML
+- Biome formats TypeScript/JavaScript; Prettier formats Markdown/YAML/**`.mdc`** Cursor rules
 - Run `pnpm run format` to auto-format; `pnpm run format:check` to verify
 
 **Linting:**
@@ -215,6 +221,24 @@ automatically in VS Code.
 }
 ```
 
+### Cursor
+
+Cursor reads agent policy from this repo's `.cursor/` directory (VS Code/Cursor share the same workspace settings in
+`.vscode/`).
+
+| Path                                | Purpose                                                                                                                       |
+| ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `.cursor/rules/*.mdc`               | Agent rules — `alwaysApply: true` for global policy; glob-scoped rules (for example `ts-file-structure.mdc` on `src/**/*.ts`) |
+| `.cursor/hooks.json`                | Hooks: `preToolUse` → RTK shell rewrite; `afterFileEdit` → format + spellcheck; `beforeShellExecution` → git safety           |
+| `.cursor/hooks/format-and-check.sh` | Post-edit Biome (TS/JS/JSON/CSS) + Prettier (MD/MDX/MDC/YAML) + cspell on touched files                                       |
+| `.cursor/hooks/shell-safety.sh`     | Blocks destructive git commands; asks before force-push                                                                       |
+| `.claude/rules/*.md`                | Condensed mirrors of key `.cursor/rules` topics for Claude Code                                                               |
+| `.claude/skills/*/SKILL.md`         | Reusable command workflows (`bt-preflight`, `bt-format`, …); Zed symlinks under `.agents/skills/`                             |
+
+When changing `package.json` scripts or preflight steps, update matching `.claude/skills/*/SKILL.md` files and any
+`.cursor/rules/*.mdc` that reference those commands. Pair `.cursor/rules/*.mdc` edits with `.claude/rules/*.md`
+summaries when the topic has a mirror (API getters, internal naming, file structure).
+
 ---
 
 ## Dependency Management
@@ -251,7 +275,7 @@ matches `package.json`. Locally: `pnpm run build` then `node scripts/check-decla
 
 ### Weekly
 
-- [ ] Review and merge Dependabot/Renovate PRs
+- [ ] Review and merge Renovate PRs
 - [ ] Check open issues and respond
 - [ ] Review open PRs
 - [ ] Update the project board (if using)

--- a/docs/input.md
+++ b/docs/input.md
@@ -18,7 +18,7 @@ The engine tracks up to four simultaneous pointers:
 | 2    | Second touch / pen contact                   |
 | 3    | Third touch / pen contact                    |
 
-Overflow contacts beyond slot 3 are dropped silently. The engine tracks **four** pointer slots (indices `0`–`3`).
+The engine tracks **four** pointer slots (indices `0`–`3`). Overflow contacts beyond slot 3 are dropped silently.
 
 ### Mouse slot (slot 0)
 
@@ -75,10 +75,9 @@ BT.isPressed(BT.BTN_POINTER_A); // left button just pressed
 BT.isReleased(BT.BTN_POINTER_A); // left button just released
 BT.isPressed(BT.BTN_POINTER_A, 2); // touch slot 2 just touched down
 
-// Composite masks (ANY-match semantics, same as multi-button masks)
+// Composite pointer mask (ANY-match semantics)
 BT.isDown(BT.BTN_POINTER_ANY); // any pointer button on slot 0
-BT.isDown(BT.BTN_ABXY, 0); // face buttons A/B/X/Y for player 0
-BT.isDown(BT.BTN_SHOULDER, 1); // L/R shoulder for player 1
+BT.isDown(BT.BTN_POINTER_A | BT.BTN_POINTER_B); // left or right mouse button held
 ```
 
 ### Mouse button mapping
@@ -137,6 +136,10 @@ BT.isPressed(BT.BTN_A, 0, 6); // edge + repeat every 6 ticks while held
 
 // Player 1 (default: arrow keys + alternate bindings)
 BT.isDown(BT.BTN_LEFT, 1);
+
+// Composite face-button masks (ANY-match semantics)
+BT.isDown(BT.BTN_ABXY, 0); // A, B, X, or Y for player 0
+BT.isDown(BT.BTN_SHOULDER, 1); // L or R shoulder for player 1
 ```
 
 Built-in defaults are exposed as read-only tables (same values the engine starts with):
@@ -187,7 +190,11 @@ Player constants:
 - `PLAYER_THREE` (`2`)
 - `PLAYER_FOUR` (`3`)
 
-Default dead zone for analog sticks is **`0.75`** (internal default in `GamepadInput`; not a public export).
+Default stick dead zone is **`0.75`** (`GamepadInput.DEFAULT_GAMEPAD_DEAD_ZONE` internally; not a public export).
+Filtering is **per axis**, not radial: each stick axis is zeroed when `Math.abs(axis) <= deadZone`, then the remaining
+range is re-normalized with `(abs - deadZone) / (1 - deadZone)`. At the default `0.75`, a stick axis must exceed ~75%
+deflection before movement registers — much larger than typical `0.1`–`0.2` dead zones. There is no public `BT` API to
+change this value today.
 
 ### Text input buffer
 

--- a/docs/input.md
+++ b/docs/input.md
@@ -18,8 +18,7 @@ The engine tracks up to four simultaneous pointers:
 | 2    | Second touch / pen contact                   |
 | 3    | Third touch / pen contact                    |
 
-Overflow contacts beyond slot 3 are dropped silently. The constant `POINTER_SLOT_COUNT` (exported from the library)
-equals `4`.
+Overflow contacts beyond slot 3 are dropped silently. The engine tracks **four** pointer slots (indices `0`–`3`).
 
 ### Mouse slot (slot 0)
 
@@ -75,6 +74,11 @@ BT.isDown(BT.BTN_POINTER_A, 1); // touch slot 1 in contact
 BT.isPressed(BT.BTN_POINTER_A); // left button just pressed
 BT.isReleased(BT.BTN_POINTER_A); // left button just released
 BT.isPressed(BT.BTN_POINTER_A, 2); // touch slot 2 just touched down
+
+// Composite masks (ANY-match semantics, same as multi-button masks)
+BT.isDown(BT.BTN_POINTER_ANY); // any pointer button on slot 0
+BT.isDown(BT.BTN_ABXY, 0); // face buttons A/B/X/Y for player 0
+BT.isDown(BT.BTN_SHOULDER, 1); // L/R shoulder for player 1
 ```
 
 ### Mouse button mapping
@@ -183,7 +187,7 @@ Player constants:
 - `PLAYER_THREE` (`2`)
 - `PLAYER_FOUR` (`3`)
 
-Default dead zone for analog sticks is `0.75` (`GamepadInput.DEFAULT_GAMEPAD_DEAD_ZONE`).
+Default dead zone for analog sticks is **`0.75`** (internal default in `GamepadInput`; not a public export).
 
 ### Text input buffer
 
@@ -264,7 +268,8 @@ Coordinates are clamped to `[0, displaySize - 1]` on each axis. The conversion i
   methods.
 - Default keyboard tables live in `defaultKeyboardMap.ts`; runtime remaps are stored in the `BT` facade and reset with
   `BT.inputMapReset()`.
-- The `POINTER_SLOT_COUNT` constant (value `4`) is exported for demos that iterate over slots.
+- Pointer slot count is **4** (indices `0`–`3`); iterate with a literal loop or constant in demo code — there is no
+  public `POINTER_SLOT_COUNT` export.
 - `PointerInput`, `KeyboardInput`, and `GamepadInput` are created and attached inside `BTAPI.init()`, so they are ready
   before `demo.init()` runs.
 - `stop()` calls `detach()` on all three input subsystems and clears references to prevent listener leaks.

--- a/docs/overlay.md
+++ b/docs/overlay.md
@@ -1,0 +1,121 @@
+# Engine Overlay
+
+The engine overlay is a screen-space HUD drawn **after** each demo `render()` when `HardwareSettings.isOverlayEnabled`
+is `true` (default). It shows present FPS, target FPS, draw calls, frame timings, active backend, resolution, and demo
+title. Demos should not duplicate this text.
+
+Configure-time flags, style objects, and worked examples live in [API: Core — Overlay](api-core.md#overlay). This guide
+maps the **internal subsystem** and common integration patterns.
+
+---
+
+## Subsystem layout
+
+```text
+src/overlay/
+  Overlay.ts              # Orchestrator: sample, toggle, layout plan, delegate draws
+  layout/layoutPlan.ts    # Computes Y positions for bars, chart, palette grid, custom rows
+  bars/Bars.ts            # Filled bar bands + label text (OverlayBars)
+  timing-chart/           # Scrolling update/render timing dots + severity/tags
+  palette/                # Live swatch grid, hover tooltip, clipboard copy, scroll
+  sampling/               # FpsSampler, TimingSampler
+  input/Toggle.ts         # Backquote + bottom-left corner toggle
+  OverlayToggleIcon.ts    # Bitmap hint icon when body is hidden
+```
+
+Palette index usage for the swatch grid is tracked in `src/core/RenderPaletteUsage.ts` (only when the overlay body is
+visible and `isOverlayPaletteEnabled` is true).
+
+---
+
+## Visibility model
+
+| State                     | What draws                                                                                      |
+| ------------------------- | ----------------------------------------------------------------------------------------------- |
+| Body **hidden** (default) | Optional bottom-left **toggle hint icon** when `isOverlayToggleHintVisible`                     |
+| Body **visible**          | Title, metrics, optional timing chart, optional palette grid, optional custom rows, footer hint |
+
+Toggle the body at runtime:
+
+- **Backquote** (`~`) when `isOverlayToggleEnabled` is true
+- Primary pointer press in the **bottom-left 48×48 px** corner
+
+Set `isOverlayVisibleAtStart: true` to show the body on the first frame. Set `isOverlayEnabled: false` to disable the
+subsystem entirely (for example release builds or full-screen custom HUD demos).
+
+---
+
+## Custom rows (`overlayRows`)
+
+Demos may implement optional `overlayRows()` on `IBlitTechDemo`. The engine calls it once per frame after `render()`
+when the overlay body is visible. Return a **reused** array of row objects when possible — avoid allocating new strings
+every frame.
+
+```javascript
+class Demo {
+  #overlayRows = [{ leftText: 'Score: 0' }];
+
+  overlayRows() {
+    this.#overlayRows[0].leftText = `Score: ${this.score}`;
+    return this.#overlayRows;
+  }
+}
+```
+
+Each `OverlayRow` supports `leftText`, optional `rightText`, and optional per-row `barPaletteIndex` /
+`textPaletteIndex`. Rows stack upward from the footer with **1 px** gaps.
+
+---
+
+## Optional bands
+
+| Feature             | Configure flag                           | Notes                                                                     |
+| ------------------- | ---------------------------------------- | ------------------------------------------------------------------------- |
+| Timing chart        | `isOverlayTimingChartEnabled`            | Scrolling dots for update/render ms; `BT.assignTag('label')` marks events |
+| Palette grid        | `isOverlayPaletteEnabled`                | Live swatch grid; wheel scroll when rows exceed visible cap               |
+| GPU diagnostics row | `isOverlayRendererDiagnosticsBarEnabled` | Text row below frame metrics                                              |
+| Chart GPU markers   | `overlayTimingChartDiagnostics`          | `'minimal'` (default when chart on), `'rich'`, or `false`                 |
+
+Reserve vertical space in demo layouts: ~**42 px** top, ~**14 px** per custom row, timing chart height (default **22
+px**), palette grid height when enabled, and ~**13 px** footer hint bar. See [API: Core — Overlay](api-core.md#overlay)
+for layout formulas.
+
+---
+
+## Colors and HUD palette slots
+
+Overlay chrome uses palette indices from `overlayStyle` (defaults: bar/gap **1**, text **2**). For demos that draw their
+own HUD text with `BT.systemPrint`, call `palette.applyHUD(startSlot?)` once at init to fill the six common UI slots
+(white, background, label, header, dim, FPS) and register `hud_*` name aliases. See
+[API: Palette — applyHUD](api-palette.md#built-in-presets) and
+[Palette Presets — HUD](palette-presets.md#hud-preset-paletteapplyhud).
+
+```ts
+const palette = Palette.vga();
+palette.applyHUD(1); // slots 1-6 + hud_* aliases
+BT.paletteSet(palette);
+
+BT.systemPrint(new Vector2i(8, 8), palette.getIndex('hud_label'), 'Custom row');
+```
+
+---
+
+## Present FPS vs target FPS
+
+- **`Target`** in the overlay = `BT.targetFPS` (fixed `update()` rate).
+- **`Present: N FPS`** = measured browser refresh cadence while the overlay body is visible — not the same as target
+  FPS.
+
+Use `BT.deltaSeconds` / `BT.ticks` for gameplay timing; use present FPS to spot GPU or draw-call bottlenecks.
+
+---
+
+## See Also
+
+| Guide                                                  | What it covers                                   |
+| ------------------------------------------------------ | ------------------------------------------------ |
+| [API: Core — Overlay](api-core.md#overlay)             | Full configure table, style objects, layout math |
+| [API: Assets — System Font](api-assets.md#system-font) | `BT.systemPrint` for demo HUD text               |
+| [API: Palette](api-palette.md)                         | `applyHUD`, preset factories, effects            |
+| [Input Guide](input.md)                                | Pointer slots for corner toggle                  |
+| [Palette Presets](palette-presets.md)                  | Exact HUD slot colors                            |

--- a/docs/performance-best-practices.md
+++ b/docs/performance-best-practices.md
@@ -51,10 +51,11 @@ patterns for managing allocations:
 **When to use:** UI code, one-time operations, and anywhere readability matters more than performance.
 
 ```ts
-// Clear and readable
-BT.drawPixel(new Vector2i(x, y), color);
-BT.drawRect(new Rect2i(10, 10, 50, 50), Color32.white);
-BT.printFont(font, new Vector2i(10, 20), 'Hello', Color32.white);
+// Clear and readable — palette indices, not Color32
+const WHITE = 1;
+BT.drawPixel(new Vector2i(x, y), WHITE);
+BT.drawRect(new Rect2i(10, 10, 50, 50), WHITE);
+BT.printFont(font, new Vector2i(10, 20), 'Hello');
 ```
 
 **Pros:**
@@ -129,7 +130,7 @@ Blit-Tech automatically batches draw calls for optimal GPU performance:
 ```ts
 // Good: All sprites from same sheet
 for (const enemy of enemies) {
-  BT.drawSprite(enemySheet, enemy.sprite, enemy.pos, enemy.tint);
+  BT.drawSprite(enemySheet, enemy.sprite, enemy.pos, enemy.paletteOffset);
 }
 
 // Less optimal: Switching between sheets
@@ -152,17 +153,18 @@ Less optimal:
 - enemy1.png, enemy2.png, enemy3.png (separate files)
 ```
 
-### Tinting Performance
+### Palette offset performance
 
-**Tinting is essentially free!** All color multiplication happens in the GPU shader, so:
+**Changing `paletteOffset` per draw is cheap** — it shifts stored texel indices before palette lookup, not RGBA tint
+multiplication:
 
 ```ts
-// Both have the same performance
-BT.drawSprite(sheet, sprite, pos, Color32.white);
-BT.drawSprite(sheet, sprite, pos, new Color32(255, 100, 100, 200));
+// Same performance — offset is a uniform add, not per-pixel color math
+BT.drawSprite(sheet, sprite, pos);
+BT.drawSprite(sheet, sprite, pos, 16); // team-color range
 ```
 
-Use tinting liberally for visual effects - it doesn't impact performance.
+Use palette offsets liberally for team colors and damage flashes — batching cost dominates, not the offset itself.
 
 ### Line Rendering Costs
 
@@ -282,15 +284,16 @@ Don't guess what's slow - **measure it**. Use:
 ### 3. Allocating in Hot Paths
 
 ```ts
-// BAD: Creating colors in tight loop
+// BAD: Allocating Vector2i in a tight loop (see pre-allocation section)
 for (let i = 0; i < 1000; i++) {
-  BT.drawPixel(pos, new Color32(255, 0, 0)); // 60,000 allocations/sec!
+  BT.drawPixel(new Vector2i(i, 0), 1); // 60,000 Vector2i allocations/sec!
 }
 
-// GOOD: Reuse color
-const red = new Color32(255, 0, 0);
+// GOOD: Reuse a pre-allocated vector
+const pos = new Vector2i(0, 0);
 for (let i = 0; i < 1000; i++) {
-  BT.drawPixel(pos, red);
+  pos.set(i, 0);
+  BT.drawPixel(pos, 1);
 }
 ```
 
@@ -352,28 +355,30 @@ render(): void {
 
 ## Example References
 
-The Blit-Tech examples demonstrate both approaches:
+Demos live in the sibling **`blit-tech-demos`** repo (`src/NNN-topic.js` files). The examples below demonstrate both
+approaches:
 
 ### Clarity-First Examples (Inline Allocation)
 
-- **`basics.ts`** - Entry-level example teaching core concepts
-- **`fonts.ts`** - Font rendering demonstrations
-- **`primitives.ts`** - Drawing primitive shapes
-- **`sprites.ts`** - Sprite rendering and tinting
+- **`001-basics.js`** - Entry-level example teaching core concepts
+- **`022-bitmap-font.js`** - Bitmap font loading and palette indexize workflow
+- **`002-primitives.js`** - Drawing primitive shapes
+- **`008-sprites.js`** - Sprite rendering and palette offsets
+- **`004-fonts.js`** - System font and text rendering
 
 These prioritize **readability and learning** over micro-optimizations.
 
 ### Performance-Optimized Examples (Pre-allocation)
 
-- **`patterns.ts`** - Complex animations with 200+ operations/frame
-- **`camera.ts`** - Scrolling world with many buildings
+- **`006-patterns.js`** - Complex animations with 200+ operations/frame
+- **`007-camera.js`** - Scrolling world with many buildings
 
 These demonstrate **when and how to optimize** for performance-critical scenarios.
 
-### New Examples
+### Effect and Animation Examples
 
-- **`animation.ts`** - Tick-based timing (inline allocation, focus on clarity)
-- **`sprite-effects.ts`** - Tinting effects (inline allocation, effects are GPU-free)
+- **`009-animation.js`** - Tick-based timing (inline allocation, focus on clarity)
+- **`010-sprite-effects.js`** - Palette offset effects for team colors and flashes
 
 ---
 

--- a/docs/security/security-runbook.md
+++ b/docs/security/security-runbook.md
@@ -132,11 +132,13 @@ pnpm run security:mcp-preflight -- \
   --allow-fallback
 
 pnpm run security:audit
-pnpm run security:audit:prod
 pnpm audit --dev --audit-level=moderate
 pnpm run preflight
 pnpm run build
 ```
+
+Note: **`blit-tech-demos` has no `security:audit:prod` script** — use `pnpm run security:audit` only for production-deps
+coverage in that repo, or run `pnpm audit --prod --audit-level=moderate` directly.
 
 After toolchain or dependency upgrades, always run `pnpm run build` as a smoke test.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -7,7 +7,8 @@ regression tracking.
 
 ### Tier 1: Unit Tests (Vitest, Node.js)
 
-Pure logic with no GPU dependencies. Tests run in Node.js for maximum speed.
+Pure logic with no GPU dependencies. Tests run in Node.js for maximum speed. The list below is **illustrative** — see
+`src/**/*.test.ts` for the full set (~60+ files).
 
 - **Vector2i** - all arithmetic, distance, comparison, factory methods
 - **Rect2i** - intersection, containment, computed properties
@@ -22,9 +23,9 @@ Pure logic with no GPU dependencies. Tests run in Node.js for maximum speed.
 
 Code that requires WebGPU objects or DOM APIs. Most tests run in Node with `src/__test__/webgpu-mock.ts` for GPU stubs
 and `vi` for browser API stubs. Tests that need a full DOM (Bootstrap, BootstrapHelpers) opt into `happy-dom` via the
-`// @vitest-environment happy-dom` directive.
+`// @vitest-environment happy-dom` directive. Inventory is **illustrative** — not exhaustive.
 
-- **AssetLoader** - image caching and deduplication (Node + vi stubs)
+- **AssetLoader** - image caching and deduplication (Node + vi stubs for `Image`)
 - **SpriteSheet** - UV calculation, lazy texture creation, indexization, `loadIndexed()` convenience flow, and
   `getIndexedPixels()` defensive-copy semantics (Node + GPU mocks)
 - **BitmapFont** - glyph lookup, text measurement (Node + vi stubs)
@@ -45,15 +46,17 @@ and `vi` for browser API stubs. Tests that need a full DOM (Bootstrap, Bootstrap
   `RenderPaletteUsage` mask helpers (`markIndexUsed`, `collectUsedIndices`), toggle hit-testing, and `updateAndRender`
   integration (Node)
 - **FrameCapture** - GPU readback, PNG conversion (Node + GPU mocks + browser stubs)
+- **consumer-doc-imports** - `src/docs/consumer-doc-imports.test.ts` guards README/docs import paths against
+  `BlitTech.ts` exports
 
 ### Tier 3: Visual Regression (Playwright, Chromium)
 
 Actual GPU rendering verified via screenshot comparison. Requires Chrome with WebGPU flags enabled.
 
-Each spec covers both the default WebGPU backend and the `?backend=software` software backend, producing separate
-baseline screenshots for each.
+Most specs cover both the default WebGPU backend and the `?backend=software` software backend, producing separate
+baseline screenshots for each. **`post-process.spec.ts` is WebGPU-only** (software backend throws on effects).
 
-- **Primitives** - pixel, line, and rectangle rendering
+- **Primitives** - pixel, line, and rectangle rendering (WebGPU + software)
 - **Sprites** - palette-indexed sprite rendering, palette offsets, batching
 - **Camera** - camera offset transforms applied to all geometry
 - **Fonts** - placeholder text rendering at known positions
@@ -255,30 +258,44 @@ GitHub Actions runs unit tests and quality gates in CI. Visual regression is loc
 Triggers on push to `main` and on pull requests targeting `main`. `labeled` / `unlabeled` PR events skip the `quality`,
 `build-library`, and `test` jobs unless the added label is `perf` (which enables the benchmark job).
 
-| Job             | What it runs                                                                                       |
-| --------------- | -------------------------------------------------------------------------------------------------- |
-| `quality`       | `pnpm run format:check`, `pnpm run lint`, `pnpm run typecheck`, `pnpm run spellcheck`              |
-| `build-library` | `pnpm run build`, declaration tooling check, uploads `dist/` artifact                              |
-| `test`          | `pnpm run test:unit:coverage`, Codecov upload                                                      |
-| `benchmark`     | On `main` push or PRs labeled `perf`: `pnpm run bench:json`, PR regression compare (25% threshold) |
+| Job              | What it runs                                                                                       |
+| ---------------- | -------------------------------------------------------------------------------------------------- |
+| `quality`        | `format:check`, `lint`, `typecheck`, `spellcheck`, **`docs:links`**                                |
+| `build-library`  | `pnpm run build`, declaration tooling check, uploads `dist/` artifact                              |
+| `test`           | `pnpm run test:unit:coverage`, Codecov upload                                                      |
+| `security-audit` | `pnpm run security:audit`, `pnpm run security:audit:prod` (dependency policy gate)                 |
+| `benchmark`      | On `main` push or PRs labeled `perf`: `pnpm run bench:json`, PR regression compare (25% threshold) |
+
+On pull requests, **`ci.yml` and `pr-checks.yml` overlap** on format/lint/typecheck/spellcheck/docs:links; `pr-checks`
+adds knip and bundle-size gates.
 
 ### `pr-checks.yml` (`PR Checks` workflow)
 
 Runs only on pull requests to `main`. Complements `ci.yml` with commit linting, bundle size limits, knip, and doc link
-checks. It does **not** run unit or visual tests.
+checks. It does **not** run unit or visual tests. There is **no separate `docs-links` job** — link checking runs inside
+the `quality` job.
 
-| Job           | What it runs                                                                                |
-| ------------- | ------------------------------------------------------------------------------------------- |
-| `quality`     | `pnpm run format:check`, `pnpm run lint`, `pnpm run typecheck`, `pnpm run spellcheck`, knip |
-| `commitlint`  | Conventional Commits validation for PR commits                                              |
-| `bundle-size` | `pnpm run build`, declaration tooling check, gzipped ESM size gate                          |
-| `docs-links`  | Markdown link check for `docs/` and `README.md`                                             |
+| Job           | What it runs                                                              |
+| ------------- | ------------------------------------------------------------------------- |
+| `quality`     | `format:check`, `lint`, `typecheck`, `spellcheck`, **`docs:links`**, knip |
+| `commitlint`  | Conventional Commits validation for PR commits                            |
+| `bundle-size` | `pnpm run build`, declaration tooling check, gzipped ESM size gate        |
 
 ### Visual regression (not in CI)
 
 `pnpm run test:visual` requires Chrome with WebGPU and is **not** executed in GitHub Actions. Run it locally before
 merging renderer, palette, or post-process changes; use `pnpm run test:visual:update` when baselines change
 intentionally. `pnpm run preflight` does not include visual tests.
+
+### Known quirks
+
+See also [CLAUDE.md](../CLAUDE.md) (**Known Testing Quirks**):
+
+- **`// @vitest-environment happy-dom`** — required at the top of test files that touch DOM APIs without GPU mocks.
+- **AssetLoader** — tests stub `Image` with `vi`; do not rely on happy-dom data-URI `onload` behavior.
+- **`Vector2i -0` vs `0`** — use `result.x + 0` in assertions when sign is meaningless.
+- **`docs:links` scope** — `scripts/check-markdown-links.mjs` walks all repo-root `*.md` / `*.mdx` files (excluding
+  ignored dirs), not only `docs/` and README.
 
 ---
 


### PR DESCRIPTION
Add docs/overlay.md — new guide covering subsystem layout, visibility model, custom rows, optional bands, HUD palette slots, and the present/target FPS distinction.

Correct factual accuracy across all existing docs:
- api-assets.md: BitmapFont quick start now shows palette indexize step (required before draw); add SpriteSheet helpers callout; add AssetLoader.loadImage single-image example
- api-rendering.md: add standalone preset imports; replace internal FrameCapture lifecycle reference with a note that it is not exported
- api-palette.md: add toFloat32Array / toFloat32ArrayInto; clarify isDirty getter description
- api-core.md: document clampCameraToWorld standalone helper, defaultConfig / mergeHardwareSettings, and applyEasing exports
- performance-best-practices.md: replace Color32 with palette indices in all examples; rename Tinting to Palette offset; correct allocation bad-practice snippet; update demo filenames to blit-tech-demos style
- input.md: remove POINTER_SLOT_COUNT (not a public export); add composite mask examples (BTN_POINTER_ANY, BTN_ABXY, BTN_SHOULDER)
- deprecations.md: add scope note (public aliases only; internal deprecated helpers excluded)

Expand developer-experience-guide.md: new Cursor section with path table, add test:declarations and build:check-declarations commands, add style/build/revert commit types, note scopes are convention only, add overlay.md to guide table. Mirror type and scope updates in CONTRIBUTING.md. Add overlay.md row to README.md guide table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR adds comprehensive documentation for the engine's overlay HUD subsystem and corrects factual accuracy across existing documentation to align with current API behavior and best practices.

## New Documentation
Overlay Guide (`docs/overlay.md`): New guide (121 lines) documenting the HUD overlay subsystem, including:
- When the overlay renders (after each demo render() when enabled) and where examples/configuration live
- Subsystem layout (orchestrator, layout planning, bars, timing chart, palette grid, sampling, input/toggle)
- Runtime visibility model (toggle behavior, startup visibility, disabling the overlay)
- Custom rows via the overlayRows() hook (reuse guidance for row objects)
- Optional components configurable via flags (timing chart, palette grid, renderer diagnostics bar, GPU marker modes)
- Overlay layout/timing/spacing expectations
- HUD palette slot usage and guidance for BT.systemPrint and HUD colors
- Clarification of present FPS vs target FPS terminology
- See-also links to related API and palette/input docs

## Documentation Accuracy Corrections

API docs and guides updated to reflect current behavior and helpers:
- docs/api-assets.md: Added single-image AssetLoader.loadImage example; clarified BitmapFont workflow requires palette registration and explicit sprite-sheet indexize(palette); added SpriteSheet helper/validation callout; updated System Font guidance to call palette.applyHUD() at initialization.
- docs/api-rendering.md: Added standalone named imports example for effect presets; removed an internal FrameCapture lifecycle reference and replaced it with a note that the FrameCapture class is internal/not exported and demos should use BT.captureFrame()/BT.downloadFrame().
- docs/api-palette.md: Added palette.toFloat32Array() and toFloat32ArrayInto(out) serialization methods; clarified Palette.isDirty getter semantics (reflects slots changed since last GPU upload).
- docs/api-core.md: Documented bootstrap() behavior with CanvasLayoutStyles CSS variables; added clampCameraToWorld helper docs; documented defaultConfig() and mergeHardwareSettings(); added applyEasing examples.
- docs/bitmap-fonts.md: Quick Start updated to a palette-index rendering workflow (create Palette, indexize font sprite sheet into palette, BT.paletteSet()); changed BT.printFont() doc from optional Color32 tint to optional paletteOffset?: number; added BitmapFont.measureTextSizeInto() and TextSize shape documentation.
- docs/performance-best-practices.md: Replaced Color32 examples with palette indices; renamed "Tinting" to "Palette offset performance"; corrected allocation bad-practice snippet to focus on Vector2i pre-allocation and reuse; updated demo filenames and references to blit-tech-demos style.
- docs/input.md: Clarified pointer slot model (engine tracks four pointer slots, indices 0–3; overflow contacts dropped silently); removed POINTER_SLOT_COUNT as a public export; added composite mask examples (BTN_POINTER_ANY, BTN_ABXY, BTN_SHOULDER); documented per-axis dead-zone default (0.75) as internal detail.
- docs/deprecations.md: Added scope note that the tracker lists public compatibility aliases only; internal deprecated helpers are excluded (pointer to searching `@deprecated` in src/).
- docs/security/security-runbook.md: Adjusted blit-tech-demos instructions—removed pnpm run security:audit:prod, added pnpm audit --dev --audit-level=moderate, and included pnpm run build in smoke tests.

## Developer Experience Changes
- CONTRIBUTING.md: Added revert to Conventional Commit types; clarified commit scopes are conventions only; expanded preflight checks to include docs link checks, unit tests, and declaration tooling tests; added new pnpm scripts entries (docs link checking, declaration tests, visual regression, benchmarks).
- docs/developer-experience-guide.md: Added Cursor section describing .cursor/ and related IDE hooks; added test:declarations and build:check-declarations commands; added style/build/revert commit types; noted scopes are convention only; added overlay.md to the documentation index; updated Repository Scripts and maintenance notes.
- README.md: Added Overlay Guide entry to the documentation guide table.

## Testing & CI Documentation
- docs/testing.md: Refined test-suite inventory and CI workflow docs; explicitly documents that docs:links runs within quality checks; added guidance for AssetLoader caching tests and visual-regression WebGPU-only note; updated Known Quirks list.

## Miscellaneous
- docs/performance-testing.md, docs/post-process-effects.md, docs/palette-* and other related docs adjusted where appropriate to align with the above changes (referenced in the PR file list).
- No code or exported public API declarations are changed; all edits are documentation-only except the docs-driven note removing POINTER_SLOT_COUNT from the public API docs.

## Commit summary highlights
- Added overlay guide and extensive doc accuracy corrections across assets, rendering, palette, core, performance, input, deprecations, developer-experience, and security docs.
- Adjusted CONTRIBUTING and README to include new guide and updated workflows.
- Doc changes collectively aim to correct factual behavior, add missing helper docs, and improve developer tooling documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->