### PR TITLE
feat(overlay): render engine label separators as gap-colored dividers

### DIFF
--- a/docs/api-overlay.md
+++ b/docs/api-overlay.md
@@ -39,6 +39,12 @@ back in with `isOverlayVisibleAtStart: true` in `configure()` until authors choo
 The overlay body stacks, top to bottom: title and backend rows, an optional timing chart, the frame-metrics rows, any
 custom rows, and the bottom band (palette grid plus hint bar).
 
+The `|` separators shown in the engine row formats below (backend/resolution, frame metrics, timing, renderer
+diagnostics, and the audio meter readout) do not render as text glyphs: each one draws as a `1px` full-row-height
+vertical divider filled with `overlayStyle.gapPaletteIndex` – the same color as the row gaps between bands – with `7px`
+of space between the line and the text on each side. Overlay text and chrome keep the same `7px` inset from the left and
+right screen edges. Custom rows are user content, so a `|` in their text stays a literal glyph.
+
 ### Top row 1 (left)
 
 - Short demo title derived from `document.title` (registry pages titled `BLIT386 Demo NNN – Topic` show as
@@ -206,7 +212,9 @@ Colors follow one path: use `overlayStyle` when set, otherwise the defaults `1` 
 
 - Globally in `configure()`: `overlayStyle: { barPaletteIndex, textPaletteIndex, gapPaletteIndex }`.
 - Per custom row on `OverlayRow`: `barPaletteIndex`, `textPaletteIndex`.
-- `gapPaletteIndex` fills inter-band row gaps and cluster separators; when omitted it matches `barPaletteIndex`.
+- `gapPaletteIndex` fills inter-band row gaps, cluster separators, and the `1px` vertical dividers between segments of
+  the engine-composed rows (backend/resolution, frame metrics, timing, renderer diagnostics, and the audio meter
+  readout); when omitted it matches `barPaletteIndex`.
 
 ## Present FPS vs. target FPS
 

--- a/docs/guide-overlay.md
+++ b/docs/guide-overlay.md
@@ -88,9 +88,12 @@ bar. See [API: Overlay](api-overlay.md) for layout formulas.
 
 ## Colors and HUD palette slots
 
-Overlay chrome uses palette indices from `overlayStyle` (defaults: bar/gap 1, text 2). For demos that draw their own HUD
-text with `BT.systemPrint`, call `palette.applyHUD(startSlot?)` once at init to fill the six common UI slots (white,
-background, label, header, dim, FPS) and register `hud_*` name aliases. See
+Overlay chrome uses palette indices from `overlayStyle` (defaults: bar/gap 1, text 2). The gap index also fills the
+`1px` vertical dividers separating segments within the engine rows (metrics, timing, diagnostics, and the audio meter
+readout), so those separators match the row gaps between bands; each divider keeps `7px` of space to the text on both
+sides, matching the `7px` text inset from the screen edges. For demos that draw their own HUD text with
+`BT.systemPrint`, call `palette.applyHUD(startSlot?)` once at init to fill the six common UI slots (white, background,
+label, header, dim, FPS) and register `hud_*` name aliases. See
 [API: Palette – applyHUD](api-palette.md#built-in-presets) and
 [Palette Presets – HUD](guide-palette-presets.md#hud-preset).
 

--- a/src/overlay/Overlay.test.ts
+++ b/src/overlay/Overlay.test.ts
@@ -10,8 +10,13 @@ import { markIndexUsed } from '../core/RenderPaletteUsage';
 import { Rect2i } from '../utils/Rect2i';
 import { Vector2i } from '../utils/Vector2i';
 import { AUDIO_METER_BAR_WIDTH_PX } from './audio-meter/constants';
+import { OVERLAY_DIVIDER_GAP_PX, SYSTEM_CHAR_ADVANCE } from './constants';
 import { OVERLAY_BAR_HEIGHT, OVERLAY_ROW_GAP_PX } from './layout/constants';
-import { createOverlayLayout, overlayRightAlignedTextX } from './layout/layoutHelpers';
+import {
+    createOverlayLayout,
+    overlayRightAlignedDividerLabelX,
+    overlayRightAlignedTextX,
+} from './layout/layoutHelpers';
 import { hintBarY, paletteBandY } from './layout/layoutPlan';
 import { Overlay } from './Overlay';
 import { hintIconPos } from './OverlayToggleIcon';
@@ -32,10 +37,12 @@ const PALETTE_GRID_OFF = false;
 
 interface OverlayTestOptions {
     style?: { barPaletteIndex?: number; textPaletteIndex?: number; gapPaletteIndex?: number };
+
     isOverlayPaletteEnabled?: boolean;
     paletteColumns?: number;
     paletteRowsVisible?: number;
     isOverlayTimingChartEnabled?: boolean;
+
     overlayTimingChartStyle?: {
         updateBarPaletteIndex?: number;
         renderBarPaletteIndex?: number;
@@ -43,6 +50,7 @@ interface OverlayTestOptions {
         errorPaletteIndex?: number;
         tagPaletteIndex?: number;
     };
+
     overlayTimingChartHeight?: number;
     overlayTimingChartDiagnostics?: false | 'minimal' | 'rich';
     isOverlayRendererDiagnosticsBarEnabled?: boolean;
@@ -105,6 +113,7 @@ describe('Overlay', () => {
 
     it('isTrackingPaletteUsage follows palette grid opt-in and visibility toggle', () => {
         const layout = createOverlayLayout(320, 240, 14);
+
         const overlay = createOverlay(layout, 'Test Demo', {
             isOverlayPaletteEnabled: true,
             isOverlayVisibleAtStart: true,
@@ -125,10 +134,12 @@ describe('Overlay', () => {
 
     it('swatch press in the toggle corner does not toggle overlay body', () => {
         const layout = createOverlayLayout(320, 240, 14);
+
         const overlay = createOverlay(layout, 'Test Demo', {
             isOverlayPaletteEnabled: true,
             isOverlayVisibleAtStart: true,
         });
+
         const grid = computeGrid(320);
         const paletteBandTop = paletteBandY(240, grid.totalHeight);
         const paletteBand = new Rect2i(0, paletteBandTop, 320, grid.totalHeight);
@@ -151,16 +162,19 @@ describe('Overlay', () => {
 
     it('scrollbar track press blocks toggle but swatch press still copies first', () => {
         const layout = createOverlayLayout(320, 240, 14);
+
         const overlay = createOverlay(layout, 'Test Demo', {
             isOverlayPaletteEnabled: true,
             isOverlayVisibleAtStart: true,
             paletteRowsVisible: 3,
         });
+
         const grid = computeGrid(320, undefined, 256, undefined, undefined, 3);
         const paletteBandTop = paletteBandY(240, grid.totalHeight);
         const paletteBand = new Rect2i(0, paletteBandTop, 320, grid.totalHeight);
         const track = new Rect2i();
         const thumb = new Rect2i();
+
         writeScrollbarRects(track, thumb, paletteBand, grid, 0, 4);
 
         overlay.handleFrameInput(
@@ -215,38 +229,58 @@ describe('Overlay', () => {
         overlay.updateAndRender(renderer, mockFont, null, null, 0);
 
         const calls = getBitmapTextCalls(renderer);
-        const topRightLabel = 'webgpu | 320x240';
-        const topRightX = overlayRightAlignedTextX(topRightLabel, 320);
 
-        expect(calls).toHaveLength(4);
+        // Segmented engine labels: each '|' marker becomes its own drawLabel segment.
+        const topRightX = overlayRightAlignedDividerLabelX('webgpu|320x240', 320);
+        const metricsY = OVERLAY_BAR_HEIGHT + OVERLAY_ROW_GAP_PX + OVERLAY_TOP_TEXT_Y;
+        const timingY = (OVERLAY_BAR_HEIGHT + OVERLAY_ROW_GAP_PX) * 2 + OVERLAY_TOP_TEXT_Y;
+
+        expect(calls).toHaveLength(9);
+
         expect(calls[0]).toEqual({
             pos: new Vector2i(OVERLAY_EDGE_MARGIN_PX, OVERLAY_TOP_TEXT_Y),
             text: topLeftLabel,
             paletteOffset: 1,
         });
+
         expect(calls[1]).toEqual({
             pos: new Vector2i(topRightX, OVERLAY_TOP_TEXT_Y),
-            text: topRightLabel,
+            text: 'webgpu',
             paletteOffset: 1,
         });
-        expect(calls[2]).toMatchObject({
-            pos: new Vector2i(OVERLAY_EDGE_MARGIN_PX, OVERLAY_BAR_HEIGHT + OVERLAY_ROW_GAP_PX + OVERLAY_TOP_TEXT_Y),
-            text: expect.stringMatching(/^Present: \d+ FPS \| Target: 60 FPS \| Draw Calls: \d+$/),
+
+        expect(calls[2]).toEqual({
+            pos: new Vector2i(topRightX + 6 * SYSTEM_CHAR_ADVANCE + 2 * OVERLAY_DIVIDER_GAP_PX, OVERLAY_TOP_TEXT_Y),
+            text: '320x240',
             paletteOffset: 1,
         });
+
         expect(calls[3]).toMatchObject({
-            pos: new Vector2i(
-                OVERLAY_EDGE_MARGIN_PX,
-                (OVERLAY_BAR_HEIGHT + OVERLAY_ROW_GAP_PX) * 2 + OVERLAY_TOP_TEXT_Y,
-            ),
-            text: expect.any(String),
+            pos: new Vector2i(OVERLAY_EDGE_MARGIN_PX, metricsY),
+            text: expect.stringMatching(/^Present \d+ FPS$/),
             paletteOffset: 1,
         });
-        expect(calls[3]?.text).toContain('Frame: ');
-        expect(calls[3]?.text).toContain(' | update(): ');
-        expect(calls[3]?.text).toContain(' | render(): ');
+
+        expect(calls[4]).toMatchObject({ pos: expect.objectContaining({ y: metricsY }), text: 'Target 60 FPS' });
+        expect(calls[5]?.text).toMatch(/^Draw Calls \d+$/);
+        expect(calls[5]?.pos.y).toBe(metricsY);
+
+        expect(calls[6]).toMatchObject({
+            pos: new Vector2i(OVERLAY_EDGE_MARGIN_PX, timingY),
+            text: expect.stringMatching(/^Frame \d+\.\dms$/),
+            paletteOffset: 1,
+        });
+
+        expect(calls[7]?.text).toMatch(/^update\(\) \d+\.\dms$/);
+        expect(calls[8]?.text).toMatch(/^render\(\) \d+\.\dms$/);
         expect(renderer.drawBarFillOnTop).toHaveBeenCalled();
-        expect(renderer.drawBarFillOnTop.rectSnapshots[0]).toMatchObject({ x: 3, y: 230, width: 11, height: 1 });
+
+        expect(renderer.drawBarFillOnTop.rectSnapshots[0]).toMatchObject({
+            x: OVERLAY_EDGE_MARGIN_PX,
+            y: 230,
+            width: 11,
+            height: 1,
+        });
     });
 
     it('uses activeBackend for the top-right label', () => {
@@ -256,8 +290,56 @@ describe('Overlay', () => {
 
         overlay.updateAndRender(renderer, mockFont, null, null, 0);
 
-        const topRightCall = getBitmapTextCalls(renderer)[1];
-        expect(topRightCall?.text).toBe('software | 320x240');
+        const calls = getBitmapTextCalls(renderer);
+
+        expect(calls[1]?.text).toBe('software');
+        expect(calls[2]?.text).toBe('320x240');
+    });
+
+    it('draws in-row label separators as 1 px full-row-height dividers in the gap index', () => {
+        const layout = createOverlayLayout(320, 240, 14);
+
+        const overlay = createOverlay(layout, 'Demo', {
+            style: { gapPaletteIndex: 7 },
+            isOverlayVisibleAtStart: true,
+        });
+
+        const renderer = createMockRenderer();
+
+        overlay.updateAndRender(renderer, mockFont, null, null, 0);
+
+        // Row gaps share palette 7 but span the full display width; dividers are the width-1 fills.
+        const dividers = renderer.drawBarFill.mock.calls
+            .map((call, callIndex) => ({
+                paletteIndex: call[1] as number,
+                rect: renderer.drawBarFill.rectSnapshots.at(callIndex) as Rect2i,
+            }))
+            .filter((fill) => fill.paletteIndex === 7 && fill.rect.width === 1);
+
+        // 1 pipe in the top-right label, 2 in the metrics row, 2 in the timing row.
+        expect(dividers).toHaveLength(5);
+
+        const topRightDivider = dividers[0]?.rect;
+        expect(topRightDivider).toMatchObject({
+            x:
+                overlayRightAlignedDividerLabelX('webgpu|320x240', 320) +
+                6 * SYSTEM_CHAR_ADVANCE +
+                OVERLAY_DIVIDER_GAP_PX -
+                1,
+            y: 0,
+            width: 1,
+            height: OVERLAY_BAR_HEIGHT,
+        });
+
+        const metricsRowY = OVERLAY_BAR_HEIGHT + OVERLAY_ROW_GAP_PX;
+        const timingRowY = (OVERLAY_BAR_HEIGHT + OVERLAY_ROW_GAP_PX) * 2;
+
+        expect(dividers.filter((fill) => fill.rect.y === metricsRowY)).toHaveLength(2);
+        expect(dividers.filter((fill) => fill.rect.y === timingRowY)).toHaveLength(2);
+
+        for (const divider of dividers) {
+            expect(divider.rect.height).toBe(OVERLAY_BAR_HEIGHT);
+        }
     });
 
     it('uses provided frame timings and shows update-step suffix when multiple updates ran', () => {
@@ -278,11 +360,12 @@ describe('Overlay', () => {
             spriteSubmittedVertices: 0,
         });
 
-        const calls = getBitmapTextCalls(renderer);
-        expect(calls[2]?.text).toContain('Draw Calls: 42');
-        expect(calls[3]?.text).toContain('Frame: 8.3ms');
-        expect(calls[3]?.text).toContain('update(): 1.5msx3');
-        expect(calls[3]?.text).toContain('render(): 3.8ms');
+        const texts = getBitmapTextCalls(renderer).map((call) => call.text);
+
+        expect(texts).toContain('Draw Calls 42');
+        expect(texts).toContain('Frame 8.3ms');
+        expect(texts).toContain('update() 1.5msx3');
+        expect(texts).toContain('render() 3.8ms');
     });
 
     it('skips draw calls when body is hidden and the toggle hint is disabled', () => {
@@ -369,6 +452,7 @@ describe('Overlay', () => {
             expect.objectContaining({ y: 13, height: OVERLAY_ROW_GAP_PX }),
             12,
         );
+
         expect(renderer.drawBarFill).toHaveBeenCalledWith(
             expect.objectContaining({ y: 41, height: OVERLAY_ROW_GAP_PX }),
             12,
@@ -377,10 +461,12 @@ describe('Overlay', () => {
 
     it('falls back gap fills to bar palette index when gapPaletteIndex is omitted', () => {
         const layout = createOverlayLayout(320, 240, 14);
+
         const overlay = createOverlay(layout, 'Demo', {
             style: { barPaletteIndex: 8, textPaletteIndex: 9 },
             isOverlayVisibleAtStart: true,
         });
+
         const renderer = createMockRenderer();
 
         overlay.updateAndRender(renderer, mockFont, null, null, 0);
@@ -393,11 +479,14 @@ describe('Overlay', () => {
 
     it('uses overlayStyle palette indices when provided', () => {
         const layout = createOverlayLayout(320, 240, 14);
+
         const overlay = createOverlay(layout, 'Demo', {
             style: { barPaletteIndex: 8, textPaletteIndex: 9 },
             isOverlayVisibleAtStart: true,
         });
+
         const renderer = createMockRenderer();
+
         overlay.updateAndRender(renderer, mockFont, null, null, 0);
 
         expect(renderer.drawBarFill).toHaveBeenCalledWith(expect.anything(), 8);
@@ -409,10 +498,12 @@ describe('Overlay', () => {
 
     it('draws custom rows with per-row palette indices', () => {
         const layout = createOverlayLayout(320, 240, 14);
+
         const overlay = createOverlay(layout, 'Demo', {
             style: { barPaletteIndex: 2, textPaletteIndex: 3 },
             isOverlayVisibleAtStart: true,
         });
+
         const renderer = createMockRenderer();
         const customRows = [{ leftText: 'Left', barPaletteIndex: 5, textPaletteIndex: 6 }];
 
@@ -431,7 +522,7 @@ describe('Overlay', () => {
         const layout = createOverlayLayout(320, 240, 14);
         const overlay = createOverlay(layout, 'Demo', { isOverlayVisibleAtStart: true });
         const renderer = createMockRenderer();
-        const customRows = [{ leftText: 'Position: 10, 20' }, { leftText: 'Bounces: 3', rightText: 'ok' }];
+        const customRows = [{ leftText: 'Position (10, 20)' }, { leftText: 'Bounces 3', rightText: 'ok' }];
 
         overlay.updateAndRender(renderer, mockFont, null, null, 0, () => customRows);
 
@@ -439,7 +530,8 @@ describe('Overlay', () => {
         const row0BarY = customRowBarY(240, 0);
         const row1BarY = customRowBarY(240, 1);
 
-        expect(fills).toHaveLength(12);
+        // 12 band/gap fills plus 5 in-row separator dividers from the top labels.
+        expect(fills).toHaveLength(17);
         expect(fills[3]).toMatchObject({ y: row0BarY, width: 320, height: OVERLAY_BAR_HEIGHT });
         expect(fills[4]).toMatchObject({ y: row1BarY, width: 320, height: OVERLAY_BAR_HEIGHT });
         expect(fills[11]).toMatchObject({ y: hintBarY(240), width: 320, height: OVERLAY_BAR_HEIGHT });
@@ -448,17 +540,21 @@ describe('Overlay', () => {
         const calls = getBitmapTextCalls(renderer);
         const rightX = overlayRightAlignedTextX('ok', 320);
 
-        expect(calls).toHaveLength(7);
+        // 3 custom row labels plus 9 segmented top-label draws.
+        expect(calls).toHaveLength(12);
+
         expect(calls[0]).toEqual({
             pos: new Vector2i(OVERLAY_EDGE_MARGIN_PX, row0BarY + OVERLAY_TOP_TEXT_Y),
-            text: 'Position: 10, 20',
+            text: 'Position (10, 20)',
             paletteOffset: 1,
         });
+
         expect(calls[1]).toEqual({
             pos: new Vector2i(OVERLAY_EDGE_MARGIN_PX, row1BarY + OVERLAY_TOP_TEXT_Y),
-            text: 'Bounces: 3',
+            text: 'Bounces 3',
             paletteOffset: 1,
         });
+
         expect(calls[2]).toEqual({
             pos: new Vector2i(rightX, row1BarY + OVERLAY_TOP_TEXT_Y),
             text: 'ok',
@@ -473,8 +569,11 @@ describe('Overlay', () => {
 
         overlay.updateAndRender(renderer, mockFont, null, null, 0, () => []);
 
-        expect(getRectFillCalls(renderer)).toHaveLength(8);
-        expect(getBitmapTextCalls(renderer)).toHaveLength(4);
+        // 8 band/gap fills plus 5 in-row separator dividers from the top labels.
+        expect(getRectFillCalls(renderer)).toHaveLength(13);
+
+        // Top labels split into segments: title, backend + resolution, 3 metrics, 3 timing.
+        expect(getBitmapTextCalls(renderer)).toHaveLength(9);
     });
 
     it('does not invoke getCustomRows while the overlay is hidden', () => {
@@ -499,6 +598,7 @@ describe('Overlay', () => {
         overlay.updateAndRender(renderer, mockFont, null, null, 0, undefined, undefined, palette, usedMask);
 
         const fills = getRectFillCalls(renderer);
+
         const paletteBandFill = fills.find(
             (rect) =>
                 rect.y === paletteBandY(240, grid.totalHeight) &&
@@ -507,9 +607,11 @@ describe('Overlay', () => {
         );
 
         expect(paletteBandFill).toBeDefined();
+
         expect(
             fills.some((rect) => rect.y === hintBarY(240) && rect.height === OVERLAY_BAR_HEIGHT && rect.width === 320),
         ).toBe(true);
+
         expect(renderer.drawBarFill.mock.calls.length).toBeGreaterThan(4);
     });
 
@@ -522,10 +624,16 @@ describe('Overlay', () => {
         overlay.updateAndRender(renderer, mockFont, null, null, 0, undefined, undefined, palette);
 
         const fills = getRectFillCalls(renderer);
+
         expect(fills.some((rect) => rect.y === hintBarY(240) && rect.height === OVERLAY_BAR_HEIGHT)).toBe(true);
+
+        // Width-1 top-label separator dividers are bar-height; palette swatch fills are not.
         const swatchCalls = renderer.drawBarFill.mock.calls.filter(
-            (call) => (call[0] as { width: number }).width === 1,
+            (call) =>
+                (call[0] as { width: number }).width === 1 &&
+                (call[0] as { height: number }).height !== OVERLAY_BAR_HEIGHT,
         );
+
         expect(swatchCalls).toHaveLength(0);
     });
 
@@ -561,7 +669,8 @@ describe('Overlay', () => {
 
         writeSwatchTopLeft(swatch, hoveredIndex, paletteBand, grid);
 
-        const customRows = [{ leftText: 'Bounces: 11' }, { leftText: 'Position: (43, 166)' }];
+        const customRows = [{ leftText: 'Bounces: 11' }, { leftText: 'Position (43, 166)' }];
+
         const pointer = {
             isActive: () => true,
             getPos: () => new Vector2i(swatch.x + 1, swatch.y + 1),
@@ -580,10 +689,11 @@ describe('Overlay', () => {
         );
 
         const calls = getBitmapTextCalls(renderer);
-        const positionLabelIndex = renderer.drawLabel.mock.calls.findIndex((call) => call[2] === 'Position: (43, 166)');
+        const positionLabelIndex = renderer.drawLabel.mock.calls.findIndex((call) => call[2] === 'Position (43, 166)');
 
-        expect(calls.some((call) => call.text === 'Position: (43, 166)')).toBe(true);
+        expect(calls.some((call) => call.text === 'Position (43, 166)')).toBe(true);
         expect(positionLabelIndex).toBeGreaterThanOrEqual(0);
+
         const labelDrawOrder = renderer.drawLabel.mock.invocationCallOrder.at(positionLabelIndex);
         const tooltipLabelDrawOrder = renderer.drawLabelOnTop.mock.invocationCallOrder.at(0);
         const lastBarFillOrder = renderer.drawBarFill.mock.invocationCallOrder.at(-1);
@@ -600,25 +710,30 @@ describe('Overlay', () => {
 
         expect(labelDrawOrder).toBeLessThan(tooltipLabelDrawOrder);
         expect(lastBarFillOrder).toBeLessThan(firstBarFillOnTopOrder);
+
         expect(renderer.drawLabelOnTop).toHaveBeenCalledWith(
             mockFont,
             expect.any(Vector2i),
             String(hoveredIndex),
             expect.any(Number),
         );
+
         expect(renderer.drawBarFillOnTop).toHaveBeenCalled();
     });
 
     it('forwards timing chart tags to drawLabelOnTop with event palette offset', () => {
         const layout = createOverlayLayout(320, 240, 14);
+
         const overlay = createOverlay(layout, 'Demo', {
             isOverlayTimingChartEnabled: true,
             overlayTimingChartStyle: { tagPaletteIndex: 7 },
             isOverlayVisibleAtStart: true,
         });
+
         const renderer = createMockRenderer();
 
         overlay.assignTag('Spawn', 42);
+
         overlay.updateAndRender(renderer, mockFont, null, null, 42, undefined, {
             frameMs: 1,
             updateMs: 1,
@@ -640,6 +755,7 @@ describe('Overlay', () => {
 
     it('draws timing chart dots when isOverlayTimingChartEnabled is enabled', () => {
         const layout = createOverlayLayout(320, 240, 14);
+
         const overlay = createOverlay(layout, 'Demo', {
             style: { barPaletteIndex: 8, textPaletteIndex: 9 },
             isOverlayTimingChartEnabled: true,
@@ -647,6 +763,7 @@ describe('Overlay', () => {
             overlayTimingChartHeight: 36,
             isOverlayVisibleAtStart: true,
         });
+
         const renderer = createMockRenderer();
 
         overlay.updateAndRender(renderer, mockFont, null, null, 0, undefined, {
@@ -673,6 +790,7 @@ describe('Overlay', () => {
 
     it('tints timing chart dots with warning palette when frame exceeds soft budget', () => {
         const layout = createOverlayLayout(320, 240, 14);
+
         const overlay = createOverlay(layout, 'Demo', {
             isOverlayTimingChartEnabled: true,
             overlayTimingChartStyle: {
@@ -683,6 +801,7 @@ describe('Overlay', () => {
             },
             isOverlayVisibleAtStart: true,
         });
+
         const renderer = createMockRenderer();
 
         overlay.updateAndRender(renderer, mockFont, null, null, 0, undefined, {
@@ -701,6 +820,7 @@ describe('Overlay', () => {
         const dotCalls = renderer.drawBarFill.mock.calls.filter(
             (call) => (call[0] as { width: number }).width === 1 && (call[0] as { height: number }).height === 1,
         );
+
         const paletteIndices = dotCalls.map((call) => call[1] as number);
 
         expect(paletteIndices.length).toBeGreaterThan(0);
@@ -709,15 +829,18 @@ describe('Overlay', () => {
 
     it('does not draw overlay while hidden but keeps timing chart samples for re-show', () => {
         const layout = createOverlayLayout(320, 240, 14);
+
         const overlay = createOverlay(layout, 'Demo', {
             isOverlayTimingChartEnabled: true,
             overlayTimingChartStyle: { updateBarPaletteIndex: 10, renderBarPaletteIndex: 11 },
             isOverlayVisibleAtStart: true,
             isOverlayToggleHintVisible: false,
         });
+
         const renderer = createMockRenderer();
 
         overlay.handleToggle(null, { isKeyPressed: (key: string) => key === 'Backquote' } as never, 1);
+
         overlay.updateAndRender(renderer, mockFont, null, null, 0, undefined, {
             frameMs: 8,
             updateMs: 12,
@@ -734,6 +857,7 @@ describe('Overlay', () => {
         expect(renderer.drawBarFill).not.toHaveBeenCalled();
 
         overlay.handleToggle(null, { isKeyPressed: (key: string) => key === 'Backquote' } as never, 2);
+
         overlay.updateAndRender(renderer, mockFont, null, null, 0, undefined, {
             frameMs: 8,
             updateMs: 12,
@@ -773,15 +897,18 @@ describe('Overlay', () => {
 
     it('records drop severity in chart history while body is hidden', () => {
         const layout = createOverlayLayout(320, 240, 14);
+
         const overlay = createOverlay(layout, 'Demo', {
             isOverlayTimingChartEnabled: true,
             overlayTimingChartStyle: { warningPaletteIndex: 3, errorPaletteIndex: 4 },
             isOverlayVisibleAtStart: true,
             isOverlayToggleHintVisible: false,
         });
+
         const renderer = createMockRenderer();
 
         overlay.handleToggle(null, { isKeyPressed: (key: string) => key === 'Backquote' } as never, 1);
+
         overlay.updateAndRender(renderer, mockFont, null, null, 0, undefined, {
             frameMs: 0,
             updateMs: 0,
@@ -798,6 +925,7 @@ describe('Overlay', () => {
         expect(renderer.drawBarFill).not.toHaveBeenCalled();
 
         overlay.handleToggle(null, { isKeyPressed: (key: string) => key === 'Backquote' } as never, 2);
+
         overlay.updateAndRender(renderer, mockFont, null, null, 0, undefined, {
             frameMs: 0,
             updateMs: 0,
@@ -884,10 +1012,12 @@ describe('Overlay', () => {
 
         it('draws audio meter track and level bars when isOverlayAudioMetersEnabled is enabled', () => {
             const layout = createOverlayLayout(320, 240, 14);
+
             const overlay = createOverlay(layout, 'Demo', {
                 isOverlayAudioMetersEnabled: true,
                 isOverlayVisibleAtStart: true,
             });
+
             const renderer = createMockRenderer();
 
             overlay.updateAndRender(
@@ -913,10 +1043,12 @@ describe('Overlay', () => {
 
         it('draws the voices/steal/drop text readout when enabled', () => {
             const layout = createOverlayLayout(320, 240, 14);
+
             const overlay = createOverlay(layout, 'Demo', {
                 isOverlayAudioMetersEnabled: true,
                 isOverlayVisibleAtStart: true,
             });
+
             const renderer = createMockRenderer();
 
             overlay.updateAndRender(
@@ -939,11 +1071,13 @@ describe('Overlay', () => {
 
         it('honors audio meter palette overrides', () => {
             const layout = createOverlayLayout(320, 240, 14);
+
             const overlay = createOverlay(layout, 'Demo', {
                 isOverlayAudioMetersEnabled: true,
                 isOverlayVisibleAtStart: true,
                 audioMeterStyle: { trackPaletteIndex: 30, levelBarPaletteIndex: 31 },
             });
+
             const renderer = createMockRenderer();
 
             overlay.updateAndRender(
@@ -969,11 +1103,13 @@ describe('Overlay', () => {
 
         it('does not draw audio meter content when no audio snapshot is supplied', () => {
             const layout = createOverlayLayout(320, 240, 14);
+
             const overlay = createOverlay(layout, 'Demo', {
                 isOverlayAudioMetersEnabled: true,
                 isOverlayVisibleAtStart: true,
                 audioMeterHeight: 13,
             });
+
             const renderer = createMockRenderer();
 
             overlay.updateAndRender(renderer, mockFont, null, null, 0);

--- a/src/overlay/Overlay.test.ts
+++ b/src/overlay/Overlay.test.ts
@@ -628,10 +628,8 @@ describe('Overlay', () => {
         expect(fills.some((rect) => rect.y === hintBarY(240) && rect.height === OVERLAY_BAR_HEIGHT)).toBe(true);
 
         // Width-1 top-label separator dividers are bar-height; palette swatch fills are not.
-        const swatchCalls = renderer.drawBarFill.mock.calls.filter(
-            (call) =>
-                (call[0] as { width: number }).width === 1 &&
-                (call[0] as { height: number }).height !== OVERLAY_BAR_HEIGHT,
+        const swatchCalls = renderer.drawBarFill.rectSnapshots.filter(
+            (rect) => rect.width === 1 && rect.height !== OVERLAY_BAR_HEIGHT,
         );
 
         expect(swatchCalls).toHaveLength(0);

--- a/src/overlay/Overlay.ts
+++ b/src/overlay/Overlay.ts
@@ -200,7 +200,7 @@ export class Overlay {
         this.#idxBg = indices.bg;
         this.#idxText = indices.text;
         this.#idxGap = indices.gap;
-        this.#topRightLabel = `${activeBackend} | ${layout.displayWidth}x${layout.displayHeight}`;
+        this.#topRightLabel = `${activeBackend}|${layout.displayWidth}x${layout.displayHeight}`;
         this.#timingChartStyle = resolveTimingChartStyle(style, timingChartStyle);
         this.#timingChartHeight = timingChartHeight ?? DEFAULT_TIMING_CHART_HEIGHT;
         this.#timingChart = createTimingChart(layout, isOverlayTimingChartEnabled, targetFps, timingChartDiagnostics);
@@ -414,6 +414,7 @@ export class Overlay {
     #createLayoutConfig(customRowCount: number, palette: Palette | null | undefined): OverlayLayoutConfig {
         const isOverlayPaletteEnabled = this.#paletteView.isEnabled;
         const colorCount = palette?.size ?? 256;
+
         const paletteGrid = isOverlayPaletteEnabled
             ? computeGrid(
                   this.#layout.displayWidth,
@@ -454,6 +455,7 @@ export class Overlay {
         palette: Palette | null | undefined,
     ): { layoutConfig: OverlayLayoutConfig; plan: OverlayLayoutPlan } {
         const layoutConfig = this.#createLayoutConfig(customRowCount, palette);
+
         const plan = buildOverlayLayoutPlan(
             layoutConfig,
             this.#layoutScratch,
@@ -524,11 +526,11 @@ export class Overlay {
         if (isBodyVisible) {
             const updateStepSuffix = this.#timing.updateSteps > 1 ? `x${this.#timing.updateSteps}` : '';
 
-            topMetricsLabel = `Present: ${this.#fps.measuredFps} FPS | Target: ${this.#targetFps} FPS | Draw Calls: ${this.#timing.drawCalls}`;
+            topMetricsLabel = `Present ${this.#fps.measuredFps} FPS|Target ${this.#targetFps} FPS|Draw Calls ${this.#timing.drawCalls}`;
 
             topTimingLabel =
-                `Frame: ${this.#timing.frameMs.toFixed(1)}ms | update(): ${this.#timing.updateMs.toFixed(1)}ms${updateStepSuffix} | ` +
-                `render(): ${this.#timing.renderMs.toFixed(1)}ms`;
+                `Frame ${this.#timing.frameMs.toFixed(1)}ms|update() ${this.#timing.updateMs.toFixed(1)}ms${updateStepSuffix}|` +
+                `render() ${this.#timing.renderMs.toFixed(1)}ms`;
 
             if (this.#isOverlayRendererDiagnosticsBarEnabled) {
                 rendererDiagnosticsLabel = this.#timing.formatRendererDiagnosticsLabel();
@@ -589,6 +591,7 @@ export class Overlay {
                 font,
                 plan,
                 this.#barStyle,
+                this.#idxGap,
                 this.#topLeftLabel,
                 this.#topRightLabel,
                 topMetricsLabel,

--- a/src/overlay/audio-meter/AudioMeter.test.ts
+++ b/src/overlay/audio-meter/AudioMeter.test.ts
@@ -16,6 +16,7 @@ const defaultStyle = {
     levelBarIndex: 8,
     trackIndex: 6,
     textIndex: 9,
+    gapIndex: 12,
     warningIndex: 3,
     clipIndex: 4,
 };
@@ -88,7 +89,11 @@ describe('AudioMeter', () => {
         meter.sample(snapshot());
         meter.draw(renderer, meterRect, defaultStyle, mockFont);
 
-        const trackRects = getRectFillCalls(renderer).filter((rect) => rect.height === meterRect.height);
+        // Readout dividers are also full band height; bus tracks are the bar-width fills.
+        const trackRects = getRectFillCalls(renderer).filter(
+            (rect) => rect.height === meterRect.height && rect.width === AUDIO_METER_BAR_WIDTH_PX,
+        );
+
         const xs = trackRects.map((rect) => rect.x).sort((a, b) => a - b);
 
         expect(xs).toEqual([
@@ -180,13 +185,33 @@ describe('AudioMeter', () => {
                 preUnlockDropCount: 2,
             }),
         );
+
         meter.draw(renderer, meterRect, defaultStyle, mockFont);
 
         const textCalls = getBitmapTextCalls(renderer);
 
-        expect(textCalls).toHaveLength(1);
-        expect(textCalls[0]?.text).toContain('5/16');
-        expect(textCalls[0]?.text).toContain('3');
-        expect(textCalls[0]?.text).toContain('drop');
+        expect(textCalls.map((call) => call.text)).toEqual(['5/16 voices', 'steal 3', 'drop 3']);
+    });
+
+    it('draws the readout separators as full-band-height dividers in the gap index', () => {
+        const meter = new AudioMeter(true);
+        const renderer = createMockRenderer();
+
+        meter.sample(snapshot({ activeVoices: 5, totalVoices: 16, voiceStealCount: 3 }));
+        meter.draw(renderer, meterRect, defaultStyle, mockFont);
+
+        const dividerIndices = renderer.drawBarFill.mock.calls
+            .map((call, callIndex) => (call[1] === defaultStyle.gapIndex ? callIndex : -1))
+            .filter((callIndex) => callIndex !== -1);
+
+        expect(dividerIndices).toHaveLength(2);
+
+        for (const callIndex of dividerIndices) {
+            expect(renderer.drawBarFill.rectSnapshots.at(callIndex)).toMatchObject({
+                y: meterRect.y,
+                width: 1,
+                height: meterRect.height,
+            });
+        }
     });
 });

--- a/src/overlay/audio-meter/AudioMeter.ts
+++ b/src/overlay/audio-meter/AudioMeter.ts
@@ -6,6 +6,7 @@ import type { BitmapFont } from '../../assets/BitmapFont';
 import type { AudioBus } from '../../core/IBTDemo';
 import { Rect2i } from '../../utils/Rect2i';
 import { Vector2i } from '../../utils/Vector2i';
+import { drawOverlayLabelWithDividers } from '../labels';
 import { OVERLAY_EDGE_MARGIN_PX, OVERLAY_TOP_TEXT_Y } from '../layout/constants';
 import { overlayBitmapTextPaletteOffset } from '../layout/layoutHelpers';
 import type { OverlayDrawTarget } from '../OverlayDrawTarget';
@@ -32,9 +33,6 @@ const ZERO_LEVELS: Readonly<Record<AudioBus, number>> = { main: 0, music: 0, sfx
 export class AudioMeter {
     /** Feature flag from the constructor; when false, {@link sample} and {@link draw} are no-ops. */
     readonly #isEnabled: boolean;
-
-    /** Reused track fill rect, overwritten in place per bus per {@link draw} call. */
-    readonly #trackScratch = new Rect2i(0, 0, 1, 1);
 
     /** Reused bottom-anchored level fill rect, overwritten in place per bus per {@link draw} call. */
     readonly #fillScratch = new Rect2i(0, 0, 1, 1);
@@ -136,9 +134,6 @@ export class AudioMeter {
 
             const x = busBarX(rect, busIndex);
 
-            this.#trackScratch.set(x, rect.y, AUDIO_METER_BAR_WIDTH_PX, rect.height);
-            target.drawBarFill(this.#trackScratch, style.trackIndex);
-
             // eslint-disable-next-line security/detect-object-injection -- bus is keyof AudioBus union, not arbitrary input
             const level = this.#levels[bus];
             const fillHeight = computeAudioMeterBarHeight(level, rect.height, AUDIO_METER_FULL_SCALE);
@@ -157,6 +152,9 @@ export class AudioMeter {
     /**
      * Draws the voices used/total, steal, and drop text readout to the right of the bus bars.
      *
+     * The `|` separators between the readout segments render as 1 px full-band-height
+     * dividers in the gap palette index, matching the other engine-composed labels.
+     *
      * @param target - Overlay draw target.
      * @param rect - Screen-space meter band.
      * @param style - Resolved meter palette indices.
@@ -169,9 +167,17 @@ export class AudioMeter {
         this.#textPos.y = rect.y + OVERLAY_TOP_TEXT_Y;
 
         const drops = this.#voiceDropCount + this.#preUnlockDropCount;
-        const text = `${this.#activeVoices}/${this.#totalVoices} voices | steal ${this.#voiceStealCount} | drop ${drops}`;
+        const text = `${this.#activeVoices}/${this.#totalVoices} voices|steal ${this.#voiceStealCount}|drop ${drops}`;
 
-        target.drawLabel(font, this.#textPos, text, overlayBitmapTextPaletteOffset(style.textIndex));
+        drawOverlayLabelWithDividers(
+            target,
+            font,
+            this.#textPos,
+            text,
+            rect,
+            overlayBitmapTextPaletteOffset(style.textIndex),
+            style.gapIndex,
+        );
     }
 
     /**

--- a/src/overlay/audio-meter/AudioMeter.ts
+++ b/src/overlay/audio-meter/AudioMeter.ts
@@ -34,6 +34,9 @@ export class AudioMeter {
     /** Feature flag from the constructor; when false, {@link sample} and {@link draw} are no-ops. */
     readonly #isEnabled: boolean;
 
+    /** Reused track fill rect, overwritten in place per bus per {@link draw} call. */
+    readonly #trackScratch = new Rect2i(0, 0, 1, 1);
+
     /** Reused bottom-anchored level fill rect, overwritten in place per bus per {@link draw} call. */
     readonly #fillScratch = new Rect2i(0, 0, 1, 1);
 
@@ -116,8 +119,8 @@ export class AudioMeter {
     }
 
     /**
-     * Draws one bottom-anchored fill rect per bus, sized to its current level, skipping
-     * buses whose level is zero.
+     * Draws one track (full band height) and, when the bus level is non-zero, one
+     * bottom-anchored fill rect per bus.
      *
      * @param target - Overlay draw target.
      * @param rect - Screen-space meter band.
@@ -133,6 +136,9 @@ export class AudioMeter {
             }
 
             const x = busBarX(rect, busIndex);
+
+            this.#trackScratch.set(x, rect.y, AUDIO_METER_BAR_WIDTH_PX, rect.height);
+            target.drawBarFill(this.#trackScratch, style.trackIndex);
 
             // eslint-disable-next-line security/detect-object-injection -- bus is keyof AudioBus union, not arbitrary input
             const level = this.#levels[bus];

--- a/src/overlay/audio-meter/AudioMeter.ts
+++ b/src/overlay/audio-meter/AudioMeter.ts
@@ -116,8 +116,8 @@ export class AudioMeter {
     }
 
     /**
-     * Draws one track (full band height) and, when the bus level is non-zero, one
-     * bottom-anchored fill rect per bus.
+     * Draws one bottom-anchored fill rect per bus, sized to its current level, skipping
+     * buses whose level is zero.
      *
      * @param target - Overlay draw target.
      * @param rect - Screen-space meter band.

--- a/src/overlay/audio-meter/constants.ts
+++ b/src/overlay/audio-meter/constants.ts
@@ -25,10 +25,10 @@ export const AUDIO_METER_BUSES: readonly AudioBus[] = ['main', 'music', 'sfx'];
 export const AUDIO_METER_BUS_COUNT = AUDIO_METER_BUSES.length;
 
 /** Width in pixels of one bus level bar. */
-export const AUDIO_METER_BAR_WIDTH_PX = 4;
+export const AUDIO_METER_BAR_WIDTH_PX = 3;
 
 /** Horizontal gap in pixels between bus level bars. */
 export const AUDIO_METER_BAR_GAP_PX = 1;
 
 /** Horizontal gap in pixels between the bus bar block and the voice/steal/drop text readout. */
-export const AUDIO_METER_TEXT_GAP_PX = 4;
+export const AUDIO_METER_TEXT_GAP_PX = 7;

--- a/src/overlay/audio-meter/style.test.ts
+++ b/src/overlay/audio-meter/style.test.ts
@@ -48,6 +48,7 @@ describe('resolveAudioMeterStyle', () => {
 
         expect(resolved.levelBarIndex).toBe(20);
         expect(resolved.trackIndex).toBe(21);
+        expect(resolved.gapIndex).toBe(12);
         expect(resolved.warningIndex).toBe(22);
         expect(resolved.clipIndex).toBe(23);
     });

--- a/src/overlay/audio-meter/style.test.ts
+++ b/src/overlay/audio-meter/style.test.ts
@@ -56,12 +56,14 @@ describe('resolveAudioMeterStyle', () => {
         const resolved = resolveAudioMeterStyle({ barPaletteIndex: 1, textPaletteIndex: 2, gapPaletteIndex: 7 }, {});
 
         expect(resolved.trackIndex).toBe(7);
+        expect(resolved.gapIndex).toBe(7);
     });
 
     it('falls back track to bar index when gap palette is omitted', () => {
         const resolved = resolveAudioMeterStyle({ barPaletteIndex: 9, textPaletteIndex: 2 }, undefined);
 
         expect(resolved.trackIndex).toBe(9);
+        expect(resolved.gapIndex).toBe(9);
     });
 
     it('resolves defaults when overlay style is entirely omitted', () => {
@@ -70,5 +72,6 @@ describe('resolveAudioMeterStyle', () => {
         expect(resolved.levelBarIndex).toBe(2);
         expect(resolved.trackIndex).toBe(1);
         expect(resolved.textIndex).toBe(2);
+        expect(resolved.gapIndex).toBe(1);
     });
 });

--- a/src/overlay/audio-meter/style.ts
+++ b/src/overlay/audio-meter/style.ts
@@ -7,6 +7,7 @@ export interface AudioMeterDrawStyle {
     readonly levelBarIndex: number;
     readonly trackIndex: number;
     readonly textIndex: number;
+    readonly gapIndex: number;
     readonly warningIndex: number;
     readonly clipIndex: number;
 }
@@ -40,6 +41,7 @@ export function resolveAudioMeterStyle(
         levelBarIndex: pickPaletteIndex(meterStyle?.levelBarPaletteIndex, textIndex),
         trackIndex: pickPaletteIndex(meterStyle?.trackPaletteIndex, gapIndex),
         textIndex,
+        gapIndex,
         warningIndex: pickPaletteIndex(meterStyle?.warningPaletteIndex, AUDIO_METER_DEFAULT_WARNING_IDX),
         clipIndex: pickPaletteIndex(meterStyle?.clipPaletteIndex, AUDIO_METER_DEFAULT_CLIP_IDX),
     };

--- a/src/overlay/bars/Bars.ts
+++ b/src/overlay/bars/Bars.ts
@@ -1,8 +1,8 @@
 import type { BitmapFont } from '../../assets/BitmapFont';
 import type { OverlayRow } from '../../core/IBTDemo';
-import { Rect2i } from '../../utils/Rect2i';
 import { Vector2i } from '../../utils/Vector2i';
-import { OVERLAY_EDGE_MARGIN_PX, OVERLAY_ROW_GAP_PX, OVERLAY_TOP_TEXT_Y } from '../layout/constants';
+import { drawOverlayLabelWithDividers } from '../labels';
+import { OVERLAY_EDGE_MARGIN_PX, OVERLAY_TOP_TEXT_Y } from '../layout/constants';
 import { overlayBitmapTextPaletteOffset, overlayRightAlignedTextX } from '../layout/layoutHelpers';
 import type { OverlayLayoutPlan } from '../layout/types';
 import type { OverlayDrawTarget } from '../OverlayDrawTarget';
@@ -21,8 +21,6 @@ export class OverlayBars {
 
     readonly #customRightPos: Vector2i[] = [];
 
-    readonly #hintSeparatorRect = new Rect2i(0, 0, 0, OVERLAY_ROW_GAP_PX);
-
     /**
      * Draws 1 px row gaps between stacked overlay bands.
      *
@@ -34,21 +32,6 @@ export class OverlayBars {
         for (const gapRect of plan.rowGapRects) {
             target.drawBarFill(gapRect, gapIndex);
         }
-    }
-
-    /**
-     * Draws the 1 px separator immediately above the bottom hint bar.
-     *
-     * @param target - Overlay draw target.
-     * @param hintBar - Bottom hint bar rect.
-     * @param gapIndex - Palette index for separator fill.
-     */
-    drawHintClusterSeparator(target: OverlayDrawTarget, hintBar: Rect2i, gapIndex: number): void {
-        this.#hintSeparatorRect.x = 0;
-        this.#hintSeparatorRect.y = hintBar.y - OVERLAY_ROW_GAP_PX;
-        this.#hintSeparatorRect.width = hintBar.width;
-        this.#hintSeparatorRect.height = OVERLAY_ROW_GAP_PX;
-        target.drawBarFill(this.#hintSeparatorRect, gapIndex);
     }
 
     /**
@@ -129,10 +112,15 @@ export class OverlayBars {
     /**
      * Draws built-in top overlay text labels (excluding the footer hint).
      *
+     * Engine-composed labels render their `|` separators as 1 px full-row-height
+     * dividers in the gap palette index; the demo title is user content and keeps
+     * literal pipes.
+     *
      * @param target - Overlay draw target.
      * @param font - System bitmap font.
      * @param plan - Computed layout plan.
      * @param style - Default overlay palette indices.
+     * @param gapIndex - Palette index for in-row separator dividers (same as row gaps).
      * @param topLeftLabel - Demo title (left).
      * @param topRightLabel - Backend and resolution (right).
      * @param topMetricsLabel - Present FPS / target / draw calls line.
@@ -144,6 +132,7 @@ export class OverlayBars {
         font: BitmapFont,
         plan: OverlayLayoutPlan,
         style: OverlayBarStyle,
+        gapIndex: number,
         topLeftLabel: string,
         topRightLabel: string,
         topMetricsLabel: string,
@@ -153,12 +142,47 @@ export class OverlayBars {
         const textPaletteOffset = overlayBitmapTextPaletteOffset(style.textIndex);
 
         target.drawLabel(font, plan.topLeftPos, topLeftLabel, textPaletteOffset);
-        target.drawLabel(font, plan.topRightPos, topRightLabel, textPaletteOffset);
-        target.drawLabel(font, plan.topMetricsPos, topMetricsLabel, textPaletteOffset);
-        target.drawLabel(font, plan.topTimingPos, topTimingLabel, textPaletteOffset);
+
+        drawOverlayLabelWithDividers(
+            target,
+            font,
+            plan.topRightPos,
+            topRightLabel,
+            plan.titleBar,
+            textPaletteOffset,
+            gapIndex,
+        );
+
+        drawOverlayLabelWithDividers(
+            target,
+            font,
+            plan.topMetricsPos,
+            topMetricsLabel,
+            plan.metricsBar,
+            textPaletteOffset,
+            gapIndex,
+        );
+
+        drawOverlayLabelWithDividers(
+            target,
+            font,
+            plan.topTimingPos,
+            topTimingLabel,
+            plan.timingTextBar,
+            textPaletteOffset,
+            gapIndex,
+        );
 
         if (rendererDiagnosticsLabel.length > 0 && plan.rendererDiagnosticsBar.height > 0) {
-            target.drawLabel(font, plan.rendererDiagnosticsPos, rendererDiagnosticsLabel, textPaletteOffset);
+            drawOverlayLabelWithDividers(
+                target,
+                font,
+                plan.rendererDiagnosticsPos,
+                rendererDiagnosticsLabel,
+                plan.rendererDiagnosticsBar,
+                textPaletteOffset,
+                gapIndex,
+            );
         }
     }
 
@@ -217,6 +241,7 @@ export class OverlayBars {
         }
 
         this.#ensureCustomRowPool(rowCount);
+
         const displayWidth = plan.titleBar.width;
 
         /* eslint-disable security/detect-object-injection -- rowIndex bounded by rows.length */
@@ -243,6 +268,7 @@ export class OverlayBars {
             if (rightText !== undefined && rightText.length > 0) {
                 rightPos.y = barY + OVERLAY_TOP_TEXT_Y;
                 rightPos.x = overlayRightAlignedTextX(rightText, displayWidth);
+
                 target.drawLabel(font, rightPos, rightText, textPaletteOffset);
             }
         }

--- a/src/overlay/constants.ts
+++ b/src/overlay/constants.ts
@@ -6,3 +6,6 @@ export const DEFAULT_IDX_TEXT = 2;
 
 /** System font glyph advance in pixels. */
 export const SYSTEM_CHAR_ADVANCE = 6;
+
+/** Visual space in pixels between an in-row divider line and the text on each side. */
+export const OVERLAY_DIVIDER_GAP_PX = 7;

--- a/src/overlay/labels.test.ts
+++ b/src/overlay/labels.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { resolveOverlayTopLeftLabel } from './labels';
+import { Rect2i } from '../utils/Rect2i';
+import { Vector2i } from '../utils/Vector2i';
+import { OVERLAY_DIVIDER_GAP_PX, SYSTEM_CHAR_ADVANCE } from './constants';
+import { drawOverlayLabelWithDividers, overlayDividerLabelWidth, resolveOverlayTopLeftLabel } from './labels';
+import { createMockRenderer, getBitmapTextCalls, mockFont } from './testFixtures';
 
 describe('resolveOverlayTopLeftLabel', () => {
     it('formats registry-style page titles without a BLIT386 prefix', () => {
@@ -15,5 +19,84 @@ describe('resolveOverlayTopLeftLabel', () => {
 
     it('passes through non-registry titles unchanged', () => {
         expect(resolveOverlayTopLeftLabel('Custom Page')).toBe('Custom Page');
+    });
+});
+
+describe('drawOverlayLabelWithDividers', () => {
+    const rowRect = new Rect2i(0, 20, 320, 13);
+    const pos = new Vector2i(10, 23);
+
+    /** Nominal advance from a segment's end to the next segment's start. */
+    const separatorAdvance = 2 * OVERLAY_DIVIDER_GAP_PX;
+
+    /** Divider line X for a segment ending at the given nominal advance end. */
+    const dividerX = (segmentEnd: number): number => segmentEnd - 1 + OVERLAY_DIVIDER_GAP_PX;
+
+    it('draws pipe-free labels unchanged with no divider fills', () => {
+        const target = createMockRenderer();
+
+        drawOverlayLabelWithDividers(target, mockFont, pos, 'Plain label', rowRect, 5, 7);
+
+        expect(target.drawLabel).toHaveBeenCalledExactlyOnceWith(mockFont, pos, 'Plain label', 5);
+        expect(target.drawBarFill).not.toHaveBeenCalled();
+    });
+
+    it('draws each pipe-separated segment at gap-spaced positions', () => {
+        const target = createMockRenderer();
+
+        drawOverlayLabelWithDividers(target, mockFont, pos, 'a|b|c', rowRect, 5, 7);
+
+        const segmentA = pos.x;
+        const segmentB = segmentA + SYSTEM_CHAR_ADVANCE + separatorAdvance;
+        const segmentC = segmentB + SYSTEM_CHAR_ADVANCE + separatorAdvance;
+        const calls = getBitmapTextCalls(target);
+
+        expect(calls).toEqual([
+            { pos: new Vector2i(segmentA, pos.y), text: 'a', paletteOffset: 5 },
+            { pos: new Vector2i(segmentB, pos.y), text: 'b', paletteOffset: 5 },
+            { pos: new Vector2i(segmentC, pos.y), text: 'c', paletteOffset: 5 },
+        ]);
+    });
+
+    it('draws a 1 px full-row-height divider in the gap index between segments', () => {
+        const target = createMockRenderer();
+
+        drawOverlayLabelWithDividers(target, mockFont, pos, 'ab|c', rowRect, 5, 7);
+
+        expect(target.drawBarFill).toHaveBeenCalledTimes(1);
+        expect(target.drawBarFill.mock.calls[0]?.[1]).toBe(7);
+        expect(target.drawBarFill.rectSnapshots[0]).toMatchObject({
+            x: dividerX(pos.x + 2 * SYSTEM_CHAR_ADVANCE),
+            y: rowRect.y,
+            width: 1,
+            height: rowRect.height,
+        });
+    });
+
+    it('draws one divider per pipe', () => {
+        const target = createMockRenderer();
+
+        drawOverlayLabelWithDividers(target, mockFont, pos, 'a|b|c', rowRect, 5, 7);
+
+        const firstSegmentEnd = pos.x + SYSTEM_CHAR_ADVANCE;
+        const secondSegmentEnd = firstSegmentEnd + separatorAdvance + SYSTEM_CHAR_ADVANCE;
+
+        expect(target.drawBarFill).toHaveBeenCalledTimes(2);
+
+        expect(target.drawBarFill.rectSnapshots.map((rect) => rect.x)).toEqual([
+            dividerX(firstSegmentEnd),
+            dividerX(secondSegmentEnd),
+        ]);
+    });
+});
+
+describe('overlayDividerLabelWidth', () => {
+    it('measures plain text like length times the glyph advance', () => {
+        expect(overlayDividerLabelWidth('Plain label')).toBe(11 * SYSTEM_CHAR_ADVANCE);
+    });
+
+    it('replaces each pipe marker with the separator advance', () => {
+        expect(overlayDividerLabelWidth('webgpu|320x240')).toBe(13 * SYSTEM_CHAR_ADVANCE + 2 * OVERLAY_DIVIDER_GAP_PX);
+        expect(overlayDividerLabelWidth('a|b|c')).toBe(3 * SYSTEM_CHAR_ADVANCE + 4 * OVERLAY_DIVIDER_GAP_PX);
     });
 });

--- a/src/overlay/labels.ts
+++ b/src/overlay/labels.ts
@@ -1,5 +1,27 @@
+import type { BitmapFont } from '../assets/BitmapFont';
+import { Rect2i } from '../utils/Rect2i';
+import { Vector2i } from '../utils/Vector2i';
+import { OVERLAY_DIVIDER_GAP_PX, SYSTEM_CHAR_ADVANCE } from './constants';
+import type { OverlayDrawTarget } from './OverlayDrawTarget';
+
 /** Matches demo registry titles: "BLIT386 Demo 006 - Patterns". */
 const REGISTRY_TITLE_PATTERN = /^BLIT386 Demo\s+.+?\s+-\s+(.+)$/;
+
+/** Trailing tracking column inside each 6 px glyph cell (glyphs ink 5 of the 6 px advance). */
+const GLYPH_TRACKING_PX = 1;
+
+/**
+ * Nominal advance from one segment's end to the next segment's start: the divider line
+ * plus {@link OVERLAY_DIVIDER_GAP_PX} of visual space on each side, minus the previous
+ * segment's built-in trailing tracking.
+ */
+const SEGMENT_SEPARATOR_ADVANCE_PX = 2 * OVERLAY_DIVIDER_GAP_PX;
+
+/** Reused divider fill rect; {@link OverlayDrawTarget.drawBarFill} consumes rects immediately. */
+const dividerScratch = new Rect2i(0, 0, 1, 0);
+
+/** Reused segment draw position; {@link OverlayDrawTarget.drawLabel} consumes positions immediately. */
+const segmentScratch = new Vector2i(0, 0);
 
 /**
  * Turns the browser page title into a short top-left overlay label.
@@ -22,4 +44,84 @@ export function resolveOverlayTopLeftLabel(pageTitle: string | undefined): strin
     }
 
     return raw;
+}
+
+/**
+ * Draws an engine-composed overlay label, rendering each `|` separator as a 1 px
+ * full-row-height vertical divider in the gap palette index instead of a text glyph.
+ *
+ * Only engine-composed labels route through this helper: `|` is treated as a separator
+ * marker with no surrounding spaces. The text is drawn as individual segments so each
+ * divider line keeps {@link OVERLAY_DIVIDER_GAP_PX} of visual space between itself and
+ * the inked glyphs on both sides. User-supplied strings (demo title, custom rows) keep
+ * literal pipes via plain {@link OverlayDrawTarget.drawLabel}. Measure the rendered
+ * width with {@link overlayDividerLabelWidth}.
+ *
+ * @param target - Overlay draw target.
+ * @param font - System bitmap font.
+ * @param pos - Label draw position.
+ * @param text - Engine-composed label; every `|` becomes a drawn divider.
+ * @param rowRect - Row band rect the dividers span vertically.
+ * @param textPaletteOffset - Palette offset for the label glyphs.
+ * @param gapIndex - Palette index for divider fills (same as row gaps).
+ */
+export function drawOverlayLabelWithDividers(
+    target: OverlayDrawTarget,
+    font: BitmapFont,
+    pos: Vector2i,
+    text: string,
+    rowRect: Rect2i,
+    textPaletteOffset: number,
+    gapIndex: number,
+): void {
+    if (!text.includes('|')) {
+        target.drawLabel(font, pos, text, textPaletteOffset);
+
+        return;
+    }
+
+    const segments = text.split('|');
+    let segmentX = pos.x;
+
+    segmentScratch.y = pos.y;
+
+    for (let index = 0; index < segments.length; index++) {
+        // eslint-disable-next-line security/detect-object-injection -- index bounded by segments.length
+        const segment = segments[index] ?? '';
+
+        segmentScratch.x = segmentX;
+
+        target.drawLabel(font, segmentScratch, segment, textPaletteOffset);
+
+        if (index === segments.length - 1) {
+            break;
+        }
+
+        const segmentEnd = segmentX + segment.length * SYSTEM_CHAR_ADVANCE;
+
+        dividerScratch.set(segmentEnd - GLYPH_TRACKING_PX + OVERLAY_DIVIDER_GAP_PX, rowRect.y, 1, rowRect.height);
+
+        target.drawBarFill(dividerScratch, gapIndex);
+
+        segmentX = segmentEnd + SEGMENT_SEPARATOR_ADVANCE_PX;
+    }
+}
+
+/**
+ * Nominal advance width of an engine-composed label rendered by
+ * {@link drawOverlayLabelWithDividers}: segment glyph advances plus
+ * {@link SEGMENT_SEPARATOR_ADVANCE_PX} per divider.
+ *
+ * @param text - Engine-composed label with `|` separator markers.
+ * @returns Rendered width in pixels (same convention as `length * SYSTEM_CHAR_ADVANCE`
+ *   for plain text, including the last glyph's trailing tracking).
+ */
+export function overlayDividerLabelWidth(text: string): number {
+    let dividerCount = 0;
+
+    for (let pipeIndex = text.indexOf('|'); pipeIndex !== -1; pipeIndex = text.indexOf('|', pipeIndex + 1)) {
+        dividerCount++;
+    }
+
+    return (text.length - dividerCount) * SYSTEM_CHAR_ADVANCE + dividerCount * SEGMENT_SEPARATOR_ADVANCE_PX;
 }

--- a/src/overlay/layout/constants.ts
+++ b/src/overlay/layout/constants.ts
@@ -1,8 +1,8 @@
 /** Height of each overlay bar strip in pixels. */
 export const OVERLAY_BAR_HEIGHT = 13;
 
-/** Horizontal inset from screen edges for overlay text. */
-export const OVERLAY_EDGE_MARGIN_PX = 3;
+/** Horizontal inset from screen edges for overlay text and chrome. */
+export const OVERLAY_EDGE_MARGIN_PX = 7;
 
 /** Vertical offset for top-row text inside the top bar. */
 export const OVERLAY_TOP_TEXT_Y = 0;

--- a/src/overlay/layout/layoutHelpers.test.ts
+++ b/src/overlay/layout/layoutHelpers.test.ts
@@ -28,6 +28,7 @@ describe('overlayRightAlignedTextX', () => {
     it('places text flush right with edge margin (+1 px inset)', () => {
         const label = 'webgpu | 320x240';
         const width = label.length * SYSTEM_CHAR_ADVANCE;
+
         expect(overlayRightAlignedTextX(label, 320)).toBe(320 - width - OVERLAY_EDGE_MARGIN_PX + 1);
     });
 

--- a/src/overlay/layout/layoutHelpers.ts
+++ b/src/overlay/layout/layoutHelpers.ts
@@ -2,6 +2,7 @@ import { Rect2i } from '../../utils/Rect2i';
 import type { Vector2i } from '../../utils/Vector2i';
 import { SYSTEM_CHAR_ADVANCE } from '../constants';
 import { OVERLAY_TOGGLE_CORNER_SIZE } from '../input/constants';
+import { overlayDividerLabelWidth } from '../labels';
 import { OVERLAY_BAR_HEIGHT, OVERLAY_EDGE_MARGIN_PX, OVERLAY_ROW_GAP_PX, OVERLAY_TOP_TEXT_Y } from './constants';
 import type { OverlayLayout } from './types';
 
@@ -50,6 +51,23 @@ export function isPointerInOverlayToggleCorner(pos: Vector2i, toggleRect: Rect2i
  */
 export function overlayRightAlignedTextX(text: string, displayWidth: number): number {
     const width = text.length * SYSTEM_CHAR_ADVANCE;
+
+    return Math.max(OVERLAY_EDGE_MARGIN_PX, displayWidth - width - OVERLAY_EDGE_MARGIN_PX + 1);
+}
+
+/**
+ * X position for a right-aligned engine-composed label whose `|` markers render as
+ * dividers via {@link drawOverlayLabelWithDividers}.
+ *
+ * Same flush-right convention as {@link overlayRightAlignedTextX}, but measured with
+ * {@link overlayDividerLabelWidth} so the divider spacing is accounted for.
+ *
+ * @param text - Engine-composed label with `|` separator markers.
+ * @param displayWidth - Logical display width in pixels.
+ * @returns Left edge X for {@link drawOverlayLabelWithDividers} (never less than the margin).
+ */
+export function overlayRightAlignedDividerLabelX(text: string, displayWidth: number): number {
+    const width = overlayDividerLabelWidth(text);
 
     return Math.max(OVERLAY_EDGE_MARGIN_PX, displayWidth - width - OVERLAY_EDGE_MARGIN_PX + 1);
 }

--- a/src/overlay/layout/layoutPlan.test.ts
+++ b/src/overlay/layout/layoutPlan.test.ts
@@ -30,6 +30,7 @@ describe('buildOverlayLayoutPlan', () => {
         expect(plan.rowGapRects[0]).toMatchObject({ y: 13, width: 320, height: OVERLAY_ROW_GAP_PX });
         expect(plan.rowGapRects[1]).toMatchObject({ y: 27, width: 320, height: OVERLAY_ROW_GAP_PX });
         expect(plan.topClusterSeparator).toMatchObject({ y: 41, width: 320, height: OVERLAY_ROW_GAP_PX });
+
         expect(plan.bottomClusterSeparator).toMatchObject({
             y: hintBarY(240) - OVERLAY_ROW_GAP_PX,
             width: 320,
@@ -59,6 +60,7 @@ describe('buildOverlayLayoutPlan', () => {
     it('inserts timing chart band when enabled', () => {
         const layout = createOverlayLayout(320, 240, 14);
         const scratch = createOverlayLayoutPlanScratch();
+
         const config = {
             ...createDefaultLayoutConfig(320, 240, 14, 0),
             isOverlayTimingChartEnabled: true,
@@ -74,6 +76,7 @@ describe('buildOverlayLayoutPlan', () => {
     it('inserts renderer diagnostics bar below timing text when enabled', () => {
         const layout = createOverlayLayout(320, 240, 14);
         const scratch = createOverlayLayoutPlanScratch();
+
         const config = {
             ...createDefaultLayoutConfig(320, 240, 14, 0),
             isOverlayRendererDiagnosticsBarEnabled: true,
@@ -87,6 +90,7 @@ describe('buildOverlayLayoutPlan', () => {
             width: 320,
             height: OVERLAY_BAR_HEIGHT,
         });
+
         expect(plan.topClusterSeparator.y).toBe(plan.rendererDiagnosticsBar.y + OVERLAY_BAR_HEIGHT);
     });
 
@@ -104,6 +108,7 @@ describe('buildOverlayLayoutPlan', () => {
     it('inserts audio meter band after timing text when enabled and diagnostics disabled', () => {
         const layout = createOverlayLayout(320, 240, 14);
         const scratch = createOverlayLayoutPlanScratch();
+
         const config = {
             ...createDefaultLayoutConfig(320, 240, 14, 0),
             isOverlayAudioMetersEnabled: true,
@@ -118,6 +123,7 @@ describe('buildOverlayLayoutPlan', () => {
             width: 320,
             height: 13,
         });
+
         expect(plan.audioMeterTextPos.y).toBe(plan.audioMeterBar.y);
         expect(plan.topClusterSeparator.y).toBe(plan.audioMeterBar.y + plan.audioMeterBar.height);
     });
@@ -125,6 +131,7 @@ describe('buildOverlayLayoutPlan', () => {
     it('inserts audio meter band after renderer diagnostics when both are enabled', () => {
         const layout = createOverlayLayout(320, 240, 14);
         const scratch = createOverlayLayoutPlanScratch();
+
         const config = {
             ...createDefaultLayoutConfig(320, 240, 14, 0),
             isOverlayRendererDiagnosticsBarEnabled: true,
@@ -140,12 +147,14 @@ describe('buildOverlayLayoutPlan', () => {
             width: 320,
             height: 13,
         });
+
         expect(plan.topClusterSeparator.y).toBe(plan.audioMeterBar.y + plan.audioMeterBar.height);
     });
 
     it('falls back to the default audio meter height when zero', () => {
         const layout = createOverlayLayout(320, 240, 14);
         const scratch = createOverlayLayoutPlanScratch();
+
         const config = {
             ...createDefaultLayoutConfig(320, 240, 14, 0),
             isOverlayAudioMetersEnabled: true,
@@ -160,6 +169,7 @@ describe('buildOverlayLayoutPlan', () => {
     it('adds row gaps around the audio meter band when enabled', () => {
         const layout = createOverlayLayout(320, 240, 14);
         const scratch = createOverlayLayoutPlanScratch();
+
         const withoutMeter = buildOverlayLayoutPlan(
             createDefaultLayoutConfig(320, 240, 14, 0),
             scratch,
@@ -170,6 +180,7 @@ describe('buildOverlayLayoutPlan', () => {
         expect(withoutMeter.rowGapRects).toHaveLength(2);
 
         const scratchWithMeter = createOverlayLayoutPlanScratch();
+
         const withMeter = buildOverlayLayoutPlan(
             { ...createDefaultLayoutConfig(320, 240, 14, 0), isOverlayAudioMetersEnabled: true, audioMeterHeight: 13 },
             scratchWithMeter,
@@ -178,9 +189,11 @@ describe('buildOverlayLayoutPlan', () => {
         );
 
         expect(withMeter.rowGapRects).toHaveLength(4);
+
         expect(withMeter.rowGapRects.some((rect) => rect.y === withMeter.audioMeterBar.y - OVERLAY_ROW_GAP_PX)).toBe(
             true,
         );
+
         expect(
             withMeter.rowGapRects.some((rect) => rect.y === withMeter.audioMeterBar.y + withMeter.audioMeterBar.height),
         ).toBe(true);
@@ -200,6 +213,7 @@ describe('buildOverlayLayoutPlan', () => {
         const layout = createOverlayLayout(320, 240, 14);
         const scratch = createOverlayLayoutPlanScratch();
         const paletteGrid = computeGrid(320, 4, 256, 1);
+
         const config = {
             ...createDefaultLayoutConfig(320, 240, 14, 0),
             isOverlayPaletteEnabled: true,
@@ -213,6 +227,7 @@ describe('buildOverlayLayoutPlan', () => {
             height: paletteGrid.totalHeight,
             width: 320,
         });
+
         expect(plan.hintBar).toMatchObject({
             y: hintBarY(240),
             height: OVERLAY_BAR_HEIGHT,
@@ -224,6 +239,7 @@ describe('buildOverlayLayoutPlan', () => {
         const layout = createOverlayLayout(320, 240, 14);
         const scratch = createOverlayLayoutPlanScratch();
         const paletteGrid = computeGrid(320, 4, 256, 1);
+
         const config = {
             ...createDefaultLayoutConfig(320, 240, 14, 1),
             isOverlayPaletteEnabled: true,
@@ -243,11 +259,13 @@ describe('buildOverlayLayoutPlan', () => {
         const paletteGrid = computeGrid(320, 4, 256, 1);
         const cappedGrid = computeGrid(320, 4, 256, 1, undefined, 3);
         const hintOnlyConfig = createDefaultLayoutConfig(320, 240, 14, 0);
+
         const paletteConfig = {
             ...hintOnlyConfig,
             isOverlayPaletteEnabled: true,
             paletteGrid,
         };
+
         const cappedPaletteConfig = {
             ...hintOnlyConfig,
             isOverlayPaletteEnabled: true,
@@ -255,12 +273,15 @@ describe('buildOverlayLayoutPlan', () => {
         };
 
         expect(resolveOverlayFooterHeight(hintOnlyConfig)).toBe(OVERLAY_BAR_HEIGHT);
+
         expect(resolveOverlayFooterHeight(paletteConfig)).toBe(
             paletteGrid.totalHeight + OVERLAY_ROW_GAP_PX + OVERLAY_BAR_HEIGHT,
         );
+
         expect(resolveOverlayFooterHeight(cappedPaletteConfig)).toBe(
             cappedGrid.totalHeight + OVERLAY_ROW_GAP_PX + OVERLAY_BAR_HEIGHT,
         );
+
         expect(cappedGrid.totalHeight).toBeLessThan(paletteGrid.totalHeight);
     });
 });

--- a/src/overlay/layout/layoutPlan.ts
+++ b/src/overlay/layout/layoutPlan.ts
@@ -222,20 +222,14 @@ function populateGapLayout(scratch: OverlayLayoutPlanScratch, config: OverlayLay
     let lastTopClusterBar = scratch.timingTextBar;
     let hasOptionalTailBand = false;
 
-    if (scratch.rendererDiagnosticsBar.height > 0) {
-        gapIndex = writeRowGapBelow(scratch, lastTopClusterBar, displayWidth, gapIndex);
+    for (const optionalTailBar of [scratch.rendererDiagnosticsBar, scratch.audioMeterBar]) {
+        if (optionalTailBar.height > 0) {
+            gapIndex = writeRowGapBelow(scratch, lastTopClusterBar, displayWidth, gapIndex);
 
-        lastTopClusterBar = scratch.rendererDiagnosticsBar;
+            lastTopClusterBar = optionalTailBar;
 
-        hasOptionalTailBand = true;
-    }
-
-    if (scratch.audioMeterBar.height > 0) {
-        gapIndex = writeRowGapBelow(scratch, lastTopClusterBar, displayWidth, gapIndex);
-
-        lastTopClusterBar = scratch.audioMeterBar;
-
-        hasOptionalTailBand = true;
+            hasOptionalTailBand = true;
+        }
     }
 
     if (hasOptionalTailBand) {

--- a/src/overlay/layout/layoutPlan.ts
+++ b/src/overlay/layout/layoutPlan.ts
@@ -11,7 +11,7 @@ import { Vector2i } from '../../utils/Vector2i';
 import { DEFAULT_AUDIO_METER_HEIGHT } from '../audio-meter/constants';
 import { DEFAULT_TIMING_CHART_HEIGHT } from '../timing-chart/constants';
 import { OVERLAY_BAR_HEIGHT, OVERLAY_EDGE_MARGIN_PX, OVERLAY_ROW_GAP_PX, OVERLAY_TOP_TEXT_Y } from './constants';
-import { overlayRightAlignedTextX } from './layoutHelpers';
+import { overlayRightAlignedDividerLabelX } from './layoutHelpers';
 import type { OverlayLayoutConfig, OverlayLayoutPlan } from './types';
 
 /** Mutable scratch object reused by {@link buildOverlayLayoutPlan}. */
@@ -224,13 +224,17 @@ function populateGapLayout(scratch: OverlayLayoutPlanScratch, config: OverlayLay
 
     if (scratch.rendererDiagnosticsBar.height > 0) {
         gapIndex = writeRowGapBelow(scratch, lastTopClusterBar, displayWidth, gapIndex);
+
         lastTopClusterBar = scratch.rendererDiagnosticsBar;
+
         hasOptionalTailBand = true;
     }
 
     if (scratch.audioMeterBar.height > 0) {
         gapIndex = writeRowGapBelow(scratch, lastTopClusterBar, displayWidth, gapIndex);
+
         lastTopClusterBar = scratch.audioMeterBar;
+
         hasOptionalTailBand = true;
     }
 
@@ -320,6 +324,7 @@ export function buildOverlayLayoutPlan(
     scratch.titleBar.y = y;
     scratch.titleBar.width = displayWidth;
     scratch.titleBar.height = OVERLAY_BAR_HEIGHT;
+
     y += OVERLAY_BAR_HEIGHT + OVERLAY_ROW_GAP_PX;
 
     if (config.isOverlayTimingChartEnabled) {
@@ -329,6 +334,7 @@ export function buildOverlayLayoutPlan(
         scratch.timingChart.y = y;
         scratch.timingChart.width = displayWidth;
         scratch.timingChart.height = chartHeight;
+
         y += chartHeight + OVERLAY_ROW_GAP_PX;
     } else {
         scratch.timingChart.x = 0;
@@ -341,6 +347,7 @@ export function buildOverlayLayoutPlan(
     scratch.metricsBar.y = y;
     scratch.metricsBar.width = displayWidth;
     scratch.metricsBar.height = OVERLAY_BAR_HEIGHT;
+
     y += OVERLAY_BAR_HEIGHT + OVERLAY_ROW_GAP_PX;
 
     scratch.timingTextBar.x = 0;
@@ -397,7 +404,7 @@ export function buildOverlayLayoutPlan(
     scratch.topLeftPos.x = OVERLAY_EDGE_MARGIN_PX;
     scratch.topLeftPos.y = OVERLAY_TOP_TEXT_Y;
 
-    scratch.topRightPos.x = overlayRightAlignedTextX(topRightLabel, displayWidth);
+    scratch.topRightPos.x = overlayRightAlignedDividerLabelX(topRightLabel, displayWidth);
     scratch.topRightPos.y = OVERLAY_TOP_TEXT_Y;
 
     scratch.topMetricsPos.x = OVERLAY_EDGE_MARGIN_PX;

--- a/src/overlay/sampling/FpsSampler.ts
+++ b/src/overlay/sampling/FpsSampler.ts
@@ -36,10 +36,12 @@ export class FpsSampler {
         if (this.#lastSampleMs === null) {
             this.#lastSampleMs = now;
             this.#smoothedFps = this.#targetFps;
+
             return;
         }
 
         const deltaSeconds = (now - this.#lastSampleMs) / MS_PER_SECOND;
+
         this.#lastSampleMs = now;
 
         if (deltaSeconds <= 0) {
@@ -51,6 +53,7 @@ export class FpsSampler {
         }
 
         const instantFps = 1 / deltaSeconds;
+
         this.#smoothedFps += (instantFps - this.#smoothedFps) * FPS_SMOOTHING;
     }
 }

--- a/src/overlay/sampling/TimingSampler.ts
+++ b/src/overlay/sampling/TimingSampler.ts
@@ -71,42 +71,6 @@ export class TimingSampler {
     }
 
     /**
-     * Most recent primitive pipeline overflow events for the frame.
-     *
-     * @returns Primitive overflow count.
-     */
-    get primitiveOverflowCount(): number {
-        return this.#primitiveOverflowCount;
-    }
-
-    /**
-     * Most recent sprite pipeline overflow events for the frame.
-     *
-     * @returns Sprite overflow count.
-     */
-    get spriteOverflowCount(): number {
-        return this.#spriteOverflowCount;
-    }
-
-    /**
-     * Most recent primitive vertices batched for GPU submission.
-     *
-     * @returns Primitive submitted vertex count.
-     */
-    get primitiveSubmittedVertices(): number {
-        return this.#primitiveSubmittedVertices;
-    }
-
-    /**
-     * Most recent sprite vertices batched for GPU submission.
-     *
-     * @returns Sprite submitted vertex count.
-     */
-    get spriteSubmittedVertices(): number {
-        return this.#spriteSubmittedVertices;
-    }
-
-    /**
      * Ingests one frame-timing snapshot.
      *
      * @param sample - Current-frame timing values from BTAPI.
@@ -142,8 +106,8 @@ export class TimingSampler {
      */
     formatRendererDiagnosticsLabel(): string {
         return (
-            `Prim ${this.#primitiveSubmittedVertices}v ov: ${this.#primitiveOverflowCount} | ` +
-            `Spr ${this.#spriteSubmittedVertices}v ov: ${this.#spriteOverflowCount}`
+            `Prim ${this.#primitiveSubmittedVertices}v ov ${this.#primitiveOverflowCount}|` +
+            `Spr ${this.#spriteSubmittedVertices}v ov ${this.#spriteOverflowCount}`
         );
     }
 }

--- a/src/overlay/testFixtures.ts
+++ b/src/overlay/testFixtures.ts
@@ -25,8 +25,8 @@ export type BitmapTextCall = {
  */
 export function createMockRenderer(): OverlayRenderer & {
     drawBitmapText: ReturnType<typeof vi.fn>;
-    drawLabel: ReturnType<typeof vi.fn>;
-    drawLabelOnTop: ReturnType<typeof vi.fn>;
+    drawLabel: ReturnType<typeof vi.fn> & { posSnapshots: Vector2i[] };
+    drawLabelOnTop: ReturnType<typeof vi.fn> & { posSnapshots: Vector2i[] };
     drawPixel: ReturnType<typeof vi.fn>;
     drawRectFill: ReturnType<typeof vi.fn>;
     drawBarFill: ReturnType<typeof vi.fn> & { rectSnapshots: Rect2i[] };
@@ -34,16 +34,34 @@ export function createMockRenderer(): OverlayRenderer & {
 } {
     const barFillSnapshots: Rect2i[] = [];
     const barFillOnTopSnapshots: Rect2i[] = [];
+    const labelPosSnapshots: Vector2i[] = [];
+    const labelOnTopPosSnapshots: Vector2i[] = [];
+
     const drawBarFill = vi.fn((rect: Rect2i) => {
         barFillSnapshots.push(new Rect2i(rect.x, rect.y, rect.width, rect.height));
     }) as ReturnType<typeof vi.fn> & { rectSnapshots: Rect2i[] };
+
     drawBarFill.rectSnapshots = barFillSnapshots;
+
     const drawBarFillOnTop = vi.fn((rect: Rect2i) => {
         barFillOnTopSnapshots.push(new Rect2i(rect.x, rect.y, rect.width, rect.height));
     }) as ReturnType<typeof vi.fn> & { rectSnapshots: Rect2i[] };
+
     drawBarFillOnTop.rectSnapshots = barFillOnTopSnapshots;
-    const drawLabel = vi.fn();
-    const drawLabelOnTop = vi.fn();
+
+    // Positions are snapshotted because draw helpers reuse scratch Vector2i instances.
+    const drawLabel = vi.fn((_font: unknown, pos: Vector2i) => {
+        labelPosSnapshots.push(new Vector2i(pos.x, pos.y));
+    }) as ReturnType<typeof vi.fn> & { posSnapshots: Vector2i[] };
+
+    drawLabel.posSnapshots = labelPosSnapshots;
+
+    const drawLabelOnTop = vi.fn((_font: unknown, pos: Vector2i) => {
+        labelOnTopPosSnapshots.push(new Vector2i(pos.x, pos.y));
+    }) as ReturnType<typeof vi.fn> & { posSnapshots: Vector2i[] };
+
+    drawLabelOnTop.posSnapshots = labelOnTopPosSnapshots;
+
     const drawPixel = vi.fn();
     const drawRect = vi.fn();
 
@@ -69,8 +87,8 @@ export function createMockRenderer(): OverlayRenderer & {
  * @returns Parsed draw calls in invocation order.
  */
 export function getBitmapTextCalls(renderer: ReturnType<typeof createMockRenderer>): BitmapTextCall[] {
-    return renderer.drawLabel.mock.calls.map((call) => ({
-        pos: call[1] as Vector2i,
+    return renderer.drawLabel.mock.calls.map((call, callIndex) => ({
+        pos: renderer.drawLabel.posSnapshots.at(callIndex) as Vector2i,
         text: call[2] as string,
         paletteOffset: (call[3] as number | undefined) ?? 0,
     }));
@@ -83,8 +101,8 @@ export function getBitmapTextCalls(renderer: ReturnType<typeof createMockRendere
  * @returns Parsed draw calls in invocation order.
  */
 export function getLabelOnTopCalls(renderer: ReturnType<typeof createMockRenderer>): BitmapTextCall[] {
-    return renderer.drawLabelOnTop.mock.calls.map((call) => ({
-        pos: call[1] as Vector2i,
+    return renderer.drawLabelOnTop.mock.calls.map((call, callIndex) => ({
+        pos: renderer.drawLabelOnTop.posSnapshots.at(callIndex) as Vector2i,
         text: call[2] as string,
         paletteOffset: (call[3] as number | undefined) ?? 0,
     }));

--- a/src/overlay/testFixtures.ts
+++ b/src/overlay/testFixtures.ts
@@ -19,6 +19,26 @@ export type BitmapTextCall = {
 };
 
 /**
+ * Creates a `vi.fn` mock paired with an array of derived snapshots, one per call.
+ *
+ * Draw helpers reuse scratch `Rect2i`/`Vector2i` instances, so recording the raw call
+ * arguments would capture their final mutated state instead of the value at call time.
+ *
+ * @param snapshot - Derives a defensive-copy snapshot from a call's arguments.
+ * @returns The mock function and the array its snapshots are pushed onto, in call order.
+ */
+function createSnapshotMock<TArgs extends unknown[], TSnapshot>(
+    snapshot: (...args: TArgs) => TSnapshot,
+): { mock: ReturnType<typeof vi.fn>; snapshots: TSnapshot[] } {
+    const snapshots: TSnapshot[] = [];
+    const mock = vi.fn((...args: TArgs) => {
+        snapshots.push(snapshot(...args));
+    });
+
+    return { mock, snapshots };
+}
+
+/**
  * Minimal renderer stub for {@link Overlay.updateAndRender}.
  *
  * @returns Renderer with spied camera, bar fills, and bitmap text draws.
@@ -32,35 +52,26 @@ export function createMockRenderer(): OverlayRenderer & {
     drawBarFill: ReturnType<typeof vi.fn> & { rectSnapshots: Rect2i[] };
     drawBarFillOnTop: ReturnType<typeof vi.fn> & { rectSnapshots: Rect2i[] };
 } {
-    const barFillSnapshots: Rect2i[] = [];
-    const barFillOnTopSnapshots: Rect2i[] = [];
-    const labelPosSnapshots: Vector2i[] = [];
-    const labelOnTopPosSnapshots: Vector2i[] = [];
+    const barFillMock = createSnapshotMock((rect: Rect2i) => new Rect2i(rect.x, rect.y, rect.width, rect.height));
+    const drawBarFill = barFillMock.mock as ReturnType<typeof vi.fn> & { rectSnapshots: Rect2i[] };
 
-    const drawBarFill = vi.fn((rect: Rect2i) => {
-        barFillSnapshots.push(new Rect2i(rect.x, rect.y, rect.width, rect.height));
-    }) as ReturnType<typeof vi.fn> & { rectSnapshots: Rect2i[] };
+    drawBarFill.rectSnapshots = barFillMock.snapshots;
 
-    drawBarFill.rectSnapshots = barFillSnapshots;
+    const barFillOnTopMock = createSnapshotMock((rect: Rect2i) => new Rect2i(rect.x, rect.y, rect.width, rect.height));
+    const drawBarFillOnTop = barFillOnTopMock.mock as ReturnType<typeof vi.fn> & { rectSnapshots: Rect2i[] };
 
-    const drawBarFillOnTop = vi.fn((rect: Rect2i) => {
-        barFillOnTopSnapshots.push(new Rect2i(rect.x, rect.y, rect.width, rect.height));
-    }) as ReturnType<typeof vi.fn> & { rectSnapshots: Rect2i[] };
-
-    drawBarFillOnTop.rectSnapshots = barFillOnTopSnapshots;
+    drawBarFillOnTop.rectSnapshots = barFillOnTopMock.snapshots;
 
     // Positions are snapshotted because draw helpers reuse scratch Vector2i instances.
-    const drawLabel = vi.fn((_font: unknown, pos: Vector2i) => {
-        labelPosSnapshots.push(new Vector2i(pos.x, pos.y));
-    }) as ReturnType<typeof vi.fn> & { posSnapshots: Vector2i[] };
+    const labelMock = createSnapshotMock((_font: unknown, pos: Vector2i) => new Vector2i(pos.x, pos.y));
+    const drawLabel = labelMock.mock as ReturnType<typeof vi.fn> & { posSnapshots: Vector2i[] };
 
-    drawLabel.posSnapshots = labelPosSnapshots;
+    drawLabel.posSnapshots = labelMock.snapshots;
 
-    const drawLabelOnTop = vi.fn((_font: unknown, pos: Vector2i) => {
-        labelOnTopPosSnapshots.push(new Vector2i(pos.x, pos.y));
-    }) as ReturnType<typeof vi.fn> & { posSnapshots: Vector2i[] };
+    const labelOnTopMock = createSnapshotMock((_font: unknown, pos: Vector2i) => new Vector2i(pos.x, pos.y));
+    const drawLabelOnTop = labelOnTopMock.mock as ReturnType<typeof vi.fn> & { posSnapshots: Vector2i[] };
 
-    drawLabelOnTop.posSnapshots = labelOnTopPosSnapshots;
+    drawLabelOnTop.posSnapshots = labelOnTopMock.snapshots;
 
     const drawPixel = vi.fn();
     const drawRect = vi.fn();


### PR DESCRIPTION
Replace literal " | " text separators in engine-composed overlay rows (backend/resolution, frame metrics, timing, renderer diagnostics, audio meter voice readout) with 1px full-row-height dividers filled in the gap palette index, matching the row-gap color instead of drawing as glyphs.

Widen the overlay edge margin and divider gap to 7px (from 3px/4px) for more breathing room around text and chrome. Drop the now-redundant hint cluster separator helper on OverlayBars and unused overflow/vertex getters on TimingSampler. Extend the overlay mock renderer to snapshot drawLabel/drawLabelOnTop positions since the new divider helper reuses a scratch Vector2i across calls.

Update docs/api-overlay.md and docs/guide-overlay.md to describe the divider rendering and new spacing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated the overlay HUD label rendering so engine-composed `|` separators no longer draw as glyph text, but instead render as 1px-wide, full-row vertical divider fills (gap palette) driven by `overlayStyle.gapPaletteIndex` across engine rows (backend/resolution, frame metrics, timing, renderer diagnostics) and the audio meter voices/steal/drop readout. Increased overlay chrome spacing by raising `OVERLAY_EDGE_MARGIN_PX` and the in-row `OVERLAY_DIVIDER_GAP_PX` to 7px, and added right-aligned support for divider-based labels via new divider width/position helpers.

Cleaned up overlay internals by removing the redundant hint-cluster separator helper from `OverlayBars` and deleting unused `TimingSampler` overflow/submitted-vertex getters (while aligning renderer-diagnostics label formatting with the new divider style). Extended the overlay mock renderer and test fixtures to snapshot `drawLabel`/`drawLabelOnTop` positions because the divider label drawer reuses a scratch `Vector2i`, and updated label/layout/audio-meter tests to assert correct segmenting, divider counts/geometry, palette index usage, and draw ordering. Audio meter layout constants were adjusted (bar width reduced to 3px, text gap increased to 7px), and the audio meter tests now validate readout separator dividers; follow-up changes restore the dropped audio meter track rectangle fill and update `AudioMeter#drawBars` JSDoc.

Documentation updates were added to `docs/api-overlay.md` and `docs/guide-overlay.md` to describe the new divider rendering and spacing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->