### PR TITLE
docs: enforce twoslash in TypeScript code blocks for published docs

### DIFF
--- a/.claude/rules/docs-sync-required.md
+++ b/.claude/rules/docs-sync-required.md
@@ -20,6 +20,9 @@ Condensed mirror of `.cursor/rules/docs-sync-required.mdc`.
   of contents (the site provides one); components only render on the site, so keep contributor-only docs plain Markdown.
   Adding a component the site does not register (`blit386-dev-fumapress/press.config.tsx`) breaks the build — register
   it there first, then verify with `pnpm run sync:docs` + `pnpm run build` in that repo.
+- TypeScript code blocks in published docs must use ` ```ts twoslash ` (never plain ` ```ts `). Each block must compile
+  on its own: self-contained blocks carry their own imports; fragment blocks add a hidden preamble above `// ---cut---`.
+  Full rules in `CLAUDE.md` (Twoslash in published docs) and `.claude/rules/twoslash-docs.md`.
 - Doc prose house style (see `CLAUDE.md` Documentation authoring style): no bold (`**`) in prose, no `---` separators,
   `×` (not `x`) for dimensions except literal program output, break up walls of text, every `###` needs a parent `##`,
   credit external inspirations with link + author. Published-doc filenames mirror the sitemap section (`api-*`,

--- a/.claude/rules/twoslash-docs.md
+++ b/.claude/rules/twoslash-docs.md
@@ -1,0 +1,47 @@
+# Twoslash in published docs
+
+Condensed mirror of `.cursor/rules/twoslash-docs.mdc`.
+
+All TypeScript code blocks in published docs (`docs/api-*.md`, `docs/guide-*.md`, `docs/performance-*.md`,
+`docs/reference-*.md`) must use ` ```ts twoslash ` so the live site (blit386.dev) renders type-on-hover popups. Plain
+` ```ts ` is never acceptable in published docs. This is non-negotiable.
+
+Every block must be self-contained for TypeScript compilation. Two patterns:
+
+**Self-contained block** (imports at the top, block compiles on its own — no cut needed):
+
+```ts twoslash
+import { BT, Color32, Palette } from 'blit386';
+const palette = Palette.c64();
+BT.paletteSet(palette);
+```
+
+**Fragment block** (shows a partial snippet, context variables assumed from prose — use a hidden preamble +
+`// ---cut---`):
+
+```ts twoslash
+import { BT, Palette } from 'blit386';
+const nightPalette = Palette.vga();
+// ---cut---
+BT.paletteFade(nightPalette, 2000, 'ease-in-out');
+```
+
+Everything above `// ---cut---` is compiled by TypeScript but hidden from the reader. Everything below is shown.
+
+Preamble rules:
+
+- Import all blit386 names used in the block from `'blit386'` in one line.
+- Use `const x = new Type(...)` for constructible types (`Palette`, `Vector2i`, `Rect2i`, `Color32`).
+- Use `declare const x: Type` for types that cannot be constructed with `new` (`SpriteSheet`, `BitmapFont`).
+- For `indexed.sheet` / `indexed.srcRect` patterns: `declare const indexed: { sheet: SpriteSheet; srcRect: Rect2i };`
+- Named palette variables (`nightPalette`, `dangerPalette`, etc.): `const nightPalette = Palette.vga();`
+- Position/rect variables assumed from context: `const pos = new Vector2i(0, 0);`,
+  `const rect = new Rect2i(0, 0, 320, 240);`
+
+After adding or editing blocks, verify in `blit386-dev-fumapress`:
+
+```bash
+pnpm run sync:docs && pnpm run build
+```
+
+A Twoslash compilation error fails the build. Fix the preamble rather than adding `// @noErrors`.

--- a/.cursor/rules/docs-sync-required.mdc
+++ b/.cursor/rules/docs-sync-required.mdc
@@ -35,6 +35,9 @@ alwaysApply: false
   its own); components render only on the live site, so leave contributor-only docs as plain Markdown. Any component
   used must be registered in `blit386-dev-fumapress/press.config.tsx` (`getMdxComponents`) or the build fails — verify
   with `pnpm run sync:docs` + `pnpm run build` (or `typecheck`) in that repo.
+- TypeScript code blocks in published docs must use ` ```ts twoslash ` (never plain ` ```ts `). Each block must compile
+  on its own: self-contained blocks carry their own imports; fragment blocks add a hidden preamble above `// ---cut---`.
+  Full rules in `CLAUDE.md` (**Twoslash in published docs**) and `.cursor/rules/twoslash-docs.mdc`.
 - Follow the doc prose house style (`CLAUDE.md` **Documentation authoring style**): no bold (`**`) in prose, no `---`
   separators, the `×` sign (not `x`) for dimensions except literal program output, break up walls of text, every `###`
   has a parent `##`, and credit external inspirations with a link and author. Published-doc filenames mirror the sitemap

--- a/.cursor/rules/twoslash-docs.mdc
+++ b/.cursor/rules/twoslash-docs.mdc
@@ -1,0 +1,49 @@
+---
+description: Enforce ts twoslash on all TypeScript code blocks in published docs
+globs: { docs/api-*.md, docs/guide-*.md, docs/performance-*.md, docs/reference-*.md }
+alwaysApply: false
+---
+
+# Twoslash in Published Docs
+
+All TypeScript code blocks in published docs must use ` ```ts twoslash `. Plain ` ```ts ` is never acceptable in
+published docs. This is non-negotiable — the live site (blit386.dev) requires it for type-on-hover popups.
+
+Every block must be self-contained for TypeScript compilation. Two patterns:
+
+**Self-contained block** — imports at the top, compiles on its own, no cut needed:
+
+```ts twoslash
+import { BT, Color32, Palette } from 'blit386';
+const palette = Palette.c64();
+BT.paletteSet(palette);
+```
+
+**Fragment block** — shows a partial snippet with context variables from prose — add a hidden preamble then
+`// ---cut---`:
+
+```ts twoslash
+import { BT, Palette } from 'blit386';
+const nightPalette = Palette.vga();
+// ---cut---
+BT.paletteFade(nightPalette, 2000, 'ease-in-out');
+```
+
+Everything above `// ---cut---` is compiled by TypeScript but hidden from the reader on the live site.
+
+Preamble rules:
+
+- One `import { ... } from 'blit386'` line covering all blit386 names used.
+- `const x = new Type(...)` for constructible types: `Palette`, `Vector2i`, `Rect2i`, `Color32`.
+- `declare const x: Type` for non-constructible types: `SpriteSheet`, `BitmapFont`.
+- `declare const indexed: { sheet: SpriteSheet; srcRect: Rect2i };` for `indexed.sheet` / `indexed.srcRect` patterns.
+- Named palette vars: `const nightPalette = Palette.vga();`
+- Generic position/rect vars: `const pos = new Vector2i(0, 0);`, `const rect = new Rect2i(0, 0, 320, 240);`
+
+After editing any block, verify in `blit386-dev-fumapress`:
+
+```bash
+pnpm run sync:docs && pnpm run build
+```
+
+Fix broken preambles rather than adding `// @noErrors`. A Twoslash error fails the production build.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,44 @@ Authoring rules (learned the hard way; keep the build green):
 - Validate before considering it done: in `blit386-dev-fumapress`, run `pnpm run sync:docs` then `pnpm run build` (or at
   least `pnpm run typecheck`). An undefined component or malformed prop fails the build, which would break the deploy.
 
