### PR TITLE
feat(core): add BT.renderAlpha for frame interpolation and update documentation

### DIFF
--- a/.claude/rules/bt-api-getters.md
+++ b/.claude/rules/bt-api-getters.md
@@ -15,7 +15,7 @@ Quick rules when changing `src/BLIT386.ts` or demos:
 | Configure-time (mirror `HardwareSettings` names) | `displaySize`, `drawingBufferSize`, `targetFPS`                                                                |
 | Derived                                          | `outputSize` (`drawingBufferSize ?? displaySize`; no `HardwareSettings` field)                                 |
 | Configure-time (backend)                         | `requestedBackend` (mirrors `HardwareSettings.backend`; `null` before init)                                    |
-| Loop timing                                      | `deltaSeconds`, `timeSeconds`, `ticks`                                                                         |
+| Loop timing                                      | `deltaSeconds`, `timeSeconds`, `ticks`, `renderAlpha`                                                          |
 | Runtime state                                    | `activeBackend`, `camera`, `palette`, `isAudioUnlocked`, `isMusicPlaying` (`activeBackend` `null` before init) |
 | Per-frame input                                  | `pointerScrollDelta`, `inputString`, `gamepadCount`                                                            |
 

--- a/.cursor/rules/bt-api-getters.mdc
+++ b/.cursor/rules/bt-api-getters.mdc
@@ -15,7 +15,7 @@ Zero-argument **read-only** values on `BT`:
 - **Derived:** `outputSize` (`drawingBufferSize ?? displaySize`; no `HardwareSettings` field)
 - **Configure-time (backend):** `requestedBackend` mirrors resolved `HardwareSettings.backend` (includes
   `?backend=software`); **`null` before `BT.init()`**
-- **Loop:** `deltaSeconds`, `timeSeconds`, `ticks`
+- **Loop:** `deltaSeconds`, `timeSeconds`, `ticks`, `renderAlpha`
 - **Runtime:** `activeBackend`, `camera`, `palette`, `isAudioUnlocked`, `isMusicPlaying` — `activeBackend` is **`null`
   before init or on failure**; `isAudioUnlocked` is `false` until the first user gesture resumes the audio context;
   `isMusicPlaying` is `true` while the music player has a live current track

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ Before writing new code, reviewing existing code, or preflighting, check here fi
 | Question                                                          | Where to look                                                                                                                                                                                                                                                       |
 | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | What does `BT.X` do (getter vs method)?                           | `src/BLIT386.ts` JSDoc, `docs/api-core.md`, BT API: getters vs methods below                                                                                                                                                                                        |
+| How do I smooth motion between fixed `update()` steps?            | `BT.renderAlpha` (`src/core/GameLoop.ts`, `docs/api-game-loop.md`); worked pattern with `Vector2i.lerp` in `docs/guide-game-loop.md`                                                                                                                                |
 | How do I document a new/changed public API and keep it versioned? | `docs/documentation-and-versioning-guide.md` (@since/@changed/@deprecated tagging, `<Since>`/`<ApiAvailability>`/`<PageChangelog>` doc components, review checklist)                                                                                                |
 | How does a subsystem work internally?                             | The relevant `src/core/` or `src/render/` file                                                                                                                                                                                                                      |
 | What does a demo implement?                                       | `src/core/IBTDemo.ts` (interface + HardwareSettings)                                                                                                                                                                                                                |
@@ -377,7 +378,7 @@ Full table in `docs/api-core.md` and `.claude/rules/bt-api-getters.md`. The cate
 - Derived: `outputSize` (`drawingBufferSize ?? displaySize`; no `HardwareSettings` field; clone per read).
 - Configure-time (backend): `requestedBackend` (resolved `HardwareSettings.backend` after merge and `?backend=software`;
   `null` before init).
-- Loop timing: `deltaSeconds`, `timeSeconds`, `ticks`.
+- Loop timing: `deltaSeconds`, `timeSeconds`, `ticks`, `renderAlpha`.
 - Runtime state: `activeBackend` (what actually started after fallback; `null` before init or on failure), `camera`,
   `palette` (live reference), `isAudioUnlocked` (`false` until the first user gesture resumes the audio context),
   `isMusicPlaying` (`true` while the music player has a live current track).

