### PR TITLE
fix(renderer): move module-level GPUTextureUsage access into methods

### DIFF
--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -18,6 +18,7 @@ import { createOverlayLayout, Overlay, resolveOverlayTopLeftLabel } from '../ove
 import type { Effect } from '../render/effects/Effect';
 import type { IRenderer } from '../render/IRenderer';
 import { SoftwareRenderer } from '../render/SoftwareRenderer';
+import { WebGPURenderer } from '../render/WebGPURenderer';
 import { applyCanvasLayoutStyles, DEFAULT_MAX_CANVAS_SIZE } from '../utils/CanvasLayoutStyles';
 import type { Color32 } from '../utils/Color32';
 import type { EasingFunction } from '../utils/Easing';
@@ -1112,10 +1113,6 @@ export class BTAPI {
                 this.context = webGPUResult.context;
 
                 console.log('[BT] Initializing renderer (backend: webgpu)');
-
-                // Lazy-load WebGPU renderer code so browsers without WebGPU globals
-                // (e.g. Firefox on Linux) can still start with the software backend.
-                const { WebGPURenderer } = await import('../render/WebGPURenderer');
 
                 this.renderer = new WebGPURenderer(
                     webGPUResult.device,

--- a/src/render/PostProcessChain.ts
+++ b/src/render/PostProcessChain.ts
@@ -2,14 +2,6 @@ import type { Vector2i } from '../utils/Vector2i';
 import type { Effect, EffectTier } from './effects/Effect';
 
 /**
- * Texture usage flags for offscreen color targets.
- *
- * `RENDER_ATTACHMENT` allows the scene to draw into the texture.
- * `TEXTURE_BINDING` allows post-process effects to sample from it.
- */
-const OFFSCREEN_USAGE = GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING;
-
-/**
  * Stackable post-processing effect chain that runs at a single resolution tier.
  *
  * The renderer owns one chain per tier:
@@ -264,7 +256,7 @@ export class PostProcessChain {
             label: `PostProcessChain[${this.tier}] texA`,
             size: { width: this.size.x, height: this.size.y, depthOrArrayLayers: 1 },
             format: this.format,
-            usage: OFFSCREEN_USAGE,
+            usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
         });
         this.texAView = this.texA.createView();
     }
@@ -275,7 +267,7 @@ export class PostProcessChain {
             label: `PostProcessChain[${this.tier}] texB`,
             size: { width: this.size.x, height: this.size.y, depthOrArrayLayers: 1 },
             format: this.format,
-            usage: OFFSCREEN_USAGE,
+            usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
         });
         this.texBView = this.texB.createView();
     }

--- a/src/render/UpscalePass.ts
+++ b/src/render/UpscalePass.ts
@@ -2,15 +2,6 @@ import type { Vector2i } from '../utils/Vector2i';
 import { VS_WGSL } from './effects/fullscreenVS';
 
 /**
- * Texture usage flags for the upscale pass output.
- *
- * The upscaled texture is sampled by the display chain (or read by frame
- * capture / blit-to-swap-chain), so it needs both render-attachment and
- * texture-binding usages.
- */
-const OUTPUT_USAGE = GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING;
-
-/**
  * Upscale filter applied between the pixel chain (logical resolution) and the
  * display chain (canvas output resolution).
  *
@@ -79,7 +70,7 @@ export class UpscalePass {
             label,
             size: { width: size.x, height: size.y, depthOrArrayLayers: 1 },
             format,
-            usage: OUTPUT_USAGE,
+            usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
         });
     }
 

--- a/src/render/WebGPURenderer.ts
+++ b/src/render/WebGPURenderer.ts
@@ -19,14 +19,6 @@ import type { UpscaleFilter } from './UpscalePass';
  */
 const PALETTE_BUFFER_SIZE = 256 * 4 * 4;
 
-/**
- * Texture usage flags for the offscreen scene framebuffer.
- *
- * `RENDER_ATTACHMENT` so primitive/sprite pipelines can draw into it,
- * `TEXTURE_BINDING` so the pixel chain (or upscale pass) can sample it.
- */
-const SCENE_TARGET_USAGE = GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING;
-
 /** Logical scene + pixel chain format (palette index in the red channel). */
 const LOGICAL_TARGET_FORMAT: GPUTextureFormat = 'r8uint';
 
@@ -823,7 +815,7 @@ export class WebGPURenderer implements IRenderer, OverlayDrawTarget {
                 label: 'Renderer Scene Framebuffer',
                 size: { width: this.displaySize.x, height: this.displaySize.y, depthOrArrayLayers: 1 },
                 format: LOGICAL_TARGET_FORMAT,
-                usage: SCENE_TARGET_USAGE,
+                usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
             });
 
             this.sceneTexView = this.sceneTex.createView();


### PR DESCRIPTION
Three module-scope constants (SCENE_TARGET_USAGE, OFFSCREEN_USAGE, OUTPUT_USAGE) evaluated GPUTextureUsage at module load time, which crashed browsers without WebGPU globals (e.g. Firefox on Linux).

PR #240 worked around this with a dynamic import of WebGPURenderer, which caused Vite to split WebGPURenderer and fullscreenVS into separate build chunks included in the npm package.

Removing the module-scope expressions and inlining them at each call site eliminates the load-time crash without dynamic import. WebGPURenderer reverts to a static import; the dist/ output is back to two files (blit-tech.js, blit-tech.cjs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR resolves module-level GPUTextureUsage access that caused crashes in browsers lacking WebGPU globals (e.g., Firefox on Linux) by inlining texture usage flags at call sites instead of evaluating them at module load time.

## Changes

**src/core/BTAPI.ts**
- Switched `WebGPURenderer` loading from lazy dynamic `import()` inside `initRenderer` to a static top-level import
- Removed the prior fallback-oriented lazy-load block from the WebGPU initialization path
- WebGPURenderer now directly instantiates from the static import

**src/render/PostProcessChain.ts**
- Removed the module-level `OFFSCREEN_USAGE` constant
- Inlined `GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING` directly into `createTexture` calls for both `texA` and `texB` offscreen textures

**src/render/UpscalePass.ts**
- Removed the module-level `OUTPUT_USAGE` constant
- Inlined `GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING` directly into the texture creation call in `createOutputTexture`

**src/render/WebGPURenderer.ts**
- Removed the module-level `SCENE_TARGET_USAGE` constant
- Inlined `GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING` directly into the scene target texture allocation

## Impact

By moving WebGPU API access from module load time to runtime execution, the module no longer crashes in environments without WebGPU globals. This eliminates the need for dynamic imports and allows WebGPURenderer to return to static imports, reverting the build output to two distribution files (blit-tech.js and blit-tech.cjs) instead of the split chunks created by the previous dynamic import workaround.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->