### PR TITLE
chore(claude): add agents entry point and docs-sync rule

### DIFF
--- a/.claude/rules/docs-sync-required.md
+++ b/.claude/rules/docs-sync-required.md
@@ -1,0 +1,13 @@
+# Docs sync required
+
+Condensed mirror of `.cursor/rules/docs-sync-required.mdc`.
+
+- Documentation is part of the implementation, not a follow-up task.
+- Public API changes: update relevant `docs/api-*.md` and related examples.
+- Runtime behavior changes: update affected guides under `docs/` (including `docs/overlay.md` for overlay changes).
+- Architecture changes: update `CLAUDE.md` architecture sections and the **Where to Find Information** table.
+- Script or preflight changes: update `.claude/skills/*/SKILL.md` and affected `.cursor/rules/*.mdc` cross-references.
+- Onboarding surface changes (`README.md` Quick Start, `bootstrap()` defaults, minimal demo shape): check sibling
+  `create-blit-tech` templates, `@blit-tech/kit` docs, and pinned `blit-tech` version range.
+- Update `README.md` only when quick start, prerequisites, features list, or compatibility is affected.
+- If no docs update is needed, state why explicitly in the final response.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -28,11 +28,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "FILE=$(echo \"$CLAUDE_TOOL_PARAMETERS\" | sed -n \"s/.*\\\"file_path\\\"[[:space:]]*:[[:space:]]*\\\"\\([^\\\"]*\\)\\\".*/\\1/p\" | head -1); if [ -n \"$FILE\" ] && [ -f \"$FILE\" ]; then cd \"$CLAUDE_PROJECT_DIR\" && npx biome check --write \"$FILE\" 2>/dev/null; npx prettier --write \"$FILE\" 2>/dev/null; fi; true"
+            "command": "FILE=$(echo \"$CLAUDE_TOOL_PARAMETERS\" | sed -n \"s/.*\\\"file_path\\\"[[:space:]]*:[[:space:]]*\\\"\\([^\\\"]*\\)\\\".*/\\1/p\" | head -1); if [ -n \"$FILE\" ] && [ -f \"$FILE\" ]; then cd \"$CLAUDE_PROJECT_DIR\" && pnpm exec biome check --write \"$FILE\" 2>/dev/null; pnpm exec prettier --write \"$FILE\" 2>/dev/null; fi; true"
           },
           {
             "type": "command",
-            "command": "FILE=$(echo \"$CLAUDE_TOOL_PARAMETERS\" | sed -n \"s/.*\\\"file_path\\\"[[:space:]]*:[[:space:]]*\\\"\\([^\\\"]*\\)\\\".*/\\1/p\" | head -1); if [ -n \"$FILE\" ] && [ -f \"$FILE\" ] && echo \"$FILE\" | grep -qE '\\.(ts|tsx|js|md|mdx)$'; then cd \"$CLAUDE_PROJECT_DIR\" && RESULT=$(npx cspell --no-progress \"$FILE\" 2>&1); if [ $? -ne 0 ]; then echo \"[SPELLCHECK] Errors found in $FILE:\"; echo \"$RESULT\"; echo \"Fix typos in the source code, or add legitimate technical terms to cspell.json in the words array.\"; fi; fi; true"
+            "command": "FILE=$(echo \"$CLAUDE_TOOL_PARAMETERS\" | sed -n \"s/.*\\\"file_path\\\"[[:space:]]*:[[:space:]]*\\\"\\([^\\\"]*\\)\\\".*/\\1/p\" | head -1); if [ -n \"$FILE\" ] && [ -f \"$FILE\" ] && echo \"$FILE\" | grep -qE '\\.(ts|tsx|js|md|mdx)$'; then cd \"$CLAUDE_PROJECT_DIR\" && RESULT=$(pnpm exec cspell --no-progress \"$FILE\" 2>&1); if [ $? -ne 0 ]; then echo \"[SPELLCHECK] Errors found in $FILE:\"; echo \"$RESULT\"; echo \"Fix typos in the source code, or add legitimate technical terms to cspell.json in the words array.\"; fi; fi; true"
           }
         ]
       }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# Agent entry point
+
+This repository uses [`CLAUDE.md`](CLAUDE.md) as the canonical policy document for agents and contributors. Read it
+first for architecture, commands, API conventions, and documentation rules.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR adds an agent entry point for Claude and introduces a documentation synchronization rule for the repository.

## Changes

**AGENTS.md** - New file establishing this repository's agent entry point. It designates `CLAUDE.md` as the canonical policy document and instructs users to read it first for architecture, commands, API conventions, and documentation rules.

**.claude/rules/docs-sync-required.md** - New rule file defining when documentation must be updated alongside implementation changes. Covers public API updates, runtime behavior changes, architecture changes, script/preflight changes, and onboarding surface changes. The file also instructs developers to explicitly state why no docs update is needed when applicable.

**.claude/settings.json** - Updated PostToolUse hooks for `Edit|MultiEdit|Write` operations to extract `file_path` from `CLAUDE_TOOL_PARAMETERS` and use `pnpm exec` instead of `npx` for running formatting and spellchecking commands. The `biome check --write` and `prettier --write` commands now use `pnpm exec`, while the `cspell` spellcheck command also uses `pnpm exec` with the same conditional logic preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->