### PR TITLE
chore: sync markdown-lint

### DIFF
--- a/.github/markdown-link-check.json
+++ b/.github/markdown-link-check.json
@@ -13,19 +13,25 @@
       "pattern": "^#"
     },
     {
-      "pattern": "^https?://www\\.w3\\.org(/|$)"
+      "pattern": "^https?://www\\.w3\\.org(?:[/?#]|$)"
     },
     {
-      "pattern": "^https?://fsd\\.it(/|$)"
+      "pattern": "^https?://fsd\\.it(?:[/?#]|$)"
     },
     {
-      "pattern": "^https?://www\\.angelcode\\.com(/|$)"
+      "pattern": "^https?://www\\.angelcode\\.com(?:[/?#]|$)"
     },
     {
-      "pattern": "^https?://renderhjs\\.net(/|$)"
+      "pattern": "^https?://renderhjs\\.net(?:[/?#]|$)"
+    },
+    {
+      "pattern": "^https?://x\\.com(/|$)"
     },
     {
       "pattern": "^https?://(www\\.)?badcastle\\.com(/|$)"
+    },
+    {
+      "pattern": "^https?://mastodon\\.gamedev\\.place(/|$)"
     },
     {
       "pattern": "^https?://github\\.com/[^/]+/[^/]+/actions(/|$)"
@@ -46,7 +52,10 @@
       "pattern": "^https?://github\\.com/[^/]+/[^/]+/compare/"
     },
     {
-      "pattern": "^https?://github\\.com/blit386/(blit386|create-blit386)(/|$)"
+      "pattern": "^https?://github\\.com/blit386/[^/]+(/|$)"
+    },
+    {
+      "pattern": "^https?://demos\\.blit386\\.dev(/|$)"
     }
   ],
   "replacementPatterns": [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated `.github/markdown-link-check.json` to broaden markdown link ignore matching:
- Relaxed several domain regexes to accept additional URL terminators using `(?:[/?#]|$)`.
- Expanded the `github.com/blit386/...` ignore rule to match any single `blit386` subpath.
- Added a new ignore pattern for `https://demos.blit386.dev(/|$)`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->