### PR TITLE
feat(api): rename package blit-tech to blit386, IBlitTechDemo to IBTDemo

### DIFF
--- a/.claude/rules/bt-api-getters.md
+++ b/.claude/rules/bt-api-getters.md
@@ -2,7 +2,7 @@
 
 Canonical reference: [CLAUDE.md](../../CLAUDE.md) (**BT API: getters vs methods**, **Boolean naming**).
 
-Quick rules when changing `src/BlitTech.ts` or demos:
+Quick rules when changing `src/BLIT386.ts` or demos:
 
 - **Getter:** zero-arg read-only snapshot (`BT.displaySize`, `BT.targetFPS`, `BT.ticks`, `BT.activeBackend`)
 - **Method:** mutation, parameters, or async (`BT.cameraSet`, `BT.pointerPos(0)`, `await BT.captureFrame()`)

--- a/.claude/rules/docs-sync-required.md
+++ b/.claude/rules/docs-sync-required.md
@@ -8,6 +8,6 @@ Condensed mirror of `.cursor/rules/docs-sync-required.mdc`.
 - Architecture changes: update `CLAUDE.md` architecture sections and the **Where to Find Information** table.
 - Script or preflight changes: update `.claude/skills/*/SKILL.md` and affected `.cursor/rules/*.mdc` cross-references.
 - Onboarding surface changes (`README.md` Quick Start, `bootstrap()` defaults, minimal demo shape): check sibling
-  `create-blit-tech` templates, `@blit-tech/kit` docs, and pinned `blit-tech` version range.
+  `create-blit386` templates, `@blit386/kit` docs, and pinned `blit386` version range.
 - Update `README.md` only when quick start, prerequisites, features list, or compatibility is affected.
 - If no docs update is needed, state why explicitly in the final response.

--- a/.github/markdown-link-check.json
+++ b/.github/markdown-link-check.json
@@ -41,6 +41,9 @@
     },
     {
       "pattern": "^https?://github\\.com/[^/]+/[^/]+/compare/"
+    },
+    {
+      "pattern": "^https?://github\\.com/blit386/"
     }
   ],
   "replacementPatterns": [

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -112,10 +112,10 @@ jobs:
       - name: Check bundle size
         id: size
         run: |
-          ESM_SIZE=$(stat -c%s dist/blit-tech.js 2>/dev/null || stat -f%z dist/blit-tech.js)
-          CJS_SIZE=$(stat -c%s dist/blit-tech.cjs 2>/dev/null || stat -f%z dist/blit-tech.cjs)
-          ESM_GZIP=$(gzip -c dist/blit-tech.js | wc -c | tr -d ' ')
-          CJS_GZIP=$(gzip -c dist/blit-tech.cjs | wc -c | tr -d ' ')
+          ESM_SIZE=$(stat -c%s dist/blit386.js 2>/dev/null || stat -f%z dist/blit386.js)
+          CJS_SIZE=$(stat -c%s dist/blit386.cjs 2>/dev/null || stat -f%z dist/blit386.cjs)
+          ESM_GZIP=$(gzip -c dist/blit386.js | wc -c | tr -d ' ')
+          CJS_GZIP=$(gzip -c dist/blit386.cjs | wc -c | tr -d ' ')
 
           echo "esm_size=$ESM_SIZE" >> $GITHUB_OUTPUT
           echo "cjs_size=$CJS_SIZE" >> $GITHUB_OUTPUT

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# Blit-Tech
+# BLIT386
 
 A palette-first WebGPU retro engine for TypeScript, inspired by RetroBlit. Pixel-perfect 2D rendering where primitives
 and sprites resolve through a shared indexed palette.
@@ -21,9 +21,9 @@ Before writing new code, reviewing existing code, or preflighting, check here fi
 
 | Question                                                   | Where to look                                                                                                                                                                                                                |
 | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| What does `BT.X` do (getter vs method)?                    | `src/BlitTech.ts` JSDoc, `docs/api-core.md`, **BT API: getters vs methods** below                                                                                                                                            |
+| What does `BT.X` do (getter vs method)?                    | `src/BLIT386.ts` JSDoc, `docs/api-core.md`, **BT API: getters vs methods** below                                                                                                                                             |
 | How does a subsystem work internally?                      | The relevant `src/core/` or `src/render/` file                                                                                                                                                                               |
-| What does a demo implement?                                | `src/core/IBlitTechDemo.ts` (interface + HardwareSettings)                                                                                                                                                                   |
+| What does a demo implement?                                | `src/core/IBTDemo.ts` (interface + HardwareSettings)                                                                                                                                                                         |
 | How does palette usage tracking work for the overlay grid? | `src/core/RenderPaletteUsage.ts`, `src/overlay/palette/PaletteView.ts`                                                                                                                                                       |
 | How does the overlay work?                                 | `docs/overlay.md`, `src/overlay/` (orchestrator + `layout/layoutPlan.ts`), `docs/api-core.md` (HardwareSettings overlay flags), `HardwareSettings.isOverlayEnabled`                                                          |
 | What palette/sprite setup pattern is correct?              | `docs/palette-guide.md`, then `docs/api-assets.md`                                                                                                                                                                           |
@@ -34,48 +34,48 @@ Before writing new code, reviewing existing code, or preflighting, check here fi
 | Dependency security policy / CI audit gate?                | `docs/security/dependency-policy.md`, `docs/security/audit-exceptions.md`                                                                                                                                                    |
 | What is the benchmark threshold?                           | `ci.yml` benchmark job (`--threshold 25` flag), not docs                                                                                                                                                                     |
 | What error message style should I use?                     | `docs/voice.md`, then `src/utils/errorMessages.ts`                                                                                                                                                                           |
-| Is this API exported publicly?                             | `src/BlitTech.ts` export block (lines 1563-1610)                                                                                                                                                                             |
+| Is this API exported publicly?                             | `src/BLIT386.ts` export block (lines 1563-1610)                                                                                                                                                                              |
 | What test mock do I need for GPU code?                     | `src/__test__/webgpu-mock.ts`                                                                                                                                                                                                |
 | Declaration tooling / TS version alignment?                | `docs/tooling.md`, `docs/developer-experience-guide.md`, `scripts/check-declaration-tooling.mjs`                                                                                                                             |
 | Should this private name repeat the class/file?            | **Internal scoped naming** below; `docs/developer-experience-guide.md` (Naming conventions)                                                                                                                                  |
 | Where do I put a new field/method in a `.ts` file?         | **TypeScript file structure** below; `.cursor/rules/ts-file-structure.mdc`; `docs/developer-experience-guide.md` (File structure and member order)                                                                           |
 | Where are Cursor agent rules and hooks?                    | `.cursor/rules/*.mdc` (always-applied + glob-scoped); `.cursor/hooks.json`; condensed mirrors in `.claude/rules/`; see [Developer Experience](docs/developer-experience-guide.md#cursor)                                     |
 | What agent skills are available for this project?          | `.agents/skills/` (Zed) and `.claude/skills/` (Claude Code) — `bt-preflight`, `bt-review`, `bt-pr`, `bt-format`, `bt-perf`, `bt-test`, `bt-release`, `bt-spellcheck`, `bt-security-run`, `bt-deep-review`, `bt-quick-format` |
-| How do users start a new project with the engine?          | `npm create blit-tech@latest` — the scaffolder lives in the sibling `create-blit-tech` repo; see **Onboarding and the scaffolder** below                                                                                     |
+| How do users start a new project with the engine?          | `npm create blit386@latest` — the scaffolder lives in the sibling `create-blit386` repo; see **Onboarding and the scaffolder** below                                                                                         |
 
 ## Onboarding and the scaffolder
 
 The recommended way for users to start a new game on top of this engine is the scaffolder:
 
 ```bash
-npm create blit-tech@latest my-game
+npm create blit386@latest my-game
 ```
 
-It lives in the sibling repo `create-blit-tech` (`packages/create-blit-tech`), generates a Vite + JavaScript project,
-installs `blit-tech`, and copies the canonical `AGENTS.md` + `docs/` from `@blit-tech/kit`. The generated `package.json`
-pins a `blit-tech` version range (`BLIT_TECH_RANGE` in `packages/create-blit-tech/src/scaffold.ts`).
+It lives in the sibling repo `create-blit386` (`packages/create-blit386`), generates a Vite + JavaScript project,
+installs `blit386`, and copies the canonical `AGENTS.md` + `docs/` from `@blit386/kit`. The generated `package.json`
+pins a `blit386` version range (`BLIT386_RANGE` in `packages/create-blit386/src/scaffold.ts`).
 
 When you change the engine's onboarding surface here (the `README.md` Quick Start, `bootstrap()` signature/defaults, or
-the minimal demo shape), check whether the `create-blit-tech` templates, kit docs, and pinned version range need a
+the minimal demo shape), check whether the `create-blit386` templates, kit docs, and pinned version range need a
 matching update. That repo has its own git history and is not part of this repo's pnpm workspace.
 
 ## Architecture
 
 All engine functionality is accessed through the static `BT` namespace. The architecture is palette-first: primitives,
 sprites, and bitmap text resolve color through the active `Palette` before final RGBA output. Demos implement the
-`IBlitTechDemo` interface (`configure?`, `init`, `update`, `render`, optional `overlayRows?`).
+`IBTDemo` interface (`configure?`, `init`, `update`, `render`, optional `overlayRows?`).
 
 The file tree below is **illustrative, not exhaustive** — it highlights notable subsystems and entry points. Colocated
 `*.test.ts` / `*.bench.ts` files and small module-local `constants.ts` / `types.ts` helpers are omitted for readability.
 
 ```text
 src/
-  BlitTech.ts              # Public API (BT namespace + export block for classes, helpers, presets)
+  BLIT386.ts              # Public API (BT namespace + export block for classes, helpers, presets)
   docs/
-    consumer-doc-imports.test.ts # Guards README/docs import paths against BlitTech.ts exports
+    consumer-doc-imports.test.ts # Guards README/docs import paths against BLIT386.ts exports
   core/
     BTAPI.ts               # Internal singleton managing subsystems (lazy-loads WebGPURenderer on WebGPU init)
-    IBlitTechDemo.ts       # Demo interface + HardwareSettings
+    IBTDemo.ts       # Demo interface + HardwareSettings
     GameLoop.ts            # Fixed-timestep game loop
     WebGPUContext.ts       # WebGPU adapter/device/context setup
     RenderPaletteUsage.ts  # Per-frame palette index usage mask for overlay grid
@@ -272,7 +272,7 @@ Examples:
 - `Bloom.ts`: `FRAGMENT_WGSL` not `BLOOM_FRAGMENT_WGSL`
 - `Palette.ts`: file-local `Serialized` (or similar), not `PaletteJSON` or `JSON`
 
-**Does not apply to public API:** `BT.*`, the `BlitTech.ts` export block, public methods on exported classes, or
+**Does not apply to public API:** `BT.*`, the `BLIT386.ts` export block, public methods on exported classes, or
 documented configure field names. When JSDoc references public symbols, use their full public names (e.g. internal
 pointer wire codes map to `BT.BTN_POINTER_A`, not gamepad `BT.BTN_A`).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to Blit-Tech
+# Contributing to BLIT386
 
-Thank you for your interest in contributing to the Blit-Tech project.
+Thank you for your interest in contributing to the BLIT386 project.
 
 ## Developer Certificate of Origin (DCO)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Blit-Tech
+# BLIT386
 
-[![CI](https://github.com/vancura/blit-tech/actions/workflows/ci.yml/badge.svg)](https://github.com/vancura/blit-tech/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/npm/v/blit-tech.svg)](https://www.npmjs.com/package/blit-tech)
+[![CI](https://github.com/blit386/blit386/actions/workflows/ci.yml/badge.svg)](https://github.com/blit386/blit386/actions/workflows/ci.yml)
+[![npm version](https://img.shields.io/npm/v/blit386.svg)](https://www.npmjs.com/package/blit386)
 [![License: ISC](https://img.shields.io/badge/License-ISC-blue.svg)](https://opensource.org/licenses/ISC)
 [![WebGPU](https://img.shields.io/badge/WebGPU-Enabled-green.svg)](https://www.w3.org/TR/webgpu/)
 [![pnpm](https://img.shields.io/badge/pnpm-10.26.2-yellow.svg)](https://pnpm.io/)
@@ -9,13 +9,13 @@
 A palette-first WebGPU retro engine for TypeScript, inspired by [RetroBlit](https://badcastle.itch.io/retroblit). Draw
 with palette indices, animate with palette cycling and fades, and ship authentic VGA-era effects on modern GPUs.
 
-![Blit-Tech logo](assets/logo.png)
+![BLIT386 logo](assets/logo.png)
 
 ## Inspiration
 
-Blit-Tech draws heavy inspiration from [RetroBlit](https://www.badcastle.com/retroblit/docs/doc/index.html) by Martin
+BLIT386 draws heavy inspiration from [RetroBlit](https://www.badcastle.com/retroblit/docs/doc/index.html) by Martin
 Cietwierkowski ([@daafu](https://github.com/daafu)) - a retro pixel demo framework for Unity that replaces the editor
-with a clean, low-level demo loop. Blit-Tech brings the same philosophy to the web using WebGPU: no scene graphs, no
+with a clean, low-level demo loop. BLIT386 brings the same philosophy to the web using WebGPU: no scene graphs, no
 complex frameworks, just sprites, primitives, and fonts.
 
 ## Features
@@ -41,9 +41,9 @@ complex frameworks, just sprites, primitives, and fonts.
 - **Overlay**: engine-drawn FPS, backend, resolution, and demo title (toggle with `~` or bottom-left corner; disable via
   `isOverlayEnabled: false` in `configure()`)
 
-## Why Blit-Tech?
+## Why BLIT386?
 
-| Feature                  | Blit-Tech                           | Typical 2D WebGPU engines        |
+| Feature                  | BLIT386                             | Typical 2D WebGPU engines        |
 | ------------------------ | ----------------------------------- | -------------------------------- |
 | Rendering model          | Native indexed palette pipeline     | RGBA textures and framebuffers   |
 | Color animation          | Palette cycling/fade/flash built-in | Manual sprite or shader rewrites |
@@ -71,38 +71,38 @@ The fastest way to start is the **scaffolder**. It writes a ready-to-run Vite pr
 a starter game and local docs:
 
 ```bash
