### PR TITLE
fix(overlay): pad numeric overlay fields to stop divider drift

### DIFF
--- a/src/overlay/Overlay.test.ts
+++ b/src/overlay/Overlay.test.ts
@@ -257,7 +257,8 @@ describe('Overlay', () => {
 
         expect(calls[3]).toMatchObject({
             pos: new Vector2i(OVERLAY_EDGE_MARGIN_PX, metricsY),
-            text: expect.stringMatching(/^Present\s+\d+ FPS$/),
+            // Present FPS pads to OVERLAY_FPS_FIELD_WIDTH (3): "60" -> " 60", plus the literal template space.
+            text: expect.stringMatching(/^Present {2}\d+ FPS$/),
             paletteOffset: 1,
         });
 
@@ -267,12 +268,14 @@ describe('Overlay', () => {
 
         expect(calls[6]).toMatchObject({
             pos: new Vector2i(OVERLAY_EDGE_MARGIN_PX, timingY),
-            text: expect.stringMatching(/^Frame\s+\d+\.\dms$/),
+            // Frame ms pads to OVERLAY_MS_FIELD_WIDTH (4): "0.0" -> " 0.0", plus the literal template space.
+            text: expect.stringMatching(/^Frame {2}\d+\.\dms$/),
             paletteOffset: 1,
         });
 
-        expect(calls[7]?.text).toMatch(/^update\(\)\s+\d+\.\dms\s*$/);
-        expect(calls[8]?.text).toMatch(/^render\(\)\s+\d+\.\dms$/);
+        // update() ms has the same 2-space lead-in, plus a 2-space trailing gap reserved for the absent xN suffix.
+        expect(calls[7]?.text).toMatch(/^update\(\) {2}\d+\.\dms {2}$/);
+        expect(calls[8]?.text).toMatch(/^render\(\) {2}\d+\.\dms$/);
         expect(renderer.drawBarFillOnTop).toHaveBeenCalled();
 
         expect(renderer.drawBarFillOnTop.rectSnapshots[0]).toMatchObject({

--- a/src/overlay/Overlay.test.ts
+++ b/src/overlay/Overlay.test.ts
@@ -257,7 +257,7 @@ describe('Overlay', () => {
 
         expect(calls[3]).toMatchObject({
             pos: new Vector2i(OVERLAY_EDGE_MARGIN_PX, metricsY),
-            text: expect.stringMatching(/^Present \d+ FPS$/),
+            text: expect.stringMatching(/^Present\s+\d+ FPS$/),
             paletteOffset: 1,
         });
 
@@ -267,12 +267,12 @@ describe('Overlay', () => {
 
         expect(calls[6]).toMatchObject({
             pos: new Vector2i(OVERLAY_EDGE_MARGIN_PX, timingY),
-            text: expect.stringMatching(/^Frame \d+\.\dms$/),
+            text: expect.stringMatching(/^Frame\s+\d+\.\dms$/),
             paletteOffset: 1,
         });
 
-        expect(calls[7]?.text).toMatch(/^update\(\) \d+\.\dms$/);
-        expect(calls[8]?.text).toMatch(/^render\(\) \d+\.\dms$/);
+        expect(calls[7]?.text).toMatch(/^update\(\)\s+\d+\.\dms\s*$/);
+        expect(calls[8]?.text).toMatch(/^render\(\)\s+\d+\.\dms$/);
         expect(renderer.drawBarFillOnTop).toHaveBeenCalled();
 
         expect(renderer.drawBarFillOnTop.rectSnapshots[0]).toMatchObject({
@@ -363,9 +363,9 @@ describe('Overlay', () => {
         const texts = getBitmapTextCalls(renderer).map((call) => call.text);
 
         expect(texts).toContain('Draw Calls 42');
-        expect(texts).toContain('Frame 8.3ms');
-        expect(texts).toContain('update() 1.5msx3');
-        expect(texts).toContain('render() 3.8ms');
+        expect(texts).toContain('Frame  8.3ms');
+        expect(texts).toContain('update()  1.5msx3');
+        expect(texts).toContain('render()  3.8ms');
     });
 
     it('skips draw calls when body is hidden and the toggle hint is disabled', () => {

--- a/src/overlay/Overlay.ts
+++ b/src/overlay/Overlay.ts
@@ -22,9 +22,16 @@ import { DEFAULT_AUDIO_METER_HEIGHT } from './audio-meter/constants';
 import type { AudioMeterDrawStyle } from './audio-meter/style';
 import { resolveAudioMeterStyle } from './audio-meter/style';
 import { OverlayBars } from './bars/Bars';
-import { DEFAULT_IDX_BG, DEFAULT_IDX_TEXT } from './constants';
+import {
+    DEFAULT_IDX_BG,
+    DEFAULT_IDX_TEXT,
+    OVERLAY_FPS_FIELD_WIDTH,
+    OVERLAY_MS_FIELD_WIDTH,
+    OVERLAY_UPDATE_STEPS_FIELD_WIDTH,
+} from './constants';
 import { OVERLAY_TOGGLE_KEY_CODE } from './input/constants';
 import { Toggle } from './input/Toggle';
+import { padOverlayField } from './labels';
 import { buildOverlayLayoutPlan, createDefaultLayoutConfig, createOverlayLayoutPlanScratch } from './layout/layoutPlan';
 import type { OverlayLayout, OverlayLayoutConfig, OverlayLayoutPlan } from './layout/types';
 import type { OverlayRenderer } from './OverlayDrawTarget';
@@ -87,6 +94,16 @@ function createTimingChart(
  */
 function createAudioMeter(isEnabled: boolean): AudioMeter {
     return new AudioMeter(isEnabled);
+}
+
+/**
+ * Formats a millisecond timing value to one decimal place, padded to the fixed overlay field width.
+ *
+ * @param valueMs - Timing value in milliseconds.
+ * @returns Padded `X.X` text for the `Frame`/`update()`/`render()` metrics row.
+ */
+function formatOverlayMsField(valueMs: number): string {
+    return padOverlayField(valueMs.toFixed(1), OVERLAY_MS_FIELD_WIDTH);
 }
 
 /**
@@ -524,13 +541,18 @@ export class Overlay {
         const paletteGrid = layoutConfig.paletteGrid ?? DEFAULT_PALETTE_GRID;
 
         if (isBodyVisible) {
-            const updateStepSuffix = this.#timing.updateSteps > 1 ? `x${this.#timing.updateSteps}` : '';
+            const presentFps = padOverlayField(String(this.#fps.measuredFps), OVERLAY_FPS_FIELD_WIDTH);
+            const frameMs = formatOverlayMsField(this.#timing.frameMs);
+            const updateMs = formatOverlayMsField(this.#timing.updateMs);
+            const renderMs = formatOverlayMsField(this.#timing.renderMs);
+            const updateStepSuffix = padOverlayField(
+                this.#timing.updateSteps > 1 ? `x${this.#timing.updateSteps}` : '',
+                OVERLAY_UPDATE_STEPS_FIELD_WIDTH,
+            );
 
-            topMetricsLabel = `Present ${this.#fps.measuredFps} FPS|Target ${this.#targetFps} FPS|Draw Calls ${this.#timing.drawCalls}`;
+            topMetricsLabel = `Present ${presentFps} FPS|Target ${this.#targetFps} FPS|Draw Calls ${this.#timing.drawCalls}`;
 
-            topTimingLabel =
-                `Frame ${this.#timing.frameMs.toFixed(1)}ms|update() ${this.#timing.updateMs.toFixed(1)}ms${updateStepSuffix}|` +
-                `render() ${this.#timing.renderMs.toFixed(1)}ms`;
+            topTimingLabel = `Frame ${frameMs}ms|update() ${updateMs}ms${updateStepSuffix}|` + `render() ${renderMs}ms`;
 
             if (this.#isOverlayRendererDiagnosticsBarEnabled) {
                 rendererDiagnosticsLabel = this.#timing.formatRendererDiagnosticsLabel();

--- a/src/overlay/constants.ts
+++ b/src/overlay/constants.ts
@@ -9,3 +9,18 @@ export const SYSTEM_CHAR_ADVANCE = 6;
 
 /** Visual space in pixels between an in-row divider line and the text on each side. */
 export const OVERLAY_DIVIDER_GAP_PX = 7;
+
+/** Fixed character width for the present-FPS metrics field (covers up to 3 digits). */
+export const OVERLAY_FPS_FIELD_WIDTH = 3;
+
+/** Fixed character width for millisecond timing fields (covers up to `99.9`). */
+export const OVERLAY_MS_FIELD_WIDTH = 4;
+
+/** Fixed character width for the update-step suffix (for example `x3`), including when absent. */
+export const OVERLAY_UPDATE_STEPS_FIELD_WIDTH = 2;
+
+/** Fixed character width for renderer diagnostics vertex counts (pipelines cap at 50k vertices/frame). */
+export const OVERLAY_DIAGNOSTICS_VERTEX_FIELD_WIDTH = 5;
+
+/** Fixed character width for renderer diagnostics overflow counts. */
+export const OVERLAY_DIAGNOSTICS_OVERFLOW_FIELD_WIDTH = 3;

--- a/src/overlay/labels.test.ts
+++ b/src/overlay/labels.test.ts
@@ -3,8 +3,29 @@ import { describe, expect, it } from 'vitest';
 import { Rect2i } from '../utils/Rect2i';
 import { Vector2i } from '../utils/Vector2i';
 import { OVERLAY_DIVIDER_GAP_PX, SYSTEM_CHAR_ADVANCE } from './constants';
-import { drawOverlayLabelWithDividers, overlayDividerLabelWidth, resolveOverlayTopLeftLabel } from './labels';
+import {
+    drawOverlayLabelWithDividers,
+    overlayDividerLabelWidth,
+    padOverlayField,
+    resolveOverlayTopLeftLabel,
+} from './labels';
 import { createMockRenderer, getBitmapTextCalls, mockFont } from './testFixtures';
+
+describe('padOverlayField', () => {
+    it('left-pads shorter text with spaces to reach the fixed width', () => {
+        expect(padOverlayField('8.3', 4)).toBe(' 8.3');
+        expect(padOverlayField('60', 3)).toBe(' 60');
+    });
+
+    it('reserves the fixed width even for an empty field', () => {
+        expect(padOverlayField('', 2)).toBe('  ');
+    });
+
+    it('leaves text unchanged once it already meets or exceeds the fixed width', () => {
+        expect(padOverlayField('123.4', 4)).toBe('123.4');
+        expect(padOverlayField('x3', 2)).toBe('x3');
+    });
+});
 
 describe('resolveOverlayTopLeftLabel', () => {
     it('formats registry-style page titles without a BLIT386 prefix', () => {

--- a/src/overlay/labels.ts
+++ b/src/overlay/labels.ts
@@ -24,6 +24,24 @@ const dividerScratch = new Rect2i(0, 0, 1, 0);
 const segmentScratch = new Vector2i(0, 0);
 
 /**
+ * Left-pads an already-formatted numeric segment with spaces to a fixed column width.
+ *
+ * Engine-composed rows join several of these segments with `|` dividers positioned by
+ * cumulative character count (see {@link drawOverlayLabelWithDividers}). Without a fixed width,
+ * a value's digit count changing from one frame to the next (for example `8.3` becoming `16.7`,
+ * or an update-step suffix like `x3` appearing and disappearing) shifts every later segment on
+ * the row. Padding every such field to the same width up front keeps divider and segment
+ * positions stable regardless of the underlying value.
+ *
+ * @param text - Already-formatted field text, e.g. `'8.3'`, `'60'`, or `'x3'` (may be empty).
+ * @param width - Fixed column width in characters.
+ * @returns `text` padded with leading spaces to at least `width` characters.
+ */
+export function padOverlayField(text: string, width: number): string {
+    return text.padStart(width, ' ');
+}
+
+/**
  * Turns the browser page title into a short top-left overlay label.
  *
  * @param pageTitle - Browser document title when available.

--- a/src/overlay/sampling/TimingSampler.ts
+++ b/src/overlay/sampling/TimingSampler.ts
@@ -1,3 +1,5 @@
+import { OVERLAY_DIAGNOSTICS_OVERFLOW_FIELD_WIDTH, OVERLAY_DIAGNOSTICS_VERTEX_FIELD_WIDTH } from '../constants';
+import { padOverlayField } from '../labels';
 import type { OverlayTimingSnapshot } from '../types';
 import { FPS_SMOOTHING } from './constants';
 
@@ -105,9 +107,23 @@ export class TimingSampler {
      * @returns Single-line GPU batch summary for the diagnostics bar.
      */
     formatRendererDiagnosticsLabel(): string {
-        return (
-            `Prim ${this.#primitiveSubmittedVertices}v ov ${this.#primitiveOverflowCount}|` +
-            `Spr ${this.#spriteSubmittedVertices}v ov ${this.#spriteOverflowCount}`
-        );
+        const primStats = this.#formatBatchStats(this.#primitiveSubmittedVertices, this.#primitiveOverflowCount);
+        const sprStats = this.#formatBatchStats(this.#spriteSubmittedVertices, this.#spriteOverflowCount);
+
+        return `Prim ${primStats}|Spr ${sprStats}`;
+    }
+
+    /**
+     * Pads one pipeline's vertex and overflow counts to their fixed field widths.
+     *
+     * @param vertices - Submitted vertex count for the pipeline.
+     * @param overflow - Overflow (dropped-batch) count for the pipeline.
+     * @returns Formatted `Xv ov Y` segment with fixed-width padded fields.
+     */
+    #formatBatchStats(vertices: number, overflow: number): string {
+        const paddedVertices = padOverlayField(String(vertices), OVERLAY_DIAGNOSTICS_VERTEX_FIELD_WIDTH);
+        const paddedOverflow = padOverlayField(String(overflow), OVERLAY_DIAGNOSTICS_OVERFLOW_FIELD_WIDTH);
+
+        return `${paddedVertices}v ov ${paddedOverflow}`;
     }
 }


### PR DESCRIPTION
Present FPS, Frame/update()/render() ms, and the GPU diagnostics vertex/overflow counts render with a digit count that can change between frames (8.3 -> 16.7, the update() xN suffix appearing or disappearing). Since divider and segment positions are computed by cumulative character count, a shorter or longer value shifted every `|` divider and segment after it on the row.

Add padOverlayField() to left-pad each formatted field to a fixed character width before composing the `|`-delimited label strings, plus per-field width constants (FPS, ms, update-step suffix, and renderer diagnostics vertex/overflow). Apply in Overlay#drawFrame and TimingSampler.formatRendererDiagnosticsLabel, deduplicating the repeated padding calls into formatOverlayMsField() and TimingSampler#formatBatchStats() respectively.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fix overlay divider drift by padding variable-width numeric fields to fixed character widths (FPS, frame/update/render milliseconds, the update-step suffix, and renderer diagnostics vertex/overflow counts).
- Add shared overlay field-width constants and a `padOverlayField()` utility for consistent HUD text alignment.
- Apply fixed-width formatting in `Overlay#drawFrame` via a new `formatOverlayMsField()` helper, and in `TimingSampler.formatRendererDiagnosticsLabel()` via padded per-batch stat formatting (`#formatBatchStats`).
- Consolidate and centralize padding/formatting logic for milliseconds and batch-stat diagnostics.
- Update overlay tests to assert exact fixed-width spacing and add direct coverage for `padOverlayField()`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->