### PR TITLE
chore: release 1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blit386",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "description": "A palette-first WebGPU retro engine for TypeScript, inspired by RetroBlit.",
   "author": {

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -62,7 +62,7 @@ export class BTAPI {
     public static readonly VERSION_MINOR = 2;
 
     /** Patch version number. */
-    public static readonly VERSION_PATCH = 0;
+    public static readonly VERSION_PATCH = 1;
 
     /** Singleton instance of BTAPI. */
     private static _instance: BTAPI | null = null;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release 1.2.1

Version update for BLIT386 engine runtime.

### Changes

- `package.json`: Version bumped from `1.2.0` to `1.2.1`
- `src/core/BTAPI.ts`: `VERSION_PATCH` incremented from `0` to `1`, updating the runtime version string printed during engine initialization

### Scope

This release includes substantial repository infrastructure additions alongside the version bump:

- Agent skills definitions (`.agents/skills/`)
- Claude development rules and settings (`.claude/`)
- Cursor IDE configuration and rules (`.cursor/`)
- Comprehensive documentation (docs/, CLAUDE.md, CONTRIBUTING.md, etc.)
- Complete source codebase (src/)
- CI/CD workflows and tooling
- Test suite (unit, visual regression, benchmarks)
- Configuration files (biome.json, eslint.config.js, vitest.config.ts, etc.)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->