### PR TITLE
fix(core): buffer keyboard edges at fixed update rate

### DIFF
--- a/docs/input.md
+++ b/docs/input.md
@@ -199,7 +199,8 @@ change this value today.
 ### Text input buffer
 
 `BT.inputString` returns characters accumulated from filtered `beforeinput` (and Tab / Escape where needed). The buffer
-clears after each frame once the engine flushes input at end-of-frame. See public JSDoc on `BT.inputString` for details.
+clears at the end of each fixed update step (read it during `update()`). See public JSDoc on `BT.inputString` for
+details.
 
 ## Scroll Delta
 
@@ -234,17 +235,20 @@ Both are no-ops before the engine is initialized. The cursor is restored automat
 
 ## Frame-Timing Semantics
 
-State is snapshotted at the **end** of each animation frame, after `demo.update()` and `demo.render()` have run. This
-means:
+Pointer and gamepad previous-state rollover happens at the **end** of each animation frame, after `demo.update()` and
+`demo.render()` have run. Keyboard press/release edges and `BT.inputString` align with the **fixed update** rate
+(`targetFPS`), not the display refresh rate:
 
-- Any pointer event that fires between two frames is visible as a transition on the **next** `update()` call.
+- On a 120 Hz monitor with `targetFPS: 60`, `render()` may run twice per `update()`. Keyboard edges are buffered on DOM
+  events and consumed on the next fixed update so fast taps are not dropped between render-only frames.
 - `pointerDelta()` reflects movement between the last `update()` and the current one.
-- Keyboard-held keys and edges follow the same end-of-frame snapshot timing as pointer input (`KeyboardInput.endFrame`
-  aligns with pointer flush).
-- Gamepad previous-state rollover also happens at end-of-frame, while current gamepad state is polled from the Gamepad
-  API during button/axis queries.
-- `isPressed()` / `isReleased()` edges are never lost even when a press and release both arrive in the same inter-frame
-  gap (they appear as pressed-then-released across consecutive frames).
+- Gamepad current state is polled from the Gamepad API during button/axis queries; previous-state rollover still happens
+  at end-of-render-frame.
+- Read `BT.inputString` during `update()`; the buffer clears at the end of each fixed update step.
+
+Pointer transitions:
+
+- Any pointer event that fires between two animation frames is visible as a transition on the **next** `update()` call.
 
 ## Page-Interaction Guards
 

