### PR TITLE
chore(ci): add bt-issue-audit skill for re-auditing open issues

### DIFF
--- a/.agents/skills/bt-issue-audit
+++ b/.agents/skills/bt-issue-audit
@@ -1,0 +1,1 @@
+../../.claude/skills/bt-issue-audit

--- a/.claude/skills/bt-issue-audit/SKILL.md
+++ b/.claude/skills/bt-issue-audit/SKILL.md
@@ -57,18 +57,26 @@ no emoji.
      the summary but do not invent a "changed" verdict for them unless the user asks for a first-time audit.
 
 2. **Find what changed in the code since the last audit.**
-   - Establish the cutoff (the most recent audit date across issues, usually shared).
-   - `git log --since=<audit-date> --pretty=format:'%h %ad %s' --date=short`
+   - Record each issue's own last-audit date from step 1 (`lastAuditDate` per issue). Audit dates differ between
+     issues - never collapse them into a single "most recent across issues" cutoff, or commits that landed between an
+     earlier-audited issue's date and that global latest date get missed, yielding false "unchanged" verdicts.
+   - For the broad prefilter, use the **earliest** `lastAuditDate` across all issues as the baseline so no relevant
+     commit is excluded: `git log --since=<earliest-lastAuditDate> --pretty=format:'%h %ad %s' --date=short`
    - Filter to behavior-changing work: `... | grep -E '(feat|fix)\('`. Ignore `docs`, `chore`, `refactor`, `test`, `ci`,
      and `style` commits - renames and formatting do not change an audit verdict. A breaking rename (`feat(...)!`) can
      matter if it adds or removes public surface.
+   - The earliest-baseline log is only a prefilter. Each candidate is judged per issue against its own `lastAuditDate`
+     in step 4, not against the global baseline.
 
 3. **Map changed feature areas to issues.**
    - Group the `feat`/`fix` commits by area (overlay, renderer, api, assets, input, etc.) and match them to the open
      issues those areas would affect. Only those issues are candidates for a changed verdict; everything else is
      unchanged by definition.
 
-4. **Verify each candidate against the codebase.**
+4. **Verify each candidate against the codebase, per issue.**
+   - Compare commits against that issue's own `lastAuditDate`, not the global baseline: a commit only counts toward a
+     changed verdict if it landed strictly after the issue was last audited
+     (`git log --since=<issue.lastAuditDate> -- <relevant paths>`).
    - Do not trust commit subjects alone. Confirm the actual public surface with `rg` / `git grep` and by reading the
      relevant `src/` files (e.g. confirm an API exists in `src/BlitTech.ts`, a type field in
      `src/core/IBlitTechDemo.ts`, a metric in `src/overlay/`).