--- a/docs/_api-history.json
+++ b/docs/_api-history.json
@@ -808,6 +808,13 @@
       "deprecated": null,
       "status": "stable"
     },
+    "BT.renderAlpha": {
+      "kind": "getter",
+      "since": "1.3.0",
+      "changes": [],
+      "deprecated": null,
+      "status": "unreleased"
+    },
     "BT.requestedBackend": {
       "kind": "getter",
       "since": "1.1.0",
@@ -1384,6 +1391,7 @@
     "api/game-loop": [
       "BT.assignTag",
       "BT.deltaSeconds",
+      "BT.renderAlpha",
       "BT.ticks",
       "BT.ticksReset",
       "BT.timeSeconds",

--- a/docs/_sitemap.json
+++ b/docs/_sitemap.json
@@ -68,6 +68,11 @@
       "description": "Pointer, keyboard, gamepad, and text-accumulation input in BLIT386."
     },
     {
+      "src": "guide-game-loop.md",
+      "path": "guides/game-loop",
+      "description": "Smoothing motion between fixed update() steps using BT.renderAlpha and Vector2i.lerp."
+    },
+    {
       "src": "guide-palette.md",
       "path": "guides/palette",
       "description": "The palette-first rendering workflow: setup, slot offsets, and palette effects."

--- a/docs/api-core.md
+++ b/docs/api-core.md
@@ -13,9 +13,9 @@
 Bootstrap, initialization, and default configuration.
 
 The rest of the core API surface lives in dedicated pages: [Overlay](api-overlay.md) (HUD configure flags and style),
-[Game Loop](api-game-loop.md) (tick timing and `Timer`), [Camera](api-camera.md), [Easing](api-easing.md),
-[Core Types](api-core-types.md) (`Vector2i`, `Rect2i`, `Color32`), [Audio](api-audio.md) (bus volume, mute, unlock
-state), and [Browser Support](api-browser-support.md).
+[Game Loop](api-game-loop.md) (tick timing, `Timer`, and the `BT.renderAlpha` render-interpolation factor),
+[Camera](api-camera.md), [Easing](api-easing.md), [Core Types](api-core-types.md) (`Vector2i`, `Rect2i`, `Color32`),
+[Audio](api-audio.md) (bus volume, mute, unlock state), and [Browser Support](api-browser-support.md).
 
 <Callout title="Starting a new project?">
   The quickest path is the scaffolder: `npm create blit386@latest my-game` (works with npm, pnpm, yarn, or bun).

--- a/docs/api-game-loop.md
+++ b/docs/api-game-loop.md
@@ -22,7 +22,10 @@ BLIT386 runs two independent cadences:
 | Render rate     | Overlay `Present: N FPS`, `BT.renderAlpha`                 | Measured `requestAnimationFrame` cadence; `render()` runs here |
 
 `render()` may run more or fewer times per second than `update()` (for example 120 Hz display with `targetFPS: 60`). Use
-tick-based timing for gameplay; use overlay present FPS only to spot GPU or draw-call bottlenecks.
+tick-based timing for gameplay; use overlay present FPS only to spot GPU or draw-call bottlenecks. Because the two
+cadences drift apart, `BT.renderAlpha` gives `render()` a normalized `[0, 1)` interpolation factor toward the next fixed
+step, for smoothing motion across that mismatch (see
+[Interpolating render state with renderAlpha](#interpolating-render-state-with-renderalpha) below).
 
 ```ts twoslash
 import { BT } from 'blit386';
@@ -30,16 +33,16 @@ import { BT } from 'blit386';
 BT.deltaSeconds; // seconds per fixed tick (1 / BT.targetFPS)
 BT.timeSeconds; // elapsed seconds since init (ticks × deltaSeconds)
 BT.ticks; // current tick counter (increments each update)
-BT.ticksReset(); // reset tick counter to 0
 BT.renderAlpha; // fractional progress [0, 1) toward the next update, for interpolation
+BT.ticksReset(); // reset tick counter to 0
 BT.assignTag('Round start'); // timing chart event tag at current tick (requires isOverlayTimingChartEnabled)
 ```
 
 <Since symbol="BT.deltaSeconds" />
 <Since symbol="BT.timeSeconds" />
 <Since symbol="BT.ticks" />
-<Since symbol="BT.ticksReset" />
 <Since symbol="BT.renderAlpha" />
+<Since symbol="BT.ticksReset" />
 <Since symbol="BT.assignTag" />
 
 <DemoEmbed demo="009-animation" title="BLIT386 animation and timing demo" />
@@ -81,9 +84,11 @@ sizeable fraction of render frames have zero preceding `update()` calls that fra
 ## Interpolating render state with renderAlpha
 
 `render()` frequently runs at a different cadence than `update()` (see the two sections above), so game state read
-during `render()` can be up to one fixed step stale. `BT.renderAlpha` exposes how far the accumulator has progressed
-toward the next `update()` call, as a fraction in `[0, 1)`: `0` means a fixed update just completed, values approaching
-`1` mean the next update is imminent.
+during `render()` can be up to one fixed step stale. The accumulator introduced above always holds less than one
+`updateInterval` of leftover time once its whole-step chunks are removed for the frame - that remainder is exactly what
+the whole-step loop couldn't consume. Dividing that leftover by `updateInterval` gives, from first principles, how far
+the simulation has already progressed toward its next step - a fraction in `[0, 1)`. `BT.renderAlpha` exposes that
+fraction: `0` means a fixed update just completed, values approaching `1` mean the next update is imminent.
 
 ```ts twoslash
 import { BT, Vector2i } from 'blit386';
@@ -97,7 +102,8 @@ const drawY = previousPos.y + (currentPos.y - previousPos.y) * alpha;
 
 Interpolating between the previous and current tick's positions smooths motion on displays whose refresh rate does not
 line up cleanly with `targetFPS`, without changing simulation timing. `BT.renderAlpha` only reflects the most recently
-completed render frame's accumulator state; read it from `render()`, not `update()`.
+completed render frame's accumulator state; read it from `render()`, not `update()`. For the full worked pattern,
+including a zero-allocation version and `Vector2i.lerp`, see [Guide: Game Loop](guide-game-loop.md).
 
 ## Timer
 
@@ -136,4 +142,5 @@ need a specific snapshot; the default is the engine tick counter.
   <Card title="API: Overlay" href="/docs/api/overlay">Present FPS, timing chart, event tags.</Card>
   <Card title="API: Camera" href="/docs/api/camera">Global pixel offset for draw calls.</Card>
   <Card title="Browser Support" href="/docs/api/browser-support">Safari's Low Power Mode requestAnimationFrame throttling.</Card>
+  <Card title="Guide: Game Loop" href="/docs/guides/game-loop">Smoothing motion between update() steps with renderAlpha.</Card>
 </Cards>

--- a/docs/api-game-loop.md
+++ b/docs/api-game-loop.md
@@ -92,8 +92,8 @@ fraction: `0` means a fixed update just completed, values approaching `1` mean t
 
 ```ts twoslash
 import { BT, Vector2i } from 'blit386';
-declare const previousPos: Vector2i;
-declare const currentPos: Vector2i;
+const previousPos = new Vector2i(0, 0);
+const currentPos = new Vector2i(0, 0);
 // ---cut---
 const alpha = BT.renderAlpha;
 const drawX = previousPos.x + (currentPos.x - previousPos.x) * alpha;

--- a/docs/api-game-loop.md
+++ b/docs/api-game-loop.md
@@ -19,7 +19,7 @@ BLIT386 runs two independent cadences:
 | Concept         | Where                                                      | Meaning                                                        |
 | --------------- | ---------------------------------------------------------- | -------------------------------------------------------------- |
 | Simulation rate | `targetFPS`, `BT.targetFPS`, `BT.deltaSeconds`, `BT.ticks` | Fixed `update()` step; game logic and `Timer` use ticks        |
-| Render rate     | Overlay `Present: N FPS`                                   | Measured `requestAnimationFrame` cadence; `render()` runs here |
+| Render rate     | Overlay `Present: N FPS`, `BT.renderAlpha`                 | Measured `requestAnimationFrame` cadence; `render()` runs here |
 
 `render()` may run more or fewer times per second than `update()` (for example 120 Hz display with `targetFPS: 60`). Use
 tick-based timing for gameplay; use overlay present FPS only to spot GPU or draw-call bottlenecks.
@@ -31,6 +31,7 @@ BT.deltaSeconds; // seconds per fixed tick (1 / BT.targetFPS)
 BT.timeSeconds; // elapsed seconds since init (ticks × deltaSeconds)
 BT.ticks; // current tick counter (increments each update)
 BT.ticksReset(); // reset tick counter to 0
+BT.renderAlpha; // fractional progress [0, 1) toward the next update, for interpolation
 BT.assignTag('Round start'); // timing chart event tag at current tick (requires isOverlayTimingChartEnabled)
 ```
 
@@ -38,6 +39,7 @@ BT.assignTag('Round start'); // timing chart event tag at current tick (requires
 <Since symbol="BT.timeSeconds" />
 <Since symbol="BT.ticks" />
 <Since symbol="BT.ticksReset" />
+<Since symbol="BT.renderAlpha" />
 <Since symbol="BT.assignTag" />
 
 <DemoEmbed demo="009-animation" title="BLIT386 animation and timing demo" />
@@ -75,6 +77,27 @@ sizeable fraction of render frames have zero preceding `update()` calls that fra
 – `BT.ticks` and any state written during the last `update()` (including the camera offset from `BT.cameraSet()`, see
 [API: Camera](api-camera.md#camera-persists-across-zero-update-frames)) still reflect the last completed tick, so
 `render()` draws the same game state twice in a row rather than resetting to defaults.
+
+## Interpolating render state with renderAlpha
+
+`render()` frequently runs at a different cadence than `update()` (see the two sections above), so game state read
+during `render()` can be up to one fixed step stale. `BT.renderAlpha` exposes how far the accumulator has progressed
+toward the next `update()` call, as a fraction in `[0, 1)`: `0` means a fixed update just completed, values approaching
+`1` mean the next update is imminent.
+
+```ts twoslash
+import { BT, Vector2i } from 'blit386';
+declare const previousPos: Vector2i;
+declare const currentPos: Vector2i;
+// ---cut---
+const alpha = BT.renderAlpha;
+const drawX = previousPos.x + (currentPos.x - previousPos.x) * alpha;
+const drawY = previousPos.y + (currentPos.y - previousPos.y) * alpha;
+```
+
+Interpolating between the previous and current tick's positions smooths motion on displays whose refresh rate does not
+line up cleanly with `targetFPS`, without changing simulation timing. `BT.renderAlpha` only reflects the most recently
+completed render frame's accumulator state; read it from `render()`, not `update()`.
 
 ## Timer
 

--- a/docs/guide-game-loop.md
+++ b/docs/guide-game-loop.md
@@ -1,0 +1,101 @@
+# Game Loop
+
+<!-- blit386.dev-banner:start -->
+
+<!-- prettier-ignore -->
+> [!TIP]
+> You're reading the raw source on GitHub. The same page lives at https://blit386.dev/docs/guides/game-loop, typeset like an
+> actual docs site and easier on the eyes. Probably the nicer place to read it, but same
+> words either way.
+
+<!-- blit386.dev-banner:end -->
+
+Fixed-step timing, tick counters, and `BT.renderAlpha` are documented in [API: Game Loop](api-game-loop.md). This guide
+walks through the standard pattern for smoothing motion when `render()` doesn't land exactly on an `update()` step.
+
+<ApiAvailability page="guides/game-loop" />
+
+## Why motion can look stale or jittery
+
+`update()` runs at a fixed rate (`targetFPS`); `render()` runs at whatever rate `requestAnimationFrame` delivers, which
+rarely divides evenly into `targetFPS`. See
+[Multiple update() steps per render frame](api-game-loop.md#multiple-update-steps-per-render-frame) and
+[Render frames with zero update() steps](api-game-loop.md#render-frames-with-zero-update-steps) for the two ways that
+mismatch shows up. A sprite that only ever draws at its last-computed `update()` position appears to hitch: it sits
+still for a render frame with no update, then jumps its full per-tick distance on the next frame that has one.
+
+## Smoothing motion between updates
+
+The fix is to interpolate: keep both the previous and current tick's position, and blend them in `render()` using
+`BT.renderAlpha` as the blend factor. Store the previous position at the start of `update()`, before moving:
+
+```ts twoslash
+import { BT, Rect2i, SpriteSheet, Vector2i } from 'blit386';
+declare const sheet: SpriteSheet;
+const srcRect = new Rect2i(0, 0, 16, 16);
+// ---cut---
+class Player {
+  position = new Vector2i(0, 0);
+  previousPosition = new Vector2i(0, 0);
+  velocity = new Vector2i(2, 0);
+
+  update(): void {
+    this.previousPosition = this.position.clone();
+    this.position = this.position.add(this.velocity);
+  }
+
+  render(): void {
+    const drawPos = Vector2i.lerp(this.previousPosition, this.position, BT.renderAlpha);
+
+    BT.drawSprite(sheet, srcRect, drawPos);
+  }
+}
+```
+
+`Vector2i.lerp` truncates its result to integer pixels (see [API: Core Types](api-core-types.md#vector2i)), so this only
+smooths motion that covers more than a pixel or two per tick - it doesn't add subpixel precision to a pixel-perfect
+renderer. For a sprite moving `2` px/tick at `targetFPS: 60` on a `144` Hz display, it turns a visible 1-then-2-then-0
+px stutter into a steadier progression across render frames.
+
+## Zero-allocation version
+
+`update()`/`render()` run every frame, so the allocating version above (`clone()`, `add()`, `Vector2i.lerp()`) is fine
+for prototyping but worth tightening in a shipping demo. Reuse fixed vectors with the in-place and `*To()` variants (see
+[Performance Best Practices](performance-best-practices.md)):
+
+```ts twoslash
+import { BT, Rect2i, SpriteSheet, Vector2i } from 'blit386';
+declare const sheet: SpriteSheet;
+const srcRect = new Rect2i(0, 0, 16, 16);
+// ---cut---
+class Player {
+  position = new Vector2i(0, 0);
+  previousPosition = new Vector2i(0, 0);
+  velocity = new Vector2i(2, 0);
+  private readonly drawPos = new Vector2i(0, 0);
+
+  update(): void {
+    this.previousPosition.copyFrom(this.position);
+    this.position.addInPlace(this.velocity);
+  }
+
+  render(): void {
+    Vector2i.lerpTo(this.previousPosition, this.position, BT.renderAlpha, this.drawPos);
+
+    BT.drawSprite(sheet, srcRect, this.drawPos);
+  }
+}
+```
+
+Color transitions (palette flashes, tinted hit-feedback) can be interpolated the same way with `Color32.lerp` /
+`Color32#lerp` - see [API: Core Types](api-core-types.md#color32).
+
+<PageChangelog page="guides/game-loop" />
+
+## See also
+
+<Cards>
+  <Card title="API: Game Loop" href="/docs/api/game-loop">Tick timing, renderAlpha, present FPS, Timer.</Card>
+  <Card title="API: Core Types" href="/docs/api/core-types">Vector2i.lerp, Color32.lerp, and the zero-allocation variants.</Card>
+  <Card title="Performance Best Practices" href="/docs/performance/best-practices">Object allocation, batching, and hot-path guidance.</Card>
+</Cards>

--- a/src/BLIT386.test.ts
+++ b/src/BLIT386.test.ts
@@ -327,6 +327,18 @@ describe('BT.ticksReset', () => {
     });
 });
 
+describe('BT.renderAlpha', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('delegates to BTAPI.instance.getRenderAlpha', () => {
+        vi.spyOn(BTAPI.instance, 'getRenderAlpha').mockReturnValue(0.42);
+
+        expect(BT.renderAlpha).toBe(0.42);
+    });
+});
+
 describe('BT.assignTag', () => {
     beforeEach(() => {
         vi.restoreAllMocks();

--- a/src/BLIT386.ts
+++ b/src/BLIT386.ts
@@ -662,6 +662,18 @@ export const BT = {
     },
 
     /**
+     * Fractional progress between the last completed fixed update and the next.
+     *
+     * Intended for interpolating render state between fixed-update steps.
+     *
+     * @since 1.3.0
+     * @returns Interpolation alpha in `[0, 1)`.
+     */
+    get renderAlpha(): number {
+        return BTAPI.instance.getRenderAlpha();
+    },
+
+    /**
      * Places a labeled marker on the overlay timing chart at the current tick.
      *
      * Requires `isOverlayTimingChartEnabled: true` in `configure()`. Tags scroll with the chart

--- a/src/core/BTAPI.test.ts
+++ b/src/core/BTAPI.test.ts
@@ -427,6 +427,10 @@ describe('BTAPI', () => {
             expect(() => BTAPI.instance.resetTicks()).not.toThrow();
         });
 
+        it('getRenderAlpha should return 0 before init', () => {
+            expect(BTAPI.instance.getRenderAlpha()).toBe(0);
+        });
+
         it('getDevice should return null before init', () => {
             expect(BTAPI.instance.getDevice()).toBeNull();
         });

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -497,6 +497,15 @@ export class BTAPI {
     }
 
     /**
+     * Gets the fractional progress between the last completed fixed update and the next.
+     *
+     * @returns Interpolation alpha in `[0, 1)`; `0` before initialization.
+     */
+    public getRenderAlpha(): number {
+        return this.loop?.getRenderAlpha() ?? 0;
+    }
+
+    /**
      * Assigns an event tag on the stats overlay timing chart.
      *
      * No-op when the overlay or timing chart is disabled.

--- a/src/core/GameLoop.test.ts
+++ b/src/core/GameLoop.test.ts
@@ -67,6 +67,14 @@ describe('GameLoop', () => {
         });
     });
 
+    describe('getRenderAlpha', () => {
+        it('should return 0 initially', () => {
+            const loop = new GameLoop(16.67, vi.fn(), vi.fn());
+
+            expect(loop.getRenderAlpha()).toBe(0);
+        });
+    });
+
     describe('stop', () => {
         it('should not throw when called before start', () => {
             const loop = new GameLoop(16.67, vi.fn(), vi.fn());
@@ -223,6 +231,54 @@ describe('GameLoop', () => {
             p.tick(10);
 
             expect(requestAnimationFrame).toHaveBeenCalled();
+        });
+
+        it('should set renderAlpha to the leftover accumulator fraction after fixed updates', () => {
+            const loop = new GameLoop(10, vi.fn(), vi.fn());
+            const p = loop as unknown as PrivateLoop;
+
+            p.isRunning = true;
+            p.lastUpdateTime = 0;
+            p.tick(25); // 25ms at 10ms interval = 2 steps, 5ms leftover
+
+            expect(loop.getRenderAlpha()).toBeCloseTo(0.5);
+        });
+
+        it('should set renderAlpha to 0 when the delta is an exact multiple of updateInterval', () => {
+            const loop = new GameLoop(10, vi.fn(), vi.fn());
+            const p = loop as unknown as PrivateLoop;
+
+            p.isRunning = true;
+            p.lastUpdateTime = 0;
+            p.tick(20); // 20ms at 10ms interval = 2 steps, 0ms leftover
+
+            expect(loop.getRenderAlpha()).toBe(0);
+        });
+
+        it('should keep renderAlpha within [0, 1) even at the max-steps clamp boundary', () => {
+            const loop = new GameLoop(10, vi.fn(), vi.fn());
+            const p = loop as unknown as PrivateLoop;
+
+            p.isRunning = true;
+            p.lastUpdateTime = 0;
+            p.tick(10000); // huge pause - MAX_STEPS clamp leaves 0 leftover
+
+            const alpha = loop.getRenderAlpha();
+
+            expect(alpha).toBeGreaterThanOrEqual(0);
+            expect(alpha).toBeLessThan(1);
+        });
+
+        it('should not produce a non-finite renderAlpha when updateInterval is corrupted to 0', () => {
+            const loop = new GameLoop(10, vi.fn(), vi.fn());
+            const p = loop as unknown as PrivateLoop & { updateInterval: number };
+
+            p.updateInterval = 0;
+            p.isRunning = true;
+            p.lastUpdateTime = 0;
+            p.tick(25);
+
+            expect(Number.isFinite(loop.getRenderAlpha())).toBe(true);
         });
     });
 

--- a/src/core/GameLoop.test.ts
+++ b/src/core/GameLoop.test.ts
@@ -68,10 +68,116 @@ describe('GameLoop', () => {
     });
 
     describe('getRenderAlpha', () => {
+        type PrivateLoop = {
+            tick: (currentTime: number) => void;
+            isRunning: boolean;
+            lastUpdateTime: number;
+            accumulator: number;
+        };
+
+        beforeEach(() => {
+            vi.stubGlobal('requestAnimationFrame', vi.fn());
+        });
+
+        afterEach(() => {
+            vi.unstubAllGlobals();
+        });
+
         it('should return 0 initially', () => {
             const loop = new GameLoop(16.67, vi.fn(), vi.fn());
 
             expect(loop.getRenderAlpha()).toBe(0);
+        });
+
+        it('should set renderAlpha to the leftover accumulator fraction after fixed updates', () => {
+            const loop = new GameLoop(10, vi.fn(), vi.fn());
+            const p = loop as unknown as PrivateLoop;
+
+            p.isRunning = true;
+            p.lastUpdateTime = 0;
+            p.tick(25); // 25ms at 10ms interval = 2 steps, 5ms leftover
+
+            expect(loop.getRenderAlpha()).toBeCloseTo(0.5);
+        });
+
+        it('should be 0 immediately after a frame whose deltaTime consumes the accumulator exactly', () => {
+            const loop = new GameLoop(10, vi.fn(), vi.fn());
+            const p = loop as unknown as PrivateLoop;
+
+            p.isRunning = true;
+            p.lastUpdateTime = 0;
+            p.tick(20); // 20ms at 10ms interval = 2 whole steps, 0ms remainder
+
+            expect(loop.getRenderAlpha()).toBe(0);
+        });
+
+        it('should approach but never reach 1 as deltaTime approaches a full updateInterval without crossing it', () => {
+            const loop = new GameLoop(100, vi.fn(), vi.fn());
+            const p = loop as unknown as PrivateLoop;
+
+            p.isRunning = true;
+            p.lastUpdateTime = 0;
+            // 97.9ms at a 100ms interval: 0 steps, 97.9ms leftover. Kept more
+            // than SNAP_EPSILON_MS (2ms) away from the 100ms boundary so the
+            // rAF-jitter snap correction does not round this up to a full step.
+            p.tick(97.9);
+
+            const alpha = loop.getRenderAlpha();
+
+            expect(alpha).toBeCloseTo(0.979);
+            expect(alpha).toBeLessThan(1);
+        });
+
+        it('should stay within [0, 1) across consecutive frames, including a multi-step catch-up frame', () => {
+            const onUpdate = vi.fn();
+            const loop = new GameLoop(10, onUpdate, vi.fn());
+            const p = loop as unknown as PrivateLoop;
+
+            p.isRunning = true;
+            p.lastUpdateTime = 0;
+
+            p.tick(7); // 7ms delta: 0 steps, 7ms leftover -> alpha 0.7
+
+            expect(loop.getRenderAlpha()).toBeGreaterThanOrEqual(0);
+            expect(loop.getRenderAlpha()).toBeLessThan(1);
+
+            p.tick(32); // 25ms delta on top of the 7ms leftover: 3 steps (catch-up), 2ms leftover -> alpha 0.2
+
+            expect(onUpdate).toHaveBeenCalledTimes(3);
+            expect(loop.getRenderAlpha()).toBeGreaterThanOrEqual(0);
+            expect(loop.getRenderAlpha()).toBeLessThan(1);
+
+            p.tick(47); // 15ms delta on top of the 2ms leftover: 1 step, 7ms leftover -> alpha 0.7
+
+            expect(onUpdate).toHaveBeenCalledTimes(4);
+            expect(loop.getRenderAlpha()).toBeGreaterThanOrEqual(0);
+            expect(loop.getRenderAlpha()).toBeLessThan(1);
+        });
+
+        it('should keep renderAlpha within [0, 1) even at the max-steps clamp boundary', () => {
+            const loop = new GameLoop(10, vi.fn(), vi.fn());
+            const p = loop as unknown as PrivateLoop;
+
+            p.isRunning = true;
+            p.lastUpdateTime = 0;
+            p.tick(10000); // huge pause - MAX_STEPS clamp leaves 0 leftover
+
+            const alpha = loop.getRenderAlpha();
+
+            expect(alpha).toBeGreaterThanOrEqual(0);
+            expect(alpha).toBeLessThan(1);
+        });
+
+        it('should not produce a non-finite renderAlpha when updateInterval is corrupted to 0', () => {
+            const loop = new GameLoop(10, vi.fn(), vi.fn());
+            const p = loop as unknown as PrivateLoop & { updateInterval: number };
+
+            p.updateInterval = 0;
+            p.isRunning = true;
+            p.lastUpdateTime = 0;
+            p.tick(25);
+
+            expect(Number.isFinite(loop.getRenderAlpha())).toBe(true);
         });
     });
 
@@ -231,54 +337,6 @@ describe('GameLoop', () => {
             p.tick(10);
 
             expect(requestAnimationFrame).toHaveBeenCalled();
-        });
-
-        it('should set renderAlpha to the leftover accumulator fraction after fixed updates', () => {
-            const loop = new GameLoop(10, vi.fn(), vi.fn());
-            const p = loop as unknown as PrivateLoop;
-
-            p.isRunning = true;
-            p.lastUpdateTime = 0;
-            p.tick(25); // 25ms at 10ms interval = 2 steps, 5ms leftover
-
-            expect(loop.getRenderAlpha()).toBeCloseTo(0.5);
-        });
-
-        it('should set renderAlpha to 0 when the delta is an exact multiple of updateInterval', () => {
-            const loop = new GameLoop(10, vi.fn(), vi.fn());
-            const p = loop as unknown as PrivateLoop;
-
-            p.isRunning = true;
-            p.lastUpdateTime = 0;
-            p.tick(20); // 20ms at 10ms interval = 2 steps, 0ms leftover
-
-            expect(loop.getRenderAlpha()).toBe(0);
-        });
-
-        it('should keep renderAlpha within [0, 1) even at the max-steps clamp boundary', () => {
-            const loop = new GameLoop(10, vi.fn(), vi.fn());
-            const p = loop as unknown as PrivateLoop;
-
-            p.isRunning = true;
-            p.lastUpdateTime = 0;
-            p.tick(10000); // huge pause - MAX_STEPS clamp leaves 0 leftover
-
-            const alpha = loop.getRenderAlpha();
-
-            expect(alpha).toBeGreaterThanOrEqual(0);
-            expect(alpha).toBeLessThan(1);
-        });
-
-        it('should not produce a non-finite renderAlpha when updateInterval is corrupted to 0', () => {
-            const loop = new GameLoop(10, vi.fn(), vi.fn());
-            const p = loop as unknown as PrivateLoop & { updateInterval: number };
-
-            p.updateInterval = 0;
-            p.isRunning = true;
-            p.lastUpdateTime = 0;
-            p.tick(25);
-
-            expect(Number.isFinite(loop.getRenderAlpha())).toBe(true);
         });
     });
 

--- a/src/core/GameLoop.ts
+++ b/src/core/GameLoop.ts
@@ -105,6 +105,9 @@ export class GameLoop {
     /** Current tick count (increments once per fixed update call). */
     private ticks: number = 0;
 
+    /** Fractional progress `[0, 1)` between the last completed fixed update and the next. */
+    private renderAlpha: number = 0;
+
     /** Timestamp of the last frame, in milliseconds. */
     private lastUpdateTime: number = 0;
 
@@ -205,6 +208,16 @@ export class GameLoop {
     }
 
     /**
+     * Gets the fractional progress between the last completed fixed update and the next.
+     *
+     * @returns Interpolation alpha in `[0, 1)`, computed from the leftover accumulator after
+     *   the most recent frame's fixed-update steps.
+     */
+    public getRenderAlpha(): number {
+        return this.renderAlpha;
+    }
+
+    /**
      * Processes one animation frame.
      *
      * Advances the accumulator, runs zero or more fixed updates, renders once,
@@ -239,6 +252,11 @@ export class GameLoop {
         }
 
         this.accumulator -= steps * this.updateInterval;
+
+        this.renderAlpha =
+            Number.isFinite(this.updateInterval) && this.updateInterval > 0
+                ? Math.min(Math.max(this.accumulator / this.updateInterval, 0), 1 - Number.EPSILON)
+                : 0;
 
         this.onRender();
 


### PR DESCRIPTION
- Resolves: #340

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added read-only `BT.renderAlpha` to expose fixed-update/render-frame interpolation progress for use during `render()`.
- Implemented `GameLoop.getRenderAlpha()` and plumbed it through `BTAPI.getRenderAlpha()`/`BT.renderAlpha`, defaulting safely to `0` pre-init and clamping to `[0, 1)`.
- Added comprehensive tests covering initial `0`, near-one values, exact-boundary behavior, bounds across consecutive frames (including catch-up), and robustness when the update interval is invalid.
- Updated documentation across the API getter rules, game-loop API page, and a new game-loop guide, including sitemap/API history entries and interpolation examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->