### PR TITLE
feat: add audio subsystem with AudioManager and hardware settings

### DIFF
--- a/.claude/rules/bt-api-getters.md
+++ b/.claude/rules/bt-api-getters.md
@@ -10,14 +10,14 @@ Quick rules when changing `src/BLIT386.ts` or demos:
 
 ## Getter lists
 
-| Category                                         | Members                                                                        |
-| ------------------------------------------------ | ------------------------------------------------------------------------------ |
-| Configure-time (mirror `HardwareSettings` names) | `displaySize`, `drawingBufferSize`, `targetFPS`                                |
-| Derived                                          | `outputSize` (`drawingBufferSize ?? displaySize`; no `HardwareSettings` field) |
-| Configure-time (backend)                         | `requestedBackend` (mirrors `HardwareSettings.backend`; `null` before init)    |
-| Loop timing                                      | `deltaSeconds`, `timeSeconds`, `ticks`                                         |
-| Runtime state                                    | `activeBackend`, `camera`, `palette` (`activeBackend` `null` before init)      |
-| Per-frame input                                  | `pointerScrollDelta`, `inputString`, `gamepadCount`                            |
+| Category                                         | Members                                                                                      |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| Configure-time (mirror `HardwareSettings` names) | `displaySize`, `drawingBufferSize`, `targetFPS`                                              |
+| Derived                                          | `outputSize` (`drawingBufferSize ?? displaySize`; no `HardwareSettings` field)               |
+| Configure-time (backend)                         | `requestedBackend` (mirrors `HardwareSettings.backend`; `null` before init)                  |
+| Loop timing                                      | `deltaSeconds`, `timeSeconds`, `ticks`                                                       |
+| Runtime state                                    | `activeBackend`, `camera`, `palette`, `isAudioUnlocked` (`activeBackend` `null` before init) |
+| Per-frame input                                  | `pointerScrollDelta`, `inputString`, `gamepadCount`                                          |
 
 `Vector2i` getters return a clone per read. `activeBackend` is what actually started after fallback, not
 `configure().backend`. `palette` is a live reference – mutating slots affects rendering on the next frame.

--- a/.cursor/rules/bt-api-getters.mdc
+++ b/.cursor/rules/bt-api-getters.mdc
@@ -16,7 +16,8 @@ Zero-argument **read-only** values on `BT`:
 - **Configure-time (backend):** `requestedBackend` mirrors resolved `HardwareSettings.backend` (includes
   `?backend=software`); **`null` before `BT.init()`**
 - **Loop:** `deltaSeconds`, `timeSeconds`, `ticks`
-- **Runtime:** `activeBackend`, `camera`, `palette` — `activeBackend` is **`null` before init or on failure**
+- **Runtime:** `activeBackend`, `camera`, `palette`, `isAudioUnlocked` — `activeBackend` is **`null` before init or on
+  failure**; `isAudioUnlocked` is `false` until the first user gesture resumes the audio context
 - **Per-frame input:** `pointerScrollDelta`, `inputString`, `gamepadCount`
 
 Good: `BT.displaySize.y`, `BT.targetFPS`, `BT.ticks % 180`
@@ -31,6 +32,8 @@ Bad: `BT.displaySize()`, `BT.fps()`, `BT.getActiveBackend()` (removed; use prope
   `paletteClearEffects`
 - **Post-process:** `effectAdd`, `effectRemove`, `effectClear`; preset namespace **`BT.preset`** (`crtPipBoy`, `amber`,
   `green`)
+- **Audio:** `audioVolumeSet(bus, value, options?)`, `audioVolumeGet(bus)`, `audioMuteSet(bus, muted)`,
+  `isAudioMuted(bus)`
 - **Drawing / clearing:** `clear`, `clearRect`, `drawPixel`, `drawLine`, `drawRect`, `drawRectFill`, `drawSprite`,
   `systemPrint`, `printFont` (4th arg is optional **`paletteOffset`**, not `Color32`)
 - Any **parameter**: `pointerPos(0)`, `isDown(BT.BTN_A)`, `cameraClamp(...)`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ Before writing new code, reviewing existing code, or preflighting, check here fi
 | What error message style should I use?                         | `docs/voice.md`, then `src/utils/errorMessages.ts`                                                                                                                                                                           |
 | Is this API exported publicly?                                 | `src/BLIT386.ts` export block (lines 1563–1610)                                                                                                                                                                              |
 | What test mock do I need for GPU code?                         | `src/__test__/webgpu-mock.ts`                                                                                                                                                                                                |
+| What test mock do I need for Web Audio code?                   | `src/__test__/webaudio-mock.ts`                                                                                                                                                                                              |
 | Declaration tooling / TS version alignment?                    | `docs/tooling.md`, `docs/developer-experience-guide.md`, `scripts/check-declaration-tooling.mjs`                                                                                                                             |
 | Should this private name repeat the class/file?                | Internal scoped naming below; `docs/developer-experience-guide.md` (Naming conventions)                                                                                                                                      |
 | Where do I put a new field/method in a `.ts` file?             | TypeScript file structure below; `.cursor/rules/ts-file-structure.mdc`; `docs/developer-experience-guide.md` (File structure and member order)                                                                               |
@@ -267,6 +268,8 @@ src/
     KeyboardInput.ts       # KeyboardEvent.code state, edges, tick repeat, beforeinput text
     GamepadInput.ts        # Polling-based gamepad input tracker (4 players, axes, buttons, dead zone)
     defaultKeyboardMap.ts  # Default face-button key tables; clone helpers for BT.inputMapReset
+  audio/
+    AudioManager.ts        # Web Audio context, bus graph (sfx/music -> main -> destination), unlock state, mute/volume
   utils/
     Bootstrap.ts           # Demo bootstrap utilities
     BootstrapHelpers.ts    # Canvas lookup and error display utilities
@@ -282,6 +285,7 @@ src/
     Timer.ts               # Elapsed-time helper (exported; Timer.fireIfElapsed)
   __test__/
     webgpu-mock.ts         # WebGPU mock factories for tests
+    webaudio-mock.ts       # Web Audio mock factories for tests (AudioContext, GainNode, AudioParam)
     setup.ts               # Vitest global setup (GPU constants)
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -358,7 +358,7 @@ Full table in `docs/api-core.md` and `.claude/rules/bt-api-getters.md`. The cate
   `null` before init).
 - Loop timing: `deltaSeconds`, `timeSeconds`, `ticks`.
 - Runtime state: `activeBackend` (what actually started after fallback; `null` before init or on failure), `camera`,
-  `palette` (live reference).
+  `palette` (live reference), `isAudioUnlocked` (`false` until the first user gesture resumes the audio context).
 - Per-frame input: `pointerScrollDelta`, `inputString`, `gamepadCount` (read once per frame).
 
 Examples: `BT.displaySize.y`, `BT.targetFPS`, `BT.ticks % 60`, `if (BT.activeBackend === 'software')`.