+## Twoslash in published docs
+
+All TypeScript code blocks in published docs (`docs/api-*.md`, `docs/guide-*.md`, `docs/performance-*.md`,
+`docs/reference-*.md`) must use ` ```ts twoslash `. Plain ` ```ts ` is never acceptable in published docs. This is
+non-negotiable — the live site (blit386.dev) uses fumadocs-twoslash for type-on-hover popups.
+
+Every block must compile cleanly on its own. Two patterns:
+
+Self-contained block — full imports at the top, no cut needed:
+
+```ts twoslash
+import { BT, Color32, Palette } from 'blit386';
+const palette = Palette.c64();
+BT.paletteSet(palette);
+```
+
+Fragment block — shows a partial snippet whose variables come from surrounding prose — add a hidden preamble then
+`// ---cut---`. Everything above the cut is compiled but hidden from the reader:
+
+```ts twoslash
+import { BT, Palette } from 'blit386';
+const nightPalette = Palette.vga();
+// ---cut---
+BT.paletteFade(nightPalette, 2000, 'ease-in-out');
+```
+
+Preamble rules:
+
+- One `import { ... } from 'blit386'` line covering all engine names used in the block.
+- `const x = new Type(...)` for constructible types: `Palette`, `Vector2i`, `Rect2i`, `Color32`.
+- `declare const x: Type` for non-constructible types: `SpriteSheet`, `BitmapFont`.
+- `declare const indexed: { sheet: SpriteSheet; srcRect: Rect2i };` for `indexed.sheet` / `indexed.srcRect` patterns.
+- Named palette vars (`nightPalette`, `dangerPalette`, etc.): `const nightPalette = Palette.vga();`
+- Generic position/rect context vars: `const pos = new Vector2i(0, 0);`, `const rect = new Rect2i(0, 0, 320, 240);`
+
+After adding or editing a block, always verify: in `blit386-dev-fumapress` run `pnpm run sync:docs && pnpm run build`. A
+Twoslash compilation error fails the production build. Fix the preamble rather than adding `// @noErrors`.
+
 ## Documentation authoring style
 
 House style for the Markdown under `docs/` (the published reference and guides). This is about authoring the docs

--- a/docs/api-assets.md
+++ b/docs/api-assets.md
@@ -46,7 +46,7 @@ clipping.
 `AssetLoader` caches images by URL so repeated loads share the same `HTMLImageElement`. Oversized images are rejected as
 soon as the browser reports decoded dimensions.
 
-```ts
+```ts twoslash
 import { AssetLoader } from 'blit386';
 
 // Load a single image (cached by URL)
