### PR TITLE
docs: point onboarding at create-blit-tech scaffolder

### DIFF
--- a/.cursor/rules/docs-sync-required.mdc
+++ b/.cursor/rules/docs-sync-required.mdc
@@ -15,4 +15,7 @@ alwaysApply: false
 - When `pnpm run` scripts or preflight steps change, update `.claude/skills/*/SKILL.md` and any affected
   `.cursor/rules/*.mdc` cross-references.
 - Update `README.md` only when quick start, prerequisites, feature list, or compatibility is affected.
+- When the onboarding surface changes (`README.md` Quick Start, `bootstrap()` signature/defaults, or the minimal demo
+  shape), check whether the sibling `create-blit-tech` scaffolder templates, `@blit-tech/kit` docs, and the pinned
+  `blit-tech` version range need a matching update (see **Onboarding and the scaffolder** in `CLAUDE.md`).
 - If no docs update is needed, state why explicitly in the final response.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,23 @@ Before writing new code, reviewing existing code, or preflighting, check here fi
 | Where do I put a new field/method in a `.ts` file?         | **TypeScript file structure** below; `.cursor/rules/ts-file-structure.mdc`; `docs/developer-experience-guide.md` (File structure and member order)                                                                           |
 | Where are Cursor agent rules and hooks?                    | `.cursor/rules/*.mdc` (always-applied + glob-scoped); `.cursor/hooks.json`; condensed mirrors in `.claude/rules/`; see [Developer Experience](docs/developer-experience-guide.md#cursor)                                     |
 | What agent skills are available for this project?          | `.agents/skills/` (Zed) and `.claude/skills/` (Claude Code) — `bt-preflight`, `bt-review`, `bt-pr`, `bt-format`, `bt-perf`, `bt-test`, `bt-release`, `bt-spellcheck`, `bt-security-run`, `bt-deep-review`, `bt-quick-format` |
+| How do users start a new project with the engine?          | `npm create blit-tech@latest` — the scaffolder lives in the sibling `create-blit-tech` repo; see **Onboarding and the scaffolder** below                                                                                     |
+
+## Onboarding and the scaffolder
+
+The recommended way for users to start a new game on top of this engine is the scaffolder:
+
+```bash
+npm create blit-tech@latest my-game
+```
+
+It lives in the sibling repo `create-blit-tech` (`packages/create-blit-tech`), generates a Vite + JavaScript project,
+installs `blit-tech`, and copies the canonical `AGENTS.md` + `docs/` from `@blit-tech/kit`. The generated `package.json`
+pins a `blit-tech` version range (`BLIT_TECH_RANGE` in `packages/create-blit-tech/src/scaffold.ts`).
+
+When you change the engine's onboarding surface here (the `README.md` Quick Start, `bootstrap()` signature/defaults, or
+the minimal demo shape), check whether the `create-blit-tech` templates, kit docs, and pinned version range need a
+matching update. That repo has its own git history and is not part of this repo's pnpm workspace.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -65,49 +65,35 @@ complex frameworks, just sprites, primitives, and fonts.
 - **Node.js** >=22.18.0 (LTS)
 - An **ESM bundler** (Vite, webpack, esbuild, and similar) to load the published package in the browser
 
-## Installation
+## Quick Start
 