@@ -371,6 +371,7 @@ Examples: `BT.displaySize.y`, `BT.targetFPS`, `BT.ticks % 60`, `if (BT.activeBac
   `paletteClearEffects`.
 - Post-process: `effectAdd`, `effectRemove`, `effectClear`; preset namespace `BT.preset` (`crtPipBoy`, `amber`,
   `green`).
+- Audio: `audioVolumeSet(bus, value, options?)`, `audioVolumeGet(bus)`, `audioMuteSet(bus, muted)`, `isAudioMuted(bus)`.
 - Drawing / clearing: `clear`, `clearRect`, `drawPixel`, `drawLine`, `drawRect`, `drawRectFill`, `drawSprite`,
   `systemPrint`, `printFont`.
 - Parameterized queries: `pointerPos(index?)`, `pointerDelta`, `isPointerActive`, `isDown`, `isPressed`, `isReleased`,

--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ bootstrap(Game);
 - CRT when you want it: A two-tier post-process chain with bundled CRT presets for that curved-glass glow.
 - Everything a tiny engine needs: Pointer, keyboard, and gamepad input, a fixed-timestep loop, bitmap fonts, a camera,
   and one-call PNG frame capture.
+- Audio buses that behave: A three-bus mixer (sfx, music, main) with volume, mute, and fades – tracking the browser's
+  autoplay-gesture unlock honestly instead of pretending it doesn't exist.
 
 ## Get started
 

--- a/cspell.json
+++ b/cspell.json
@@ -91,6 +91,8 @@
     "Uints",
     "unflushed",
     "unmodulated",
+    "unmutes",
+    "unmuting",
     "unorm",
     "unstub",
     "upscale",

--- a/docs/_sitemap.json
+++ b/docs/_sitemap.json
@@ -58,6 +58,11 @@
       "description": "Sprite sheets, bitmap fonts, and asset loading."
     },
     {
+      "src": "api-audio.md",
+      "path": "api/audio",
+      "description": "Audio bus volume, mute, and the browser autoplay-unlock state."
+    },
+    {
       "src": "guide-input.md",
       "path": "guides/input",
       "description": "Pointer, keyboard, gamepad, and text-accumulation input in BLIT386."
@@ -86,6 +91,11 @@
       "src": "guide-bitmap-fonts.md",
       "path": "guides/bitmap-fonts",
       "description": "The system font and custom .btfont bitmap fonts: format, loading, and BMFont conversion."
+    },
+    {
+      "src": "guide-audio.md",
+      "path": "guides/audio",
+      "description": "The audio subsystem layout, locked vs. unlocked gesture state, and web audio constraints."
     },
     {
       "src": "performance-best-practices.md",

--- a/docs/api-audio.md
+++ b/docs/api-audio.md
@@ -1,0 +1,105 @@
+# Audio
+
+<!-- blit386.dev-banner:start -->
+
+<!-- prettier-ignore -->
+> [!TIP]
+> You're reading the raw source on GitHub. The same page lives at https://blit386.dev/docs/api/audio, typeset like an
+> actual docs site and easier on the eyes. Probably the nicer place to read it, but same
+> words either way.
+
+<!-- blit386.dev-banner:end -->
+
+Bus volume, mute, and the browser autoplay-unlock state. For the higher-level subsystem walkthrough (bus graph layout,
+locked vs. unlocked, and web autoplay constraints), see the [Audio Guide](guide-audio.md).
+
+The audio graph has three buses: `'sfx'` and `'music'` feed into `'main'`, which feeds the browser's audio destination.
+All three are independently controllable.
+
+```text
+sfx    ─┐
+music  ─┼─► main ─► destination
+```
+
+`AudioBus` is the type of a bus name:
+
+```ts twoslash
+import { type AudioBus } from 'blit386';
+// ---cut---
+declare const bus: AudioBus; // 'main' | 'music' | 'sfx'
+```
+
+## Volume
+
+`BT.audioVolumeSet` sets a bus's volume, optionally fading to it. `BT.audioVolumeGet` reads it back.
+
+```ts twoslash
+import { BT } from 'blit386';
+// ---cut---
+BT.audioVolumeSet('music', 0.5); // immediate change
+BT.audioVolumeSet('sfx', 0, { fadeMs: 300 }); // linear fade to silence over 300 ms
+BT.audioVolumeSet('main', 0.8, { fadeMs: 500, easing: 'ease-out' }); // eased fade
+
+BT.audioVolumeGet('music'); // 0.5
+```
+
+`options` fields:
+
+<TypeTable type={{
+    fadeMs: { type: 'number', description: 'Fade duration in milliseconds. Omit for an immediate change.' },
+    easing: { type: 'EasingFunction', default: "'linear'", description: 'Easing curve for the fade. Ignored when fadeMs is omitted.' },
+  }} />
+
+With no `fadeMs`, the bus gain changes immediately. With `fadeMs`, `'linear'` easing schedules a linear ramp; any other
+[easing curve](api-easing.md) is sampled into a value curve so the fade follows that curve rather than a straight line.
+
+## Mute
+
+`BT.audioMuteSet` mutes or unmutes a bus without touching its configured volume. `BT.isAudioMuted` reports the current
+mute state.
+
+```ts twoslash
+import { BT } from 'blit386';
+// ---cut---
+BT.audioVolumeSet('music', 0.75);
+
+BT.audioMuteSet('music', true); // silences the bus immediately (no fade)
+BT.isAudioMuted('music'); // true
+BT.audioVolumeGet('music'); // still 0.75 - muting never overwrites the configured level
+
+BT.audioMuteSet('music', false); // restores audio at 0.75
+```
+
+`BT.audioVolumeGet` always returns the logical (pre-mute) volume, so reading it while muted still reports the level you
+configured, not `0`.
+
+## Unlock state
+
+Browsers block audio playback until a user gesture. `BT.isAudioUnlocked` is `false` until the first `pointerdown`,
+`keydown`, or `touchstart` on the canvas successfully resumes the audio context, and stays `true` for the rest of the
+session.
+
+```ts twoslash
+import { BT } from 'blit386';
+// ---cut---
+if (!BT.isAudioUnlocked) {
+  // Show a "click or press a key to enable audio" prompt.
+}
+```
+
+See [Web audio constraints](guide-audio.md#web-audio-constraints) for what happens to volume/mute calls made before the
+gesture, and why no configure flag can skip this requirement.
+
+## Hardware settings
+
+`audioVoices` (default `16`, reserved for an upcoming SFX voice-limiting pass; not yet enforced) is documented in
+[Hardware settings](api-core.md#hardware-settings).
+
+## See also
+
+<Cards>
+  <Card title="Audio Guide" href="/docs/guides/audio">Subsystem layout, locked vs. unlocked, web audio constraints.</Card>
+  <Card title="API: Easing" href="/docs/api/easing">Named easing curves used by fadeMs.</Card>
+  <Card title="API: Core" href="/docs/api/core">Hardware settings, including audioVoices.</Card>
+  <Card title="API: Browser Support" href="/docs/api/browser-support">Browser/build support matrix.</Card>
+</Cards>

--- a/docs/api-browser-support.md
+++ b/docs/api-browser-support.md
@@ -35,5 +35,6 @@ package in the browser.
 
 <Cards>
   <Card title="API: Core" href="/docs/api/core">Bootstrap, init, requested vs. active backend.</Card>
+  <Card title="API: Audio" href="/docs/api/audio">Autoplay-unlock gesture requirement, independent of backend.</Card>
   <Card title="Software Fallback Smoke Matrix" href="/docs/performance/smoke-matrix">Manual Canvas 2D fallback checklist.</Card>
 </Cards>

--- a/docs/api-core.md
+++ b/docs/api-core.md
@@ -14,7 +14,8 @@ Bootstrap, initialization, and default configuration.
 
 The rest of the core API surface lives in dedicated pages: [Overlay](api-overlay.md) (HUD configure flags and style),
 [Game Loop](api-game-loop.md) (tick timing and `Timer`), [Camera](api-camera.md), [Easing](api-easing.md),
-[Core Types](api-core-types.md) (`Vector2i`, `Rect2i`, `Color32`), and [Browser Support](api-browser-support.md).
+[Core Types](api-core-types.md) (`Vector2i`, `Rect2i`, `Color32`), [Audio](api-audio.md) (bus volume, mute, unlock
+state), and [Browser Support](api-browser-support.md).
 
 <Callout title="Starting a new project?">
   The quickest path is the scaffolder: `npm create blit386@latest my-game` (works with npm, pnpm, yarn, or bun).
@@ -142,28 +143,29 @@ Resolved after `configure()`; the hook may return a partial object.
 - Include `displaySize` when you want a custom logical size; optional fields you omit then stay unset (for example no
   `drawingBufferSize` means a 1:1 drawing buffer).
 
-| Field                                    | Type                           | Default     | Description                                                                                        |
-| ---------------------------------------- | ------------------------------ | ----------- | -------------------------------------------------------------------------------------------------- |
-| `displaySize`                            | `Vector2i`                     | `320×240`   | Logical render resolution                                                                          |
-| `drawingBufferSize`                      | `Vector2i`                     | `640×480`   | Drawing buffer size; enables display-tier effects when set                                         |
-| `maxCanvasSize`                          | `Vector2i`                     | `960×720`   | CSS cap – maximum on-screen canvas size                                                            |
-| `targetFPS`                              | `number`                       | `60`        | Fixed `update()` rate (simulation ticks per second)                                                |
-| `backend`                                | `'webgpu' \| 'software'`       | `'webgpu'`  | Force rendering backend                                                                            |
-| `outputUpscaleFilter`                    | `'nearest' \| 'linear'`        | `'nearest'` | Upscale filter                                                                                     |
-| `isDetectingDroppedFrames`               | `boolean`                      | `false`     | Log a console warning on missed vsync                                                              |
-| `isOverlayEnabled`                       | `boolean`                      | `true`      | Engine overlay HUD after each `render()`                                                           |
-| `isOverlayVisibleAtStart`                | `boolean`                      | `false`     | Show overlay body (metrics/palette/custom rows) on first frame                                     |
-| `isOverlayToggleHintVisible`             | `boolean`                      | `true`      | Draw toggle hint icon while overlay body is hidden                                                 |
-| `isOverlayToggleEnabled`                 | `boolean`                      | `true`      | Enable Backquote and bottom-left corner toggle input                                               |
-| `isOverlayPaletteEnabled`                | `boolean`                      | `false`     | Live palette swatch grid in the overlay bottom band (opt-in)                                       |
-| `overlayPaletteColumns`                  | `number`                       | _unset_     | Max palette swatches per grid row (default: widest fit)                                            |
-| `overlayPaletteRowsVisible`              | `number`                       | _unset_     | Max visible palette grid rows (default: all rows; band height capped)                              |
-| `overlayStyle`                           | `OverlayStyle`                 | _unset_     | Optional bar/text/gap palette indices for overlay                                                  |
-| `isOverlayTimingChartEnabled`            | `boolean`                      | `false`     | Scrolling update/render timing chart between title and metrics rows                                |
-| `overlayTimingChartHeight`               | `number`                       | `22`        | Timing chart band height in pixels when the chart is enabled                                       |
-| `overlayTimingChartStyle`                | `OverlayTimingChartStyle`      | _unset_     | Optional timing chart palette indices (defaults to overlay bar/text)                               |
-| `overlayTimingChartDiagnostics`          | `false \| 'minimal' \| 'rich'` | _unset_     | Renderer diagnostic visualization on the timing chart (`'minimal'` when chart enabled and omitted) |
-| `isOverlayRendererDiagnosticsBarEnabled` | `boolean`                      | `false`     | Optional GPU diagnostics text row below frame timing metrics                                       |
+| Field                                    | Type                           | Default     | Description                                                                                            |
+| ---------------------------------------- | ------------------------------ | ----------- | ------------------------------------------------------------------------------------------------------ |
+| `displaySize`                            | `Vector2i`                     | `320×240`   | Logical render resolution                                                                              |
+| `drawingBufferSize`                      | `Vector2i`                     | `640×480`   | Drawing buffer size; enables display-tier effects when set                                             |
+| `maxCanvasSize`                          | `Vector2i`                     | `960×720`   | CSS cap – maximum on-screen canvas size                                                                |
+| `targetFPS`                              | `number`                       | `60`        | Fixed `update()` rate (simulation ticks per second)                                                    |
+| `backend`                                | `'webgpu' \| 'software'`       | `'webgpu'`  | Force rendering backend                                                                                |
+| `audioVoices`                            | `number`                       | `16`        | Max simultaneous SFX voices, `1`-`64` (reserved for an upcoming voice-limiting pass; not yet enforced) |
+| `outputUpscaleFilter`                    | `'nearest' \| 'linear'`        | `'nearest'` | Upscale filter                                                                                         |
+| `isDetectingDroppedFrames`               | `boolean`                      | `false`     | Log a console warning on missed vsync                                                                  |
+| `isOverlayEnabled`                       | `boolean`                      | `true`      | Engine overlay HUD after each `render()`                                                               |
+| `isOverlayVisibleAtStart`                | `boolean`                      | `false`     | Show overlay body (metrics/palette/custom rows) on first frame                                         |
+| `isOverlayToggleHintVisible`             | `boolean`                      | `true`      | Draw toggle hint icon while overlay body is hidden                                                     |
+| `isOverlayToggleEnabled`                 | `boolean`                      | `true`      | Enable Backquote and bottom-left corner toggle input                                                   |
+| `isOverlayPaletteEnabled`                | `boolean`                      | `false`     | Live palette swatch grid in the overlay bottom band (opt-in)                                           |
+| `overlayPaletteColumns`                  | `number`                       | _unset_     | Max palette swatches per grid row (default: widest fit)                                                |
+| `overlayPaletteRowsVisible`              | `number`                       | _unset_     | Max visible palette grid rows (default: all rows; band height capped)                                  |
+| `overlayStyle`                           | `OverlayStyle`                 | _unset_     | Optional bar/text/gap palette indices for overlay                                                      |
+| `isOverlayTimingChartEnabled`            | `boolean`                      | `false`     | Scrolling update/render timing chart between title and metrics rows                                    |
+| `overlayTimingChartHeight`               | `number`                       | `22`        | Timing chart band height in pixels when the chart is enabled                                           |
+| `overlayTimingChartStyle`                | `OverlayTimingChartStyle`      | _unset_     | Optional timing chart palette indices (defaults to overlay bar/text)                                   |
+| `overlayTimingChartDiagnostics`          | `false \| 'minimal' \| 'rich'` | _unset_     | Renderer diagnostic visualization on the timing chart (`'minimal'` when chart enabled and omitted)     |
+| `isOverlayRendererDiagnosticsBarEnabled` | `boolean`                      | `false`     | Optional GPU diagnostics text row below frame timing metrics                                           |
 
 - `displaySize`, `drawingBufferSize`, and `maxCanvasSize` must be positive whole-number pixel dimensions.
 - Each size is capped at `8192×8192` per axis and `16,777,216` total pixels (`4096×4096`).
@@ -187,6 +189,8 @@ The overlay-related fields above (`isOverlay*`, `overlay*`) are documented in de
 
 - `activeBackend` is runtime state (what actually started; may differ from `requestedBackend` after WebGPU fallback).
   See [Resolution model](#resolution-model) for drawing-buffer vocabulary.
+- `isAudioUnlocked` is runtime state too: `false` until a user gesture resumes the audio context, `true` for the rest of
+  the session afterward. See [API: Audio](api-audio.md#unlock-state).
 
 ### Requested vs. active backend
 
@@ -256,7 +260,7 @@ const settings = mergeHardwareSettings(defaultConfig(), { targetFPS: 30 });
 ```
 
 `defaultConfig()` returns a full `HardwareSettings` object (`320×240` logical, `640×480` drawing buffer, overlay
-enabled, WebGPU backend, and other defaults documented in the table above).
+enabled, WebGPU backend, `16` SFX voices, and other defaults documented in the table above).
 
 ## Putting it together
 
@@ -274,6 +278,7 @@ enabled, WebGPU backend, and other defaults documented in the table above).
   <Card title="API: Rendering" href="/docs/api/rendering">Primitives, sprites, text, post-process, frame capture.</Card>
   <Card title="API: Palette" href="/docs/api/palette">Palette setup, presets, effects.</Card>
   <Card title="API: Assets" href="/docs/api/assets">Sprite sheets, bitmap fonts, asset loading.</Card>
+  <Card title="API: Audio" href="/docs/api/audio">Bus volume, mute, and the unlock getter.</Card>
   <Card title="Overlay Guide" href="/docs/guides/overlay">Engine HUD subsystem, toggle, layout.</Card>
   <Card title="Post-Process Effects" href="/docs/guides/post-process-effects">Effect chain and tiers.</Card>
   <Card title="Deprecation Timeline" href="/docs/reference/deprecations">Renamed configure flags and getters.</Card>

