### PR TITLE
feat: enhance audio management with VoicePool and AudioParam improvements

### DIFF
--- a/.cursor/rules/bt-api-getters.mdc
+++ b/.cursor/rules/bt-api-getters.mdc
@@ -33,7 +33,9 @@ Bad: `BT.displaySize()`, `BT.fps()`, `BT.getActiveBackend()` (removed; use prope
 - **Post-process:** `effectAdd`, `effectRemove`, `effectClear`; preset namespace **`BT.preset`** (`crtPipBoy`, `amber`,
   `green`)
 - **Audio:** `audioVolumeSet(bus, value, options?)`, `audioVolumeGet(bus)`, `audioMuteSet(bus, muted)`,
-  `isAudioMuted(bus)`
+  `isAudioMuted(bus)`, `soundPlay(clip, options?)`, `soundStop(ref, options?)`, `isSoundPlaying(ref)`,
+  `soundVolumeSet(ref, value, options?)`, `soundVolumeGet(ref)`, `soundPitchSet(ref, value, options?)`,
+  `soundPitchGet(ref)`, `soundPanSet(ref, value, options?)`, `soundPanGet(ref)`
 - **Drawing / clearing:** `clear`, `clearRect`, `drawPixel`, `drawLine`, `drawRect`, `drawRectFill`, `drawSprite`,
   `systemPrint`, `printFont` (4th arg is optional **`paletteOffset`**, not `Color32`)
 - Any **parameter**: `pointerPos(0)`, `isDown(BT.BTN_A)`, `cameraClamp(...)`

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -152,12 +152,12 @@ jobs:
 
       - name: Check size limits
         run: |
-          # Fail if gzipped ESM exceeds 55 KB (adjust as needed)
+          # Fail if gzipped ESM exceeds 60 KB (adjust as needed)
           ESM_GZIP=${{ steps.size.outputs.esm_gzip }}
-          MAX_SIZE=56320  # 55 KB in bytes
+          MAX_SIZE=61440  # 60 KB in bytes
 
           if [ "$ESM_GZIP" -gt "$MAX_SIZE" ]; then
-            echo "::error::Bundle size (${{ steps.size.outputs.esm_gzip_kb }} KB gzipped) exceeds limit (55 KB)"
+            echo "::error::Bundle size (${{ steps.size.outputs.esm_gzip_kb }} KB gzipped) exceeds limit (60 KB)"
             exit 1
           fi
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ Before writing new code, reviewing existing code, or preflighting, check here fi
 | What agent skills are available for this project?              | `.agents/skills/` (Zed) and `.claude/skills/` (Claude Code) – `bt-preflight`, `bt-review`, `bt-pr`, `bt-format`, `bt-perf`, `bt-test`, `bt-release`, `bt-spellcheck`, `bt-security-run`, `bt-deep-review`, `bt-quick-format` |
 | How do users start a new project with the engine?              | `npm create blit386@latest` – the scaffolder lives in the sibling `create-blit386` repo; see Onboarding and the scaffolder below                                                                                             |
 | How do I load an audio clip?                                   | `src/assets/AudioClip.ts`, `docs/api-audio.md` (Loading section), `docs/guide-audio.md` (Preloading audio clips)                                                                                                             |
-| How does the SFX voice pool allocate/steal voices?             | `src/audio/VoicePool.ts` (internal-only – not yet exposed via `BT`)                                                                                                                                                          |
+| How does the SFX voice pool allocate/steal voices?             | `src/audio/VoicePool.ts`; exposed via `BT.soundPlay` and friends (`docs/api-audio.md`, Playback (SFX) section)                                                                                                               |
 
 ## Onboarding and the scaffolder
 
@@ -381,7 +381,10 @@ Examples: `BT.displaySize.y`, `BT.targetFPS`, `BT.ticks % 60`, `if (BT.activeBac
   `paletteClearEffects`.
 - Post-process: `effectAdd`, `effectRemove`, `effectClear`; preset namespace `BT.preset` (`crtPipBoy`, `amber`,
   `green`).
-- Audio: `audioVolumeSet(bus, value, options?)`, `audioVolumeGet(bus)`, `audioMuteSet(bus, muted)`, `isAudioMuted(bus)`.
+- Audio: `audioVolumeSet(bus, value, options?)`, `audioVolumeGet(bus)`, `audioMuteSet(bus, muted)`, `isAudioMuted(bus)`,
+  `soundPlay(clip, options?)`, `soundStop(ref, options?)`, `isSoundPlaying(ref)`,
+  `soundVolumeSet(ref, value, options?)`, `soundVolumeGet(ref)`, `soundPitchSet(ref, value, options?)`,
+  `soundPitchGet(ref)`, `soundPanSet(ref, value, options?)`, `soundPanGet(ref)`.
 - Drawing / clearing: `clear`, `clearRect`, `drawPixel`, `drawLine`, `drawRect`, `drawRectFill`, `drawSprite`,
   `systemPrint`, `printFont`.
 - Parameterized queries: `pointerPos(index?)`, `pointerDelta`, `isPointerActive`, `isDown`, `isPressed`, `isReleased`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ Before writing new code, reviewing existing code, or preflighting, check here fi
 | What agent skills are available for this project?              | `.agents/skills/` (Zed) and `.claude/skills/` (Claude Code) – `bt-preflight`, `bt-review`, `bt-pr`, `bt-format`, `bt-perf`, `bt-test`, `bt-release`, `bt-spellcheck`, `bt-security-run`, `bt-deep-review`, `bt-quick-format` |
 | How do users start a new project with the engine?              | `npm create blit386@latest` – the scaffolder lives in the sibling `create-blit386` repo; see Onboarding and the scaffolder below                                                                                             |
 | How do I load an audio clip?                                   | `src/assets/AudioClip.ts`, `docs/api-audio.md` (Loading section), `docs/guide-audio.md` (Preloading audio clips)                                                                                                             |
+| How does the SFX voice pool allocate/steal voices?             | `src/audio/VoicePool.ts` (internal-only – not yet exposed via `BT`)                                                                                                                                                          |
 
 ## Onboarding and the scaffolder
 
@@ -271,8 +272,9 @@ src/
     GamepadInput.ts        # Polling-based gamepad input tracker (4 players, axes, buttons, dead zone)
     defaultKeyboardMap.ts  # Default face-button key tables; clone helpers for BT.inputMapReset
   audio/
-    AudioManager.ts        # Web Audio context, bus graph (sfx/music -> main -> destination), unlock state, mute/volume
-    audioDecodeContext.ts  # Module-scoped decode-context registry + AudioClip unload seam (Phase 2 plumbing)
+    AudioManager.ts        # Web Audio context, bus graph (sfx/music -> main -> destination), unlock state, mute/volume, SFX playback
+    audioDecodeContext.ts  # Module-scoped decode-context registry + AudioClip unload seam (wired to VoicePool)
+    VoicePool.ts            # Fixed-size SFX voice pool: allocation/stealing, generational SoundRef handles, per-voice fades
   utils/
     Bootstrap.ts           # Demo bootstrap utilities
     BootstrapHelpers.ts    # Canvas lookup and error display utilities
@@ -284,6 +286,7 @@ src/
     Rect2i.ts              # Integer rectangle
     Color32.ts             # 32-bit RGBA color
     Easing.ts              # Easing functions for palette effects
+    AudioParamRamp.ts       # Shared AudioParam ramp scheduling (bus fades + per-voice fades)
     FrameCapture.ts        # GPU readback + PNG export
     Timer.ts               # Elapsed-time helper (exported; Timer.fireIfElapsed)
   __test__/

--- a/docs/api-audio.md
+++ b/docs/api-audio.md
@@ -144,13 +144,87 @@ theme.unload(); // releases the decoded buffer; safe to call more than once
   unsupported container/codec decode failures, and loading before the engine has started.
 - Prefer a fallback list (for example `['theme.ogg', 'theme.mp3']`) for any clip whose primary format might not decode
   in every browser - see [Audio formats](api-browser-support.md#audio-formats).
-- Playing loaded clips back (SFX/music voices routed through the bus graph) is not implemented yet; this phase covers
-  the bus graph, volume, mute, unlock tracking, and clip loading that a future playback API will build on.
+- Playing a loaded clip back as SFX is covered in [Playback (SFX)](#playback-sfx) below. Music playback (a separate,
+  loopable player distinct from the SFX voice pool) is not implemented yet.
+
+## Playback (SFX)
+
+`BT.soundPlay` plays a loaded `AudioClip` through a fixed-size pool of SFX voices. Each call returns an opaque
+`SoundRef` handle - pass it to `BT.soundStop` and the per-sound volume, pitch, and pan controls.
+
+```ts twoslash
+import { AudioClip, BT } from 'blit386';
+
+const hit = await AudioClip.load('audio/hit.mp3');
+
+const ref = BT.soundPlay(hit, { volume: 0.8 });
+
+BT.isSoundPlaying(ref); // true
+
+BT.soundStop(ref, { fadeOutMs: 200 }); // fades out over 200 ms
+```
+
+`options` fields:
+
+<TypeTable type={{
+    loop: { type: 'boolean', default: 'false', description: 'Whether the clip loops.' },
+    volume: { type: 'number', default: '1', description: 'Initial gain in [0, 1] (unclamped).' },
+    pitch: { type: 'number', default: '1', description: 'Initial playback rate.' },
+    pan: { type: 'number', default: '0', description: 'Initial stereo pan in [-1, 1] (unclamped).' },
+    priority: { type: 'number', default: '0', description: 'Allocation priority; higher survives voice stealing longer.' },
+    fadeInMs: { type: 'number', description: 'Linear fade-in duration in milliseconds, from silence to volume.' },
+    atTime: { type: 'number', description: 'Audio-clock start time. Defaults to "now".' },
+  }} />
+
+<Callout title="Voice cap and stealing">
+
+`HardwareSettings.audioVoices` (default `16`) sizes a fixed pool of voices - it never grows. When every voice is in use,
+a new `BT.soundPlay` call steals the lowest-priority active voice at or below the incoming priority (ties broken by
+whichever voice started first). If every active voice outranks the incoming priority, the new sound is dropped silently:
+no throw, and the returned `SoundRef` is inert (`BT.isSoundPlaying` reports `false` for it immediately).
+
+</Callout>
+
+A common pattern - vary pitch slightly per play so a repeated sound (footsteps, hits) doesn't sound robotic:
+
+```ts twoslash
+import { AudioClip, BT } from 'blit386';
+
+const footstep = await AudioClip.load('audio/footstep.mp3');
+
+function playFootstep() {
+  const pitch = 0.9 + Math.random() * 0.2; // 0.9-1.1x
+
+  BT.soundPlay(footstep, { pitch, volume: 0.6 });
+}
+```
+
+Per-sound controls, all silent no-ops on a stale or invalid `SoundRef` (already stopped, stolen, or completed - never
+throws):
+
+```ts twoslash
+import { AudioClip, BT } from 'blit386';
+
+const hit = await AudioClip.load('audio/hit.mp3');
+const ref = BT.soundPlay(hit);
+// ---cut---
+BT.soundVolumeSet(ref, 0.5, { fadeMs: 100 });
+BT.soundVolumeGet(ref); // 0.5
+
+BT.soundPitchSet(ref, 1.2);
+BT.soundPitchGet(ref); // 1.2
+
+BT.soundPanSet(ref, -0.3);
+BT.soundPanGet(ref); // -0.3
+```
+
+`BT.soundPlay` also returns an inert `SoundRef` (no throw) when `clip` hasn't finished loading yet, or was already
+released with `clip.unload()`.
 
 ## Hardware settings
 
-`audioVoices` (default `16`, reserved for an upcoming SFX voice-limiting pass; not yet enforced) is documented in
-[Hardware settings](api-core.md#hardware-settings).
+`audioVoices` (default `16`) caps the number of simultaneous SFX voices - see [Playback (SFX)](#playback-sfx) for the
+allocation and stealing policy. Documented in [Hardware settings](api-core.md#hardware-settings).
 
 ## See also
 

--- a/docs/guide-audio.md
+++ b/docs/guide-audio.md
@@ -123,6 +123,21 @@ This cap exists because each slot is a real `AudioBufferSourceNode -> GainNode -
 pool grow unbounded would let a busy scene (an explosion with dozens of debris impacts, for example) spend unbounded CPU
 on nodes the player can't meaningfully hear over each other anyway.
 
+A sound that plays often (footsteps, hits, bullet casings) reads as repetitive at a fixed pitch - vary it slightly per
+play instead:
+
+```ts twoslash
+import { AudioClip, BT } from 'blit386';
+
+const footstep = await AudioClip.load('audio/footstep.mp3');
+
+function playFootstep() {
+  const pitch = 0.9 + Math.random() * 0.2; // 0.9-1.1x
+
+  BT.soundPlay(footstep, { pitch, volume: 0.6 });
+}
+```
+
 ## See also
 
 <Cards>

--- a/docs/guide-audio.md
+++ b/docs/guide-audio.md
@@ -106,9 +106,10 @@ start audio unlocked, and none is planned.
   `BT.activeBackend` or the WebGPU/Canvas 2D fallback described in [Browser Support](api-browser-support.md) - a demo
   can be fully unlocked on the software renderer, or fully locked on WebGPU.
 - Loading and decoding clips is implemented via `AudioClip` (see [Loading](api-audio.md#loading)) and works regardless
-  of lock state. `BT.soundPlay` (see [Playback (SFX)](api-audio.md#playback-sfx)) is gated on the same unlock gesture as
-  bus volume/mute: a call made before unlock is dropped silently (no throw), exactly like a pre-unlock
-  `BT.audioVolumeSet`.
+  of lock state. `BT.soundPlay` (see [Playback (SFX)](api-audio.md#playback-sfx)) behaves differently from a pre-unlock
+  bus call: `playSound()` drops the request entirely before unlock (no voice allocated, no throw, counted as a dropped
+  SFX request), where `AudioManager.volumeSet()` (`BT.audioVolumeSet`) still updates the engine's internal bus state and
+  applies once the context resumes - it is only inaudible while locked, not dropped.
 
 ## Playing SFX
 

--- a/docs/guide-audio.md
+++ b/docs/guide-audio.md
@@ -17,14 +17,15 @@ locked/unlocked gesture state, and the web platform constraints that shape it.
 
 ```text
 src/audio/
-  AudioManager.ts        # Web Audio context, bus graph, unlock state machine, mute/volume
+  AudioManager.ts        # Web Audio context, bus graph, unlock state machine, mute/volume, SFX playback
   audioDecodeContext.ts  # Decode-context registry AudioClip reads from to decode
+  VoicePool.ts           # Fixed-size SFX voice pool: allocation/stealing, generational refs, per-voice fades
 src/assets/
   AudioClip.ts           # Decoded AudioBuffer asset: streamed fetch+decode, cache/dedup, fallback URL lists
 ```
 
 `AudioManager` is owned by the internal `BTAPI` singleton (created and torn down alongside pointer, keyboard, and
-gamepad input) and is never exposed to demo code directly - only through the `BT.audio*` methods and the
+gamepad input) and is never exposed to demo code directly - only through the `BT.audio*`/`BT.sound*` methods and the
 `BT.isAudioUnlocked` getter documented in [API: Audio](api-audio.md). On `attach()`, `AudioManager` registers its Web
 Audio context in `audioDecodeContext.ts`, a small bridge that `AudioClip` reads from to decode audio data without
 needing a direct reference to `AudioManager` itself.
@@ -105,8 +106,22 @@ start audio unlocked, and none is planned.
   `BT.activeBackend` or the WebGPU/Canvas 2D fallback described in [Browser Support](api-browser-support.md) - a demo
   can be fully unlocked on the software renderer, or fully locked on WebGPU.
 - Loading and decoding clips is implemented via `AudioClip` (see [Loading](api-audio.md#loading)) and works regardless
-  of lock state. Playing them back - SFX/music voices routed through the bus graph - is not implemented yet; this phase
-  covers the bus graph, volume, mute, unlock tracking, and clip loading that a future playback API will build on.
+  of lock state. `BT.soundPlay` (see [Playback (SFX)](api-audio.md#playback-sfx)) is gated on the same unlock gesture as
+  bus volume/mute: a call made before unlock is dropped silently (no throw), exactly like a pre-unlock
+  `BT.audioVolumeSet`.
+
+## Playing SFX
+
+`BT.soundPlay` routes every SFX voice through the `'sfx'` bus (see [Subsystem layout](#subsystem-layout) above), so
+`BT.audioVolumeSet('sfx', ...)` and `BT.audioMuteSet('sfx', ...)` affect every currently-playing sound at once, on top
+of each sound's own per-voice volume from `BT.soundVolumeSet`.
+
+The pool itself (`src/audio/VoicePool.ts`) is a fixed-size array sized by `HardwareSettings.audioVoices` - it never
+grows at runtime. Each `BT.soundPlay` call either claims a free slot or steals the lowest-priority active voice at or
+below the incoming priority; see [Playback (SFX)](api-audio.md#playback-sfx) for the exact policy and a worked example.
+This cap exists because each slot is a real `AudioBufferSourceNode -> GainNode -> StereoPannerNode` chain - letting the
+pool grow unbounded would let a busy scene (an explosion with dozens of debris impacts, for example) spend unbounded CPU
+on nodes the player can't meaningfully hear over each other anyway.
 
 ## See also
 

--- a/src/BLIT386.test.ts
+++ b/src/BLIT386.test.ts
@@ -10,6 +10,7 @@
 
 import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
 
+import type { AudioClip } from './assets/AudioClip';
 import type { BitmapFont, HardwareSettings } from './BLIT386';
 import { BT, Palette, Rect2i, SpriteSheet, Vector2i } from './BLIT386';
 import { BTAPI } from './core/BTAPI';
@@ -336,6 +337,130 @@ describe('BT.assignTag', () => {
         BT.assignTag('Milestone');
 
         expect(spy).toHaveBeenCalledWith('Milestone');
+    });
+});
+
+describe('BT.soundPlay', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('delegates to BTAPI.instance.soundPlay', () => {
+        const ref = { voiceIndex: 0, generation: 1 };
+        const clip = {} as unknown as AudioClip;
+        const spy = vi.spyOn(BTAPI.instance, 'soundPlay').mockReturnValue(ref);
+
+        const result = BT.soundPlay(clip, { volume: 0.5 });
+
+        expect(spy).toHaveBeenCalledWith(clip, { volume: 0.5 });
+        expect(result).toBe(ref);
+    });
+});
+
+describe('BT.soundStop', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('delegates to BTAPI.instance.soundStop, unpacking fadeOutMs', () => {
+        const ref = { voiceIndex: 0, generation: 1 };
+        const spy = vi.spyOn(BTAPI.instance, 'soundStop').mockReturnValue(undefined);
+
+        BT.soundStop(ref, { fadeOutMs: 200 });
+
+        expect(spy).toHaveBeenCalledWith(ref, 200);
+    });
+
+    it('passes undefined fadeOutMs when options are omitted', () => {
+        const ref = { voiceIndex: 0, generation: 1 };
+        const spy = vi.spyOn(BTAPI.instance, 'soundStop').mockReturnValue(undefined);
+
+        BT.soundStop(ref);
+
+        expect(spy).toHaveBeenCalledWith(ref, undefined);
+    });
+});
+
+describe('BT.isSoundPlaying', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('delegates to BTAPI.instance.isSoundPlaying', () => {
+        const ref = { voiceIndex: 0, generation: 1 };
+        const spy = vi.spyOn(BTAPI.instance, 'isSoundPlaying').mockReturnValue(true);
+
+        expect(BT.isSoundPlaying(ref)).toBe(true);
+        expect(spy).toHaveBeenCalledWith(ref);
+    });
+});
+
+describe('BT.soundVolumeSet / BT.soundVolumeGet', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('soundVolumeSet delegates to BTAPI.instance.soundVolumeSet, unpacking fadeMs', () => {
+        const ref = { voiceIndex: 0, generation: 1 };
+        const spy = vi.spyOn(BTAPI.instance, 'soundVolumeSet').mockReturnValue(undefined);
+
+        BT.soundVolumeSet(ref, 0.5, { fadeMs: 100 });
+
+        expect(spy).toHaveBeenCalledWith(ref, 0.5, 100);
+    });
+
+    it('soundVolumeGet delegates to BTAPI.instance.soundVolumeGet', () => {
+        const ref = { voiceIndex: 0, generation: 1 };
+        const spy = vi.spyOn(BTAPI.instance, 'soundVolumeGet').mockReturnValue(0.5);
+
+        expect(BT.soundVolumeGet(ref)).toBe(0.5);
+        expect(spy).toHaveBeenCalledWith(ref);
+    });
+});
+
+describe('BT.soundPitchSet / BT.soundPitchGet', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('soundPitchSet delegates to BTAPI.instance.soundPitchSet, unpacking fadeMs', () => {
+        const ref = { voiceIndex: 0, generation: 1 };
+        const spy = vi.spyOn(BTAPI.instance, 'soundPitchSet').mockReturnValue(undefined);
+
+        BT.soundPitchSet(ref, 1.5, { fadeMs: 50 });
+
+        expect(spy).toHaveBeenCalledWith(ref, 1.5, 50);
+    });
+
+    it('soundPitchGet delegates to BTAPI.instance.soundPitchGet', () => {
+        const ref = { voiceIndex: 0, generation: 1 };
+        const spy = vi.spyOn(BTAPI.instance, 'soundPitchGet').mockReturnValue(1.5);
+
+        expect(BT.soundPitchGet(ref)).toBe(1.5);
+        expect(spy).toHaveBeenCalledWith(ref);
+    });
+});
+
+describe('BT.soundPanSet / BT.soundPanGet', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('soundPanSet delegates to BTAPI.instance.soundPanSet, unpacking fadeMs', () => {
+        const ref = { voiceIndex: 0, generation: 1 };
+        const spy = vi.spyOn(BTAPI.instance, 'soundPanSet').mockReturnValue(undefined);
+
+        BT.soundPanSet(ref, -0.5, { fadeMs: 50 });
+
+        expect(spy).toHaveBeenCalledWith(ref, -0.5, 50);
+    });
+
+    it('soundPanGet delegates to BTAPI.instance.soundPanGet', () => {
+        const ref = { voiceIndex: 0, generation: 1 };
+        const spy = vi.spyOn(BTAPI.instance, 'soundPanGet').mockReturnValue(-0.5);
+
+        expect(BT.soundPanGet(ref)).toBe(-0.5);
+        expect(spy).toHaveBeenCalledWith(ref);
     });
 });
 

--- a/src/BLIT386.ts
+++ b/src/BLIT386.ts
@@ -12,11 +12,13 @@
  */
 
 import { AssetLoader } from './assets/AssetLoader';
+import { AudioClip } from './assets/AudioClip';
 import type { TextSize } from './assets/BitmapFont';
 import { BitmapFont } from './assets/BitmapFont';
 import { Palette } from './assets/Palette';
 import type { IndexedSpriteLoadResult } from './assets/SpriteSheet';
 import { SpriteSheet } from './assets/SpriteSheet';
+import type { SoundParamSetOptions, SoundPlayOptions, SoundRef, SoundStopOptions } from './audio/VoicePool';
 import { BTAPI } from './core/BTAPI';
 import {
     type AudioBus,
@@ -597,6 +599,110 @@ export const BT = {
      */
     isAudioMuted: (bus: AudioBus): boolean => {
         return BTAPI.instance.isAudioMuted(bus);
+    },
+
+    /**
+     * Plays a loaded audio clip through the SFX voice pool.
+     *
+     * Returns an inert {@link SoundRef} without allocating a voice when the clip hasn't finished
+     * loading yet (or was already unloaded), when the pool has no free or stealable voice at this
+     * priority, or before the engine has unlocked audio playback.
+     *
+     * @param clip - Loaded audio clip to play.
+     * @param options - Playback options.
+     * @returns A handle identifying the new voice; pass it to {@link BT.soundStop} and the other
+     *   per-sound controls. Safe to use even when playback was silently dropped - every accessor
+     *   on an inert handle is a no-op.
+     */
+    soundPlay: (clip: AudioClip, options?: SoundPlayOptions): SoundRef => {
+        return BTAPI.instance.soundPlay(clip, options);
+    },
+
+    /**
+     * Stops a playing sound, optionally fading it out.
+     *
+     * @param ref - Sound to stop, from {@link BT.soundPlay}.
+     * @param options - Optional fade behavior.
+     * @param options.fadeOutMs - Fade-out duration in milliseconds. Omit to stop immediately.
+     */
+    soundStop: (ref: SoundRef, options?: SoundStopOptions): void => {
+        BTAPI.instance.soundStop(ref, options?.fadeOutMs);
+    },
+
+    /**
+     * Reports whether a sound is still playing.
+     *
+     * @param ref - Sound to query.
+     * @returns `true` when still playing; `false` once it has stopped, been stolen, or completed.
+     */
+    isSoundPlaying: (ref: SoundRef): boolean => {
+        return BTAPI.instance.isSoundPlaying(ref);
+    },
+
+    /**
+     * Sets a sound's gain, optionally fading to it.
+     *
+     * @param ref - Sound to update.
+     * @param value - Target gain.
+     * @param options - Optional fade behavior.
+     * @param options.fadeMs - Fade duration in milliseconds. Omit for an immediate change.
+     */
+    soundVolumeSet: (ref: SoundRef, value: number, options?: SoundParamSetOptions): void => {
+        BTAPI.instance.soundVolumeSet(ref, value, options?.fadeMs);
+    },
+
+    /**
+     * Gets a sound's current gain.
+     *
+     * @param ref - Sound to query.
+     * @returns Current gain, or `1` once the sound has stopped.
+     */
+    soundVolumeGet: (ref: SoundRef): number => {
+        return BTAPI.instance.soundVolumeGet(ref);
+    },
+
+    /**
+     * Sets a sound's playback rate, optionally fading to it.
+     *
+     * @param ref - Sound to update.
+     * @param value - Target playback rate.
+     * @param options - Optional fade behavior.
+     * @param options.fadeMs - Fade duration in milliseconds. Omit for an immediate change.
+     */
+    soundPitchSet: (ref: SoundRef, value: number, options?: SoundParamSetOptions): void => {
+        BTAPI.instance.soundPitchSet(ref, value, options?.fadeMs);
+    },
+
+    /**
+     * Gets a sound's current playback rate.
+     *
+     * @param ref - Sound to query.
+     * @returns Current playback rate, or `1` once the sound has stopped.
+     */
+    soundPitchGet: (ref: SoundRef): number => {
+        return BTAPI.instance.soundPitchGet(ref);
+    },
+
+    /**
+     * Sets a sound's stereo pan, optionally fading to it.
+     *
+     * @param ref - Sound to update.
+     * @param value - Target pan.
+     * @param options - Optional fade behavior.
+     * @param options.fadeMs - Fade duration in milliseconds. Omit for an immediate change.
+     */
+    soundPanSet: (ref: SoundRef, value: number, options?: SoundParamSetOptions): void => {
+        BTAPI.instance.soundPanSet(ref, value, options?.fadeMs);
+    },
+
+    /**
+     * Gets a sound's current stereo pan.
+     *
+     * @param ref - Sound to query.
+     * @returns Current pan, or `0` once the sound has stopped.
+     */
+    soundPanGet: (ref: SoundRef): number => {
+        return BTAPI.instance.soundPanGet(ref);
     },
 
     /**
@@ -1638,6 +1744,7 @@ export {
     amber,
     applyEasing,
     AssetLoader,
+    AudioClip,
     BarrelDistortion,
     BitmapFont,
     Bloom,
@@ -1680,6 +1787,10 @@ export type {
     OverlayRow,
     OverlayStyle,
     OverlayTimingChartStyle,
+    SoundParamSetOptions,
+    SoundPlayOptions,
+    SoundRef,
+    SoundStopOptions,
     TextSize,
 };
 export type { IndexedSpriteLoadResult };

--- a/src/__test__/webaudio-mock.test.ts
+++ b/src/__test__/webaudio-mock.test.ts
@@ -5,6 +5,7 @@ import {
     createMockAudioContext,
     createMockStereoPannerNode,
     type MockAudioContext,
+    setMockCurrentTime,
 } from './webaudio-mock';
 
 describe('createMockAudioBufferSourceNode', () => {
@@ -17,9 +18,20 @@ describe('createMockAudioBufferSourceNode', () => {
         source.stop(3);
 
         expect((source as unknown as { connectCalls: unknown[] }).connectCalls).toEqual([destination]);
-        expect((source as unknown as { startCalls: number[] }).startCalls).toEqual([1.5]);
+        expect((source as unknown as { startCalls: Array<{ when: number }> }).startCalls).toEqual([{ when: 1.5 }]);
         expect((source as unknown as { stopCalls: number[] }).stopCalls).toEqual([3]);
         expect(source.playbackRate.value).toBe(1);
+    });
+
+    it('records offset and duration arguments passed to start', () => {
+        const source = createMockAudioBufferSourceNode();
+
+        source.start(1.5, 0.25, 2);
+
+        expect(
+            (source as unknown as { startCalls: Array<{ when: number; offset?: number; duration?: number }> })
+                .startCalls,
+        ).toEqual([{ when: 1.5, offset: 0.25, duration: 2 }]);
     });
 
     it('throws when started twice', () => {
@@ -67,5 +79,21 @@ describe('createMockAudioContext', () => {
 
         expect(mockContext.createBufferSourceCalls).toEqual([source]);
         expect(mockContext.createStereoPannerCalls).toEqual([panner]);
+    });
+
+    it('starts at currentTime 0', () => {
+        const context = createMockAudioContext();
+
+        expect(context.currentTime).toBe(0);
+    });
+});
+
+describe('setMockCurrentTime', () => {
+    it('advances a mock context currentTime', () => {
+        const context = createMockAudioContext();
+
+        setMockCurrentTime(context, 12.5);
+
+        expect(context.currentTime).toBe(12.5);
     });
 });

--- a/src/__test__/webaudio-mock.test.ts
+++ b/src/__test__/webaudio-mock.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    createMockAudioBufferSourceNode,
+    createMockAudioContext,
+    createMockStereoPannerNode,
+    type MockAudioContext,
+} from './webaudio-mock';
+
+describe('createMockAudioBufferSourceNode', () => {
+    it('records connect, start, and stop calls and exposes playbackRate', () => {
+        const source = createMockAudioBufferSourceNode();
+        const destination = {} as AudioNode;
+
+        source.connect(destination);
+        source.start(1.5);
+        source.stop(3);
+
+        expect((source as unknown as { connectCalls: unknown[] }).connectCalls).toEqual([destination]);
+        expect((source as unknown as { startCalls: number[] }).startCalls).toEqual([1.5]);
+        expect((source as unknown as { stopCalls: number[] }).stopCalls).toEqual([3]);
+        expect(source.playbackRate.value).toBe(1);
+    });
+
+    it('throws when started twice', () => {
+        const source = createMockAudioBufferSourceNode();
+
+        source.start(0);
+
+        expect(() => source.start(0)).toThrow();
+    });
+
+    it('supports assigning onended', () => {
+        const source = createMockAudioBufferSourceNode();
+        let fired = false;
+
+        source.onended = () => {
+            fired = true;
+        };
+
+        (source.onended as () => void)();
+
+        expect(fired).toBe(true);
+    });
+});
+
+describe('createMockStereoPannerNode', () => {
+    it('records connect calls and exposes pan', () => {
+        const panner = createMockStereoPannerNode();
+        const destination = {} as AudioNode;
+
+        panner.connect(destination);
+
+        expect((panner as unknown as { connectCalls: unknown[] }).connectCalls).toEqual([destination]);
+        expect(panner.pan.value).toBe(0);
+    });
+});
+
+describe('createMockAudioContext', () => {
+    it('tracks createBufferSource and createStereoPanner calls', () => {
+        const context = createMockAudioContext() as unknown as MockAudioContext;
+
+        const source = context.createBufferSource();
+        const panner = context.createStereoPanner();
+
+        expect(context.createBufferSourceCalls).toEqual([source]);
+        expect(context.createStereoPannerCalls).toEqual([panner]);
+    });
+});

--- a/src/__test__/webaudio-mock.test.ts
+++ b/src/__test__/webaudio-mock.test.ts
@@ -58,12 +58,14 @@ describe('createMockStereoPannerNode', () => {
 
 describe('createMockAudioContext', () => {
     it('tracks createBufferSource and createStereoPanner calls', () => {
-        const context = createMockAudioContext() as unknown as MockAudioContext;
+        const context = createMockAudioContext();
 
         const source = context.createBufferSource();
         const panner = context.createStereoPanner();
 
-        expect(context.createBufferSourceCalls).toEqual([source]);
-        expect(context.createStereoPannerCalls).toEqual([panner]);
+        const mockContext = context as unknown as MockAudioContext;
+
+        expect(mockContext.createBufferSourceCalls).toEqual([source]);
+        expect(mockContext.createStereoPannerCalls).toEqual([panner]);
     });
 });

--- a/src/__test__/webaudio-mock.ts
+++ b/src/__test__/webaudio-mock.ts
@@ -40,24 +40,6 @@ export interface MockGainNode extends MockAudioNode {
     readonly gain: MockAudioParam;
 }
 
-/** Recorded `AudioBufferSourceNode` state: connect/start/stop tracking plus the mock playbackRate param. */
-export interface MockAudioBufferSourceNode extends MockAudioNode {
-    /** Playback rate parameter with scheduling call tracking. */
-    readonly playbackRate: MockAudioParam;
-
-    /** Arguments recorded from every `start` call, in call order. */
-    readonly startCalls: number[];
-
-    /** Arguments recorded from every `stop` call, in call order. */
-    readonly stopCalls: number[];
-}
-
-/** Recorded `StereoPannerNode` state: connect tracking plus the mock pan parameter. */
-export interface MockStereoPannerNode extends MockAudioNode {
-    /** Pan parameter with scheduling call tracking. */
-    readonly pan: MockAudioParam;
-}
-
 /** Recorded `AudioContext` state: created gain nodes plus resume/close call counts. */
 export interface MockAudioContext {
     /** Gain nodes created via `createGain()`, in call order. */

--- a/src/__test__/webaudio-mock.ts
+++ b/src/__test__/webaudio-mock.ts
@@ -149,7 +149,7 @@ export function createMockGainNode(): GainNode {
  */
 export function createMockAudioBufferSourceNode(): AudioBufferSourceNode {
     const connectCalls: unknown[] = [];
-    const startCalls: number[] = [];
+    const startCalls: Array<{ when: number; offset?: number; duration?: number }> = [];
     const stopCalls: number[] = [];
     let hasStarted = false;
 
@@ -167,13 +167,24 @@ export function createMockAudioBufferSourceNode(): AudioBufferSourceNode {
             return destination;
         },
         disconnect: () => {},
-        start: (when: number = 0) => {
+        start: (when: number = 0, offset?: number, duration?: number) => {
             if (hasStarted) {
                 throw new Error('cannot start an AudioBufferSourceNode more than once');
             }
 
             hasStarted = true;
-            startCalls.push(when);
+
+            const call: { when: number; offset?: number; duration?: number } = { when };
+
+            if (offset !== undefined) {
+                call.offset = offset;
+            }
+
+            if (duration !== undefined) {
+                call.duration = duration;
+            }
+
+            startCalls.push(call);
         },
         stop: (when: number = 0) => {
             stopCalls.push(when);
@@ -298,6 +309,19 @@ export function createMockAudioContext(): AudioContext {
     };
 
     return context as unknown as AudioContext;
+}
+
+/**
+ * Advances (or rewinds) a mock `AudioContext`'s `currentTime`, simulating audio-clock
+ * progression for tests exercising `atTime` scheduling or fade-timing assertions anchored to a
+ * non-zero clock.
+ *
+ * @param context - Mock context created by {@link createMockAudioContext} (or the instance
+ *   returned by {@link installMockAudioContext}'s `getLastInstance()`).
+ * @param currentTime - New `currentTime` value in seconds.
+ */
+export function setMockCurrentTime(context: AudioContext, currentTime: number): void {
+    (context as unknown as { currentTime: number }).currentTime = currentTime;
 }
 
 /**

--- a/src/__test__/webaudio-mock.ts
+++ b/src/__test__/webaudio-mock.ts
@@ -40,10 +40,34 @@ export interface MockGainNode extends MockAudioNode {
     readonly gain: MockAudioParam;
 }
 
+/** Recorded `AudioBufferSourceNode` state: connect/start/stop tracking plus the mock playbackRate param. */
+export interface MockAudioBufferSourceNode extends MockAudioNode {
+    /** Playback rate parameter with scheduling call tracking. */
+    readonly playbackRate: MockAudioParam;
+
+    /** Arguments recorded from every `start` call, in call order. */
+    readonly startCalls: number[];
+
+    /** Arguments recorded from every `stop` call, in call order. */
+    readonly stopCalls: number[];
+}
+
+/** Recorded `StereoPannerNode` state: connect tracking plus the mock pan parameter. */
+export interface MockStereoPannerNode extends MockAudioNode {
+    /** Pan parameter with scheduling call tracking. */
+    readonly pan: MockAudioParam;
+}
+
 /** Recorded `AudioContext` state: created gain nodes plus resume/close call counts. */
 export interface MockAudioContext {
     /** Gain nodes created via `createGain()`, in call order. */
     readonly createGainCalls: readonly GainNode[];
+
+    /** Buffer source nodes created via `createBufferSource()`, in call order. */
+    readonly createBufferSourceCalls: readonly AudioBufferSourceNode[];
+
+    /** Stereo panner nodes created via `createStereoPanner()`, in call order. */
+    readonly createStereoPannerCalls: readonly StereoPannerNode[];
 
     /** Destination node passed to `main.connect(...)` in a well-wired bus graph. */
     readonly destination: AudioNode;
@@ -136,6 +160,71 @@ export function createMockGainNode(): GainNode {
 }
 
 /**
+ * Creates a mock `AudioBufferSourceNode`: a `connect`-tracking, one-shot-`start`-enforcing node
+ * with a mock {@link createMockAudioParam} `playbackRate` and a settable `onended` callback.
+ *
+ * @returns Mock `AudioBufferSourceNode` stub, cast from a plain tracking object.
+ */
+export function createMockAudioBufferSourceNode(): AudioBufferSourceNode {
+    const connectCalls: unknown[] = [];
+    const startCalls: number[] = [];
+    const stopCalls: number[] = [];
+    let hasStarted = false;
+
+    const node = {
+        buffer: null as AudioBuffer | null,
+        loop: false,
+        playbackRate: createMockAudioParam(1),
+        onended: null as (() => void) | null,
+        connectCalls,
+        startCalls,
+        stopCalls,
+        connect: (destination: unknown) => {
+            connectCalls.push(destination);
+
+            return destination;
+        },
+        disconnect: () => {},
+        start: (when: number = 0) => {
+            if (hasStarted) {
+                throw new Error('cannot start an AudioBufferSourceNode more than once');
+            }
+
+            hasStarted = true;
+            startCalls.push(when);
+        },
+        stop: (when: number = 0) => {
+            stopCalls.push(when);
+        },
+    };
+
+    return node as unknown as AudioBufferSourceNode;
+}
+
+/**
+ * Creates a mock `StereoPannerNode`: a `connect`-tracking node with a mock
+ * {@link createMockAudioParam} `pan`.
+ *
+ * @returns Mock `StereoPannerNode` stub, cast from a plain tracking object.
+ */
+export function createMockStereoPannerNode(): StereoPannerNode {
+    const connectCalls: unknown[] = [];
+
+    const node = {
+        pan: createMockAudioParam(0),
+        connectCalls,
+        connect: (destination: unknown) => {
+            connectCalls.push(destination);
+
+            return destination;
+        },
+        disconnect: () => {},
+    };
+
+    return node as unknown as StereoPannerNode;
+}
+
+/**
  * Creates a fake `AudioBuffer`-shaped object for {@link createMockAudioContext}'s
  * default `decodeAudioData` resolution.
  *
@@ -163,6 +252,8 @@ export function createMockAudioBuffer(): AudioBuffer {
  */
 export function createMockAudioContext(): AudioContext {
     const createGainCalls: GainNode[] = [];
+    const createBufferSourceCalls: AudioBufferSourceNode[] = [];
+    const createStereoPannerCalls: StereoPannerNode[] = [];
     const destination = {} as unknown as AudioNode;
     const decodeAudioDataCalls: ArrayBuffer[] = [];
     let resumeCallCount = 0;
@@ -174,6 +265,8 @@ export function createMockAudioContext(): AudioContext {
         state: 'suspended' as AudioContextState,
         destination,
         createGainCalls,
+        createBufferSourceCalls,
+        createStereoPannerCalls,
         decodeAudioDataCalls,
         decodeAudioDataImpl: (_audioData: ArrayBuffer) => Promise.resolve(createMockAudioBuffer()),
         get resumeCallCount() {
@@ -186,6 +279,20 @@ export function createMockAudioContext(): AudioContext {
             const node = createMockGainNode();
 
             createGainCalls.push(node);
+
+            return node;
+        },
+        createBufferSource: () => {
+            const node = createMockAudioBufferSourceNode();
+
+            createBufferSourceCalls.push(node);
+
+            return node;
+        },
+        createStereoPanner: () => {
+            const node = createMockStereoPannerNode();
+
+            createStereoPannerCalls.push(node);
 
             return node;
         },

--- a/src/assets/AudioClip.ts
+++ b/src/assets/AudioClip.ts
@@ -379,12 +379,10 @@ export class AudioClip {
 
     /**
      * Releases the decoded buffer, removes this clip from the resolved cache,
-     * and notifies the voice-stop hook so any future voice system can stop
-     * nodes still referencing the released buffer.
+     * and stops and invalidates any voice still playing this buffer via the
+     * registered `AudioClip` unload hook (see `audioDecodeContext.ts`).
      *
-     * Voice-stopping is currently a no-op (no voice pool exists yet); it will
-     * be fully enforced once voices exist. Safe to call more than once - the
-     * second and later calls are a no-op.
+     * Safe to call more than once - the second and later calls are a no-op.
      */
     unload(): void {
         if (this.decodedBuffer === null) {

--- a/src/audio/AudioManager.test.ts
+++ b/src/audio/AudioManager.test.ts
@@ -119,6 +119,45 @@ describe('AudioManager', () => {
         });
     });
 
+    describe('internal accessors', () => {
+        it('getContext returns null before attach', () => {
+            expect(audio.getContext()).toBeNull();
+        });
+
+        it('getContext returns the live context after attach', () => {
+            audio.attach(canvas);
+
+            expect(audio.getContext()).toBe(getMockContext());
+        });
+
+        it('getContext returns null after detach', () => {
+            audio.attach(canvas);
+            audio.detach();
+
+            expect(audio.getContext()).toBeNull();
+        });
+
+        it('getSfxBus returns null before attach', () => {
+            expect(audio.getSfxBus()).toBeNull();
+        });
+
+        it('getSfxBus returns the sfx bus gain node after attach', () => {
+            audio.attach(canvas);
+
+            const context = getMockContext();
+            const sfx = nthGainNode(context.createGainCalls, 2);
+
+            expect(audio.getSfxBus()).toBe(sfx);
+        });
+
+        it('getSfxBus returns null after detach', () => {
+            audio.attach(canvas);
+            audio.detach();
+
+            expect(audio.getSfxBus()).toBeNull();
+        });
+    });
+
     describe('detach', () => {
         it('closes the audio context', () => {
             audio.attach(canvas);

--- a/src/audio/AudioManager.test.ts
+++ b/src/audio/AudioManager.test.ts
@@ -375,6 +375,74 @@ describe('AudioManager', () => {
         });
     });
 
+    describe('sound playback controls', () => {
+        beforeEach(async () => {
+            audio.attach(canvas);
+
+            canvas.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+
+            await vi.waitFor(() => {
+                expect(audio.isUnlocked()).toBe(true);
+            });
+        });
+
+        it('soundStop stops a playing sound', () => {
+            const ref = audio.playSound(createMockAudioBuffer());
+
+            audio.soundStop(ref);
+
+            expect(audio.isSoundPlaying(ref)).toBe(false);
+        });
+
+        it('soundStop accepts an optional fadeOutMs without throwing', () => {
+            const ref = audio.playSound(createMockAudioBuffer());
+
+            expect(() => audio.soundStop(ref, 200)).not.toThrow();
+        });
+
+        it('isSoundPlaying reports true for a live sound and false for an invalid ref', () => {
+            const ref = audio.playSound(createMockAudioBuffer());
+
+            expect(audio.isSoundPlaying(ref)).toBe(true);
+            expect(audio.isSoundPlaying(INVALID_SOUND_REF)).toBe(false);
+        });
+
+        it('soundVolumeSet and soundVolumeGet round-trip', () => {
+            const ref = audio.playSound(createMockAudioBuffer());
+
+            audio.soundVolumeSet(ref, 0.4);
+
+            expect(audio.soundVolumeGet(ref)).toBe(0.4);
+        });
+
+        it('soundPitchSet and soundPitchGet round-trip', () => {
+            const ref = audio.playSound(createMockAudioBuffer());
+
+            audio.soundPitchSet(ref, 1.5);
+
+            expect(audio.soundPitchGet(ref)).toBe(1.5);
+        });
+
+        it('soundPanSet and soundPanGet round-trip', () => {
+            const ref = audio.playSound(createMockAudioBuffer());
+
+            audio.soundPanSet(ref, -0.5);
+
+            expect(audio.soundPanGet(ref)).toBe(-0.5);
+        });
+
+        it('every accessor reports inert defaults on a manager that was never attached', () => {
+            const detachedAudio = new AudioManager();
+
+            expect(detachedAudio.isSoundPlaying(INVALID_SOUND_REF)).toBe(false);
+            expect(detachedAudio.soundVolumeGet(INVALID_SOUND_REF)).toBe(1);
+            expect(detachedAudio.soundPitchGet(INVALID_SOUND_REF)).toBe(1);
+            expect(detachedAudio.soundPanGet(INVALID_SOUND_REF)).toBe(0);
+            expect(() => detachedAudio.soundStop(INVALID_SOUND_REF)).not.toThrow();
+            expect(() => detachedAudio.soundVolumeSet(INVALID_SOUND_REF, 0.5)).not.toThrow();
+        });
+    });
+
     describe('voice pool lifecycle', () => {
         it('stops all voices and closes the context in the right order on detach', async () => {
             audio.attach(canvas);

--- a/src/audio/AudioManager.test.ts
+++ b/src/audio/AudioManager.test.ts
@@ -464,6 +464,7 @@ describe('AudioManager', () => {
             audio.attach(canvas);
             expect(() => audio.playSound(createMockAudioBuffer())).not.toThrow();
             expect(ref).not.toEqual(INVALID_SOUND_REF);
+            expect(audio.isSoundPlaying(ref)).toBe(false);
         });
     });
 });

--- a/src/audio/AudioManager.test.ts
+++ b/src/audio/AudioManager.test.ts
@@ -14,6 +14,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+    createMockAudioBuffer,
     installMockAudioContext,
     type MockAudioContext,
     type MockAudioParam,
@@ -21,6 +22,7 @@ import {
     uninstallMockAudioContext,
 } from '../__test__/webaudio-mock';
 import { AudioManager } from './AudioManager';
+import { INVALID_SOUND_REF } from './VoicePool';
 
 /**
  * Mounts a canvas for {@link AudioManager.attach}.
@@ -338,6 +340,62 @@ describe('AudioManager', () => {
             canvas.dispatchEvent(new Event('pointerdown', { bubbles: true }));
 
             expect(context.resumeCallCount).toBe(1);
+        });
+    });
+
+    describe('playSound', () => {
+        it('drops the request and returns an invalid ref before unlock', () => {
+            audio.attach(canvas);
+
+            const ref = audio.playSound(createMockAudioBuffer());
+
+            expect(ref).toEqual(INVALID_SOUND_REF);
+            expect(audio.getDroppedSfxCount()).toBe(1);
+        });
+
+        it('delegates to the voice pool once unlocked', async () => {
+            audio.attach(canvas);
+
+            canvas.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+
+            await vi.waitFor(() => {
+                expect(audio.isUnlocked()).toBe(true);
+            });
+
+            const ref = audio.playSound(createMockAudioBuffer());
+
+            expect(ref).not.toEqual(INVALID_SOUND_REF);
+            expect(audio.getDroppedSfxCount()).toBe(0);
+        });
+
+        it('returns an invalid ref when the manager has never been attached', () => {
+            const ref = audio.playSound(createMockAudioBuffer());
+
+            expect(ref).toEqual(INVALID_SOUND_REF);
+        });
+    });
+
+    describe('voice pool lifecycle', () => {
+        it('stops all voices and closes the context in the right order on detach', async () => {
+            audio.attach(canvas);
+
+            canvas.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+
+            await vi.waitFor(() => {
+                expect(audio.isUnlocked()).toBe(true);
+            });
+
+            const ref = audio.playSound(createMockAudioBuffer());
+
+            audio.detach();
+
+            expect(audio.getSfxBus()).toBeNull();
+
+            // Re-attaching and asking the (new, empty) pool about the old ref must not throw and
+            // must report it as not playing - the old pool instance was discarded on detach.
+            audio.attach(canvas);
+            expect(() => audio.playSound(createMockAudioBuffer())).not.toThrow();
+            expect(ref).not.toEqual(INVALID_SOUND_REF);
         });
     });
 });

--- a/src/audio/AudioManager.ts
+++ b/src/audio/AudioManager.ts
@@ -11,7 +11,15 @@ import type { AudioBus } from '../core/IBTDemo';
 import { applyAudioParamRamp } from '../utils/AudioParamRamp';
 import type { EasingFunction } from '../utils/Easing';
 import { setAudioClipUnloadHandler, setAudioDecodeContext } from './audioDecodeContext';
-import { INVALID_SOUND_REF, type SoundRef, type VoicePlayOptions, VoicePool } from './VoicePool';
+import {
+    DEFAULT_PAN,
+    DEFAULT_PITCH,
+    DEFAULT_VOLUME,
+    INVALID_SOUND_REF,
+    type SoundRef,
+    type VoicePlayOptions,
+    VoicePool,
+} from './VoicePool';
 
 /** Default (full) gain for a freshly created or reset bus. */
 const DEFAULT_BUS_VOLUME = 1;
@@ -360,6 +368,89 @@ export class AudioManager {
         }
 
         return this.voicePool?.play(buffer, options) ?? INVALID_SOUND_REF;
+    }
+
+    /**
+     * Stops a playing sound, optionally fading it out.
+     *
+     * @param ref - Sound to stop.
+     * @param fadeOutMs - Optional linear fade-out duration in milliseconds.
+     */
+    public soundStop(ref: SoundRef, fadeOutMs?: number): void {
+        this.voicePool?.stop(ref, fadeOutMs);
+    }
+
+    /**
+     * Reports whether a sound is still playing.
+     *
+     * @param ref - Sound to query.
+     * @returns `true` when `ref` still identifies a live voice; `false` on a stale ref or before {@link attach}.
+     */
+    public isSoundPlaying(ref: SoundRef): boolean {
+        return this.voicePool?.isPlaying(ref) ?? false;
+    }
+
+    /**
+     * Sets a sound's gain, optionally fading to it.
+     *
+     * @param ref - Sound to update.
+     * @param value - Target gain.
+     * @param fadeMs - Optional fade duration in milliseconds; omit for an immediate change.
+     */
+    public soundVolumeSet(ref: SoundRef, value: number, fadeMs?: number): void {
+        this.voicePool?.volumeSet(ref, value, fadeMs);
+    }
+
+    /**
+     * Gets a sound's current gain.
+     *
+     * @param ref - Sound to query.
+     * @returns Current gain, or {@link DEFAULT_VOLUME} on a stale ref or before {@link attach}.
+     */
+    public soundVolumeGet(ref: SoundRef): number {
+        return this.voicePool?.volumeGet(ref) ?? DEFAULT_VOLUME;
+    }
+
+    /**
+     * Sets a sound's playback rate, optionally fading to it.
+     *
+     * @param ref - Sound to update.
+     * @param value - Target playback rate.
+     * @param fadeMs - Optional fade duration in milliseconds; omit for an immediate change.
+     */
+    public soundPitchSet(ref: SoundRef, value: number, fadeMs?: number): void {
+        this.voicePool?.pitchSet(ref, value, fadeMs);
+    }
+
+    /**
+     * Gets a sound's current playback rate.
+     *
+     * @param ref - Sound to query.
+     * @returns Current playback rate, or {@link DEFAULT_PITCH} on a stale ref or before {@link attach}.
+     */
+    public soundPitchGet(ref: SoundRef): number {
+        return this.voicePool?.pitchGet(ref) ?? DEFAULT_PITCH;
+    }
+
+    /**
+     * Sets a sound's stereo pan, optionally fading to it.
+     *
+     * @param ref - Sound to update.
+     * @param value - Target pan.
+     * @param fadeMs - Optional fade duration in milliseconds; omit for an immediate change.
+     */
+    public soundPanSet(ref: SoundRef, value: number, fadeMs?: number): void {
+        this.voicePool?.panSet(ref, value, fadeMs);
+    }
+
+    /**
+     * Gets a sound's current stereo pan.
+     *
+     * @param ref - Sound to query.
+     * @returns Current pan, or {@link DEFAULT_PAN} on a stale ref or before {@link attach}.
+     */
+    public soundPanGet(ref: SoundRef): number {
+        return this.voicePool?.panGet(ref) ?? DEFAULT_PAN;
     }
 
     /**

--- a/src/audio/AudioManager.ts
+++ b/src/audio/AudioManager.ts
@@ -1,16 +1,17 @@
 /**
  * Internal audio subsystem: Web Audio context, bus graph, browser autoplay-unlock
- * state machine, and pre-unlock SFX/music drop counters.
+ * state machine, SFX voice pool, and pre-unlock SFX/music drop counters.
  *
  * Owned by {@link BTAPI} (not itself a singleton) and never exposed to demo code.
- * Actual SFX/music playback methods are added in a later phase; this class only
- * manages the audio graph, bus volume/mute, and unlock tracking.
+ * Music playback is added in a later phase; this class manages the audio graph, bus
+ * volume/mute, unlock tracking, and SFX voice playback via {@link playSound}.
  */
 
 import type { AudioBus } from '../core/IBTDemo';
 import { applyAudioParamRamp } from '../utils/AudioParamRamp';
 import type { EasingFunction } from '../utils/Easing';
-import { setAudioDecodeContext } from './audioDecodeContext';
+import { setAudioClipUnloadHandler, setAudioDecodeContext } from './audioDecodeContext';
+import { INVALID_SOUND_REF, type SoundRef, type VoicePlayOptions, VoicePool } from './VoicePool';
 
 /** Default (full) gain for a freshly created or reset bus. */
 const DEFAULT_BUS_VOLUME = 1;
@@ -31,8 +32,8 @@ type PerBus<T> = Record<AudioBus, T>;
  * Construct, then call {@link attach} with the rendering canvas. Call {@link detach}
  * to remove listeners and close the audio context (engine restarts, tests).
  *
- * Actual SFX/music playback methods are added in a later phase; this class only
- * exposes bus volume, mute, and unlock-state accessors.
+ * Music playback is added in a later phase; this class exposes bus volume, mute,
+ * unlock-state accessors, and SFX voice playback via {@link playSound}.
  */
 export class AudioManager {
     /** Live Web Audio context, or `null` before {@link attach} / after {@link detach}. */
@@ -40,6 +41,9 @@ export class AudioManager {
 
     /** Gain nodes for the bus graph, or `null` before {@link attach} / after {@link detach}. */
     private busNodes: PerBus<GainNode> | null = null;
+
+    /** SFX voice pool, or `null` before {@link attach} / after {@link detach}. */
+    private voicePool: VoicePool | null = null;
 
     /** Canvas passed to {@link attach}; the unlock gesture listener target. */
     private target: HTMLCanvasElement | null = null;
@@ -121,6 +125,9 @@ export class AudioManager {
 
         setAudioDecodeContext(this.context);
 
+        this.voicePool = new VoicePool(this);
+        setAudioClipUnloadHandler((buffer) => this.voicePool?.stopVoicesUsingBuffer(buffer));
+
         this.target = target;
 
         target.addEventListener('pointerdown', this.onPointerDown);
@@ -136,6 +143,10 @@ export class AudioManager {
      */
     public detach(): void {
         this.removeUnlockListeners();
+
+        this.voicePool?.stopAll();
+        this.voicePool = null;
+        setAudioClipUnloadHandler(() => {});
 
         if (this.context !== null) {
             this.context.close().catch(() => {
@@ -324,6 +335,27 @@ export class AudioManager {
      */
     public clearRememberedMusicRequest(): void {
         this.isMusicRequestRemembered = false;
+    }
+
+    /**
+     * Plays `buffer` through the SFX voice pool.
+     *
+     * Drops the request (counted via {@link noteDroppedSfx}) and returns
+     * {@link INVALID_SOUND_REF} without allocating a voice while the context is locked
+     * (pre-unlock), so the pool's slots are never spent on sound that would be inaudible anyway.
+     *
+     * @param buffer - Decoded audio buffer to play.
+     * @param options - Playback options; see {@link VoicePlayOptions}.
+     * @returns A {@link SoundRef} identifying the new voice, or {@link INVALID_SOUND_REF}.
+     */
+    public playSound(buffer: AudioBuffer, options?: VoicePlayOptions): SoundRef {
+        if (!this.unlocked) {
+            this.noteDroppedSfx();
+
+            return INVALID_SOUND_REF;
+        }
+
+        return this.voicePool?.play(buffer, options) ?? INVALID_SOUND_REF;
     }
 
     /**

--- a/src/audio/AudioManager.ts
+++ b/src/audio/AudioManager.ts
@@ -8,12 +8,9 @@
  */
 
 import type { AudioBus } from '../core/IBTDemo';
+import { applyAudioParamRamp } from '../utils/AudioParamRamp';
 import type { EasingFunction } from '../utils/Easing';
-import { applyEasing } from '../utils/Easing';
 import { setAudioDecodeContext } from './audioDecodeContext';
-
-/** Number of samples used to build an eased gain ramp curve for `setValueCurveAtTime`. */
-const FADE_CURVE_SAMPLE_COUNT = 32;
 
 /** Default (full) gain for a freshly created or reset bus. */
 const DEFAULT_BUS_VOLUME = 1;
@@ -210,7 +207,7 @@ export class AudioManager {
             return;
         }
 
-        this.applyBusGain(node, clamped, fadeMs, easing);
+        applyAudioParamRamp(node.gain, this.context?.currentTime ?? 0, clamped, fadeMs, easing);
     }
 
     /**
@@ -376,72 +373,6 @@ export class AudioManager {
         this.target.removeEventListener('keydown', this.onKeyDown);
         this.target.removeEventListener('touchstart', this.onTouchStart);
     }
-
-    /**
-     * Schedules or immediately applies a gain change on `node`.
-     *
-     * With no `fadeMs` (or a non-positive one), sets `node.gain.value` immediately.
-     * With `fadeMs`, anchors the ramp to `context.currentTime`: `'linear'` easing uses
-     * `linearRampToValueAtTime`; other easings sample {@link applyEasing} into a curve
-     * fed to `setValueCurveAtTime`.
-     *
-     * @param node - Gain node to update.
-     * @param targetValue - Target gain value.
-     * @param fadeMs - Optional fade duration in milliseconds.
-     * @param easing - Easing curve applied when `fadeMs` is a positive duration.
-     */
-    private applyBusGain(
-        node: GainNode,
-        targetValue: number,
-        fadeMs: number | undefined,
-        easing: EasingFunction,
-    ): void {
-        const context = this.context;
-
-        if (context === null || fadeMs === undefined || fadeMs <= 0) {
-            node.gain.value = targetValue;
-
-            return;
-        }
-
-        const startValue = node.gain.value;
-        const now = context.currentTime;
-        const durationSeconds = fadeMs / 1000;
-
-        node.gain.cancelScheduledValues(now);
-        node.gain.setValueAtTime(startValue, now);
-
-        if (easing === 'linear') {
-            node.gain.linearRampToValueAtTime(targetValue, now + durationSeconds);
-
-            return;
-        }
-
-        node.gain.setValueCurveAtTime(sampleEasingCurve(startValue, targetValue, easing), now, durationSeconds);
-    }
-}
-
-/**
- * Samples an eased gain curve from `startValue` to `targetValue` for
- * `AudioParam.setValueCurveAtTime`.
- *
- * @param startValue - Gain value at the start of the fade.
- * @param targetValue - Gain value at the end of the fade.
- * @param easing - Easing curve to sample.
- * @returns Sampled curve of {@link FADE_CURVE_SAMPLE_COUNT} values.
- */
-function sampleEasingCurve(startValue: number, targetValue: number, easing: EasingFunction): Float32Array {
-    const curve = new Float32Array(FADE_CURVE_SAMPLE_COUNT);
-
-    for (let i = 0; i < FADE_CURVE_SAMPLE_COUNT; i++) {
-        const t = i / (FADE_CURVE_SAMPLE_COUNT - 1);
-        const eased = applyEasing(t, easing);
-
-        // eslint-disable-next-line security/detect-object-injection -- bounded loop counter
-        curve[i] = startValue + (targetValue - startValue) * eased;
-    }
-
-    return curve;
 }
 
 /**

--- a/src/audio/AudioManager.ts
+++ b/src/audio/AudioManager.ts
@@ -344,6 +344,10 @@ export class AudioManager {
      * {@link INVALID_SOUND_REF} without allocating a voice while the context is locked
      * (pre-unlock), so the pool's slots are never spent on sound that would be inaudible anyway.
      *
+     * {@link getDroppedSfxCount} only counts these pre-unlock drops; pool-exhaustion drops (no
+     * free or stealable slot) are tracked separately by the pool's own `getDropCount()`, which is
+     * internal-only and not yet exposed through `AudioManager`.
+     *
      * @param buffer - Decoded audio buffer to play.
      * @param options - Playback options; see {@link VoicePlayOptions}.
      * @returns A {@link SoundRef} identifying the new voice, or {@link INVALID_SOUND_REF}.

--- a/src/audio/AudioManager.ts
+++ b/src/audio/AudioManager.ts
@@ -167,6 +167,28 @@ export class AudioManager {
     }
 
     /**
+     * Returns the live Web Audio context, internal only – never exposed via `BTAPI` or `BT`.
+     *
+     * Used by {@link VoicePool} to build each voice's node chain.
+     *
+     * @returns The live audio context, or `null` before {@link attach} / after {@link detach}.
+     */
+    public getContext(): AudioContext | null {
+        return this.context;
+    }
+
+    /**
+     * Returns the `sfx` bus gain node, internal only – never exposed via `BTAPI` or `BT`.
+     *
+     * Used by {@link VoicePool} to connect each per-voice node chain's terminal `StereoPannerNode`.
+     *
+     * @returns The `sfx` bus gain node, or `null` before {@link attach} / after {@link detach}.
+     */
+    public getSfxBus(): GainNode | null {
+        return this.busNodes?.sfx ?? null;
+    }
+
+    /**
      * Returns the logical (pre-mute) volume for `bus`.
      *
      * Unaffected by {@link muteSet} - muting never overwrites the configured level.

--- a/src/audio/VoicePool.test.ts
+++ b/src/audio/VoicePool.test.ts
@@ -10,11 +10,16 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { installMockAudioContext, uninstallMockAudioContext } from '../__test__/webaudio-mock';
+import {
+    createMockAudioBuffer,
+    installMockAudioContext,
+    type MockAudioContext,
+    uninstallMockAudioContext,
+} from '../__test__/webaudio-mock';
 import { BTAPI } from '../core/BTAPI';
 import type { HardwareSettings } from '../core/IBTDemo';
 import { AudioManager } from './AudioManager';
-import { VoicePool } from './VoicePool';
+import { INVALID_SOUND_REF, VoicePool } from './VoicePool';
 
 /**
  * Mounts a canvas for {@link AudioManager.attach}.
@@ -27,12 +32,20 @@ const createCanvas = (): HTMLCanvasElement => {
     return canvas;
 };
 
+/**
+ * Returns the mock context most recently constructed by `installed`, cast for access to its
+ * call-tracking fields.
+ */
+const getMockContext = (installed: ReturnType<typeof installMockAudioContext>): MockAudioContext =>
+    installed.getLastInstance() as unknown as MockAudioContext;
+
 describe('VoicePool', () => {
     let canvas: HTMLCanvasElement;
     let audio: AudioManager;
+    let installed: ReturnType<typeof installMockAudioContext>;
 
     beforeEach(() => {
-        installMockAudioContext();
+        installed = installMockAudioContext();
         canvas = createCanvas();
         audio = new AudioManager();
         audio.attach(canvas);
@@ -73,6 +86,172 @@ describe('VoicePool', () => {
 
             expect(pool.getDropCount()).toBe(0);
             expect(pool.getStealCount()).toBe(0);
+        });
+    });
+
+    describe('play', () => {
+        it('builds the source -> gain -> panner -> sfx bus chain', () => {
+            vi.spyOn(BTAPI.instance, 'getHardwareSettings').mockReturnValue({
+                audioVoices: 4,
+            } as HardwareSettings);
+
+            const pool = new VoicePool(audio);
+            const buffer = createMockAudioBuffer();
+
+            pool.play(buffer);
+
+            const context = getMockContext(installed);
+            const source = context.createBufferSourceCalls[0];
+            const gain = context.createGainCalls[3]; // 0-2 are main/music/sfx from buildBusGraph
+            const panner = context.createStereoPannerCalls[0];
+
+            expect((source as unknown as { connectCalls: unknown[] }).connectCalls).toEqual([gain]);
+            expect((gain as unknown as { connectCalls: unknown[] }).connectCalls).toEqual([panner]);
+            expect((panner as unknown as { connectCalls: unknown[] }).connectCalls).toEqual([audio.getSfxBus()]);
+        });
+
+        it('applies volume, pitch, and pan options to the created nodes', () => {
+            vi.spyOn(BTAPI.instance, 'getHardwareSettings').mockReturnValue({
+                audioVoices: 4,
+            } as HardwareSettings);
+
+            const pool = new VoicePool(audio);
+            const buffer = createMockAudioBuffer();
+
+            pool.play(buffer, { volume: 0.5, pitch: 1.5, pan: -0.5 });
+
+            const context = getMockContext(installed);
+            const source = context.createBufferSourceCalls[0];
+            const gain = context.createGainCalls[3];
+            const panner = context.createStereoPannerCalls[0];
+
+            expect(gain?.gain.value).toBe(0.5);
+            expect(source?.playbackRate.value).toBe(1.5);
+            expect(panner?.pan.value).toBe(-0.5);
+        });
+
+        it('defaults volume, pitch, and pan when omitted', () => {
+            vi.spyOn(BTAPI.instance, 'getHardwareSettings').mockReturnValue({
+                audioVoices: 4,
+            } as HardwareSettings);
+
+            const pool = new VoicePool(audio);
+
+            pool.play(createMockAudioBuffer());
+
+            const context = getMockContext(installed);
+            const gain = context.createGainCalls[3];
+            const source = context.createBufferSourceCalls[0];
+            const panner = context.createStereoPannerCalls[0];
+
+            expect(gain?.gain.value).toBe(1);
+            expect(source?.playbackRate.value).toBe(1);
+            expect(panner?.pan.value).toBe(0);
+        });
+
+        it('sets loop and starts at the given atTime', () => {
+            vi.spyOn(BTAPI.instance, 'getHardwareSettings').mockReturnValue({
+                audioVoices: 4,
+            } as HardwareSettings);
+
+            const pool = new VoicePool(audio);
+
+            pool.play(createMockAudioBuffer(), { loop: true, atTime: 2.5 });
+
+            const context = getMockContext(installed);
+            const source = context.createBufferSourceCalls[0];
+
+            expect(source?.loop).toBe(true);
+            expect((source as unknown as { startCalls: number[] }).startCalls).toEqual([2.5]);
+        });
+
+        it('ramps gain from silence over fadeInMs', () => {
+            vi.spyOn(BTAPI.instance, 'getHardwareSettings').mockReturnValue({
+                audioVoices: 4,
+            } as HardwareSettings);
+
+            const pool = new VoicePool(audio);
+
+            pool.play(createMockAudioBuffer(), { volume: 0.8, fadeInMs: 200 });
+
+            const context = getMockContext(installed);
+            const gain = context.createGainCalls[3];
+
+            expect(
+                (gain?.gain as unknown as { linearRampToValueAtTimeCalls: Array<{ value: number }> })
+                    .linearRampToValueAtTimeCalls,
+            ).toEqual([{ value: 0.8, endTime: 0.2 }]);
+        });
+
+        it('returns unique, incrementing generations for sequential plays into the same slot pool', () => {
+            vi.spyOn(BTAPI.instance, 'getHardwareSettings').mockReturnValue({
+                audioVoices: 1,
+            } as HardwareSettings);
+
+            const pool = new VoicePool(audio);
+
+            const first = pool.play(createMockAudioBuffer());
+            const second = pool.play(createMockAudioBuffer());
+
+            expect(first.voiceIndex).toBe(0);
+            expect(second.voiceIndex).toBe(0);
+            expect(second.generation).toBeGreaterThan(first.generation);
+        });
+
+        it('steals the lowest-priority active voice when the pool is full', () => {
+            vi.spyOn(BTAPI.instance, 'getHardwareSettings').mockReturnValue({
+                audioVoices: 2,
+            } as HardwareSettings);
+
+            const pool = new VoicePool(audio);
+
+            pool.play(createMockAudioBuffer(), { priority: 5 });
+            const low = pool.play(createMockAudioBuffer(), { priority: 1 });
+
+            const stolenRef = pool.play(createMockAudioBuffer(), { priority: 3 });
+
+            expect(stolenRef.voiceIndex).toBe(low.voiceIndex);
+            expect(pool.getStealCount()).toBe(1);
+        });
+
+        it('breaks stealing ties at equal priority by oldest start order', () => {
+            vi.spyOn(BTAPI.instance, 'getHardwareSettings').mockReturnValue({
+                audioVoices: 2,
+            } as HardwareSettings);
+
+            const pool = new VoicePool(audio);
+
+            const oldest = pool.play(createMockAudioBuffer(), { priority: 2 });
+            pool.play(createMockAudioBuffer(), { priority: 2 });
+
+            const stolenRef = pool.play(createMockAudioBuffer(), { priority: 2 });
+
+            expect(stolenRef.voiceIndex).toBe(oldest.voiceIndex);
+        });
+
+        it('drops the request and returns an invalid ref when no slot qualifies to be stolen', () => {
+            vi.spyOn(BTAPI.instance, 'getHardwareSettings').mockReturnValue({
+                audioVoices: 1,
+            } as HardwareSettings);
+
+            const pool = new VoicePool(audio);
+
+            pool.play(createMockAudioBuffer(), { priority: 5 });
+            const dropped = pool.play(createMockAudioBuffer(), { priority: 1 });
+
+            expect(dropped).toEqual(INVALID_SOUND_REF);
+            expect(pool.getDropCount()).toBe(1);
+        });
+
+        it('returns an invalid ref without allocating when the manager has no live context', () => {
+            audio.detach();
+
+            const pool = new VoicePool(audio);
+
+            const ref = pool.play(createMockAudioBuffer());
+
+            expect(ref).toEqual(INVALID_SOUND_REF);
+            expect(pool.getDropCount()).toBe(0);
         });
     });
 });

--- a/src/audio/VoicePool.test.ts
+++ b/src/audio/VoicePool.test.ts
@@ -1,0 +1,78 @@
+// @vitest-environment happy-dom
+
+/**
+ * Unit tests for {@link VoicePool}.
+ *
+ * Constructs a real {@link AudioManager} attached against the Web Audio mock (see
+ * `src/__test__/webaudio-mock.ts`) so `VoicePool` exercises its real `getContext()` /
+ * `getSfxBus()` accessors, then constructs `VoicePool` instances directly against that manager.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { installMockAudioContext, uninstallMockAudioContext } from '../__test__/webaudio-mock';
+import { BTAPI } from '../core/BTAPI';
+import type { HardwareSettings } from '../core/IBTDemo';
+import { AudioManager } from './AudioManager';
+import { VoicePool } from './VoicePool';
+
+/**
+ * Mounts a canvas for {@link AudioManager.attach}.
+ */
+const createCanvas = (): HTMLCanvasElement => {
+    const canvas = document.createElement('canvas');
+
+    document.body.appendChild(canvas);
+
+    return canvas;
+};
+
+describe('VoicePool', () => {
+    let canvas: HTMLCanvasElement;
+    let audio: AudioManager;
+
+    beforeEach(() => {
+        installMockAudioContext();
+        canvas = createCanvas();
+        audio = new AudioManager();
+        audio.attach(canvas);
+    });
+
+    afterEach(() => {
+        audio.detach();
+        canvas.remove();
+        uninstallMockAudioContext();
+        vi.restoreAllMocks();
+    });
+
+    describe('sizing', () => {
+        it('defaults to 16 voice slots when hardware settings are unavailable', () => {
+            vi.spyOn(BTAPI.instance, 'getHardwareSettings').mockReturnValue(null);
+
+            const pool = new VoicePool(audio);
+
+            expect(pool.getStealCount()).toBe(0);
+            expect(pool.getDropCount()).toBe(0);
+
+            // Sizing is verified indirectly in Task 5 (allocation exhaustion); this test only
+            // establishes that construction with no hardware settings does not throw.
+        });
+
+        it('reads the configured audioVoices count', () => {
+            vi.spyOn(BTAPI.instance, 'getHardwareSettings').mockReturnValue({
+                audioVoices: 2,
+            } as HardwareSettings);
+
+            expect(() => new VoicePool(audio)).not.toThrow();
+        });
+    });
+
+    describe('counters', () => {
+        it('starts with zero drop and steal counts', () => {
+            const pool = new VoicePool(audio);
+
+            expect(pool.getDropCount()).toBe(0);
+            expect(pool.getStealCount()).toBe(0);
+        });
+    });
+});

--- a/src/audio/VoicePool.test.ts
+++ b/src/audio/VoicePool.test.ts
@@ -364,5 +364,21 @@ describe('VoicePool', () => {
             expect(() => pool.stop({ voiceIndex: 999, generation: 0 })).not.toThrow();
             expect(pool.isPlaying({ voiceIndex: 999, generation: 0 })).toBe(false);
         });
+
+        it('rejects a negative voiceIndex even when it would coincidentally match the last slot via Array.at(-1)', () => {
+            vi.spyOn(BTAPI.instance, 'getHardwareSettings').mockReturnValue({
+                audioVoices: 2,
+            } as HardwareSettings);
+
+            const pool = new VoicePool(audio);
+
+            // A fresh pool's last slot has generation 0 - the same value `Array.at(-1)` would
+            // wrap to if the explicit bounds check in getActiveSlot were ever removed. This ref
+            // must still be rejected because voiceIndex -1 is out of range.
+            const wouldWrapToLastSlot = { voiceIndex: -1, generation: 0 };
+
+            expect(pool.isPlaying(wouldWrapToLastSlot)).toBe(false);
+            expect(() => pool.stop(wouldWrapToLastSlot)).not.toThrow();
+        });
     });
 });

--- a/src/audio/VoicePool.test.ts
+++ b/src/audio/VoicePool.test.ts
@@ -381,4 +381,81 @@ describe('VoicePool', () => {
             expect(() => pool.stop(wouldWrapToLastSlot)).not.toThrow();
         });
     });
+
+    describe('volume, pitch, and pan', () => {
+        it('gets and sets volume immediately with no fadeMs', () => {
+            vi.spyOn(BTAPI.instance, 'getHardwareSettings').mockReturnValue({
+                audioVoices: 2,
+            } as HardwareSettings);
+
+            const pool = new VoicePool(audio);
+            const ref = pool.play(createMockAudioBuffer(), { volume: 1 });
+
+            pool.volumeSet(ref, 0.3);
+
+            expect(pool.volumeGet(ref)).toBe(0.3);
+        });
+
+        it('ramps volume over fadeMs', () => {
+            vi.spyOn(BTAPI.instance, 'getHardwareSettings').mockReturnValue({
+                audioVoices: 2,
+            } as HardwareSettings);
+
+            const pool = new VoicePool(audio);
+            const ref = pool.play(createMockAudioBuffer(), { volume: 1 });
+
+            pool.volumeSet(ref, 0.2, 100);
+
+            const context = getMockContext(installed);
+            const gain = context.createGainCalls[3];
+
+            expect(
+                (gain?.gain as unknown as { linearRampToValueAtTimeCalls: unknown[] }).linearRampToValueAtTimeCalls,
+            ).toHaveLength(1);
+        });
+
+        it('gets and sets pitch immediately', () => {
+            vi.spyOn(BTAPI.instance, 'getHardwareSettings').mockReturnValue({
+                audioVoices: 2,
+            } as HardwareSettings);
+
+            const pool = new VoicePool(audio);
+            const ref = pool.play(createMockAudioBuffer());
+
+            pool.pitchSet(ref, 2);
+
+            expect(pool.pitchGet(ref)).toBe(2);
+        });
+
+        it('gets and sets pan immediately', () => {
+            vi.spyOn(BTAPI.instance, 'getHardwareSettings').mockReturnValue({
+                audioVoices: 2,
+            } as HardwareSettings);
+
+            const pool = new VoicePool(audio);
+            const ref = pool.play(createMockAudioBuffer());
+
+            pool.panSet(ref, -1);
+
+            expect(pool.panGet(ref)).toBe(-1);
+        });
+
+        it('returns inert defaults and no-ops for a stale ref', () => {
+            vi.spyOn(BTAPI.instance, 'getHardwareSettings').mockReturnValue({
+                audioVoices: 2,
+            } as HardwareSettings);
+
+            const pool = new VoicePool(audio);
+            const ref = pool.play(createMockAudioBuffer());
+
+            pool.stop(ref);
+
+            expect(pool.volumeGet(ref)).toBe(1);
+            expect(pool.pitchGet(ref)).toBe(1);
+            expect(pool.panGet(ref)).toBe(0);
+            expect(() => pool.volumeSet(ref, 0.1)).not.toThrow();
+            expect(() => pool.pitchSet(ref, 2)).not.toThrow();
+            expect(() => pool.panSet(ref, 1)).not.toThrow();
+        });
+    });
 });

--- a/src/audio/VoicePool.test.ts
+++ b/src/audio/VoicePool.test.ts
@@ -14,6 +14,7 @@ import {
     createMockAudioBuffer,
     installMockAudioContext,
     type MockAudioContext,
+    setMockCurrentTime,
     uninstallMockAudioContext,
 } from '../__test__/webaudio-mock';
 import { BTAPI } from '../core/BTAPI';
@@ -38,6 +39,20 @@ const createCanvas = (): HTMLCanvasElement => {
  */
 const getMockContext = (installed: ReturnType<typeof installMockAudioContext>): MockAudioContext =>
     installed.getLastInstance() as unknown as MockAudioContext;
+
+/**
+ * Returns the live mock context most recently constructed by `installed`, for use with
+ * {@link setMockCurrentTime}. Throws if called before `audio.attach()` has constructed one.
+ */
+const getLiveContext = (installed: ReturnType<typeof installMockAudioContext>): AudioContext => {
+    const context = installed.getLastInstance();
+
+    if (context === null) {
+        throw new Error('expected a live mock AudioContext; call audio.attach() first');
+    }
+
+    return context;
+};
 
 describe('VoicePool', () => {
     let canvas: HTMLCanvasElement;
@@ -175,7 +190,24 @@ describe('VoicePool', () => {
             const source = context.createBufferSourceCalls[0];
 
             expect(source?.loop).toBe(true);
-            expect((source as unknown as { startCalls: number[] }).startCalls).toEqual([2.5]);
+            expect((source as unknown as { startCalls: Array<{ when: number }> }).startCalls).toEqual([{ when: 2.5 }]);
+        });
+
+        it('defaults atTime to the current audio-clock time when omitted', () => {
+            vi.spyOn(BTAPI.instance, 'getHardwareSettings').mockReturnValue({
+                audioVoices: 4,
+            } as HardwareSettings);
+
+            const pool = new VoicePool(audio);
+            const context = getMockContext(installed);
+
+            setMockCurrentTime(getLiveContext(installed), 7);
+
+            pool.play(createMockAudioBuffer());
+
+            const source = context.createBufferSourceCalls[0];
+
+            expect((source as unknown as { startCalls: Array<{ when: number }> }).startCalls).toEqual([{ when: 7 }]);
         });
 
         it('ramps gain from silence over fadeInMs', () => {
@@ -194,6 +226,34 @@ describe('VoicePool', () => {
                 (gain?.gain as unknown as { linearRampToValueAtTimeCalls: Array<{ value: number }> })
                     .linearRampToValueAtTimeCalls,
             ).toEqual([{ value: 0.8, endTime: 0.2 }]);
+        });
+
+        it('anchors a fade-in ramp to a non-zero audio-clock time', () => {
+            vi.spyOn(BTAPI.instance, 'getHardwareSettings').mockReturnValue({
+                audioVoices: 4,
+            } as HardwareSettings);
+
+            const pool = new VoicePool(audio);
+            const context = getMockContext(installed);
+
+            setMockCurrentTime(getLiveContext(installed), 10);
+
+            pool.play(createMockAudioBuffer(), { volume: 0.8, fadeInMs: 200 });
+
+            const gain = context.createGainCalls[3];
+
+            expect(
+                (
+                    gain?.gain as unknown as {
+                        setValueAtTimeCalls: Array<{ value: number; startTime: number }>;
+                        linearRampToValueAtTimeCalls: Array<{ value: number; endTime: number }>;
+                    }
+                ).setValueAtTimeCalls,
+            ).toEqual([{ value: 0, startTime: 10 }]);
+            expect(
+                (gain?.gain as unknown as { linearRampToValueAtTimeCalls: Array<{ value: number; endTime: number }> })
+                    .linearRampToValueAtTimeCalls,
+            ).toEqual([{ value: 0.8, endTime: 10.2 }]);
         });
 
         it('returns unique, incrementing generations for sequential plays into the same slot pool', () => {
@@ -336,6 +396,29 @@ describe('VoicePool', () => {
             expect((source as unknown as { stopCalls: number[] }).stopCalls).toEqual([0.5]);
         });
 
+        it('anchors a fadeOutMs ramp and the delayed stop to a non-zero audio-clock time', () => {
+            vi.spyOn(BTAPI.instance, 'getHardwareSettings').mockReturnValue({
+                audioVoices: 2,
+            } as HardwareSettings);
+
+            const pool = new VoicePool(audio);
+            const ref = pool.play(createMockAudioBuffer(), { volume: 1 });
+
+            const context = getMockContext(installed);
+            const gain = context.createGainCalls[3];
+            const source = context.createBufferSourceCalls[0];
+
+            setMockCurrentTime(getLiveContext(installed), 20);
+
+            pool.stop(ref, 500);
+
+            expect(
+                (gain?.gain as unknown as { linearRampToValueAtTimeCalls: Array<{ value: number; endTime: number }> })
+                    .linearRampToValueAtTimeCalls,
+            ).toEqual([{ value: 0, endTime: 20.5 }]);
+            expect((source as unknown as { stopCalls: number[] }).stopCalls).toEqual([20.5]);
+        });
+
         it('stop frees the slot for immediate reuse by a new play()', () => {
             vi.spyOn(BTAPI.instance, 'getHardwareSettings').mockReturnValue({
                 audioVoices: 1,
@@ -425,6 +508,27 @@ describe('VoicePool', () => {
             expect(
                 (gain?.gain as unknown as { linearRampToValueAtTimeCalls: unknown[] }).linearRampToValueAtTimeCalls,
             ).toHaveLength(1);
+        });
+
+        it('anchors a volumeSet fade to a non-zero audio-clock time', () => {
+            vi.spyOn(BTAPI.instance, 'getHardwareSettings').mockReturnValue({
+                audioVoices: 2,
+            } as HardwareSettings);
+
+            const pool = new VoicePool(audio);
+            const ref = pool.play(createMockAudioBuffer(), { volume: 1 });
+
+            const context = getMockContext(installed);
+            const gain = context.createGainCalls[3];
+
+            setMockCurrentTime(getLiveContext(installed), 5);
+
+            pool.volumeSet(ref, 0.2, 100);
+
+            expect(
+                (gain?.gain as unknown as { linearRampToValueAtTimeCalls: Array<{ value: number; endTime: number }> })
+                    .linearRampToValueAtTimeCalls,
+            ).toEqual([{ value: 0.2, endTime: 5.1 }]);
         });
 
         it('gets and sets pitch immediately', () => {

--- a/src/audio/VoicePool.test.ts
+++ b/src/audio/VoicePool.test.ts
@@ -254,4 +254,115 @@ describe('VoicePool', () => {
             expect(pool.getDropCount()).toBe(0);
         });
     });
+
+    describe('stop and isPlaying', () => {
+        it('reports isPlaying true for a freshly played voice', () => {
+            vi.spyOn(BTAPI.instance, 'getHardwareSettings').mockReturnValue({
+                audioVoices: 2,
+            } as HardwareSettings);
+
+            const pool = new VoicePool(audio);
+            const ref = pool.play(createMockAudioBuffer());
+
+            expect(pool.isPlaying(ref)).toBe(true);
+        });
+
+        it('reports isPlaying false for INVALID_SOUND_REF', () => {
+            const pool = new VoicePool(audio);
+
+            expect(pool.isPlaying(INVALID_SOUND_REF)).toBe(false);
+        });
+
+        it('stop immediately frees the slot and invalidates the ref', () => {
+            vi.spyOn(BTAPI.instance, 'getHardwareSettings').mockReturnValue({
+                audioVoices: 2,
+            } as HardwareSettings);
+
+            const pool = new VoicePool(audio);
+            const ref = pool.play(createMockAudioBuffer());
+
+            pool.stop(ref);
+
+            expect(pool.isPlaying(ref)).toBe(false);
+        });
+
+        it('stop without fadeOutMs stops the source node immediately', () => {
+            vi.spyOn(BTAPI.instance, 'getHardwareSettings').mockReturnValue({
+                audioVoices: 2,
+            } as HardwareSettings);
+
+            const pool = new VoicePool(audio);
+            const ref = pool.play(createMockAudioBuffer());
+
+            const context = getMockContext(installed);
+            const source = context.createBufferSourceCalls[0];
+
+            pool.stop(ref);
+
+            expect((source as unknown as { stopCalls: number[] }).stopCalls).toEqual([0]);
+        });
+
+        it('stop with fadeOutMs ramps gain to zero and schedules a delayed stop', () => {
+            vi.spyOn(BTAPI.instance, 'getHardwareSettings').mockReturnValue({
+                audioVoices: 2,
+            } as HardwareSettings);
+
+            const pool = new VoicePool(audio);
+            const ref = pool.play(createMockAudioBuffer(), { volume: 1 });
+
+            const context = getMockContext(installed);
+            const gain = context.createGainCalls[3];
+            const source = context.createBufferSourceCalls[0];
+
+            pool.stop(ref, 500);
+
+            expect(
+                (gain?.gain as unknown as { linearRampToValueAtTimeCalls: Array<{ value: number; endTime: number }> })
+                    .linearRampToValueAtTimeCalls,
+            ).toEqual([{ value: 0, endTime: 0.5 }]);
+            expect((source as unknown as { stopCalls: number[] }).stopCalls).toEqual([0.5]);
+        });
+
+        it('stop frees the slot for immediate reuse by a new play()', () => {
+            vi.spyOn(BTAPI.instance, 'getHardwareSettings').mockReturnValue({
+                audioVoices: 1,
+            } as HardwareSettings);
+
+            const pool = new VoicePool(audio);
+            const first = pool.play(createMockAudioBuffer());
+
+            pool.stop(first, 500);
+
+            const second = pool.play(createMockAudioBuffer());
+
+            expect(second.voiceIndex).toBe(first.voiceIndex);
+            expect(pool.getStealCount()).toBe(0);
+        });
+
+        it('is a no-op when stopping an already-stale ref', () => {
+            vi.spyOn(BTAPI.instance, 'getHardwareSettings').mockReturnValue({
+                audioVoices: 2,
+            } as HardwareSettings);
+
+            const pool = new VoicePool(audio);
+            const ref = pool.play(createMockAudioBuffer());
+
+            pool.stop(ref);
+
+            expect(() => pool.stop(ref)).not.toThrow();
+        });
+
+        it('is a no-op when stopping INVALID_SOUND_REF', () => {
+            const pool = new VoicePool(audio);
+
+            expect(() => pool.stop(INVALID_SOUND_REF)).not.toThrow();
+        });
+
+        it('is a no-op for an out-of-range voiceIndex', () => {
+            const pool = new VoicePool(audio);
+
+            expect(() => pool.stop({ voiceIndex: 999, generation: 0 })).not.toThrow();
+            expect(pool.isPlaying({ voiceIndex: 999, generation: 0 })).toBe(false);
+        });
+    });
 });

--- a/src/audio/VoicePool.test.ts
+++ b/src/audio/VoicePool.test.ts
@@ -458,4 +458,121 @@ describe('VoicePool', () => {
             expect(() => pool.panSet(ref, 1)).not.toThrow();
         });
     });
+
+    describe('natural completion', () => {
+        it('recycles the slot when onended fires', () => {
+            vi.spyOn(BTAPI.instance, 'getHardwareSettings').mockReturnValue({
+                audioVoices: 2,
+            } as HardwareSettings);
+
+            const pool = new VoicePool(audio);
+            const ref = pool.play(createMockAudioBuffer());
+
+            const context = getMockContext(installed);
+            const source = context.createBufferSourceCalls[0];
+
+            (source?.onended as () => void)();
+
+            expect(pool.isPlaying(ref)).toBe(false);
+        });
+
+        it('disconnects the ended nodes', () => {
+            vi.spyOn(BTAPI.instance, 'getHardwareSettings').mockReturnValue({
+                audioVoices: 2,
+            } as HardwareSettings);
+
+            const pool = new VoicePool(audio);
+
+            pool.play(createMockAudioBuffer());
+
+            const context = getMockContext(installed);
+            const source = context.createBufferSourceCalls[0];
+            const disconnectSpy = vi.spyOn(source as AudioBufferSourceNode, 'disconnect');
+
+            (source?.onended as () => void)();
+
+            expect(disconnectSpy).toHaveBeenCalledTimes(1);
+        });
+
+        it('a stale onended from a stolen voice does not clobber the new occupant', () => {
+            vi.spyOn(BTAPI.instance, 'getHardwareSettings').mockReturnValue({
+                audioVoices: 1,
+            } as HardwareSettings);
+
+            const pool = new VoicePool(audio);
+            const first = pool.play(createMockAudioBuffer(), { priority: 1 });
+
+            const context = getMockContext(installed);
+            const firstSource = context.createBufferSourceCalls[0];
+
+            const second = pool.play(createMockAudioBuffer(), { priority: 5 });
+
+            (firstSource?.onended as () => void)();
+
+            expect(pool.isPlaying(second)).toBe(true);
+            expect(first.voiceIndex).toBe(second.voiceIndex);
+        });
+
+        it('frees the slot for a new play() after natural completion', () => {
+            vi.spyOn(BTAPI.instance, 'getHardwareSettings').mockReturnValue({
+                audioVoices: 1,
+            } as HardwareSettings);
+
+            const pool = new VoicePool(audio);
+            pool.play(createMockAudioBuffer());
+
+            const context = getMockContext(installed);
+            const source = context.createBufferSourceCalls[0];
+
+            (source?.onended as () => void)();
+
+            const next = pool.play(createMockAudioBuffer());
+
+            expect(pool.getStealCount()).toBe(0);
+            expect(next.voiceIndex).toBe(0);
+        });
+    });
+
+    describe('stopAll', () => {
+        it('stops and disconnects every active voice', () => {
+            vi.spyOn(BTAPI.instance, 'getHardwareSettings').mockReturnValue({
+                audioVoices: 2,
+            } as HardwareSettings);
+
+            const pool = new VoicePool(audio);
+            const first = pool.play(createMockAudioBuffer());
+            const second = pool.play(createMockAudioBuffer());
+
+            pool.stopAll();
+
+            expect(pool.isPlaying(first)).toBe(false);
+            expect(pool.isPlaying(second)).toBe(false);
+        });
+
+        it('is a no-op on an empty pool', () => {
+            const pool = new VoicePool(audio);
+
+            expect(() => pool.stopAll()).not.toThrow();
+        });
+    });
+
+    describe('stopVoicesUsingBuffer', () => {
+        it('stops only voices referencing the released buffer', () => {
+            vi.spyOn(BTAPI.instance, 'getHardwareSettings').mockReturnValue({
+                audioVoices: 2,
+            } as HardwareSettings);
+
+            const pool = new VoicePool(audio);
+            const releasedBuffer = createMockAudioBuffer();
+            const otherBuffer = createMockAudioBuffer();
+
+            const releasedRef = pool.play(releasedBuffer);
+            const otherRef = pool.play(otherBuffer);
+
+            pool.stopVoicesUsingBuffer(releasedBuffer);
+
+            expect(pool.isPlaying(releasedRef)).toBe(false);
+            expect(pool.isPlaying(otherRef)).toBe(true);
+        });
+    });
 });

--- a/src/audio/VoicePool.test.ts
+++ b/src/audio/VoicePool.test.ts
@@ -64,11 +64,15 @@ describe('VoicePool', () => {
 
             const pool = new VoicePool(audio);
 
-            expect(pool.getStealCount()).toBe(0);
-            expect(pool.getDropCount()).toBe(0);
+            for (let i = 0; i < 16; i++) {
+                pool.play(createMockAudioBuffer());
+            }
 
-            // Sizing is verified indirectly in Task 5 (allocation exhaustion); this test only
-            // establishes that construction with no hardware settings does not throw.
+            expect(pool.getStealCount()).toBe(0);
+
+            pool.play(createMockAudioBuffer());
+
+            expect(pool.getStealCount()).toBe(1);
         });
 
         it('reads the configured audioVoices count', () => {
@@ -76,7 +80,16 @@ describe('VoicePool', () => {
                 audioVoices: 2,
             } as HardwareSettings);
 
-            expect(() => new VoicePool(audio)).not.toThrow();
+            const pool = new VoicePool(audio);
+
+            pool.play(createMockAudioBuffer());
+            pool.play(createMockAudioBuffer());
+
+            expect(pool.getStealCount()).toBe(0);
+
+            pool.play(createMockAudioBuffer());
+
+            expect(pool.getStealCount()).toBe(1);
         });
     });
 

--- a/src/audio/VoicePool.test.ts
+++ b/src/audio/VoicePool.test.ts
@@ -54,6 +54,13 @@ const getLiveContext = (installed: ReturnType<typeof installMockAudioContext>): 
     return context;
 };
 
+/**
+ * Returns the most recently created gain node - the current voice's gain. Bus gains
+ * (main/music/sfx) are all created once during `attach()`, before any voice plays, so the last
+ * entry is always the voice gain regardless of how many bus gains exist.
+ */
+const getVoiceGain = (context: MockAudioContext): GainNode | undefined => context.createGainCalls.at(-1);
+
 describe('VoicePool', () => {
     let canvas: HTMLCanvasElement;
     let audio: AudioManager;
@@ -130,7 +137,7 @@ describe('VoicePool', () => {
 
             const context = getMockContext(installed);
             const source = context.createBufferSourceCalls[0];
-            const gain = context.createGainCalls[3]; // 0-2 are main/music/sfx from buildBusGraph
+            const gain = getVoiceGain(context);
             const panner = context.createStereoPannerCalls[0];
 
             expect((source as unknown as { connectCalls: unknown[] }).connectCalls).toEqual([gain]);
@@ -150,7 +157,7 @@ describe('VoicePool', () => {
 
             const context = getMockContext(installed);
             const source = context.createBufferSourceCalls[0];
-            const gain = context.createGainCalls[3];
+            const gain = getVoiceGain(context);
             const panner = context.createStereoPannerCalls[0];
 
             expect(gain?.gain.value).toBe(0.5);
@@ -168,7 +175,7 @@ describe('VoicePool', () => {
             pool.play(createMockAudioBuffer());
 
             const context = getMockContext(installed);
-            const gain = context.createGainCalls[3];
+            const gain = getVoiceGain(context);
             const source = context.createBufferSourceCalls[0];
             const panner = context.createStereoPannerCalls[0];
 
@@ -220,7 +227,7 @@ describe('VoicePool', () => {
             pool.play(createMockAudioBuffer(), { volume: 0.8, fadeInMs: 200 });
 
             const context = getMockContext(installed);
-            const gain = context.createGainCalls[3];
+            const gain = getVoiceGain(context);
 
             expect(
                 (gain?.gain as unknown as { linearRampToValueAtTimeCalls: Array<{ value: number }> })
@@ -240,7 +247,7 @@ describe('VoicePool', () => {
 
             pool.play(createMockAudioBuffer(), { volume: 0.8, fadeInMs: 200 });
 
-            const gain = context.createGainCalls[3];
+            const gain = getVoiceGain(context);
 
             expect(
                 (
@@ -384,7 +391,7 @@ describe('VoicePool', () => {
             const ref = pool.play(createMockAudioBuffer(), { volume: 1 });
 
             const context = getMockContext(installed);
-            const gain = context.createGainCalls[3];
+            const gain = getVoiceGain(context);
             const source = context.createBufferSourceCalls[0];
 
             pool.stop(ref, 500);
@@ -405,7 +412,7 @@ describe('VoicePool', () => {
             const ref = pool.play(createMockAudioBuffer(), { volume: 1 });
 
             const context = getMockContext(installed);
-            const gain = context.createGainCalls[3];
+            const gain = getVoiceGain(context);
             const source = context.createBufferSourceCalls[0];
 
             setMockCurrentTime(getLiveContext(installed), 20);
@@ -503,7 +510,7 @@ describe('VoicePool', () => {
             pool.volumeSet(ref, 0.2, 100);
 
             const context = getMockContext(installed);
-            const gain = context.createGainCalls[3];
+            const gain = getVoiceGain(context);
 
             expect(
                 (gain?.gain as unknown as { linearRampToValueAtTimeCalls: unknown[] }).linearRampToValueAtTimeCalls,
@@ -519,7 +526,7 @@ describe('VoicePool', () => {
             const ref = pool.play(createMockAudioBuffer(), { volume: 1 });
 
             const context = getMockContext(installed);
-            const gain = context.createGainCalls[3];
+            const gain = getVoiceGain(context);
 
             setMockCurrentTime(getLiveContext(installed), 5);
 

--- a/src/audio/VoicePool.ts
+++ b/src/audio/VoicePool.ts
@@ -12,10 +12,26 @@
  */
 
 import { BTAPI } from '../core/BTAPI';
+import { applyAudioParamRamp } from '../utils/AudioParamRamp';
 import type { AudioManager } from './AudioManager';
 
 /** Fallback voice count used when `HardwareSettings.audioVoices` is unavailable. Mirrors `defaultConfig()`. */
 const DEFAULT_VOICE_COUNT = 16;
+
+/** Default per-voice gain applied when {@link VoicePlayOptions.volume} is omitted. */
+const DEFAULT_VOLUME = 1;
+
+/** Default playback rate applied when {@link VoicePlayOptions.pitch} is omitted. */
+const DEFAULT_PITCH = 1;
+
+/** Default stereo pan applied when {@link VoicePlayOptions.pan} is omitted. */
+const DEFAULT_PAN = 0;
+
+/** Default allocation priority applied when {@link VoicePlayOptions.priority} is omitted. */
+const DEFAULT_PRIORITY = 0;
+
+/** Default loop flag applied when {@link VoicePlayOptions.loop} is omitted. */
+const DEFAULT_LOOP = false;
 
 /**
  * Opaque generational handle identifying a single pool-allocated voice.
@@ -91,14 +107,12 @@ interface VoiceSlot {
  */
 export class VoicePool {
     /** Owning audio manager; source of the live context and `sfx` bus. */
-    // @ts-expect-error TS6133: 'audioManager' will be used in play/stop methods (Tasks 5+).
     private readonly audioManager: AudioManager;
 
     /** Fixed-size slot array, sized at construction from `HardwareSettings.audioVoices`. */
     private readonly slots: VoiceSlot[];
 
     /** Monotonic counter incremented on every `play()`; used for stealing age tiebreaks. */
-    // @ts-expect-error TS6133: 'nextStartOrder' will be used in play/stop methods (Tasks 5+).
     private nextStartOrder = 0;
 
     /** Count of `play()` calls that found no free or stealable slot. */
@@ -115,6 +129,52 @@ export class VoicePool {
     constructor(audioManager: AudioManager) {
         this.audioManager = audioManager;
         this.slots = Array.from({ length: resolveVoiceCount() }, () => createEmptySlot());
+    }
+
+    /**
+     * Allocates a voice and starts playing `buffer` through it.
+     *
+     * Picks the first free slot, or steals the lowest-priority active slot at or below the
+     * incoming priority (oldest {@link VoiceSlot.startOrder} breaks ties). Returns
+     * {@link INVALID_SOUND_REF} without allocating when the audio manager has no live context
+     * or `sfx` bus (not attached, or already detached), and increments {@link getDropCount} when
+     * every active slot outranks the incoming priority.
+     *
+     * @param buffer - Decoded audio buffer to play.
+     * @param options - Playback options; see {@link VoicePlayOptions}.
+     * @returns A {@link SoundRef} identifying the new voice, or {@link INVALID_SOUND_REF}.
+     */
+    public play(buffer: AudioBuffer, options: VoicePlayOptions = {}): SoundRef {
+        const context = this.audioManager.getContext();
+        const sfxBus = this.audioManager.getSfxBus();
+
+        if (context === null || sfxBus === null) {
+            return INVALID_SOUND_REF;
+        }
+
+        const priority = options.priority ?? DEFAULT_PRIORITY;
+        const slotIndex = this.allocateSlot(priority);
+
+        if (slotIndex === null) {
+            this.dropCount += 1;
+
+            return INVALID_SOUND_REF;
+        }
+
+        const slot = this.slots.at(slotIndex);
+
+        if (slot === undefined) {
+            return INVALID_SOUND_REF;
+        }
+
+        if (slot.isActive) {
+            this.stealCount += 1;
+            this.disconnectVoice(slot);
+        }
+
+        this.startVoice(slot, slotIndex, buffer, options, priority, context, sfxBus);
+
+        return { voiceIndex: slotIndex, generation: slot.generation };
     }
 
     /**
@@ -141,7 +201,6 @@ export class VoicePool {
      * @param priority - Allocation priority of the incoming voice.
      * @returns Slot index to use, or `null` when no free or stealable slot exists.
      */
-    // @ts-expect-error TS6133: 'allocateSlot' will be called by play() (Task 6).
     private allocateSlot(priority: number): number | null {
         const freeIndex = this.slots.findIndex((slot) => !slot.isActive);
 
@@ -182,6 +241,117 @@ export class VoicePool {
         }
 
         return candidateIndex;
+    }
+
+    /**
+     * Builds a fresh `source -> gain -> panner -> sfx bus` chain in `slot` and starts playback.
+     *
+     * Bumps `slot.generation` so the returned {@link SoundRef} (built by the caller from the
+     * post-call `slot.generation`) is unique even when reusing a stolen slot.
+     *
+     * @param slot - Slot to populate (already disconnected from any prior voice by the caller).
+     * @param slotIndex - Index of `slot`, captured for the `onended` recycle callback.
+     * @param buffer - Decoded audio buffer to play.
+     * @param options - Playback options; see {@link VoicePlayOptions}.
+     * @param priority - Resolved allocation priority (already defaulted by the caller).
+     * @param context - Live audio context (already validated non-null by the caller).
+     * @param sfxBus - Live `sfx` bus gain node (already validated non-null by the caller).
+     */
+    private startVoice(
+        slot: VoiceSlot,
+        slotIndex: number,
+        buffer: AudioBuffer,
+        options: VoicePlayOptions,
+        priority: number,
+        context: AudioContext,
+        sfxBus: GainNode,
+    ): void {
+        const source = context.createBufferSource();
+        const gain = context.createGain();
+        const panner = context.createStereoPanner();
+
+        source.buffer = buffer;
+        source.loop = options.loop ?? DEFAULT_LOOP;
+        source.playbackRate.value = options.pitch ?? DEFAULT_PITCH;
+        panner.pan.value = options.pan ?? DEFAULT_PAN;
+
+        source.connect(gain);
+        gain.connect(panner);
+        panner.connect(sfxBus);
+
+        const generation = slot.generation + 1;
+        const startOrder = this.nextStartOrder++;
+
+        slot.source = source;
+        slot.gain = gain;
+        slot.panner = panner;
+        slot.buffer = buffer;
+        slot.isActive = true;
+        slot.priority = priority;
+        slot.startOrder = startOrder;
+        slot.generation = generation;
+
+        source.onended = () => {
+            source.disconnect();
+            gain.disconnect();
+            panner.disconnect();
+            this.handleVoiceEnded(slotIndex, generation);
+        };
+
+        const targetVolume = options.volume ?? DEFAULT_VOLUME;
+        const atTime = options.atTime ?? context.currentTime;
+
+        if (options.fadeInMs !== undefined && options.fadeInMs > 0) {
+            gain.gain.value = 0;
+            applyAudioParamRamp(gain.gain, atTime, targetVolume, options.fadeInMs, 'linear');
+        } else {
+            gain.gain.value = targetVolume;
+        }
+
+        source.start(atTime);
+    }
+
+    /**
+     * Immediately stops and disconnects `slot`'s current node chain, if any.
+     *
+     * Clears `onended` first so the about-to-be-superseded voice's natural-completion callback
+     * never fires (its cleanup - disconnect and generation-guarded slot reset - is handled here
+     * instead, synchronously, since the caller is about to overwrite or reset this slot).
+     *
+     * @param slot - Slot whose current node chain should be torn down.
+     */
+    private disconnectVoice(slot: VoiceSlot): void {
+        if (slot.source !== null) {
+            slot.source.onended = null;
+            slot.source.stop();
+            slot.source.disconnect();
+        }
+
+        slot.gain?.disconnect();
+        slot.panner?.disconnect();
+    }
+
+    /**
+     * Recycles `slotIndex` when its generation still matches `expectedGeneration` (a no-op when
+     * the slot has already been reused - see {@link disconnectVoice}). Implemented fully in a
+     * later task; for now this only exists so {@link startVoice}'s `onended` closure compiles.
+     *
+     * @param slotIndex - Index of the slot whose voice just ended.
+     * @param expectedGeneration - Generation captured when the ended voice was started.
+     */
+    private handleVoiceEnded(slotIndex: number, expectedGeneration: number): void {
+        const slot = this.slots.at(slotIndex);
+
+        if (slot === undefined || slot.generation !== expectedGeneration) {
+            return;
+        }
+
+        slot.source = null;
+        slot.gain = null;
+        slot.panner = null;
+        slot.buffer = null;
+        slot.isActive = false;
+        slot.generation += 1;
     }
 }
 

--- a/src/audio/VoicePool.ts
+++ b/src/audio/VoicePool.ts
@@ -19,13 +19,13 @@ import type { AudioManager } from './AudioManager';
 const DEFAULT_VOICE_COUNT = 16;
 
 /** Default per-voice gain applied when {@link VoicePlayOptions.volume} is omitted. */
-const DEFAULT_VOLUME = 1;
+export const DEFAULT_VOLUME = 1;
 
 /** Default playback rate applied when {@link VoicePlayOptions.pitch} is omitted. */
-const DEFAULT_PITCH = 1;
+export const DEFAULT_PITCH = 1;
 
 /** Default stereo pan applied when {@link VoicePlayOptions.pan} is omitted. */
-const DEFAULT_PAN = 0;
+export const DEFAULT_PAN = 0;
 
 /** Default allocation priority applied when {@link VoicePlayOptions.priority} is omitted. */
 const DEFAULT_PRIORITY = 0;
@@ -73,6 +73,42 @@ export interface VoicePlayOptions {
 
     /** Audio-clock start time (`AudioContext.currentTime`-relative). Defaults to "now". */
     atTime?: number;
+}
+
+/** Options accepted by {@link BTAPI.soundPlay} and {@link BT.soundPlay}. */
+export interface SoundPlayOptions {
+    /** Whether the clip loops. Defaults to `false`. */
+    loop?: boolean;
+
+    /** Initial gain in `[0, 1]` (unclamped). Defaults to `1`. */
+    volume?: number;
+
+    /** Initial playback rate. Defaults to `1`. */
+    pitch?: number;
+
+    /** Initial stereo pan in `[-1, 1]` (unclamped). Defaults to `0`. */
+    pan?: number;
+
+    /** Allocation priority; higher survives voice stealing longer. Defaults to `0`. */
+    priority?: number;
+
+    /** Optional linear fade-in duration in milliseconds, from silence to `volume`. */
+    fadeInMs?: number;
+
+    /** Audio-clock start time (`AudioContext.currentTime`-relative). Defaults to "now". */
+    atTime?: number;
+}
+
+/** Options accepted by {@link BT.soundStop}. */
+export interface SoundStopOptions {
+    /** Optional linear fade-out duration in milliseconds before the voice actually stops. */
+    fadeOutMs?: number;
+}
+
+/** Options accepted by {@link BT.soundVolumeSet}, {@link BT.soundPitchSet}, and {@link BT.soundPanSet}. */
+export interface SoundParamSetOptions {
+    /** Fade duration in milliseconds. Omit for an immediate change. */
+    fadeMs?: number;
 }
 
 /** Per-slot playback state. Fields are `null`/inactive when the slot holds no live voice. */

--- a/src/audio/VoicePool.ts
+++ b/src/audio/VoicePool.ts
@@ -320,6 +320,11 @@ export class VoicePool {
      * Called by the {@link AudioClip.unload} guard (via `audioDecodeContext`'s unload handler)
      * so a released buffer can never keep playing from a stale voice.
      *
+     * A voice already mid-fade-out via {@link stop} is not affected by this call - `resetSlot`
+     * already cleared its `buffer` reference when `stop()` ran, so it is no longer tracked as
+     * using this buffer. That is safe: Web Audio keeps the decoded buffer alive as long as a
+     * source node is still using it, independent of {@link AudioClip}'s own JS-side reference.
+     *
      * @param buffer - Buffer being released.
      */
     public stopVoicesUsingBuffer(buffer: AudioBuffer): void {

--- a/src/audio/VoicePool.ts
+++ b/src/audio/VoicePool.ts
@@ -197,7 +197,7 @@ export class VoicePool {
             return;
         }
 
-        const currentTime = this.audioManager.getContext()?.currentTime ?? 0;
+        const currentTime = this.currentTime();
 
         if (fadeOutMs !== undefined && fadeOutMs > 0 && slot.gain !== null) {
             applyAudioParamRamp(slot.gain.gain, currentTime, 0, fadeOutMs, 'linear');
@@ -217,6 +217,87 @@ export class VoicePool {
      */
     public isPlaying(ref: SoundRef): boolean {
         return this.getActiveSlot(ref) !== null;
+    }
+
+    /**
+     * Returns a voice's current gain.
+     *
+     * @param ref - Voice to query.
+     * @returns Current gain, or {@link DEFAULT_VOLUME} on a stale/invalid ref.
+     */
+    public volumeGet(ref: SoundRef): number {
+        return this.getActiveSlot(ref)?.gain?.gain.value ?? DEFAULT_VOLUME;
+    }
+
+    /**
+     * Sets a voice's gain, optionally ramping to it.
+     *
+     * @param ref - Voice to update.
+     * @param value - Target gain.
+     * @param fadeMs - Optional fade duration in milliseconds; omit for an immediate change.
+     */
+    public volumeSet(ref: SoundRef, value: number, fadeMs?: number): void {
+        const slot = this.getActiveSlot(ref);
+
+        if (slot === null || slot.gain === null) {
+            return;
+        }
+
+        applyAudioParamRamp(slot.gain.gain, this.currentTime(), value, fadeMs, 'linear');
+    }
+
+    /**
+     * Returns a voice's current playback rate.
+     *
+     * @param ref - Voice to query.
+     * @returns Current playback rate, or {@link DEFAULT_PITCH} on a stale/invalid ref.
+     */
+    public pitchGet(ref: SoundRef): number {
+        return this.getActiveSlot(ref)?.source?.playbackRate.value ?? DEFAULT_PITCH;
+    }
+
+    /**
+     * Sets a voice's playback rate, optionally ramping to it.
+     *
+     * @param ref - Voice to update.
+     * @param value - Target playback rate.
+     * @param fadeMs - Optional fade duration in milliseconds; omit for an immediate change.
+     */
+    public pitchSet(ref: SoundRef, value: number, fadeMs?: number): void {
+        const slot = this.getActiveSlot(ref);
+
+        if (slot === null || slot.source === null) {
+            return;
+        }
+
+        applyAudioParamRamp(slot.source.playbackRate, this.currentTime(), value, fadeMs, 'linear');
+    }
+
+    /**
+     * Returns a voice's current stereo pan.
+     *
+     * @param ref - Voice to query.
+     * @returns Current pan, or {@link DEFAULT_PAN} on a stale/invalid ref.
+     */
+    public panGet(ref: SoundRef): number {
+        return this.getActiveSlot(ref)?.panner?.pan.value ?? DEFAULT_PAN;
+    }
+
+    /**
+     * Sets a voice's stereo pan, optionally ramping to it.
+     *
+     * @param ref - Voice to update.
+     * @param value - Target pan.
+     * @param fadeMs - Optional fade duration in milliseconds; omit for an immediate change.
+     */
+    public panSet(ref: SoundRef, value: number, fadeMs?: number): void {
+        const slot = this.getActiveSlot(ref);
+
+        if (slot === null || slot.panner === null) {
+            return;
+        }
+
+        applyAudioParamRamp(slot.panner.pan, this.currentTime(), value, fadeMs, 'linear');
     }
 
     /**
@@ -392,6 +473,15 @@ export class VoicePool {
         }
 
         return slot;
+    }
+
+    /**
+     * Returns the live audio-clock time, or `0` when the manager has no live context.
+     *
+     * @returns `AudioContext.currentTime`, or `0` when not attached.
+     */
+    private currentTime(): number {
+        return this.audioManager.getContext()?.currentTime ?? 0;
     }
 
     /**

--- a/src/audio/VoicePool.ts
+++ b/src/audio/VoicePool.ts
@@ -75,29 +75,16 @@ export interface VoicePlayOptions {
     atTime?: number;
 }
 
-/** Options accepted by {@link BTAPI.soundPlay} and {@link BT.soundPlay}. */
-export interface SoundPlayOptions {
-    /** Whether the clip loops. Defaults to `false`. */
-    loop?: boolean;
-
-    /** Initial gain in `[0, 1]` (unclamped). Defaults to `1`. */
-    volume?: number;
-
-    /** Initial playback rate. Defaults to `1`. */
-    pitch?: number;
-
-    /** Initial stereo pan in `[-1, 1]` (unclamped). Defaults to `0`. */
-    pan?: number;
-
-    /** Allocation priority; higher survives voice stealing longer. Defaults to `0`. */
-    priority?: number;
-
-    /** Optional linear fade-in duration in milliseconds, from silence to `volume`. */
-    fadeInMs?: number;
-
-    /** Audio-clock start time (`AudioContext.currentTime`-relative). Defaults to "now". */
-    atTime?: number;
-}
+/**
+ * Options accepted by {@link BTAPI.soundPlay} and {@link BT.soundPlay}.
+ *
+ * Identical to {@link VoicePlayOptions} by design - `soundPlay` forwards this object unchanged
+ * down to {@link AudioManager.playSound} and {@link VoicePool.play}. Declared as an `extends` of
+ * `VoicePlayOptions` (rather than redeclaring the same fields) so a future field added to either
+ * type cannot silently drift out of sync with the other.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type -- intentional no-op extends keeps SoundPlayOptions in lockstep with VoicePlayOptions
+export interface SoundPlayOptions extends VoicePlayOptions {}
 
 /** Options accepted by {@link BT.soundStop}. */
 export interface SoundStopOptions {

--- a/src/audio/VoicePool.ts
+++ b/src/audio/VoicePool.ts
@@ -178,6 +178,48 @@ export class VoicePool {
     }
 
     /**
+     * Stops a playing voice, immediately freeing its slot for reuse.
+     *
+     * When `fadeOutMs` is given, ramps gain to `0` over that duration and schedules the
+     * underlying source to stop only once the ramp completes - the fade is still audible even
+     * though the slot itself is already free and may be reused by the very next `play()` call
+     * (the reused slot gets fresh nodes; the fading-out nodes keep playing independently until
+     * their own scheduled stop fires and their `onended` closure disconnects them). Silently
+     * no-ops when `ref` is stale, out of range, or already stopped.
+     *
+     * @param ref - Voice to stop.
+     * @param fadeOutMs - Optional linear fade-out duration in milliseconds.
+     */
+    public stop(ref: SoundRef, fadeOutMs?: number): void {
+        const slot = this.getActiveSlot(ref);
+
+        if (slot === null) {
+            return;
+        }
+
+        const currentTime = this.audioManager.getContext()?.currentTime ?? 0;
+
+        if (fadeOutMs !== undefined && fadeOutMs > 0 && slot.gain !== null) {
+            applyAudioParamRamp(slot.gain.gain, currentTime, 0, fadeOutMs, 'linear');
+            slot.source?.stop(currentTime + fadeOutMs / 1000);
+        } else {
+            slot.source?.stop();
+        }
+
+        this.resetSlot(slot);
+    }
+
+    /**
+     * Reports whether `ref` still identifies a live voice.
+     *
+     * @param ref - Voice to query.
+     * @returns `true` when `ref`'s generation matches its slot's current generation.
+     */
+    public isPlaying(ref: SoundRef): boolean {
+        return this.getActiveSlot(ref) !== null;
+    }
+
+    /**
      * Returns the number of `play()` calls dropped because no slot was free or stealable.
      *
      * @returns Drop count.
@@ -332,9 +374,44 @@ export class VoicePool {
     }
 
     /**
+     * Returns `ref`'s slot when `ref` still identifies a live voice, or `null` when the index is
+     * out of range or the generation no longer matches (stale ref).
+     *
+     * @param ref - Voice reference to validate.
+     * @returns The live slot, or `null` on a stale/invalid ref.
+     */
+    private getActiveSlot(ref: SoundRef): VoiceSlot | null {
+        if (ref.voiceIndex < 0 || ref.voiceIndex >= this.slots.length) {
+            return null;
+        }
+
+        const slot = this.slots.at(ref.voiceIndex);
+
+        if (slot === undefined || slot.generation !== ref.generation) {
+            return null;
+        }
+
+        return slot;
+    }
+
+    /**
+     * Clears a slot's node references and marks it inactive, bumping its generation so any
+     * outstanding {@link SoundRef} pointing at it becomes stale.
+     *
+     * @param slot - Slot to reset.
+     */
+    private resetSlot(slot: VoiceSlot): void {
+        slot.source = null;
+        slot.gain = null;
+        slot.panner = null;
+        slot.buffer = null;
+        slot.isActive = false;
+        slot.generation += 1;
+    }
+
+    /**
      * Recycles `slotIndex` when its generation still matches `expectedGeneration` (a no-op when
-     * the slot has already been reused - see {@link disconnectVoice}). Implemented fully in a
-     * later task; for now this only exists so {@link startVoice}'s `onended` closure compiles.
+     * the slot has already been reused - see {@link disconnectVoice}).
      *
      * @param slotIndex - Index of the slot whose voice just ended.
      * @param expectedGeneration - Generation captured when the ended voice was started.
@@ -346,12 +423,7 @@ export class VoicePool {
             return;
         }
 
-        slot.source = null;
-        slot.gain = null;
-        slot.panner = null;
-        slot.buffer = null;
-        slot.isActive = false;
-        slot.generation += 1;
+        this.resetSlot(slot);
     }
 }
 

--- a/src/audio/VoicePool.ts
+++ b/src/audio/VoicePool.ts
@@ -301,6 +301,36 @@ export class VoicePool {
     }
 
     /**
+     * Stops and disconnects every active voice, invalidating all outstanding refs.
+     *
+     * Called by {@link AudioManager.detach} before the audio context closes.
+     */
+    public stopAll(): void {
+        for (const slot of this.slots) {
+            if (slot.isActive) {
+                this.forceStopSlot(slot);
+            }
+        }
+    }
+
+    /**
+     * Stops and disconnects every active voice currently playing `buffer`, invalidating their
+     * refs.
+     *
+     * Called by the {@link AudioClip.unload} guard (via `audioDecodeContext`'s unload handler)
+     * so a released buffer can never keep playing from a stale voice.
+     *
+     * @param buffer - Buffer being released.
+     */
+    public stopVoicesUsingBuffer(buffer: AudioBuffer): void {
+        for (const slot of this.slots) {
+            if (slot.isActive && slot.buffer === buffer) {
+                this.forceStopSlot(slot);
+            }
+        }
+    }
+
+    /**
      * Returns the number of `play()` calls dropped because no slot was free or stealable.
      *
      * @returns Drop count.
@@ -437,21 +467,35 @@ export class VoicePool {
     /**
      * Immediately stops and disconnects `slot`'s current node chain, if any.
      *
-     * Clears `onended` first so the about-to-be-superseded voice's natural-completion callback
-     * never fires (its cleanup - disconnect and generation-guarded slot reset - is handled here
-     * instead, synchronously, since the caller is about to overwrite or reset this slot).
+     * Does not clear `onended` - the original callback may still fire later (asynchronously,
+     * once the browser actually ends the stopped source), but {@link handleVoiceEnded}'s
+     * generation guard safely no-ops it by then, since the caller has already reassigned or
+     * reset this slot to a new generation before that callback can run (JavaScript's
+     * single-threaded execution guarantees no interleaving between this synchronous teardown
+     * and the slot's next synchronous mutation).
      *
      * @param slot - Slot whose current node chain should be torn down.
      */
     private disconnectVoice(slot: VoiceSlot): void {
         if (slot.source !== null) {
-            slot.source.onended = null;
             slot.source.stop();
             slot.source.disconnect();
         }
 
         slot.gain?.disconnect();
         slot.panner?.disconnect();
+    }
+
+    /**
+     * Immediately stops, disconnects, and recycles `slot` if it is active. Unlike
+     * {@link stop}, this always tears the node chain down synchronously - used for teardown
+     * paths ({@link stopAll}, {@link stopVoicesUsingBuffer}) where lingering audio is not wanted.
+     *
+     * @param slot - Slot to force-stop.
+     */
+    private forceStopSlot(slot: VoiceSlot): void {
+        this.disconnectVoice(slot);
+        this.resetSlot(slot);
     }
 
     /**

--- a/src/audio/VoicePool.ts
+++ b/src/audio/VoicePool.ts
@@ -12,11 +12,17 @@
  */
 
 import { BTAPI } from '../core/BTAPI';
+import { defaultConfig } from '../core/IBTDemo';
 import { applyAudioParamRamp } from '../utils/AudioParamRamp';
 import type { AudioManager } from './AudioManager';
 
-/** Fallback voice count used when `HardwareSettings.audioVoices` is unavailable. Mirrors `defaultConfig()`. */
-const DEFAULT_VOICE_COUNT = 16;
+/**
+ * Fallback voice count used when `HardwareSettings.audioVoices` is unavailable. Sourced from
+ * `defaultConfig()` so this can never drift from the engine-wide default; the `?? 16` only
+ * satisfies `audioVoices`' optional type and is unreachable in practice, since `defaultConfig()`
+ * always sets it.
+ */
+const DEFAULT_VOICE_COUNT = defaultConfig().audioVoices ?? 16;
 
 /** Default per-voice gain applied when {@link VoicePlayOptions.volume} is omitted. */
 export const DEFAULT_VOLUME = 1;

--- a/src/audio/VoicePool.ts
+++ b/src/audio/VoicePool.ts
@@ -1,0 +1,166 @@
+/**
+ * Fixed-size SFX voice pool for {@link AudioManager}.
+ *
+ * Each voice is a per-play `AudioBufferSourceNode -> GainNode -> StereoPannerNode -> sfx bus`
+ * chain, built fresh on every {@link VoicePool.play} call (source nodes are one-shot and cannot
+ * be replayed). The pool is sized from `HardwareSettings.audioVoices` and never grows; when
+ * every slot is in use, a new `play()` call steals the lowest-priority active voice at or below
+ * the incoming priority (oldest start order breaks ties - see {@link VoiceSlot.startOrder}), or
+ * drops the request when no slot qualifies. Callers identify a playing voice by an opaque,
+ * generational {@link SoundRef} - every accessor validates the ref's generation against the
+ * live slot and silently no-ops with inert defaults on a stale ref.
+ */
+
+import { BTAPI } from '../core/BTAPI';
+import type { AudioManager } from './AudioManager';
+
+/** Fallback voice count used when `HardwareSettings.audioVoices` is unavailable. Mirrors `defaultConfig()`. */
+const DEFAULT_VOICE_COUNT = 16;
+
+/**
+ * Opaque generational handle identifying a single pool-allocated voice.
+ *
+ * `generation` increments every time the referenced slot is recycled (natural completion,
+ * explicit {@link VoicePool.stop}, or being stolen by a later `play()`), so a ref captured
+ * before a recycle silently fails every {@link VoicePool} accessor's generation check.
+ */
+export interface SoundRef {
+    /** Index into the pool's fixed slot array. */
+    readonly voiceIndex: number;
+
+    /** Generation of the slot at the time this ref was issued. */
+    readonly generation: number;
+}
+
+/** Inert handle returned when a voice could not be allocated (pool exhausted, or not yet attached). */
+export const INVALID_SOUND_REF: SoundRef = { voiceIndex: -1, generation: -1 };
+
+/** Options accepted by {@link VoicePool.play}. */
+export interface VoicePlayOptions {
+    /** Whether the buffer loops. Defaults to `false`. */
+    loop?: boolean;
+
+    /** Initial gain in `[0, 1]` (unclamped). Defaults to `1`. */
+    volume?: number;
+
+    /** Initial `playbackRate`. Defaults to `1`. */
+    pitch?: number;
+
+    /** Initial stereo pan in `[-1, 1]` (unclamped). Defaults to `0`. */
+    pan?: number;
+
+    /** Allocation priority; higher survives stealing longer. Defaults to `0`. */
+    priority?: number;
+
+    /** Optional linear fade-in duration in milliseconds, from silence to `volume`. */
+    fadeInMs?: number;
+
+    /** Audio-clock start time (`AudioContext.currentTime`-relative). Defaults to "now". */
+    atTime?: number;
+}
+
+/** Per-slot playback state. Fields are `null`/inactive when the slot holds no live voice. */
+interface VoiceSlot {
+    /** Source node for the current voice, or `null` when inactive. */
+    source: AudioBufferSourceNode | null;
+
+    /** Gain node for the current voice, or `null` when inactive. */
+    gain: GainNode | null;
+
+    /** Panner node for the current voice, or `null` when inactive. */
+    panner: StereoPannerNode | null;
+
+    /** Buffer the current voice was started with, or `null` when inactive - used by {@link VoicePool.stopVoicesUsingBuffer}. */
+    buffer: AudioBuffer | null;
+
+    /** `true` while this slot holds a live voice. */
+    isActive: boolean;
+
+    /** Allocation priority of the current voice. */
+    priority: number;
+
+    /** Monotonic allocation counter; smaller means older. Breaks stealing ties. */
+    startOrder: number;
+
+    /** Current generation; bumped every time the slot is recycled. */
+    generation: number;
+}
+
+/**
+ * Fixed-size pool of SFX voices, owned and constructed by {@link AudioManager.attach}.
+ */
+export class VoicePool {
+    /** Owning audio manager; source of the live context and `sfx` bus. */
+    // @ts-expect-error TS6133: 'audioManager' will be used in play/stop methods (Tasks 5+).
+    private readonly audioManager: AudioManager;
+
+    /** Fixed-size slot array, sized at construction from `HardwareSettings.audioVoices`. */
+    // @ts-expect-error TS6133: 'slots' will be used in play/stop methods (Tasks 5+).
+    private readonly slots: VoiceSlot[];
+
+    /** Monotonic counter incremented on every `play()`; used for stealing age tiebreaks. */
+    // @ts-expect-error TS6133: 'nextStartOrder' will be used in play/stop methods (Tasks 5+).
+    private nextStartOrder = 0;
+
+    /** Count of `play()` calls that found no free or stealable slot. */
+    private dropCount = 0;
+
+    /** Count of `play()` calls that stole an active slot. */
+    private stealCount = 0;
+
+    /**
+     * Creates a pool with a fixed number of voice slots.
+     *
+     * @param audioManager - Owning audio manager; used to reach the live context and `sfx` bus.
+     */
+    constructor(audioManager: AudioManager) {
+        this.audioManager = audioManager;
+        this.slots = Array.from({ length: resolveVoiceCount() }, () => createEmptySlot());
+    }
+
+    /**
+     * Returns the number of `play()` calls dropped because no slot was free or stealable.
+     *
+     * @returns Drop count.
+     */
+    public getDropCount(): number {
+        return this.dropCount;
+    }
+
+    /**
+     * Returns the number of `play()` calls that stole an active slot.
+     *
+     * @returns Steal count.
+     */
+    public getStealCount(): number {
+        return this.stealCount;
+    }
+}
+
+/**
+ * Reads the configured voice count from hardware settings, falling back to
+ * {@link DEFAULT_VOICE_COUNT}.
+ *
+ * @returns Resolved voice slot count.
+ */
+function resolveVoiceCount(): number {
+    return BTAPI.instance.getHardwareSettings()?.audioVoices ?? DEFAULT_VOICE_COUNT;
+}
+
+/**
+ * Creates an inactive slot with no live nodes.
+ *
+ * @returns Fresh, inactive {@link VoiceSlot}.
+ */
+function createEmptySlot(): VoiceSlot {
+    return {
+        source: null,
+        gain: null,
+        panner: null,
+        buffer: null,
+        isActive: false,
+        priority: 0,
+        startOrder: 0,
+        generation: 0,
+    };
+}

--- a/src/audio/VoicePool.ts
+++ b/src/audio/VoicePool.ts
@@ -95,7 +95,6 @@ export class VoicePool {
     private readonly audioManager: AudioManager;
 
     /** Fixed-size slot array, sized at construction from `HardwareSettings.audioVoices`. */
-    // @ts-expect-error TS6133: 'slots' will be used in play/stop methods (Tasks 5+).
     private readonly slots: VoiceSlot[];
 
     /** Monotonic counter incremented on every `play()`; used for stealing age tiebreaks. */
@@ -134,6 +133,55 @@ export class VoicePool {
      */
     public getStealCount(): number {
         return this.stealCount;
+    }
+
+    /**
+     * Picks a slot for a new voice: the first free slot, or the best steal candidate.
+     *
+     * @param priority - Allocation priority of the incoming voice.
+     * @returns Slot index to use, or `null` when no free or stealable slot exists.
+     */
+    // @ts-expect-error TS6133: 'allocateSlot' will be called by play() (Task 6).
+    private allocateSlot(priority: number): number | null {
+        const freeIndex = this.slots.findIndex((slot) => !slot.isActive);
+
+        if (freeIndex !== -1) {
+            return freeIndex;
+        }
+
+        return this.findStealCandidate(priority);
+    }
+
+    /**
+     * Finds the best active slot to steal for an incoming voice: the lowest-priority active
+     * slot at or below `incomingPriority`, breaking ties by oldest {@link VoiceSlot.startOrder}.
+     *
+     * @param incomingPriority - Allocation priority of the incoming voice.
+     * @returns Slot index to steal, or `null` when every active slot outranks `incomingPriority`.
+     */
+    private findStealCandidate(incomingPriority: number): number | null {
+        let candidateIndex: number | null = null;
+        let candidatePriority = Number.POSITIVE_INFINITY;
+        let candidateStartOrder = Number.POSITIVE_INFINITY;
+
+        for (let i = 0; i < this.slots.length; i++) {
+            const slot = this.slots.at(i);
+
+            if (slot === undefined || !slot.isActive || slot.priority > incomingPriority) {
+                continue;
+            }
+
+            const isLowerPriority = slot.priority < candidatePriority;
+            const isOlderAtSamePriority = slot.priority === candidatePriority && slot.startOrder < candidateStartOrder;
+
+            if (candidateIndex === null || isLowerPriority || isOlderAtSamePriority) {
+                candidateIndex = i;
+                candidatePriority = slot.priority;
+                candidateStartOrder = slot.startOrder;
+            }
+        }
+
+        return candidateIndex;
     }
 }
 

--- a/src/audio/audioDecodeContext.ts
+++ b/src/audio/audioDecodeContext.ts
@@ -35,10 +35,9 @@ export function getAudioDecodeContext(): AudioContext | null {
 /**
  * Handler invoked by `AudioClip.unload()` with the buffer being released.
  *
- * This is the seam where the future voice system will stop any
- * `AudioBufferSourceNode`s still referencing the released buffer, so an
- * unloaded clip's audio can never keep playing from a stale node. Defaults to
- * a no-op since the voice pool does not exist yet.
+ * `AudioManager.attach()` registers `VoicePool.stopVoicesUsingBuffer` here so an unloaded
+ * clip's audio can never keep playing from a stale node; `AudioManager.detach()` restores the
+ * no-op default. Defaults to a no-op before the first `attach()`.
  */
 let audioClipUnloadHandler: (buffer: AudioBuffer) => void = () => {};
 

--- a/src/core/BTAPI.test.ts
+++ b/src/core/BTAPI.test.ts
@@ -18,15 +18,19 @@ import { fileURLToPath } from 'node:url';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { createMockAudioBuffer } from '../__test__/webaudio-mock';
 import {
     createMockGPUCanvasContext,
     createMockGPUDevice,
     installMockNavigatorGPU,
     uninstallMockNavigatorGPU,
 } from '../__test__/webgpu-mock';
+import type { AudioClip } from '../assets/AudioClip';
 import type { BitmapFont } from '../assets/BitmapFont';
 import { Palette } from '../assets/Palette';
 import type { SpriteSheet } from '../assets/SpriteSheet';
+import { AudioManager } from '../audio/AudioManager';
+import { INVALID_SOUND_REF } from '../audio/VoicePool';
 import { BT } from '../BLIT386';
 import type { OverlayDrawTarget } from '../overlay';
 import { DEFAULT_IDX_TEXT, Overlay, paletteBandY } from '../overlay';
@@ -125,6 +129,133 @@ function makeOffscreenCanvas2dContext(): OffscreenCanvas2DMock {
         putImageData: vi.fn(),
     };
 }
+
+describe('sound playback passthroughs', () => {
+    beforeEach(() => {
+        resetSingleton();
+    });
+
+    afterEach(() => {
+        resetSingleton();
+    });
+
+    function setAudio(audio: AudioManager | null): void {
+        // BTAPI's `audio` field is private; this cast is the same test-isolation technique
+        // `resetSingleton()` above uses for `_instance` - it lets these tests inject a real
+        // AudioManager without running a full init()/WebGPU/AudioContext mock setup, since none
+        // of these passthroughs need a live renderer or context.
+        (BTAPI.instance as unknown as { audio: AudioManager | null }).audio = audio;
+    }
+
+    it('soundPlay returns INVALID_SOUND_REF when the audio subsystem is not initialized', () => {
+        const clip = { buffer: createMockAudioBuffer() } as unknown as AudioClip;
+
+        expect(BTAPI.instance.soundPlay(clip)).toEqual(INVALID_SOUND_REF);
+    });
+
+    it('soundPlay returns INVALID_SOUND_REF when the clip buffer is null', () => {
+        setAudio(new AudioManager());
+
+        const clip = { buffer: null } as unknown as AudioClip;
+
+        expect(BTAPI.instance.soundPlay(clip)).toEqual(INVALID_SOUND_REF);
+    });
+
+    it('soundPlay delegates to AudioManager.playSound with the clip buffer', () => {
+        const audio = new AudioManager();
+        const buffer = createMockAudioBuffer();
+        const ref = { voiceIndex: 0, generation: 1 };
+        const spy = vi.spyOn(audio, 'playSound').mockReturnValue(ref);
+
+        setAudio(audio);
+
+        const clip = { buffer } as unknown as AudioClip;
+        const result = BTAPI.instance.soundPlay(clip, { volume: 0.5 });
+
+        expect(spy).toHaveBeenCalledWith(buffer, { volume: 0.5 });
+        expect(result).toBe(ref);
+    });
+
+    it('soundStop delegates to AudioManager.soundStop', () => {
+        const audio = new AudioManager();
+        const spy = vi.spyOn(audio, 'soundStop').mockReturnValue(undefined);
+
+        setAudio(audio);
+        BTAPI.instance.soundStop(INVALID_SOUND_REF, 200);
+
+        expect(spy).toHaveBeenCalledWith(INVALID_SOUND_REF, 200);
+    });
+
+    it('soundStop is a no-op when the audio subsystem is not initialized', () => {
+        expect(() => BTAPI.instance.soundStop(INVALID_SOUND_REF)).not.toThrow();
+    });
+
+    it('isSoundPlaying delegates to AudioManager.isSoundPlaying', () => {
+        const audio = new AudioManager();
+        const spy = vi.spyOn(audio, 'isSoundPlaying').mockReturnValue(true);
+
+        setAudio(audio);
+
+        expect(BTAPI.instance.isSoundPlaying(INVALID_SOUND_REF)).toBe(true);
+        expect(spy).toHaveBeenCalledWith(INVALID_SOUND_REF);
+    });
+
+    it('isSoundPlaying returns false when the audio subsystem is not initialized', () => {
+        expect(BTAPI.instance.isSoundPlaying(INVALID_SOUND_REF)).toBe(false);
+    });
+
+    it('soundVolumeSet delegates to AudioManager.soundVolumeSet', () => {
+        const audio = new AudioManager();
+        const spy = vi.spyOn(audio, 'soundVolumeSet').mockReturnValue(undefined);
+
+        setAudio(audio);
+        BTAPI.instance.soundVolumeSet(INVALID_SOUND_REF, 0.5, 100);
+
+        expect(spy).toHaveBeenCalledWith(INVALID_SOUND_REF, 0.5, 100);
+    });
+
+    it('soundVolumeGet delegates to AudioManager.soundVolumeGet', () => {
+        const audio = new AudioManager();
+        const spy = vi.spyOn(audio, 'soundVolumeGet').mockReturnValue(0.75);
+
+        setAudio(audio);
+
+        expect(BTAPI.instance.soundVolumeGet(INVALID_SOUND_REF)).toBe(0.75);
+        expect(spy).toHaveBeenCalledWith(INVALID_SOUND_REF);
+    });
+
+    it('soundVolumeGet returns 1 when the audio subsystem is not initialized', () => {
+        expect(BTAPI.instance.soundVolumeGet(INVALID_SOUND_REF)).toBe(1);
+    });
+
+    it('soundPitchSet delegates to AudioManager.soundPitchSet', () => {
+        const audio = new AudioManager();
+        const spy = vi.spyOn(audio, 'soundPitchSet').mockReturnValue(undefined);
+
+        setAudio(audio);
+        BTAPI.instance.soundPitchSet(INVALID_SOUND_REF, 1.5, 50);
+
+        expect(spy).toHaveBeenCalledWith(INVALID_SOUND_REF, 1.5, 50);
+    });
+
+    it('soundPitchGet returns 1 when the audio subsystem is not initialized', () => {
+        expect(BTAPI.instance.soundPitchGet(INVALID_SOUND_REF)).toBe(1);
+    });
+
+    it('soundPanSet delegates to AudioManager.soundPanSet', () => {
+        const audio = new AudioManager();
+        const spy = vi.spyOn(audio, 'soundPanSet').mockReturnValue(undefined);
+
+        setAudio(audio);
+        BTAPI.instance.soundPanSet(INVALID_SOUND_REF, -0.5, 50);
+
+        expect(spy).toHaveBeenCalledWith(INVALID_SOUND_REF, -0.5, 50);
+    });
+
+    it('soundPanGet returns 0 when the audio subsystem is not initialized', () => {
+        expect(BTAPI.instance.soundPanGet(INVALID_SOUND_REF)).toBe(0);
+    });
+});
 
 describe('BTAPI', () => {
     beforeEach(() => {

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -1,3 +1,4 @@
+import type { AudioClip } from '../assets/AudioClip';
 import type { BitmapFont } from '../assets/BitmapFont';
 import type { Palette } from '../assets/Palette';
 import {
@@ -11,6 +12,7 @@ import {
 import type { SpriteSheet } from '../assets/SpriteSheet';
 import { createSystemFont } from '../assets/SystemFont';
 import { AudioManager } from '../audio/AudioManager';
+import { INVALID_SOUND_REF, type SoundPlayOptions, type SoundRef } from '../audio/VoicePool';
 import { GamepadInput } from '../input/GamepadInput';
 import { KeyboardInput } from '../input/KeyboardInput';
 import { PointerInput } from '../input/PointerInput';
@@ -554,6 +556,108 @@ export class BTAPI {
      */
     public isAudioMuted(bus: AudioBus): boolean {
         return this.audio?.isMuted(bus) ?? false;
+    }
+
+    /**
+     * Plays a loaded audio clip through the SFX voice pool.
+     *
+     * Returns {@link INVALID_SOUND_REF} without allocating a voice when the clip's buffer isn't
+     * available (not finished loading yet, or already unloaded) or when the audio subsystem is
+     * not initialized.
+     *
+     * @param clip - Loaded audio clip to play.
+     * @param options - Playback options; see {@link SoundPlayOptions}.
+     * @returns A {@link SoundRef} identifying the new voice, or {@link INVALID_SOUND_REF}.
+     */
+    public soundPlay(clip: AudioClip, options?: SoundPlayOptions): SoundRef {
+        if (clip.buffer === null) {
+            return INVALID_SOUND_REF;
+        }
+
+        return this.audio?.playSound(clip.buffer, options) ?? INVALID_SOUND_REF;
+    }
+
+    /**
+     * Stops a playing sound, optionally fading it out.
+     *
+     * @param ref - Sound to stop.
+     * @param fadeOutMs - Optional linear fade-out duration in milliseconds.
+     */
+    public soundStop(ref: SoundRef, fadeOutMs?: number): void {
+        this.audio?.soundStop(ref, fadeOutMs);
+    }
+
+    /**
+     * Reports whether a sound is still playing.
+     *
+     * @param ref - Sound to query.
+     * @returns `true` when still playing; `false` on a stale ref or when the audio subsystem is not initialized.
+     */
+    public isSoundPlaying(ref: SoundRef): boolean {
+        return this.audio?.isSoundPlaying(ref) ?? false;
+    }
+
+    /**
+     * Sets a sound's gain, optionally fading to it.
+     *
+     * @param ref - Sound to update.
+     * @param value - Target gain.
+     * @param fadeMs - Optional fade duration in milliseconds; omit for an immediate change.
+     */
+    public soundVolumeSet(ref: SoundRef, value: number, fadeMs?: number): void {
+        this.audio?.soundVolumeSet(ref, value, fadeMs);
+    }
+
+    /**
+     * Gets a sound's current gain.
+     *
+     * @param ref - Sound to query.
+     * @returns Current gain in `[0, 1]`, or `1` on a stale ref or when the audio subsystem is not initialized.
+     */
+    public soundVolumeGet(ref: SoundRef): number {
+        return this.audio?.soundVolumeGet(ref) ?? 1;
+    }
+
+    /**
+     * Sets a sound's playback rate, optionally fading to it.
+     *
+     * @param ref - Sound to update.
+     * @param value - Target playback rate.
+     * @param fadeMs - Optional fade duration in milliseconds; omit for an immediate change.
+     */
+    public soundPitchSet(ref: SoundRef, value: number, fadeMs?: number): void {
+        this.audio?.soundPitchSet(ref, value, fadeMs);
+    }
+
+    /**
+     * Gets a sound's current playback rate.
+     *
+     * @param ref - Sound to query.
+     * @returns Current playback rate, or `1` on a stale ref or when the audio subsystem is not initialized.
+     */
+    public soundPitchGet(ref: SoundRef): number {
+        return this.audio?.soundPitchGet(ref) ?? 1;
+    }
+
+    /**
+     * Sets a sound's stereo pan, optionally fading to it.
+     *
+     * @param ref - Sound to update.
+     * @param value - Target pan.
+     * @param fadeMs - Optional fade duration in milliseconds; omit for an immediate change.
+     */
+    public soundPanSet(ref: SoundRef, value: number, fadeMs?: number): void {
+        this.audio?.soundPanSet(ref, value, fadeMs);
+    }
+
+    /**
+     * Gets a sound's current stereo pan.
+     *
+     * @param ref - Sound to query.
+     * @returns Current pan, or `0` on a stale ref or when the audio subsystem is not initialized.
+     */
+    public soundPanGet(ref: SoundRef): number {
+        return this.audio?.soundPanGet(ref) ?? 0;
     }
 
     /**

--- a/src/utils/AudioParamRamp.test.ts
+++ b/src/utils/AudioParamRamp.test.ts
@@ -20,6 +20,19 @@ describe('applyAudioParamRamp', () => {
         expect(param.value).toBe(0.5);
     });
 
+    it('cancels a pending ramp before setting the value immediately, so it cannot override the new value later', () => {
+        const param = createMockAudioParam(1) as unknown as MockAudioParam;
+
+        // Schedule a ramp toward 0.9 ending at t=1.
+        applyAudioParamRamp(param as unknown as AudioParam, 0, 0.9, 1000, 'linear');
+
+        // Immediately override with 0.5 at t=0.3, before the ramp above would have finished.
+        applyAudioParamRamp(param as unknown as AudioParam, 0.3, 0.5, undefined, 'linear');
+
+        expect(param.cancelScheduledValuesCalls).toEqual([0, 0.3]);
+        expect(param.value).toBe(0.5);
+    });
+
     it('schedules a linear ramp anchored to currentTime', () => {
         const param = createMockAudioParam(1) as unknown as MockAudioParam;
 

--- a/src/utils/AudioParamRamp.test.ts
+++ b/src/utils/AudioParamRamp.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { createMockAudioParam, type MockAudioParam } from '../__test__/webaudio-mock';
+import { applyAudioParamRamp } from './AudioParamRamp';
+
+describe('applyAudioParamRamp', () => {
+    it('sets the value immediately when fadeMs is omitted', () => {
+        const param = createMockAudioParam(1);
+
+        applyAudioParamRamp(param, 0, 0.5, undefined, 'linear');
+
+        expect(param.value).toBe(0.5);
+    });
+
+    it('sets the value immediately when fadeMs is zero or negative', () => {
+        const param = createMockAudioParam(1);
+
+        applyAudioParamRamp(param, 0, 0.5, 0, 'linear');
+
+        expect(param.value).toBe(0.5);
+    });
+
+    it('schedules a linear ramp anchored to currentTime', () => {
+        const param = createMockAudioParam(1) as unknown as MockAudioParam;
+
+        applyAudioParamRamp(param as unknown as AudioParam, 2, 0.25, 500, 'linear');
+
+        expect(param.cancelScheduledValuesCalls).toEqual([2]);
+        expect(param.setValueAtTimeCalls).toEqual([{ value: 1, startTime: 2 }]);
+        expect(param.linearRampToValueAtTimeCalls).toEqual([{ value: 0.25, endTime: 2.5 }]);
+        expect(param.value).toBe(0.25);
+    });
+
+    it('samples an eased curve via setValueCurveAtTime for non-linear easing', () => {
+        const param = createMockAudioParam(0) as unknown as MockAudioParam;
+
+        applyAudioParamRamp(param as unknown as AudioParam, 1, 1, 200, 'ease-out');
+
+        expect(param.setValueCurveAtTimeCalls).toHaveLength(1);
+        expect(param.setValueCurveAtTimeCalls[0]?.startTime).toBe(1);
+        expect(param.setValueCurveAtTimeCalls[0]?.duration).toBe(0.2);
+        expect(param.value).toBeCloseTo(1, 5);
+    });
+});

--- a/src/utils/AudioParamRamp.ts
+++ b/src/utils/AudioParamRamp.ts
@@ -1,0 +1,73 @@
+/**
+ * Shared `AudioParam` ramp scheduling, used for bus-volume fades ({@link AudioManager}) and
+ * per-voice volume/pitch/pan fades ({@link VoicePool}).
+ */
+
+import type { EasingFunction } from './Easing';
+import { applyEasing } from './Easing';
+
+/** Number of samples used to build an eased ramp curve for `setValueCurveAtTime`. */
+const FADE_CURVE_SAMPLE_COUNT = 32;
+
+/**
+ * Schedules or immediately applies a value change on an `AudioParam`.
+ *
+ * With no `fadeMs` (or a non-positive one), sets `param.value` immediately. With `fadeMs`,
+ * anchors the ramp to `currentTime`: `'linear'` easing uses `linearRampToValueAtTime`; other
+ * easings sample {@link applyEasing} into a curve fed to `setValueCurveAtTime`.
+ *
+ * @param param - `AudioParam` to update (gain, `playbackRate`, or pan).
+ * @param currentTime - Audio-clock time to anchor the ramp to (`AudioContext.currentTime`).
+ * @param targetValue - Target parameter value.
+ * @param fadeMs - Optional fade duration in milliseconds.
+ * @param easing - Easing curve applied when `fadeMs` is a positive duration.
+ */
+export function applyAudioParamRamp(
+    param: AudioParam,
+    currentTime: number,
+    targetValue: number,
+    fadeMs: number | undefined,
+    easing: EasingFunction,
+): void {
+    if (fadeMs === undefined || fadeMs <= 0) {
+        param.value = targetValue;
+
+        return;
+    }
+
+    const startValue = param.value;
+    const durationSeconds = fadeMs / 1000;
+
+    param.cancelScheduledValues(currentTime);
+    param.setValueAtTime(startValue, currentTime);
+
+    if (easing === 'linear') {
+        param.linearRampToValueAtTime(targetValue, currentTime + durationSeconds);
+
+        return;
+    }
+
+    param.setValueCurveAtTime(sampleEasingCurve(startValue, targetValue, easing), currentTime, durationSeconds);
+}
+
+/**
+ * Samples an eased curve from `startValue` to `targetValue` for `AudioParam.setValueCurveAtTime`.
+ *
+ * @param startValue - Parameter value at the start of the fade.
+ * @param targetValue - Parameter value at the end of the fade.
+ * @param easing - Easing curve to sample.
+ * @returns Sampled curve of {@link FADE_CURVE_SAMPLE_COUNT} values.
+ */
+function sampleEasingCurve(startValue: number, targetValue: number, easing: EasingFunction): Float32Array {
+    const curve = new Float32Array(FADE_CURVE_SAMPLE_COUNT);
+
+    for (let i = 0; i < FADE_CURVE_SAMPLE_COUNT; i++) {
+        const t = i / (FADE_CURVE_SAMPLE_COUNT - 1);
+        const eased = applyEasing(t, easing);
+
+        // eslint-disable-next-line security/detect-object-injection -- bounded loop counter
+        curve[i] = startValue + (targetValue - startValue) * eased;
+    }
+
+    return curve;
+}

--- a/src/utils/AudioParamRamp.ts
+++ b/src/utils/AudioParamRamp.ts
@@ -30,6 +30,10 @@ export function applyAudioParamRamp(
     easing: EasingFunction,
 ): void {
     if (fadeMs === undefined || fadeMs <= 0) {
+        // Cancel any pending ramp first - setting `.value` directly does not cancel scheduled
+        // automation events, so a fade started earlier could otherwise keep running and override
+        // this "immediate" value once its scheduled end time arrives.
+        param.cancelScheduledValues(currentTime);
         param.value = targetValue;
 
         return;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Added SFX voice-pool support across the audio stack and exposed it through the BT/BLIT386 facades.

- Introduced `src/audio/VoicePool.ts`: a fixed-size SFX voice pool backed by generational `SoundRef`s (`INVALID_SOUND_REF` for invalid/unallocatable refs), with voice allocation, priority-based stealing, silent no-op handling for stale refs, per-voice volume/pitch/pan getters/setters, fade-in/out (including `atTime` start), lifecycle cleanup via `onended`, and counters for drops/steals.  
- Integrated `VoicePool` into `AudioManager`: creates/destroys the pool on `attach`/`detach`, wires `AudioClip` unload to stop voices using released buffers, gates pre-unlock `BT.soundPlay` requests (dropped and counted), switches volume ramps to the shared ramp utility, and adds internal accessors used to build the voice node chain.
- Updated `BTAPI` + `BLIT386` to add typed SFX APIs: `soundPlay`, `soundStop`, `isSoundPlaying`, and per-sound `soundVolumeSet/Get`, `soundPitchSet/Get`, `soundPanSet/Get`, including defined fallback return values when audio is unavailable and defaulting fade options via `fadeMs` unpacking.
- Added shared Web Audio parameter ramping via `src/utils/AudioParamRamp.ts` (`applyAudioParamRamp`) and replaced in-class ramping in `AudioManager` with this utility.
- Expanded unit test coverage: `VoicePool` behavior (allocation/steal rules, fade-in/out scheduling, slot recycling, unload/buffer stopping), `AudioManager` sound lifecycle and unlock gating, `BTAPI` sound passthroughs, `BLIT386` facade delegation, `AudioParamRamp` correctness, and extended the WebAudio mock (`AudioBufferSourceNode`, `StereoPannerNode`, controllable mock `currentTime`).
- Updated documentation and contributor guidance: new/expanded SFX playback sections, voice-cap/stealing behavior, unlock gating semantics, and updated BT API conventions to treat the expanded audio getter/setter family as methods; also adjusted bundle-size check threshold in CI to allow a slightly larger gzipped ESM output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->