### PR TITLE
docs(rules): wire api versioning workflow into docs-sync rules

### DIFF
--- a/.claude/rules/docs-sync-required.md
+++ b/.claude/rules/docs-sync-required.md
@@ -4,6 +4,14 @@ Condensed mirror of `.cursor/rules/docs-sync-required.mdc`.
 
 - Documentation is part of the implementation, not a follow-up task.
 - Public API changes: update relevant `docs/api-*.md` and related examples.
+- Adding a public export, a new `BT` member, or a `HardwareSettings`/config type; changing an existing public symbol's
+  signature or behavior; or deprecating a public symbol: follow `docs/documentation-and-versioning-guide.md`. Add
+  `@since <version>` / `@changed <version> <note>` / `@deprecated Deprecated since <version> (<date>). ...` JSDoc tags
+  at the symbol's original declaration (not the re-export line), then run `pnpm run api:history` to regenerate
+  `docs/_api-history.json` (never hand-edit it – commit the regenerated file). Add or update the `<Since symbol="...">`,
+  `<ApiAvailability page="...">`, and `<PageChangelog page="...">` MDX components on the symbol's one documentation home
+  (the page with real explanatory prose – see the guide's Step 3 for how to pick it). `pnpm run preflight` already runs
+  `api:since:check` and `api:history:check`, so a missing or malformed tag fails preflight before docs work even starts.
 - Runtime behavior changes: update affected guides under `docs/` (including `docs/guide-overlay.md` for overlay
   changes).
 - Adding/removing/renaming a public `docs/*.md` page (one that should appear on blit386.dev): update

--- a/.cursor/rules/docs-sync-required.mdc
+++ b/.cursor/rules/docs-sync-required.mdc
@@ -17,6 +17,15 @@ alwaysApply: false
 
 - Documentation is part of the implementation, not a follow-up task.
 - When public API changes, update relevant `docs/api-*.md` and related examples in the same change.
+- When you add a public export, a new `BT` member, or a `HardwareSettings`/config type, change an existing public
+  symbol's signature or behavior, or deprecate a public symbol, follow `docs/documentation-and-versioning-guide.md`: add
+  `@since <version>` / `@changed <version> <note>` / `@deprecated Deprecated since <version> (<date>). ...` JSDoc tags
+  at the symbol's original declaration (not the re-export line), then run `pnpm run api:history` to regenerate
+  `docs/_api-history.json` (never hand-edit it – commit the regenerated file). Add or update the `<Since symbol="...">`,
+  `<ApiAvailability page="...">`, and `<PageChangelog page="...">` MDX components on the symbol's one documentation home
+  (the page with real explanatory prose – see the guide's Step 3 for how to pick it when more than one page mentions the
+  symbol). `pnpm run preflight` already runs `api:since:check` and `api:history:check`, so a missing or malformed tag
+  fails preflight before docs work even starts.
 - When runtime behavior changes, update affected guides under `docs/` (including `docs/guide-overlay.md` for overlay
   subsystem changes).
 - When you add, remove, or rename a `docs/*.md` page that should appear on the public site (blit386.dev), update

--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,9 @@ pnpm-debug.log*
 tmp/
 temp/
 
+# Superpowers skill scratch (task briefs, review diffs, progress ledger)
+.superpowers/
+
 # Local security run reports (MCP preflight / governance)
 security-reports/
 


### PR DESCRIPTION
The @since/@changed/@deprecated tagging workflow and the Since/ ApiAvailability/PageChangelog MDX components (added in a9bb189 and a9b5099) were only documented in docs/documentation-and-versioning-guide.md, with no trigger in the rule files that actually govern agent behavior when touching public API. Add a bullet to both docs-sync-required.md and its Cursor mirror so adding, changing, or deprecating a public symbol reliably surfaces the tagging steps, the api:history regeneration command, and the preflight gates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the docs-sync guidance to require documentation/versioning steps when public API symbols are added, changed, or deprecated. Both rule files now point contributors to the documentation/versioning guide, call out `@since`, `@changed`, and `@deprecated` tagging on the original declaration, and require regenerating `docs/_api-history.json` with `pnpm run api:history`. The Cursor mirror also adds the related MDX docs components (`Since`, `ApiAvailability`, and `PageChangelog`) and clarifies that `pnpm run preflight` enforces the `api:since:check` and `api:history:check` gates.

Also added `.superpowers/` to `.gitignore` with a comment describing it as a scratch area for task briefs, review diffs, and progress tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->