### PR TITLE
fix(assets): allocate a new object per measureTextSize() call

### DIFF
--- a/src/assets/BitmapFont.test.ts
+++ b/src/assets/BitmapFont.test.ts
@@ -597,15 +597,20 @@ describe('BitmapFont', () => {
             expect(width).toBe(24);
         });
 
-        it('should return a reusable object from measureTextSize', () => {
+        it('should return a new object from measureTextSize on each call', () => {
             const size1 = font.measureTextSize('A');
             const size2 = font.measureTextSize('AB');
 
-            // Same reference (reused object)
-            expect(size1).toBe(size2);
+            // Different references -- no aliasing.
+            expect(size1).not.toBe(size2);
 
-            // But values reflect the latest measurement
+            // size1 keeps its own values even after size2 is computed.
+            expect(size1.width).toBe(9);
+            expect(size1.height).toBe(14);
+
+            // size2 reflects its own text, independently.
             expect(size2.width).toBe(17);
+            expect(size2.height).toBe(14);
         });
     });
 

--- a/src/assets/BitmapFont.ts
+++ b/src/assets/BitmapFont.ts
@@ -173,9 +173,6 @@ export class BitmapFont {
     /** Cache for text measurement results to avoid repeated calculations. */
     private measureCache: Map<string, number> = new Map();
 
-    /** Reusable result object for measureTextSize to avoid allocations. */
-    private readonly textSizeResult: TextSize = { width: 0, height: 0 };
-
     /**
      * Creates a BitmapFont instance.
      * Use {@link BitmapFont.load} or {@link BitmapFont.createFromGlyphs} to construct instances.
@@ -757,21 +754,26 @@ export class BitmapFont {
     /**
      * Measures the pixel size of a single-line text string.
      *
-     * Returns a reusable internal object to avoid allocations. Copy the values
-     * before calling `measureTextSize()` again if you need to retain them.
+     * Allocates and returns a new `{ width, height }` object on every call, so
+     * results from separate calls never alias each other. For hot loops where
+     * per-call allocation matters, use `measureTextSizeInto()` instead.
      *
      * @param text - String to measure.
-     * @returns Reused width/height pair for the measured text.
+     * @returns A new width/height pair for the measured text.
      */
     measureTextSize(text: string): TextSize {
-        this.textSizeResult.width = this.measureText(text);
-        this.textSizeResult.height = this.lineHeight;
-
-        return this.textSizeResult;
+        return {
+            width: this.measureText(text),
+            height: this.lineHeight,
+        };
     }
 
     /**
      * Measures the pixel size of a single-line text string into a caller-owned object.
+     *
+     * Zero-allocation variant of `measureTextSize()` for hot loops or other
+     * performance-sensitive call sites: writes into `result` instead of
+     * allocating a new object.
      *
      * @param text - String to measure.
      * @param result - Object that receives the measured width and height.


### PR DESCRIPTION
`measureTextSize()` returned the same shared internal object on every call, so two outstanding results silently aliased each other and both reflected the most recent measurement. It now allocates a fresh `{ width, height }` object per call; `measureTextSizeInto()` remains the zero-allocation path for hot loops.

- Resolves: #213

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Updated `BitmapFont.measureTextSize()` to return a fresh `{ width, height }` object on each call instead of reusing shared internal state, eliminating aliasing between stored results.
- Kept `measureTextSizeInto()` as the zero-allocation option for performance-sensitive code and updated the inline documentation to reflect the new behavior.
- Adjusted the unit test to verify returned objects are distinct and that earlier measurements remain unchanged after subsequent calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->