-Install **blit-tech** from npm:
+The fastest way to start is the **scaffolder**. It writes a ready-to-run Vite project, installs the engine, and includes
+a starter game and local docs:
+
+```bash
+npm create blit-tech@latest my-game
+cd my-game
+npm run dev
+```
+
+Works with npm, pnpm, yarn, or bun (it uses whichever you ran it with). See
+[create-blit-tech](https://github.com/vancura/create-blit-tech) for options and what the project contains.
+
+### Add to an existing project
+
+Install **blit-tech** from npm ([npmjs.com/package/blit-tech](https://www.npmjs.com/package/blit-tech)):
 
 ```bash
 pnpm add blit-tech
 ```
 
-Or with npm:
-
-```bash
-npm install blit-tech
-```
-
-Package page: [npmjs.com/package/blit-tech](https://www.npmjs.com/package/blit-tech)
-
-## Examples & Demos
-
-For interactive examples and demos, visit the [Blit-Tech Demos repository](https://github.com/vancura/blit-tech-demos).
-
-## Quick Start
-
 `bootstrap()` expects a canvas inside `#canvas-container` (defaults: canvas id `blit-tech-canvas`, container id
-`canvas-container`). Pair the HTML below with a TypeScript entry module in any ESM bundler setup.
-
-**`index.html`**
+`canvas-container`):
 
 ```html
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>My Blit-Tech Demo</title>
-  </head>
-  <body>
-    <div id="canvas-container"><canvas id="blit-tech-canvas"></canvas></div>
-    <script type="module" src="/src/main.ts"></script>
-  </body>
-</html>
+<div id="canvas-container"><canvas id="blit-tech-canvas"></canvas></div>
+<script type="module" src="/src/main.ts"></script>
 ```
-
-**`src/main.ts`**
 
 ```ts
 import { bootstrap, BT, Color32, Palette, Rect2i, type IBlitTechDemo } from 'blit-tech';
@@ -125,9 +111,6 @@ class MyDemo implements IBlitTechDemo {
     // Animate every pixel that uses slots 9..12 (water/lava style cycling).
     BT.paletteCycle(WATER_A, WATER_B, 6);
 
-    // Quick full-screen impact flash via palette manipulation.
-    BT.paletteFlash(Color32.white, 120);
-
     return true;
   }
 
@@ -144,15 +127,11 @@ class MyDemo implements IBlitTechDemo {
 bootstrap(MyDemo);
 ```
 
-**Scaffold and run** (Vite + TypeScript):
+See [API: Core](docs/api-core.md) for full `bootstrap()` options.
 
-```bash
-pnpm create vite my-demo --template vanilla-ts
-cd my-demo
-pnpm add blit-tech
-# Add the HTML and main.ts snippets above, then:
-pnpm run dev
-```
+## Examples & Demos
+
+For interactive examples and demos, visit the [Blit-Tech Demos repository](https://github.com/vancura/blit-tech-demos).
 
 ## Documentation
 

--- a/cspell.json
+++ b/cspell.json
@@ -72,6 +72,7 @@
     "RRGGBBAA",
     "runbook",
     "Runlayer",
+    "scaffolder",
     "semgrep",
     "spritesheet",
     "subcoord",

--- a/docs/api-core.md
+++ b/docs/api-core.md
@@ -2,6 +2,11 @@
 
 Bootstrap, initialization, game loop timing, camera, and core types.
 
+> **Starting a new project?** The quickest path is the scaffolder: `npm create blit-tech@latest my-game` (works with
+> npm, pnpm, yarn, or bun). It generates a ready-to-run Vite project with the engine installed, a starter game, and
+> local docs. See [create-blit-tech](https://github.com/vancura/create-blit-tech). The rest of this page documents the
+> `bootstrap()` API for hand-wired or existing projects.
+
 ---
 
 ## Bootstrap


### PR DESCRIPTION
Lead README Quick Start with npm create blit-tech@latest and trim the manual Vite boilerplate. Document the scaffolder in api-core.md and CLAUDE.md, add a cross-repo sync note in docs-sync-required.mdc, and add "scaffolder" to cspell.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR restructures the onboarding documentation to promote the `npm create blit-tech@latest` scaffolder as the primary way to get started with blit-tech.

**Key changes:**

- **README.md**: Replaced the Quick Start section with a scaffolder-first workflow. Removed manual Vite boilerplate setup in favor of the automated `npm create blit-tech@latest` command. Reorganized post-demo documentation links to point readers to "API: Core" for full `bootstrap()` options and moved the "Examples & Demos" repository link accordingly. Trimmed the embedded TypeScript demo example by removing a palette-based effect call.

- **docs/api-core.md**: Added an early callout section near the top, directing new project creators to use the `npm create blit-tech@latest my-game` scaffolder command and linking to the `create-blit-tech` repository, with a note that the remainder of the page documents manual `bootstrap()` setup.

- **CLAUDE.md**: Introduced a new "Onboarding and the scaffolder" section after the Cursor/Claude agent skills table. Documents the recommended npm create workflow, references the sibling `create-blit-tech` repository and its template implementation, and specifies that onboarding surface changes should be mirrored in scaffolder templates, kit documentation, and pinned version ranges.

- **.cursor/rules/docs-sync-required.mdc**: Added a directive requiring verification that scaffolder templates, kit documentation, and pinned version ranges in the `create-blit-tech` repository stay synchronized when README.md onboarding content changes (e.g., Quick Start, `bootstrap()` signature/defaults, or minimal demo shape).

- **cspell.json**: Added the word "scaffolder" to the dictionary to prevent spelling validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->