-npm create blit-tech@latest my-game
+npm create blit386@latest my-game
 cd my-game
 npm run dev
 ```
 
 Works with npm, pnpm, yarn, or bun (it uses whichever you ran it with). See
-[create-blit-tech](https://github.com/vancura/create-blit-tech) for options and what the project contains.
+[create-blit386](https://github.com/blit386/create-blit386) for options and what the project contains.
 
 ### Add to an existing project
 
-Install **blit-tech** from npm ([npmjs.com/package/blit-tech](https://www.npmjs.com/package/blit-tech)):
+Install **blit386** from npm ([npmjs.com/package/blit386](https://www.npmjs.com/package/blit386)):
 
 ```bash
-pnpm add blit-tech
+pnpm add blit386
 ```
 
-`bootstrap()` expects a canvas inside `#canvas-container` (defaults: canvas id `blit-tech-canvas`, container id
+`bootstrap()` expects a canvas inside `#canvas-container` (defaults: canvas id `blit386-canvas`, container id
 `canvas-container`):
 
 ```html
-<div id="canvas-container"><canvas id="blit-tech-canvas"></canvas></div>
+<div id="canvas-container"><canvas id="blit386-canvas"></canvas></div>
 <script type="module" src="/src/main.ts"></script>
 ```
 
 ```ts
-import { bootstrap, BT, Color32, Palette, Rect2i, type IBlitTechDemo } from 'blit-tech';
+import { bootstrap, BT, Color32, Palette, Rect2i, type IBTDemo } from 'blit386';
 
 const BG = 1;
 const WATER_A = 9;
 const WATER_B = 12;
 
-class MyDemo implements IBlitTechDemo {
+class MyDemo implements IBTDemo {
   async init(): Promise<boolean> {
     const palette = Palette.c64();
     palette.set(BG, new Color32(20, 30, 40, 255));
@@ -131,7 +131,7 @@ See [API: Core](docs/api-core.md) for full `bootstrap()` options.
 
 ## Examples & Demos
 
-For interactive examples and demos, visit the [Blit-Tech Demos repository](https://github.com/vancura/blit-tech-demos).
+For interactive examples and demos, visit the [BLIT386 Demos repository](https://github.com/blit386/blit386-demos).
 
 ## Documentation
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,14 +15,14 @@ The **1.x** release line is actively maintained. Security fixes are published as
 If you discover a security vulnerability in a supported **1.x** release, please report it responsibly.
 
 **Do not open a public issue.** Instead, email the maintainers directly or use
-[GitHub's private vulnerability reporting](https://github.com/vancura/blit-tech/security/advisories/new).
+[GitHub's private vulnerability reporting](https://github.com/blit386/blit386/security/advisories/new).
 
 We will acknowledge receipt within 48 hours and provide a timeline for a fix. Once resolved, we will publish a fix on
 the supported **1.x** line and credit you in the release notes (unless you prefer to remain anonymous).
 
 ## Scope
 
-blit-tech is a client-side WebGPU rendering library. Security concerns are primarily:
+blit386 is a client-side WebGPU rendering library. Security concerns are primarily:
 
 - Supply chain (dependencies)
 - Build pipeline integrity

--- a/cspell.json
+++ b/cspell.json
@@ -14,6 +14,8 @@
     "biomejs",
     "bitwise",
     "blit",
+    "blit386",
+    "BLIT386",
     "blits",
     "bmfont",
     "Bresenham",

--- a/docs/api-assets.md
+++ b/docs/api-assets.md
@@ -36,7 +36,7 @@ sheets. Prefer separate PNG files for large atlases so the JSON payload stays un
 soon as the browser reports decoded dimensions.
 
 ```ts
-import { AssetLoader } from 'blit-tech';
+import { AssetLoader } from 'blit386';
 
 // Load a single image (cached by URL)
 const image = await AssetLoader.loadImage('sprites.png');
@@ -58,7 +58,7 @@ Use `SpriteSheet.loadIndexed()` for all standard sprite setup. It combines color
 palette indexization in one call.
 
 ```ts
-import { SpriteSheet, Palette } from 'blit-tech';
+import { SpriteSheet, Palette } from 'blit386';
 
 const palette = new Palette(256);
 
@@ -128,7 +128,7 @@ Load `.btfont` files for proportional, palette-indexed bitmap fonts. After loadi
 indexize the font's internal sprite sheet before drawing (same pattern as manual sprite setup).
 
 ```ts
-import { BitmapFont, Palette } from 'blit-tech';
+import { BitmapFont, Palette } from 'blit386';
 
 const palette = new Palette(256);
 const font = await BitmapFont.load('fonts/MyFont.btfont');

--- a/docs/api-core.md
+++ b/docs/api-core.md
@@ -2,9 +2,9 @@
 
 Bootstrap, initialization, game loop timing, camera, and core types.
 
