### PR TITLE
fix(camera): persist camera offset across zero-update render frames

### DIFF
--- a/docs/api-camera.md
+++ b/docs/api-camera.md
@@ -37,6 +37,15 @@ const clamped = BT.cameraClamp(desired, worldSize);
 const clamped2 = BT.cameraClamp(desired, worldSize, new Vector2i(160, 120));
 ```
 
+## Camera persists across zero-update frames
+
+`BT.cameraSet()`'s offset persists across render frames automatically, including frames where `update()` does not run –
+common on high refresh-rate displays where `render()` outpaces the fixed update rate (see
+[Render frames with zero update() steps](api-game-loop.md#render-frames-with-zero-update-steps) in API: Game Loop). Call
+`cameraSet()` once per `update()` tick and `cameraReset()` at the end of `render()` to switch to screen space for UI
+overlays, as the demos below do; the engine re-applies the last offset before the next render pass begins, so the reset
+never leaks into the following frame's world draw.
+
 Standalone helper (same math as `BT.cameraClamp`):
 
 <Since symbol="clampCameraToWorld" />

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -96,6 +96,19 @@ export class BTAPI {
     private activeBackend: Backend | null = null;
 
     /**
+     * World camera offset last applied via {@link setCameraOffset}, persisted across frames.
+     *
+     * Re-applied at the start of every render pass, before the demo's `render()` runs (see
+     * the `onRender` callback built in {@link init}). Without this, a render frame with zero
+     * fixed-update steps (common once the render rate approaches or exceeds the fixed update
+     * rate, for example at 120 Hz) would draw the world with whatever the *previous* frame's
+     * `render()` left the live offset at after its own {@link resetCamera} call for
+     * screen-space UI - which is always `(0, 0)` - producing a visible snap-to-origin flash
+     * instead of holding the last correct scroll position.
+     */
+    private lastCameraOffset: Vector2i = Vector2i.zero();
+
+    /**
      * Engine overlay; non-null when {@link HardwareSettings.isOverlayEnabled}
      * is not `false`. Layout is fixed at init; drawn after demo `render()` each frame.
      */
@@ -327,6 +340,7 @@ export class BTAPI {
         this.pendingUpdateMs = 0;
         this.pendingUpdateSteps = 0;
         this.pendingDrawCalls = 0;
+        this.lastCameraOffset = Vector2i.zero();
         this.overlayTiming.frameMs = 0;
         this.overlayTiming.updateMs = 0;
         this.overlayTiming.renderMs = 0;
@@ -375,6 +389,10 @@ export class BTAPI {
                     this.beginRenderFrame();
 
                     this.renderer.beginFrame();
+
+                    // Re-prime the world camera before the demo draws, in case this render
+                    // frame has zero fixed-update steps (see lastCameraOffset doc comment).
+                    this.renderer.setCameraOffset(this.lastCameraOffset);
 
                     const renderStartMs = performance.now();
 
@@ -1074,6 +1092,7 @@ export class BTAPI {
      * @param offset - Camera position offset in pixels.
      */
     public setCameraOffset(offset: Vector2i): void {
+        this.lastCameraOffset = offset.clone();
         this.renderer?.setCameraOffset(offset);
     }
 

--- a/src/core/GameLoop.ts
+++ b/src/core/GameLoop.ts
@@ -75,6 +75,24 @@ export class GameLoop {
     private static readonly BASELINE_WINDOW = 60;
 
     /**
+     * Tolerance, in milliseconds, for snapping a rAF delta onto the nearest exact
+     * multiple of {@link updateInterval} before it is added to the accumulator.
+     *
+     * Browsers coarsen `performance.now()` resolution (commonly to ~1 ms, as a
+     * Spectre-era timing-attack mitigation), so a display genuinely refreshing at the
+     * target rate on average still reports deltas like 16 and 17 ms rather than a
+     * clean 16.667 ms. Left uncorrected, that rounding noise walks the accumulator's
+     * phase back and forth across a step boundary, producing a deterministic
+     * "extra step, then a stalled frame" beat (for example 2, 0, 1, 2, 0, 1, ...)
+     * instead of a steady one-step-per-frame cadence - visible as camera/scroll
+     * jitter even though the true average frame rate matches the target exactly.
+     * 2 ms comfortably covers that rounding noise while staying far below
+     * {@link DROP_THRESHOLD_MULTIPLIER}'s much larger gap, so a genuine dropped frame
+     * is never masked.
+     */
+    private static readonly SNAP_EPSILON_MS = 2;
+
+    /**
      * Minimum samples required before the baseline is trusted enough to drive
      * detection. Avoids false positives during page-load warm-up where a few
      * rAF callbacks may fire with unusual cadence.
@@ -204,7 +222,7 @@ export class GameLoop {
 
         this.detectFrameDrop(deltaTime);
 
-        this.accumulator += deltaTime;
+        this.accumulator += this.snapDeltaTime(deltaTime);
 
         const maxAccumulator = this.updateInterval * GameLoop.MAX_STEPS;
 
@@ -225,6 +243,19 @@ export class GameLoop {
         this.onRender();
 
         requestAnimationFrame((t) => this.tick(t));
+    }
+
+    /**
+     * Corrects rAF timer coarsening by snapping a delta that already lands close to an
+     * exact multiple of {@link updateInterval} onto that multiple.
+     *
+     * @param deltaTime - Raw milliseconds between the current and previous rAF callback.
+     * @returns `deltaTime`, or the nearest update-interval multiple when within {@link SNAP_EPSILON_MS} of it.
+     */
+    private snapDeltaTime(deltaTime: number): number {
+        const nearestMultiple = Math.round(deltaTime / this.updateInterval) * this.updateInterval;
+
+        return Math.abs(deltaTime - nearestMultiple) <= GameLoop.SNAP_EPSILON_MS ? nearestMultiple : deltaTime;
     }
 
     /**


### PR DESCRIPTION
Re-apply the last camera offset at the start of every render pass so a frame with no fixed-update steps (common once render rate approaches or exceeds targetFPS, e.g. 120 Hz) doesn't snap to origin from the previous frame's screen-space reset before the demo draws.

Also snap GameLoop's rAF delta onto the nearest updateInterval multiple when within 2ms, correcting for performance.now() coarsening that otherwise walks the fixed-update accumulator's phase back and forth across a step boundary and produces visible camera jitter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Prevented camera snapping during render frames without fixed-update steps by reapplying the last camera offset before world rendering.
- Added render-loop delta snapping near `updateInterval` multiples to reduce timing drift and accumulator phase changes.
- Documented camera offset persistence and guidance for screen-space UI rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->