--- a/src/BLIT386.ts
+++ b/src/BLIT386.ts
@@ -1370,11 +1370,11 @@ export const BT = {
     },
 
     /**
-     * Text accumulated since the last end-of-frame flush from filtered `beforeinput`
-     * (and Tab / Escape where `beforeinput` is unreliable). Read during `update()` /
-     * `render()`; the buffer clears after each frame.
+     * Text accumulated since the last fixed-update flush from filtered `beforeinput`
+     * (and Tab / Escape where `beforeinput` is unreliable). Read during `update()`;
+     * the buffer clears at the end of each fixed update step.
      *
-     * @returns Characters typed since the last frame flush.
+     * @returns Characters typed since the last fixed-update flush.
      */
     get inputString(): string {
         return BTAPI.instance.getKeyboard()?.getInputString() ?? '';

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -310,6 +310,12 @@ export class BTAPI {
                 this.demo?.update();
                 this.pendingUpdateMs += Math.max(0, performance.now() - updateStartMs);
                 this.pendingUpdateSteps++;
+
+                const tick = this.loop?.getTicks() ?? 0;
+
+                // Keyboard edges and text buffer align with fixed update rate, not display
+                // refresh rate (render may run 2x update on 120 Hz / 60 FPS setups).
+                this.keyboard?.endUpdate(tick);
             },
             () => {
                 const frameStartMs = performance.now();
@@ -361,7 +367,6 @@ export class BTAPI {
 
                 const tick = this.loop?.getTicks() ?? 0;
 
-                this.keyboard?.endFrame(tick);
                 this.gamepad?.endFrame(tick);
 
                 this.overlayTiming.frameMs = Math.max(0, performance.now() - frameStartMs);

--- a/src/input/KeyboardInput.test.ts
+++ b/src/input/KeyboardInput.test.ts
@@ -193,6 +193,21 @@ describe('KeyboardInput', () => {
         kb.detach();
     });
 
+    it('ignores keyup for keys that were not held', () => {
+        const canvas = createCanvas();
+        const kb = new KeyboardInput();
+
+        kb.attach(canvas, { getTicks: () => tick });
+
+        kb.endUpdate(0);
+
+        canvas.dispatchEvent(new KeyboardEvent('keyup', { code: 'KeyX', bubbles: true }));
+
+        expect(kb.isKeyReleased('KeyX')).toBe(false);
+
+        kb.detach();
+    });
+
     it('accumulates insertText into input string and clears on endFrame', () => {
         const canvas = createCanvas();
         const kb = new KeyboardInput();

--- a/src/input/KeyboardInput.test.ts
+++ b/src/input/KeyboardInput.test.ts
@@ -148,6 +148,51 @@ describe('KeyboardInput', () => {
         kb.detach();
     });
 
+    it('buffers press and release edges across render-only gaps', () => {
+        const canvas = createCanvas();
+        const kb = new KeyboardInput();
+
+        kb.attach(canvas, { getTicks: () => tick });
+
+        kb.endUpdate(0);
+
+        canvas.dispatchEvent(new KeyboardEvent('keydown', { code: 'KeyJ', bubbles: true }));
+        canvas.dispatchEvent(new KeyboardEvent('keyup', { code: 'KeyJ', bubbles: true }));
+
+        expect(kb.isKeyPressed('KeyJ', undefined, 0)).toBe(true);
+        expect(kb.isKeyReleased('KeyJ')).toBe(true);
+
+        kb.endUpdate(1);
+
+        expect(kb.isKeyPressed('KeyJ', undefined, 1)).toBe(false);
+        expect(kb.isKeyReleased('KeyJ')).toBe(false);
+
+        kb.detach();
+    });
+
+    it('retains inputString until endUpdate', () => {
+        const canvas = createCanvas();
+        const kb = new KeyboardInput();
+
+        kb.attach(canvas, { getTicks: () => tick });
+
+        canvas.dispatchEvent(
+            new InputEvent('beforeinput', {
+                inputType: 'insertText',
+                data: 'z',
+                bubbles: true,
+            }),
+        );
+
+        expect(kb.getInputString()).toBe('z');
+
+        kb.endUpdate(0);
+
+        expect(kb.getInputString()).toBe('');
+
+        kb.detach();
+    });
+
     it('accumulates insertText into input string and clears on endFrame', () => {
         const canvas = createCanvas();
         const kb = new KeyboardInput();

--- a/src/input/KeyboardInput.ts
+++ b/src/input/KeyboardInput.ts
@@ -14,20 +14,33 @@ export interface KeyboardAttachOptions {
 
 /**
  * Tracks held keys using `KeyboardEvent.code`, snapshots once per frame for
- * edge detection (aligned with {@link PointerInput.endFrame} timing), and
+ * edge detection (aligned with fixed-update timing via {@link endUpdate}), and
  * accumulates filtered text from `beforeinput`.
  */
 export class KeyboardInput {
     /** Keys currently held (`keydown`, cleared on `keyup` / blur). */
     private readonly held: Set<string> = new Set();
 
-    /** Snapshot of `held` at the last {@link endFrame} (previous frame). */
+    /** Snapshot of `held` at the last {@link endUpdate} (previous fixed tick). */
     private readonly prevHeld: Set<string> = new Set();
+
+    /**
+     * Key codes that received a `keydown` since the last {@link endUpdate}.
+     * Buffered so press edges survive render-only frames (for example 120 Hz display
+     * with `targetFPS: 60`).
+     */
+    private readonly pendingPress: Set<string> = new Set();
+
+    /**
+     * Key codes that received a `keyup` since the last {@link endUpdate}.
+     * Paired with {@link pendingPress} for the same high-refresh edge case.
+     */
+    private readonly pendingRelease: Set<string> = new Set();
 
     /** Tick index when each code first went down (for repeat). */
     private readonly firstPressTick: Map<string, number> = new Map();
 
-    /** Characters queued for {@link getInputString}; cleared in {@link endFrame}. */
+    /** Characters queued for {@link getInputString}; cleared in {@link endUpdate}. */
     private inputBuffer: string = '';
 
     private canvas: HTMLCanvasElement | null = null;
@@ -97,12 +110,15 @@ export class KeyboardInput {
     }
 
     /**
-     * Snapshots held keys into `prevHeld` for next frame's edge detection.
-     * Clears the text buffer after the frame (call after demo has read {@link getInputString}).
+     * Ends a fixed update step: snapshots `prevHeld`, clears pending edges and
+     * {@link getInputString}. Call once per `demo.update()` (not once per render frame).
      *
-     * @param _currentTick - Fixed-update tick count after this frame's updates (`BT.ticks`).
+     * @param _currentTick - Reserved for future use; fixed-update tick when the demo read input.
      */
-    public endFrame(_currentTick: number): void {
+    public endUpdate(_currentTick: number): void {
+        this.pendingPress.clear();
+        this.pendingRelease.clear();
+
         this.prevHeld.clear();
 
         for (const code of this.held) {
@@ -110,6 +126,16 @@ export class KeyboardInput {
         }
 
         this.inputBuffer = '';
+    }
+
+    /**
+     * Alias for {@link endUpdate}; kept for tests and callers that still use the old name.
+     *
+     * @deprecated Call {@link endUpdate} once per fixed update instead.
+     * @param currentTick - Passed through to {@link endUpdate}.
+     */
+    public endFrame(currentTick: number): void {
+        this.endUpdate(currentTick);
     }
 
     /**
@@ -131,7 +157,7 @@ export class KeyboardInput {
      * @returns `true` on the initial press edge or on repeat ticks when configured.
      */
     public isKeyPressed(code: string, repeatRate: number | undefined, currentTick: number): boolean {
-        const isPressEdge = this.held.has(code) && !this.prevHeld.has(code);
+        const isPressEdge = this.pendingPress.has(code) || (this.held.has(code) && !this.prevHeld.has(code));
 
         if (repeatRate === undefined || repeatRate <= 0) {
             return isPressEdge;
@@ -163,6 +189,10 @@ export class KeyboardInput {
      * @returns `true` on the frame the key transitions from down to up.
      */
     public isKeyReleased(code: string): boolean {
+        if (this.pendingRelease.has(code)) {
+            return true;
+        }
+
         return !this.held.has(code) && this.prevHeld.has(code);
     }
 
@@ -210,6 +240,10 @@ export class KeyboardInput {
             return false;
         }
 
+        if (codes.some((c) => this.pendingPress.has(c))) {
+            return true;
+        }
+
         const isDown = this.isButtonDown(codes);
         const isPrevDown = codes.some((c) => this.prevHeld.has(c));
 
@@ -247,6 +281,10 @@ export class KeyboardInput {
             return false;
         }
 
+        if (codes.some((c) => this.pendingRelease.has(c))) {
+            return true;
+        }
+
         if (this.isButtonDown(codes)) {
             return false;
         }
@@ -282,6 +320,8 @@ export class KeyboardInput {
     private clearAllState(): void {
         this.held.clear();
         this.prevHeld.clear();
+        this.pendingPress.clear();
+        this.pendingRelease.clear();
         this.firstPressTick.clear();
         this.inputBuffer = '';
     }
@@ -299,6 +339,7 @@ export class KeyboardInput {
         }
 
         this.held.add(code);
+        this.pendingPress.add(code);
 
         const tick = this.getTicks?.() ?? 0;
 
@@ -322,6 +363,7 @@ export class KeyboardInput {
 
         this.held.delete(code);
         this.firstPressTick.delete(code);
+        this.pendingRelease.add(code);
     }
 
     /**

--- a/src/input/KeyboardInput.ts
+++ b/src/input/KeyboardInput.ts
@@ -361,7 +361,10 @@ export class KeyboardInput {
     private handleKeyUp(event: KeyboardEvent): void {
         const code = event.code;
 
-        this.held.delete(code);
+        if (!this.held.delete(code)) {
+            return;
+        }
+
         this.firstPressTick.delete(code);
         this.pendingRelease.add(code);
     }


### PR DESCRIPTION
Keyboard `endFrame` ran once per render frame while `demo.update` runs at `targetFPS.` On 120 Hz displays with `targetFPS` 60, `prevHeld` was snapshotted twice per tick and fast taps/releases could be dropped.

Buffer press and release edges on DOM events, call `endUpdate` after each fixed update step, and document the timing split in docs/input.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Synchronize keyboard input timing with fixed update rate

This PR fixes a timing desynchronization in keyboard handling that happened when the keyboard lifecycle ran at a different frequency than the game logic’s fixed update cycle. On high refresh rate displays (e.g., 120+ Hz) with a 60 FPS target, keyboard state was effectively snapshotted more than once per game tick, causing fast press/release taps to be dropped between fixed steps.

### Changes

**Keyboard input core (`src/input/KeyboardInput.ts`)**
- Added internal `pendingPress` / `pendingRelease` buffers so key down/up edges recorded from DOM events are carried into the next fixed update step.
- Introduced `endUpdate(_currentTick)` as the fixed-timestep boundary that:
  - snapshots `held` into `prevHeld`
  - clears pending edge buffers
  - clears the accumulated input text buffer
- Updated edge queries to consume pending buffers first:
  - `isKeyPressed` treats entries in `pendingPress` as immediate press edges
  - `isKeyReleased` returns `true` immediately when a code is in `pendingRelease`
  - button-level `isButtonPressed` / `isButtonReleased` follow the same pending behavior
- Updated `endFrame(currentTick)` to be a deprecated alias that forwards to `endUpdate(currentTick)` (instead of doing the previous end-of-frame flush).
- Extended `clearAllState()` to also clear `pendingPress` / `pendingRelease`.
- Guarded against stray `keyup` edges by only queuing releases when the key was actually held.

**Main loop integration (`src/core/BTAPI.ts`)**
- Moved keyboard rollover/snapshotting to occur after each fixed update step (`keyboard.endUpdate(tick)`).
- Removed keyboard’s end-of-frame flushing from the render-frame path (render rollover now continues without the keyboard end-of-frame step).

**Documentation (`docs/input.md`)**
- Updated `BT.inputString` timing semantics to state the typed-text buffer is cleared at the end of each fixed update step (and read during `update()`), not at end-of-frame.
- Revised “Frame-Timing Semantics” to clarify:
  - keyboard press/release edges and `BT.inputString` align with the fixed update rate (`targetFPS`)
  - pointer/gamepad previous-state rollover continues at end of animation frames
  - pointer transition visibility remains “next `update()` call”
  - wording was refined (including removal of an earlier statement about edges not being lost across inter-frame gaps).

**Tests (`src/input/KeyboardInput.test.ts`)**
- Added coverage that:
  - key press/release edges are preserved across render-only gaps when using `endUpdate`, and only clear after the next `endUpdate`
  - `getInputString()` retains buffered `beforeinput` text until `endUpdate`
  - `keyup` for keys that were not held does not produce a released edge.

### Impact
Keyboard edges and typed-text buffering are now consistently captured and cleared at the fixed update rate, preventing missed inputs caused by render/update frequency mismatches on high refresh rate systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->