### PR TITLE
chore(release): 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blit386",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "type": "module",
   "description": "A palette-first WebGPU retro engine for TypeScript, inspired by RetroBlit.",
   "author": {

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -59,10 +59,10 @@ export class BTAPI {
     public static readonly VERSION_MAJOR = 1;
 
     /** Minor version number. */
-    public static readonly VERSION_MINOR = 1;
+    public static readonly VERSION_MINOR = 2;
 
     /** Patch version number. */
-    public static readonly VERSION_PATCH = 1;
+    public static readonly VERSION_PATCH = 0;
 
     /** Singleton instance of BTAPI. */
     private static _instance: BTAPI | null = null;


### PR DESCRIPTION
## Summary

- Bump version to 1.2.0 in `package.json`
- Update `BTAPI.VERSION_MINOR` to 2 and `BTAPI.VERSION_PATCH` to 0 (logged at engine init)

## Test plan

- [ ] CI passes on this branch
- [ ] After merge: tag `1.2.0` on main, then `pnpm publish` from `blit386/`

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This pull request updates the blit386 project to version 1.2.0 by updating version numbers across the codebase.

## Changes Made

**package.json**: Version number updated from 1.1.1 to 1.2.0.

**src/core/BTAPI.ts**: Version constants updated to reflect the new version:
- `VERSION_MINOR` changed from 1 to 2
- `VERSION_PATCH` changed from 1 to 0

These constants are logged at engine initialization.

## Testing Plan

Before merge, CI must pass on the branch. After merge, the commit should be tagged as `1.2.0` on the main branch followed by running `pnpm publish` from the `blit386/` directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->