-> **Starting a new project?** The quickest path is the scaffolder: `npm create blit-tech@latest my-game` (works with
-> npm, pnpm, yarn, or bun). It generates a ready-to-run Vite project with the engine installed, a starter game, and
-> local docs. See [create-blit-tech](https://github.com/vancura/create-blit-tech). The rest of this page documents the
+> **Starting a new project?** The quickest path is the scaffolder: `npm create blit386@latest my-game` (works with npm,
+> pnpm, yarn, or bun). It generates a ready-to-run Vite project with the engine installed, a starter game, and local
+> docs. See [create-blit386](https://github.com/blit386/create-blit386). The rest of this page documents the
 > `bootstrap()` API for hand-wired or existing projects.
 
 ---
@@ -15,9 +15,9 @@ The `bootstrap()` function is the recommended entry point. It handles DOM ready,
 (WebGPU or software fallback), and error display automatically.
 
 ```ts
-import { bootstrap, type BootstrapOptions } from 'blit-tech';
+import { bootstrap, type BootstrapOptions } from 'blit386';
 
-// One-liner - canvas id defaults to 'blit-tech-canvas', container to 'canvas-container'
+// One-liner - canvas id defaults to 'blit386-canvas', container to 'canvas-container'
 bootstrap(MyDemo);
 
 // With options
@@ -34,7 +34,7 @@ bootstrap(MyDemo, {
 
 | Field                  | Type                     | Default              | Description                    |
 | ---------------------- | ------------------------ | -------------------- | ------------------------------ |
-| `canvasID`             | `string`                 | `'blit-tech-canvas'` | Canvas element id              |
+| `canvasID`             | `string`                 | `'blit386-canvas'`   | Canvas element id              |
 | `containerID`          | `string`                 | `'canvas-container'` | Container id for error display |
 | `onSuccess`            | `() => void`             | -                    | Called after successful init   |
 | `onError`              | `(error: Error) => void` | -                    | Called on any init failure     |
@@ -43,7 +43,7 @@ bootstrap(MyDemo, {
 **Manual utilities** (for custom initialization flows):
 
 ```ts
-import { displayError, getCanvas } from 'blit-tech';
+import { displayError, getCanvas } from 'blit386';
 
 const canvas = getCanvas('my-canvas'); // returns null on missing element
 displayError('Init Failed', 'WebGPU unavailable.', 'my-container');
@@ -71,7 +71,7 @@ set `canvas.tabIndex = 0` and call `canvas.focus()` so keyboard events reach the
 
 ### Resolution model
 
-Blit-Tech tracks several related pixel dimensions. Public configure/getter names (`displaySize`, `drawingBufferSize`,
+BLIT386 tracks several related pixel dimensions. Public configure/getter names (`displaySize`, `drawingBufferSize`,
 `maxCanvasSize`) map to the layers below; **display-tier** is a separate post-process term.
 
 | Term               | What it is                                                                                         | Configure field             | `BT` getter               |
@@ -219,9 +219,8 @@ the system font metrics.
 always-visible metrics should opt back in with `isOverlayVisibleAtStart: true` in `configure()` until authors choose
 otherwise.
 
-- **Top row 1 (left):** short demo title derived from `document.title` (registry pages titled
-  `Blit-Tech Demo NNN - Topic` show as `Topic Demo`); **top row 1 (right):** active backend and logical resolution (for
-  example `webgpu | 320x240`)
+- **Top row 1 (left):** short demo title derived from `document.title` (registry pages titled `BLIT386 Demo NNN - Topic`
+  show as `Topic Demo`); **top row 1 (right):** active backend and logical resolution (for example `webgpu | 320x240`)
 - **Timing chart (optional):** when `isOverlayTimingChartEnabled: true`, a scrolling band of **one-pixel dots** shows
   raw per-frame `update()` vs `render()` CPU time (one column per present frame, not per fixed `update()` tick). Band
   height defaults to **22 px**; override with `overlayTimingChartHeight`. Dot height scales linearly so about **16 ms**
@@ -276,13 +275,13 @@ otherwise.
 - **Custom rows (optional):** extra bars from `overlayRows()` stacked above the bottom band, **1 px** filled gaps apart,
   each with left text and optional right text (same 13 px bar style as the built-in rows)
 
-Demos may implement optional `overlayRows()` on `IBlitTechDemo`. The engine calls it once per render frame after
-`render()` when the overlay is enabled and the **body** is visible (not hidden with Backquote or the corner toggle).
-Return `undefined` or an empty array when no custom rows are needed. Reuse the same array and row objects when possible;
-update `leftText` / `rightText` in place to avoid per-frame allocations.
+Demos may implement optional `overlayRows()` on `IBTDemo`. The engine calls it once per render frame after `render()`
+when the overlay is enabled and the **body** is visible (not hidden with Backquote or the corner toggle). Return
+`undefined` or an empty array when no custom rows are needed. Reuse the same array and row objects when possible; update
+`leftText` / `rightText` in place to avoid per-frame allocations.
 
 ```ts
-/** @implements {IBlitTechDemo} */
+/** @implements {IBTDemo} */
 class Demo {
   readonly #overlayRows = [{ leftText: 'Position: 0, 0' }, { leftText: 'Score: 0', rightText: 'ready' }];
 
@@ -382,7 +381,7 @@ configure() {
 
 ## Game Loop Timing
 
-Blit-Tech runs two independent cadences:
+BLIT386 runs two independent cadences:
 
 | Concept             | Where                                                      | Meaning                                                        |
 | ------------------- | ---------------------------------------------------------- | -------------------------------------------------------------- |
@@ -443,7 +442,7 @@ const clamped = BT.cameraClamp(desired, worldSize, new Vector2i(160, 120));
 Standalone helper (same math as `BT.cameraClamp`):
 
 ```ts
-import { clampCameraToWorld } from 'blit-tech';
+import { clampCameraToWorld } from 'blit386';
 
 const clamped = clampCameraToWorld(desired, worldSize, viewSize);
 ```
@@ -455,7 +454,7 @@ const clamped = clampCameraToWorld(desired, worldSize, viewSize);
 Import `defaultConfig` and `mergeHardwareSettings` when building custom configure flows outside `bootstrap()`:
 
 ```ts
-import { defaultConfig, mergeHardwareSettings } from 'blit-tech';
+import { defaultConfig, mergeHardwareSettings } from 'blit386';
 
 const settings = mergeHardwareSettings(defaultConfig(), { targetFPS: 30 });
 ```
@@ -470,7 +469,7 @@ enabled, WebGPU backend, and other defaults documented in the table above).
 Palette fade effects accept an `EasingFunction`. Use `applyEasing` to evaluate named curves:
 
 ```ts
-import { applyEasing } from 'blit-tech';
+import { applyEasing } from 'blit386';
 
 const t = applyEasing('ease-in-out', 0.5); // 0..1 progress → eased value
 ```

--- a/docs/api-rendering.md
+++ b/docs/api-rendering.md
@@ -139,7 +139,7 @@ for (const fx of BT.preset.amber()) BT.effectAdd(fx);
 for (const fx of BT.preset.green()) BT.effectAdd(fx);
 
 // Equivalent standalone imports also work:
-import { crtPipBoy, amber, green } from 'blit-tech';
+import { crtPipBoy, amber, green } from 'blit386';
 for (const fx of crtPipBoy()) BT.effectAdd(fx);
 ```
 
@@ -150,8 +150,8 @@ for (const fx of crtPipBoy()) BT.effectAdd(fx);
 | Pixel   | `PixelGlitch`, `PixelMosaic`                                                                                                           |
 | Display | `BarrelDistortion`, `Scanlines`, `RGBMask`, `Vignette`, `ChromaticAberration`, `Flicker`, `RollLine`, `Interference`, `Noise`, `Bloom` |
 
-All effect classes are exported from `'blit-tech'`. Each instance owns its own GPU resources and may be mutated each
-frame from demo code.
+All effect classes are exported from `'blit386'`. Each instance owns its own GPU resources and may be mutated each frame
+from demo code.
 
 See [Post-Process Effects Guide](post-process-effects.md) for parameter reference, the `Effect` interface, `EffectTier`,
 the `FullscreenEffect` base class, and how to write a custom effect.
@@ -175,7 +175,7 @@ await BT.downloadFrame('screenshot-001.png'); // custom filename
 ### Internal implementation note
 
 `BT.captureFrame()` uses the internal `FrameCapture` class (`src/utils/FrameCapture.ts`), which is **not** exported from
-`'blit-tech'`. Demos should use `BT.captureFrame()` and `BT.downloadFrame()` only.
+`'blit386'`. Demos should use `BT.captureFrame()` and `BT.downloadFrame()` only.
 
 ---
 

--- a/docs/bitmap-fonts.md
+++ b/docs/bitmap-fonts.md
@@ -1,6 +1,6 @@
-# Bitmap Fonts in Blit-Tech
+# Bitmap Fonts in BLIT386
 
-Blit-Tech ships with a built-in system font and supports custom `.btfont` bitmap fonts with variable-width glyphs,
+BLIT386 ships with a built-in system font and supports custom `.btfont` bitmap fonts with variable-width glyphs,
 per-character offsets, Unicode characters, and either embedded or external textures.
 
 ## Built-in System Font
@@ -36,7 +36,7 @@ For proportional fonts, Unicode support, or custom aesthetics, load a `.btfont` 
 ## Quick Start
 
 ```ts
-import { BitmapFont, BT, Palette, Vector2i } from 'blit-tech';
+import { BitmapFont, BT, Palette, Vector2i } from 'blit386';
 
 // Load a font and register its colors in the palette
 const palette = new Palette(256);
@@ -171,21 +171,21 @@ The conversion script works best when run directly in your terminal:
 **macOS/Linux:**
 
 ```bash
-cd /path/to/blit-tech
+cd /path/to/blit386
 node scripts/convert-bmfont.mjs input.fnt output.btfont --embed
 ```
 
 **Windows (PowerShell):**
 
 ```powershell
-cd D:\path\to\blit-tech
+cd D:\path\to\blit386
 node scripts/convert-bmfont.mjs input.fnt output.btfont --embed
 ```
 
 **Windows (CMD):**
 
 ```cmd
-cd D:\path\to\blit-tech
+cd D:\path\to\blit386
 node scripts\convert-bmfont.mjs input.fnt output.btfont --embed
 ```
 
@@ -237,7 +237,7 @@ If you prefer to convert manually:
 
 4. **Custom Font Editor** (Coming Soon)
 
-- Blit-Tech will include its own font editor.
+- BLIT386 will include its own font editor.
 - Native `.btfont` export with embedded textures.
 
 ### Tips for Creating Fonts

--- a/docs/developer-experience-guide.md
+++ b/docs/developer-experience-guide.md
@@ -1,7 +1,7 @@
 # Developer Experience Guide
 
 This guide covers the contributing workflow, code style conventions, IDE setup, and maintenance checklists for the
-Blit-Tech project.
+BLIT386 project.
 
 ---
 
@@ -20,7 +20,7 @@ See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor workflow. Key
 
 ## Repository Scripts
 
-These commands apply when building or maintaining **blit-tech** from a repository checkout (not when consuming the npm
+These commands apply when building or maintaining **blit386** from a repository checkout (not when consuming the npm
 package).
 
 | Command                             | Description                                                                                     |
@@ -261,7 +261,7 @@ Public `.d.ts` output is produced by `vite-plugin-dts` with `rollupTypes: true`,
 `package.json` (not TypeScript 6.x) to avoid compiler drift warnings and keep declaration analysis deterministic.
 
 When bumping `typescript` or `vite-plugin-dts`, confirm `pnpm run build` logs **no** TS/API Extractor version mismatch
-and that `dist/blit-tech.d.ts` still rolls up cleanly. Re-run `pnpm run typecheck` after any TypeScript line change; TS
+and that `dist/blit386.d.ts` still rolls up cleanly. Re-run `pnpm run typecheck` after any TypeScript line change; TS
 5.9 stricter WebGPU typings may require small test/production fixes (for example `ArrayBuffer`-backed uniform buffers).
 
 **CI guard:** the `build-library` job runs `node scripts/check-declaration-tooling.mjs` on the `pnpm run build` log
@@ -285,7 +285,7 @@ matches `package.json`. Locally: `pnpm run build` then `node scripts/check-decla
 - [ ] Review analytics/usage (if available)
 - [ ] Update roadmap
 - [ ] Check for security advisories
-- [ ] Run MCP governance preflight for `blit-tech` and `blit-tech-demos`
+- [ ] Run MCP governance preflight for `blit386` and `blit386-demos`
       (`pnpm run security:mcp-preflight -- --governance-only`; see
       [docs/security/security-runbook.md](security/security-runbook.md))
 - [ ] Review shadow MCP flags and re-auth critical security MCPs if needed
@@ -298,8 +298,8 @@ matches `package.json`. Locally: `pnpm run build` then `node scripts/check-decla
 - [ ] Test library build
 - [ ] Test examples deployment
 - [ ] Create a GitHub release with notes
-- [ ] Publish `blit-tech` to npm (`pnpm run release` or `pnpm publish --access public` after `pnpm run build`)
-- [ ] Verify package page and install flow: https://www.npmjs.com/package/blit-tech and `npm install blit-tech`
+- [ ] Publish `blit386` to npm (`pnpm run release` or `pnpm publish --access public` after `pnpm run build`)
+- [ ] Verify package page and install flow: https://www.npmjs.com/package/blit386 and `npm install blit386`
 
 npm **provenance** is not enabled: publishing is local-only today. `pnpm publish --provenance` needs an OIDC-backed CI
 publish job; see [dependency-policy.md](security/dependency-policy.md#npm-publish-provenance).
@@ -319,7 +319,7 @@ publish job; see [dependency-policy.md](security/dependency-policy.md#npm-publis
 
 ## Planned Improvements
 
-The following items are tracked in Linear (VV team / Blit-Tech project) as low-priority `feat(dx)` tickets:
+The following items are tracked in Linear (VV team / BLIT386 project) as low-priority `feat(dx)` tickets:
 
 - GitHub issue templates (`.github/ISSUE_TEMPLATE/`)
 - Pull request template (`.github/PULL_REQUEST_TEMPLATE.md`)

--- a/docs/input.md
+++ b/docs/input.md
@@ -1,6 +1,6 @@
 # Input Guide
 
-Blit-Tech provides DOM-backed input: **pointer** (mouse, touch, pen), **keyboard** (`KeyboardEvent.code` tracking and
+BLIT386 provides DOM-backed input: **pointer** (mouse, touch, pen), **keyboard** (`KeyboardEvent.code` tracking and
 virtual face buttons), **gamepad** (up to four players via `navigator.getGamepads()`), and **text accumulation** for UI
 entry (`BT.inputString`).
 
@@ -271,7 +271,7 @@ Coordinates are clamped to `[0, displaySize - 1]` on each axis. The conversion i
 
 ## Implementation Notes
 
-- `PointerInput`, `KeyboardInput`, and `GamepadInput` are internal; import from `blit-tech` and access through `BT.*`
+- `PointerInput`, `KeyboardInput`, and `GamepadInput` are internal; import from `blit386` and access through `BT.*`
   methods.
 - Default keyboard tables live in `defaultKeyboardMap.ts`; runtime remaps are stored in the `BT` facade and reset with
   `BT.inputMapReset()`.

--- a/docs/overlay.md
+++ b/docs/overlay.md
@@ -47,9 +47,9 @@ subsystem entirely (for example release builds or full-screen custom HUD demos).
 
 ## Custom rows (`overlayRows`)
 
-Demos may implement optional `overlayRows()` on `IBlitTechDemo`. The engine calls it once per frame after `render()`
-when the overlay body is visible. Return a **reused** array of row objects when possible — avoid allocating new strings
-every frame.
+Demos may implement optional `overlayRows()` on `IBTDemo`. The engine calls it once per frame after `render()` when the
+overlay body is visible. Return a **reused** array of row objects when possible — avoid allocating new strings every
+frame.
 
 ```javascript
 class Demo {

--- a/docs/palette-guide.md
+++ b/docs/palette-guide.md
@@ -1,6 +1,6 @@
 # Palette Guide
 
-Blit-Tech is palette-first: every visible pixel stores a palette slot index, and final RGB color comes from the active
+BLIT386 is palette-first: every visible pixel stores a palette slot index, and final RGB color comes from the active
 `Palette`. Changing palette data changes every pixel that references those slots.
 
 This guide covers the end-to-end workflow: setup, indexed sprites, palette offsets, runtime effects, and when to call
@@ -14,7 +14,7 @@ For terminology (**slot** vs **`paletteIndex`** vs **`paletteOffset`**) and when
 ## 1) Create and activate a palette
 
 ```ts
-import { BT, Color32, Palette } from 'blit-tech';
+import { BT, Color32, Palette } from 'blit386';
 
 const palette = Palette.c64(); // or new Palette(256)
 palette.set(1, new Color32(20, 30, 40, 255)); // custom background slot
@@ -53,7 +53,7 @@ When slot `6` changes in the active palette, every pixel drawn with absolute ind
 Use this when loading sprites for normal game/demo work.
 
 ```ts
-import { SpriteSheet } from 'blit-tech';
+import { SpriteSheet } from 'blit386';
 
 const indexed = await SpriteSheet.loadIndexed('sprites/hero.png', palette, 32, { sort: 'luminance' });
 BT.paletteSet(palette);

--- a/docs/palette-presets.md
+++ b/docs/palette-presets.md
@@ -11,7 +11,7 @@ All preset hex values are lowercase `RRGGBB` (no `#`), matching `src/assets/pale
 
 ## Slot mapping note (important)
 
-Blit-Tech reserves palette slot `0` for transparency. Preset factories therefore write colors starting at slot `1`.
+BLIT386 reserves palette slot `0` for transparency. Preset factories therefore write colors starting at slot `1`.
 
 That means:
 

--- a/docs/performance-best-practices.md
+++ b/docs/performance-best-practices.md
@@ -1,6 +1,6 @@
 # Performance Best Practices
 
-This guide explains when and how to optimize your Blit-Tech demos for performance, with a focus on object allocation
+This guide explains when and how to optimize your BLIT386 demos for performance, with a focus on object allocation
 patterns and rendering efficiency.
 
 ## Table of Contents
@@ -43,7 +43,7 @@ a 60 Hz simulation on a 120 Hz monitor still has a ~8.33 ms render budget per rA
 
 ## Object Allocation Patterns
 
-JavaScript's garbage collector can cause frame hitches if you allocate many objects per frame. Blit-Tech provides two
+JavaScript's garbage collector can cause frame hitches if you allocate many objects per frame. BLIT386 provides two
 patterns for managing allocations:
 
 ### Inline Allocation (Simple & Clear)
@@ -74,7 +74,7 @@ BT.printFont(font, new Vector2i(10, 20), 'Hello');
 **When to use:** Tight loops that run 50+ times per frame.
 
 ```ts
-class MyDemo implements IBlitTechDemo {
+class MyDemo implements IBTDemo {
   // Pre-allocate reusable objects
   private readonly tempVec = new Vector2i(0, 0);
   private readonly tempRect = new Rect2i(0, 0, 0, 0);
@@ -119,7 +119,7 @@ pre-allocation provides measurable benefits.
 
 ### Batching
 
-Blit-Tech automatically batches draw calls for optimal GPU performance:
+BLIT386 automatically batches draw calls for optimal GPU performance:
 
 - **Primitive batching:** All primitives (pixels, lines, rects) are batched together
 - **Texture batching:** Sprites from the same `SpriteSheet` are batched
@@ -213,7 +213,7 @@ for (let i = 0; i < 200; i++) {
 
 ### Fixed Timestep
 
-Blit-Tech uses a fixed **simulation** timestep by default (`targetFPS: 60` → `update()` about 60 times per second).
+BLIT386 uses a fixed **simulation** timestep by default (`targetFPS: 60` → `update()` about 60 times per second).
 `render()` still runs at the browser's refresh rate. This provides:
 
 - **Deterministic behavior:** Same inputs always produce same results
@@ -355,7 +355,7 @@ render(): void {
 
 ## Example References
 
-Demos live in the sibling **`blit-tech-demos`** repo (`src/NNN-topic.js` files). The examples below demonstrate both
+Demos live in the sibling **`blit386-demos`** repo (`src/NNN-topic.js` files). The examples below demonstrate both
 approaches:
 
 ### Clarity-First Examples (Inline Allocation)

--- a/docs/performance-testing.md
+++ b/docs/performance-testing.md
@@ -1,7 +1,7 @@
 # Performance Testing
 
-Blit-Tech has CPU micro-benchmarks for hot methods. This guide explains when to use them, how to add a new benchmark,
-and how CI uses the results.
+BLIT386 has CPU micro-benchmarks for hot methods. This guide explains when to use them, how to add a new benchmark, and
+how CI uses the results.
 
 ## Table of Contents
 
@@ -16,7 +16,7 @@ and how CI uses the results.
 
 ## Overview
 
-Blit-Tech uses Vitest bench for CPU micro-benchmarks. These measure isolated methods, hot loops, cache lookups, math
+BLIT386 uses Vitest bench for CPU micro-benchmarks. These measure isolated methods, hot loops, cache lookups, math
 helpers, and allocation patterns.
 
 For visual correctness (not performance), use the visual regression tests: `pnpm run test:visual`. They run Playwright

--- a/docs/post-process-effects.md
+++ b/docs/post-process-effects.md
@@ -1,6 +1,6 @@
 # Post-Process Effects
 
-Blit-Tech ships a **two-tier post-process system** that runs between the scene render and the swap-chain present. It is
+BLIT386 ships a **two-tier post-process system** that runs between the scene render and the swap-chain present. It is
 opt-in and adds zero cost while no effect is registered. Effects are organized into two chains by what they operate on:
 
 - **Pixel tier** - runs at the logical render resolution (e.g. `320x240`) on an **`r8uint` index framebuffer** (one byte
@@ -22,7 +22,7 @@ see [Resolution model](api-core.md#resolution-model) in the core API docs.
 ## Quick start
 
 ```ts
-import { BT, Vector2i, BarrelDistortion, Scanlines, RGBMask, Bloom, PixelGlitch } from 'blit-tech';
+import { BT, Vector2i, BarrelDistortion, Scanlines, RGBMask, Bloom, PixelGlitch } from 'blit386';
 
 class Demo {
   configure() {
@@ -110,7 +110,7 @@ Removes every effect in both tiers and destroys all offscreen GPU resources. Thr
 ### `Effect` interface
 
 ```ts
-import type { Effect, EffectTier, Vector2i } from 'blit-tech';
+import type { Effect, EffectTier, Vector2i } from 'blit386';
 
 export class MyEffect implements Effect {
   public readonly tier: EffectTier = 'display'; // or 'pixel'
@@ -315,7 +315,7 @@ Extend `FullscreenEffect` when sampling RGBA at output resolution. Subclasses pr
 `sampler`), declare `tier = 'display'`, set `uniformBytes`, and implement `writeUniforms`.
 
 ```ts
-import { FullscreenEffect, type Vector2i } from 'blit-tech';
+import { FullscreenEffect, type Vector2i } from 'blit386';
 
 export class GammaEffect extends FullscreenEffect {
   public readonly tier = 'display' as const;
@@ -409,7 +409,7 @@ extensions until the upstream source and license have been identified.
 
 The individual building blocks (hash-based pseudo-random, sin/cos roll line, band-noise glitch shifts, chromatic
 aberration via offset sampling) are common shader patterns and not original to any one author, but the specific
-composition mirrors the PipBoy fork. The Blit-Tech port is original WGSL.
+composition mirrors the PipBoy fork. The BLIT386 port is original WGSL.
 
 If you intend to reuse `Interference`, `RollLine`, or `PixelGlitch` in a context with stricter licensing requirements,
 confirm provenance first. The license audit is still open. If you can identify the upstream PipBoy fork, please open a

--- a/docs/security/dependency-policy.md
+++ b/docs/security/dependency-policy.md
@@ -1,6 +1,6 @@
 # Dependency security policy
 
-Continuous dependency vulnerability gating for the `blit-tech` library repo.
+Continuous dependency vulnerability gating for the `blit386` library repo.
 
 ## Severity gate
 
@@ -17,7 +17,7 @@ CI runs both checks on every pull request and push to `main` via the **Dependenc
 ## Local verification
 
 ```bash
-cd blit-tech
+cd blit386
 pnpm install --frozen-lockfile
 pnpm run security:audit
 pnpm run security:audit:prod

--- a/docs/security/security-runbook.md
+++ b/docs/security/security-runbook.md
@@ -1,18 +1,18 @@
 # Security runbook
 
-Deterministic security workflow for Blit-Tech repos when MCP scanners are healthy, degraded, or unavailable. Use with
-the `/security-run` skill and `pnpm run security:mcp-preflight`.
+Deterministic security workflow for BLIT386 repos when MCP scanners are healthy, degraded, or unavailable. Use with the
+`/security-run` skill and `pnpm run security:mcp-preflight`.
 
 ## Maintainers
 
 | Role                | Contact / owner                                       | Notes                                                                  |
 | ------------------- | ----------------------------------------------------- | ---------------------------------------------------------------------- |
-| Primary security    | [@vancura](https://github.com/vancura) (`CODEOWNERS`) | Sole maintainer for `blit-tech` and `blit-tech-demos` (May 2026).      |
+| Primary security    | [@vancura](https://github.com/vancura) (`CODEOWNERS`) | Sole maintainer for `blit386` and `blit386-demos` (May 2026).          |
 | Backup / escalation | _None_ (solo project)                                 | No secondary on-call; treat delayed response as accepted project risk. |
 
 **Incident triage (solo maintainer):**
 
-1. Open or triage a [GitHub issue](https://github.com/vancura/blit-tech/issues): apply label `security` if that label
+1. Open or triage a [GitHub issue](https://github.com/blit386/blit386/issues): apply label `security` if that label
    exists in the repository and you have permission; if it does not exist, create the issue and add the label when you
    can edit repository labels. If you cannot create or label issues, contact [@vancura](https://github.com/vancura)
    (primary security owner) and record the incident in Linear.
@@ -37,7 +37,7 @@ Agents must pass the Cursor project MCP descriptor path from the session (for ex
 `~/.cursor/projects/<workspace-id>/mcps`).
 
 ```bash
-cd <repo-root>   # blit-tech: directory containing this repo's package.json
+cd <repo-root>   # blit386: directory containing this repo's package.json
 
 pnpm run security:mcp-preflight -- \
   --mcps-dir "<cursor-project-mcps-path>" \
@@ -69,7 +69,7 @@ the report.
 
 | Capability            | Primary MCP                   | Fallback (always available)                                                                                                                                  |
 | --------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Dependency / SCA      | Opsera `security-scan`, JFrog | `pnpm run security:audit`, `pnpm run security:audit:prod` (per repo); CI gate in blit-tech [dependency-policy.md](./dependency-policy.md)                    |
+| Dependency / SCA      | Opsera `security-scan`, JFrog | `pnpm run security:audit`, `pnpm run security:audit:prod` (per repo); CI gate in blit386 [dependency-policy.md](./dependency-policy.md)                      |
 | SAST / code patterns  | Opsera, Semgrep MCP           | `pnpm run lint` (eslint-plugin-security), targeted `rg` patterns (below), optional `semgrep --config auto` only if CLI is already installed (do not install) |
 | Compliance            | Opsera `compliance-audit`     | Manual checklist below                                                                                                                                       |
 | Architecture          | Opsera `architecture-analyze` | `security-threat-model` and `security-ownership-map` skills under `~/.codex/skills/`                                                                         |
@@ -96,16 +96,16 @@ When Opsera `compliance-audit` MCP is unavailable, gather evidence manually:
 | Code quality / static checks | `pnpm run preflight`, `pnpm run lint`                                                                          |
 | Secrets in repo              | `.gitignore`, hooks blocking `.env`; `rg` for hardcoded tokens (no secret values in reports)                   |
 | CI integrity                 | `.github/workflows/*.yml` — pinned actions, least privilege                                                    |
-| Deploy headers (demos)       | `blit-tech-demos/public/_headers`, `curl -I` on deployed URLs                                                  |
+| Deploy headers (demos)       | `blit386-demos/public/_headers`, `curl -I` on deployed URLs                                                    |
 | Ownership / bus factor       | [Maintainers](#maintainers) (solo); optional `security-ownership-map` skill output (`summary.json`)            |
 | MCP governance               | `pnpm run security:mcp-preflight --governance-only`                                                            |
 
 ## Repo-native commands
 
-### blit-tech
+### blit386
 
 ```bash
-cd <repo-root>   # or: cd "$PWD" after cloning blit-tech
+cd <repo-root>   # or: cd "$PWD" after cloning blit386
 
 pnpm run security:mcp-preflight -- --mcps-dir "<mcps>" --repo-root . --allow-fallback
 pnpm run security:audit
@@ -121,10 +121,10 @@ npm view vite version time.modified license
 npm view typescript version time.modified license
 ```
 
-### blit-tech-demos
+### blit386-demos
 
 ```bash
-cd <repo-root>   # blit-tech-demos: directory containing this repo's package.json
+cd <repo-root>   # blit386-demos: directory containing this repo's package.json
 
 pnpm run security:mcp-preflight -- \
   --mcps-dir "<mcps>" \
@@ -137,23 +137,23 @@ pnpm run preflight
 pnpm run build
 ```
 
-Note: **`blit-tech-demos` has no `security:audit:prod` script** — use `pnpm run security:audit` only for production-deps
+Note: **`blit386-demos` has no `security:audit:prod` script** — use `pnpm run security:audit` only for production-deps
 coverage in that repo, or run `pnpm audit --prod --audit-level=moderate` directly.
 
 After toolchain or dependency upgrades, always run `pnpm run build` as a smoke test.
 
 Demos can invoke the canonical preflight script from the library repo (prefer `pnpm run security:mcp-preflight` when the
-sibling layout matches `package.json`). If invoking the script directly, set `<blit-tech-root>` to the blit-tech repo
-path (or export `BLIT_TECH_ROOT` and use `"$BLIT_TECH_ROOT"`):
+sibling layout matches `package.json`). If invoking the script directly, set `<blit386-root>` to the blit386 repo path
+(or export `BLIT386_ROOT` and use `"$BLIT386_ROOT"`):
 
 ```bash
-node "<blit-tech-root>/scripts/security/mcp-preflight.mjs" \
+node "<blit386-root>/scripts/security/mcp-preflight.mjs" \
   --mcps-dir "<mcps>" \
   --repo-root . \
   --allow-fallback
 
-# Example: export BLIT_TECH_ROOT=/path/to/blit-tech
-# node "$BLIT_TECH_ROOT/scripts/security/mcp-preflight.mjs" --mcps-dir "<mcps>" --repo-root . --allow-fallback
+# Example: export BLIT386_ROOT=/path/to/blit386
+# node "$BLIT386_ROOT/scripts/security/mcp-preflight.mjs" --mcps-dir "<mcps>" --repo-root . --allow-fallback
 ```
 
 ## Periodic governance (monthly)
@@ -177,13 +177,13 @@ Use this structure in agent output or issue/PR comments:
 - Semgrep: <status>
 - Fallbacks used: <list>
 
-### blit-tech
+### blit386
 
 - security:audit: <pass/fail summary>
 - prod audit: <pass/fail>
 - preflight: <pass/fail>
 
-### blit-tech-demos
+### blit386-demos
 
 - security:audit: <pass/fail summary>
 - prod audit: <pass/fail>

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,6 +1,6 @@
 # Testing
 
-Blit-Tech uses three primary testing tiers (unit, integration, visual) plus a benchmark tier for CPU performance
+BLIT386 uses three primary testing tiers (unit, integration, visual) plus a benchmark tier for CPU performance
 regression tracking.
 
 ## Architecture
@@ -17,7 +17,7 @@ Pure logic with no GPU dependencies. Tests run in Node.js for maximum speed. The
 - **PaletteEffect** - manager lifecycle, CycleEffect rotation, FadeEffect/FadeRangeEffect lerp, FlashEffect, paletteSwap
 - **Easing** - boundary values, monotonicity, midpoint checks for all easing curves
 - **GameLoop** - constructor validation, tick counter
-- **IBlitTechDemo** - `defaultConfig()` and optional `configure()`
+- **IBTDemo** - `defaultConfig()` and optional `configure()`
 
 ### Tier 2: Integration Tests (Vitest, Node + GPU mocks)
 
@@ -47,7 +47,7 @@ and `vi` for browser API stubs. Tests that need a full DOM (Bootstrap, Bootstrap
   integration (Node)
 - **FrameCapture** - GPU readback, PNG conversion (Node + GPU mocks + browser stubs)
 - **consumer-doc-imports** - `src/docs/consumer-doc-imports.test.ts` guards README/docs import paths against
-  `BlitTech.ts` exports
+  `BLIT386.ts` exports
 
 ### Tier 3: Visual Regression (Playwright, Chromium)
 

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -7,11 +7,11 @@ Build, declaration, and quality-tooling notes for contributors. For the full con
 
 The workspace pins **TypeScript 5.9.3** in `package.json` to match the compiler bundled with **API Extractor** (invoked
 by `vite-plugin-dts` when `rollupTypes: true`). This avoids TS/API Extractor drift warnings during `pnpm run build` and
-keeps rolled-up `dist/blit-tech.d.ts` deterministic.
+keeps rolled-up `dist/blit386.d.ts` deterministic.
 
 When bumping `typescript` or `vite-plugin-dts`, confirm the build log reports the same bundled version and that
 `node scripts/check-declaration-tooling.mjs build.log` passes (log alignment plus required `BT` getters in
-`dist/blit-tech.d.ts`, including `requestedBackend` and `activeBackend`). See
+`dist/blit386.d.ts`, including `requestedBackend` and `activeBackend`). See
 [Declaration tooling](developer-experience-guide.md#declaration-tooling-typescript--api-extractor) in the DX guide for
 CI details.
 

--- a/docs/voice.md
+++ b/docs/voice.md
@@ -3,7 +3,7 @@
 ## Why This Exists
 
 Error messages, canvas banners, and console output that reach a developer or end user define the first impression of the
-engine. Blit-Tech targets two distinct audiences, and mixing their styles produces confusing output for both.
+engine. BLIT386 targets two distinct audiences, and mixing their styles produces confusing output for both.
 
 This guide defines the rules. Before writing any `throw`, `console.error`, `displayError`, or canvas-visible string,
 read the relevant section below.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "blit-tech",
+  "name": "blit386",
   "version": "1.1.1",
   "type": "module",
   "description": "A palette-first WebGPU retro engine for TypeScript, inspired by RetroBlit.",
@@ -10,11 +10,11 @@
   "license": "ISC",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vancura/blit-tech.git"
+    "url": "git+https://github.com/blit386/blit386.git"
   },
-  "homepage": "https://vancura.dev",
+  "homepage": "https://blit386.dev",
   "bugs": {
-    "url": "https://github.com/vancura/blit-tech/issues"
+    "url": "https://github.com/blit386/blit386/issues"
   },
   "keywords": [
     "typescript",
@@ -36,14 +36,14 @@
   "engines": {
     "node": ">=22.18.0"
   },
-  "main": "./dist/blit-tech.cjs",
-  "module": "./dist/blit-tech.js",
-  "types": "./dist/blit-tech.d.ts",
+  "main": "./dist/blit386.cjs",
+  "module": "./dist/blit386.js",
+  "types": "./dist/blit386.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/blit-tech.d.ts",
-      "import": "./dist/blit-tech.js",
-      "require": "./dist/blit-tech.cjs"
+      "types": "./dist/blit386.d.ts",
+      "import": "./dist/blit386.js",
+      "require": "./dist/blit386.cjs"
     }
   },
   "files": [

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,5 +1,5 @@
 /**
- * Prettier configuration for Blit-Tech
+ * Prettier configuration for BLIT386
  *
  * NOTE: Prettier is used for Markdown and YAML files only.
  * TypeScript, JavaScript, JSON, and CSS are formatted by Biome.

--- a/scripts/check-declaration-tooling.mjs
+++ b/scripts/check-declaration-tooling.mjs
@@ -4,10 +4,10 @@ import { fileURLToPath } from 'node:url';
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const PACKAGE_JSON_PATH = path.join(REPO_ROOT, 'package.json');
-const DECLARATION_OUTPUT = path.join(REPO_ROOT, 'dist', 'blit-tech.d.ts');
+const DECLARATION_OUTPUT = path.join(REPO_ROOT, 'dist', 'blit386.d.ts');
 
 /**
- * Public `BT` getters that must appear in rolled-up `dist/blit-tech.d.ts`.
+ * Public `BT` getters that must appear in rolled-up `dist/blit386.d.ts`.
  * Add entries here when shipping new configure/runtime getters on the facade.
  */
 export const REQUIRED_BT_DECLARATION_MEMBERS = ['requestedBackend', 'activeBackend'];
@@ -85,7 +85,7 @@ export function findAlignmentFailures(logText, expectedVersion) {
     return failures;
 }
 
-/** Opening forms for the rolled-up `BT` object type in `dist/blit-tech.d.ts`. */
+/** Opening forms for the rolled-up `BT` object type in `dist/blit386.d.ts`. */
 const BT_DECLARATION_OPENERS = [
     /(?:export\s+)?declare\s+const\s+BT\s*:\s*\{/,
     /(?:export\s+)?declare\s+namespace\s+BT\s*\{/,
@@ -97,7 +97,7 @@ const BT_DECLARATION_OPENERS = [
 /**
  * Extracts the `{ ... }` body of the public `BT` declaration from rolled-up `.d.ts` text.
  *
- * @param {string} dtsText Contents of `dist/blit-tech.d.ts`.
+ * @param {string} dtsText Contents of `dist/blit386.d.ts`.
  * @returns {string | null} Balanced brace block for `BT`, or null when not found.
  */
 export function extractBtDeclarationBlock(dtsText) {
@@ -133,7 +133,7 @@ export function extractBtDeclarationBlock(dtsText) {
 /**
  * Verifies rolled-up declarations export required `BT` facade members.
  *
- * @param {string} dtsText Contents of `dist/blit-tech.d.ts`.
+ * @param {string} dtsText Contents of `dist/blit386.d.ts`.
  * @param {readonly string[]} [requiredMembers] Getter names that must be present.
  * @returns {string[]} Human-readable failure messages (empty when all members are found).
  */
@@ -141,7 +141,7 @@ export function findMissingBtDeclarationMembers(dtsText, requiredMembers = REQUI
     const btBlock = extractBtDeclarationBlock(dtsText);
     if (!btBlock) {
         return requiredMembers.map(
-            (member) => `dist/blit-tech.d.ts is missing BT declaration block (cannot verify getter: ${member})`,
+            (member) => `dist/blit386.d.ts is missing BT declaration block (cannot verify getter: ${member})`,
         );
     }
 
@@ -150,7 +150,7 @@ export function findMissingBtDeclarationMembers(dtsText, requiredMembers = REQUI
     for (const member of requiredMembers) {
         const pattern = new RegExp(`\\breadonly\\s+${member}\\s*:`, 'm');
         if (!pattern.test(btBlock)) {
-            failures.push(`dist/blit-tech.d.ts is missing BT getter: ${member}`);
+            failures.push(`dist/blit386.d.ts is missing BT getter: ${member}`);
         }
     }
 

--- a/scripts/convert-bmfont.mjs
+++ b/scripts/convert-bmfont.mjs
@@ -3,7 +3,7 @@
 /**
  * BMFont to .btfont Converter
  *
- * Converts BMFont XML format (.fnt + .png) to Blit-Tech's .btfont JSON format.
+ * Converts BMFont XML format (.fnt + .png) to BLIT386's .btfont JSON format.
  */
 
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
@@ -367,7 +367,7 @@ function convertBMFont(fntPath, outputPath, embedTexture = false) {
 /**
  * Main function that serves as the entry point for the BMFont to .btfont converter.
  * It processes command-line arguments, provides help instructions, and initiates the
- * conversion process from BMFont XML format to Blit-Tech's .btfont JSON format.
+ * conversion process from BMFont XML format to BLIT386's .btfont JSON format.
  *
  * Behavior:
  * - If no arguments are provided, `--help`, or `-h` is passed, usage instructions
@@ -386,7 +386,7 @@ function main() {
         console.log(`
 BMFont to .btfont Converter
 
-Converts BMFont XML format (.fnt + .png) to Blit-Tech’s .btfont JSON format.
+Converts BMFont XML format (.fnt + .png) to BLIT386’s .btfont JSON format.
 
 Usage:
   node tools/convert-bmfont.mjs <input.fnt> <output.btfont> [--embed]

--- a/scripts/convert-bmfont.mjs
+++ b/scripts/convert-bmfont.mjs
@@ -389,15 +389,15 @@ BMFont to .btfont Converter
 Converts BMFont XML format (.fnt + .png) to BLIT386’s .btfont JSON format.
 
 Usage:
-  node tools/convert-bmfont.mjs <input.fnt> <output.btfont> [--embed]
+  node scripts/convert-bmfont.mjs <input.fnt> <output.btfont> [--embed]
 
 Options:
   --embed        Embed the texture as base64 instead of referencing it
   -h, --help     Show this help message
 
 Examples:
-  node tools/convert-bmfont.mjs fonts/MyFont.fnt fonts/MyFont.btfont
-  node tools/convert-bmfont.mjs fonts/MyFont.fnt fonts/MyFont.btfont --embed
+  node scripts/convert-bmfont.mjs fonts/MyFont.fnt fonts/MyFont.btfont
+  node scripts/convert-bmfont.mjs fonts/MyFont.fnt fonts/MyFont.btfont --embed
 `);
         process.exit(0);
     }
@@ -412,7 +412,7 @@ Examples:
 
     if (unknownFlags.length > 0) {
         console.error(`Error: Unknown flag(s): ${unknownFlags.join(', ')}`);
-        console.error('Usage: node tools/convert-bmfont.mjs <input.fnt> <output.btfont> [--embed]');
+        console.error('Usage: node scripts/convert-bmfont.mjs <input.fnt> <output.btfont> [--embed]');
         console.error('Run with --help for more information');
 
         process.exit(1);
@@ -420,7 +420,7 @@ Examples:
 
     if (paths.length < 2) {
         console.error('Error: Please provide input and output paths');
-        console.error('Usage: node tools/convert-bmfont.mjs <input.fnt> <output.btfont> [--embed]');
+        console.error('Usage: node scripts/convert-bmfont.mjs <input.fnt> <output.btfont> [--embed]');
 
         process.exit(1);
     }
@@ -428,7 +428,7 @@ Examples:
     // Validate no extra positional arguments.
     if (paths.length !== 2) {
         console.error(`Error: Expected 2 paths, but got ${paths.length}: ${paths.join(', ')}`);
-        console.error('Usage: node tools/convert-bmfont.mjs <input.fnt> <output.btfont> [--embed]');
+        console.error('Usage: node scripts/convert-bmfont.mjs <input.fnt> <output.btfont> [--embed]');
 
         process.exit(1);
     }

--- a/src/BLIT386.test.ts
+++ b/src/BLIT386.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 /**
- * Unit tests for the public `BT` facade exported from `BlitTech.ts`.
+ * Unit tests for the public `BT` facade exported from `BLIT386.ts`.
  *
  * Covers delegation from top-level `BT.*` calls into `BTAPI.instance`,
  * default return behavior for hardware-dependent queries, and the warning
@@ -10,8 +10,8 @@
 
 import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
 
-import type { BitmapFont, HardwareSettings } from './BlitTech';
-import { BT, Palette, Rect2i, SpriteSheet, Vector2i } from './BlitTech';
+import type { BitmapFont, HardwareSettings } from './BLIT386';
+import { BT, Palette, Rect2i, SpriteSheet, Vector2i } from './BLIT386';
 import { BTAPI } from './core/BTAPI';
 import type { FaceButtonCode } from './input/defaultKeyboardMap';
 import { DEFAULT_CONTAINER_ID } from './utils/BootstrapHelpers';
@@ -1171,7 +1171,7 @@ describe('BT.downloadFrame', () => {
 
         await BT.downloadFrame();
 
-        expect(mockAnchor.download).toBe('blit-tech-capture.png');
+        expect(mockAnchor.download).toBe('blit386-capture.png');
     });
 });
 

--- a/src/BLIT386.ts
+++ b/src/BLIT386.ts
@@ -1,5 +1,5 @@
 /**
- * Public Blit-Tech entrypoint.
+ * Public BLIT386 entrypoint.
  *
  * This module re-exports the main runtime types and exposes the `BT` facade
  * used by demos for rendering, timing, bootstrap, and input (pointer, keyboard, gamepad).
@@ -22,12 +22,12 @@ import {
     type Backend,
     defaultConfig,
     type HardwareSettings,
-    type IBlitTechDemo,
+    type IBTDemo,
     mergeHardwareSettings,
     type OverlayRow,
     type OverlayStyle,
     type OverlayTimingChartStyle,
-} from './core/IBlitTechDemo';
+} from './core/IBTDemo';
 import {
     createDefaultKeyboardRuntimeMaps,
     DEFAULT_KEYBOARD_PLAYER1,
@@ -238,7 +238,7 @@ function pointerFlagToPointerCode(pointerFlag: number): number | null {
     }
 }
 
-/** Main Blit-Tech API namespace used by runtime demos. */
+/** Main BLIT386 API namespace used by runtime demos. */
 export const BT = {
     /** Horizontal flip flag for sprite rendering. */
     FLIP_H: 1,
@@ -386,7 +386,7 @@ export const BT = {
      * @param canvas - Canvas used as the engine render target.
      * @returns `true` when initialization succeeds; otherwise `false`.
      */
-    init: async (demo: IBlitTechDemo, canvas: HTMLCanvasElement): Promise<boolean> => {
+    init: async (demo: IBTDemo, canvas: HTMLCanvasElement): Promise<boolean> => {
         return await BTAPI.instance.init(demo, canvas);
     },
 
@@ -1469,7 +1469,7 @@ export const BT = {
      * await BT.downloadFrame();
      * await BT.downloadFrame('screenshot-001.png');
      */
-    downloadFrame: async (filename: string = 'blit-tech-capture.png'): Promise<void> => {
+    downloadFrame: async (filename: string = 'blit386-capture.png'): Promise<void> => {
         const blob = await BTAPI.instance.captureFrame();
         const url = URL.createObjectURL(blob);
         const link = document.createElement('a');
@@ -1600,7 +1600,7 @@ export type {
     Effect,
     EffectTier,
     HardwareSettings,
-    IBlitTechDemo,
+    IBTDemo,
     OverlayRow,
     OverlayStyle,
     OverlayTimingChartStyle,

--- a/src/__test__/setup.ts
+++ b/src/__test__/setup.ts
@@ -1,4 +1,4 @@
-// Global test setup for blit-tech.
+// Global test setup for blit386.
 // Imported by vitest.config.ts setupFiles.
 
 type GlobalRecord = Record<string, unknown>;

--- a/src/assets/palettes/hudData.ts
+++ b/src/assets/palettes/hudData.ts
@@ -2,7 +2,7 @@
  * Built-in HUD palette preset data used by {@link Palette.applyHUD}.
  *
  * Six named UI color slots applied contiguously starting at a caller-supplied
- * start index. Values match the most common pattern seen across blit-tech demos:
+ * start index. Values match the most common pattern seen across blit386 demos:
  * white text, a dark background, label gray, golden header, dim gray for FPS,
  * and a slate blue for code snippets.
  */

--- a/src/core/BTAPI.test.ts
+++ b/src/core/BTAPI.test.ts
@@ -27,7 +27,7 @@ import {
 import type { BitmapFont } from '../assets/BitmapFont';
 import { Palette } from '../assets/Palette';
 import type { SpriteSheet } from '../assets/SpriteSheet';
-import { BT } from '../BlitTech';
+import { BT } from '../BLIT386';
 import type { OverlayDrawTarget } from '../overlay';
 import { DEFAULT_IDX_TEXT, Overlay, paletteBandY } from '../overlay';
 import { OVERLAY_EDGE_MARGIN_PX } from '../overlay/layout/constants';
@@ -41,7 +41,7 @@ import type { Effect } from '../render/effects/Effect';
 import { Rect2i } from '../utils/Rect2i';
 import { Vector2i } from '../utils/Vector2i';
 import { BTAPI } from './BTAPI';
-import type { IBlitTechDemo, OverlayRow } from './IBlitTechDemo';
+import type { IBTDemo, OverlayRow } from './IBTDemo';
 import { collectUsedIndices } from './RenderPaletteUsage';
 
 function resetSingleton(): void {
@@ -51,7 +51,7 @@ function resetSingleton(): void {
     (BTAPI as unknown as { _instance: BTAPI | null })._instance = null;
 }
 
-function makeMockDemo(targetFPS = 60, initResult = true): IBlitTechDemo {
+function makeMockDemo(targetFPS = 60, initResult = true): IBTDemo {
     return {
         configure: vi.fn().mockReturnValue({
             displaySize: new Vector2i(320, 240),
@@ -360,7 +360,7 @@ describe('BTAPI', () => {
         });
 
         it('rejects invalid displaySize before layout or renderer setup', async () => {
-            const demo: IBlitTechDemo = {
+            const demo: IBTDemo = {
                 configure: vi.fn().mockReturnValue({
                     displaySize: { x: 0, y: 240 } as Vector2i,
                     targetFPS: 60,
@@ -384,7 +384,7 @@ describe('BTAPI', () => {
         });
 
         it('rejects invalid software drawingBufferSize before software renderer allocation', async () => {
-            const demo: IBlitTechDemo = {
+            const demo: IBTDemo = {
                 configure: vi.fn().mockReturnValue({
                     displaySize: new Vector2i(320, 240),
                     drawingBufferSize: { x: 8193, y: 480 } as Vector2i,
@@ -408,7 +408,7 @@ describe('BTAPI', () => {
         });
 
         it('rejects invalid maxCanvasSize before layout or renderer setup', async () => {
-            const demo: IBlitTechDemo = {
+            const demo: IBTDemo = {
                 configure: vi.fn().mockReturnValue({
                     displaySize: new Vector2i(320, 240),
                     maxCanvasSize: { x: Number.NaN, y: 720 } as Vector2i,
@@ -449,7 +449,7 @@ describe('BTAPI', () => {
                 writable: true,
                 configurable: true,
             });
-            const demo: IBlitTechDemo = {
+            const demo: IBTDemo = {
                 configure: vi.fn().mockReturnValue({
                     displaySize: new Vector2i(2048, 1024),
                     targetFPS: 60,
@@ -487,7 +487,7 @@ describe('BTAPI', () => {
                 writable: true,
                 configurable: true,
             });
-            const demo: IBlitTechDemo = {
+            const demo: IBTDemo = {
                 configure: vi.fn().mockReturnValue({
                     displaySize: new Vector2i(320, 240),
                     drawingBufferSize: new Vector2i(2048, 1024),
@@ -529,7 +529,7 @@ describe('BTAPI', () => {
                 writable: true,
                 configurable: true,
             });
-            const demo: IBlitTechDemo = {
+            const demo: IBTDemo = {
                 configure: vi.fn().mockReturnValue({
                     displaySize: new Vector2i(320, 240),
                     drawingBufferSize: new Vector2i(1024, 768),
@@ -579,7 +579,7 @@ describe('BTAPI', () => {
                     }
                 },
             );
-            const demo: IBlitTechDemo = {
+            const demo: IBTDemo = {
                 configure: () => ({
                     displaySize: new Vector2i(320, 240),
                     drawingBufferSize: new Vector2i(640, 480),
@@ -616,7 +616,7 @@ describe('BTAPI', () => {
             );
             uninstallMockNavigatorGPU();
 
-            const demo: IBlitTechDemo = {
+            const demo: IBTDemo = {
                 configure: () => ({
                     displaySize: new Vector2i(320, 240),
                     drawingBufferSize: new Vector2i(640, 480),
@@ -642,7 +642,7 @@ describe('BTAPI', () => {
         it('ignores unknown backend query values and keeps configure backend', async () => {
             vi.stubGlobal('location', { search: '?backend=banana' });
 
-            const demo: IBlitTechDemo = {
+            const demo: IBTDemo = {
                 configure: () => ({
                     displaySize: new Vector2i(320, 240),
                     drawingBufferSize: new Vector2i(640, 480),
@@ -728,7 +728,7 @@ describe('BTAPI', () => {
         });
 
         it('should merge partial configure with defaultConfig', async () => {
-            const demo: IBlitTechDemo = {
+            const demo: IBTDemo = {
                 configure: () => ({ targetFPS: 30 }),
                 init: vi.fn().mockResolvedValue(true),
                 update: vi.fn(),
@@ -748,7 +748,7 @@ describe('BTAPI', () => {
         });
 
         it('should use defaultConfig when configure is omitted', async () => {
-            const demo: IBlitTechDemo = {
+            const demo: IBTDemo = {
                 init: vi.fn().mockResolvedValue(true),
                 update: vi.fn(),
                 render: vi.fn(),
@@ -815,7 +815,7 @@ describe('BTAPI', () => {
 
         it('forwards overlayRows from the demo into Overlay.updateAndRender', async () => {
             const customRows: OverlayRow[] = [{ leftText: 'Position: 1, 2' }];
-            const demo: IBlitTechDemo = {
+            const demo: IBTDemo = {
                 ...makeMockDemo(),
                 configure: vi.fn().mockReturnValue({
                     displaySize: new Vector2i(320, 240),
@@ -985,7 +985,7 @@ describe('BTAPI', () => {
             );
             uninstallMockNavigatorGPU();
 
-            const demo: IBlitTechDemo = {
+            const demo: IBTDemo = {
                 configure: () => ({
                     displaySize: new Vector2i(320, 240),
                     drawingBufferSize: new Vector2i(640, 480),
@@ -1027,7 +1027,7 @@ describe('BTAPI', () => {
                     }
                 },
             );
-            const demo: IBlitTechDemo = {
+            const demo: IBTDemo = {
                 configure: () => ({
                     displaySize: new Vector2i(320, 240),
                     targetFPS: 60,
@@ -1078,7 +1078,7 @@ describe('BTAPI', () => {
             );
             uninstallMockNavigatorGPU();
 
-            const demo: IBlitTechDemo = {
+            const demo: IBTDemo = {
                 configure: () => ({
                     displaySize: new Vector2i(320, 240),
                     targetFPS: 60,
@@ -1111,7 +1111,7 @@ describe('BTAPI', () => {
                 },
             );
 
-            const demo: IBlitTechDemo = {
+            const demo: IBTDemo = {
                 configure: () => ({
                     displaySize: new Vector2i(320, 240),
                     targetFPS: 60,
@@ -1132,7 +1132,7 @@ describe('BTAPI', () => {
     describe('assignTag', () => {
         it('forwards tags to Overlay when the timing chart is enabled', async () => {
             const assignSpy = vi.spyOn(Overlay.prototype, 'assignTag');
-            const demo: IBlitTechDemo = {
+            const demo: IBTDemo = {
                 configure: () => ({
                     displaySize: new Vector2i(320, 240),
                     targetFPS: 60,
@@ -1152,7 +1152,7 @@ describe('BTAPI', () => {
         it('does not store tags when isOverlayTimingChartEnabled is disabled', async () => {
             const { TimingChart } = await import('../overlay/timing-chart/TimingChart');
             const assignSpy = vi.spyOn(TimingChart.prototype, 'assignTag');
-            const demo: IBlitTechDemo = {
+            const demo: IBTDemo = {
                 configure: () => ({
                     displaySize: new Vector2i(320, 240),
                     targetFPS: 60,
@@ -1179,7 +1179,7 @@ describe('BTAPI', () => {
          * @returns Overlay spy from the initialized instance.
          */
         async function initAndDrainUntil(
-            demo: IBlitTechDemo,
+            demo: IBTDemo,
             stopWhen: (overlaySpy: ReturnType<typeof vi.spyOn>) => boolean,
         ): Promise<ReturnType<typeof vi.spyOn>> {
             const overlaySpy = vi.spyOn(Overlay.prototype, 'updateAndRender');
@@ -1226,7 +1226,7 @@ describe('BTAPI', () => {
                 (await import('../render/WebGPURenderer')).WebGPURenderer.prototype,
                 'getFrameDiagnostics',
             );
-            const demo: IBlitTechDemo = {
+            const demo: IBTDemo = {
                 configure: () => ({
                     displaySize: new Vector2i(320, 240),
                     targetFPS: 60,
@@ -1247,7 +1247,7 @@ describe('BTAPI', () => {
                 (await import('../render/WebGPURenderer')).WebGPURenderer.prototype,
                 'getFrameDiagnostics',
             );
-            const demo: IBlitTechDemo = {
+            const demo: IBTDemo = {
                 configure: () => ({
                     displaySize: new Vector2i(320, 240),
                     targetFPS: 60,
@@ -1269,7 +1269,7 @@ describe('BTAPI', () => {
                 (await import('../render/WebGPURenderer')).WebGPURenderer.prototype,
                 'getFrameDiagnostics',
             );
-            const demo: IBlitTechDemo = {
+            const demo: IBTDemo = {
                 configure: () => ({
                     displaySize: new Vector2i(320, 240),
                     targetFPS: 60,
@@ -1299,7 +1299,7 @@ describe('BTAPI', () => {
                 'getFrameDiagnostics',
             ).mockReturnValue(mockDiagnostics);
 
-            const demo: IBlitTechDemo = {
+            const demo: IBTDemo = {
                 configure: () => ({
                     displaySize: new Vector2i(320, 240),
                     targetFPS: 60,
@@ -1348,7 +1348,7 @@ describe('BTAPI', () => {
             const markSpy = vi.fn();
             const mockSheet = makeIndexizedSpriteSheet(markSpy);
             const mockFont = { getSpriteSheet: () => mockSheet } as unknown as BitmapFont;
-            const demo: IBlitTechDemo = {
+            const demo: IBTDemo = {
                 configure: () => ({
                     displaySize: new Vector2i(320, 240),
                     targetFPS: 60,
@@ -1376,7 +1376,7 @@ describe('BTAPI', () => {
                 getSpriteSheet: () => mockSheet,
                 getGlyph: () => ({ rect: new Rect2i(0, 0, 8, 8) }),
             } as unknown as BitmapFont;
-            const demo: IBlitTechDemo = {
+            const demo: IBTDemo = {
                 configure: () => ({
                     displaySize: new Vector2i(320, 240),
                     targetFPS: 60,
@@ -1401,7 +1401,7 @@ describe('BTAPI', () => {
         it('skips palette scans when the palette grid is enabled but the overlay body is hidden', async () => {
             const markSpy = vi.fn();
             const mockSheet = makeIndexizedSpriteSheet(markSpy);
-            const demo: IBlitTechDemo = {
+            const demo: IBTDemo = {
                 configure: () => ({
                     displaySize: new Vector2i(320, 240),
                     targetFPS: 60,
@@ -1429,7 +1429,7 @@ describe('BTAPI', () => {
         it('skips palette scans when the overlay body is hidden even if the toggle hint is visible', async () => {
             const markSpy = vi.fn();
             const mockSheet = makeIndexizedSpriteSheet(markSpy);
-            const demo: IBlitTechDemo = {
+            const demo: IBTDemo = {
                 configure: () => ({
                     displaySize: new Vector2i(320, 240),
                     targetFPS: 60,
@@ -1469,7 +1469,7 @@ describe('BTAPI', () => {
 
             const palette = Palette.cga();
             const usedSlots = [5, 6] as const;
-            const demo: IBlitTechDemo = {
+            const demo: IBTDemo = {
                 configure: () => ({
                     displaySize: new Vector2i(320, 240),
                     targetFPS: 60,
@@ -1579,7 +1579,7 @@ describe('BTAPI', () => {
 
         it('drawSystemText marks only the text palette index and does not scan glyph rects', async () => {
             const glyphScanSpy = vi.fn();
-            const demo: IBlitTechDemo = {
+            const demo: IBTDemo = {
                 configure: () => ({
                     displaySize: new Vector2i(320, 240),
                     targetFPS: 60,
@@ -1623,7 +1623,7 @@ describe('BTAPI', () => {
                 getSpriteSheet: () => mockSheet,
                 getGlyph: (char: string) => ({ rect: new Rect2i(0, 0, 8, 8), char }),
             } as unknown as BitmapFont;
-            const demo: IBlitTechDemo = {
+            const demo: IBTDemo = {
                 configure: () => ({
                     displaySize: new Vector2i(320, 240),
                     targetFPS: 60,
@@ -1685,7 +1685,7 @@ describe('BTAPI', () => {
                 }
             };
 
-            const demo: IBlitTechDemo = {
+            const demo: IBTDemo = {
                 configure: () => ({
                     displaySize: new Vector2i(320, 240),
                     targetFPS: 60,

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -34,18 +34,18 @@ import { RenderDimensionLimitError, validateDimensions } from '../utils/RenderLi
 import { Vector2i } from '../utils/Vector2i';
 import type { FrameDropCallback, FrameDropEvent } from './GameLoop';
 import { GameLoop } from './GameLoop';
-import type { Backend, HardwareSettings, IBlitTechDemo } from './IBlitTechDemo';
+import type { Backend, HardwareSettings, IBTDemo } from './IBTDemo';
 import {
     defaultConfig,
     mergeHardwareSettings,
     needsOverlayRendererDiagnostics,
     resolveOverlayTimingChartDiagnostics,
-} from './IBlitTechDemo';
+} from './IBTDemo';
 import { markIndexUsed, resetUsage, USAGE_CAPACITY } from './RenderPaletteUsage';
 import { initWebGPU } from './WebGPUContext';
 
 /**
- * Central runtime facade for Blit-Tech engine services.
+ * Central runtime facade for BLIT386 engine services.
  *
  * `BTAPI` owns engine initialization, keeps references to the active renderer
  * and optional WebGPU device/context (null on the software backend), and exposes
@@ -67,8 +67,8 @@ export class BTAPI {
     /** Singleton instance of BTAPI. */
     private static _instance: BTAPI | null = null;
 
-    /** Current demo instance implementing IBlitTechDemo. */
-    private demo: IBlitTechDemo | null = null;
+    /** Current demo instance implementing IBTDemo. */
+    private demo: IBTDemo | null = null;
 
     /** Hardware configuration settings from the demo. */
     private hwSettings: HardwareSettings | null = null;
@@ -232,11 +232,11 @@ export class BTAPI {
      * - run the demo's async `init()`
      * - start the fixed-timestep game loop
      *
-     * @param demo - Demo implementing the IBlitTechDemo interface.
+     * @param demo - Demo implementing the IBTDemo interface.
      * @param canvas - Render target canvas (WebGPU or software backend).
      * @returns `true` when initialization succeeds; otherwise `false`.
      */
-    public async init(demo: IBlitTechDemo, canvas: HTMLCanvasElement): Promise<boolean> {
+    public async init(demo: IBTDemo, canvas: HTMLCanvasElement): Promise<boolean> {
         console.log(`[BT] Initializing engine v${BTAPI.VERSION_MAJOR}.${BTAPI.VERSION_MINOR}.${BTAPI.VERSION_PATCH}`);
 
         this.demo = demo;
@@ -973,10 +973,10 @@ export class BTAPI {
     /**
      * Reads and validates demo `configure()` output into resolved hardware settings.
      *
-     * @param demo - Demo implementing {@link IBlitTechDemo}.
+     * @param demo - Demo implementing {@link IBTDemo}.
      * @returns `false` when hardware settings are invalid (bad dimensions or targetFPS).
      */
-    private loadHardwareSettings(demo: IBlitTechDemo): boolean {
+    private loadHardwareSettings(demo: IBTDemo): boolean {
         try {
             this.hwSettings = mergeHardwareSettings(demo.configure?.());
         } catch (error) {
@@ -1202,14 +1202,14 @@ export class BTAPI {
     }
 
     /**
-     * Runs the demo's async {@link IBlitTechDemo.init}. On throw or
+     * Runs the demo's async {@link IBTDemo.init}. On throw or
      * `false`, clears input subsystems that were attached earlier in the init
      * sequence.
      *
      * @param demo - Active demo instance.
      * @returns `true` when the demo reports success.
      */
-    private async runDemoInit(demo: IBlitTechDemo): Promise<boolean> {
+    private async runDemoInit(demo: IBTDemo): Promise<boolean> {
         try {
             const ok = await demo.init();
 

--- a/src/core/IBTDemo.test.ts
+++ b/src/core/IBTDemo.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for {@link defaultConfig} exported from {@link IBlitTechDemo}.
+ * Unit tests for {@link defaultConfig} exported from {@link IBTDemo}.
  *
  * Confirms the default display resolution, frame rate, and canvas sizing
  * (`defaultConfig()` includes `drawingBufferSize` by default), and verifies each
@@ -16,7 +16,7 @@ import {
     mergeHardwareSettings,
     needsOverlayRendererDiagnostics,
     resolveOverlayTimingChartDiagnostics,
-} from './IBlitTechDemo';
+} from './IBTDemo';
 
 describe('defaultConfig', () => {
     it('should return 320x240 display size', () => {

--- a/src/core/IBTDemo.ts
+++ b/src/core/IBTDemo.ts
@@ -79,7 +79,7 @@ export interface HardwareSettings {
     outputUpscaleFilter?: OutputUpscaleFilter;
 
     /**
-     * Target fixed-update rate: how often {@link IBlitTechDemo.update} runs per second.
+     * Target fixed-update rate: how often {@link IBTDemo.update} runs per second.
      *
      * Not the measured render rate shown as `Present FPS` on the overlay; `render()` follows
      * `requestAnimationFrame` and may differ (for example 60 Hz updates on a 120 Hz display).
@@ -301,7 +301,7 @@ export interface OverlayTimingChartStyle {
  *
  * Rendered as a 13 px bar stacked above the footer (palette grid + hint bar when
  * {@link HardwareSettings.isOverlayPaletteEnabled} is `true`, or the hint bar alone) with 1 px gaps.
- * Reuse the same array instance from {@link IBlitTechDemo.overlayRows} when possible to avoid
+ * Reuse the same array instance from {@link IBTDemo.overlayRows} when possible to avoid
  * per-frame allocations.
  */
 export interface OverlayRow {
@@ -325,7 +325,7 @@ export interface OverlayRow {
 }
 
 /**
- * Demo contract implemented by Blit-Tech applications.
+ * Demo contract implemented by BLIT386 applications.
  *
  * Engine lifecycle order:
  * 1. configure() - Optional; called first to set display size, output buffer, FPS, overlay
@@ -334,7 +334,7 @@ export interface OverlayRow {
  * 4. render() - Called once per requestAnimationFrame (browser refresh rate)
  * 5. (engine) overlay - When {@link HardwareSettings.isOverlayEnabled} is true, drawn after `render()` on top
  */
-export interface IBlitTechDemo {
+export interface IBTDemo {
     /**
      * Optional hook to declare display size, optional output drawing-buffer size,
      * upscale filter, target fixed-update rate, rendering backend, and overlay.
@@ -413,7 +413,7 @@ export interface IBlitTechDemo {
 /**
  * Creates a fresh default hardware configuration for quick demos.
  *
- * Matches the most common setup across Blit-Tech demos: `320x240` logical resolution,
+ * Matches the most common setup across BLIT386 demos: `320x240` logical resolution,
  * `640x480` canvas output (2x nearest upscale), `60` FPS fixed updates, and the engine
  * overlay enabled.
  *

--- a/src/core/RenderPaletteUsage.ts
+++ b/src/core/RenderPaletteUsage.ts
@@ -1,7 +1,7 @@
 /**
  * Per-frame palette index usage tracking for debug overlays.
  *
- * BTAPI marks indices referenced by demo draw calls during {@link IBlitTechDemo.render}
+ * BTAPI marks indices referenced by demo draw calls during {@link IBTDemo.render}
  * and passes the usage mask directly to the overlay palette grid.
  */
 

--- a/src/docs/consumer-doc-imports.test.ts
+++ b/src/docs/consumer-doc-imports.test.ts
@@ -1,8 +1,8 @@
 /**
  * Regression tests for package-consumer documentation imports.
  *
- * README and docs guides must import from the published `blit-tech` package,
- * not from repository source paths such as `../src/BlitTech`.
+ * README and docs guides must import from the published `blit386` package,
+ * not from repository source paths such as `../src/BLIT386`.
  */
 
 import { readdirSync, readFileSync } from 'node:fs';
@@ -14,10 +14,10 @@ import { describe, expect, it } from 'vitest';
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '../..');
 
 /** Imports that bypass the published package entry point. */
-const FORBIDDEN_SOURCE_IMPORT = /from\s+['"]\.\.\/src\/BlitTech['"]/;
+const FORBIDDEN_SOURCE_IMPORT = /from\s+['"]\.\.\/src\/BLIT386['"]/;
 
 /** Deep package subpath imports not exposed in package.json exports. */
-const FORBIDDEN_DEEP_PACKAGE_IMPORT = /from\s+['"]blit-tech\/render\//;
+const FORBIDDEN_DEEP_PACKAGE_IMPORT = /from\s+['"]blit386\/render\//;
 
 /**
  * Recursively collects markdown file paths under a directory.
@@ -46,14 +46,14 @@ const CONSUMER_DOC_FILES = ['README.md', ...collectMarkdownFiles(join(REPO_ROOT,
 
 describe('consumer documentation imports', () => {
     for (const relativePath of CONSUMER_DOC_FILES) {
-        it(`${relativePath} must not import from ../src/BlitTech`, () => {
+        it(`${relativePath} must not import from ../src/BLIT386`, () => {
             const content = readFileSync(join(REPO_ROOT, relativePath), 'utf8');
             const match = FORBIDDEN_SOURCE_IMPORT.exec(content);
 
             expect(match, `found forbidden source import in ${relativePath}: ${match?.[0] ?? ''}`).toBeNull();
         });
 
-        it(`${relativePath} must not deep-import blit-tech/render/...`, () => {
+        it(`${relativePath} must not deep-import blit386/render/...`, () => {
             const content = readFileSync(join(REPO_ROOT, relativePath), 'utf8');
             const match = FORBIDDEN_DEEP_PACKAGE_IMPORT.exec(content);
 

--- a/src/input/GamepadInput.test.ts
+++ b/src/input/GamepadInput.test.ts
@@ -5,7 +5,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { BT } from '../BlitTech';
+import { BT } from '../BLIT386';
 import { DEFAULT_GAMEPAD_DEAD_ZONE, GamepadInput } from './GamepadInput';
 
 interface PadState {

--- a/src/overlay/Overlay.ts
+++ b/src/overlay/Overlay.ts
@@ -13,7 +13,7 @@ import type {
     OverlayStyle,
     OverlayTimingChartDiagnosticsMode,
     OverlayTimingChartStyle,
-} from '../core/IBlitTechDemo';
+} from '../core/IBTDemo';
 import type { KeyboardInput } from '../input/KeyboardInput';
 import type { PointerInput } from '../input/PointerInput';
 import { OverlayBars } from './bars/Bars';

--- a/src/overlay/bars/Bars.ts
+++ b/src/overlay/bars/Bars.ts
@@ -1,5 +1,5 @@
 import type { BitmapFont } from '../../assets/BitmapFont';
-import type { OverlayRow } from '../../core/IBlitTechDemo';
+import type { OverlayRow } from '../../core/IBTDemo';
 import { Rect2i } from '../../utils/Rect2i';
 import { Vector2i } from '../../utils/Vector2i';
 import { OVERLAY_EDGE_MARGIN_PX, OVERLAY_ROW_GAP_PX, OVERLAY_TOP_TEXT_Y } from '../layout/constants';

--- a/src/overlay/labels.test.ts
+++ b/src/overlay/labels.test.ts
@@ -3,9 +3,9 @@ import { describe, expect, it } from 'vitest';
 import { resolveOverlayTopLeftLabel } from './labels';
 
 describe('resolveOverlayTopLeftLabel', () => {
-    it('formats registry-style page titles without a Blit-Tech prefix', () => {
-        expect(resolveOverlayTopLeftLabel('Blit-Tech Demo 006 - Patterns')).toBe('Patterns Demo');
-        expect(resolveOverlayTopLeftLabel('Blit-Tech Demo 002 - Primitives')).toBe('Primitives Demo');
+    it('formats registry-style page titles without a BLIT386 prefix', () => {
+        expect(resolveOverlayTopLeftLabel('BLIT386 Demo 006 - Patterns')).toBe('Patterns Demo');
+        expect(resolveOverlayTopLeftLabel('BLIT386 Demo 002 - Primitives')).toBe('Primitives Demo');
     });
 
     it('falls back when title is empty', () => {

--- a/src/overlay/labels.ts
+++ b/src/overlay/labels.ts
@@ -1,12 +1,12 @@
-/** Matches demo registry titles: "Blit-Tech Demo 006 - Patterns". */
-const REGISTRY_TITLE_PATTERN = /^Blit-Tech Demo\s+.+?\s+-\s+(.+)$/;
+/** Matches demo registry titles: "BLIT386 Demo 006 - Patterns". */
+const REGISTRY_TITLE_PATTERN = /^BLIT386 Demo\s+.+?\s+-\s+(.+)$/;
 
 /**
  * Turns the browser page title into a short top-left overlay label.
  *
  * @param pageTitle - Browser document title when available.
  * @returns Short label for the top-left bar (registry titles such as
- *   `Blit-Tech Demo 002 - Primitives` become `Primitives Demo`).
+ *   `BLIT386 Demo 002 - Primitives` become `Primitives Demo`).
  */
 export function resolveOverlayTopLeftLabel(pageTitle: string | undefined): string {
     const raw = typeof pageTitle === 'string' ? pageTitle.trim() : '';

--- a/src/overlay/timing-chart/TimingChart.ts
+++ b/src/overlay/timing-chart/TimingChart.ts
@@ -3,7 +3,7 @@
  */
 
 import type { BitmapFont } from '../../assets/BitmapFont';
-import type { OverlayTimingChartDiagnosticsMode } from '../../core/IBlitTechDemo';
+import type { OverlayTimingChartDiagnosticsMode } from '../../core/IBTDemo';
 import { Rect2i } from '../../utils/Rect2i';
 import { Vector2i } from '../../utils/Vector2i';
 import type { OverlayDrawTarget } from '../OverlayDrawTarget';

--- a/src/overlay/timing-chart/style.ts
+++ b/src/overlay/timing-chart/style.ts
@@ -1,4 +1,4 @@
-import type { OverlayStyle, OverlayTimingChartStyle } from '../../core/IBlitTechDemo';
+import type { OverlayStyle, OverlayTimingChartStyle } from '../../core/IBTDemo';
 import type { Rect2i } from '../../utils/Rect2i';
 import { DEFAULT_IDX_BG, DEFAULT_IDX_TEXT } from '../constants';
 import {

--- a/src/utils/Bootstrap.test.ts
+++ b/src/utils/Bootstrap.test.ts
@@ -18,11 +18,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { BTAPI } from '../core/BTAPI';
-import type { IBlitTechDemo } from '../core/IBlitTechDemo';
+import type { IBTDemo } from '../core/IBTDemo';
 import { bootstrap } from './Bootstrap';
 import { DEFAULT_CANVAS_ID, DEFAULT_CONTAINER_ID } from './BootstrapHelpers';
 
-class MockDemo implements IBlitTechDemo {
+class MockDemo implements IBTDemo {
     async init() {
         return true;
     }
@@ -140,7 +140,7 @@ describe('bootstrap', () => {
             setupDOM();
             const initSpy = vi.spyOn(BTAPI.instance, 'init');
 
-            class BrokenDemo implements IBlitTechDemo {
+            class BrokenDemo implements IBTDemo {
                 async init() {
                     return true;
                 }
@@ -153,7 +153,7 @@ describe('bootstrap', () => {
             (BrokenDemo.prototype as unknown as { update?: unknown }).update = undefined;
 
             const onError = vi.fn();
-            const result = await bootstrap(BrokenDemo as unknown as new () => IBlitTechDemo, {
+            const result = await bootstrap(BrokenDemo as unknown as new () => IBTDemo, {
                 isWaitingForDOMReady: false,
                 onError,
             });

--- a/src/utils/Bootstrap.ts
+++ b/src/utils/Bootstrap.ts
@@ -1,5 +1,5 @@
 /**
- * Bootstrap Utilities for Blit-Tech
+ * Bootstrap Utilities for BLIT386
  *
  * Provides a one-liner demo bootstrap that resolves the canvas, calls
  * {@link BTAPI.init}, and displays initialization errors on failure. Backend
@@ -7,7 +7,7 @@
  */
 
 import { BTAPI } from '../core/BTAPI';
-import type { IBlitTechDemo } from '../core/IBlitTechDemo';
+import type { IBTDemo } from '../core/IBTDemo';
 import type { ErrorContent } from './BootstrapHelpers';
 import { DEFAULT_CANVAS_ID, DEFAULT_CONTAINER_ID, displayError, getCanvas } from './BootstrapHelpers';
 import { CANVAS_NOT_FOUND_MESSAGE, INIT_FAILED_MESSAGE } from './errorMessages';
@@ -18,7 +18,7 @@ import { CANVAS_NOT_FOUND_MESSAGE, INIT_FAILED_MESSAGE } from './errorMessages';
 export interface BootstrapOptions {
     /**
      * Canvas element ID to use.
-     * Default: 'blit-tech-canvas'
+     * Default: 'blit386-canvas'
      */
     canvasID?: string;
 
@@ -59,7 +59,7 @@ export interface BootstrapOptions {
 /**
  * Constructor type for demo classes.
  */
-export type DemoConstructor = new () => IBlitTechDemo;
+export type DemoConstructor = new () => IBTDemo;
 
 /**
  * Internal result type for bootstrap steps.
@@ -201,14 +201,14 @@ async function initDemo(
 }
 
 /**
- * One-liner bootstrap function for Blit-Tech demos.
+ * One-liner bootstrap function for BLIT386 demos.
  * Handles canvas retrieval and engine initialization. Backend selection
  * (WebGPU or software fallback) is managed internally by BTAPI.
  *
  * This function provides a streamlined way to start a demo with sensible defaults
  * while allowing customization through options.
  *
- * @param DemoClass - Demo class constructor implementing `IBlitTechDemo` (optional `configure()` for hardware settings).
+ * @param DemoClass - Demo class constructor implementing `IBTDemo` (optional `configure()` for hardware settings).
  * @param options - Optional configuration for IDs and callbacks.
  * @returns `true` when the demo boots successfully; otherwise `false`.
  *

--- a/src/utils/BootstrapHelpers.test.ts
+++ b/src/utils/BootstrapHelpers.test.ts
@@ -6,8 +6,8 @@ import { DEFAULT_CANVAS_ID, DEFAULT_CONTAINER_ID, displayError, getCanvas } from
 
 describe('BootstrapHelpers', () => {
     describe('Constants', () => {
-        it('should have DEFAULT_CANVAS_ID equal to blit-tech-canvas', () => {
-            expect(DEFAULT_CANVAS_ID).toBe('blit-tech-canvas');
+        it('should have DEFAULT_CANVAS_ID equal to blit386-canvas', () => {
+            expect(DEFAULT_CANVAS_ID).toBe('blit386-canvas');
         });
 
         it('should have DEFAULT_CONTAINER_ID equal to canvas-container', () => {

--- a/src/utils/BootstrapHelpers.ts
+++ b/src/utils/BootstrapHelpers.ts
@@ -1,11 +1,11 @@
 /**
- * DOM utility helpers for Blit-Tech bootstrap.
+ * DOM utility helpers for BLIT386 bootstrap.
  *
  * Canvas lookup and error display utilities used by the bootstrap function.
  */
 
 /** Default canvas element ID. */
-export const DEFAULT_CANVAS_ID = 'blit-tech-canvas';
+export const DEFAULT_CANVAS_ID = 'blit386-canvas';
 
 /** Default container element ID for error display. */
 export const DEFAULT_CONTAINER_ID = 'canvas-container';
@@ -134,7 +134,7 @@ export function displayError(title: string, content: ErrorContent, containerID: 
  * Retrieves a canvas element from the DOM by ID.
  * Validates that the element exists and is a canvas element.
  *
- * @param canvasID - ID of the canvas element. Default: 'blit-tech-canvas'
+ * @param canvasID - ID of the canvas element. Default: 'blit386-canvas'
  * @returns The canvas element if found and valid, null otherwise.
  *
  * @example

--- a/src/utils/Timer.ts
+++ b/src/utils/Timer.ts
@@ -1,10 +1,10 @@
 import { BTAPI } from '../core/BTAPI';
 
 /**
- * Fixed-tick interval helper for {@link IBlitTechDemo.update} loops.
+ * Fixed-tick interval helper for {@link IBTDemo.update} loops.
  *
  * Counts engine ticks ({@link BT.ticks}), which advance once per fixed update at
- * {@link HardwareSettings.targetFPS}, not once per {@link IBlitTechDemo.render} frame.
+ * {@link HardwareSettings.targetFPS}, not once per {@link IBTDemo.render} frame.
  * Convert ticks to seconds with `intervalTicks / BT.targetFPS`.
  *
  * Tracks a "last fired" tick and reports when a configured interval has elapsed.

--- a/src/utils/errorMessages.test.ts
+++ b/src/utils/errorMessages.test.ts
@@ -34,7 +34,7 @@ import {
 describe('errorMessages', () => {
     describe('CANVAS_NOT_FOUND_MESSAGE', () => {
         it('should interpolate the canvas ID into the message', () => {
-            expect(CANVAS_NOT_FOUND_MESSAGE('blit-tech-canvas')).toContain('blit-tech-canvas');
+            expect(CANVAS_NOT_FOUND_MESSAGE('blit386-canvas')).toContain('blit386-canvas');
         });
 
         it('should produce different messages for different canvas IDs', () => {

--- a/src/utils/errorMessages.ts
+++ b/src/utils/errorMessages.ts
@@ -1,5 +1,5 @@
 /**
- * Shared user-facing error message strings for the Blit-Tech bootstrap and runtime paths.
+ * Shared user-facing error message strings for the BLIT386 bootstrap and runtime paths.
  *
  * Imported by {@link Bootstrap} and runtime/asset code so user-facing strings
  * stay centralized and consistent.

--- a/tests/visual/fixtures/camera.html
+++ b/tests/visual/fixtures/camera.html
@@ -18,11 +18,11 @@
 
     <body>
         <div id="canvas-container">
-            <canvas height="240" id="blit-tech-canvas" width="320"></canvas>
+            <canvas height="240" id="blit386-canvas" width="320"></canvas>
         </div>
 
         <script type="module">
-            import { bootstrap, BT, Color32, Palette, Rect2i, Vector2i } from 'blit-tech';
+            import { bootstrap, BT, Color32, Palette, Rect2i, Vector2i } from 'blit386';
 
             window.__RENDER_COMPLETE__ = false;
             window.__INIT_FAILED__ = false;

--- a/tests/visual/fixtures/fonts.html
+++ b/tests/visual/fixtures/fonts.html
@@ -18,11 +18,11 @@
 
     <body>
         <div id="canvas-container">
-            <canvas height="240" id="blit-tech-canvas" width="320"></canvas>
+            <canvas height="240" id="blit386-canvas" width="320"></canvas>
         </div>
 
         <script type="module">
-            import { bootstrap, BT, Color32, Palette, Vector2i } from 'blit-tech';
+            import { bootstrap, BT, Color32, Palette, Vector2i } from 'blit386';
 
             window.__RENDER_COMPLETE__ = false;
             window.__INIT_FAILED__ = false;

--- a/tests/visual/fixtures/mixed.html
+++ b/tests/visual/fixtures/mixed.html
@@ -18,11 +18,11 @@
 
     <body>
         <div id="canvas-container">
-            <canvas height="240" id="blit-tech-canvas" width="320"></canvas>
+            <canvas height="240" id="blit386-canvas" width="320"></canvas>
         </div>
 
         <script type="module">
-            import { bootstrap, BT, Color32, Palette, Rect2i, SpriteSheet, Vector2i } from 'blit-tech';
+            import { bootstrap, BT, Color32, Palette, Rect2i, SpriteSheet, Vector2i } from 'blit386';
 
             window.__RENDER_COMPLETE__ = false;
             window.__INIT_FAILED__ = false;

--- a/tests/visual/fixtures/post-process.html
+++ b/tests/visual/fixtures/post-process.html
@@ -18,7 +18,7 @@
 
     <body>
         <div id="canvas-container">
-            <canvas id="blit-tech-canvas"></canvas>
+            <canvas id="blit386-canvas"></canvas>
         </div>
 
         <script type="module">
@@ -37,7 +37,7 @@
                 Scanlines,
                 Vector2i,
                 Vignette,
-            } from 'blit-tech';
+            } from 'blit386';
 
             // Effect mode is selected via the URL hash so a single fixture covers
             // many snapshot variants.

--- a/tests/visual/fixtures/primitives.html
+++ b/tests/visual/fixtures/primitives.html
@@ -18,11 +18,11 @@
 
     <body>
         <div id="canvas-container">
-            <canvas height="240" id="blit-tech-canvas" width="320"></canvas>
+            <canvas height="240" id="blit386-canvas" width="320"></canvas>
         </div>
 
         <script type="module">
-            import { bootstrap, BT, Color32, Palette, Rect2i, Vector2i } from 'blit-tech';
+            import { bootstrap, BT, Color32, Palette, Rect2i, Vector2i } from 'blit386';
 
             // Signal test readiness regardless of success/failure.
             window.__RENDER_COMPLETE__ = false;

--- a/tests/visual/fixtures/sprites.html
+++ b/tests/visual/fixtures/sprites.html
@@ -18,11 +18,11 @@
 
     <body>
         <div id="canvas-container">
-            <canvas height="240" id="blit-tech-canvas" width="320"></canvas>
+            <canvas height="240" id="blit386-canvas" width="320"></canvas>
         </div>
 
         <script type="module">
-            import { bootstrap, BT, Color32, Palette, Rect2i, SpriteSheet, Vector2i } from 'blit-tech';
+            import { bootstrap, BT, Color32, Palette, Rect2i, SpriteSheet, Vector2i } from 'blit386';
 
             // Signal test readiness regardless of success/failure.
             window.__RENDER_COMPLETE__ = false;

--- a/tests/visual/fixtures/vite.config.ts
+++ b/tests/visual/fixtures/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
     },
     resolve: {
         alias: {
-            'blit-tech': path.resolve(__dirname, '../../../src/BlitTech.ts'),
+            blit386: path.resolve(__dirname, '../../../src/BLIT386.ts'),
         },
     },
     plugins: [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,7 +16,7 @@ export default defineConfig(() => {
                 exclude: ['src/main.ts'],
                 rollupTypes: true,
                 beforeWriteFile: (filePath, content) => ({
-                    filePath: filePath.replace(/BlitTech\.d\.ts$/, 'blit-tech.d.ts'),
+                    filePath: filePath.replace(/BLIT386\.d\.ts$/, 'blit386.d.ts'),
                     content,
                 }),
             }),
@@ -28,9 +28,9 @@ export default defineConfig(() => {
         build: {
             // Library build configuration
             lib: {
-                entry: 'src/BlitTech.ts',
-                name: 'BlitTech',
-                fileName: 'blit-tech',
+                entry: 'src/BLIT386.ts',
+                name: 'BLIT386',
+                fileName: 'blit386',
                 formats: ['es', 'cjs'] as LibraryFormats[],
             },
             target: 'es2022',


### PR DESCRIPTION
Rename the npm package from blit-tech to blit386 and the public IBlitTechDemo interface to IBTDemo. Key changes:

- src/BlitTech.ts -> src/BLIT386.ts (public API entrypoint)
- src/BlitTech.test.ts -> src/BLIT386.test.ts
- src/core/IBlitTechDemo.ts -> src/core/IBTDemo.ts
- src/core/IBlitTechDemo.test.ts -> src/core/IBTDemo.test.ts
- DEFAULT_CANVAS_ID: 'blit-tech-canvas' -> 'blit386-canvas'
- Default capture filename: 'blit-tech-capture.png' -> 'blit386-capture.png'
- Fix REGISTRY_TITLE_PATTERN in labels.ts (was already broken; demos output "BLIT386 Demo" titles but the regex still matched "Blit-Tech Demo")
- dist output filenames: blit-tech.* -> blit386.*
- package.json: name, repository, homepage, bugs, main/module/types/exports
- vite.config.ts: entry, lib name, output filename, declaration rename
- cspell.json: add blit386 / BLIT386 words
- All docs, comments, and GitHub URLs updated throughout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This pull request rebrands the package from `blit-tech` to `blit386` and renames the public demo interface from `IBlitTechDemo` to `IBTDemo`. Changes update source/API entrypoints, exported type wiring, defaults/constants, build/package configuration, CI checks, and broad documentation/test updates to match the new names.

## Core Changes

### File and API Renames
- `src/BlitTech.ts` → `src/BLIT386.ts`
- `src/BlitTech.test.ts` → `src/BLIT386.test.ts`
- `src/core/IBlitTechDemo.ts` → `src/core/IBTDemo.ts`
- `src/core/IBlitTechDemo.test.ts` → `src/core/IBTDemo.test.ts`

### Public API Updates
- Public interface rename:
  - `IBlitTechDemo` → `IBTDemo`
- Updated the facade/type usage so runtime and helpers accept `IBTDemo` (notably `BTAPI.init(...)`, `BT.init(...)`, and Bootstrap-related demo constructor typing).

### Constants and Defaults
- `DEFAULT_CANVAS_ID`: `blit-tech-canvas` → `blit386-canvas`
- Default capture filename: `blit-tech-capture.png` → `blit386-capture.png`

### Package/Build Configuration
- `package.json`:
  - `"name"`: `blit-tech` → `blit386`
  - Updated repository/homepage/bugs URLs to `blit386/blit386`
  - Updated `main`/`module`/`types` and `exports` to `./dist/blit386.*`
- `vite.config.ts`:
  - Build entry updated to `src/BLIT386.ts`
  - Library naming/output filename updated to `blit386`
  - Declaration output rewriting updated to produce `dist/blit386.d.ts`
- `scripts/check-declaration-tooling.mjs`:
  - Validates `dist/blit386.d.ts` (instead of `dist/blit-tech.d.ts`)
- `.github/workflows/pr-checks.yml`:
  - `bundle-size` job now measures `dist/blit386.js` and `dist/blit386.cjs`

## Bug Fixes

- `src/overlay/labels.ts`: fixed `REGISTRY_TITLE_PATTERN` so `resolveOverlayTopLeftLabel` matches the `BLIT386 Demo ...` registry title format.
- `scripts/convert-bmfont.mjs`: corrected CLI help/error output to reference the relocated script path (`node scripts/convert-bmfont.mjs ...`) instead of the old `tools/convert-bmfont.mjs` path, preventing ENOENT failures when users follow the instructions.

## Documentation, Tooling, and Tests

- Documentation-wide branding/import updates from `blit-tech`/`Blit-Tech` to `blit386`/`BLIT386`, including scaffolder references (`create-blit386`) and interface name changes (`IBTDemo`).
- Tests/fixtures updated to:
  - Import from `blit386` (no forbidden deep/source imports from repo paths)
  - Use `blit386-canvas`
  - Use mocked/typed demo interface `IBTDemo`
- Visual fixtures and Vite test fixture alias updated to map `blit386` → `src/BLIT386.ts`.
- Spellchecking:
  - `cspell.json`: added `blit386` and `BLIT386`.
- Misc repo maintenance updates (e.g., markdown link check ignores and `.claude/rules/*` guidance) updated to reference `blit386`/`BLIT386` and the new entrypoint names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->