### PR TITLE
feat(audio): implement crossfading music playback and enhance API documentation

### DIFF
--- a/.claude/rules/bt-api-getters.md
+++ b/.claude/rules/bt-api-getters.md
@@ -10,14 +10,14 @@ Quick rules when changing `src/BLIT386.ts` or demos:
 
 ## Getter lists
 
-| Category                                         | Members                                                                                      |
-| ------------------------------------------------ | -------------------------------------------------------------------------------------------- |
-| Configure-time (mirror `HardwareSettings` names) | `displaySize`, `drawingBufferSize`, `targetFPS`                                              |
-| Derived                                          | `outputSize` (`drawingBufferSize ?? displaySize`; no `HardwareSettings` field)               |
-| Configure-time (backend)                         | `requestedBackend` (mirrors `HardwareSettings.backend`; `null` before init)                  |
-| Loop timing                                      | `deltaSeconds`, `timeSeconds`, `ticks`                                                       |
-| Runtime state                                    | `activeBackend`, `camera`, `palette`, `isAudioUnlocked` (`activeBackend` `null` before init) |
-| Per-frame input                                  | `pointerScrollDelta`, `inputString`, `gamepadCount`                                          |
+| Category                                         | Members                                                                                                        |
+| ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
+| Configure-time (mirror `HardwareSettings` names) | `displaySize`, `drawingBufferSize`, `targetFPS`                                                                |
+| Derived                                          | `outputSize` (`drawingBufferSize ?? displaySize`; no `HardwareSettings` field)                                 |
+| Configure-time (backend)                         | `requestedBackend` (mirrors `HardwareSettings.backend`; `null` before init)                                    |
+| Loop timing                                      | `deltaSeconds`, `timeSeconds`, `ticks`                                                                         |
+| Runtime state                                    | `activeBackend`, `camera`, `palette`, `isAudioUnlocked`, `isMusicPlaying` (`activeBackend` `null` before init) |
+| Per-frame input                                  | `pointerScrollDelta`, `inputString`, `gamepadCount`                                                            |
 
 `Vector2i` getters return a clone per read. `activeBackend` is what actually started after fallback, not
 `configure().backend`. `palette` is a live reference – mutating slots affects rendering on the next frame.

--- a/.cursor/rules/bt-api-getters.mdc
+++ b/.cursor/rules/bt-api-getters.mdc
@@ -16,8 +16,9 @@ Zero-argument **read-only** values on `BT`:
 - **Configure-time (backend):** `requestedBackend` mirrors resolved `HardwareSettings.backend` (includes
   `?backend=software`); **`null` before `BT.init()`**
 - **Loop:** `deltaSeconds`, `timeSeconds`, `ticks`
-- **Runtime:** `activeBackend`, `camera`, `palette`, `isAudioUnlocked` — `activeBackend` is **`null` before init or on
-  failure**; `isAudioUnlocked` is `false` until the first user gesture resumes the audio context
+- **Runtime:** `activeBackend`, `camera`, `palette`, `isAudioUnlocked`, `isMusicPlaying` — `activeBackend` is **`null`
+  before init or on failure**; `isAudioUnlocked` is `false` until the first user gesture resumes the audio context;
+  `isMusicPlaying` is `true` while the music player has a live current track
 - **Per-frame input:** `pointerScrollDelta`, `inputString`, `gamepadCount`
 
 Good: `BT.displaySize.y`, `BT.targetFPS`, `BT.ticks % 180`
@@ -35,7 +36,8 @@ Bad: `BT.displaySize()`, `BT.fps()`, `BT.getActiveBackend()` (removed; use prope
 - **Audio:** `audioVolumeSet(bus, value, options?)`, `audioVolumeGet(bus)`, `audioMuteSet(bus, muted)`,
   `isAudioMuted(bus)`, `soundPlay(clip, options?)`, `soundStop(ref, options?)`, `isSoundPlaying(ref)`,
   `soundVolumeSet(ref, value, options?)`, `soundVolumeGet(ref)`, `soundPitchSet(ref, value, options?)`,
-  `soundPitchGet(ref)`, `soundPanSet(ref, value, options?)`, `soundPanGet(ref)`
+  `soundPitchGet(ref)`, `soundPanSet(ref, value, options?)`, `soundPanGet(ref)`, `musicPlay(clip, options?)`,
+  `musicStop(options?)`, `musicVolumeSet(value, options?)`, `musicVolumeGet()`
 - **Drawing / clearing:** `clear`, `clearRect`, `drawPixel`, `drawLine`, `drawRect`, `drawRectFill`, `drawSprite`,
   `systemPrint`, `printFont` (4th arg is optional **`paletteOffset`**, not `Color32`)
 - Any **parameter**: `pointerPos(0)`, `isDown(BT.BTN_A)`, `cameraClamp(...)`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,7 @@ Before writing new code, reviewing existing code, or preflighting, check here fi
 | How do users start a new project with the engine?                 | `npm create blit386@latest` – the scaffolder lives in the sibling `create-blit386` repo; see Onboarding and the scaffolder below                                                                                                                        |
 | How do I load an audio clip?                                      | `src/assets/AudioClip.ts`, `docs/api-audio.md` (Loading section), `docs/guide-audio.md` (Preloading audio clips)                                                                                                                                        |
 | How does the SFX voice pool allocate/steal voices?                | `src/audio/VoicePool.ts`; exposed via `BT.soundPlay` and friends (`docs/api-audio.md`, Playback (SFX) section)                                                                                                                                          |
+| How does music playback crossfade and loop?                       | `src/audio/MusicPlayer.ts`; exposed via `BT.musicPlay` and friends (`docs/api-audio.md`, Playback (Music) section)                                                                                                                                      |
 | How do I synthesize a sound procedurally (no source file)?        | `AudioClip.synth` in `src/assets/AudioClip.ts`; render/validation math in `src/assets/synth/` (`SynthParams.ts`, `synthEnvelope.ts`, `synthPitch.ts`, `synthWaveforms.ts`, `synthRender.ts`, `synthValidation.ts`); `docs/api-audio.md` (Synth section) |
 | Is there a built-in sound preset library (jump, explosion, etc.)? | `src/assets/synth/synthPresets.ts`, exposed publicly as `BT.synthPreset.{jump,pickup,explosion,laser,hit,blip}`; `docs/api-audio.md` (Presets section), `docs/guide-audio.md` (Design a sound)                                                          |
 
@@ -276,9 +277,10 @@ src/
     GamepadInput.ts        # Polling-based gamepad input tracker (4 players, axes, buttons, dead zone)
     defaultKeyboardMap.ts  # Default face-button key tables; clone helpers for BT.inputMapReset
   audio/
-    AudioManager.ts        # Web Audio context, bus graph (sfx/music -> main -> destination), unlock state, mute/volume, SFX playback
+    AudioManager.ts        # Web Audio context, bus graph (sfx/music -> main -> destination), unlock state, mute/volume, SFX + music playback
     audioDecodeContext.ts  # Module-scoped decode-context registry + AudioClip unload seam (wired to VoicePool)
     VoicePool.ts            # Fixed-size SFX voice pool: allocation/stealing, generational SoundRef handles, per-voice fades
+    MusicPlayer.ts          # Crossfading music player: current/previous voice pair, fadeMs/overlap timing, loop points
   utils/
     Bootstrap.ts           # Demo bootstrap utilities
     BootstrapHelpers.ts    # Canvas lookup and error display utilities
@@ -373,7 +375,8 @@ Full table in `docs/api-core.md` and `.claude/rules/bt-api-getters.md`. The cate
   `null` before init).
 - Loop timing: `deltaSeconds`, `timeSeconds`, `ticks`.
 - Runtime state: `activeBackend` (what actually started after fallback; `null` before init or on failure), `camera`,
-  `palette` (live reference), `isAudioUnlocked` (`false` until the first user gesture resumes the audio context).
+  `palette` (live reference), `isAudioUnlocked` (`false` until the first user gesture resumes the audio context),
+  `isMusicPlaying` (`true` while the music player has a live current track).
 - Per-frame input: `pointerScrollDelta`, `inputString`, `gamepadCount` (read once per frame).
 
 Examples: `BT.displaySize.y`, `BT.targetFPS`, `BT.ticks % 60`, `if (BT.activeBackend === 'software')`.
@@ -389,7 +392,8 @@ Examples: `BT.displaySize.y`, `BT.targetFPS`, `BT.ticks % 60`, `if (BT.activeBac
 - Audio: `audioVolumeSet(bus, value, options?)`, `audioVolumeGet(bus)`, `audioMuteSet(bus, muted)`, `isAudioMuted(bus)`,
   `soundPlay(clip, options?)`, `soundStop(ref, options?)`, `isSoundPlaying(ref)`,
   `soundVolumeSet(ref, value, options?)`, `soundVolumeGet(ref)`, `soundPitchSet(ref, value, options?)`,
-  `soundPitchGet(ref)`, `soundPanSet(ref, value, options?)`, `soundPanGet(ref)`; procedural synthesis via
+  `soundPitchGet(ref)`, `soundPanSet(ref, value, options?)`, `soundPanGet(ref)`, `musicPlay(clip, options?)`,
+  `musicStop(options?)`, `musicVolumeSet(value, options?)`, `musicVolumeGet()`; procedural synthesis via
   `AudioClip.synth(params)` (not a `BT` method); preset namespace `BT.synthPreset` (`jump`, `pickup`, `explosion`,
   `laser`, `hit`, `blip`).
 - Drawing / clearing: `clear`, `clearRect`, `drawPixel`, `drawLine`, `drawRect`, `drawRectFill`, `drawSprite`,

--- a/docs/_api-history.json
+++ b/docs/_api-history.json
@@ -596,6 +596,13 @@
       "deprecated": null,
       "status": "stable"
     },
+    "BT.isMusicPlaying": {
+      "kind": "getter",
+      "since": "1.3.0",
+      "changes": [],
+      "deprecated": null,
+      "status": "unreleased"
+    },
     "BT.isPointerActive": {
       "kind": "method",
       "since": "1.1.1",
@@ -656,6 +663,34 @@
         "note": "Use {@link isKeyReleased} instead."
       },
       "status": "deprecated"
+    },
+    "BT.musicPlay": {
+      "kind": "method",
+      "since": "1.3.0",
+      "changes": [],
+      "deprecated": null,
+      "status": "unreleased"
+    },
+    "BT.musicStop": {
+      "kind": "method",
+      "since": "1.3.0",
+      "changes": [],
+      "deprecated": null,
+      "status": "unreleased"
+    },
+    "BT.musicVolumeGet": {
+      "kind": "method",
+      "since": "1.3.0",
+      "changes": [],
+      "deprecated": null,
+      "status": "unreleased"
+    },
+    "BT.musicVolumeSet": {
+      "kind": "method",
+      "since": "1.3.0",
+      "changes": [],
+      "deprecated": null,
+      "status": "unreleased"
     },
     "BT.outputSize": {
       "kind": "getter",
@@ -1018,6 +1053,13 @@
       "deprecated": null,
       "status": "stable"
     },
+    "MusicPlayOptions": {
+      "kind": "interface",
+      "since": "1.3.0",
+      "changes": [],
+      "deprecated": null,
+      "status": "unreleased"
+    },
     "Noise": {
       "kind": "class",
       "since": "1.0.3",
@@ -1279,7 +1321,12 @@
       "BT.audioVolumeSet",
       "BT.isAudioMuted",
       "BT.isAudioUnlocked",
+      "BT.isMusicPlaying",
       "BT.isSoundPlaying",
+      "BT.musicPlay",
+      "BT.musicStop",
+      "BT.musicVolumeGet",
+      "BT.musicVolumeSet",
       "BT.soundPanGet",
       "BT.soundPanSet",
       "BT.soundPitchGet",
@@ -1289,6 +1336,7 @@
       "BT.soundVolumeGet",
       "BT.soundVolumeSet",
       "BT.synthPreset",
+      "MusicPlayOptions",
       "SoundPlayOptions",
       "SoundRef",
       "SynthEnvelope",

--- a/docs/api-audio.md
+++ b/docs/api-audio.md
@@ -158,8 +158,8 @@ theme.unload(); // releases the decoded buffer; safe to call more than once
   unsupported container/codec decode failures, and loading before the engine has started.
 - Prefer a fallback list (for example `['theme.ogg', 'theme.mp3']`) for any clip whose primary format might not decode
   in every browser - see [Audio formats](api-browser-support.md#audio-formats).
-- Playing a loaded clip back as SFX is covered in [Playback (SFX)](#playback-sfx) below. Music playback (a separate,
-  loopable player distinct from the SFX voice pool) is not implemented yet.
+- Playing a loaded clip back as SFX is covered in [Playback (SFX)](#playback-sfx) below; as looping, crossfading music
+  in [Playback (Music)](#playback-music).
 
 ## Synth
 
@@ -353,6 +353,110 @@ BT.soundPanGet(ref); // -0.3
 
 `BT.soundPlay` also returns an inert `SoundRef` (no throw) when `clip` hasn't finished loading yet, or was already
 released with `clip.unload()`.
+
+## Playback (Music)
+
+<Since symbol="BT.musicPlay" />
+<Since symbol="BT.musicStop" />
+<Since symbol="BT.isMusicPlaying" />
+
+`BT.musicPlay` plays a loaded `AudioClip` through a single looping music player, distinct from the SFX voice pool -
+there is no `SoundRef` to manage, and calling it again crossfades from whatever is currently playing into the new track
+rather than layering the two.
+
+```ts twoslash
+import { AudioClip, BT } from 'blit386';
+
+const theme = await AudioClip.load('audio/theme.mp3');
+
+BT.musicPlay(theme, { volume: 0.8 });
+
+BT.isMusicPlaying; // true
+
+BT.musicStop({ fadeMs: 500 }); // fades out over 500 ms
+```
+
+<Since symbol="MusicPlayOptions" />
+
+`options` fields:
+
+<TypeTable type={{
+    volume: { type: 'number', default: '1', description: 'Target gain for the incoming track in [0, 1] (unclamped).' },
+    fadeMs: { type: 'number', default: '0', description: 'Crossfade duration in milliseconds, applied to both the outgoing fade-out and the incoming fade-in. 0 switches immediately.' },
+    overlap: { type: 'number', default: '1', description: 'Crossfade timing offset in [-1, 1]. See Crossfading below.' },
+    easeIn: { type: 'EasingFunction', default: "'linear'", description: "Easing curve for the incoming track's fade-in." },
+    easeOut: { type: 'EasingFunction', default: "'linear'", description: "Easing curve for the outgoing track's fade-out." },
+    loop: { type: 'boolean', default: 'true', description: 'Whether the whole track loops. Ignored when loopStart/loopEnd are given.' },
+    loopStart: { type: 'number', description: 'Loop region start in seconds. Requires loopEnd.' },
+    loopEnd: { type: 'number', description: 'Loop region end in seconds. Requires loopStart.' },
+  }} />
+
+### Crossfading
+
+`fadeMs` sets how long each side of a crossfade takes; `overlap` sets how the two sides line up in time:
+
+```ts twoslash
+import { AudioClip, BT } from 'blit386';
+
+const calm = await AudioClip.load('audio/calm.mp3');
+const battle = await AudioClip.load('audio/battle.mp3');
+
+BT.musicPlay(calm);
+
+// Later, when the fight starts:
+BT.musicPlay(battle, { fadeMs: 800, overlap: 1 }); // calm fades out while battle fades in, at the same time
+BT.musicPlay(battle, { fadeMs: 800, overlap: 0 }); // battle starts fading in exactly as calm finishes fading out
+BT.musicPlay(battle, { fadeMs: 800, overlap: -1 }); // an 800 ms silence gap between the two
+```
+
+Calling `BT.musicPlay` again before a crossfade finishes immediately cuts the track that was already fading out - only
+one crossfade is ever in flight, so rapid calls (menu navigation, quick scene changes) never pile up.
+
+### Loop points
+
+Loop the whole track (the default), a one-shot, or a specific region such as a bridge that repeats while an intro plays
+only once:
+
+```ts twoslash
+import { AudioClip, BT } from 'blit386';
+
+const theme = await AudioClip.load('audio/theme.mp3');
+
+BT.musicPlay(theme); // loops the whole track (default)
+BT.musicPlay(theme, { loop: false }); // plays once and stops
+BT.musicPlay(theme, { loopStart: 8, loopEnd: 32 }); // an 8s intro, then loops the 8-32s region forever
+```
+
+`loopStart` and `loopEnd` must be given together, with `0 <= loopStart < loopEnd <= duration` - `BT.musicPlay` throws a
+beginner-friendly error otherwise, since a mismatched pair is always a programmer mistake rather than something that can
+happen from normal play.
+
+<Since symbol="BT.musicVolumeSet" />
+<Since symbol="BT.musicVolumeGet" />
+
+`BT.musicVolumeSet` sets the current track's gain, optionally fading to it; `BT.musicVolumeGet` reads back the last
+requested target (not a mid-fade instantaneous value):
+
+```ts twoslash
+import { AudioClip, BT } from 'blit386';
+
+const theme = await AudioClip.load('audio/theme.mp3');
+BT.musicPlay(theme);
+// ---cut---
+BT.musicVolumeSet(0.4, { fadeMs: 300 });
+BT.musicVolumeGet(); // 0.4
+```
+
+<Callout title="Remembered while locked, not dropped">
+
+Unlike `BT.soundPlay`, a `BT.musicPlay` call made before `BT.isAudioUnlocked` is `true` is not dropped - the engine
+remembers the most recent pending request and starts it automatically the instant the context unlocks. Calling
+`BT.musicPlay` again while still locked replaces the remembered request; only the latest survives to unlock.
+
+</Callout>
+
+`BT.musicPlay` silently does nothing (no throw) when `clip` hasn't finished loading yet, or was already released with
+`clip.unload()` - the same as `BT.soundPlay`.
 
 ## Hardware settings
 

--- a/docs/api-audio.md
+++ b/docs/api-audio.md
@@ -458,6 +458,9 @@ remembers the most recent pending request and starts it automatically the instan
 `BT.musicPlay` silently does nothing (no throw) when `clip` hasn't finished loading yet, or was already released with
 `clip.unload()` - the same as `BT.soundPlay`.
 
+See [Playing music](guide-audio.md#playing-music) in the Audio Guide for a state-based music switching pattern and an
+intro-then-loop recipe.
+
 ## Hardware settings
 
 `audioVoices` (default `16`) caps the number of simultaneous SFX voices - see [Playback (SFX)](#playback-sfx) for the

--- a/docs/guide-audio.md
+++ b/docs/guide-audio.md
@@ -19,18 +19,19 @@ locked/unlocked gesture state, and the web platform constraints that shape it.
 
 ```text
 src/audio/