@@ -66,7 +66,7 @@ if (AssetLoader.isLoaded('sprites.png')) {
 Use `SpriteSheet.loadIndexed()` for all standard sprite setup. It combines color registration, image loading, and
 palette indexization in one call.
 
-```ts
+```ts twoslash
 import { BT, Palette, SpriteSheet, Vector2i } from 'blit386';
 
 const palette = new Palette(256);
@@ -96,7 +96,7 @@ BT.drawSprite(indexed.sheet, indexed.srcRect, new Vector2i(20, 20));
 Use this only when you need fine-grained control over the palette layout or want to load several sheets into the same
 palette sequentially.
 
-```ts
+```ts twoslash
 import { BT, Palette, SpriteSheet } from 'blit386';
 
 const palette = new Palette(256);
@@ -111,7 +111,10 @@ const palette = new Palette(256);
 Each call appends the image's colors starting at the given slot; chain them with running offsets to pack several sheets
 into one palette.
 
-```ts
+```ts twoslash
+import { Palette, SpriteSheet } from 'blit386';
+const palette = new Palette(256);
+// ---cut---
 const colors = await SpriteSheet.loadColorsIntoPalette('hero.png', palette, 10);
 const tileColors = await SpriteSheet.loadColorsIntoPalette('tiles.png', palette, 10 + colors.length);
 ```
@@ -122,7 +125,9 @@ const tileColors = await SpriteSheet.loadColorsIntoPalette('tiles.png', palette,
 
 ### Load the image into a sprite sheet
 
-```ts
+```ts twoslash
+import { SpriteSheet } from 'blit386';
+// ---cut---
 const sheet = await SpriteSheet.load('hero.png');
 ```
 
@@ -134,7 +139,11 @@ const sheet = await SpriteSheet.load('hero.png');
 
 `indexize()` maps every pixel to its palette slot; activate the palette afterward.
 
-```ts
+```ts twoslash
+import { BT, Palette, SpriteSheet } from 'blit386';
+const palette = new Palette(256);
+declare const sheet: SpriteSheet;
+// ---cut---
 sheet.indexize(palette);
 BT.paletteSet(palette);
 ```
@@ -145,7 +154,12 @@ BT.paletteSet(palette);
 
 To create a sheet from raw palette-indexed pixel data (advanced / test use):
 
-```ts
+```ts twoslash
+import { SpriteSheet } from 'blit386';
+declare const width: number;
+declare const height: number;
+declare const indexedPixels: Uint8Array;
+// ---cut---
 const sheet = SpriteSheet.fromIndexedPixels(width, height, indexedPixels);
 ```
 
@@ -155,7 +169,12 @@ Pass a `paletteOffset` (per-draw shift, not an absolute slot) to `BT.drawSprite(
 texel indices before palette lookup. Useful for team-color variations and damage flashes. Terminology and examples:
 [Palette addressing](api-palette.md#palette-addressing). Draw semantics: [API: Rendering](api-rendering.md).
 
-```ts
+```ts twoslash
+import { BT, Rect2i, SpriteSheet, Vector2i } from 'blit386';
+declare const sheet: SpriteSheet;
+const srcRect = new Rect2i(0, 0, 32, 32);
+const pos = new Vector2i(0, 0);
+// ---cut---
 BT.drawSprite(sheet, srcRect, pos, 16); // render in "blue team" color range
 ```
 
@@ -164,9 +183,10 @@ BT.drawSprite(sheet, srcRect, pos, 16); // render in "blue team" color range
 Load `.btfont` files for proportional, palette-indexed bitmap fonts. After loading, register colors in the palette and
 indexize the font's internal sprite sheet before drawing (same pattern as manual sprite setup).
 
-```ts
-import { BitmapFont, Palette } from 'blit386';
-
+```ts twoslash
+import { BitmapFont, BT, Palette, Vector2i } from 'blit386';
+declare const paletteOffset: number;
+// ---cut---
 const palette = new Palette(256);
 const font = await BitmapFont.load('fonts/MyFont.btfont');
 font.getSpriteSheet().indexize(palette);
@@ -187,7 +207,10 @@ BT.printFont(font, new Vector2i(10, 10), 'Hello!', paletteOffset); // per-draw i
 
 A built-in 6×14 monospace font covering printable ASCII (characters 32-126). No load step needed.
 
-```ts
+```ts twoslash
+import { BT, Vector2i } from 'blit386';
+declare const paletteIndex: number;
+// ---cut---
 BT.systemPrint(new Vector2i(10, 10), paletteIndex, 'Score: 100');
 BT.systemPrintMeasure('Score: 100'); // → Vector2i (pixel width, height)
 ```

--- a/docs/api-camera.md
+++ b/docs/api-camera.md
@@ -12,7 +12,13 @@
 
 The camera applies a global pixel offset to all subsequent draw calls. Integer only – pass `Vector2i`, never floats.
 
-```ts
+```ts twoslash
+import { BT, Vector2i } from 'blit386';
+declare const scrollX: number;
+declare const scrollY: number;
+declare const desired: Vector2i;
+declare const worldSize: Vector2i;
+// ---cut---
 BT.cameraSet(new Vector2i(scrollX, scrollY)); // apply offset
 BT.camera; // Vector2i - current offset
 BT.cameraReset(); // set back to (0, 0)
@@ -21,14 +27,17 @@ BT.cameraReset(); // set back to (0, 0)
 const clamped = BT.cameraClamp(desired, worldSize);
 
 // Optional third argument overrides the viewport size (default: BT.displaySize):
-const clamped = BT.cameraClamp(desired, worldSize, new Vector2i(160, 120));
+const clamped2 = BT.cameraClamp(desired, worldSize, new Vector2i(160, 120));
 ```
 
 Standalone helper (same math as `BT.cameraClamp`):
 
-```ts
-import { clampCameraToWorld } from 'blit386';
-
+```ts twoslash
+import { clampCameraToWorld, Vector2i } from 'blit386';
+declare const desired: Vector2i;
+declare const worldSize: Vector2i;
+declare const viewSize: Vector2i;
+// ---cut---
 const clamped = clampCameraToWorld(desired, worldSize, viewSize);
 ```
 

--- a/docs/api-core-types.md
+++ b/docs/api-core-types.md
@@ -16,7 +16,15 @@ The integer-coordinate primitives shared across the engine: `Vector2i`, `Rect2i`
 
 Integer 2D vector. Constructor auto-truncates floats toward zero. Used for all positions, sizes, and camera offsets.
 
-```ts
+```ts twoslash
+import { Vector2i } from 'blit386';
+declare const x: number;
+declare const y: number;
+declare const a: Vector2i;
+declare const b: Vector2i;
+declare const t: number;
+declare const out: Vector2i;
+// ---cut---
 const v = new Vector2i(10, 20);
 v.x;
 v.y; // direct access
@@ -47,7 +55,30 @@ Instance methods: `.add()`, `.sub()`, `.scale()`, `.dot()`, `.clone()`, `.isEqua
 
 Integer rectangle with `x, y, width, height` fields.
 
-```ts
+```ts twoslash
+import { Rect2i, Vector2i } from 'blit386';
+declare const x: number;
+declare const y: number;
+declare const width: number;
+declare const height: number;
+declare const min: Vector2i;
+declare const max: Vector2i;
+declare const minX: number;
+declare const minY: number;
+declare const maxX: number;
+declare const maxY: number;
+declare const center: Vector2i;
+declare const size: Vector2i;
+declare const cx: number;
+declare const cy: number;
+declare const w: number;
+declare const h: number;
+declare const point: Vector2i;
+declare const px: number;
+declare const py: number;
+declare const other: Rect2i;
+declare const out: Rect2i;
+// ---cut---
 const r = new Rect2i(x, y, width, height);
 
 // Static factories
@@ -73,17 +104,35 @@ r.max; // Vector2i getter (bottom-right)
 
 32-bit RGBA color (channels 0-255).
 
-```ts
+```ts twoslash
+import { Color32 } from 'blit386';
+declare const r: number;
+declare const g: number;
+declare const b: number;
+declare const a: number;
+declare const value: number;
+declare const newColor: Color32;
+declare const ca: Color32;
+declare const cb: Color32;
+declare const t: number;
+declare const other: Color32;
+// ---cut---
 const c = new Color32(r, g, b, a);
 
 // Cached color constants (static getters; frozen singletons)
-Color32.white       Color32.black       Color32.transparent
-Color32.red         Color32.green       Color32.blue
-Color32.yellow      Color32.cyan        Color32.magenta
-Color32.gray(value) // grayscale, value 0-255
+Color32.white;
+Color32.black;
+Color32.transparent;
+Color32.red;
+Color32.green;
+Color32.blue;
+Color32.yellow;
+Color32.cyan;
+Color32.magenta;
+Color32.gray(value); // grayscale, value 0-255
 
 // Hex parsing
-Color32.fromHex('#ff8800') // returns Color32
+Color32.fromHex('#ff8800'); // returns Color32
 
 // Named color registry (global, case-insensitive)
 Color32.registerColor('brand', new Color32(255, 128, 0, 255));
@@ -92,14 +141,14 @@ Color32.updateColor('brand', newColor);
 Color32.unregisterColor('brand');
 
 // Interpolation
-Color32.lerp(a, b, t); // blend a→b; t clamped [0,1]; RGBA independent; truncates like instance lerp
+Color32.lerp(ca, cb, t); // blend a→b; t clamped [0,1]; RGBA independent; truncates like instance lerp
 c.lerp(other, t); // same semantics as static helper
 
 // Conversion
-c.toFloat32Array() // [r/255, g/255, b/255, a/255]
-c.luminance // perceived brightness: 0.299r + 0.587g + 0.114b
-c.toHex() // '#rrggbb' string
-c.isEqual(other) // boolean - all RGBA channels match
+c.toFloat32Array(); // [r/255, g/255, b/255, a/255]
+c.luminance; // perceived brightness: 0.299r + 0.587g + 0.114b
+c.toHex(); // '#rrggbb' string
+c.isEqual(other); // boolean - all RGBA channels match
 ```
 
 ## See also

--- a/docs/api-core.md
+++ b/docs/api-core.md
@@ -28,9 +28,11 @@ The rest of the core API surface lives in dedicated pages: [Overlay](api-overlay
 The `bootstrap()` function is the recommended entry point. It handles DOM ready, canvas lookup, backend selection
 (WebGPU or software fallback), and error display automatically.
 
-```ts
-import { bootstrap, type BootstrapOptions } from 'blit386';
-
+```ts twoslash
+import { bootstrap, type IBTDemo, type BootstrapOptions } from 'blit386';
+declare const MyDemo: new () => IBTDemo;
+declare function trackError(err: Error): void;
+// ---cut---
 // One-liner - canvas id defaults to 'blit386-canvas', container to 'canvas-container'
 bootstrap(MyDemo);
 
@@ -56,7 +58,7 @@ bootstrap(MyDemo, {
 
 Manual utilities (for custom initialization flows):
 
-```ts
+```ts twoslash
 import { displayError, getCanvas } from 'blit386';
 
 const canvas = getCanvas('my-canvas'); // returns null on missing element
@@ -68,7 +70,11 @@ displayError('Init Failed', 'WebGPU unavailable.', 'my-container');
 
 ## Initialization
 
-```ts
+```ts twoslash
+import { BT, type IBTDemo } from 'blit386';
+declare const demo: IBTDemo;
+declare const canvas: HTMLCanvasElement;
+// ---cut---
 const ok = await BT.init(demo, canvas); // low-level init; prefer bootstrap()
 BT.displaySize; // Vector2i - configured logical resolution (clone per read)
 BT.drawingBufferSize; // Vector2i | null - output buffer when set in configure()
@@ -208,7 +214,9 @@ without hitting module-load errors from WebGPU-only code.
 
 Use `activeBackend`, not `requestedBackend`:
 
-```ts
+```ts twoslash
+import { BT } from 'blit386';
+// ---cut---
 // Correct: gate on the backend that actually started; BT.effectAdd takes one effect
 if (BT.activeBackend === 'webgpu') {
   for (const fx of BT.preset.crtPipBoy()) {
@@ -226,9 +234,11 @@ if (BT.requestedBackend === 'webgpu') {
 
 Forcing software up front avoids the fallback path entirely:
 
-```ts
-configure() {
-  return { backend: 'software', /* ... */ };
+```ts twoslash
+import { type HardwareSettings } from 'blit386';
+// ---cut---
+function configure(): Partial<HardwareSettings> {
+  return { backend: 'software' /* ... */ };
 }
 // requestedBackend === activeBackend === 'software' after init
 ```
@@ -237,7 +247,7 @@ configure() {
 
 Import `defaultConfig` and `mergeHardwareSettings` when building custom configure flows outside `bootstrap()`:
 
-```ts
+```ts twoslash
 import { defaultConfig, mergeHardwareSettings } from 'blit386';
 
 const settings = mergeHardwareSettings(defaultConfig(), { targetFPS: 30 });

--- a/docs/api-easing.md
+++ b/docs/api-easing.md
@@ -12,7 +12,7 @@
 
 Palette fade effects accept an `EasingFunction`. Use `applyEasing` to evaluate named curves:
 
-```ts
+```ts twoslash
 import { applyEasing } from 'blit386';
 
 const t = applyEasing('ease-in-out', 0.5); // 0..1 progress → eased value

--- a/docs/api-game-loop.md
+++ b/docs/api-game-loop.md
@@ -22,7 +22,9 @@ BLIT386 runs two independent cadences:
 `render()` may run more or fewer times per second than `update()` (for example 120 Hz display with `targetFPS: 60`). Use
 tick-based timing for gameplay; use overlay present FPS only to spot GPU or draw-call bottlenecks.
 
-```ts
+```ts twoslash
+import { BT } from 'blit386';
+// ---cut---
 BT.deltaSeconds; // seconds per fixed tick (1 / BT.targetFPS)
 BT.timeSeconds; // elapsed seconds since init (ticks × deltaSeconds)
 BT.ticks; // current tick counter (increments each update)
@@ -35,7 +37,10 @@ BT.assignTag('Round start'); // timing chart event tag at current tick (requires
 `Timer` counts fixed update ticks, not render frames. Intervals are in ticks; convert to seconds with
 `intervalTicks / BT.targetFPS`. Use it in `update()` for periodic events: particle spawns, score ticks, palette swaps.
 
-```ts
+```ts twoslash
+import { Timer } from 'blit386';
+declare function spawnEnemy(): void;
+// ---cut---
 const spawn = new Timer(180); // every 180 ticks (3 s when BT.targetFPS === 60)
 
 // Inside update():

--- a/docs/api-overlay.md
+++ b/docs/api-overlay.md
@@ -146,10 +146,14 @@ custom rows, and the bottom band (palette grid plus hint bar).
 - Reuse the same array and row objects when possible; update `leftText` / `rightText` in place to avoid per-frame
   allocations.
 
-```ts
+```ts twoslash
+import { type IBTDemo } from 'blit386';
+// ---cut---
 /** @implements {IBTDemo} */
 class Demo {
   readonly #overlayRows = [{ leftText: 'Position: 0, 0' }, { leftText: 'Score: 0', rightText: 'ready' }];
+  pos = { x: 0, y: 0 };
+  score = 0;
 
   overlayRows() {
     this.#overlayRows[0].leftText = `Position: ${this.pos.x}, ${this.pos.y}`;
@@ -240,17 +244,23 @@ bottomReserve = paletteGridHeight + 1 + 13
 - Implementation lives in `src/overlay/palette/PaletteView.ts` (`computeGrid`, `pickGridColumnCount`,
   `resolveGridVisibleRows`).
 
-```ts
+```ts twoslash
+import { type HardwareSettings, Vector2i } from 'blit386';
+// ---cut---
 // Overlay off (release build or custom full-screen HUD).
-configure() {
+function configure(): Partial<HardwareSettings> {
   return {
     displaySize: new Vector2i(320, 240),
     isOverlayEnabled: false,
   };
 }
+```
 
+```ts twoslash
+import { type HardwareSettings, Vector2i } from 'blit386';
+// ---cut---
 // Overlay on with palette grid and timing chart.
-configure() {
+function configure(): Partial<HardwareSettings> {
   return {
     displaySize: new Vector2i(320, 240),
     isOverlayEnabled: true,

--- a/docs/api-palette.md
+++ b/docs/api-palette.md
@@ -33,7 +33,11 @@ Slot and `paletteIndex` mean the same integer: which entry in the active palette
 
 The draw call picks the slot directly. Slot `0` stays transparent (not drawn).
 
-```ts
+```ts twoslash
+import { BT, Rect2i, Vector2i } from 'blit386';
+const rect = new Rect2i(0, 0, 320, 240);
+const pos = new Vector2i(0, 0);
+// ---cut---
 BT.drawRectFill(rect, 6); // every pixel uses palette slot 6 (absolute)
 BT.systemPrint(pos, 3, 'Score'); // glyphs use absolute slot 3
 ```
@@ -44,7 +48,12 @@ Indexed sprites and bitmap fonts store small indices in the texture (starting at
 draw time the WebGPU sprite shader computes `combined = storedIndex + paletteOffset`, then `index = min(combined, 255u)`
 before palette lookup.
 
-```ts
+```ts twoslash
+import { BT, Rect2i, SpriteSheet, Vector2i } from 'blit386';
+declare const sheet: SpriteSheet;
+const src = new Rect2i(0, 0, 32, 32);
+const pos = new Vector2i(0, 0);
+// ---cut---
 BT.drawSprite(sheet, src, pos, 0); // stored 1 → palette[1], stored 2 → palette[2]
 BT.drawSprite(sheet, src, pos, 16); // stored 1 → palette[17], stored 2 → palette[18]
 ```
@@ -67,10 +76,12 @@ after a layout swap when colors moved to different slot numbers (then also call 
 
 ## Palette setup
 
-```ts
+```ts twoslash
+import { BT, Color32, Palette } from 'blit386';
+// ---cut---
 // Create
 const palette = new Palette(256);
-const palette = BT.paletteCreate(256); // equivalent BT-namespace shorthand
+// const palette2 = BT.paletteCreate(256); // equivalent BT-namespace shorthand
 
 // Set and get colors (slot = absolute palette index; see Palette addressing above)
 palette.set(1, new Color32(255, 0, 0, 255)); // red at absolute slot 1
@@ -86,7 +97,9 @@ BT.palette; // → active Palette; throws if none set
 
 Each preset returns a fully populated `Palette` instance.
 
-```ts
+```ts twoslash
+import { Palette } from 'blit386';
+// ---cut---
 Palette.vga(); // VGA 256-color
 Palette.cga(); // CGA 16-color
 Palette.c64(); // Commodore 64 16-color
@@ -99,7 +112,10 @@ Palette.nes(); // NES 64-color
 
 Fills six consecutive UI-purpose slots into an existing palette and registers `hud_*` name aliases.
 
-```ts
+```ts twoslash
+import { BT, Palette } from 'blit386';
+const palette = new Palette(256);
+// ---cut---
 palette.applyHUD(); // fills slots 1-6 (default startSlot = 1)
 palette.applyHUD(10); // fills slots 10-15
 BT.paletteSet(palette);
@@ -118,7 +134,10 @@ The six slots in order, by alias:
 
 Override individual slots after `applyHUD()`:
 
-```ts
+```ts twoslash
+import { BT, Color32, Palette } from 'blit386';
+const palette = new Palette(256);
+// ---cut---
 palette.applyHUD(1);
 palette.set(2, new Color32(20, 16, 32)); // override hud_bg
 BT.paletteSet(palette);
@@ -126,7 +145,10 @@ BT.paletteSet(palette);
 
 ## Named slot aliases
 
-```ts
+```ts twoslash
+import { Palette } from 'blit386';
+const palette = new Palette(256);
+// ---cut---
 palette.setNamed('player', 3); // alias 'player' → slot 3
 palette.getNamed('player'); // → 3 (the slot index)
 palette.getNamedColor('player'); // → Color32 at that slot
@@ -136,7 +158,12 @@ palette.getNamedColor('player'); // → Color32 at that slot
 
 ## Serialization
 
-```ts
+```ts twoslash
+import { Color32, Palette } from 'blit386';
+const palette = new Palette(256);
+declare const out: Float32Array;
+declare const color: Color32;
+// ---cut---
 // JSON round-trip (preserves colors and named aliases)
 const json = palette.toJSON();
 const restored = Palette.fromJSON(json);
@@ -145,8 +172,8 @@ const restored = Palette.fromJSON(json);
 const bytes = palette.toUint8Array(); // Uint8Array, 3 bytes per slot
 const floats = palette.toFloat32Array(); // Float32Array, 4 floats per slot (RGBA 0..1)
 palette.toFloat32ArrayInto(out); // zero-allocation variant into existing buffer
-const p = Palette.fromUint8Array(bytes); // auto-detect size
-const p = Palette.fromUint8Array(bytes, 16); // explicit size
+const p1 = Palette.fromUint8Array(bytes); // auto-detect size
+const p2 = Palette.fromUint8Array(bytes, 16); // explicit size
 
 // Clone
 const copy = palette.clone();
@@ -162,7 +189,16 @@ upload). Multiple effects can run simultaneously on different palette ranges and
 `Palette.isDirty` getter reflects whether slots changed since the last GPU upload – effects set this flag; no polling
 needed.
 
-```ts
+```ts twoslash
+import { BT, Color32, Palette } from 'blit386';
+declare const start: number;
+declare const end: number;
+declare const speed: number;
+const targetPalette = Palette.vga();
+declare const durationMs: number;
+declare const indexA: number;
+declare const indexB: number;
+// ---cut---
 // Cycle a range of slots (water, fire, plasma)
 BT.paletteCycle(start, end, speed);
 // speed: steps/second, positive = forward, negative = backward

--- a/docs/api-rendering.md
+++ b/docs/api-rendering.md
@@ -20,7 +20,16 @@ optional `paletteOffset` added to stored texel indices. See [Palette addressing]
 
 ## Primitives
 
-```ts
+```ts twoslash
+import { BT, Rect2i, Vector2i } from 'blit386';
+declare const paletteIndex: number;
+const rect = new Rect2i(0, 0, 320, 240);
+const pos = new Vector2i(0, 0);
+declare const x: number;
+declare const y: number;
+const p0 = new Vector2i(0, 0);
+const p1 = new Vector2i(100, 100);
+// ---cut---
 BT.clear(paletteIndex); // fill entire display
 BT.clearRect(rect, paletteIndex); // fill rectangular region
 
@@ -38,7 +47,13 @@ All primitives write palette indices, not RGBA – the active palette resolves c
 
 ### Drawing
 
-```ts
+```ts twoslash
+import { BT, Rect2i, SpriteSheet, Vector2i } from 'blit386';
+declare const sheet: SpriteSheet;
+const srcRect = new Rect2i(0, 0, 32, 32);
+const destPos = new Vector2i(0, 0);
+declare const paletteOffset: number;
+// ---cut---
 BT.drawSprite(sheet, srcRect, destPos);
 BT.drawSprite(sheet, srcRect, destPos, paletteOffset);
 ```
@@ -65,7 +80,11 @@ the palette without re-uploading texels.
 - Clamping: the WebGPU sprite shader computes `combined = storedIndex + paletteOffset` and clamps with
   `index = min(combined, 255u)`, so any sum past `255` maps to palette slot `255`.
 
-```ts
+```ts twoslash
+import { BT, Rect2i, SpriteSheet, Vector2i } from 'blit386';
+declare const sheet: SpriteSheet;
+const srcRect = new Rect2i(0, 0, 32, 32);
+// ---cut---
 BT.drawSprite(sheet, srcRect, new Vector2i(10, 10)); // normal
 BT.drawSprite(sheet, srcRect, new Vector2i(10, 10), 16); // blue-team shift
 ```
@@ -76,7 +95,9 @@ Draws are auto-batched by texture. Group draws from the same sheet to minimize G
 
 The following flags are defined for future use. They are not yet accepted by `BT.drawSprite()`:
 
-```ts
+```ts twoslash
+import { BT } from 'blit386';
+// ---cut---
 BT.FLIP_H; // horizontal flip
 BT.FLIP_V; // vertical flip
 BT.ROT_90_CW; // rotate 90° clockwise
@@ -86,7 +107,10 @@ BT.ROT_270_CW; // rotate 270° clockwise
 
 ### Refreshing after a palette-layout swap
 
-```ts
+```ts twoslash
+import { BT, Palette } from 'blit386';
+const newLayoutPalette = Palette.vga();
+// ---cut---
 BT.paletteSet(newLayoutPalette);
 BT.spritesRefresh(); // re-maps all tracked sheets to the new slot positions
 ```
@@ -106,7 +130,12 @@ RGBA values are gone.
 
 Built-in 6×14 monospace font covering printable ASCII (characters 32-126).
 
-```ts
+```ts twoslash
+import { BT, Vector2i } from 'blit386';
+const pos = new Vector2i(0, 0);
+declare const paletteIndex: number;
+declare const text: string;
+// ---cut---
 BT.systemPrint(pos, paletteIndex, text); // draw text at pos
 BT.systemPrintMeasure(text); // → Vector2i (pixel width × height)
 ```
@@ -115,7 +144,12 @@ BT.systemPrintMeasure(text); // → Vector2i (pixel width × height)
 
 Variable-width fonts from `.btfont` files. The font's sprite sheet must be indexized before use.
 
-```ts
+```ts twoslash
+import { BitmapFont, BT, Vector2i } from 'blit386';
+const pos = new Vector2i(0, 0);
+declare const text: string;
+declare const paletteOffset: number;
+// ---cut---
 const font = await BitmapFont.load('fonts/MyFont.btfont');
 BT.printFont(font, pos, text);
 BT.printFont(font, pos, text, paletteOffset); // palette-swap variant
@@ -144,7 +178,10 @@ error. Gate effect registration on `BT.activeBackend === 'webgpu'`.
 
 </Callout>
 
-```ts
+```ts twoslash
+import { BT, BarrelDistortion, Scanlines, Bloom, PixelGlitch, type Effect } from 'blit386';
+declare const effect: Effect;
+// ---cut---
 // Add effect - routed to pixel or display chain by Effect.tier automatically
 BT.effectAdd(new BarrelDistortion());
 BT.effectAdd(new Scanlines());
@@ -182,7 +219,9 @@ See [Post-Process Effects Guide](guide-post-process-effects.md) for parameter re
 
 Capture the current rendered frame as a PNG.
 
-```ts
+```ts twoslash
+import { BT } from 'blit386';
+// ---cut---
 // Resolves after the next render pass completes
 const blob = await BT.captureFrame();
 const url = URL.createObjectURL(blob);

--- a/docs/guide-bitmap-fonts.md
+++ b/docs/guide-bitmap-fonts.md
@@ -18,7 +18,9 @@ per-character offsets, Unicode characters, and either embedded or external textu
 The engine includes a 6×14 monospace bitmap font covering printable ASCII (characters 32-126). It requires no file
 loading and is available immediately after initialization:
 
-```ts
+```ts twoslash
+import { BT, Vector2i } from 'blit386';
+// ---cut---
 // Draw text with the system font (palette index selects the color)
 BT.systemPrint(new Vector2i(10, 10), 1, 'Hello World!');
 
@@ -45,7 +47,7 @@ For proportional fonts, Unicode support, or custom aesthetics, load a `.btfont` 
 
 ## Quick start
 
-```ts
+```ts twoslash
 import { BitmapFont, BT, Palette, Vector2i } from 'blit386';
 
 // Load a font and register its colors in the palette
@@ -309,23 +311,26 @@ Point it at the PNG filename, or embed it as base64.
 
 ### BitmapFont
 
-```ts
-class BitmapFont {
-  // Load from .btfont file
-  static async load(url: string): Promise<BitmapFont>;
-
-  // Properties
+```ts twoslash
+import { type Rect2i, type TextSize, type SpriteSheet } from 'blit386';
+interface Glyph {
+  rect: Rect2i;
+  offsetX: number;
+  offsetY: number;
+  advance: number;
+}
+// ---cut---
+declare class BitmapFont {
+  static load(url: string): Promise<BitmapFont>;
   readonly name: string;
   readonly size: number;
   readonly lineHeight: number;
   readonly baseline: number;
   readonly glyphCount: number;
-
-  // Methods
   getGlyph(char: string): Glyph | null;
   measureText(text: string): number;
-  measureTextSize(text: string): { width: number; height: number };
-  measureTextSizeInto(text: string, out: { width: number; height: number }): void;
+  measureTextSize(text: string): TextSize;
+  measureTextSizeInto(text: string, out: TextSize): TextSize;
   hasGlyph(char: string): boolean;
   getSpriteSheet(): SpriteSheet;
 }
@@ -335,20 +340,25 @@ Exported type `TextSize` is `{ width: number; height: number }`.
 
 ### BT.printFont()
 
-```ts
-BT.printFont(
-  font: BitmapFont,       // The loaded font (sprite sheet must be indexized)
-  pos: Vector2i,          // Position (top-left corner)
-  text: string,           // Text to render
-  paletteOffset?: number // Per-draw index shift (default 0); not a Color32
-): void;
+```ts twoslash
+import { BT, type BitmapFont, type Vector2i } from 'blit386';
+declare const font: BitmapFont;
+declare const pos: Vector2i;
+declare const text: string;
+declare const paletteOffset: number;
+// ---cut---
+BT.printFont(font, pos, text);
+BT.printFont(font, pos, text, paletteOffset); // Per-draw index shift (default 0); not a Color32
 ```
 
 ## Examples
 
 ### Multi-line text
 
-```ts
+```ts twoslash
+import { BT, type BitmapFont, Vector2i } from 'blit386';
+declare const font: BitmapFont;
+// ---cut---
 const lines = ['Line 1', 'Line 2', 'Line 3'];
 let y = 10;
 
@@ -360,7 +370,10 @@ for (const line of lines) {
 
 ### Centered text
 
-```ts
+```ts twoslash
+import { BT, type BitmapFont, Vector2i } from 'blit386';
+declare const font: BitmapFont;
+// ---cut---
 const text = 'Centered';
 const textWidth = font.measureText(text);
 const screenWidth = BT.displaySize.x;
@@ -371,7 +384,11 @@ BT.printFont(font, new Vector2i(x, 10), text);
 
 ### Per-character palette offsets
 
-```ts
+```ts twoslash
+import { BT, type BitmapFont, Vector2i } from 'blit386';
+declare const font: BitmapFont;
+declare const text: string;
+// ---cut---
 let x = 10;
 for (let i = 0; i < text.length; i++) {
   const char = text[i];

--- a/docs/guide-input.md
+++ b/docs/guide-input.md
@@ -46,7 +46,9 @@ The engine tracks four pointer slots (indices `0`–`3`). Overflow contacts beyo
 
 ## Position and delta
 
-```ts
+```ts twoslash
+import { BT } from 'blit386';
+// ---cut---
 // Current position in display coordinates
 const pos = BT.pointerPos(); // slot 0 (mouse)
 const touch = BT.pointerPos(1); // slot 1 (first touch)
@@ -73,7 +75,9 @@ if (BT.isPointerActive(1)) {
 Use `BT.isDown()`, `BT.isPressed()`, and `BT.isReleased()` with the `BTN_POINTER_*` constants. The second parameter is
 the pointer slot (defaults to `0`):
 
-```ts
+```ts twoslash
+import { BT } from 'blit386';
+// ---cut---
 // Hold detection
 BT.isDown(BT.BTN_POINTER_A); // left mouse button held
 BT.isDown(BT.BTN_POINTER_B); // right mouse button held
@@ -120,7 +124,9 @@ not `event.key` layout text.
 
 Use these for direct key checks:
 
-```ts
+```ts twoslash
+import { BT } from 'blit386';
+// ---cut---
 // Held state
 if (BT.isKeyDown('KeyW')) {
   // W key held
@@ -148,7 +154,9 @@ For player 0 and player 1, face-button reads merge keyboard maps and gamepad sta
 `BT.isPressed` supports optional tick-based repeat via `repeatRate` (`0` or omitted = edge only), matching
 `BT.isKeyPressed` semantics.
 
-```ts
+```ts twoslash
+import { BT } from 'blit386';
+// ---cut---
 // Player 0 (default: WASD-style + Space / KeyB for A, etc.)
 BT.isDown(BT.BTN_UP, 0);
 BT.isPressed(BT.BTN_A, 0, 6); // edge + repeat every 6 ticks while held
@@ -171,7 +179,9 @@ Built-in defaults are exposed as read-only tables (same values the engine starts
 Override bindings at runtime. The first argument is the zero-based player index (`0` or `1` only; other values are
 ignored). The second is the face button constant. Remaining arguments are `KeyboardEvent.code` strings.
 
-```ts
+```ts twoslash
+import { BT } from 'blit386';
+// ---cut---
 BT.inputMap(0, BT.BTN_A, 'Space');
 BT.inputMap(0, BT.BTN_UP, 'ArrowUp', 'KeyW'); // either key triggers UP for player 0
 BT.inputMap(1, BT.BTN_START, 'Enter', 'NumpadEnter');
@@ -182,13 +192,17 @@ BT.inputMapReset();
 
 Pass no key codes to clear keyboard bindings for that player and button until you map again:
 
-```ts
+```ts twoslash
+import { BT } from 'blit386';
+// ---cut---
 BT.inputMap(0, BT.BTN_X); // player 0 X has no keyboard keys until remapped
 ```
 
 ### Gamepad API
 
-```ts
+```ts twoslash
+import { BT } from 'blit386';
+// ---cut---
 BT.isGamepadConnected(0); // true when player 0 has a connected gamepad
 BT.gamepadCount; // number of connected gamepads (0..4)
 
@@ -227,7 +241,9 @@ details.
 
 ## Scroll delta
 
-```ts
+```ts twoslash
+import { BT } from 'blit386';
+// ---cut---
 // Accumulated vertical scroll for the current frame, in pixels
 const scroll = BT.pointerScrollDelta;
 
@@ -245,7 +261,9 @@ scroll while the canvas has focus.
 
 ## Cursor control
 
-```ts
+```ts twoslash
+import { BT } from 'blit386';
+// ---cut---
 // In init(): hide the OS cursor and draw your own crosshair / sprite
 BT.hideCursor();
 

--- a/docs/guide-overlay.md
+++ b/docs/guide-overlay.md
@@ -88,12 +88,14 @@ background, label, header, dim, FPS) and register `hud_*` name aliases. See
 [API: Palette – applyHUD](api-palette.md#built-in-presets) and
 [Palette Presets – HUD](guide-palette-presets.md#hud-preset).
 
-```ts
+```ts twoslash
+import { BT, Palette, Vector2i } from 'blit386';
+// ---cut---
 const palette = Palette.vga();
 palette.applyHUD(1); // slots 1-6 + hud_* aliases
 BT.paletteSet(palette);
 
-BT.systemPrint(new Vector2i(8, 8), palette.getIndex('hud_label'), 'Custom row');
+BT.systemPrint(new Vector2i(8, 8), palette.getNamed('hud_label'), 'Custom row');
 ```
 
 ## Present FPS vs. target FPS

--- a/docs/guide-palette-presets.md
+++ b/docs/guide-palette-presets.md
@@ -40,7 +40,7 @@ That means:
 
 ### VGA base 16 (`VGA_HEX[0..15]`)
 
-```ts
+```ts twoslash
 [
   '000000',
   '800000',
@@ -63,13 +63,13 @@ That means:
 
 ### VGA cube steps
 
-```ts
+```ts twoslash
 [0, 95, 135, 175, 215, 255];
 ```
 
 ### VGA grayscale ramp (`8..238`, step 10)
 
-```ts
+```ts twoslash
 [8, 18, 28, 38, 48, 58, 68, 78, 88, 98, 108, 118, 128, 138, 148, 158, 168, 178, 188, 198, 208, 218, 228, 238];
 ```
 
@@ -77,7 +77,7 @@ That means:
 
 `Palette.cga()`:
 
-```ts
+```ts twoslash
 [
   '000000',
   '0000aa',
@@ -102,7 +102,7 @@ That means:
 
 `Palette.c64()`:
 
-```ts
+```ts twoslash
 [
   '000000',
   'ffffff',
@@ -127,7 +127,7 @@ That means:
 
 `Palette.gameboy()`:
 
-```ts
+```ts twoslash
 ['0f380f', '306230', '8bac0f', '9bbc0f'];
 ```
 
@@ -135,7 +135,7 @@ That means:
 
 `Palette.pico8()`:
 
-```ts
+```ts twoslash
 [
   '000000',
   '1d2b53',
@@ -163,7 +163,7 @@ That means:
 `NES_HEX` currently defines 56 source entries. After transparent slot reservation and preset copy, remaining palette
 slots keep their constructor default (black).
 
-```ts
+```ts twoslash
 [
   '7c7c7c',
   '0000fc',
@@ -228,7 +228,7 @@ slots keep their constructor default (black).
 
 `palette.applyHUD(startSlot = 1)` writes six consecutive slots:
 
-```ts
+```ts twoslash
 [
   { hex: 'ffffff', name: 'hud_white' },
   { hex: '1e1428', name: 'hud_bg' },

--- a/docs/guide-palette.md
+++ b/docs/guide-palette.md
@@ -25,7 +25,7 @@ For terminology (slot vs. `paletteIndex` vs. `paletteOffset`) and when to call `
 
 ## Create and activate a palette
 
-```ts
+```ts twoslash
 import { BT, Color32, Palette } from 'blit386';
 
 const palette = Palette.c64(); // or new Palette(256)
@@ -50,7 +50,12 @@ Key rules:
 Primitive and clear APIs take an absolute `paletteIndex` (the exact slot written to the framebuffer), not direct RGBA
 values. See [Palette addressing](api-palette.md#palette-addressing).
 
-```ts
+```ts twoslash
+import { BT, Rect2i, Vector2i } from 'blit386';
+const rect = new Rect2i(0, 0, 320, 240);
+const start = new Vector2i(0, 0);
+const end = new Vector2i(100, 100);
+// ---cut---
 BT.clear(1); // absolute paletteIndex 1
 BT.drawRectFill(rect, 6); // absolute paletteIndex 6
 BT.drawLine(start, end, 12); // absolute paletteIndex 12
@@ -70,9 +75,11 @@ When slot `6` changes in the active palette, every pixel drawn with absolute ind
 
 Use this when loading sprites for normal game/demo work.
 
-```ts
-import { SpriteSheet } from 'blit386';
-
+```ts twoslash
+import { BT, Palette, SpriteSheet, Vector2i } from 'blit386';
+const palette = new Palette(256);
+const pos = new Vector2i(0, 0);
+// ---cut---
 const indexed = await SpriteSheet.loadIndexed('sprites/hero.png', palette, 32, { sort: 'luminance' });
 BT.paletteSet(palette);
 BT.drawSprite(indexed.sheet, indexed.srcRect, pos);
@@ -91,7 +98,10 @@ What it does:
 
 Use this when you need custom slot planning across multiple images.
 
-```ts
+```ts twoslash
+import { BT, Palette, SpriteSheet } from 'blit386';
+const palette = new Palette(256);
+// ---cut---
 await SpriteSheet.loadColorsIntoPalette('sprites/hero.png', palette, 32);
 const sheet = await SpriteSheet.load('sprites/hero.png');
 sheet.indexize(palette);
@@ -111,7 +121,13 @@ BT.paletteSet(palette);
 `BT.drawSprite(..., paletteOffset)` adds a shift to each stored sprite index before lookup (not an absolute slot). See
 [Palette addressing](api-palette.md#palette-addressing).
 
-```ts
+```ts twoslash
+import { BT, Rect2i, SpriteSheet, Vector2i } from 'blit386';
+declare const heroSheet: SpriteSheet;
+const heroSrc = new Rect2i(0, 0, 32, 32);
+const leftTeamPos = new Vector2i(0, 0);
+const rightTeamPos = new Vector2i(100, 0);
+// ---cut---
 BT.drawSprite(heroSheet, heroSrc, leftTeamPos, 0); // base range
 BT.drawSprite(heroSheet, heroSrc, rightTeamPos, 16); // same art, shifted color range
 ```
@@ -133,7 +149,11 @@ No duplicate textures required.
 
 Palette effects mutate slots over time and are applied in the engine frame pipeline.
 
-```ts
+```ts twoslash
+import { BT, Color32, Palette } from 'blit386';
+const nightPalette = Palette.vga();
+const dangerPalette = Palette.vga();
+// ---cut---
 // Cycling: water/lava/plasma
 BT.paletteCycle(240, 248, 4);
 
@@ -180,7 +200,10 @@ Examples:
 
 If the same colors move to different slot indices, call:
 
-```ts
+```ts twoslash
+import { BT, Palette } from 'blit386';
+const newLayoutPalette = Palette.vga();
+// ---cut---
 BT.paletteSet(newLayoutPalette);
 BT.spritesRefresh();
 ```

--- a/docs/guide-post-process-effects.md
+++ b/docs/guide-post-process-effects.md
@@ -29,15 +29,17 @@ For how logical, drawing buffer, CSS cap, and effect tier map to `HardwareSettin
 
 ## Quick start
 
-```ts
+```ts twoslash
 import { BT, Vector2i, BarrelDistortion, Scanlines, RGBMask, Bloom, PixelGlitch } from 'blit386';
-
+// ---cut---
 class Demo {
+  glitch: PixelGlitch | null = null;
+
   configure() {
     return {
       displaySize: new Vector2i(320, 240), // logical pixel-art resolution
       drawingBufferSize: new Vector2i(1280, 960), // output drawing-buffer size
-      outputUpscaleFilter: 'nearest', // 'nearest' | 'linear'
+      outputUpscaleFilter: 'nearest' as const, // 'nearest' | 'linear'
       targetFPS: 60,
     };
   }
@@ -113,7 +115,7 @@ Removes every effect in both tiers and destroys all offscreen GPU resources. Thr
 
 ### `Effect` interface
 
-```ts
+```ts twoslash
 import type { Effect, EffectTier, Vector2i } from 'blit386';
 
 export class MyEffect implements Effect {
@@ -146,7 +148,9 @@ vs. RGBA paths – see [Writing a custom effect](#writing-a-custom-effect) below
 
 ### `HardwareSettings`
 
-```ts
+```ts twoslash
+import type { Vector2i } from 'blit386';
+// ---cut---
 interface HardwareSettings {
   displaySize: Vector2i;
   drawingBufferSize?: Vector2i; // drives drawing buffer + CSS, enables display tier
@@ -317,7 +321,7 @@ not yet implemented.
 Extend `FullscreenEffect` when sampling RGBA at output resolution. Subclasses provide one WGSL fragment shader (`src` +
 `sampler`), declare `tier = 'display'`, set `uniformBytes`, and implement `writeUniforms`.
 
-```ts
+```ts twoslash
 import { FullscreenEffect, type Vector2i } from 'blit386';
 
 export class GammaEffect extends FullscreenEffect {

--- a/docs/performance-best-practices.md
+++ b/docs/performance-best-practices.md
@@ -76,7 +76,12 @@ patterns for managing allocations:
 
 When to use: UI code, one-time operations, and anywhere readability matters more than performance.
 
-```ts
+```ts twoslash
+import { BT, type BitmapFont, Rect2i, Vector2i } from 'blit386';
+declare const x: number;
+declare const y: number;
+declare const font: BitmapFont;
+// ---cut---
 // Clear and readable – palette indices, not Color32
 const WHITE = 1;
 BT.drawPixel(new Vector2i(x, y), WHITE);
@@ -101,7 +106,12 @@ Cons:
 
 When to use: Tight loops that run 50+ times per frame.
 
-```ts
+```ts twoslash
+import { BT, type IBTDemo, Rect2i, Vector2i } from 'blit386';
+declare const x: number;
+declare const y: number;
+declare const color: number;
+// ---cut---
 class MyDemo implements IBTDemo {
   // Pre-allocate reusable objects
   private readonly tempVec = new Vector2i(0, 0);
@@ -157,7 +167,23 @@ BLIT386 automatically batches draw calls for optimal GPU performance:
 
 Optimization tips:
 
-```ts
+```ts twoslash
+import { BT, Rect2i, SpriteSheet, Vector2i } from 'blit386';
+declare const enemySheet: SpriteSheet;
+declare const playerSheet: SpriteSheet;
+interface Enemy {
+  sprite: Rect2i;
+  pos: Vector2i;
+  paletteOffset: number;
+}
+declare const enemies: Enemy[];
+const sprite1 = new Rect2i(0, 0, 16, 16);
+const sprite2 = new Rect2i(0, 0, 16, 16);
+const sprite3 = new Rect2i(0, 0, 16, 16);
+const pos1 = new Vector2i(0, 0);
+const pos2 = new Vector2i(16, 0);
+const pos3 = new Vector2i(32, 0);
+// ---cut---
 // Good: All sprites from same sheet
 for (const enemy of enemies) {
   BT.drawSprite(enemySheet, enemy.sprite, enemy.pos, enemy.paletteOffset);
@@ -188,7 +214,12 @@ Less optimal:
 Changing `paletteOffset` per draw is cheap – it shifts stored texel indices before palette lookup, not RGBA tint
 multiplication:
 
-```ts
+```ts twoslash
+import { BT, Rect2i, SpriteSheet, Vector2i } from 'blit386';
+declare const sheet: SpriteSheet;
+const sprite = new Rect2i(0, 0, 16, 16);
+const pos = new Vector2i(0, 0);
+// ---cut---
 // Same performance – offset is a uniform add, not per-pixel color math
 BT.drawSprite(sheet, sprite, pos);
 BT.drawSprite(sheet, sprite, pos, 16); // team-color range
@@ -215,7 +246,12 @@ This produces the classic "staircase" look expected in retro demos but requires 
 
 Optimization tips for diagonal lines:
 
-```ts
+```ts twoslash
+import { BT, Vector2i } from 'blit386';
+declare const color: number;
+const p1 = new Vector2i(0, 0);
+const p2 = new Vector2i(100, 100);
+// ---cut---
 // GOOD: Grid lines (axis-aligned) are very cheap
 for (let x = 0; x < 800; x += 40) {
   BT.drawLine(new Vector2i(x, 0), new Vector2i(x, 600), color); // 6 vertices each
@@ -250,7 +286,13 @@ still runs at the browser's refresh rate. This provides:
 
 ### Using ticks for timing
 
-```ts
+```ts twoslash
+import { BT } from 'blit386';
+declare function performAction(): void;
+declare let lastActionTick: number;
+declare let elapsedTime: number;
+declare const deltaTime: number;
+// ---cut---
 // Frame-based timer (recommended)
 if (BT.ticks - lastActionTick >= 60) {
   performAction();
@@ -285,18 +327,25 @@ If your `update()` or `render()` takes too long:
 
 <Accordion title="1. Premature optimization">
 
-```ts
+```ts twoslash
+import { BT, type BitmapFont, Vector2i } from 'blit386';
+declare const font: BitmapFont;
+// ---cut---
 // BAD: Over-engineering simple UI code
-private readonly uiVec = new Vector2i(0, 0);
+class BadDemo {
+  private readonly uiVec = new Vector2i(0, 0);
 
-drawUI(): void {
+  drawUI(): void {
     this.uiVec.set(10, 10);
-    BT.printFont(font, this.uiVec, "Score: 0"); // Only called once per frame!
+    BT.printFont(font, this.uiVec, 'Score: 0'); // Only called once per frame!
+  }
 }
 
 // GOOD: Keep it simple
-drawUI(): void {
-    BT.printFont(font, new Vector2i(10, 10), "Score: 0");
+class GoodDemo {
+  drawUI(): void {
+    BT.printFont(font, new Vector2i(10, 10), 'Score: 0');
+  }
 }
 ```
 
@@ -315,7 +364,9 @@ Don't guess what's slow – measure it. Use:
 
 <Accordion title="3. Allocating in hot paths">
 
-```ts
+```ts twoslash
+import { BT, Vector2i } from 'blit386';
+// ---cut---
 // BAD: Allocating Vector2i in a tight loop (see pre-allocation section)
 for (let i = 0; i < 1000; i++) {
   BT.drawPixel(new Vector2i(i, 0), 1); // 60,000 Vector2i allocations/sec!
@@ -333,24 +384,40 @@ for (let i = 0; i < 1000; i++) {
 
 <Accordion title="4. Excessive string concatenation">
 
-```ts
+```ts twoslash
+import { BT, type BitmapFont, Vector2i } from 'blit386';
+declare const font: BitmapFont;
+const pos = new Vector2i(10, 10);
+// ---cut---
 // BAD: Creates new string every frame
-render(): void {
-    BT.printFont(font, pos, "Score: " + this.score); // String allocation!
+class BadStringDemo {
+  score = 0;
+
+  render(): void {
+    BT.printFont(font, pos, 'Score: ' + this.score); // String allocation!
+  }
 }
 
 // BETTER: Template strings (still allocates, but cleaner)
-render(): void {
+class BetterStringDemo {
+  score = 0;
+
+  render(): void {
     BT.printFont(font, pos, `Score: ${this.score}`);
+  }
 }
 
 // BEST: Only update when score changes
-updateScore(newScore: number): void {
-    this.scoreText = `Score: ${newScore}`;
-}
+class BestStringDemo {
+  scoreText = 'Score: 0';
 
-render(): void {
+  updateScore(newScore: number): void {
+    this.scoreText = `Score: ${newScore}`;
+  }
+
+  render(): void {
     BT.printFont(font, pos, this.scoreText); // Reuse string
+  }
 }
 ```
 

--- a/docs/performance-testing.md
+++ b/docs/performance-testing.md
@@ -103,7 +103,7 @@ src/render/SpritePipeline.bench.ts
 
 ### Basic structure
 
-```ts
+```ts twoslash
 import { bench, describe } from 'vitest';
 
 import { MyType } from './MyType';

--- a/docs/reference-testing.md
+++ b/docs/reference-testing.md
@@ -131,7 +131,7 @@ tests/visual/
 
 ## Writing a new test
 
-```ts
+```ts twoslash
 import { describe, expect, it } from 'vitest';
 
 import { MyClass } from './MyClass';
@@ -173,7 +173,7 @@ Use these patterns when adding or reviewing palette-related features:
 
 For tests that need GPU objects, import from the mock factory:
 
-```ts
+```ts twoslash
 import { createMockGPUDevice, createMockGPUTexture } from '../__test__/webgpu-mock';
 
 const device = createMockGPUDevice();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR enforces the use of Twoslash-formatted TypeScript code blocks across published documentation, standardizing code examples and ensuring they compile independently.

## Rule Documentation

New rule files were added to standardize Twoslash usage:

- `.claude/rules/twoslash-docs.md` (47 lines): Comprehensive guide requiring `ts twoslash` formatting for all TypeScript blocks in published docs, with explicit rules for self-contained vs. fragment blocks (using `// ---cut---` separators), preamble conventions (single blit386 import, proper const/declare usage), and verification via `pnpm run sync:docs && pnpm run build`.

- `.cursor/rules/twoslash-docs.mdc` (49 lines): Cursor rule configuration enforcing Twoslash usage for specific documentation globs (`docs/api-*.md`, `docs/guide-*.md`, `docs/performance-*.md`, `docs/reference-*.md`), including verification workflow and prohibition of error suppression.

Existing rule files were updated to reference these new standards:

- `.claude/rules/docs-sync-required.md`: Added requirement that published docs use `ts twoslash` formatting
- `.cursor/rules/docs-sync-required.mdc`: Added corresponding enforcement constraint

Main documentation file `CLAUDE.md` now includes a "Twoslash in published docs" section (38 lines) standardizing TypeScript example authorship with explicit formatting requirements and build integration.

## Documentation Updates

All published documentation files were updated to use `ts twoslash` formatting with explicit imports and `// ---cut---` markers:

**API Documentation** (`docs/api-*.md`):
- `docs/api-assets.md`: Updated sprite setup, palette registration, and bitmap font examples (35 lines changed)
- `docs/api-camera.md`: Added Vector2i declarations and viewport override examples (14 lines changed)
- `docs/api-core-types.md`: Enhanced Vector2i, Rect2i, and Color32 examples with imports and declarations (62 lines changed)
- `docs/api-core.md`: Updated Bootstrap, initialization, runtime checks, and configuration examples (20 lines changed)
- `docs/api-easing.md`: Converted applyEasing snippet to twoslash format (1 line changed)
- `docs/api-game-loop.md`: Added BT and Timer import scaffolding for timing sections (7 lines changed)
- `docs/api-overlay.md`: Added IBTDemo import and HardwareSettings type annotations (14 lines changed)
- `docs/api-palette.md`: Enriched palette examples with typed imports and scaffolding (48 lines changed)
- `docs/api-rendering.md`: Added twoslash blocks for primitives, sprites, effects, and frame capture (48 lines changed)

**Guide Documentation** (`docs/guide-*.md`):
- `docs/guide-bitmap-fonts.md`: Updated code blocks to twoslash format and refined API reference signatures. Type declarations changed: `static async load` to `static load` returning `Promise<BitmapFont>`, and `measureTextSize` methods now return `TextSize` type (39 lines changed)
- `docs/guide-input.md`: Added twoslash scaffolding for position, buttons, key queries, gamepad, scroll, and cursor control examples (27 lines changed)
- `docs/guide-overlay.md`: Updated palette slot example to use `getNamed('hud_label')` with twoslash formatting (4 lines changed)
- `docs/guide-palette-presets.md`: Converted palette array examples to twoslash format (9 lines changed)
- `docs/guide-palette.md`: Added twoslash setup snippets for palette creation, indexed sprites, and effects (32 lines changed)
- `docs/guide-post-process-effects.md`: Updated Effect interface and HardwareSettings examples to twoslash with Vector2i imports (10 lines changed)

**Performance and Testing** (`docs/performance-*.md`, `docs/reference-*.md`):
- `docs/performance-best-practices.md`: Converted object allocation, batching, palette-offset, timing, and common pitfalls examples to twoslash format with explicit imports (87 lines changed)
- `docs/performance-testing.md`: Updated basic structure example fence (1 line changed)
- `docs/reference-testing.md`: Updated test writing and WebGPU mock examples to twoslash format (2 lines changed)

All updates maintain the existing prose and API descriptions while standardizing code example presentation to ensure they compile independently and follow the new Twoslash requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->