--- a/docs/guide-audio.md
+++ b/docs/guide-audio.md
@@ -1,0 +1,82 @@
+# Audio
+
+<!-- blit386.dev-banner:start -->
+
+<!-- prettier-ignore -->
+> [!TIP]
+> You're reading the raw source on GitHub. The same page lives at https://blit386.dev/docs/guides/audio, typeset like an
+> actual docs site and easier on the eyes. Probably the nicer place to read it, but same
+> words either way.
+
+<!-- blit386.dev-banner:end -->
+
+Bus volume, mute, and worked examples live in [API: Audio](api-audio.md). This guide maps the internal subsystem, the
+locked/unlocked gesture state, and the web platform constraints that shape it.
+
+## Subsystem layout
+
+```text
+src/audio/
+  AudioManager.ts   # Web Audio context, bus graph, unlock state machine, mute/volume
+```
+
+`AudioManager` is owned by the internal `BTAPI` singleton (created and torn down alongside pointer, keyboard, and
+gamepad input) and is never exposed to demo code directly - only through the `BT.audio*` methods and the
+`BT.isAudioUnlocked` getter documented in [API: Audio](api-audio.md).
+
+Tests mock the Web Audio API with `src/__test__/webaudio-mock.ts`, since neither Node.js nor happy-dom implement it.
+
+## Locked vs. unlocked
+
+| State                            | What that means                                                                                                                                                                                |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Locked (default until a gesture) | `BT.isAudioUnlocked` is `false`. `audioVolumeSet`/`audioMuteSet` calls still update engine-side state, but the browser's audio context is suspended, so nothing is audible yet.                |
+| Unlocked                         | `BT.isAudioUnlocked` is `true`. Set once `AudioContext.resume()` resolves after the first `pointerdown`, `keydown`, or `touchstart` on the canvas. Stays unlocked for the rest of the session. |
+
+The engine listens for all three gesture types at once and removes the listeners as soon as one of them succeeds, so
+whichever input method a player uses first (mouse, keyboard, or touch) unlocks audio.
+
+## Usage example
+
+```ts twoslash
+import { BT, type IBTDemo, Vector2i } from 'blit386';
+
+class Demo implements IBTDemo {
+  async init() {
+    BT.audioVolumeSet('music', 0.6);
+    BT.audioVolumeSet('sfx', 0.9);
+
+    return true;
+  }
+
+  update() {}
+
+  render() {
+    if (!BT.isAudioUnlocked) {
+      BT.systemPrint(new Vector2i(8, 8), 2, 'Click or press a key to enable audio');
+    }
+  }
+}
+```
+
+## Web audio constraints
+
+Every major browser enforces an autoplay policy: an `AudioContext` starts `'suspended'` and stays that way until a user
+gesture calls `resume()`. This is a platform rule, not something BLIT386 can configure around - there is no flag to
+start audio unlocked, and none is planned.
+
+- Volume and mute calls made before the gesture are not lost; they update the engine's internal bus state and take
+  effect immediately once the context resumes.
+- The gesture requirement is independent of the render backend. Unlocking audio has nothing to do with
+  `BT.activeBackend` or the WebGPU/Canvas 2D fallback described in [Browser Support](api-browser-support.md) - a demo
+  can be fully unlocked on the software renderer, or fully locked on WebGPU.
+- Actual sound triggering (loading and playing SFX/music clips) is not implemented yet. This phase covers the bus graph,
+  volume, mute, and unlock tracking that a future playback API will build on.
+
+## See also
+
+<Cards>
+  <Card title="API: Audio" href="/docs/api/audio">Bus volume, mute, and the unlock getter.</Card>
+  <Card title="API: Browser Support" href="/docs/api/browser-support">Browser/build support matrix.</Card>
+  <Card title="Input Guide" href="/docs/guides/input">Pointer, keyboard, and gamepad input that can trigger unlock.</Card>
+</Cards>

