### PR TITLE
ci: parallelize independent quality check steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,21 +81,29 @@ jobs:
 
       - name: Check formatting
         run: pnpm run format:check
+        background: true
 
       - name: Lint code
         run: pnpm run lint
+        background: true
 
       - name: Type check
         run: pnpm run typecheck
+        background: true
 
       - name: Spell check
         run: pnpm run spellcheck
+        background: true
 
       - name: Check documentation links
         run: pnpm run docs:links
+        background: true
 
       - name: Check doc site banners
         run: pnpm run sync:doc-banners:check
+        background: true
+
+      - wait-all:
 
   build-library:
     name: Build Library

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -33,21 +33,29 @@ jobs:
 
       - name: Check formatting
         run: pnpm run format:check
+        background: true
 
       - name: Lint
         run: pnpm run lint
+        background: true
 
       - name: Type check
         run: pnpm run typecheck
+        background: true
 
       - name: Spell check
         run: pnpm run spellcheck
+        background: true
 
       - name: Check unused exports and dependencies
         run: pnpm run knip
+        background: true
 
       - name: Check documentation links
         run: pnpm run docs:links
+        background: true
+
+      - wait-all:
 
   commitlint:
     name: Lint Commits


### PR DESCRIPTION
Use the new GitHub Actions background: true / wait-all: keywords to run format, lint, typecheck, spellcheck, docs:links, and sync:doc-banners:check concurrently after pnpm install in both ci.yml (quality job) and pr-checks.yml (quality job). Setup steps remain sequential.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated CI and PR checks to run independent quality steps in parallel after installation completes. Both workflow files now use `background: true` for the relevant checks and `wait-all` to join them afterward, reducing overall pipeline time while keeping setup steps sequential.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->