### PR TITLE
chore: move lint-staged config out of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,17 +103,6 @@
       "esbuild": true
     }
   },
-  "lint-staged": {
-    "*.{ts,tsx,js,cjs,mjs,json,jsonc,css}": [
-      "biome check --write"
-    ],
-    "*.{md,mdx,mdc,yml,yaml}": [
-      "prettier --write"
-    ],
-    "*.{ts,tsx,js,cjs,mjs,md,mdx}": [
-      "cspell --no-progress"
-    ]
-  },
   "devDependencies": {
     "@biomejs/biome": "^2.4.15",
     "@commitlint/cli": "^20.5.3",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

The lint-staged configuration has been extracted from `package.json` into a dedicated `.lintstagedrc.json` file. This refactoring removes the inline `lint-staged` block (11 lines) from `package.json` while maintaining the same pre-commit hook rules in the new configuration file.

The `.lintstagedrc.json` file defines linting and formatting tasks for multiple file types:
- TypeScript and TSX files: biome check/format, eslint, and cspell
- JavaScript/CommonJS files: biome check/format and eslint
- JSON/JSONC files: biome format
- CSS files: biome format
- Markdown/MDX files: prettier and cspell
- YAML files: prettier

This separation follows the common practice of extracting tool-specific configurations from `package.json` into dedicated configuration files, keeping `package.json` focused on package metadata and dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->