### PR TITLE
fix(render): request COPY_SRC canvas usage for WebGPU frame capture

### DIFF
--- a/src/core/WebGPUContext.test.ts
+++ b/src/core/WebGPUContext.test.ts
@@ -223,4 +223,20 @@ describe('initWebGPU', () => {
         expect(canvas.width).toBe(640);
         expect(canvas.height).toBe(480);
     });
+
+    it('should configure the canvas context with COPY_SRC usage so captureFrame can read back the swap-chain texture', async () => {
+        installMockNavigatorGPU();
+
+        const configure = vi.fn();
+        const gpuContext = { ...createMockGPUCanvasContext(), configure };
+        const canvas = createMockCanvas(gpuContext);
+
+        await initWebGPU(canvas, displaySize);
+
+        expect(configure).toHaveBeenCalledWith(
+            expect.objectContaining({
+                usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+            }),
+        );
+    });
 });

--- a/src/core/WebGPUContext.ts
+++ b/src/core/WebGPUContext.ts
@@ -133,6 +133,13 @@ export async function initWebGPU(
         device,
         format: canvasFormat,
         alphaMode: 'premultiplied',
+
+        // COPY_SRC is required alongside the default RENDER_ATTACHMENT so FrameCapture can
+        // copy the swap-chain texture straight to a staging buffer (see WebGPURenderer.submitFrame).
+        // Without it, copyTextureToBuffer on the current texture is a WebGPU validation error;
+        // implementations that drop the invalid copy leave the staging buffer zero-filled,
+        // which BT.captureFrame/downloadFrame then encodes as a fully transparent PNG.
+        usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
     });
 
     console.log('[BT] WebGPU initialized successfully');


### PR DESCRIPTION
`BT.captureFrame()` / `downloadFrame()` copy pixels straight from the canvas swap-chain texture, but `context.configure()` never requested `COPY_SRC` usage (the default is `RENDER_ATTACHMENT` only).

Per the WebGPU spec, `copyTextureToBuffer` on a texture without `COPY_SRC` is a validation error; implementations that enforce it drop the copy and leave the staging buffer zero-filled, which encodes as a fully transparent PNG.

Reproduces inconsistently across browsers/GPU backends depending on how strictly they validate texture usage.

- Resolves: #279

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated WebGPU canvas configuration to include `GPUTextureUsage.COPY_SRC` alongside `RENDER_ATTACHMENT`, ensuring frame captures can copy the swap-chain texture to a staging buffer without WebGPU validation errors. This fixes `captureFrame()`/`downloadFrame()` producing transparent PNGs in affected browsers/backends.

Added a unit test covering the new `initWebGPU` configuration to verify the canvas context is configured with both usage flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->