### PR TITLE
docs: document Safari Low Power Mode effects and rendering behavior

### DIFF
--- a/docs/api-browser-support.md
+++ b/docs/api-browser-support.md
@@ -52,6 +52,22 @@ periodically. This is why `AudioClip.load()` accepts an ordered fallback list (f
 
 </Callout>
 
+## Safari render throttling (macOS Low Power Mode)
+
+macOS Low Power Mode makes Safari/WebKit halve its `requestAnimationFrame` dispatch rate to about `30 Hz`, even on a
+`120 Hz` display and even when the page's JavaScript is nowhere near the frame budget. This is a documented WebKit
+power-saving policy – see [WebKit bug 168837](https://bugs.webkit.org/show_bug.cgi?id=168837), "Throttle
+requestAnimationFrame to 30fps in low power mode" – not a web standard, and a page cannot opt out of it. Chromium
+(Chrome/Edge) and Gecko (Firefox) do not tie their `requestAnimationFrame` cadence to the OS power state this way; both
+keep dispatching at the display's native rate regardless of Low Power Mode.
+
+BLIT386's `render()` runs on `requestAnimationFrame`, so this halves the render rate while `update()` keeps advancing at
+`targetFPS` through the fixed-timestep accumulator – see
+[Multiple update() steps per render frame](api-game-loop.md#multiple-update-steps-per-render-frame). Game logic stays
+correct; only the visible frame rate drops, and the overlay's frame-metrics row shows the resulting `x2` (or higher)
+suffix on `update()`. Turning off Low Power Mode restores a clean `60 fps` ceiling on WebKit (capped by its own "prefer
+page rendering updates near 60 fps" policy, not the display's full refresh rate).
+
 <PageChangelog page="api/browser-support" />
 
 ## See also
@@ -61,4 +77,5 @@ periodically. This is why `AudioClip.load()` accepts an ordered fallback list (f
   <Card title="API: Audio" href="/docs/api/audio">Autoplay-unlock gesture requirement, independent of backend.</Card>
   <Card title="Loading Audio Clips" href="/docs/api/audio#loading">AudioClip.load(), fallback lists, and progress reporting.</Card>
   <Card title="Software Fallback Smoke Matrix" href="/docs/performance/smoke-matrix">Manual Canvas 2D fallback checklist.</Card>
+  <Card title="Game Loop" href="/docs/api/game-loop">Fixed-timestep accumulator and the update() xN overlay suffix.</Card>
 </Cards>

--- a/docs/api-browser-support.md
+++ b/docs/api-browser-support.md
@@ -55,11 +55,13 @@ periodically. This is why `AudioClip.load()` accepts an ordered fallback list (f
 ## Safari render throttling (macOS Low Power Mode)
 
 macOS Low Power Mode makes Safari/WebKit halve its `requestAnimationFrame` dispatch rate to about `30 Hz`, even on a
-`120 Hz` display and even when the page's JavaScript is nowhere near the frame budget. This is a documented WebKit
-power-saving policy – see [WebKit bug 168837](https://bugs.webkit.org/show_bug.cgi?id=168837), "Throttle
-requestAnimationFrame to 30fps in low power mode" – not a web standard, and a page cannot opt out of it. Chromium
-(Chrome/Edge) and Gecko (Firefox) do not tie their `requestAnimationFrame` cadence to the OS power state this way; both
-keep dispatching at the display's native rate regardless of Low Power Mode.
+`120 Hz` display and even when the page's JavaScript is nowhere near the frame budget. WebKit first shipped this
+throttle for iOS – see [WebKit bug 168837](https://bugs.webkit.org/show_bug.cgi?id=168837), "[iOS] Throttle
+requestAnimationFrame to 30fps in low power mode" – and the same WebKit power-saving policy applies on macOS once Apple
+added Low Power Mode there in macOS `12` (2021), where it is reproducible on Apple silicon laptops. It is not a web
+standard, and a page cannot opt out of it. Chromium (Chrome/Edge) and Gecko (Firefox) do not tie their
+`requestAnimationFrame` cadence to the OS power state this way; both keep dispatching at the display's native rate
+regardless of Low Power Mode.
 
 BLIT386's `render()` runs on `requestAnimationFrame`, so this halves the render rate while `update()` keeps advancing at
 `targetFPS` through the fixed-timestep accumulator – see

--- a/docs/api-game-loop.md
+++ b/docs/api-game-loop.md
@@ -42,6 +42,25 @@ BT.assignTag('Round start'); // timing chart event tag at current tick (requires
 
 <DemoEmbed demo="009-animation" title="BLIT386 animation and timing demo" />
 
+## Multiple update() steps per render frame
+
+The fixed step runs through an accumulator: each render frame adds the elapsed wall-clock time to a running total, then
+drains as many `updateInterval`-sized (`1000 / targetFPS`) chunks as fit, capped at 8 steps per frame to avoid a
+spiral-of-death catch-up burst after a long pause (a backgrounded tab, a breakpoint, a slow asset load). Ordinarily that
+accumulator drains exactly one chunk per render frame, so `update()` and `render()` alternate 1:1.
+
+When `render()` falls behind `targetFPS` – a throttled background tab, a slow device, or a browser power-saving cap on
+`requestAnimationFrame` – the accumulator has more than one `updateInterval` worth of time to drain before the next
+render, so multiple `update()` calls run in a row ahead of that single `render()` call. Game logic still advances at the
+correct rate (`BT.ticks` still increments once per fixed step, `BT.deltaSeconds` is unchanged); only the render cadence
+drops. The engine overlay's frame-metrics row surfaces this as an `xN` suffix on `update()` – see
+[Top row 3 (left)](api-overlay.md#top-row-3-left) in the Overlay API docs.
+
+A concrete real-world trigger: macOS Low Power Mode makes Safari/WebKit halve its `requestAnimationFrame` dispatch rate
+to about `30 Hz`, unrelated to script performance or display refresh rate. See
+[Safari render throttling](api-browser-support.md#safari-render-throttling-macos-low-power-mode) in Browser Support for
+the WebKit reference and why other engines are unaffected.
+
 ## Timer
 
 <Since symbol="Timer" />
@@ -78,4 +97,5 @@ need a specific snapshot; the default is the engine tick counter.
   <Card title="API: Core" href="/docs/api/core">Bootstrap, init, default configuration.</Card>
   <Card title="API: Overlay" href="/docs/api/overlay">Present FPS, timing chart, event tags.</Card>
   <Card title="API: Camera" href="/docs/api/camera">Global pixel offset for draw calls.</Card>
+  <Card title="Browser Support" href="/docs/api/browser-support">Safari's Low Power Mode requestAnimationFrame throttling.</Card>
 </Cards>

--- a/docs/api-game-loop.md
+++ b/docs/api-game-loop.md
@@ -61,6 +61,15 @@ to about `30 Hz`, unrelated to script performance or display refresh rate. See
 [Safari render throttling](api-browser-support.md#safari-render-throttling-macos-low-power-mode) in Browser Support for
 the WebKit reference and why other engines are unaffected.
 
+## Render frames with zero update() steps
+
+The opposite direction happens too: on a high refresh-rate display (120 Hz or higher) with `targetFPS: 60`,
+`requestAnimationFrame` calls `render()` more often than the accumulator drains a full `updateInterval` chunk, so a
+sizeable fraction of render frames have zero preceding `update()` calls that frame. This is normal, not a dropped frame
+– `BT.ticks` and any state written during the last `update()` (including the camera offset from `BT.cameraSet()`, see
+[API: Camera](api-camera.md#camera-persists-across-zero-update-frames)) still reflect the last completed tick, so
+`render()` draws the same game state twice in a row rather than resetting to defaults.
+
 ## Timer
 
 <Since symbol="Timer" />

--- a/docs/api-game-loop.md
+++ b/docs/api-game-loop.md
@@ -45,9 +45,15 @@ BT.assignTag('Round start'); // timing chart event tag at current tick (requires
 ## Multiple update() steps per render frame
 
 The fixed step runs through an accumulator: each render frame adds the elapsed wall-clock time to a running total, then
-drains as many `updateInterval`-sized (`1000 / targetFPS`) chunks as fit, capped at 8 steps per frame to avoid a
-spiral-of-death catch-up burst after a long pause (a backgrounded tab, a breakpoint, a slow asset load). Ordinarily that
-accumulator drains exactly one chunk per render frame, so `update()` and `render()` alternate 1:1.
+drains as many `updateInterval`-sized (`1000 / targetFPS`) chunks as fit. Before draining, the accumulator is clamped to
+`8 × updateInterval` (`MAX_STEPS`), so at most 8 `update()` calls run per frame – a guard against a spiral-of-death
+catch-up burst after a long pause (a backgrounded tab, a breakpoint, a slow asset load). When that cap is hit, only the
+executed steps are subtracted from the accumulator and the excess wall-clock time is discarded: `BT.ticks` still
+advances once per executed `update()`, but a long pause skips the missed simulation time rather than fully catching up
+on it. When render and update cadences are close – a `60 Hz` display with `targetFPS: 60` – the accumulator typically
+drains exactly one chunk per render frame, so `update()` and `render()` alternate 1:1; when `render()` runs faster than
+`targetFPS`, some frames drain zero chunks (see
+[Render frames with zero update() steps](#render-frames-with-zero-update-steps) below).
 
 When `render()` falls behind `targetFPS` – a throttled background tab, a slow device, or a browser power-saving cap on
 `requestAnimationFrame` – the accumulator has more than one `updateInterval` worth of time to drain before the next

--- a/docs/api-overlay.md
+++ b/docs/api-overlay.md
@@ -142,6 +142,10 @@ right screen edges. Custom rows are user content, so a `|` in their text stays a
 ### Top row 3 (left)
 
 - `Frame: Xms | update(): Yms | render(): Zms` (shows `xN` on `update()` when multiple fixed updates ran this frame)
+- `N` is the number of fixed `update()` steps the accumulator drained for that render frame – normally `1`; higher when
+  `render()` falls behind `targetFPS` (a throttled background tab, a slow device, or a power-saving cap on
+  `requestAnimationFrame`). Game logic stays time-correct either way; see
+  [Multiple update() steps per render frame](api-game-loop.md#multiple-update-steps-per-render-frame) in Game Loop.
 
 ### Bottom band
 

--- a/docs/guide-overlay.md
+++ b/docs/guide-overlay.md
@@ -114,6 +114,14 @@ BT.systemPrint(new Vector2i(8, 8), palette.getNamed('hud_label'), 'Custom row');
 
 Use `BT.deltaSeconds` / `BT.ticks` for gameplay timing; use present FPS to spot GPU or draw-call bottlenecks.
 
+## Stable column widths
+
+The present-FPS, timing (`Frame`/`update()`/`render()`), and GPU diagnostics rows pad their numeric fields to a fixed
+character width before drawing. Without this, a value's digit count changing between frames (for example `8.3` becoming
+`16.7`, or the `update()` step suffix like `x3` appearing only when the fixed-update loop runs a catch-up burst) would
+shift every later segment on that row, since segments are drawn left to right based on the previous segment's rendered
+width. Padding keeps the `|` dividers and the segments after them in place regardless of how the values change.
+
 <PageChangelog page="guides/overlay" />
 
 ## See also


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added documentation on Safari Low Power Mode/WebKit throttling of `requestAnimationFrame`, explaining its impact on `render()` cadence while fixed-timestep `update()` continues via the accumulator.
- Documented fixed-timestep edge cases in the game loop: draining a clamped accumulator with possible multiple consecutive `update()` calls (including the `xN` overlay indicator) and high-refresh behavior where renders can occur with zero preceding `update()` steps while preserving the last completed tick.
- Clarified overlay semantics by explaining that the `N` value reflects how many fixed `update()` steps the accumulator drained for the current render frame.
- Updated overlay guide layout to keep numeric diagnostics aligned by using stable fixed-width column padding.
- Extended “See also” cross-links between browser support, game loop, and overlay documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->