-  AudioManager.ts        # Web Audio context, bus graph, unlock state machine, mute/volume, SFX playback
+  AudioManager.ts        # Web Audio context, bus graph, unlock state machine, mute/volume, SFX + music playback
   audioDecodeContext.ts  # Decode-context registry AudioClip reads from to decode
   VoicePool.ts           # Fixed-size SFX voice pool: allocation/stealing, generational refs, per-voice fades
+  MusicPlayer.ts          # Crossfading music player: current/previous voice pair, fadeMs/overlap timing, loop points
 src/assets/
   AudioClip.ts           # Decoded AudioBuffer asset: streamed fetch+decode, cache/dedup, fallback URL lists
 ```
 
 `AudioManager` is owned by the internal `BTAPI` singleton (created and torn down alongside pointer, keyboard, and
-gamepad input) and is never exposed to demo code directly - only through the `BT.audio*`/`BT.sound*` methods and the
-`BT.isAudioUnlocked` getter documented in [API: Audio](api-audio.md). On `attach()`, `AudioManager` registers its Web
-Audio context in `audioDecodeContext.ts`, a small bridge that `AudioClip` reads from to decode audio data without
-needing a direct reference to `AudioManager` itself.
+gamepad input) and is never exposed to demo code directly - only through the `BT.audio*`/`BT.sound*`/`BT.music*` methods
+and the `BT.isAudioUnlocked`/`BT.isMusicPlaying` getters documented in [API: Audio](api-audio.md). On `attach()`,
+`AudioManager` registers its Web Audio context in `audioDecodeContext.ts`, a small bridge that `AudioClip` reads from to
+decode audio data without needing a direct reference to `AudioManager` itself.
 
 `AudioClip` (see [Loading](api-audio.md#loading)) lives alongside the other asset loaders in `src/assets/` and uses that
 bridge to decode fetched audio bytes into a reusable `AudioBuffer`.
@@ -112,6 +113,10 @@ start audio unlocked, and none is planned.
   bus call: `playSound()` drops the request entirely before unlock (no voice allocated, no throw, counted as a dropped
   SFX request), where `AudioManager.volumeSet()` (`BT.audioVolumeSet`) still updates the engine's internal bus state and
   applies once the context resumes - it is only inaudible while locked, not dropped.
+- `BT.musicPlay` (see [Playback (Music)](api-audio.md#playback-music)) sits between those two behaviors: a pre-unlock
+  call isn't dropped like `BT.soundPlay`, but it isn't merely inaudible-and-applied like a bus call either - it is
+  remembered and starts automatically the instant the context unlocks. Calling `BT.musicPlay` again while still locked
+  replaces the remembered request, so only the last call before unlock actually plays.
 
 ## Playing SFX
 
@@ -140,6 +145,64 @@ function playFootstep() {
   BT.soundPlay(footstep, { pitch, volume: 0.6 });
 }
 ```