--- a/src/BLIT386.ts
+++ b/src/BLIT386.ts
@@ -19,6 +19,7 @@ import type { IndexedSpriteLoadResult } from './assets/SpriteSheet';
 import { SpriteSheet } from './assets/SpriteSheet';
 import { BTAPI } from './core/BTAPI';
 import {
+    type AudioBus,
     type Backend,
     defaultConfig,
     type HardwareSettings,
@@ -538,6 +539,64 @@ export const BT = {
      */
     get activeBackend(): Backend | null {
         return BTAPI.instance.getActiveBackend();
+    },
+
+    /**
+     * Whether the audio context has been unlocked by a user gesture.
+     *
+     * Browsers require a user gesture (pointer, key, or touch press) before
+     * allowing audio playback. Starts `false`; flips to `true` for the rest of
+     * the session after the first gesture successfully resumes the audio context.
+     *
+     * @returns `true` once unlocked; `false` when locked or before initialization.
+     */
+    get isAudioUnlocked(): boolean {
+        return BTAPI.instance.isAudioUnlocked();
+    },
+
+    /**
+     * Sets the logical volume for an audio bus, optionally fading to it.
+     *
+     * @param bus - Audio bus to update (`'main'`, `'music'`, or `'sfx'`).
+     * @param value - Target volume, clamped to `[0, 1]`.
+     * @param options - Optional fade behavior.
+     * @param options.fadeMs - Fade duration in milliseconds. Omit for an immediate change.
+     * @param options.easing - Easing curve for the fade. Defaults to `'linear'`; ignored when `fadeMs` is omitted.
+     */
+    audioVolumeSet: (bus: AudioBus, value: number, options?: { fadeMs?: number; easing?: EasingFunction }): void => {
+        BTAPI.instance.audioVolumeSet(bus, value, options?.fadeMs, options?.easing);
+    },
+
+    /**
+     * Gets the logical (pre-mute) volume for an audio bus.
+     *
+     * Unaffected by {@link BT.audioMuteSet} - muting never overwrites the configured level.
+     *
+     * @param bus - Audio bus to query.
+     * @returns Volume in `[0, 1]`, or `0` before initialization.
+     */
+    audioVolumeGet: (bus: AudioBus): number => {
+        return BTAPI.instance.audioVolumeGet(bus);
+    },
+
+    /**
+     * Mutes or unmutes an audio bus.
+     *
+     * @param bus - Audio bus to mute or unmute.
+     * @param muted - `true` to mute, `false` to unmute.
+     */
+    audioMuteSet: (bus: AudioBus, muted: boolean): void => {
+        BTAPI.instance.audioMuteSet(bus, muted);
+    },
+
+    /**
+     * Reports whether an audio bus is currently muted.
+     *
+     * @param bus - Audio bus to query.
+     * @returns `true` when muted; `false` when unmuted or before initialization.
+     */
+    isAudioMuted: (bus: AudioBus): boolean => {
+        return BTAPI.instance.isAudioMuted(bus);
     },
 
     /**
@@ -1610,6 +1669,7 @@ export {
     Vignette,
 };
 export type {
+    AudioBus,
     Backend,
     BootstrapOptions,
     EasingFunction,

--- a/src/__test__/setup.ts
+++ b/src/__test__/setup.ts
@@ -93,3 +93,110 @@ installGlobalIfMissing(
         }
     },
 );
+
+/** Mock `AudioParam`: tracks the current value; scheduling calls apply it immediately (no real audio clock in tests). */
+class MockAudioParam {
+    /** Current (immediately applied) parameter value. */
+    public value = 1;
+
+    /**
+     * Sets `value` immediately (mock: ignores scheduling time).
+     *
+     * @param value The value to apply.
+     * @param _startTime Scheduled start time (ignored).
+     */
+    setValueAtTime(value: number, _startTime: number) {
+        this.value = value;
+
+        return this;
+    }
+
+    /**
+     * Sets `value` immediately (mock: ignores the ramp duration).
+     *
+     * @param value The target value.
+     * @param _endTime Scheduled ramp end time (ignored).
+     */
+    linearRampToValueAtTime(value: number, _endTime: number) {
+        this.value = value;
+
+        return this;
+    }
+
+    /**
+     * Jumps straight to the curve's final sample (mock: ignores intermediate samples and timing).
+     *
+     * @param values Sampled curve values.
+     * @param _startTime Scheduled start time (ignored).
+     * @param _duration Curve duration in seconds (ignored).
+     */
+    setValueCurveAtTime(values: Float32Array | readonly number[], _startTime: number, _duration: number) {
+        this.value = values[values.length - 1] ?? this.value;
+
+        return this;
+    }
+
+    /**
+     * No-op in the mock (no scheduled changes to cancel).
+     *
+     * @param _startTime Time after which scheduled changes would be cleared (ignored).
+     */
+    cancelScheduledValues(_startTime: number) {
+        return this;
+    }
+}
+
+/** Mock `AudioNode`: tracks connections without producing or routing any audio. */
+class MockAudioNode {
+    /**
+     * Records a connection to another node (mock: no-op, returns the destination).
+     *
+     * @param destination The node this node connects to.
+     */
+    connect(destination: unknown) {
+        return destination;
+    }
+
+    /** Disconnects all outputs (no-op in the mock). */
+    disconnect() {}
+}
+
+/** Mock `GainNode`: a {@link MockAudioNode} with a {@link MockAudioParam} gain. */
+class MockGainNode extends MockAudioNode {
+    /** Gain parameter (default 1, matching the real `GainNode` default). */
+    public gain = new MockAudioParam();
+}
+
+/** Provide `AudioContext` (and `GainNode`/`AudioParam` behavior) that doesn't exist in Node.js or happy-dom. */
+installGlobalIfMissing(
+    'AudioContext',
+    class {
+        /** Simulated audio clock; stays at 0 since the mock never advances time. */
+        public currentTime = 0;
+
+        /** Context lifecycle state, mirroring the real `AudioContextState` values. */
+        public state: 'suspended' | 'running' | 'closed' = 'suspended';
+
+        /** Destination node terminating the bus graph. */
+        public destination = new MockAudioNode();
+
+        /** Creates a new {@link MockGainNode}. */
+        createGain() {
+            return new MockGainNode();
+        }
+
+        /** Resolves immediately and flips {@link state} to `'running'`. */
+        resume() {
+            this.state = 'running';
+
+            return Promise.resolve();
+        }
+
+        /** Resolves immediately and flips {@link state} to `'closed'`. */
+        close() {
+            this.state = 'closed';
+
+            return Promise.resolve();
+        }
+    },
+);

--- a/src/__test__/setup.ts
+++ b/src/__test__/setup.ts
@@ -1,6 +1,8 @@
 // Global test setup for blit386.
 // Imported by vitest.config.ts setupFiles.
 
+import { createMockAudioContext } from './webaudio-mock';
+
 type GlobalRecord = Record<string, unknown>;
 
 /**
@@ -94,109 +96,11 @@ installGlobalIfMissing(
     },
 );
 
-/** Mock `AudioParam`: tracks the current value; scheduling calls apply it immediately (no real audio clock in tests). */
-class MockAudioParam {
-    /** Current (immediately applied) parameter value. */
-    public value = 1;
-
-    /**
-     * Sets `value` immediately (mock: ignores scheduling time).
-     *
-     * @param value The value to apply.
-     * @param _startTime Scheduled start time (ignored).
-     */
-    setValueAtTime(value: number, _startTime: number) {
-        this.value = value;
-
-        return this;
-    }
-
-    /**
-     * Sets `value` immediately (mock: ignores the ramp duration).
-     *
-     * @param value The target value.
-     * @param _endTime Scheduled ramp end time (ignored).
-     */
-    linearRampToValueAtTime(value: number, _endTime: number) {
-        this.value = value;
-
-        return this;
-    }
-
-    /**
-     * Jumps straight to the curve's final sample (mock: ignores intermediate samples and timing).
-     *
-     * @param values Sampled curve values.
-     * @param _startTime Scheduled start time (ignored).
-     * @param _duration Curve duration in seconds (ignored).
-     */
-    setValueCurveAtTime(values: Float32Array | readonly number[], _startTime: number, _duration: number) {
-        this.value = values[values.length - 1] ?? this.value;
-
-        return this;
-    }
-
-    /**
-     * No-op in the mock (no scheduled changes to cancel).
-     *
-     * @param _startTime Time after which scheduled changes would be cleared (ignored).
-     */
-    cancelScheduledValues(_startTime: number) {
-        return this;
-    }
-}
-
-/** Mock `AudioNode`: tracks connections without producing or routing any audio. */
-class MockAudioNode {
-    /**
-     * Records a connection to another node (mock: no-op, returns the destination).
-     *
-     * @param destination The node this node connects to.
-     */
-    connect(destination: unknown) {
-        return destination;
-    }
-
-    /** Disconnects all outputs (no-op in the mock). */
-    disconnect() {}
-}
-
-/** Mock `GainNode`: a {@link MockAudioNode} with a {@link MockAudioParam} gain. */
-class MockGainNode extends MockAudioNode {
-    /** Gain parameter (default 1, matching the real `GainNode` default). */
-    public gain = new MockAudioParam();
-}
-
-/** Provide `AudioContext` (and `GainNode`/`AudioParam` behavior) that doesn't exist in Node.js or happy-dom. */
-installGlobalIfMissing(
-    'AudioContext',
-    class {
-        /** Simulated audio clock; stays at 0 since the mock never advances time. */
-        public currentTime = 0;
-
-        /** Context lifecycle state, mirroring the real `AudioContextState` values. */
-        public state: 'suspended' | 'running' | 'closed' = 'suspended';
-
-        /** Destination node terminating the bus graph. */
-        public destination = new MockAudioNode();
-
-        /** Creates a new {@link MockGainNode}. */
-        createGain() {
-            return new MockGainNode();
-        }
-
-        /** Resolves immediately and flips {@link state} to `'running'`. */
-        resume() {
-            this.state = 'running';
-
-            return Promise.resolve();
-        }
-
-        /** Resolves immediately and flips {@link state} to `'closed'`. */
-        close() {
-            this.state = 'closed';
-
-            return Promise.resolve();
-        }
-    },
-);
+/**
+ * Provide `AudioContext` (and `GainNode`/`AudioParam` behavior) that doesn't exist in Node.js or happy-dom.
+ * Reuses the same factory as `webaudio-mock.ts` so there is one implementation, not two; tests that need
+ * call-tracking access install their own instance via `installMockAudioContext()`/`uninstallMockAudioContext()`.
+ */
+installGlobalIfMissing('AudioContext', function AudioContextStub() {
+    return createMockAudioContext();
+});

--- a/src/__test__/webaudio-mock.ts
+++ b/src/__test__/webaudio-mock.ts
@@ -1,0 +1,214 @@
+/**
+ * Lightweight Web Audio mock factories for unit and integration tests.
+ * Mirrors the structure of `webgpu-mock.ts`: pure factory functions producing
+ * stub objects that track calls without requiring a real audio device.
+ */
+
+/** Sample rate reported by a mock audio context, matching a typical browser default. */
+const MOCK_SAMPLE_RATE = 48000;
+
+/** Default gain value for a freshly created mock `AudioParam`, matching the real `GainNode` default. */
+const DEFAULT_GAIN_VALUE = 1;
+
+/** Recorded `AudioParam` scheduling calls, readable via a cast back from the returned `AudioParam`. */
+export interface MockAudioParam {
+    /** Current (immediately applied) parameter value. */
+    value: number;
+
+    /** Arguments recorded from every `setValueAtTime` call, in call order. */
+    readonly setValueAtTimeCalls: Array<{ value: number; startTime: number }>;
+
+    /** Arguments recorded from every `linearRampToValueAtTime` call, in call order. */
+    readonly linearRampToValueAtTimeCalls: Array<{ value: number; endTime: number }>;
+
+    /** Arguments recorded from every `setValueCurveAtTime` call, in call order. */
+    readonly setValueCurveAtTimeCalls: Array<{ values: Float32Array; startTime: number; duration: number }>;
+
+    /** `startTime` arguments recorded from every `cancelScheduledValues` call, in call order. */
+    readonly cancelScheduledValuesCalls: number[];
+}
+
+/** Recorded `connect` calls, readable via a cast back from a mock `AudioNode`/`GainNode`. */
+export interface MockAudioNode {
+    /** Arguments recorded from every `connect` call, in call order. */
+    readonly connectCalls: unknown[];
+}
+
+/** Recorded `GainNode` state: connect tracking plus the mock gain parameter. */
+export interface MockGainNode extends MockAudioNode {
+    /** Gain parameter with scheduling call tracking. */
+    readonly gain: MockAudioParam;
+}
+
+/** Recorded `AudioContext` state: created gain nodes plus resume/close call counts. */
+export interface MockAudioContext {
+    /** Gain nodes created via `createGain()`, in call order. */
+    readonly createGainCalls: readonly GainNode[];
+
+    /** Destination node passed to `main.connect(...)` in a well-wired bus graph. */
+    readonly destination: AudioNode;
+
+    /** Number of times `resume()` was called. */
+    readonly resumeCallCount: number;
+
+    /** Number of times `close()` was called. */
+    readonly closeCallCount: number;
+}
+
+/**
+ * Creates a mock `AudioParam` that applies every scheduling call immediately
+ * (no real audio clock in tests) while recording call arguments.
+ *
+ * @param initialValue - Starting parameter value. Defaults to {@link DEFAULT_GAIN_VALUE}.
+ * @returns Mock `AudioParam` stub, cast from a plain tracking object.
+ */
+export function createMockAudioParam(initialValue: number = DEFAULT_GAIN_VALUE): AudioParam {
+    const setValueAtTimeCalls: Array<{ value: number; startTime: number }> = [];
+    const linearRampToValueAtTimeCalls: Array<{ value: number; endTime: number }> = [];
+    const setValueCurveAtTimeCalls: Array<{ values: Float32Array; startTime: number; duration: number }> = [];
+    const cancelScheduledValuesCalls: number[] = [];
+
+    const param = {
+        value: initialValue,
+        setValueAtTimeCalls,
+        linearRampToValueAtTimeCalls,
+        setValueCurveAtTimeCalls,
+        cancelScheduledValuesCalls,
+        setValueAtTime: (value: number, startTime: number) => {
+            setValueAtTimeCalls.push({ value, startTime });
+            param.value = value;
+
+            return param;
+        },
+        linearRampToValueAtTime: (value: number, endTime: number) => {
+            linearRampToValueAtTimeCalls.push({ value, endTime });
+            param.value = value;
+
+            return param;
+        },
+        setValueCurveAtTime: (values: Float32Array, startTime: number, duration: number) => {
+            setValueCurveAtTimeCalls.push({ values, startTime, duration });
+            param.value = values[values.length - 1] ?? param.value;
+
+            return param;
+        },
+        cancelScheduledValues: (startTime: number) => {
+            cancelScheduledValuesCalls.push(startTime);
+
+            return param;
+        },
+    };
+
+    return param as unknown as AudioParam;
+}
+
+/**
+ * Creates a mock `GainNode`: a `connect`-tracking node with a mock
+ * {@link createMockAudioParam} gain.
+ *
+ * @returns Mock `GainNode` stub, cast from a plain tracking object.
+ */
+export function createMockGainNode(): GainNode {
+    const connectCalls: unknown[] = [];
+
+    const node = {
+        gain: createMockAudioParam(),
+        connectCalls,
+        connect: (destination: unknown) => {
+            connectCalls.push(destination);
+
+            return destination;
+        },
+        disconnect: () => {},
+    };
+
+    return node as unknown as GainNode;
+}
+
+/**
+ * Creates a mock `AudioContext` whose `createGain()` returns
+ * {@link createMockGainNode} stubs and whose `resume()`/`close()` resolve
+ * immediately while recording call counts.
+ *
+ * @returns Mock `AudioContext` stub, cast from a plain tracking object.
+ */
+export function createMockAudioContext(): AudioContext {
+    const createGainCalls: GainNode[] = [];
+    const destination = {} as unknown as AudioNode;
+    let resumeCallCount = 0;
+    let closeCallCount = 0;
+
+    const context = {
+        currentTime: 0,
+        sampleRate: MOCK_SAMPLE_RATE,
+        state: 'suspended' as AudioContextState,
+        destination,
+        createGainCalls,
+        get resumeCallCount() {
+            return resumeCallCount;
+        },
+        get closeCallCount() {
+            return closeCallCount;
+        },
+        createGain: () => {
+            const node = createMockGainNode();
+
+            createGainCalls.push(node);
+
+            return node;
+        },
+        resume: () => {
+            resumeCallCount += 1;
+            context.state = 'running';
+
+            return Promise.resolve();
+        },
+        close: () => {
+            closeCallCount += 1;
+            context.state = 'closed';
+
+            return Promise.resolve();
+        },
+    };
+
+    return context as unknown as AudioContext;
+}
+
+/**
+ * Installs a mock `AudioContext` constructor on `globalThis`, since Node.js
+ * and happy-dom provide no Web Audio APIs. Tracks every constructed instance
+ * so tests can retrieve the context an attached subsystem actually created.
+ *
+ * @returns Accessor for the most recently constructed mock `AudioContext`.
+ */
+export function installMockAudioContext(): { getLastInstance: () => AudioContext | null } {
+    let lastInstance: AudioContext | null = null;
+
+    function MockAudioContextCtor(): AudioContext {
+        const instance = createMockAudioContext();
+
+        lastInstance = instance;
+
+        return instance;
+    }
+
+    Object.defineProperty(globalThis, 'AudioContext', {
+        value: MockAudioContextCtor,
+        writable: true,
+        configurable: true,
+    });
+
+    return {
+        getLastInstance: () => lastInstance,
+    };
+}
+
+/**
+ * Removes the mock `AudioContext` constructor from `globalThis`.
+ * Call in afterEach/afterAll to clean up.
+ */
+export function uninstallMockAudioContext(): void {
+    if ('AudioContext' in globalThis) {
+        delete (globalThis as unknown as Record<string, unknown>).AudioContext;
+    }
+}

--- a/src/audio/AudioManager.test.ts
+++ b/src/audio/AudioManager.test.ts
@@ -1,0 +1,268 @@
+// @vitest-environment happy-dom
+
+/**
+ * Unit tests for {@link AudioManager}.
+ *
+ * Verifies the bus graph wiring (`sfx`/`music` -> `main` -> `destination`),
+ * bus volume get/set, mute semantics (mute preserves the configured volume;
+ * unmute restores it), and the browser autoplay-unlock gesture state machine
+ * (pointerdown/keydown flip locked -> unlocked and self-remove the gesture
+ * listeners). Uses the Web Audio mock factories since Node.js and happy-dom
+ * provide no Web Audio APIs.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+    installMockAudioContext,
+    type MockAudioContext,
+    type MockAudioParam,
+    type MockGainNode,
+    uninstallMockAudioContext,
+} from '../__test__/webaudio-mock';
+import { AudioManager } from './AudioManager';
+
+/**
+ * Mounts a canvas for {@link AudioManager.attach}.
+ */
+const createCanvas = (): HTMLCanvasElement => {
+    const canvas = document.createElement('canvas');
+
+    document.body.appendChild(canvas);
+
+    return canvas;
+};
+
+/**
+ * Returns the gain node created at `index` in `AudioManager.buildBusGraph()`'s
+ * `createGain()` call order (0 = main, 1 = music, 2 = sfx), throwing if the
+ * bus graph was not built with at least `index + 1` nodes.
+ */
+const nthGainNode = (calls: readonly GainNode[], index: number): MockGainNode => {
+    // eslint-disable-next-line security/detect-object-injection -- index is a small caller-supplied literal (0-2), not user input
+    const node = calls[index];
+
+    if (node === undefined) {
+        throw new Error(`expected a gain node at index ${index}, got ${calls.length} total`);
+    }
+
+    return node as unknown as MockGainNode;
+};
+
+describe('AudioManager', () => {
+    let canvas: HTMLCanvasElement;
+    let audio: AudioManager;
+    let installed: ReturnType<typeof installMockAudioContext>;
+
+    beforeEach(() => {
+        installed = installMockAudioContext();
+        canvas = createCanvas();
+        audio = new AudioManager();
+    });
+
+    afterEach(() => {
+        audio.detach();
+        canvas.remove();
+        uninstallMockAudioContext();
+    });
+
+    describe('bus graph wiring', () => {
+        it('creates main, music, and sfx gain nodes on attach', () => {
+            audio.attach(canvas);
+
+            const context = installed.getLastInstance() as unknown as MockAudioContext;
+
+            expect(context.createGainCalls).toHaveLength(3);
+        });
+
+        it('wires sfx and music into main, and main into destination', () => {
+            audio.attach(canvas);
+
+            const context = installed.getLastInstance() as unknown as MockAudioContext;
+
+            const main = nthGainNode(context.createGainCalls, 0);
+            const music = nthGainNode(context.createGainCalls, 1);
+            const sfx = nthGainNode(context.createGainCalls, 2);
+
+            expect(music.connectCalls).toEqual([main]);
+            expect(sfx.connectCalls).toEqual([main]);
+            expect(main.connectCalls).toEqual([context.destination]);
+        });
+
+        it('rebuilds a fresh bus graph on a second attach', () => {
+            audio.attach(canvas);
+            audio.attach(canvas);
+
+            const context = installed.getLastInstance() as unknown as MockAudioContext;
+
+            expect(context.createGainCalls).toHaveLength(3);
+        });
+    });
+
+    describe('volume', () => {
+        beforeEach(() => {
+            audio.attach(canvas);
+        });
+
+        it('defaults every bus to full volume', () => {
+            expect(audio.volumeGet('main')).toBe(1);
+            expect(audio.volumeGet('music')).toBe(1);
+            expect(audio.volumeGet('sfx')).toBe(1);
+        });
+
+        it('sets and gets logical volume immediately with no fadeMs', () => {
+            audio.volumeSet('music', 0.5);
+
+            expect(audio.volumeGet('music')).toBe(0.5);
+        });
+
+        it('applies the volume to the underlying gain node immediately with no fadeMs', () => {
+            const context = installed.getLastInstance() as unknown as MockAudioContext;
+            const music = nthGainNode(context.createGainCalls, 1);
+
+            audio.volumeSet('music', 0.25);
+
+            expect(music.gain.value).toBe(0.25);
+        });
+
+        it('clamps volume above 1 down to 1', () => {
+            audio.volumeSet('sfx', 5);
+
+            expect(audio.volumeGet('sfx')).toBe(1);
+        });
+
+        it('clamps volume below 0 up to 0', () => {
+            audio.volumeSet('sfx', -5);
+
+            expect(audio.volumeGet('sfx')).toBe(0);
+        });
+
+        it('schedules a linear ramp on the gain param when fadeMs is provided', () => {
+            const context = installed.getLastInstance() as unknown as MockAudioContext;
+            const main = nthGainNode(context.createGainCalls, 0);
+
+            audio.volumeSet('main', 0.5, 200);
+
+            const gain = main.gain as unknown as MockAudioParam;
+
+            expect(gain.linearRampToValueAtTimeCalls).toHaveLength(1);
+            expect(gain.linearRampToValueAtTimeCalls[0]?.value).toBe(0.5);
+            expect(gain.value).toBe(0.5);
+        });
+
+        it('samples an eased curve via setValueCurveAtTime for non-linear easing', () => {
+            const context = installed.getLastInstance() as unknown as MockAudioContext;
+            const main = nthGainNode(context.createGainCalls, 0);
+
+            audio.volumeSet('main', 0.8, 200, 'ease-out');
+
+            const gain = main.gain as unknown as MockAudioParam;
+
+            expect(gain.setValueCurveAtTimeCalls).toHaveLength(1);
+            // Float32Array storage loses a little precision versus the JS double target.
+            expect(gain.value).toBeCloseTo(0.8, 5);
+        });
+    });
+
+    describe('mute', () => {
+        beforeEach(() => {
+            audio.attach(canvas);
+        });
+
+        it('reports unmuted by default', () => {
+            expect(audio.isMuted('main')).toBe(false);
+        });
+
+        it('mute preserves the configured (logical) volume and unmute restores it', () => {
+            audio.volumeSet('music', 0.75);
+
+            audio.muteSet('music', true);
+            expect(audio.isMuted('music')).toBe(true);
+            expect(audio.volumeGet('music')).toBe(0.75);
+
+            audio.muteSet('music', false);
+            expect(audio.isMuted('music')).toBe(false);
+            expect(audio.volumeGet('music')).toBe(0.75);
+        });
+
+        it('zeroes the underlying gain node on mute and restores it on unmute', () => {
+            const context = installed.getLastInstance() as unknown as MockAudioContext;
+            const sfx = nthGainNode(context.createGainCalls, 2);
+
+            audio.volumeSet('sfx', 0.4);
+
+            audio.muteSet('sfx', true);
+            expect(sfx.gain.value).toBe(0);
+
+            audio.muteSet('sfx', false);
+            expect(sfx.gain.value).toBe(0.4);
+        });
+
+        it('is a no-op when muting an already-muted bus', () => {
+            audio.muteSet('main', true);
+            audio.muteSet('main', true);
+
+            expect(audio.isMuted('main')).toBe(true);
+        });
+    });
+
+    describe('unlock state machine', () => {
+        it('starts locked', () => {
+            audio.attach(canvas);
+
+            expect(audio.isUnlocked()).toBe(false);
+        });
+
+        it('unlocks on pointerdown and removes the gesture listeners', async () => {
+            audio.attach(canvas);
+
+            const removeSpy = vi.spyOn(canvas, 'removeEventListener');
+
+            canvas.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+
+            await vi.waitFor(() => {
+                expect(audio.isUnlocked()).toBe(true);
+            });
+
+            expect(removeSpy).toHaveBeenCalledWith('pointerdown', expect.any(Function));
+            expect(removeSpy).toHaveBeenCalledWith('keydown', expect.any(Function));
+            expect(removeSpy).toHaveBeenCalledWith('touchstart', expect.any(Function));
+        });
+
+        it('unlocks on keydown', async () => {
+            audio.attach(canvas);
+
+            canvas.dispatchEvent(new Event('keydown', { bubbles: true }));
+
+            await vi.waitFor(() => {
+                expect(audio.isUnlocked()).toBe(true);
+            });
+        });
+
+        it('unlocks on touchstart', async () => {
+            audio.attach(canvas);
+
+            canvas.dispatchEvent(new Event('touchstart', { bubbles: true }));
+
+            await vi.waitFor(() => {
+                expect(audio.isUnlocked()).toBe(true);
+            });
+        });
+
+        it('calls resume exactly once even if a second gesture fires after unlock', async () => {
+            audio.attach(canvas);
+
+            const context = installed.getLastInstance() as unknown as MockAudioContext;
+
+            canvas.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+
+            await vi.waitFor(() => {
+                expect(audio.isUnlocked()).toBe(true);
+            });
+
+            canvas.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+
+            expect(context.resumeCallCount).toBe(1);
+        });
+    });
+});

--- a/src/audio/AudioManager.test.ts
+++ b/src/audio/AudioManager.test.ts
@@ -54,6 +54,13 @@ describe('AudioManager', () => {
     let audio: AudioManager;
     let installed: ReturnType<typeof installMockAudioContext>;
 
+    /**
+     * Returns the mock context most recently constructed by `installed`, cast for
+     * access to its call-tracking fields. Centralizes the cast so individual tests
+     * don't repeat it.
+     */
+    const getMockContext = (): MockAudioContext => installed.getLastInstance() as unknown as MockAudioContext;
+
     beforeEach(() => {
         installed = installMockAudioContext();
         canvas = createCanvas();
@@ -70,7 +77,7 @@ describe('AudioManager', () => {
         it('creates main, music, and sfx gain nodes on attach', () => {
             audio.attach(canvas);
 
-            const context = installed.getLastInstance() as unknown as MockAudioContext;
+            const context = getMockContext();
 
             expect(context.createGainCalls).toHaveLength(3);
         });
@@ -78,7 +85,7 @@ describe('AudioManager', () => {
         it('wires sfx and music into main, and main into destination', () => {
             audio.attach(canvas);
 
-            const context = installed.getLastInstance() as unknown as MockAudioContext;
+            const context = getMockContext();
 
             const main = nthGainNode(context.createGainCalls, 0);
             const music = nthGainNode(context.createGainCalls, 1);
@@ -93,9 +100,38 @@ describe('AudioManager', () => {
             audio.attach(canvas);
             audio.attach(canvas);
 
-            const context = installed.getLastInstance() as unknown as MockAudioContext;
+            const context = getMockContext();
 
             expect(context.createGainCalls).toHaveLength(3);
+        });
+
+        it('does not throw when AudioContext construction fails', () => {
+            Object.defineProperty(globalThis, 'AudioContext', {
+                value: function ThrowingAudioContext(): never {
+                    throw new Error('AudioContext limit reached');
+                },
+                writable: true,
+                configurable: true,
+            });
+
+            expect(() => audio.attach(canvas)).not.toThrow();
+            expect(audio.isUnlocked()).toBe(false);
+        });
+    });
+
+    describe('detach', () => {
+        it('closes the audio context', () => {
+            audio.attach(canvas);
+
+            const context = getMockContext();
+
+            audio.detach();
+
+            expect(context.closeCallCount).toBe(1);
+        });
+
+        it('is safe to call before attach', () => {
+            expect(() => audio.detach()).not.toThrow();
         });
     });
 
@@ -117,7 +153,7 @@ describe('AudioManager', () => {
         });
 
         it('applies the volume to the underlying gain node immediately with no fadeMs', () => {
-            const context = installed.getLastInstance() as unknown as MockAudioContext;
+            const context = getMockContext();
             const music = nthGainNode(context.createGainCalls, 1);
 
             audio.volumeSet('music', 0.25);
@@ -138,7 +174,7 @@ describe('AudioManager', () => {
         });
 
         it('schedules a linear ramp on the gain param when fadeMs is provided', () => {
-            const context = installed.getLastInstance() as unknown as MockAudioContext;
+            const context = getMockContext();
             const main = nthGainNode(context.createGainCalls, 0);
 
             audio.volumeSet('main', 0.5, 200);
@@ -151,7 +187,7 @@ describe('AudioManager', () => {
         });
 
         it('samples an eased curve via setValueCurveAtTime for non-linear easing', () => {
-            const context = installed.getLastInstance() as unknown as MockAudioContext;
+            const context = getMockContext();
             const main = nthGainNode(context.createGainCalls, 0);
 
             audio.volumeSet('main', 0.8, 200, 'ease-out');
@@ -186,7 +222,7 @@ describe('AudioManager', () => {
         });
 
         it('zeroes the underlying gain node on mute and restores it on unmute', () => {
-            const context = installed.getLastInstance() as unknown as MockAudioContext;
+            const context = getMockContext();
             const sfx = nthGainNode(context.createGainCalls, 2);
 
             audio.volumeSet('sfx', 0.4);
@@ -252,7 +288,7 @@ describe('AudioManager', () => {
         it('calls resume exactly once even if a second gesture fires after unlock', async () => {
             audio.attach(canvas);
 
-            const context = installed.getLastInstance() as unknown as MockAudioContext;
+            const context = getMockContext();
 
             canvas.dispatchEvent(new Event('pointerdown', { bubbles: true }));
 

--- a/src/audio/AudioManager.ts
+++ b/src/audio/AudioManager.ts
@@ -7,6 +7,7 @@
  * manages the audio graph, bus volume/mute, and unlock tracking.
  */
 
+import type { AudioBus } from '../core/IBTDemo';
 import type { EasingFunction } from '../utils/Easing';
 import { applyEasing } from '../utils/Easing';
 
@@ -21,9 +22,6 @@ const MIN_BUS_VOLUME = 0;
 
 /** Maximum accepted bus volume. */
 const MAX_BUS_VOLUME = 1;
-
-/** Named buses in the audio graph: `sfx` and `music` feed into `main`, which feeds `destination`. */
-export type AudioBus = 'main' | 'music' | 'sfx';
 
 /** Per-bus value keyed the same way as the bus graph (`main`, `music`, `sfx`). */
 type PerBus<T> = Record<AudioBus, T>;

--- a/src/audio/AudioManager.ts
+++ b/src/audio/AudioManager.ts
@@ -49,6 +49,9 @@ export class AudioManager {
     /** `true` once a user gesture has successfully resumed the audio context. */
     private unlocked = false;
 
+    /** `true` while a {@link resumeAndUnlock} call is in flight, guarding against concurrent resume attempts. */
+    private isUnlocking = false;
+
     /** Logical (pre-mute) volume per bus, reported by {@link volumeGet} regardless of mute state. */
     private logicalVolume: PerBus<number>;
 
@@ -94,16 +97,30 @@ export class AudioManager {
      * gesture listeners on `target`.
      *
      * Calls {@link detach} first so a repeated `attach()` (for example across
-     * engine restarts) never leaks a previous context or listener set.
+     * engine restarts) never leaks a previous context or listener set. Logs and
+     * returns without installing listeners if constructing the audio context or
+     * bus graph throws (for example a browser hitting its concurrent
+     * `AudioContext` limit), so a failure here never rejects the caller's
+     * `BTAPI.init()`.
      *
      * @param target - Canvas that receives the one-shot unlock gesture listeners.
      */
     public attach(target: HTMLCanvasElement): void {
         this.detach();
 
+        try {
+            this.context = new AudioContext();
+            this.buildBusGraph(this.context);
+        } catch (error) {
+            console.error('[BT] Failed to create the audio context', error);
+
+            this.context = null;
+            this.busNodes = null;
+
+            return;
+        }
+
         this.target = target;
-        this.context = new AudioContext();
-        this.buildBusGraph(this.context);
 
         target.addEventListener('pointerdown', this.onPointerDown);
         target.addEventListener('keydown', this.onKeyDown);
@@ -119,17 +136,16 @@ export class AudioManager {
         this.removeUnlockListeners();
 
         if (this.context !== null) {
-            try {
-                void this.context.close();
-            } catch {
-                // Context may already be closed.
-            }
+            this.context.close().catch(() => {
+                // Context may already be closed; close() rejects rather than throwing synchronously.
+            });
         }
 
         this.context = null;
         this.busNodes = null;
         this.target = null;
         this.unlocked = false;
+        this.isUnlocking = false;
         this.logicalVolume = { main: DEFAULT_BUS_VOLUME, music: DEFAULT_BUS_VOLUME, sfx: DEFAULT_BUS_VOLUME };
         this.mutedState = { main: false, music: false, sfx: false };
         this.mutedGainSnapshot = {};
@@ -204,6 +220,8 @@ export class AudioManager {
     /**
      * Mutes or unmutes `bus`.
      *
+     * Cancels any in-flight {@link volumeSet} fade before applying the mute so a
+     * scheduled ramp or curve can never override the mute/unmute value afterward.
      * Muting snapshots the bus node's current gain value and zeroes the node
      * immediately (no fade). Unmuting restores the exact snapshotted value, so
      * a mute/unmute pair never destroys the level configured by {@link volumeSet}.
@@ -219,6 +237,8 @@ export class AudioManager {
         if (node === undefined || this.mutedState[bus] === muted) {
             return;
         }
+
+        node.gain.cancelScheduledValues(this.context?.currentTime ?? 0);
 
         if (muted) {
             // eslint-disable-next-line security/detect-object-injection -- bus is keyof AudioBus union, not arbitrary input
@@ -302,17 +322,24 @@ export class AudioManager {
      * Resumes the audio context on the first successful unlock gesture and
      * removes the gesture listeners. Left attached (to retry on the next
      * gesture) when `resume()` rejects.
+     *
+     * Guarded by {@link isUnlocking} so rapid-fire gestures (for example a
+     * pointerdown and a keydown in the same frame) only trigger one concurrent
+     * `resume()` attempt.
      */
     private unlock(): void {
-        if (this.unlocked || this.context === null) {
+        if (this.unlocked || this.isUnlocking || this.context === null) {
             return;
         }
+
+        this.isUnlocking = true;
 
         void this.resumeAndUnlock(this.context);
     }
 
     /**
-     * Awaits `context.resume()` and flips {@link unlocked} on success.
+     * Awaits `context.resume()` and flips {@link unlocked} on success. Always
+     * clears {@link isUnlocking} so a failed attempt can retry on the next gesture.
      *
      * @param context - Audio context to resume.
      */
@@ -324,6 +351,8 @@ export class AudioManager {
             this.removeUnlockListeners();
         } catch (error) {
             console.error('[BT] Failed to resume the audio context', error);
+        } finally {
+            this.isUnlocking = false;
         }
     }
 

--- a/src/audio/AudioManager.ts
+++ b/src/audio/AudioManager.ts
@@ -1,0 +1,421 @@
+/**
+ * Internal audio subsystem: Web Audio context, bus graph, browser autoplay-unlock
+ * state machine, and pre-unlock SFX/music drop counters.
+ *
+ * Owned by {@link BTAPI} (not itself a singleton) and never exposed to demo code.
+ * Actual SFX/music playback methods are added in a later phase; this class only
+ * manages the audio graph, bus volume/mute, and unlock tracking.
+ */
+
+import type { EasingFunction } from '../utils/Easing';
+import { applyEasing } from '../utils/Easing';
+
+/** Number of samples used to build an eased gain ramp curve for `setValueCurveAtTime`. */
+const FADE_CURVE_SAMPLE_COUNT = 32;
+
+/** Default (full) gain for a freshly created or reset bus. */
+const DEFAULT_BUS_VOLUME = 1;
+
+/** Minimum accepted bus volume. */
+const MIN_BUS_VOLUME = 0;
+
+/** Maximum accepted bus volume. */
+const MAX_BUS_VOLUME = 1;
+
+/** Named buses in the audio graph: `sfx` and `music` feed into `main`, which feeds `destination`. */
+export type AudioBus = 'main' | 'music' | 'sfx';
+
+/** Per-bus value keyed the same way as the bus graph (`main`, `music`, `sfx`). */
+type PerBus<T> = Record<AudioBus, T>;
+
+/**
+ * Owns the Web Audio context, the bus graph (`sfx` / `music` -> `main` -> `destination`),
+ * the autoplay-unlock state machine, and pre-unlock SFX/music request counters.
+ *
+ * Construct, then call {@link attach} with the rendering canvas. Call {@link detach}
+ * to remove listeners and close the audio context (engine restarts, tests).
+ *
+ * Actual SFX/music playback methods are added in a later phase; this class only
+ * exposes bus volume, mute, and unlock-state accessors.
+ */
+export class AudioManager {
+    /** Live Web Audio context, or `null` before {@link attach} / after {@link detach}. */
+    private context: AudioContext | null = null;
+
+    /** Gain nodes for the bus graph, or `null` before {@link attach} / after {@link detach}. */
+    private busNodes: PerBus<GainNode> | null = null;
+
+    /** Canvas passed to {@link attach}; the unlock gesture listener target. */
+    private target: HTMLCanvasElement | null = null;
+
+    /** `true` once a user gesture has successfully resumed the audio context. */
+    private unlocked = false;
+
+    /** Logical (pre-mute) volume per bus, reported by {@link volumeGet} regardless of mute state. */
+    private logicalVolume: PerBus<number>;
+
+    /** Mute flag per bus. */
+    private mutedState: PerBus<boolean>;
+
+    /** Raw gain value captured at mute time for each muted bus, restored verbatim by {@link muteSet}. */
+    private mutedGainSnapshot: Partial<PerBus<number>> = {};
+
+    /** Count of SFX play requests dropped while the audio context was locked. */
+    private sfxDroppedCount = 0;
+
+    /** Whether a music play request arrived while locked, remembered for later resumption. */
+    private isMusicRequestRemembered = false;
+
+    /** Bound `pointerdown` unlock gesture handler; removed by reference in {@link removeUnlockListeners}. */
+    private readonly onPointerDown: (event: Event) => void;
+
+    /** Bound `keydown` unlock gesture handler; removed by reference in {@link removeUnlockListeners}. */
+    private readonly onKeyDown: (event: Event) => void;
+
+    /** Bound `touchstart` unlock gesture handler; removed by reference in {@link removeUnlockListeners}. */
+    private readonly onTouchStart: (event: Event) => void;
+
+    /**
+     * Creates an `AudioManager` with no context, bus graph, or listeners attached.
+     *
+     * Binds the one-shot unlock-gesture handler references so {@link detach} can
+     * remove the same function instances that {@link attach} added, and
+     * initializes every bus to full logical volume and unmuted.
+     */
+    constructor() {
+        this.logicalVolume = { main: DEFAULT_BUS_VOLUME, music: DEFAULT_BUS_VOLUME, sfx: DEFAULT_BUS_VOLUME };
+        this.mutedState = { main: false, music: false, sfx: false };
+
+        this.onPointerDown = () => this.unlock();
+        this.onKeyDown = () => this.unlock();
+        this.onTouchStart = () => this.unlock();
+    }
+
+    /**
+     * Creates the audio context and bus graph, and installs one-shot unlock
+     * gesture listeners on `target`.
+     *
+     * Calls {@link detach} first so a repeated `attach()` (for example across
+     * engine restarts) never leaks a previous context or listener set.
+     *
+     * @param target - Canvas that receives the one-shot unlock gesture listeners.
+     */
+    public attach(target: HTMLCanvasElement): void {
+        this.detach();
+
+        this.target = target;
+        this.context = new AudioContext();
+        this.buildBusGraph(this.context);
+
+        target.addEventListener('pointerdown', this.onPointerDown);
+        target.addEventListener('keydown', this.onKeyDown);
+        target.addEventListener('touchstart', this.onTouchStart);
+    }
+
+    /**
+     * Removes unlock gesture listeners, closes the audio context, and resets
+     * all bus, mute, and drop-counter state. Safe to call repeatedly or before
+     * {@link attach}.
+     */
+    public detach(): void {
+        this.removeUnlockListeners();
+
+        if (this.context !== null) {
+            try {
+                void this.context.close();
+            } catch {
+                // Context may already be closed.
+            }
+        }
+
+        this.context = null;
+        this.busNodes = null;
+        this.target = null;
+        this.unlocked = false;
+        this.logicalVolume = { main: DEFAULT_BUS_VOLUME, music: DEFAULT_BUS_VOLUME, sfx: DEFAULT_BUS_VOLUME };
+        this.mutedState = { main: false, music: false, sfx: false };
+        this.mutedGainSnapshot = {};
+        this.sfxDroppedCount = 0;
+        this.isMusicRequestRemembered = false;
+    }
+
+    /**
+     * Reports whether the audio context has been unlocked by a user gesture.
+     *
+     * @returns `true` once {@link AudioContext.resume} has resolved after a gesture.
+     */
+    public isUnlocked(): boolean {
+        return this.unlocked;
+    }
+
+    /**
+     * Returns the logical (pre-mute) volume for `bus`.
+     *
+     * Unaffected by {@link muteSet} - muting never overwrites the configured level.
+     *
+     * @param bus - Audio bus to query.
+     * @returns Volume in `[0, 1]`.
+     */
+    public volumeGet(bus: AudioBus): number {
+        // eslint-disable-next-line security/detect-object-injection -- bus is keyof AudioBus union, not arbitrary input
+        return this.logicalVolume[bus];
+    }
+
+    /**
+     * Sets the logical volume for `bus` and applies it to the bus gain node,
+     * unless the bus is currently muted (in which case only the logical value
+     * updates; the audible gain stays at 0 until {@link muteSet} unmutes it).
+     *
+     * @param bus - Audio bus to update.
+     * @param volume - Target volume, clamped to `[0, 1]`.
+     * @param fadeMs - Optional fade duration in milliseconds; omit for an immediate change.
+     * @param easing - Easing curve for the fade. Defaults to `'linear'`; ignored when `fadeMs` is omitted.
+     */
+    public volumeSet(bus: AudioBus, volume: number, fadeMs?: number, easing: EasingFunction = 'linear'): void {
+        const clamped = clampVolume(volume);
+
+        // eslint-disable-next-line security/detect-object-injection -- bus is keyof AudioBus union, not arbitrary input
+        this.logicalVolume[bus] = clamped;
+
+        // eslint-disable-next-line security/detect-object-injection -- bus is keyof AudioBus union, not arbitrary input
+        if (this.mutedState[bus]) {
+            return;
+        }
+
+        // eslint-disable-next-line security/detect-object-injection -- bus is keyof AudioBus union, not arbitrary input
+        const node = this.busNodes?.[bus];
+
+        if (node === undefined) {
+            return;
+        }
+
+        this.applyBusGain(node, clamped, fadeMs, easing);
+    }
+
+    /**
+     * Reports whether `bus` is currently muted.
+     *
+     * @param bus - Audio bus to query.
+     * @returns `true` when the bus gain is held at 0 by {@link muteSet}.
+     */
+    public isMuted(bus: AudioBus): boolean {
+        // eslint-disable-next-line security/detect-object-injection -- bus is keyof AudioBus union, not arbitrary input
+        return this.mutedState[bus];
+    }
+
+    /**
+     * Mutes or unmutes `bus`.
+     *
+     * Muting snapshots the bus node's current gain value and zeroes the node
+     * immediately (no fade). Unmuting restores the exact snapshotted value, so
+     * a mute/unmute pair never destroys the level configured by {@link volumeSet}.
+     *
+     * @param bus - Audio bus to mute or unmute.
+     * @param muted - `true` to mute, `false` to unmute.
+     */
+    public muteSet(bus: AudioBus, muted: boolean): void {
+        // eslint-disable-next-line security/detect-object-injection -- bus is keyof AudioBus union, not arbitrary input
+        const node = this.busNodes?.[bus];
+
+        // eslint-disable-next-line security/detect-object-injection -- bus is keyof AudioBus union, not arbitrary input
+        if (node === undefined || this.mutedState[bus] === muted) {
+            return;
+        }
+
+        if (muted) {
+            // eslint-disable-next-line security/detect-object-injection -- bus is keyof AudioBus union, not arbitrary input
+            this.mutedGainSnapshot[bus] = node.gain.value;
+            node.gain.value = 0;
+        } else {
+            // eslint-disable-next-line security/detect-object-injection -- bus is keyof AudioBus union, not arbitrary input
+            node.gain.value = this.mutedGainSnapshot[bus] ?? this.logicalVolume[bus];
+        }
+
+        // eslint-disable-next-line security/detect-object-injection -- bus is keyof AudioBus union, not arbitrary input
+        this.mutedState[bus] = muted;
+    }
+
+    /**
+     * Records an SFX play request dropped while the audio context was locked.
+     *
+     * Called by future SFX playback methods; only the counter is implemented here.
+     */
+    public noteDroppedSfx(): void {
+        this.sfxDroppedCount += 1;
+    }
+
+    /**
+     * Returns the number of SFX play requests dropped before unlock.
+     *
+     * @returns Dropped SFX request count.
+     */
+    public getDroppedSfxCount(): number {
+        return this.sfxDroppedCount;
+    }
+
+    /**
+     * Remembers that a music play request arrived while the audio context was
+     * locked, so future playback can resume it once unlocked.
+     *
+     * Called by future music playback methods; only the flag is implemented here.
+     */
+    public rememberMusicRequest(): void {
+        this.isMusicRequestRemembered = true;
+    }
+
+    /**
+     * Reports whether a music play request is remembered from before unlock.
+     *
+     * @returns `true` when a pre-unlock music request is pending resumption.
+     */
+    public hasRememberedMusicRequest(): boolean {
+        return this.isMusicRequestRemembered;
+    }
+
+    /**
+     * Clears the remembered pre-unlock music request.
+     *
+     * Called by future music playback methods once the remembered request has
+     * been handled.
+     */
+    public clearRememberedMusicRequest(): void {
+        this.isMusicRequestRemembered = false;
+    }
+
+    /**
+     * Creates the `sfx` / `music` / `main` gain nodes and wires `sfx` and
+     * `music` into `main`, which connects to `destination`.
+     *
+     * @param context - Audio context to build the graph on.
+     */
+    private buildBusGraph(context: AudioContext): void {
+        const main = context.createGain();
+        const music = context.createGain();
+        const sfx = context.createGain();
+
+        music.connect(main);
+        sfx.connect(main);
+        main.connect(context.destination);
+
+        this.busNodes = { main, music, sfx };
+    }
+
+    /**
+     * Resumes the audio context on the first successful unlock gesture and
+     * removes the gesture listeners. Left attached (to retry on the next
+     * gesture) when `resume()` rejects.
+     */
+    private unlock(): void {
+        if (this.unlocked || this.context === null) {
+            return;
+        }
+
+        void this.resumeAndUnlock(this.context);
+    }
+
+    /**
+     * Awaits `context.resume()` and flips {@link unlocked} on success.
+     *
+     * @param context - Audio context to resume.
+     */
+    private async resumeAndUnlock(context: AudioContext): Promise<void> {
+        try {
+            await context.resume();
+
+            this.unlocked = true;
+            this.removeUnlockListeners();
+        } catch (error) {
+            console.error('[BT] Failed to resume the audio context', error);
+        }
+    }
+
+    /**
+     * Removes the pointerdown/keydown/touchstart unlock gesture listeners from
+     * {@link target}. Safe to call when not attached or already removed.
+     */
+    private removeUnlockListeners(): void {
+        if (this.target === null) {
+            return;
+        }
+
+        this.target.removeEventListener('pointerdown', this.onPointerDown);
+        this.target.removeEventListener('keydown', this.onKeyDown);
+        this.target.removeEventListener('touchstart', this.onTouchStart);
+    }
+
+    /**
+     * Schedules or immediately applies a gain change on `node`.
+     *
+     * With no `fadeMs` (or a non-positive one), sets `node.gain.value` immediately.
+     * With `fadeMs`, anchors the ramp to `context.currentTime`: `'linear'` easing uses
+     * `linearRampToValueAtTime`; other easings sample {@link applyEasing} into a curve
+     * fed to `setValueCurveAtTime`.
+     *
+     * @param node - Gain node to update.
+     * @param targetValue - Target gain value.
+     * @param fadeMs - Optional fade duration in milliseconds.
+     * @param easing - Easing curve applied when `fadeMs` is a positive duration.
+     */
+    private applyBusGain(
+        node: GainNode,
+        targetValue: number,
+        fadeMs: number | undefined,
+        easing: EasingFunction,
+    ): void {
+        const context = this.context;
+
+        if (context === null || fadeMs === undefined || fadeMs <= 0) {
+            node.gain.value = targetValue;
+
+            return;
+        }
+
+        const startValue = node.gain.value;
+        const now = context.currentTime;
+        const durationSeconds = fadeMs / 1000;
+
+        node.gain.cancelScheduledValues(now);
+        node.gain.setValueAtTime(startValue, now);
+
+        if (easing === 'linear') {
+            node.gain.linearRampToValueAtTime(targetValue, now + durationSeconds);
+
+            return;
+        }
+
+        node.gain.setValueCurveAtTime(sampleEasingCurve(startValue, targetValue, easing), now, durationSeconds);
+    }
+}
+
+/**
+ * Samples an eased gain curve from `startValue` to `targetValue` for
+ * `AudioParam.setValueCurveAtTime`.
+ *
+ * @param startValue - Gain value at the start of the fade.
+ * @param targetValue - Gain value at the end of the fade.
+ * @param easing - Easing curve to sample.
+ * @returns Sampled curve of {@link FADE_CURVE_SAMPLE_COUNT} values.
+ */
+function sampleEasingCurve(startValue: number, targetValue: number, easing: EasingFunction): Float32Array {
+    const curve = new Float32Array(FADE_CURVE_SAMPLE_COUNT);
+
+    for (let i = 0; i < FADE_CURVE_SAMPLE_COUNT; i++) {
+        const t = i / (FADE_CURVE_SAMPLE_COUNT - 1);
+        const eased = applyEasing(t, easing);
+
+        // eslint-disable-next-line security/detect-object-injection -- bounded loop counter
+        curve[i] = startValue + (targetValue - startValue) * eased;
+    }
+
+    return curve;
+}
+
+/**
+ * Clamps a bus volume to `[0, 1]`.
+ *
+ * @param volume - Raw volume value.
+ * @returns Volume clamped to `[MIN_BUS_VOLUME, MAX_BUS_VOLUME]`.
+ */
+function clampVolume(volume: number): number {
+    return Math.min(MAX_BUS_VOLUME, Math.max(MIN_BUS_VOLUME, volume));
+}

--- a/src/core/BTAPI.test.ts
+++ b/src/core/BTAPI.test.ts
@@ -51,12 +51,13 @@ function resetSingleton(): void {
     (BTAPI as unknown as { _instance: BTAPI | null })._instance = null;
 }
 
-function makeMockDemo(targetFPS = 60, initResult = true): IBTDemo {
+function makeMockDemo(targetFPS = 60, initResult = true, audioVoices?: number): IBTDemo {
     return {
         configure: vi.fn().mockReturnValue({
             displaySize: new Vector2i(320, 240),
             drawingBufferSize: new Vector2i(640, 480),
             targetFPS,
+            ...(audioVoices === undefined ? {} : { audioVoices }),
         }),
         init: vi.fn().mockResolvedValue(initResult),
         update: vi.fn(),
@@ -357,6 +358,44 @@ describe('BTAPI', () => {
             const result = await BTAPI.instance.init(makeMockDemo(-30), makeMockCanvas());
 
             expect(result).toBe(false);
+        });
+
+        it('should return false for non-integer audioVoices', async () => {
+            const result = await BTAPI.instance.init(makeMockDemo(60, true, 1.5), makeMockCanvas());
+
+            expect(result).toBe(false);
+        });
+
+        it('should return false for audioVoices below 1', async () => {
+            const result = await BTAPI.instance.init(makeMockDemo(60, true, 0), makeMockCanvas());
+
+            expect(result).toBe(false);
+        });
+
+        it('should return false for audioVoices above 64', async () => {
+            const result = await BTAPI.instance.init(makeMockDemo(60, true, 65), makeMockCanvas());
+
+            expect(result).toBe(false);
+        });
+
+        it('should accept the default audioVoices (16)', async () => {
+            const result = await BTAPI.instance.init(makeMockDemo(), makeMockCanvas());
+
+            expect(result).toBe(true);
+        });
+
+        it('should accept a valid custom audioVoices value', async () => {
+            const result = await BTAPI.instance.init(makeMockDemo(60, true, 32), makeMockCanvas());
+
+            expect(result).toBe(true);
+        });
+
+        it('should accept the boundary audioVoices values 1 and 64', async () => {
+            expect(await BTAPI.instance.init(makeMockDemo(60, true, 1), makeMockCanvas())).toBe(true);
+
+            resetSingleton();
+
+            expect(await BTAPI.instance.init(makeMockDemo(60, true, 64), makeMockCanvas())).toBe(true);
         });
 
         it('rejects invalid displaySize before layout or renderer setup', async () => {

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -10,7 +10,6 @@ import {
 } from '../assets/PaletteEffect';
 import type { SpriteSheet } from '../assets/SpriteSheet';
 import { createSystemFont } from '../assets/SystemFont';
-import type { AudioBus } from '../audio/AudioManager';
 import { AudioManager } from '../audio/AudioManager';
 import { GamepadInput } from '../input/GamepadInput';
 import { KeyboardInput } from '../input/KeyboardInput';
@@ -36,7 +35,7 @@ import { RenderDimensionLimitError, validateDimensions } from '../utils/RenderLi
 import { Vector2i } from '../utils/Vector2i';
 import type { FrameDropCallback, FrameDropEvent } from './GameLoop';
 import { GameLoop } from './GameLoop';
-import type { Backend, HardwareSettings, IBTDemo } from './IBTDemo';
+import type { AudioBus, Backend, HardwareSettings, IBTDemo } from './IBTDemo';
 import {
     defaultConfig,
     mergeHardwareSettings,

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -994,7 +994,7 @@ export class BTAPI {
      * Reads and validates demo `configure()` output into resolved hardware settings.
      *
      * @param demo - Demo implementing {@link IBTDemo}.
-     * @returns `false` when hardware settings are invalid (bad dimensions or targetFPS).
+     * @returns `false` when hardware settings are invalid (bad dimensions, targetFPS, or audioVoices).
      */
     private loadHardwareSettings(demo: IBTDemo): boolean {
         try {
@@ -1019,6 +1019,14 @@ export class BTAPI {
 
         if (!Number.isFinite(targetFPS) || targetFPS <= 0) {
             console.error(`[BT] Invalid targetFPS: ${targetFPS}. Must be a finite number > 0.`);
+
+            return false;
+        }
+
+        const { audioVoices } = this.hwSettings;
+
+        if (audioVoices !== undefined && (!Number.isInteger(audioVoices) || audioVoices < 1 || audioVoices > 64)) {
+            console.error(`[BT] ${errorMessages.audioVoicesRangeError(audioVoices)}`);
 
             return false;
         }

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -10,6 +10,8 @@ import {
 } from '../assets/PaletteEffect';
 import type { SpriteSheet } from '../assets/SpriteSheet';
 import { createSystemFont } from '../assets/SystemFont';
+import type { AudioBus } from '../audio/AudioManager';
+import { AudioManager } from '../audio/AudioManager';
 import { GamepadInput } from '../input/GamepadInput';
 import { KeyboardInput } from '../input/KeyboardInput';
 import { PointerInput } from '../input/PointerInput';
@@ -176,11 +178,14 @@ export class BTAPI {
     /** Keyboard input. Created during {@link init}. */
     private keyboard: KeyboardInput | null = null;
 
-    // TODO: Additional subsystems for future implementation:
-    // AudioManager, AssetManager
-
     /** Gamepad input. Created during {@link init}. */
     private gamepad: GamepadInput | null = null;
+
+    /** Audio context, bus graph, and unlock state. Created during {@link init}. */
+    private audio: AudioManager | null = null;
+
+    // TODO: Additional subsystems for future implementation:
+    // AssetManager
 
     /**
      * Private constructor to enforce singleton access via `BTAPI.instance`.
@@ -277,8 +282,7 @@ export class BTAPI {
         this.systemFont = createSystemFont();
         this.setupOverlay();
         this.attachInputSubsystems(canvas);
-
-        // TODO: Initialize audio subsystem when implemented.
+        this.attachAudioSubsystem(canvas);
 
         console.log('[BT] Initializing demo');
 
@@ -412,11 +416,11 @@ export class BTAPI {
     }
 
     /**
-     * Stops the active game loop and detaches input subsystems.
+     * Stops the active game loop and detaches input and audio subsystems.
      *
-     * Pointer, keyboard, and gamepad subsystems are detached so listeners and
-     * polling state do not leak across engine restarts (relevant in tests where
-     * the same DOM persists).
+     * Pointer, keyboard, gamepad, and audio subsystems are detached so listeners,
+     * polling state, and the audio context do not leak across engine restarts
+     * (relevant in tests where the same DOM persists).
      */
     public stop(): void {
         this.loop?.stop();
@@ -487,6 +491,70 @@ export class BTAPI {
      */
     public getCanvas(): HTMLCanvasElement | null {
         return this.canvas;
+    }
+
+    /**
+     * Gets the audio subsystem, internal only; never exposed via the `BT` namespace.
+     *
+     * @returns Audio manager, or null if not initialized.
+     */
+    public getAudio(): AudioManager | null {
+        return this.audio;
+    }
+
+    /**
+     * Reports whether the audio context has been unlocked by a user gesture.
+     *
+     * @returns `true` once unlocked; `false` when locked or not initialized.
+     */
+    public isAudioUnlocked(): boolean {
+        return this.audio?.isUnlocked() ?? false;
+    }
+
+    /**
+     * Sets the logical volume for an audio bus, optionally fading to it.
+     *
+     * No-op when the audio subsystem is not initialized.
+     *
+     * @param bus - Audio bus to update.
+     * @param volume - Target volume, clamped to `[0, 1]`.
+     * @param fadeMs - Optional fade duration in milliseconds; omit for an immediate change.
+     * @param easing - Easing curve for the fade. Defaults to `'linear'`; ignored when `fadeMs` is omitted.
+     */
+    public audioVolumeSet(bus: AudioBus, volume: number, fadeMs?: number, easing?: EasingFunction): void {
+        this.audio?.volumeSet(bus, volume, fadeMs, easing);
+    }
+
+    /**
+     * Gets the logical (pre-mute) volume for an audio bus.
+     *
+     * @param bus - Audio bus to query.
+     * @returns Volume in `[0, 1]`, or `0` when the audio subsystem is not initialized.
+     */
+    public audioVolumeGet(bus: AudioBus): number {
+        return this.audio?.volumeGet(bus) ?? 0;
+    }
+
+    /**
+     * Mutes or unmutes an audio bus.
+     *
+     * No-op when the audio subsystem is not initialized.
+     *
+     * @param bus - Audio bus to mute or unmute.
+     * @param muted - `true` to mute, `false` to unmute.
+     */
+    public audioMuteSet(bus: AudioBus, muted: boolean): void {
+        this.audio?.muteSet(bus, muted);
+    }
+
+    /**
+     * Reports whether an audio bus is currently muted.
+     *
+     * @param bus - Audio bus to query.
+     * @returns `true` when muted; `false` when unmuted or not initialized.
+     */
+    public isAudioMuted(bus: AudioBus): boolean {
+        return this.audio?.isMuted(bus) ?? false;
     }
 
     /**
@@ -1102,6 +1170,23 @@ export class BTAPI {
     }
 
     /**
+     * Attaches the audio context, bus graph, and unlock listeners to the canvas.
+     *
+     * @param canvas - Render target canvas.
+     */
+    private attachAudioSubsystem(canvas: HTMLCanvasElement): void {
+        const hw = this.hwSettings;
+
+        if (!hw) {
+            return;
+        }
+
+        this.audio?.detach();
+        this.audio = new AudioManager();
+        this.audio.attach(canvas);
+    }
+
+    /**
      * Constructs and initializes the renderer for the active hardware settings.
      *
      * Logs the selected backend name, constructs the matching {@link IRenderer},
@@ -1213,10 +1298,11 @@ export class BTAPI {
     }
 
     /**
-     * Removes pointer, keyboard, and gamepad subsystems.
+     * Removes pointer, keyboard, gamepad, and audio subsystems.
      *
-     * Pointer/keyboard detach DOM listeners; gamepad detaches polling state and
-     * clears subsystem references.
+     * Pointer/keyboard detach DOM listeners; gamepad detaches polling state; audio
+     * detaches unlock listeners and closes the audio context. All subsystem
+     * references are cleared so listeners/contexts do not leak across restarts.
      */
     private clearInputSubsystems(): void {
         this.pointer?.detach();
@@ -1227,12 +1313,15 @@ export class BTAPI {
 
         this.gamepad?.detach();
         this.gamepad = null;
+
+        this.audio?.detach();
+        this.audio = null;
     }
 
     /**
      * Runs the demo's async {@link IBTDemo.init}. On throw or
-     * `false`, clears input subsystems that were attached earlier in the init
-     * sequence.
+     * `false`, clears input and audio subsystems that were attached earlier in
+     * the init sequence.
      *
      * @param demo - Active demo instance.
      * @returns `true` when the demo reports success.

--- a/src/core/IBTDemo.test.ts
+++ b/src/core/IBTDemo.test.ts
@@ -58,6 +58,12 @@ describe('defaultConfig', () => {
         expect(settings.backend).toBe('webgpu');
     });
 
+    it('should default audioVoices to 16', () => {
+        const settings = defaultConfig();
+
+        expect(settings.audioVoices).toBe(16);
+    });
+
     it('should enable overlay by default', () => {
         const settings = defaultConfig();
 
@@ -134,6 +140,30 @@ describe('mergeHardwareSettings', () => {
         expect(settings.drawingBufferSize).toBeUndefined();
         expect(settings.targetFPS).toBe(60);
         expect(settings.backend).toBe('webgpu');
+    });
+
+    it('merges audioVoices-only partials with full defaults', () => {
+        const settings = mergeHardwareSettings({ audioVoices: 32 });
+
+        expect(settings.audioVoices).toBe(32);
+        expect(settings.targetFPS).toBe(60);
+    });
+
+    it('keeps audioVoices unset when displaySize is provided without an explicit audioVoices', () => {
+        const settings = mergeHardwareSettings({
+            displaySize: new Vector2i(320, 240),
+        });
+
+        expect(settings.audioVoices).toBeUndefined();
+    });
+
+    it('applies an explicit audioVoices alongside displaySize', () => {
+        const settings = mergeHardwareSettings({
+            displaySize: new Vector2i(320, 240),
+            audioVoices: 8,
+        });
+
+        expect(settings.audioVoices).toBe(8);
     });
 
     it('applies only provided fields when displaySize is set', () => {

--- a/src/core/IBTDemo.ts
+++ b/src/core/IBTDemo.ts
@@ -19,6 +19,14 @@ export type OutputUpscaleFilter = 'nearest' | 'linear';
 export type Backend = 'webgpu' | 'software';
 
 /**
+ * Named buses in the audio graph, used by {@link BT.audioVolumeSet},
+ * {@link BT.audioVolumeGet}, {@link BT.audioMuteSet}, and {@link BT.isAudioMuted}.
+ *
+ * `'sfx'` and `'music'` feed into `'main'`, which feeds the audio destination.
+ */
+export type AudioBus = 'main' | 'music' | 'sfx';
+
+/**
  * Engine-facing hardware configuration returned by `configure()` when a demo
  * implements that optional hook, or by {@link defaultConfig} otherwise.
  */

--- a/src/core/IBTDemo.ts
+++ b/src/core/IBTDemo.ts
@@ -117,6 +117,12 @@ export interface HardwareSettings {
     backend?: Backend;
 
     /**
+     * Maximum number of simultaneous audio voices (concurrently playing sounds). Defaults to
+     * `16` in {@link defaultConfig}. Valid range is `1`-`64`.
+     */
+    audioVoices?: number;
+
+    /**
      * When `true` (default), the engine draws a screen-space overlay after
      * each demo `render()` call (FPS, target rate, resolution, backend, demo title).
      * The overlay body starts hidden unless {@link isOverlayVisibleAtStart} is
@@ -427,6 +433,7 @@ export function defaultConfig(): HardwareSettings {
         targetFPS: 60,
         outputUpscaleFilter: 'nearest',
         backend: 'webgpu',
+        audioVoices: 16,
         isOverlayEnabled: true,
         isOverlayVisibleAtStart: false,
         isOverlayToggleHintVisible: true,
@@ -585,6 +592,7 @@ function pickDefinedHardwareSettings(partial: Partial<HardwareSettings>): Partia
     pickIfDefinedPartial(picked, partial, 'outputUpscaleFilter');
     pickIfDefinedPartial(picked, partial, 'isDetectingDroppedFrames');
     pickIfDefinedPartial(picked, partial, 'backend');
+    pickIfDefinedPartial(picked, partial, 'audioVoices');
     pickDefinedOverlaySettings(picked, partial);
 
     return picked;
@@ -725,6 +733,7 @@ function assignFullDefaultMergeScalars(
         picked.isDetectingDroppedFrames ?? defaults.isDetectingDroppedFrames,
     );
     assignIfDefined(optionals, 'backend', picked.backend ?? defaults.backend);
+    assignIfDefined(optionals, 'audioVoices', picked.audioVoices ?? defaults.audioVoices);
 
     assignIfDefined(optionals, 'overlayStyle', shallowCloneOptional(picked.overlayStyle ?? defaults.overlayStyle));
 
@@ -822,6 +831,7 @@ function buildExplicitDisplayOptionals(
     );
     assignIfDefined(optionals, 'outputUpscaleFilter', picked.outputUpscaleFilter);
     assignIfDefined(optionals, 'isDetectingDroppedFrames', picked.isDetectingDroppedFrames);
+    assignIfDefined(optionals, 'audioVoices', picked.audioVoices);
     assignIfDefined(optionals, 'overlayStyle', shallowCloneOptional(picked.overlayStyle));
     assignIfDefined(optionals, 'overlayPaletteColumns', picked.overlayPaletteColumns);
     assignIfDefined(optionals, 'overlayPaletteRowsVisible', picked.overlayPaletteRowsVisible);

--- a/src/utils/errorMessages.ts
+++ b/src/utils/errorMessages.ts
@@ -107,6 +107,19 @@ export function renderDimensionGPULimitError(field: string, size: string, maxTex
 }
 
 /**
+ * Returns the error message for an `audioVoices` hardware setting outside the supported range.
+ *
+ * @param value - Invalid `audioVoices` value.
+ * @returns User-facing error string.
+ */
+export function audioVoicesRangeError(value: number): string {
+    return (
+        `audioVoices must be a whole number from 1 to 64 (got ${value}). ` +
+        'Update configure() to return a valid voice count'
+    );
+}
+
+/**
  * Returns the error message for an asset whose width or height is not a positive whole number.
  *
  * @param context - Asset label (for example `'sprite sheet'`).


### PR DESCRIPTION
- Resolves: #319

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Implemented a fully wired internal audio subsystem for BT:

- Added an internal `AudioManager`, created during `BTAPI.init()` and detached during shutdown, to manage a Web Audio context and bus graph.
- Built the audio bus topology (`sfx` and `music` into `main`, then to `destination`) with per-bus logical volume, optional fading/easing, and mute/unmute behavior that preserves/restores volume.
- Implemented autoplay unlock handling: the audio context is created eagerly, resumes on the first user gesture, unlock is tracked via `BT.isAudioUnlocked`, and unlock logic prevents duplicate resume attempts.
- Added pre-unlock bookkeeping for dropped SFX and remembered music requests.
- Introduced `HardwareSettings.audioVoices` (default `16`, validated as an integer in range `1–64`) with a dedicated `audioVoicesRangeError`.
- Exposed BT audio controls on the public facade: `audioVolumeSet`, `audioVolumeGet`, `audioMuteSet`, `isAudioMuted`, plus the `isAudioUnlocked` runtime-state getter (with safe no-op/default behavior when audio isn’t initialized).
- Added Web Audio test mocks (`src/__test__/webaudio-mock.ts`) and expanded unit tests for attach/detach, attach failure behavior, bus graph connections, volume/mute semantics, and unlock gesture state transitions.
- Updated documentation and reference pages to describe the new Audio API (`api-audio.md`, `guide-audio.md`) and reflect `isAudioUnlocked` and the new audio methods/getters across BT API docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->