--- a/.claude/skills/bt-issue-audit/SKILL.md
+++ b/.claude/skills/bt-issue-audit/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: bt-issue-audit
+description:
+  Re-audit open GitHub issues against the current codebase and post a new audit-update comment only when the situation
+  has genuinely changed since the last audit.
+---
+
+# Issue Audit Pass
+
+Walk every open issue on `vancura/blit-tech`, compare its last recorded audit comment against the current state of the
+code, and post a fresh audit-update comment **only** for issues whose situation is now materially different. Issues
+whose feature area has seen no relevant change get nothing.
+
+Use `gh` for all GitHub reads and writes (GitHub MCP is an acceptable substitute if `gh` is unavailable).
+
+## Usage
+
+```text
+/bt-issue-audit
+```
+
+## Core rule
+
+Add a new comment **only if the situation is now different** from the most recent audit comment on that issue (the audit
+bucket, evidence, or recommended status has changed). When in doubt, do not comment. Never restate an unchanged audit.
+
+## Audit buckets
+
+- `not implemented` - no shipped code addresses the ticket
+- `partial` - some of the requested surface shipped; concrete gaps remain
+- `implemented` - the requested behavior is shipped (candidate to close)
+
+## Comment format
+
+Match the existing audit comments exactly. Every comment starts with a dated heading:
+
+```md
+## Audit update (YYYY-MM-DD)
+
+- Audit bucket: <bucket> (was: <previous bucket> on <previous date>)
+- Evidence: <specific files / APIs / commits proving the current state>
+- Recommended next status: <Keep Backlog | Keep Todo | Close | ...>
+- Suggested next step: <concrete action>
+```
+
+Include the `(was: ...)` parenthetical only when the bucket actually changed. Cite real symbols and paths (e.g.
+`OverlayTimingSnapshot`, `HardwareSettings.isOverlayRendererDiagnosticsBarEnabled`), not vague claims. Plain text only,
+no emoji.
+
+## Steps
+
+1. **List open issues and their last audit.**
+   - `gh issue list --repo vancura/blit-tech --state open --limit 100 --json number,title,labels,updatedAt`
+   - For each issue, pull the most recent audit comment:
+     `gh issue view <n> --repo vancura/blit-tech --json comments --jq '.comments[] | select(.body | startswith("## Audit update")) | .body'`
+   - Note the date of the latest audit comment per issue. Issues with no audit comment have no baseline - flag them in
+     the summary but do not invent a "changed" verdict for them unless the user asks for a first-time audit.
+
+2. **Find what changed in the code since the last audit.**
+   - Establish the cutoff (the most recent audit date across issues, usually shared).
+   - `git log --since=<audit-date> --pretty=format:'%h %ad %s' --date=short`
+   - Filter to behavior-changing work: `... | grep -E '(feat|fix)\('`. Ignore `docs`, `chore`, `refactor`, `test`, `ci`,
+     and `style` commits - renames and formatting do not change an audit verdict. A breaking rename (`feat(...)!`) can
+     matter if it adds or removes public surface.
+
+3. **Map changed feature areas to issues.**
+   - Group the `feat`/`fix` commits by area (overlay, renderer, api, assets, input, etc.) and match them to the open
+     issues those areas would affect. Only those issues are candidates for a changed verdict; everything else is
+     unchanged by definition.
+
+4. **Verify each candidate against the codebase.**
+   - Do not trust commit subjects alone. Confirm the actual public surface with `rg` / `git grep` and by reading the
+     relevant `src/` files (e.g. confirm an API exists in `src/BlitTech.ts`, a type field in
+     `src/core/IBlitTechDemo.ts`, a metric in `src/overlay/`).
+   - Re-read the issue body so the verdict addresses what the ticket actually asked for, including partial coverage
+     (some sub-points shipped, others not).
+
+5. **Decide and post.**
+   - If the bucket / evidence / recommended status is unchanged: post nothing.
+   - If it changed: post one audit-update comment in the format above, dated today.
+     `gh issue comment <n> --repo vancura/blit-tech --body '<comment>'`
+   - Be precise about what shipped and what is still missing; name the residual gap so the ticket can be re-scoped or
+     closed.
+
+6. **Summarize for the user.**
+   - List which issues got a new comment and why (old bucket -> new bucket).
+   - List issues that were candidates but ruled unchanged after verification.
+   - List any open issues with no prior audit baseline (e.g. CodeRabbit-only comments) that were skipped.
+
+## Notes
+
+- This is a read-then-write workflow against live GitHub issues. Posting comments is outward-facing; only post the
+  comments warranted by step 5. If unsure whether a verdict changed, report it in the summary and let the user decide
+  rather than commenting.
+- Prefer one comment per genuinely-changed issue. Do not bulk-comment.
+- Cross-reference `CLAUDE.md` for the public API shape (getters vs methods, `HardwareSettings` field names) when judging
+  whether requested surface actually exists.


### PR DESCRIPTION
Add a reusable skill that re-audits open GitHub issues against the current codebase and posts a new audit-update comment only when the situation has changed since the last audit. Captures the workflow: list issues with their last audit, diff feat/fix commits since the audit date, map changed areas to issues, verify against src, and comment in the existing audit-update format.

Mirror the skill into the Zed .agents/skills tree as a symlink, matching the existing bt-* skill entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR introduces the `bt-issue-audit` skill, a reusable CI workflow that re-audits open GitHub issues against the current codebase and posts audit-update comments only when material changes are detected since the last audit.

## Changes

### New Files
- `.claude/skills/bt-issue-audit/SKILL.md` (105 lines): Comprehensive skill documentation defining the GitHub issues re-audit workflow
- `.agents/skills/bt-issue-audit`: Symlink pointing to `../../.claude/skills/bt-issue-audit` to mirror the skill into the Zed .agents/skills tree alongside other `bt-*` skill entries

### Workflow Details
The skill implements a structured auditing process that:
- Lists open issues and retrieves each issue’s most recent "Audit update" comment (or flags issues with no baseline)
- Uses the earliest per-issue last-audit date as a broad prefilter for the commit log, then verifies candidate commits per-issue against that issue's own last-audit date (fixes previous global-cutoff bug)
- Identifies behavior-changing commits (feat/fix) since the prefilter and maps changed code areas to potentially affected issues
- Verifies candidates directly against the codebase and issue descriptions (confirming actual public surface in src/)
- Posts a single new audit-update comment in the existing format only when an issue's audit status materially changes (bucket, evidence, or recommended action); otherwise posts nothing

The documentation specifies exact comment formatting rules (including conditional "(was: ...)" parenthetical), requires `gh` for reads/writes, and follows a conservative "when in doubt, do not comment" rule.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->