+
+## Playing music
+
+`BT.musicPlay` (see [Playback (Music)](api-audio.md#playback-music)) drives a single looping music player through the
+`'music'` bus - there is no per-track handle to manage like `SoundRef`, and a second call crossfades from whatever is
+currently playing into the new track instead of layering the two. Two patterns cover most games: switching tracks by
+game state, and looping a region after a one-shot intro.
+
+### Switching music by game state
+
+The common shape: preload every track a scene needs, then call `BT.musicPlay` from wherever your game logic already
+transitions state, guarding against re-triggering the crossfade while a state is merely held:
+
+```ts twoslash
+import { AudioClip, BT } from 'blit386';
+
+type GameState = 'menu' | 'exploring' | 'combat';
+
+const tracks = {
+  menu: await AudioClip.load('audio/menu.mp3'),
+  exploring: await AudioClip.load('audio/exploring.mp3'),
+  combat: await AudioClip.load('audio/combat.mp3'),
+};
+
+let currentState: GameState = 'menu';
+
+function setGameState(next: GameState) {
+  if (next === currentState) {
+    return; // holding a state shouldn't retrigger the crossfade every frame
+  }
+
+  currentState = next;
+
+  BT.musicPlay(tracks[next], { fadeMs: 1000 }); // simultaneous crossfade (default overlap)
+}
+```
+
+Reach for `overlap: 0` instead of the default simultaneous crossfade when the outgoing track should finish cleanly
+before the new one starts (a menu jingle that shouldn't blend into gameplay music), or `overlap: -1` for a deliberate
+beat of silence between tracks (a boss intro sting) - see [Crossfading](api-audio.md#crossfading) for the exact timing
+math.
+
+### Intro then loop
+
+A theme with a distinct opening flourish sounds wrong repeating on every loop. `loopStart`/`loopEnd` let the intro play
+once while only a later region repeats:
+
+```ts twoslash
+import { AudioClip, BT } from 'blit386';
+
+const theme = await AudioClip.load('audio/theme.mp3');
+
+// The first 8 seconds play once, then the engine loops the 8-32s region forever.
+BT.musicPlay(theme, { loopStart: 8, loopEnd: 32 });
+```
+
+`loopStart` and `loopEnd` must be given together and satisfy `0 <= loopStart < loopEnd <= duration` - see
+[Loop points](api-audio.md#loop-points) for the exact validation rule and its error.
 
 ## Design a sound
 
@@ -209,7 +272,7 @@ const explosion = await AudioClip.synth(restored);
 ## See also
 
 <Cards>
-  <Card title="API: Audio" href="/docs/api/audio">Bus volume, mute, the unlock getter, and the synth engine.</Card>
+  <Card title="API: Audio" href="/docs/api/audio">Bus volume, mute, unlock, SFX and music playback, and the synth engine.</Card>
   <Card title="API: Browser Support" href="/docs/api/browser-support">Browser/build support matrix.</Card>
   <Card title="Input Guide" href="/docs/guides/input">Pointer, keyboard, and gamepad input that can trigger unlock.</Card>
 </Cards>

--- a/src/BLIT386.test.ts
+++ b/src/BLIT386.test.ts
@@ -465,6 +465,77 @@ describe('BT.soundPanSet / BT.soundPanGet', () => {
     });
 });
 
+describe('BT.musicPlay', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('delegates to BTAPI.instance.musicPlay', () => {
+        const clip = {} as unknown as AudioClip;
+        const spy = vi.spyOn(BTAPI.instance, 'musicPlay').mockReturnValue(undefined);
+
+        BT.musicPlay(clip, { volume: 0.5, fadeMs: 400 });
+
+        expect(spy).toHaveBeenCalledWith(clip, { volume: 0.5, fadeMs: 400 });
+    });
+});
+
+describe('BT.musicStop', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('delegates to BTAPI.instance.musicStop, unpacking fadeMs', () => {
+        const spy = vi.spyOn(BTAPI.instance, 'musicStop').mockReturnValue(undefined);
+
+        BT.musicStop({ fadeMs: 500 });
+
+        expect(spy).toHaveBeenCalledWith(500);
+    });
+
+    it('passes undefined fadeMs when options are omitted', () => {
+        const spy = vi.spyOn(BTAPI.instance, 'musicStop').mockReturnValue(undefined);
+
+        BT.musicStop();
+
+        expect(spy).toHaveBeenCalledWith(undefined);
+    });
+});
+
+describe('BT.isMusicPlaying', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('delegates to BTAPI.instance.isMusicPlaying', () => {
+        const spy = vi.spyOn(BTAPI.instance, 'isMusicPlaying').mockReturnValue(true);
+
+        expect(BT.isMusicPlaying).toBe(true);
+        expect(spy).toHaveBeenCalledWith();
+    });
+});
+
+describe('BT.musicVolumeSet / BT.musicVolumeGet', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('musicVolumeSet delegates to BTAPI.instance.musicVolumeSet, unpacking fadeMs', () => {
+        const spy = vi.spyOn(BTAPI.instance, 'musicVolumeSet').mockReturnValue(undefined);
+
+        BT.musicVolumeSet(0.5, { fadeMs: 100 });
+
+        expect(spy).toHaveBeenCalledWith(0.5, 100);
+    });
+
+    it('musicVolumeGet delegates to BTAPI.instance.musicVolumeGet', () => {
+        const spy = vi.spyOn(BTAPI.instance, 'musicVolumeGet').mockReturnValue(0.5);
+
+        expect(BT.musicVolumeGet()).toBe(0.5);
+        expect(spy).toHaveBeenCalledWith();
+    });
+});
+
 describe('BT.synthPreset', () => {
     it('exposes exactly the preset sound library factories', () => {
         expect(Object.keys(BT.synthPreset).sort()).toEqual(

--- a/src/BLIT386.ts
+++ b/src/BLIT386.ts
@@ -26,6 +26,7 @@ import type {
     SynthWaveform,
 } from './assets/synth/SynthParams';
 import { blip, explosion, hit, jump, laser, pickup } from './assets/synth/synthPresets';
+import type { MusicPlayOptions } from './audio/MusicPlayer';
 import type { SoundParamSetOptions, SoundPlayOptions, SoundRef, SoundStopOptions } from './audio/VoicePool';
 import { BTAPI } from './core/BTAPI';
 import {
@@ -870,6 +871,67 @@ export const BT = {
      */
     soundPanGet: (ref: SoundRef): number => {
         return BTAPI.instance.soundPanGet(ref);
+    },
+
+    /**
+     * Plays a loaded audio clip through the music player, crossfading out whatever is currently
+     * playing.
+     *
+     * Silently does nothing when the clip hasn't finished loading yet (or was already unloaded
+     * with `clip.unload()`), or before the engine has initialized. While the audio context is
+     * still locked (before the first unlock gesture), the request is remembered instead of
+     * dropped - it starts automatically the instant the context unlocks, unlike {@link BT.soundPlay}.
+     *
+     * @since 1.3.0
+     * @param clip - Loaded audio clip to play.
+     * @param options - Crossfade, volume, and loop options; see {@link MusicPlayOptions}.
+     */
+    musicPlay: (clip: AudioClip, options?: MusicPlayOptions): void => {
+        BTAPI.instance.musicPlay(clip, options);
+    },
+
+    /**
+     * Stops the music player, optionally fading out first.
+     *
+     * @since 1.3.0
+     * @param options - Optional fade behavior.
+     * @param options.fadeMs - Fade-out duration in milliseconds. Omit to stop immediately.
+     */
+    musicStop: (options?: { fadeMs?: number }): void => {
+        BTAPI.instance.musicStop(options?.fadeMs);
+    },
+
+    /**
+     * Whether music is currently playing.
+     *
+     * @since 1.3.0
+     * @returns `true` when the music player has a live current track; `false` when stopped or
+     *   not yet started.
+     */
+    get isMusicPlaying(): boolean {
+        return BTAPI.instance.isMusicPlaying();
+    },
+
+    /**
+     * Sets the music player's volume, optionally fading to it.
+     *
+     * @since 1.3.0
+     * @param value - Target gain.
+     * @param options - Optional fade behavior.
+     * @param options.fadeMs - Fade duration in milliseconds. Omit for an immediate change.
+     */
+    musicVolumeSet: (value: number, options?: { fadeMs?: number }): void => {
+        BTAPI.instance.musicVolumeSet(value, options?.fadeMs);
+    },
+
+    /**
+     * Gets the music player's current target volume.
+     *
+     * @since 1.3.0
+     * @returns Current target gain, or `1` before initialization.
+     */
+    musicVolumeGet: (): number => {
+        return BTAPI.instance.musicVolumeGet();
     },
 
     /**
@@ -2030,6 +2092,7 @@ export type {
     EffectTier,
     HardwareSettings,
     IBTDemo,
+    MusicPlayOptions,
     OverlayRow,
     OverlayStyle,
     OverlayTimingChartStyle,

--- a/src/audio/AudioManager.test.ts
+++ b/src/audio/AudioManager.test.ts
@@ -489,8 +489,11 @@ describe('AudioManager', () => {
         it('only the latest pending request survives multiple musicPlay calls while locked', async () => {
             audio.attach(canvas);
 
-            audio.musicPlay(createMockAudioBuffer());
-            audio.musicPlay(createMockAudioBuffer());
+            const firstBuffer = createMockAudioBuffer();
+            const secondBuffer = createMockAudioBuffer();
+
+            audio.musicPlay(firstBuffer);
+            audio.musicPlay(secondBuffer);
 
             const context = getMockContext();
 
@@ -506,9 +509,14 @@ describe('AudioManager', () => {
                 expect(audio.isUnlocked()).toBe(true);
             });
 
-            expect((context as unknown as { createBufferSourceCalls: unknown[] }).createBufferSourceCalls).toHaveLength(
-                1,
-            );
+            const sources = (context as unknown as { createBufferSourceCalls: AudioBufferSourceNode[] })
+                .createBufferSourceCalls;
+
+            // Exactly one voice started, and it must be the second (latest) request's buffer -
+            // proving "latest wins" concretely instead of only inferring it from a call count.
+            expect(sources).toHaveLength(1);
+            expect(sources[0]?.buffer).toBe(secondBuffer);
+            expect(sources[0]?.buffer).not.toBe(firstBuffer);
         });
 
         it('starts playback immediately once unlocked', async () => {
@@ -556,8 +564,40 @@ describe('AudioManager', () => {
             expect((audio as unknown as { pendingMusicRequest: unknown }).pendingMusicRequest).toBeNull();
         });
 
+        it('clears the remembered request and logs distinctly even if starting it throws', async () => {
+            audio.attach(canvas);
+
+            const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+            // Invalid loopStart/loopEnd pair - MusicPlayer.play() validates and throws
+            // synchronously, which must not be mistaken for a context.resume() failure.
+            audio.musicPlay(createMockAudioBuffer(), { loopStart: 5, loopEnd: 1 });
+
+            canvas.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+
+            await vi.waitFor(() => {
+                expect(audio.isUnlocked()).toBe(true);
+            });
+
+            expect(audio.hasRememberedMusicRequest()).toBe(false);
+            expect((audio as unknown as { pendingMusicRequest: unknown }).pendingMusicRequest).toBeNull();
+            expect(consoleErrorSpy).toHaveBeenCalledWith(
+                '[BT] Failed to start the remembered music request',
+                expect.any(Error),
+            );
+            expect(consoleErrorSpy).not.toHaveBeenCalledWith(
+                '[BT] Failed to resume the audio context',
+                expect.anything(),
+            );
+
+            consoleErrorSpy.mockRestore();
+        });
+
         it('does not replay a stale remembered request on a later unlock attempt', async () => {
             audio.attach(canvas);
+
+            // Queue a request while locked, then unlock - this replays it exactly once.
+            audio.musicPlay(createMockAudioBuffer());
 
             canvas.dispatchEvent(new Event('pointerdown', { bubbles: true }));
 
@@ -568,7 +608,15 @@ describe('AudioManager', () => {
             const context = getMockContext();
 
             expect((context as unknown as { createBufferSourceCalls: unknown[] }).createBufferSourceCalls).toHaveLength(
-                0,
+                1,
+            );
+
+            // A later gesture must not find a stale remembered request to replay - the source
+            // count stays at 1, not 2.
+            canvas.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+
+            expect((context as unknown as { createBufferSourceCalls: unknown[] }).createBufferSourceCalls).toHaveLength(
+                1,
             );
         });
 

--- a/src/audio/AudioManager.test.ts
+++ b/src/audio/AudioManager.test.ts
@@ -476,6 +476,14 @@ describe('AudioManager', () => {
 
             expect(audio.isMusicPlaying()).toBe(false);
             expect(audio.hasRememberedMusicRequest()).toBe(true);
+
+            // No voice was actually started - the request is only remembered, never dropped
+            // silently like a pre-unlock playSound() call, but also not started early.
+            const context = getMockContext();
+
+            expect((context as unknown as { createBufferSourceCalls: unknown[] }).createBufferSourceCalls).toHaveLength(
+                0,
+            );
         });
 
         it('only the latest pending request survives multiple musicPlay calls while locked', async () => {
@@ -485,6 +493,12 @@ describe('AudioManager', () => {
             audio.musicPlay(createMockAudioBuffer());
 
             const context = getMockContext();
+
+            // Still locked - neither call started a voice yet, only the second overwrote the
+            // first as the remembered pending request.
+            expect((context as unknown as { createBufferSourceCalls: unknown[] }).createBufferSourceCalls).toHaveLength(
+                0,
+            );
 
             canvas.dispatchEvent(new Event('pointerdown', { bubbles: true }));
 
@@ -519,6 +533,8 @@ describe('AudioManager', () => {
 
             expect(audio.isMusicPlaying()).toBe(false);
 
+            const context = getMockContext();
+
             canvas.dispatchEvent(new Event('pointerdown', { bubbles: true }));
 
             await vi.waitFor(() => {
@@ -527,6 +543,17 @@ describe('AudioManager', () => {
 
             expect(audio.isMusicPlaying()).toBe(true);
             expect(audio.hasRememberedMusicRequest()).toBe(false);
+
+            // The remembered request actually started a live voice, not just flipped the flag.
+            const sources = (context as unknown as { createBufferSourceCalls: AudioBufferSourceNode[] })
+                .createBufferSourceCalls;
+
+            expect(sources).toHaveLength(1);
+            expect((sources[0] as unknown as { startCalls: unknown[] }).startCalls).toHaveLength(1);
+
+            // The stored {buffer, options} payload is cleared alongside the boolean flag, so a
+            // later unlock attempt (see the test below) can never find a stale request to replay.
+            expect((audio as unknown as { pendingMusicRequest: unknown }).pendingMusicRequest).toBeNull();
         });
 
         it('does not replay a stale remembered request on a later unlock attempt', async () => {

--- a/src/audio/AudioManager.test.ts
+++ b/src/audio/AudioManager.test.ts
@@ -467,4 +467,141 @@ describe('AudioManager', () => {
             expect(audio.isSoundPlaying(ref)).toBe(false);
         });
     });
+
+    describe('music playback', () => {
+        it('drops nothing but remembers the request when locked: musicPlay before unlock', () => {
+            audio.attach(canvas);
+
+            audio.musicPlay(createMockAudioBuffer());
+
+            expect(audio.isMusicPlaying()).toBe(false);
+            expect(audio.hasRememberedMusicRequest()).toBe(true);
+        });
+
+        it('only the latest pending request survives multiple musicPlay calls while locked', async () => {
+            audio.attach(canvas);
+
+            audio.musicPlay(createMockAudioBuffer());
+            audio.musicPlay(createMockAudioBuffer());
+
+            const context = getMockContext();
+
+            canvas.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+
+            await vi.waitFor(() => {
+                expect(audio.isUnlocked()).toBe(true);
+            });
+
+            expect((context as unknown as { createBufferSourceCalls: unknown[] }).createBufferSourceCalls).toHaveLength(
+                1,
+            );
+        });
+
+        it('starts playback immediately once unlocked', async () => {
+            audio.attach(canvas);
+
+            canvas.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+
+            await vi.waitFor(() => {
+                expect(audio.isUnlocked()).toBe(true);
+            });
+
+            audio.musicPlay(createMockAudioBuffer());
+
+            expect(audio.isMusicPlaying()).toBe(true);
+            expect(audio.hasRememberedMusicRequest()).toBe(false);
+        });
+
+        it('starts the remembered request and clears it once the context unlocks', async () => {
+            audio.attach(canvas);
+
+            audio.musicPlay(createMockAudioBuffer(), { volume: 0.5 });
+
+            expect(audio.isMusicPlaying()).toBe(false);
+
+            canvas.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+
+            await vi.waitFor(() => {
+                expect(audio.isUnlocked()).toBe(true);
+            });
+
+            expect(audio.isMusicPlaying()).toBe(true);
+            expect(audio.hasRememberedMusicRequest()).toBe(false);
+        });
+
+        it('does not replay a stale remembered request on a later unlock attempt', async () => {
+            audio.attach(canvas);
+
+            canvas.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+
+            await vi.waitFor(() => {
+                expect(audio.isUnlocked()).toBe(true);
+            });
+
+            const context = getMockContext();
+
+            expect((context as unknown as { createBufferSourceCalls: unknown[] }).createBufferSourceCalls).toHaveLength(
+                0,
+            );
+        });
+
+        describe('controls once unlocked', () => {
+            beforeEach(async () => {
+                audio.attach(canvas);
+
+                canvas.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+
+                await vi.waitFor(() => {
+                    expect(audio.isUnlocked()).toBe(true);
+                });
+            });
+
+            it('musicStop stops playback', () => {
+                audio.musicPlay(createMockAudioBuffer());
+
+                audio.musicStop();
+
+                expect(audio.isMusicPlaying()).toBe(false);
+            });
+
+            it('musicStop accepts an optional fadeMs without throwing', () => {
+                audio.musicPlay(createMockAudioBuffer());
+
+                expect(() => audio.musicStop(500)).not.toThrow();
+            });
+
+            it('musicVolumeSet and musicVolumeGet round-trip', () => {
+                audio.musicPlay(createMockAudioBuffer());
+
+                audio.musicVolumeSet(0.4);
+
+                expect(audio.musicVolumeGet()).toBe(0.4);
+            });
+        });
+
+        it('every accessor reports inert defaults on a manager that was never attached', () => {
+            const detachedAudio = new AudioManager();
+
+            expect(detachedAudio.isMusicPlaying()).toBe(false);
+            expect(detachedAudio.musicVolumeGet()).toBe(1);
+            expect(() => detachedAudio.musicPlay(createMockAudioBuffer())).not.toThrow();
+            expect(() => detachedAudio.musicStop()).not.toThrow();
+            expect(() => detachedAudio.musicVolumeSet(0.5)).not.toThrow();
+        });
+
+        it('detach stops music playback', async () => {
+            audio.attach(canvas);
+
+            canvas.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+
+            await vi.waitFor(() => {
+                expect(audio.isUnlocked()).toBe(true);
+            });
+
+            audio.musicPlay(createMockAudioBuffer());
+            audio.detach();
+
+            expect(audio.isMusicPlaying()).toBe(false);
+        });
+    });
 });

--- a/src/audio/AudioManager.ts
+++ b/src/audio/AudioManager.ts
@@ -571,29 +571,51 @@ export class AudioManager {
      * clears {@link isUnlocking} so a failed attempt can retry on the next gesture.
      *
      * On success, starts any music request remembered from before unlock (see
-     * {@link musicPlay}) and clears it via {@link clearRememberedMusicRequest} so it never
-     * replays on a later unlock attempt.
+     * {@link musicPlay}) via {@link startRememberedMusicRequest}.
      *
      * @param context - Audio context to resume.
      */
     private async resumeAndUnlock(context: AudioContext): Promise<void> {
         try {
             await context.resume();
-
-            this.unlocked = true;
-            this.removeUnlockListeners();
-
-            if (this.hasRememberedMusicRequest() && this.pendingMusicRequest !== null) {
-                const { buffer, options } = this.pendingMusicRequest;
-
-                this.musicPlayer?.play(buffer, options);
-                this.clearRememberedMusicRequest();
-                this.pendingMusicRequest = null;
-            }
         } catch (error) {
             console.error('[BT] Failed to resume the audio context', error);
+
+            return;
         } finally {
             this.isUnlocking = false;
+        }
+
+        this.unlocked = true;
+        this.removeUnlockListeners();
+        this.startRememberedMusicRequest();
+    }
+
+    /**
+     * Starts the music request remembered from before unlock (see {@link musicPlay}), if any.
+     *
+     * Clears {@link isMusicRequestRemembered} and {@link pendingMusicRequest} before calling
+     * {@link MusicPlayer.play} (rather than after), so a `play()` failure - for example invalid
+     * `loopStart`/`loopEnd` - can never leave a stale request dangling forever. `unlock()` never
+     * calls {@link resumeAndUnlock} again once {@link unlocked} is `true`, so a request left
+     * uncleared here would never get another chance to be replayed or discarded. A `play()`
+     * failure is logged separately from a `context.resume()` failure so the two are never
+     * conflated.
+     */
+    private startRememberedMusicRequest(): void {
+        if (!this.hasRememberedMusicRequest() || this.pendingMusicRequest === null) {
+            return;
+        }
+
+        const { buffer, options } = this.pendingMusicRequest;
+
+        this.clearRememberedMusicRequest();
+        this.pendingMusicRequest = null;
+
+        try {
+            this.musicPlayer?.play(buffer, options);
+        } catch (error) {
+            console.error('[BT] Failed to start the remembered music request', error);
         }
     }
 

--- a/src/audio/AudioManager.ts
+++ b/src/audio/AudioManager.ts
@@ -1,16 +1,17 @@
 /**
  * Internal audio subsystem: Web Audio context, bus graph, browser autoplay-unlock
- * state machine, SFX voice pool, and pre-unlock SFX/music drop counters.
+ * state machine, SFX voice pool, music player, and pre-unlock SFX/music drop counters.
  *
- * Owned by {@link BTAPI} (not itself a singleton) and never exposed to demo code.
- * Music playback is added in a later phase; this class manages the audio graph, bus
- * volume/mute, unlock tracking, and SFX voice playback via {@link playSound}.
+ * Owned by {@link BTAPI} (not itself a singleton) and never exposed to demo code. This class
+ * manages the audio graph, bus volume/mute, unlock tracking, SFX voice playback via
+ * {@link playSound}, and music playback via {@link musicPlay}.
  */
 
 import type { AudioBus } from '../core/IBTDemo';
 import { applyAudioParamRamp } from '../utils/AudioParamRamp';
 import type { EasingFunction } from '../utils/Easing';
 import { setAudioClipUnloadHandler, setAudioDecodeContext } from './audioDecodeContext';
+import { MusicPlayer, type MusicPlayOptions } from './MusicPlayer';
 import {
     DEFAULT_PAN,
     DEFAULT_PITCH,
@@ -40,8 +41,8 @@ type PerBus<T> = Record<AudioBus, T>;
  * Construct, then call {@link attach} with the rendering canvas. Call {@link detach}
  * to remove listeners and close the audio context (engine restarts, tests).
  *
- * Music playback is added in a later phase; this class exposes bus volume, mute,
- * unlock-state accessors, and SFX voice playback via {@link playSound}.
+ * Exposes bus volume, mute, and unlock-state accessors, SFX voice playback via
+ * {@link playSound}, and music playback via {@link musicPlay}.
  */
 export class AudioManager {
     /** Live Web Audio context, or `null` before {@link attach} / after {@link detach}. */
@@ -52,6 +53,9 @@ export class AudioManager {
 
     /** SFX voice pool, or `null` before {@link attach} / after {@link detach}. */
     private voicePool: VoicePool | null = null;
+
+    /** Music player, or `null` before {@link attach} / after {@link detach}. */
+    private musicPlayer: MusicPlayer | null = null;
 
     /** Canvas passed to {@link attach}; the unlock gesture listener target. */
     private target: HTMLCanvasElement | null = null;
@@ -76,6 +80,9 @@ export class AudioManager {
 
     /** Whether a music play request arrived while locked, remembered for later resumption. */
     private isMusicRequestRemembered = false;
+
+    /** Buffer and options from the latest {@link musicPlay} call made while locked; overwritten by a newer pending call, consumed by {@link resumeAndUnlock}. */
+    private pendingMusicRequest: { buffer: AudioBuffer; options: MusicPlayOptions | undefined } | null = null;
 
     /** Bound `pointerdown` unlock gesture handler; removed by reference in {@link removeUnlockListeners}. */
     private readonly onPointerDown: (event: Event) => void;
@@ -119,9 +126,12 @@ export class AudioManager {
     public attach(target: HTMLCanvasElement): void {
         this.detach();
 
+        let busNodes: PerBus<GainNode>;
+
         try {
             this.context = new AudioContext();
-            this.buildBusGraph(this.context);
+            busNodes = this.buildBusGraph(this.context);
+            this.busNodes = busNodes;
         } catch (error) {
             console.error('[BT] Failed to create the audio context', error);
 
@@ -135,6 +145,8 @@ export class AudioManager {
 
         this.voicePool = new VoicePool(this);
         setAudioClipUnloadHandler((buffer) => this.voicePool?.stopVoicesUsingBuffer(buffer));
+
+        this.musicPlayer = new MusicPlayer(this.context, busNodes.music);
 
         this.target = target;
 
@@ -156,6 +168,9 @@ export class AudioManager {
         this.voicePool = null;
         setAudioClipUnloadHandler(() => {});
 
+        this.musicPlayer?.stop();
+        this.musicPlayer = null;
+
         if (this.context !== null) {
             this.context.close().catch(() => {
                 // Context may already be closed; close() rejects rather than throwing synchronously.
@@ -174,6 +189,7 @@ export class AudioManager {
         this.mutedGainSnapshot = {};
         this.sfxDroppedCount = 0;
         this.isMusicRequestRemembered = false;
+        this.pendingMusicRequest = null;
     }
 
     /**
@@ -318,9 +334,10 @@ export class AudioManager {
 
     /**
      * Remembers that a music play request arrived while the audio context was
-     * locked, so future playback can resume it once unlocked.
+     * locked, so {@link resumeAndUnlock} can resume it once unlocked.
      *
-     * Called by future music playback methods; only the flag is implemented here.
+     * Called by {@link musicPlay}; carries no payload itself - see {@link pendingMusicRequest}
+     * for the actual buffer and options.
      */
     public rememberMusicRequest(): void {
         this.isMusicRequestRemembered = true;
@@ -338,8 +355,7 @@ export class AudioManager {
     /**
      * Clears the remembered pre-unlock music request.
      *
-     * Called by future music playback methods once the remembered request has
-     * been handled.
+     * Called by {@link resumeAndUnlock} once the remembered request has been started.
      */
     public clearRememberedMusicRequest(): void {
         this.isMusicRequestRemembered = false;
@@ -454,12 +470,72 @@ export class AudioManager {
     }
 
     /**
+     * Plays `buffer` through the music player, crossfading out whatever is currently playing.
+     *
+     * While the context is locked (pre-unlock), the request is not dropped like {@link playSound}
+     * - it is stored as the pending music request and remembered via {@link rememberMusicRequest},
+     * so {@link resumeAndUnlock} can start it the moment the context unlocks. A newer call while
+     * still locked overwrites the previously stored request; only the latest survives to unlock.
+     *
+     * @param buffer - Decoded audio buffer to play.
+     * @param options - Playback options; see {@link MusicPlayOptions}.
+     */
+    public musicPlay(buffer: AudioBuffer, options?: MusicPlayOptions): void {
+        if (!this.unlocked) {
+            this.pendingMusicRequest = { buffer, options };
+            this.rememberMusicRequest();
+
+            return;
+        }
+
+        this.musicPlayer?.play(buffer, options);
+    }
+
+    /**
+     * Stops the music player, optionally fading out first.
+     *
+     * @param fadeMs - Optional linear fade-out duration in milliseconds; omit to stop immediately.
+     */
+    public musicStop(fadeMs?: number): void {
+        this.musicPlayer?.stop(fadeMs);
+    }
+
+    /**
+     * Sets the music player's volume, optionally fading to it.
+     *
+     * @param value - Target gain.
+     * @param fadeMs - Optional fade duration in milliseconds; omit for an immediate change.
+     */
+    public musicVolumeSet(value: number, fadeMs?: number): void {
+        this.musicPlayer?.volumeSet(value, fadeMs);
+    }
+
+    /**
+     * Gets the music player's current target volume.
+     *
+     * @returns Current target gain, or {@link DEFAULT_VOLUME} before {@link attach}.
+     */
+    public musicVolumeGet(): number {
+        return this.musicPlayer?.volumeGet() ?? DEFAULT_VOLUME;
+    }
+
+    /**
+     * Reports whether music is currently playing.
+     *
+     * @returns `true` when the music player has a live current track.
+     */
+    public isMusicPlaying(): boolean {
+        return this.musicPlayer?.isPlaying() ?? false;
+    }
+
+    /**
      * Creates the `sfx` / `music` / `main` gain nodes and wires `sfx` and
      * `music` into `main`, which connects to `destination`.
      *
      * @param context - Audio context to build the graph on.
+     * @returns The newly created bus gain nodes.
      */
-    private buildBusGraph(context: AudioContext): void {
+    private buildBusGraph(context: AudioContext): PerBus<GainNode> {
         const main = context.createGain();
         const music = context.createGain();
         const sfx = context.createGain();
@@ -468,7 +544,7 @@ export class AudioManager {
         sfx.connect(main);
         main.connect(context.destination);
 
-        this.busNodes = { main, music, sfx };
+        return { main, music, sfx };
     }
 
     /**
@@ -494,6 +570,10 @@ export class AudioManager {
      * Awaits `context.resume()` and flips {@link unlocked} on success. Always
      * clears {@link isUnlocking} so a failed attempt can retry on the next gesture.
      *
+     * On success, starts any music request remembered from before unlock (see
+     * {@link musicPlay}) and clears it via {@link clearRememberedMusicRequest} so it never
+     * replays on a later unlock attempt.
+     *
      * @param context - Audio context to resume.
      */
     private async resumeAndUnlock(context: AudioContext): Promise<void> {
@@ -502,6 +582,14 @@ export class AudioManager {
 
             this.unlocked = true;
             this.removeUnlockListeners();
+
+            if (this.hasRememberedMusicRequest() && this.pendingMusicRequest !== null) {
+                const { buffer, options } = this.pendingMusicRequest;
+
+                this.musicPlayer?.play(buffer, options);
+                this.clearRememberedMusicRequest();
+                this.pendingMusicRequest = null;
+            }
         } catch (error) {
             console.error('[BT] Failed to resume the audio context', error);
         } finally {

--- a/src/audio/MusicPlayer.test.ts
+++ b/src/audio/MusicPlayer.test.ts
@@ -262,6 +262,27 @@ describe('MusicPlayer', () => {
 
             expect(asMockSource(source).startCalls).toEqual([{ when: 5 }]);
         });
+
+        it('ignores overlap on the very first play() - there is no outgoing voice to offset from', () => {
+            const { player, context } = createPlayer();
+
+            setMockCurrentTime(context, 5);
+
+            // overlap: -1 would normally push fadeInStart two full fadeMs later, but with no
+            // current voice playing there is nothing to crossfade against, so the very first
+            // track must still start immediately at now.
+            player.play(createMockAudioBuffer(), { fadeMs: 500, overlap: -1 });
+
+            const context2 = context as unknown as {
+                createGainCalls: GainNode[];
+                createBufferSourceCalls: AudioBufferSourceNode[];
+            };
+            const source = context2.createBufferSourceCalls.at(-1) as AudioBufferSourceNode;
+            const gain = asMockGain(context2.createGainCalls.at(-1) as GainNode);
+
+            expect(asMockSource(source).startCalls).toEqual([{ when: 5 }]);
+            expect(gain.gain.setValueAtTimeCalls).toEqual([{ value: 0, startTime: 5 }]);
+        });
     });
 
     describe('crossfade timing on replace', () => {
@@ -580,6 +601,35 @@ describe('MusicPlayer', () => {
             // play() call; stop() force-releases it immediately on top of that, so the source
             // sees both calls (a real AudioBufferSourceNode lets the later stop() win).
             expect(asMockSource(fadingPrevious).stopCalls).toEqual([1, 0]);
+        });
+
+        it('a repeated stop() call immediately silences the voice still fading from the first stop() call', () => {
+            const { player, context } = createPlayer();
+
+            player.play(createMockAudioBuffer());
+
+            const context2 = context as unknown as { createBufferSourceCalls: AudioBufferSourceNode[] };
+            const source = context2.createBufferSourceCalls.at(-1) as AudioBufferSourceNode;
+
+            player.stop(1000); // scheduled fade-out and stop, not yet complete
+            player.stop(); // must find and immediately force-stop the still-fading voice
+
+            expect(asMockSource(source).stopCalls).toEqual([1, 0]);
+        });
+
+        it('play() right after stop() force-stops the voice still fading from stop()', () => {
+            const { player, context } = createPlayer();
+
+            player.play(createMockAudioBuffer());
+
+            const context2 = context as unknown as { createBufferSourceCalls: AudioBufferSourceNode[] };
+            const stoppedSource = context2.createBufferSourceCalls.at(0) as AudioBufferSourceNode;
+
+            player.stop(1000); // scheduled fade-out and stop, not yet complete
+            player.play(createMockAudioBuffer()); // must immediately silence the still-fading voice, not leave it orphaned
+
+            expect(asMockSource(stoppedSource).stopCalls).toEqual([1, 0]);
+            expect(player.isPlaying()).toBe(true);
         });
 
         it('is a no-op when nothing is playing', () => {

--- a/src/audio/MusicPlayer.test.ts
+++ b/src/audio/MusicPlayer.test.ts
@@ -1,0 +1,633 @@
+// @vitest-environment happy-dom
+
+/**
+ * Unit tests for {@link MusicPlayer}.
+ *
+ * Constructs a `MusicPlayer` directly against a mock `AudioContext` and a mock `music` bus gain
+ * node (see `src/__test__/webaudio-mock.ts`), mirroring how `AudioManager.attach()` wires it up
+ * without needing a full `AudioManager` instance.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+    createMockAudioBuffer,
+    createMockAudioContext,
+    type MockGainNode,
+    setMockCurrentTime,
+} from '../__test__/webaudio-mock';
+import { MusicPlayer } from './MusicPlayer';
+
+/** Casts a `GainNode` back to its mock tracking shape. */
+const asMockGain = (node: GainNode): MockGainNode => node as unknown as MockGainNode;
+
+/** Casts an `AudioBufferSourceNode` back to its mock tracking shape. */
+const asMockSource = (
+    node: AudioBufferSourceNode,
+): AudioBufferSourceNode & {
+    connectCalls: unknown[];
+    startCalls: Array<{ when: number }>;
+    stopCalls: number[];
+    onended: (() => void) | null;
+} =>
+    node as unknown as AudioBufferSourceNode & {
+        connectCalls: unknown[];
+        startCalls: Array<{ when: number }>;
+        stopCalls: number[];
+        onended: (() => void) | null;
+    };
+
+/** Builds a fresh `MusicPlayer` wired to a fresh mock context and music bus. */
+function createPlayer(): { player: MusicPlayer; context: AudioContext; musicBus: GainNode } {
+    const context = createMockAudioContext();
+    const musicBus = context.createGain();
+
+    return { player: new MusicPlayer(context, musicBus), context, musicBus };
+}
+
+describe('MusicPlayer', () => {
+    describe('play - node graph', () => {
+        it('connects a fresh voice gain to the injected music bus', () => {
+            const { player, context, musicBus } = createPlayer();
+
+            player.play(createMockAudioBuffer());
+
+            const context2 = context as unknown as { createGainCalls: GainNode[] };
+            const voiceGain = context2.createGainCalls.at(-1);
+
+            expect(voiceGain).toBeDefined();
+            expect(asMockGain(voiceGain as GainNode).connectCalls).toEqual([musicBus]);
+        });
+
+        it('connects the source through the voice gain', () => {
+            const { player, context } = createPlayer();
+
+            player.play(createMockAudioBuffer());
+
+            const context2 = context as unknown as {
+                createBufferSourceCalls: AudioBufferSourceNode[];
+                createGainCalls: GainNode[];
+            };
+            const source = context2.createBufferSourceCalls.at(-1) as AudioBufferSourceNode;
+            const voiceGain = context2.createGainCalls.at(-1) as GainNode;
+
+            expect(asMockSource(source).connectCalls).toEqual([voiceGain]);
+        });
+
+        it('sets buffer on the source node', () => {
+            const { player, context } = createPlayer();
+            const buffer = createMockAudioBuffer();
+
+            player.play(buffer);
+
+            const context2 = context as unknown as { createBufferSourceCalls: AudioBufferSourceNode[] };
+            const source = context2.createBufferSourceCalls.at(-1) as AudioBufferSourceNode;
+
+            expect(source.buffer).toBe(buffer);
+        });
+    });
+
+    describe('play - volume defaults', () => {
+        it('defaults volume to 1 immediately (no fade)', () => {
+            const { player, context } = createPlayer();
+
+            player.play(createMockAudioBuffer());
+
+            const context2 = context as unknown as { createGainCalls: GainNode[] };
+            const voiceGain = context2.createGainCalls.at(-1) as GainNode;
+
+            expect(voiceGain.gain.value).toBe(1);
+        });
+
+        it('applies a custom volume immediately (no fade)', () => {
+            const { player, context } = createPlayer();
+
+            player.play(createMockAudioBuffer(), { volume: 0.4 });
+
+            const context2 = context as unknown as { createGainCalls: GainNode[] };
+            const voiceGain = context2.createGainCalls.at(-1) as GainNode;
+
+            expect(voiceGain.gain.value).toBe(0.4);
+        });
+
+        it('starts the source at the current audio-clock time with no fade', () => {
+            const { player, context } = createPlayer();
+
+            setMockCurrentTime(context, 3);
+            player.play(createMockAudioBuffer());
+
+            const context2 = context as unknown as { createBufferSourceCalls: AudioBufferSourceNode[] };
+            const source = context2.createBufferSourceCalls.at(-1) as AudioBufferSourceNode;
+
+            expect(asMockSource(source).startCalls).toEqual([{ when: 3 }]);
+        });
+    });
+
+    describe('play - loop options', () => {
+        it('defaults to looping the whole track', () => {
+            const { player, context } = createPlayer();
+
+            player.play(createMockAudioBuffer());
+
+            const context2 = context as unknown as { createBufferSourceCalls: AudioBufferSourceNode[] };
+            const source = context2.createBufferSourceCalls.at(-1) as AudioBufferSourceNode;
+
+            expect(source.loop).toBe(true);
+        });
+
+        it('honors loop: false for a one-shot', () => {
+            const { player, context } = createPlayer();
+
+            player.play(createMockAudioBuffer(), { loop: false });
+
+            const context2 = context as unknown as { createBufferSourceCalls: AudioBufferSourceNode[] };
+            const source = context2.createBufferSourceCalls.at(-1) as AudioBufferSourceNode;
+
+            expect(source.loop).toBe(false);
+        });
+
+        it('sets loopStart/loopEnd and forces loop true when both are given', () => {
+            const { player, context } = createPlayer();
+            const buffer = createMockAudioBuffer(1, 10, 10); // duration 1s at sampleRate 10
+
+            player.play(buffer, { loopStart: 0.2, loopEnd: 0.8, loop: false });
+
+            const context2 = context as unknown as { createBufferSourceCalls: AudioBufferSourceNode[] };
+            const source = context2.createBufferSourceCalls.at(-1) as AudioBufferSourceNode;
+
+            expect(source.loop).toBe(true);
+            expect(source.loopStart).toBe(0.2);
+            expect(source.loopEnd).toBe(0.8);
+        });
+
+        it('throws when only loopStart is given', () => {
+            const { player } = createPlayer();
+            const buffer = createMockAudioBuffer(1, 10, 10);
+
+            expect(() => player.play(buffer, { loopStart: 0.2 })).toThrow(/loopStart and loopEnd/);
+        });
+
+        it('throws when only loopEnd is given', () => {
+            const { player } = createPlayer();
+            const buffer = createMockAudioBuffer(1, 10, 10);
+
+            expect(() => player.play(buffer, { loopEnd: 0.8 })).toThrow(/loopStart and loopEnd/);
+        });
+
+        it('throws when loopStart is negative', () => {
+            const { player } = createPlayer();
+            const buffer = createMockAudioBuffer(1, 10, 10);
+
+            expect(() => player.play(buffer, { loopStart: -0.1, loopEnd: 0.5 })).toThrow(/invalid loop region/);
+        });
+
+        it('throws when loopStart is not less than loopEnd', () => {
+            const { player } = createPlayer();
+            const buffer = createMockAudioBuffer(1, 10, 10);
+
+            expect(() => player.play(buffer, { loopStart: 0.5, loopEnd: 0.5 })).toThrow(/invalid loop region/);
+        });
+
+        it('throws when loopEnd exceeds buffer duration', () => {
+            const { player } = createPlayer();
+            const buffer = createMockAudioBuffer(1, 10, 10);
+
+            expect(() => player.play(buffer, { loopStart: 0, loopEnd: 5 })).toThrow(/invalid loop region/);
+        });
+
+        it('does not start any voice when loop validation fails', () => {
+            const { player, context } = createPlayer();
+            const buffer = createMockAudioBuffer(1, 10, 10);
+
+            expect(() => player.play(buffer, { loopStart: 5, loopEnd: 1 })).toThrow();
+            expect(player.isPlaying()).toBe(false);
+
+            const context2 = context as unknown as { createBufferSourceCalls: AudioBufferSourceNode[] };
+
+            expect(context2.createBufferSourceCalls).toHaveLength(0);
+        });
+    });
+
+    describe('play - fade-in', () => {
+        it('ramps gain from silence over fadeMs with linear easing by default', () => {
+            const { player, context } = createPlayer();
+
+            player.play(createMockAudioBuffer(), { volume: 0.9, fadeMs: 200 });
+
+            const context2 = context as unknown as { createGainCalls: GainNode[] };
+            const voiceGain = asMockGain(context2.createGainCalls.at(-1) as GainNode);
+
+            expect(voiceGain.gain.setValueAtTimeCalls).toEqual([{ value: 0, startTime: 0 }]);
+            expect(voiceGain.gain.linearRampToValueAtTimeCalls).toEqual([{ value: 0.9, endTime: 0.2 }]);
+        });
+
+        it('uses setValueCurveAtTime for a non-linear easeIn', () => {
+            const { player, context } = createPlayer();
+
+            player.play(createMockAudioBuffer(), { volume: 0.9, fadeMs: 200, easeIn: 'ease-out' });
+
+            const context2 = context as unknown as { createGainCalls: GainNode[] };
+            const voiceGain = asMockGain(context2.createGainCalls.at(-1) as GainNode);
+
+            expect(voiceGain.gain.setValueCurveAtTimeCalls).toHaveLength(1);
+        });
+
+        it('starts the source at the current time even when fading in (overlap defaults to simultaneous)', () => {
+            const { player, context } = createPlayer();
+
+            setMockCurrentTime(context, 5);
+            player.play(createMockAudioBuffer(), { fadeMs: 500 });
+
+            const context2 = context as unknown as { createBufferSourceCalls: AudioBufferSourceNode[] };
+            const source = context2.createBufferSourceCalls.at(-1) as AudioBufferSourceNode;
+
+            expect(asMockSource(source).startCalls).toEqual([{ when: 5 }]);
+        });
+    });
+
+    describe('crossfade timing on replace', () => {
+        it('fades the previous voice out starting immediately at now', () => {
+            const { player, context } = createPlayer();
+
+            setMockCurrentTime(context, 10);
+            player.play(createMockAudioBuffer(), { fadeMs: 0 });
+
+            const context2 = context as unknown as {
+                createGainCalls: GainNode[];
+                createBufferSourceCalls: AudioBufferSourceNode[];
+            };
+            const firstGain = asMockGain(context2.createGainCalls.at(-1) as GainNode);
+            const firstSource = context2.createBufferSourceCalls.at(-1) as AudioBufferSourceNode;
+
+            player.play(createMockAudioBuffer(), { fadeMs: 400, overlap: 1 });
+
+            expect(firstGain.gain.linearRampToValueAtTimeCalls).toEqual([{ value: 0, endTime: 10.4 }]);
+            expect(asMockSource(firstSource).stopCalls).toEqual([10.4]);
+        });
+
+        it('overlap 1 starts the fade-in at the same time as the fade-out (simultaneous)', () => {
+            const { player, context } = createPlayer();
+
+            setMockCurrentTime(context, 10);
+            player.play(createMockAudioBuffer(), { fadeMs: 0 });
+
+            player.play(createMockAudioBuffer(), { fadeMs: 400, overlap: 1 });
+
+            const context2 = context as unknown as { createBufferSourceCalls: AudioBufferSourceNode[] };
+            const secondSource = context2.createBufferSourceCalls.at(-1) as AudioBufferSourceNode;
+
+            expect(asMockSource(secondSource).startCalls).toEqual([{ when: 10 }]);
+        });
+
+        it('overlap 0 starts the fade-in exactly when the fade-out ends (sequential)', () => {
+            const { player, context } = createPlayer();
+
+            setMockCurrentTime(context, 10);
+            player.play(createMockAudioBuffer(), { fadeMs: 0 });
+
+            player.play(createMockAudioBuffer(), { fadeMs: 400, overlap: 0 });
+
+            const context2 = context as unknown as { createBufferSourceCalls: AudioBufferSourceNode[] };
+            const secondSource = context2.createBufferSourceCalls.at(-1) as AudioBufferSourceNode;
+
+            expect(asMockSource(secondSource).startCalls).toEqual([{ when: 10.4 }]);
+        });
+
+        it('overlap -1 inserts a silence gap of fadeMs between fade-out end and fade-in start', () => {
+            const { player, context } = createPlayer();
+
+            setMockCurrentTime(context, 10);
+            player.play(createMockAudioBuffer(), { fadeMs: 0 });
+
+            player.play(createMockAudioBuffer(), { fadeMs: 400, overlap: -1 });
+
+            const context2 = context as unknown as { createBufferSourceCalls: AudioBufferSourceNode[] };
+            const secondSource = context2.createBufferSourceCalls.at(-1) as AudioBufferSourceNode;
+
+            expect(asMockSource(secondSource).startCalls).toEqual([{ when: 10.8 }]);
+        });
+
+        it('interpolates intermediate overlap values', () => {
+            const { player, context } = createPlayer();
+
+            setMockCurrentTime(context, 0);
+            player.play(createMockAudioBuffer(), { fadeMs: 0 });
+
+            player.play(createMockAudioBuffer(), { fadeMs: 1000, overlap: 0.5 });
+
+            const context2 = context as unknown as { createBufferSourceCalls: AudioBufferSourceNode[] };
+            const secondSource = context2.createBufferSourceCalls.at(-1) as AudioBufferSourceNode;
+
+            expect(asMockSource(secondSource).startCalls).toEqual([{ when: 0.5 }]);
+        });
+
+        it('clamps an out-of-range overlap above 1', () => {
+            const { player, context } = createPlayer();
+
+            setMockCurrentTime(context, 0);
+            player.play(createMockAudioBuffer(), { fadeMs: 0 });
+
+            player.play(createMockAudioBuffer(), { fadeMs: 400, overlap: 5 });
+
+            const context2 = context as unknown as { createBufferSourceCalls: AudioBufferSourceNode[] };
+            const secondSource = context2.createBufferSourceCalls.at(-1) as AudioBufferSourceNode;
+
+            expect(asMockSource(secondSource).startCalls).toEqual([{ when: 0 }]);
+        });
+
+        it('clamps an out-of-range overlap below -1', () => {
+            const { player, context } = createPlayer();
+
+            setMockCurrentTime(context, 0);
+            player.play(createMockAudioBuffer(), { fadeMs: 0 });
+
+            player.play(createMockAudioBuffer(), { fadeMs: 400, overlap: -5 });
+
+            const context2 = context as unknown as { createBufferSourceCalls: AudioBufferSourceNode[] };
+            const secondSource = context2.createBufferSourceCalls.at(-1) as AudioBufferSourceNode;
+
+            expect(asMockSource(secondSource).startCalls).toEqual([{ when: 0.8 }]);
+        });
+
+        it('uses a non-linear easeOut for the outgoing fade', () => {
+            const { player, context } = createPlayer();
+
+            player.play(createMockAudioBuffer(), { fadeMs: 0 });
+
+            const context2 = context as unknown as { createGainCalls: GainNode[] };
+            const firstGain = asMockGain(context2.createGainCalls.at(-1) as GainNode);
+
+            player.play(createMockAudioBuffer(), { fadeMs: 400, easeOut: 'ease-in' });
+
+            expect(firstGain.gain.setValueCurveAtTimeCalls).toHaveLength(1);
+        });
+
+        it('does not fade out anything on the very first play (no previous track)', () => {
+            const { player, context } = createPlayer();
+
+            player.play(createMockAudioBuffer(), { fadeMs: 400 });
+
+            const context2 = context as unknown as { createBufferSourceCalls: AudioBufferSourceNode[] };
+
+            expect(context2.createBufferSourceCalls).toHaveLength(1);
+        });
+    });
+
+    describe('replace-while-fading', () => {
+        it('immediately stops a still-fading previous voice when play() is called again', () => {
+            const { player, context } = createPlayer();
+
+            player.play(createMockAudioBuffer(), { fadeMs: 0 });
+            player.play(createMockAudioBuffer(), { fadeMs: 1000, overlap: 0 }); // creates a previous voice mid-fade
+
+            const context2 = context as unknown as { createBufferSourceCalls: AudioBufferSourceNode[] };
+            const stillFadingSource = context2.createBufferSourceCalls.at(1) as AudioBufferSourceNode;
+
+            player.play(createMockAudioBuffer(), { fadeMs: 0 }); // third call while the 2nd is still fading in as current->previous
+
+            // The voice started by the 2nd call becomes the previous voice of the 3rd call and
+            // must be force-stopped immediately (stop with no scheduled time), not scheduled.
+            expect(asMockSource(stillFadingSource).stopCalls).toEqual([0]);
+        });
+
+        it('never leaves more than one previous voice live', () => {
+            const { player, context } = createPlayer();
+
+            player.play(createMockAudioBuffer(), { fadeMs: 1000 });
+            player.play(createMockAudioBuffer(), { fadeMs: 1000 });
+            player.play(createMockAudioBuffer(), { fadeMs: 1000 });
+
+            const context2 = context as unknown as { createBufferSourceCalls: AudioBufferSourceNode[] };
+
+            expect(context2.createBufferSourceCalls).toHaveLength(3);
+            expect(player.isPlaying()).toBe(true);
+        });
+    });
+
+    describe('stop', () => {
+        it('isPlaying is false before any play() call', () => {
+            const { player } = createPlayer();
+
+            expect(player.isPlaying()).toBe(false);
+        });
+
+        it('isPlaying is true after play()', () => {
+            const { player } = createPlayer();
+
+            player.play(createMockAudioBuffer());
+
+            expect(player.isPlaying()).toBe(true);
+        });
+
+        it('isPlaying is false immediately after stop(), even with a fade in progress', () => {
+            const { player } = createPlayer();
+
+            player.play(createMockAudioBuffer());
+            player.stop(500);
+
+            expect(player.isPlaying()).toBe(false);
+        });
+
+        it('stop() with no fadeMs stops the source immediately', () => {
+            const { player, context } = createPlayer();
+
+            player.play(createMockAudioBuffer());
+
+            const context2 = context as unknown as { createBufferSourceCalls: AudioBufferSourceNode[] };
+            const source = context2.createBufferSourceCalls.at(-1) as AudioBufferSourceNode;
+
+            player.stop();
+
+            expect(asMockSource(source).stopCalls).toEqual([0]);
+        });
+
+        it('stop(fadeMs) ramps gain to 0 and schedules a delayed stop', () => {
+            const { player, context } = createPlayer();
+
+            setMockCurrentTime(context, 2);
+            player.play(createMockAudioBuffer());
+
+            const context2 = context as unknown as {
+                createGainCalls: GainNode[];
+                createBufferSourceCalls: AudioBufferSourceNode[];
+            };
+            const gain = asMockGain(context2.createGainCalls.at(-1) as GainNode);
+            const source = context2.createBufferSourceCalls.at(-1) as AudioBufferSourceNode;
+
+            player.stop(500);
+
+            expect(gain.gain.linearRampToValueAtTimeCalls).toEqual([{ value: 0, endTime: 2.5 }]);
+            expect(asMockSource(source).stopCalls).toEqual([2.5]);
+        });
+
+        it('stop() also releases a voice that was still crossfading out', () => {
+            const { player, context } = createPlayer();
+
+            player.play(createMockAudioBuffer(), { fadeMs: 0 });
+            player.play(createMockAudioBuffer(), { fadeMs: 1000 });
+
+            const context2 = context as unknown as { createBufferSourceCalls: AudioBufferSourceNode[] };
+            const fadingPrevious = context2.createBufferSourceCalls.at(0) as AudioBufferSourceNode;
+
+            player.stop();
+
+            // Already had a scheduled stop (endTime 1) from being demoted to previous by the 2nd
+            // play() call; stop() force-releases it immediately on top of that, so the source
+            // sees both calls (a real AudioBufferSourceNode lets the later stop() win).
+            expect(asMockSource(fadingPrevious).stopCalls).toEqual([1, 0]);
+        });
+
+        it('is a no-op when nothing is playing', () => {
+            const { player } = createPlayer();
+
+            expect(() => player.stop()).not.toThrow();
+            expect(() => player.stop(500)).not.toThrow();
+        });
+    });
+
+    describe('volume', () => {
+        it('defaults to 1 before any play()', () => {
+            const { player } = createPlayer();
+
+            expect(player.volumeGet()).toBe(1);
+        });
+
+        it('reflects the volume passed to play()', () => {
+            const { player } = createPlayer();
+
+            player.play(createMockAudioBuffer(), { volume: 0.6 });
+
+            expect(player.volumeGet()).toBe(0.6);
+        });
+
+        it('volumeSet updates the reported volume', () => {
+            const { player } = createPlayer();
+
+            player.play(createMockAudioBuffer());
+            player.volumeSet(0.3);
+
+            expect(player.volumeGet()).toBe(0.3);
+        });
+
+        it('volumeSet applies immediately to the current voice gain with no fadeMs', () => {
+            const { player, context } = createPlayer();
+
+            player.play(createMockAudioBuffer());
+
+            const context2 = context as unknown as { createGainCalls: GainNode[] };
+            const gain = asMockGain(context2.createGainCalls.at(-1) as GainNode);
+
+            player.volumeSet(0.25);
+
+            expect(gain.gain.value).toBe(0.25);
+        });
+
+        it('volumeSet ramps the current voice gain over fadeMs', () => {
+            const { player, context } = createPlayer();
+
+            player.play(createMockAudioBuffer());
+
+            const context2 = context as unknown as { createGainCalls: GainNode[] };
+            const gain = asMockGain(context2.createGainCalls.at(-1) as GainNode);
+
+            player.volumeSet(0.2, 100);
+
+            expect(gain.gain.linearRampToValueAtTimeCalls).toHaveLength(1);
+        });
+
+        it('volumeSet before any play() does not throw and still updates volumeGet', () => {
+            const { player } = createPlayer();
+
+            expect(() => player.volumeSet(0.5)).not.toThrow();
+            expect(player.volumeGet()).toBe(0.5);
+        });
+
+        it('volumeGet keeps the last value after stop()', () => {
+            const { player } = createPlayer();
+
+            player.play(createMockAudioBuffer(), { volume: 0.7 });
+            player.stop();
+
+            expect(player.volumeGet()).toBe(0.7);
+        });
+    });
+
+    describe('natural completion and onended guards', () => {
+        it('recycles the current voice when its source ends naturally', () => {
+            const { player, context } = createPlayer();
+
+            player.play(createMockAudioBuffer(), { loop: false });
+
+            const context2 = context as unknown as { createBufferSourceCalls: AudioBufferSourceNode[] };
+            const source = context2.createBufferSourceCalls.at(-1) as AudioBufferSourceNode;
+
+            (asMockSource(source).onended as () => void)();
+
+            expect(player.isPlaying()).toBe(false);
+        });
+
+        it('disconnects the ended source and gain', () => {
+            const { player, context } = createPlayer();
+
+            player.play(createMockAudioBuffer(), { loop: false });
+
+            const context2 = context as unknown as {
+                createBufferSourceCalls: AudioBufferSourceNode[];
+                createGainCalls: GainNode[];
+            };
+            const source = context2.createBufferSourceCalls.at(-1) as AudioBufferSourceNode;
+            const gain = context2.createGainCalls.at(-1) as GainNode;
+
+            const sourceDisconnectCalls: unknown[] = [];
+            const originalDisconnect = source.disconnect.bind(source);
+
+            source.disconnect = (...args: unknown[]) => {
+                sourceDisconnectCalls.push(args);
+
+                return (originalDisconnect as (...innerArgs: unknown[]) => unknown)(...args);
+            };
+
+            let gainDisconnected = false;
+
+            gain.disconnect = () => {
+                gainDisconnected = true;
+            };
+
+            (asMockSource(source).onended as () => void)();
+
+            expect(sourceDisconnectCalls).toHaveLength(1);
+            expect(gainDisconnected).toBe(true);
+        });
+
+        it('a stale onended from a force-stopped previous voice does not clobber the new current voice', () => {
+            const { player, context } = createPlayer();
+
+            player.play(createMockAudioBuffer(), { fadeMs: 0 });
+
+            const context2 = context as unknown as { createBufferSourceCalls: AudioBufferSourceNode[] };
+            const firstSource = context2.createBufferSourceCalls.at(0) as AudioBufferSourceNode;
+
+            player.play(createMockAudioBuffer(), { fadeMs: 1000 }); // first -> previous, mid-fade
+            player.play(createMockAudioBuffer(), { fadeMs: 0 }); // force-stops the stale previous (firstSource)
+
+            (asMockSource(firstSource).onended as () => void)();
+
+            expect(player.isPlaying()).toBe(true);
+        });
+
+        it('a stale onended from a replaced current voice does not clear the new current voice', () => {
+            const { player, context } = createPlayer();
+
+            player.play(createMockAudioBuffer(), { fadeMs: 0 });
+
+            const context2 = context as unknown as { createBufferSourceCalls: AudioBufferSourceNode[] };
+            const firstSource = context2.createBufferSourceCalls.at(0) as AudioBufferSourceNode;
+
+            player.play(createMockAudioBuffer(), { fadeMs: 0 }); // firstSource is now the previous voice
+
+            (asMockSource(firstSource).onended as () => void)();
+
+            expect(player.isPlaying()).toBe(true);
+        });
+    });
+});

--- a/src/audio/MusicPlayer.test.ts
+++ b/src/audio/MusicPlayer.test.ts
@@ -206,6 +206,25 @@ describe('MusicPlayer', () => {
 
             expect(context2.createBufferSourceCalls).toHaveLength(0);
         });
+
+        it('leaves an already-playing track untouched when a later play() call fails loop validation', () => {
+            const { player, context } = createPlayer();
+            const invalidBuffer = createMockAudioBuffer(1, 10, 10);
+
+            player.play(createMockAudioBuffer());
+
+            expect(() => player.play(invalidBuffer, { loopStart: 5, loopEnd: 1 })).toThrow();
+
+            // Validation runs before any promotion/teardown, so the already-playing track from
+            // the first play() call is still the current voice - never demoted to previous, never
+            // stopped.
+            expect(player.isPlaying()).toBe(true);
+
+            const context2 = context as unknown as { createBufferSourceCalls: AudioBufferSourceNode[] };
+
+            expect(context2.createBufferSourceCalls).toHaveLength(1);
+            expect(asMockSource(context2.createBufferSourceCalls[0] as AudioBufferSourceNode).stopCalls).toEqual([]);
+        });
     });
 
     describe('play - fade-in', () => {
@@ -265,17 +284,32 @@ describe('MusicPlayer', () => {
             expect(asMockSource(firstSource).stopCalls).toEqual([10.4]);
         });
 
-        it('overlap 1 starts the fade-in at the same time as the fade-out (simultaneous)', () => {
+        it('overlap 1 fades both voices simultaneously - gain ramps and source timings all anchor to now', () => {
             const { player, context } = createPlayer();
 
             setMockCurrentTime(context, 10);
             player.play(createMockAudioBuffer(), { fadeMs: 0 });
 
+            const context2 = context as unknown as {
+                createGainCalls: GainNode[];
+                createBufferSourceCalls: AudioBufferSourceNode[];
+            };
+            const firstGain = asMockGain(context2.createGainCalls.at(-1) as GainNode);
+            const firstSource = context2.createBufferSourceCalls.at(-1) as AudioBufferSourceNode;
+
             player.play(createMockAudioBuffer(), { fadeMs: 400, overlap: 1 });
 
-            const context2 = context as unknown as { createBufferSourceCalls: AudioBufferSourceNode[] };
+            const secondGain = asMockGain(context2.createGainCalls.at(-1) as GainNode);
             const secondSource = context2.createBufferSourceCalls.at(-1) as AudioBufferSourceNode;
 
+            // Outgoing voice fades to silence starting at now (10), ending at now + fadeMs (10.4).
+            expect(firstGain.gain.setValueAtTimeCalls).toEqual([{ value: 1, startTime: 10 }]);
+            expect(firstGain.gain.linearRampToValueAtTimeCalls).toEqual([{ value: 0, endTime: 10.4 }]);
+            expect(asMockSource(firstSource).stopCalls).toEqual([10.4]);
+
+            // Incoming voice fades in over the exact same window since overlap 1 is simultaneous.
+            expect(secondGain.gain.setValueAtTimeCalls).toEqual([{ value: 0, startTime: 10 }]);
+            expect(secondGain.gain.linearRampToValueAtTimeCalls).toEqual([{ value: 1, endTime: 10.4 }]);
             expect(asMockSource(secondSource).startCalls).toEqual([{ when: 10 }]);
         });
 
@@ -285,11 +319,25 @@ describe('MusicPlayer', () => {
             setMockCurrentTime(context, 10);
             player.play(createMockAudioBuffer(), { fadeMs: 0 });
 
+            const context2 = context as unknown as {
+                createGainCalls: GainNode[];
+                createBufferSourceCalls: AudioBufferSourceNode[];
+            };
+            const firstGain = asMockGain(context2.createGainCalls.at(-1) as GainNode);
+            const firstSource = context2.createBufferSourceCalls.at(-1) as AudioBufferSourceNode;
+
             player.play(createMockAudioBuffer(), { fadeMs: 400, overlap: 0 });
 
-            const context2 = context as unknown as { createBufferSourceCalls: AudioBufferSourceNode[] };
+            const secondGain = asMockGain(context2.createGainCalls.at(-1) as GainNode);
             const secondSource = context2.createBufferSourceCalls.at(-1) as AudioBufferSourceNode;
 
+            expect(firstGain.gain.setValueAtTimeCalls).toEqual([{ value: 1, startTime: 10 }]);
+            expect(firstGain.gain.linearRampToValueAtTimeCalls).toEqual([{ value: 0, endTime: 10.4 }]);
+            expect(asMockSource(firstSource).stopCalls).toEqual([10.4]);
+
+            // Incoming voice starts fading in exactly when the outgoing voice finishes (10.4).
+            expect(secondGain.gain.setValueAtTimeCalls).toEqual([{ value: 0, startTime: 10.4 }]);
+            expect(secondGain.gain.linearRampToValueAtTimeCalls).toEqual([{ value: 1, endTime: 10.8 }]);
             expect(asMockSource(secondSource).startCalls).toEqual([{ when: 10.4 }]);
         });
 
@@ -299,11 +347,27 @@ describe('MusicPlayer', () => {
             setMockCurrentTime(context, 10);
             player.play(createMockAudioBuffer(), { fadeMs: 0 });
 
+            const context2 = context as unknown as {
+                createGainCalls: GainNode[];
+                createBufferSourceCalls: AudioBufferSourceNode[];
+            };
+            const firstGain = asMockGain(context2.createGainCalls.at(-1) as GainNode);
+            const firstSource = context2.createBufferSourceCalls.at(-1) as AudioBufferSourceNode;
+
             player.play(createMockAudioBuffer(), { fadeMs: 400, overlap: -1 });
 
-            const context2 = context as unknown as { createBufferSourceCalls: AudioBufferSourceNode[] };
+            const secondGain = asMockGain(context2.createGainCalls.at(-1) as GainNode);
             const secondSource = context2.createBufferSourceCalls.at(-1) as AudioBufferSourceNode;
 
+            expect(firstGain.gain.setValueAtTimeCalls).toEqual([{ value: 1, startTime: 10 }]);
+            expect(firstGain.gain.linearRampToValueAtTimeCalls).toEqual([{ value: 0, endTime: 10.4 }]);
+            expect(asMockSource(firstSource).stopCalls).toEqual([10.4]);
+
+            // Incoming voice waits a full extra fadeMs (400ms) of silence after the fade-out ends.
+            expect(secondGain.gain.setValueAtTimeCalls).toEqual([{ value: 0, startTime: 10.8 }]);
+            expect(secondGain.gain.linearRampToValueAtTimeCalls).toHaveLength(1);
+            expect(secondGain.gain.linearRampToValueAtTimeCalls[0]?.value).toBe(1);
+            expect(secondGain.gain.linearRampToValueAtTimeCalls[0]?.endTime).toBeCloseTo(11.2, 10);
             expect(asMockSource(secondSource).startCalls).toEqual([{ when: 10.8 }]);
         });
 
@@ -313,11 +377,25 @@ describe('MusicPlayer', () => {
             setMockCurrentTime(context, 0);
             player.play(createMockAudioBuffer(), { fadeMs: 0 });
 
+            const context2 = context as unknown as {
+                createGainCalls: GainNode[];
+                createBufferSourceCalls: AudioBufferSourceNode[];
+            };
+            const firstGain = asMockGain(context2.createGainCalls.at(-1) as GainNode);
+            const firstSource = context2.createBufferSourceCalls.at(-1) as AudioBufferSourceNode;
+
             player.play(createMockAudioBuffer(), { fadeMs: 1000, overlap: 0.5 });
 
-            const context2 = context as unknown as { createBufferSourceCalls: AudioBufferSourceNode[] };
+            const secondGain = asMockGain(context2.createGainCalls.at(-1) as GainNode);
             const secondSource = context2.createBufferSourceCalls.at(-1) as AudioBufferSourceNode;
 
+            // fadeSeconds*(1 - overlap) = 1 * 0.5 = 0.5s offset, halfway between simultaneous and sequential.
+            expect(firstGain.gain.setValueAtTimeCalls).toEqual([{ value: 1, startTime: 0 }]);
+            expect(firstGain.gain.linearRampToValueAtTimeCalls).toEqual([{ value: 0, endTime: 1 }]);
+            expect(asMockSource(firstSource).stopCalls).toEqual([1]);
+
+            expect(secondGain.gain.setValueAtTimeCalls).toEqual([{ value: 0, startTime: 0.5 }]);
+            expect(secondGain.gain.linearRampToValueAtTimeCalls).toEqual([{ value: 1, endTime: 1.5 }]);
             expect(asMockSource(secondSource).startCalls).toEqual([{ when: 0.5 }]);
         });
 
@@ -401,6 +479,33 @@ describe('MusicPlayer', () => {
 
             expect(context2.createBufferSourceCalls).toHaveLength(3);
             expect(player.isPlaying()).toBe(true);
+        });
+
+        it('driving the force-stopped voice to completion via onended leaves the current voice untouched', () => {
+            const { player, context } = createPlayer();
+
+            player.play(createMockAudioBuffer(), { fadeMs: 0 });
+
+            const context2 = context as unknown as { createBufferSourceCalls: AudioBufferSourceNode[] };
+            const firstSource = context2.createBufferSourceCalls.at(0) as AudioBufferSourceNode;
+
+            player.play(createMockAudioBuffer(), { fadeMs: 1000 }); // first -> previous, mid-fade
+            player.play(createMockAudioBuffer(), { fadeMs: 0 }); // force-stops firstSource (stale previous)
+
+            const thirdSource = context2.createBufferSourceCalls.at(2) as AudioBufferSourceNode;
+
+            // The browser eventually fires onended for the force-stopped source; the generation
+            // guard (object identity here) must recognize it no longer belongs to any tracked
+            // voice and no-op instead of clearing the live current voice.
+            (asMockSource(firstSource).onended as () => void)();
+
+            expect(player.isPlaying()).toBe(true);
+
+            // The still-live current voice (from the third play() call) is unaffected and can
+            // still be driven to its own natural completion afterward.
+            (asMockSource(thirdSource).onended as () => void)();
+
+            expect(player.isPlaying()).toBe(false);
         });
     });
 
@@ -522,9 +627,10 @@ describe('MusicPlayer', () => {
             expect(gain.gain.value).toBe(0.25);
         });
 
-        it('volumeSet ramps the current voice gain over fadeMs', () => {
+        it('volumeSet ramps the current voice gain over fadeMs, anchored to the current audio-clock time', () => {
             const { player, context } = createPlayer();
 
+            setMockCurrentTime(context, 4);
             player.play(createMockAudioBuffer());
 
             const context2 = context as unknown as { createGainCalls: GainNode[] };
@@ -532,7 +638,8 @@ describe('MusicPlayer', () => {
 
             player.volumeSet(0.2, 100);
 
-            expect(gain.gain.linearRampToValueAtTimeCalls).toHaveLength(1);
+            expect(gain.gain.setValueAtTimeCalls).toEqual([{ value: 1, startTime: 4 }]);
+            expect(gain.gain.linearRampToValueAtTimeCalls).toEqual([{ value: 0.2, endTime: 4.1 }]);
         });
 
         it('volumeSet before any play() does not throw and still updates volumeGet', () => {

--- a/src/audio/MusicPlayer.ts
+++ b/src/audio/MusicPlayer.ts
@@ -10,6 +10,7 @@
 
 import { applyAudioParamRamp } from '../utils/AudioParamRamp';
 import type { EasingFunction } from '../utils/Easing';
+import { musicLoopRangeError } from '../utils/errorMessages';
 
 /** Default gain applied to an incoming track when {@link MusicPlayOptions.volume} is omitted. */
 const DEFAULT_VOLUME = 1;
@@ -32,7 +33,11 @@ const DEFAULT_LOOP = true;
 /** Default easing curve applied to a fade-in/fade-out ramp when omitted. */
 const DEFAULT_EASING: EasingFunction = 'linear';
 
-/** Options accepted by {@link MusicPlayer.play}. */
+/**
+ * Options accepted by {@link MusicPlayer.play}, {@link BTAPI.musicPlay}, and {@link BT.musicPlay}.
+ *
+ * @since 1.3.0
+ */
 export interface MusicPlayOptions {
     /** Target gain for the incoming track in `[0, 1]` (unclamped). Defaults to `1`. */
     volume?: number;
@@ -385,6 +390,10 @@ function applyLoopOptions(source: AudioBufferSourceNode, options: MusicPlayOptio
  * playback state changes, so an invalid call to {@link MusicPlayer.play} never leaves the
  * player mid-mutated.
  *
+ * This is the one deliberate throw in the music playback path - clearly-invalid programmer
+ * input, the same way {@link AudioClip.synth} and {@link VoicePool} validate their own
+ * boundary values.
+ *
  * @param options - Playback options; see {@link MusicPlayOptions}.
  * @param duration - Duration in seconds of the buffer about to be played.
  * @throws Error if only one of `loopStart`/`loopEnd` is given, or the pair does not satisfy
@@ -397,16 +406,11 @@ function validateLoopRegion(options: MusicPlayOptions, duration: number): void {
         return;
     }
 
-    if (loopStart === undefined || loopEnd === undefined) {
-        throw new Error(
-            `MusicPlayer.play(): loopStart and loopEnd must be provided together (got loopStart=${loopStart}, loopEnd=${loopEnd})`,
-        );
-    }
-
-    if (!(loopStart >= 0 && loopStart < loopEnd && loopEnd <= duration)) {
-        throw new Error(
-            `MusicPlayer.play(): invalid loop region [${loopStart}, ${loopEnd}] for a ${duration}s buffer - ` +
-                'loopStart must be >= 0 and < loopEnd, and loopEnd must be <= the buffer duration',
-        );
+    if (
+        loopStart === undefined ||
+        loopEnd === undefined ||
+        !(loopStart >= 0 && loopStart < loopEnd && loopEnd <= duration)
+    ) {
+        throw new Error(musicLoopRangeError(loopStart, loopEnd, duration));
     }
 }

--- a/src/audio/MusicPlayer.ts
+++ b/src/audio/MusicPlayer.ts
@@ -90,12 +90,6 @@ interface Voice {
  * the crossfade model.
  */
 export class MusicPlayer {
-    /** Live audio context; scheduling is always anchored to its `currentTime`. */
-    private readonly context: AudioContext;
-
-    /** Injected `music` bus gain node every voice's gain connects to. */
-    private readonly musicBus: GainNode;
-
     /** Most recently started voice, or `null` when nothing is playing. */
     private current: Voice | null = null;
 
@@ -111,10 +105,12 @@ export class MusicPlayer {
      * @param context - Live audio context to schedule against.
      * @param musicBus - `music` bus gain node every voice connects to.
      */
-    constructor(context: AudioContext, musicBus: GainNode) {
-        this.context = context;
-        this.musicBus = musicBus;
-    }
+    constructor(
+        /** Live audio context to schedule against. */
+        private readonly context: AudioContext,
+        /** `music` bus gain node every voice connects to. */
+        private readonly musicBus: GainNode,
+    ) {}
 
     /**
      * Starts `buffer` as the new current track, crossfading out any track already playing.
@@ -141,7 +137,11 @@ export class MusicPlayer {
         const now = this.context.currentTime;
         const fadeSeconds = Math.max(0, options.fadeMs ?? DEFAULT_FADE_MS) / 1000;
         const overlap = clampOverlap(options.overlap ?? DEFAULT_OVERLAP);
-        const fadeInStart = now + fadeSeconds * (1 - overlap);
+
+        // overlap only describes the offset between an outgoing and incoming fade - with no
+        // current voice to crossfade against, there is nothing to offset from, so the new track
+        // always starts at now regardless of overlap.
+        const fadeInStart = this.current !== null ? now + fadeSeconds * (1 - overlap) : now;
 
         if (this.previous !== null) {
             this.forceStopVoice(this.previous);
@@ -169,10 +169,12 @@ export class MusicPlayer {
      * Stops playback, optionally fading out first.
      *
      * Immediately stops and releases any voice still crossfading out from a prior {@link play}
-     * call, and schedules the current voice's fade-out and stop the same way {@link play} does
-     * for a replaced track. Both {@link current} and {@link previous} are cleared synchronously,
-     * so {@link isPlaying} reports `false` right away even while the fade-out is still audible.
-     * No-op when nothing is playing.
+     * call, then demotes the current voice to "previous" and schedules its fade-out and stop the
+     * same way {@link play} does for a replaced track - it stays tracked (not discarded) until
+     * the fade actually completes, so a subsequent {@link play} or {@link stop} call can still
+     * find and immediately silence it instead of leaving it to fade out on its own unmanaged.
+     * {@link current} is cleared synchronously, so {@link isPlaying} reports `false` right away
+     * even while the fade-out is still audible. No-op when nothing is playing.
      *
      * @param fadeMs - Optional linear fade-out duration in milliseconds; omit to stop immediately.
      */
@@ -186,8 +188,9 @@ export class MusicPlayer {
         }
 
         if (this.current !== null) {
-            this.scheduleFadeOutAndStop(this.current, now, fadeSeconds, DEFAULT_EASING);
+            this.previous = this.current;
             this.current = null;
+            this.scheduleFadeOutAndStop(this.previous, now, fadeSeconds, DEFAULT_EASING);
         }
     }
 

--- a/src/audio/MusicPlayer.ts
+++ b/src/audio/MusicPlayer.ts
@@ -1,0 +1,412 @@
+/**
+ * Self-contained crossfading music player, owned and constructed by {@link AudioManager.attach}.
+ *
+ * Tracks at most two live voices: a "current" voice (the most recently started track) and a
+ * "previous" voice (a track crossfading out because a new one just started). Every fade and
+ * start/stop is scheduled as Web Audio automation anchored to `AudioContext.currentTime` -
+ * there is no per-frame update dependency, so scheduled crossfades keep playing correctly even
+ * if the engine's game loop stalls.
+ */
+
+import { applyAudioParamRamp } from '../utils/AudioParamRamp';
+import type { EasingFunction } from '../utils/Easing';
+
+/** Default gain applied to an incoming track when {@link MusicPlayOptions.volume} is omitted. */
+const DEFAULT_VOLUME = 1;
+
+/** Default crossfade duration in milliseconds when {@link MusicPlayOptions.fadeMs} is omitted (immediate switch). */
+const DEFAULT_FADE_MS = 0;
+
+/** Default crossfade timing offset when {@link MusicPlayOptions.overlap} is omitted (simultaneous fade-in/fade-out). */
+const DEFAULT_OVERLAP = 1;
+
+/** Minimum accepted {@link MusicPlayOptions.overlap}. */
+const MIN_OVERLAP = -1;
+
+/** Maximum accepted {@link MusicPlayOptions.overlap}. */
+const MAX_OVERLAP = 1;
+
+/** Default loop flag applied when neither {@link MusicPlayOptions.loop} nor loop points are given. */
+const DEFAULT_LOOP = true;
+
+/** Default easing curve applied to a fade-in/fade-out ramp when omitted. */
+const DEFAULT_EASING: EasingFunction = 'linear';
+
+/** Options accepted by {@link MusicPlayer.play}. */
+export interface MusicPlayOptions {
+    /** Target gain for the incoming track in `[0, 1]` (unclamped). Defaults to `1`. */
+    volume?: number;
+
+    /** Crossfade duration in milliseconds, applied to both the outgoing fade-out and the incoming fade-in. Defaults to `0` (immediate switch). */
+    fadeMs?: number;
+
+    /**
+     * Crossfade timing offset in `[-1, 1]`. `1` fades the incoming track in and the outgoing
+     * track out at the same time; `0` starts the fade-in exactly when the fade-out ends
+     * (sequential); `-1` inserts a silence gap of `fadeMs` between the fade-out ending and the
+     * fade-in starting. Intermediate values interpolate. Defaults to `1`.
+     */
+    overlap?: number;
+
+    /** Easing curve for the incoming track's fade-in. Defaults to `'linear'`. */
+    easeIn?: EasingFunction;
+
+    /** Easing curve for the outgoing track's fade-out. Defaults to `'linear'`. */
+    easeOut?: EasingFunction;
+
+    /** Whether the whole track loops. Ignored when `loopStart`/`loopEnd` are given. Defaults to `true`. */
+    loop?: boolean;
+
+    /** Loop region start in seconds. Requires `loopEnd`; see {@link MusicPlayer.play}. */
+    loopStart?: number;
+
+    /** Loop region end in seconds. Requires `loopStart`; see {@link MusicPlayer.play}. */
+    loopEnd?: number;
+}
+
+/**
+ * A single crossfade-pair voice: one shared gain node feeding the music bus, and the source
+ * node(s) carrying its audio. `sources` holds one entry today but is plural-ready for future
+ * multi-stem tracks (for example separate loops layered under one fade envelope).
+ */
+interface Voice {
+    /** Per-voice gain, connected once to the music bus at creation and never reconnected. */
+    readonly gain: GainNode;
+
+    /** Source nodes carrying this voice's audio. */
+    readonly sources: AudioBufferSourceNode[];
+
+    /** Count of `sources` that have not yet fired `onended`; the voice finalizes at `0`. */
+    pendingSources: number;
+}
+
+/**
+ * Crossfading music player owned by {@link AudioManager}. See the module doc comment above for
+ * the crossfade model.
+ */
+export class MusicPlayer {
+    /** Live audio context; scheduling is always anchored to its `currentTime`. */
+    private readonly context: AudioContext;
+
+    /** Injected `music` bus gain node every voice's gain connects to. */
+    private readonly musicBus: GainNode;
+
+    /** Most recently started voice, or `null` when nothing is playing. */
+    private current: Voice | null = null;
+
+    /** Voice crossfading out because {@link current} replaced it, or `null` when none is fading. */
+    private previous: Voice | null = null;
+
+    /** Last requested target volume, reported by {@link volumeGet} regardless of fade state. */
+    private volume = DEFAULT_VOLUME;
+
+    /**
+     * Creates a player with no live voices.
+     *
+     * @param context - Live audio context to schedule against.
+     * @param musicBus - `music` bus gain node every voice connects to.
+     */
+    constructor(context: AudioContext, musicBus: GainNode) {
+        this.context = context;
+        this.musicBus = musicBus;
+    }
+
+    /**
+     * Starts `buffer` as the new current track, crossfading out any track already playing.
+     *
+     * Promotes the existing current voice (if any) to "previous" and schedules its fade-out,
+     * then starts a new current voice with a scheduled fade-in. When a previous voice is already
+     * mid-fade (this is called again before the last crossfade finished), that stale previous
+     * voice is stopped and released immediately so only one crossfade pair is ever live.
+     *
+     * Crossfade timing is derived from `options.fadeMs` and `options.overlap` and anchored to
+     * `AudioContext.currentTime`: the outgoing fade-out always starts immediately; the incoming
+     * fade-in starts `fadeMs * (1 - overlap)` seconds later, so `overlap = 1` fades both at once,
+     * `overlap = 0` starts the fade-in exactly as the fade-out ends, and `overlap = -1` leaves a
+     * silence gap of `fadeMs` between them.
+     *
+     * @param buffer - Decoded audio buffer to play.
+     * @param options - Playback options; see {@link MusicPlayOptions}.
+     * @throws Error if `loopStart`/`loopEnd` are given without each other, or describe an invalid
+     *   region for `buffer`'s duration.
+     */
+    public play(buffer: AudioBuffer, options: MusicPlayOptions = {}): void {
+        validateLoopRegion(options, buffer.duration);
+
+        const now = this.context.currentTime;
+        const fadeSeconds = Math.max(0, options.fadeMs ?? DEFAULT_FADE_MS) / 1000;
+        const overlap = clampOverlap(options.overlap ?? DEFAULT_OVERLAP);
+        const fadeInStart = now + fadeSeconds * (1 - overlap);
+
+        if (this.previous !== null) {
+            this.forceStopVoice(this.previous);
+            this.previous = null;
+        }
+
+        if (this.current !== null) {
+            this.previous = this.current;
+            this.current = null;
+            this.scheduleFadeOutAndStop(this.previous, now, fadeSeconds, options.easeOut ?? DEFAULT_EASING);
+        }
+
+        this.volume = options.volume ?? DEFAULT_VOLUME;
+        this.current = this.startVoice(
+            buffer,
+            options,
+            this.volume,
+            fadeInStart,
+            fadeSeconds,
+            options.easeIn ?? DEFAULT_EASING,
+        );
+    }
+
+    /**
+     * Stops playback, optionally fading out first.
+     *
+     * Immediately stops and releases any voice still crossfading out from a prior {@link play}
+     * call, and schedules the current voice's fade-out and stop the same way {@link play} does
+     * for a replaced track. Both {@link current} and {@link previous} are cleared synchronously,
+     * so {@link isPlaying} reports `false` right away even while the fade-out is still audible.
+     * No-op when nothing is playing.
+     *
+     * @param fadeMs - Optional linear fade-out duration in milliseconds; omit to stop immediately.
+     */
+    public stop(fadeMs?: number): void {
+        const now = this.context.currentTime;
+        const fadeSeconds = Math.max(0, fadeMs ?? 0) / 1000;
+
+        if (this.previous !== null) {
+            this.forceStopVoice(this.previous);
+            this.previous = null;
+        }
+
+        if (this.current !== null) {
+            this.scheduleFadeOutAndStop(this.current, now, fadeSeconds, DEFAULT_EASING);
+            this.current = null;
+        }
+    }
+
+    /**
+     * Sets the current track's gain, optionally ramping to it, and remembers the value for
+     * future {@link volumeGet} calls even before the next {@link play}.
+     *
+     * @param value - Target gain.
+     * @param fadeMs - Optional fade duration in milliseconds; omit for an immediate change.
+     */
+    public volumeSet(value: number, fadeMs?: number): void {
+        this.volume = value;
+
+        if (this.current === null) {
+            return;
+        }
+
+        applyAudioParamRamp(this.current.gain.gain, this.context.currentTime, value, fadeMs, DEFAULT_EASING);
+    }
+
+    /**
+     * Returns the last requested target volume.
+     *
+     * @returns Current target gain, defaulting to {@link DEFAULT_VOLUME} before the first {@link play}.
+     */
+    public volumeGet(): number {
+        return this.volume;
+    }
+
+    /**
+     * Reports whether a current track is playing.
+     *
+     * @returns `true` while a current voice exists (starting, fading in, or fully audible);
+     *   `false` once it is stopped or naturally finishes.
+     */
+    public isPlaying(): boolean {
+        return this.current !== null;
+    }
+
+    /**
+     * Builds a fresh `source -> gain -> music bus` chain and starts playback with a scheduled
+     * fade-in.
+     *
+     * @param buffer - Decoded audio buffer to play.
+     * @param options - Playback options; see {@link MusicPlayOptions}.
+     * @param targetVolume - Resolved target gain (already defaulted by the caller).
+     * @param fadeInStart - Audio-clock time the fade-in (and playback) starts at.
+     * @param fadeSeconds - Fade-in duration in seconds; `0` starts at `targetVolume` immediately.
+     * @param easeIn - Easing curve for the fade-in ramp.
+     * @returns The newly started voice.
+     */
+    private startVoice(
+        buffer: AudioBuffer,
+        options: MusicPlayOptions,
+        targetVolume: number,
+        fadeInStart: number,
+        fadeSeconds: number,
+        easeIn: EasingFunction,
+    ): Voice {
+        const gain = this.context.createGain();
+
+        gain.connect(this.musicBus);
+
+        const source = this.context.createBufferSource();
+
+        source.buffer = buffer;
+        applyLoopOptions(source, options);
+
+        source.connect(gain);
+
+        const fadeMs = fadeSeconds > 0 ? fadeSeconds * 1000 : undefined;
+
+        if (fadeMs !== undefined) {
+            gain.gain.value = 0;
+        }
+
+        applyAudioParamRamp(gain.gain, fadeInStart, targetVolume, fadeMs, easeIn);
+
+        const voice: Voice = { gain, sources: [source], pendingSources: 1 };
+
+        source.onended = () => {
+            source.disconnect();
+            this.handleVoiceSourceEnded(voice);
+        };
+
+        source.start(fadeInStart);
+
+        return voice;
+    }
+
+    /**
+     * Schedules `voice`'s gain to fade to `0` and its source(s) to stop once the fade completes.
+     *
+     * Does not disconnect anything synchronously - the node chain keeps playing until the
+     * scheduled stop time, and each source's `onended` handler (installed in {@link startVoice})
+     * disconnects it when that actually fires.
+     *
+     * @param voice - Voice to fade out and stop.
+     * @param startTime - Audio-clock time the fade-out starts at.
+     * @param fadeSeconds - Fade-out duration in seconds; `0` stops immediately.
+     * @param easeOut - Easing curve for the fade-out ramp.
+     */
+    private scheduleFadeOutAndStop(
+        voice: Voice,
+        startTime: number,
+        fadeSeconds: number,
+        easeOut: EasingFunction,
+    ): void {
+        const fadeMs = fadeSeconds > 0 ? fadeSeconds * 1000 : undefined;
+
+        applyAudioParamRamp(voice.gain.gain, startTime, 0, fadeMs, easeOut);
+
+        const stopAt = startTime + fadeSeconds;
+
+        for (const source of voice.sources) {
+            source.stop(stopAt);
+        }
+    }
+
+    /**
+     * Immediately stops and disconnects `voice`'s entire node chain, with no fade.
+     *
+     * Used to release a stale previous voice when {@link play} or {@link stop} is called again
+     * before its crossfade finished, so only one crossfade pair is ever live.
+     *
+     * @param voice - Voice to force-stop.
+     */
+    private forceStopVoice(voice: Voice): void {
+        for (const source of voice.sources) {
+            source.stop();
+            source.disconnect();
+        }
+
+        voice.gain.disconnect();
+    }
+
+    /**
+     * Recycles `voice` once every one of its sources has fired `onended`.
+     *
+     * Guards against a stale callback from a voice already replaced or force-stopped by
+     * comparing object identity against {@link current} and {@link previous} - unlike
+     * {@link VoicePool}'s fixed, reused slots, `Voice` objects here are never recycled (each
+     * {@link startVoice} call allocates a fresh one), so identity alone disambiguates without
+     * needing a generation counter.
+     *
+     * @param voice - Voice one of whose sources just ended.
+     */
+    private handleVoiceSourceEnded(voice: Voice): void {
+        voice.pendingSources -= 1;
+
+        if (voice.pendingSources > 0) {
+            return;
+        }
+
+        voice.gain.disconnect();
+
+        if (this.current === voice) {
+            this.current = null;
+        }
+
+        if (this.previous === voice) {
+            this.previous = null;
+        }
+    }
+}
+
+/**
+ * Clamps a crossfade overlap value to `[-1, 1]`.
+ *
+ * @param overlap - Raw overlap value.
+ * @returns Overlap clamped to `[MIN_OVERLAP, MAX_OVERLAP]`.
+ */
+function clampOverlap(overlap: number): number {
+    return Math.min(MAX_OVERLAP, Math.max(MIN_OVERLAP, overlap));
+}
+
+/**
+ * Applies `options.loop` / `options.loopStart` / `options.loopEnd` to a freshly created source
+ * node. Assumes {@link validateLoopRegion} already passed.
+ *
+ * @param source - Source node to configure.
+ * @param options - Playback options; see {@link MusicPlayOptions}.
+ */
+function applyLoopOptions(source: AudioBufferSourceNode, options: MusicPlayOptions): void {
+    const { loopStart, loopEnd } = options;
+
+    if (loopStart !== undefined && loopEnd !== undefined) {
+        source.loop = true;
+        source.loopStart = loopStart;
+        source.loopEnd = loopEnd;
+
+        return;
+    }
+
+    source.loop = options.loop ?? DEFAULT_LOOP;
+}
+
+/**
+ * Validates `options.loopStart` / `options.loopEnd` against a buffer's duration before any
+ * playback state changes, so an invalid call to {@link MusicPlayer.play} never leaves the
+ * player mid-mutated.
+ *
+ * @param options - Playback options; see {@link MusicPlayOptions}.
+ * @param duration - Duration in seconds of the buffer about to be played.
+ * @throws Error if only one of `loopStart`/`loopEnd` is given, or the pair does not satisfy
+ *   `0 <= loopStart < loopEnd <= duration`.
+ */
+function validateLoopRegion(options: MusicPlayOptions, duration: number): void {
+    const { loopStart, loopEnd } = options;
+
+    if (loopStart === undefined && loopEnd === undefined) {
+        return;
+    }
+
+    if (loopStart === undefined || loopEnd === undefined) {
+        throw new Error(
+            `MusicPlayer.play(): loopStart and loopEnd must be provided together (got loopStart=${loopStart}, loopEnd=${loopEnd})`,
+        );
+    }
+
+    if (!(loopStart >= 0 && loopStart < loopEnd && loopEnd <= duration)) {
+        throw new Error(
+            `MusicPlayer.play(): invalid loop region [${loopStart}, ${loopEnd}] for a ${duration}s buffer - ` +
+                'loopStart must be >= 0 and < loopEnd, and loopEnd must be <= the buffer duration',
+        );
+    }
+}

--- a/src/core/BTAPI.test.ts
+++ b/src/core/BTAPI.test.ts
@@ -257,6 +257,107 @@ describe('sound playback passthroughs', () => {
     });
 });
 
+describe('music playback passthroughs', () => {
+    beforeEach(() => {
+        resetSingleton();
+    });
+
+    afterEach(() => {
+        resetSingleton();
+    });
+
+    function setAudio(audio: AudioManager | null): void {
+        // Same test-isolation technique as the "sound playback passthroughs" block above - see
+        // its comment for why this cast is safe here.
+        (BTAPI.instance as unknown as { audio: AudioManager | null }).audio = audio;
+    }
+
+    it('musicPlay is a no-op when the audio subsystem is not initialized', () => {
+        const clip = { buffer: createMockAudioBuffer() } as unknown as AudioClip;
+
+        expect(() => BTAPI.instance.musicPlay(clip)).not.toThrow();
+    });
+
+    it('musicPlay is a no-op when the clip buffer is null', () => {
+        const audio = new AudioManager();
+        const spy = vi.spyOn(audio, 'musicPlay').mockReturnValue(undefined);
+
+        setAudio(audio);
+
+        const clip = { buffer: null } as unknown as AudioClip;
+
+        BTAPI.instance.musicPlay(clip);
+
+        expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('musicPlay delegates to AudioManager.musicPlay with the clip buffer', () => {
+        const audio = new AudioManager();
+        const buffer = createMockAudioBuffer();
+        const spy = vi.spyOn(audio, 'musicPlay').mockReturnValue(undefined);
+
+        setAudio(audio);
+
+        const clip = { buffer } as unknown as AudioClip;
+
+        BTAPI.instance.musicPlay(clip, { volume: 0.5 });
+
+        expect(spy).toHaveBeenCalledWith(buffer, { volume: 0.5 });
+    });
+
+    it('musicStop delegates to AudioManager.musicStop', () => {
+        const audio = new AudioManager();
+        const spy = vi.spyOn(audio, 'musicStop').mockReturnValue(undefined);
+
+        setAudio(audio);
+        BTAPI.instance.musicStop(200);
+
+        expect(spy).toHaveBeenCalledWith(200);
+    });
+
+    it('musicStop is a no-op when the audio subsystem is not initialized', () => {
+        expect(() => BTAPI.instance.musicStop()).not.toThrow();
+    });
+
+    it('isMusicPlaying delegates to AudioManager.isMusicPlaying', () => {
+        const audio = new AudioManager();
+        const spy = vi.spyOn(audio, 'isMusicPlaying').mockReturnValue(true);
+
+        setAudio(audio);
+
+        expect(BTAPI.instance.isMusicPlaying()).toBe(true);
+        expect(spy).toHaveBeenCalledWith();
+    });
+
+    it('isMusicPlaying returns false when the audio subsystem is not initialized', () => {
+        expect(BTAPI.instance.isMusicPlaying()).toBe(false);
+    });
+
+    it('musicVolumeSet delegates to AudioManager.musicVolumeSet', () => {
+        const audio = new AudioManager();
+        const spy = vi.spyOn(audio, 'musicVolumeSet').mockReturnValue(undefined);
+
+        setAudio(audio);
+        BTAPI.instance.musicVolumeSet(0.4, 100);
+
+        expect(spy).toHaveBeenCalledWith(0.4, 100);
+    });
+
+    it('musicVolumeGet delegates to AudioManager.musicVolumeGet', () => {
+        const audio = new AudioManager();
+        const spy = vi.spyOn(audio, 'musicVolumeGet').mockReturnValue(0.75);
+
+        setAudio(audio);
+
+        expect(BTAPI.instance.musicVolumeGet()).toBe(0.75);
+        expect(spy).toHaveBeenCalledWith();
+    });
+
+    it('musicVolumeGet returns 1 when the audio subsystem is not initialized', () => {
+        expect(BTAPI.instance.musicVolumeGet()).toBe(1);
+    });
+});
+
 describe('BTAPI', () => {
     beforeEach(() => {
         resetSingleton();

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -12,6 +12,7 @@ import {
 import type { SpriteSheet } from '../assets/SpriteSheet';
 import { createSystemFont } from '../assets/SystemFont';
 import { AudioManager } from '../audio/AudioManager';
+import type { MusicPlayOptions } from '../audio/MusicPlayer';
 import { INVALID_SOUND_REF, type SoundPlayOptions, type SoundRef } from '../audio/VoicePool';
 import { GamepadInput } from '../input/GamepadInput';
 import { KeyboardInput } from '../input/KeyboardInput';
@@ -658,6 +659,62 @@ export class BTAPI {
      */
     public soundPanGet(ref: SoundRef): number {
         return this.audio?.soundPanGet(ref) ?? 0;
+    }
+
+    /**
+     * Plays a loaded audio clip through the music player, crossfading out whatever is currently
+     * playing.
+     *
+     * No-ops when the clip's buffer isn't available (not finished loading yet, or already
+     * unloaded), mirroring {@link soundPlay}, or when the audio subsystem is not initialized.
+     *
+     * @param clip - Loaded audio clip to play.
+     * @param options - Playback options; see {@link MusicPlayOptions}.
+     */
+    public musicPlay(clip: AudioClip, options?: MusicPlayOptions): void {
+        if (clip.buffer === null) {
+            return;
+        }
+
+        this.audio?.musicPlay(clip.buffer, options);
+    }
+
+    /**
+     * Stops the music player, optionally fading out first.
+     *
+     * @param fadeMs - Optional linear fade-out duration in milliseconds; omit to stop immediately.
+     */
+    public musicStop(fadeMs?: number): void {
+        this.audio?.musicStop(fadeMs);
+    }
+
+    /**
+     * Reports whether music is currently playing.
+     *
+     * @returns `true` when the music player has a live current track; `false` when stopped, not
+     *   yet started, or when the audio subsystem is not initialized.
+     */
+    public isMusicPlaying(): boolean {
+        return this.audio?.isMusicPlaying() ?? false;
+    }
+
+    /**
+     * Sets the music player's volume, optionally fading to it.
+     *
+     * @param value - Target gain.
+     * @param fadeMs - Optional fade duration in milliseconds; omit for an immediate change.
+     */
+    public musicVolumeSet(value: number, fadeMs?: number): void {
+        this.audio?.musicVolumeSet(value, fadeMs);
+    }
+
+    /**
+     * Gets the music player's current target volume.
+     *
+     * @returns Current target gain, or `1` when the audio subsystem is not initialized.
+     */
+    public musicVolumeGet(): number {
+        return this.audio?.musicVolumeGet() ?? 1;
     }
 
     /**

--- a/src/utils/errorMessages.ts
+++ b/src/utils/errorMessages.ts
@@ -712,3 +712,28 @@ export function audioClipSynthPitchSweepFrequencyError(toFrequency: number): str
         'Set pitchSweep.toFrequency to a positive number.'
     );
 }
+
+/**
+ * Returns the error message for an invalid `loopStart`/`loopEnd` pair passed to
+ * `BT.musicPlay`.
+ *
+ * Covers both failure shapes: only one of the pair given, or a pair that fails
+ * `0 <= loopStart < loopEnd <= duration`. `loopStart`/`loopEnd` are `undefined` when missing
+ * entirely, so the message still shows the caller exactly what was supplied.
+ *
+ * @param loopStart - Supplied loop region start in seconds, or `undefined` if omitted.
+ * @param loopEnd - Supplied loop region end in seconds, or `undefined` if omitted.
+ * @param duration - Duration in seconds of the buffer being played.
+ * @returns User-facing error string.
+ */
+export function musicLoopRangeError(
+    loopStart: number | undefined,
+    loopEnd: number | undefined,
+    duration: number,
+): string {
+    return (
+        `BT.musicPlay() got an invalid loop region (loopStart=${loopStart}, loopEnd=${loopEnd}) for a ${duration}s track. ` +
+        'Provide both loopStart and loopEnd together, with 0 <= loopStart < loopEnd <= the track duration, ' +
+        'or omit both and use loop instead'
+    );
+}


### PR DESCRIPTION
- Resolves: #322

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Implemented dedicated music playback support with per-call crossfading, looping/loop-region control, and unlock-safe deferred start behavior.

- Added `MusicPlayer` to run a single active music stream using current/previous voices on a dedicated music bus, with sample-accurate `loopStart`/`loopEnd` validation, overlap clamping to `[-1, 1]`, and Web Audio–scheduled fade-in/out and crossfade timing.
- Wired the public BT audio API to expose `BT.musicPlay`, `BT.musicStop`, `BT.musicVolumeSet`, `BT.musicVolumeGet`, and `BT.isMusicPlaying` (delegating through `BTAPI`/`AudioManager` to the new `MusicPlayer`), including defaults for volume and “not playing” runtime state.
- Preserved pre-unlock behavior by remembering the latest `musicPlay` request made while audio is locked, starting it automatically on unlock, and preventing stale/failed start attempts from leaving orphaned pending state.
- Added tests covering music playback wiring, loop validation and error messages, crossfade overlap modes (including replacement while fading), stop semantics (immediate vs fade-out), volume set/get, and unlock/pending-request replay rules.
- Updated docs (`docs/api-audio.md`, `docs/guide-audio.md`, and related Claude cursor/rules + `CLAUDE.md` and API history) to document the new music controls, loop/crossfade behavior, and the new `isMusicPlaying` runtime getter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->