### PR TITLE
chore: release 1.3.0

### DIFF
--- a/docs/_api-history.json
+++ b/docs/_api-history.json
@@ -1,6 +1,6 @@
 {
-  "packageVersion": "1.2.1",
-  "unreleasedVersion": "1.3.0",
+  "packageVersion": "1.3.0",
+  "unreleasedVersion": "1.3.1",
   "versions": {
     "0.1.0": "2025-12-13T11:02:41+01:00",
     "0.2.0": "2025-12-22T16:19:15+01:00",
@@ -9,8 +9,8 @@
     "1.0.5": "2026-05-21T15:03:37+02:00",
     "1.1.0": "2026-05-30T16:05:31+02:00",
     "1.1.1": "2026-06-07T14:08:44+02:00",
-    "1.2.1": "2026-06-20T21:07:22+02:00",
-    "1.3.0": null
+    "1.3.0": null,
+    "1.3.1": null
   },
   "symbols": {
     "AssetLoader": {
@@ -25,14 +25,14 @@
       "since": "1.3.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "AudioClip": {
       "kind": "class",
       "since": "1.3.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "BT.AXIS_LEFT_X": {
       "kind": "const",
@@ -305,21 +305,21 @@
       "since": "1.3.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "BT.audioVolumeGet": {
       "kind": "method",
       "since": "1.3.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "BT.audioVolumeSet": {
       "kind": "method",
       "since": "1.3.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "BT.buttonDown": {
       "kind": "method",
@@ -552,14 +552,14 @@
       "since": "1.3.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "BT.isAudioUnlocked": {
       "kind": "getter",
       "since": "1.3.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "BT.isDown": {
       "kind": "method",
@@ -601,7 +601,7 @@
       "since": "1.3.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "BT.isPointerActive": {
       "kind": "method",
@@ -629,7 +629,7 @@
       "since": "1.3.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "BT.keyDown": {
       "kind": "method",
@@ -669,28 +669,28 @@
       "since": "1.3.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "BT.musicStop": {
       "kind": "method",
       "since": "1.3.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "BT.musicVolumeGet": {
       "kind": "method",
       "since": "1.3.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "BT.musicVolumeSet": {
       "kind": "method",
       "since": "1.3.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "BT.outputSize": {
       "kind": "getter",
@@ -813,7 +813,7 @@
       "since": "1.3.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "BT.requestedBackend": {
       "kind": "getter",
@@ -834,56 +834,56 @@
       "since": "1.3.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "BT.soundPanSet": {
       "kind": "method",
       "since": "1.3.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "BT.soundPitchGet": {
       "kind": "method",
       "since": "1.3.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "BT.soundPitchSet": {
       "kind": "method",
       "since": "1.3.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "BT.soundPlay": {
       "kind": "method",
       "since": "1.3.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "BT.soundStop": {
       "kind": "method",
       "since": "1.3.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "BT.soundVolumeGet": {
       "kind": "method",
       "since": "1.3.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "BT.soundVolumeSet": {
       "kind": "method",
       "since": "1.3.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "BT.spritesRefresh": {
       "kind": "method",
@@ -897,7 +897,7 @@
       "since": "1.3.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "BT.systemPrint": {
       "kind": "method",
@@ -1065,7 +1065,7 @@
       "since": "1.3.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "Noise": {
       "kind": "class",
@@ -1079,7 +1079,7 @@
       "since": "1.3.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "OverlayRow": {
       "kind": "interface",
@@ -1156,28 +1156,28 @@
       "since": "1.3.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "SoundPlayOptions": {
       "kind": "interface",
       "since": "1.3.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "SoundRef": {
       "kind": "interface",
       "since": "1.3.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "SoundStopOptions": {
       "kind": "interface",
       "since": "1.3.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "SpriteSheet": {
       "kind": "class",
@@ -1191,35 +1191,35 @@
       "since": "1.3.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "SynthParams": {
       "kind": "interface",
       "since": "1.3.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "SynthPitchSweep": {
       "kind": "interface",
       "since": "1.3.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "SynthVibrato": {
       "kind": "interface",
       "since": "1.3.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "SynthWaveform": {
       "kind": "type",
       "since": "1.3.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "TextSize": {
       "kind": "interface",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,7 +19,7 @@ This page is editorial – release highlights and migration notes, not an exhaus
 `guides/*` reference page, or [GitHub Releases](https://github.com/blit386/blit386/releases) for the full PR-by-PR
 notes, including dependency bumps and CI changes omitted here for brevity.
 
-## 1.3.0 - Unreleased
+## 1.3.0 - 2026-07-13
 
 The audio release: the engine gains a full sound subsystem, from bus mixing to procedural synthesis, plus render-time
 interpolation for smoother motion between fixed update steps.
@@ -60,6 +60,8 @@ interpolation for smoother motion between fixed update steps.
 - WebGPU frame capture requests `COPY_SRC` canvas usage, fixing `BT.captureFrame()` / `BT.downloadFrame()` on backends
   that require it.
 - `BT.systemPrintMeasure()` returns a fresh size object on every call instead of mutating a shared instance.
+- The engine overlay's toggle key press is now sampled during the fixed-update tick instead of the render phase, fixing
+  intermittently dropped toggle presses under rapid input on high-refresh displays.
 
 ## 1.2.1 - 2026-06-20
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blit386",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "type": "module",
   "description": "A palette-first WebGPU retro engine for TypeScript, inspired by RetroBlit.",
   "author": {

--- a/scripts/gen-api-history.mjs
+++ b/scripts/gen-api-history.mjs
@@ -45,7 +45,7 @@ const PACKAGE_JSON_PATH = join(ROOT, 'package.json');
  * (it is not yet tagged), so it is a maintained constant: bump it by hand in the same commit
  * that bumps `package.json` `version` after a release ships.
  */
-const UNRELEASED_VERSION = '1.3.0';
+const UNRELEASED_VERSION = '1.3.1';
 
 /** Compiler options used when no real tsconfig is supplied (fixture / unit-test programs). */
 export const DEFAULT_TEST_COMPILER_OPTIONS = {

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -66,10 +66,10 @@ export class BTAPI {
     public static readonly VERSION_MAJOR = 1;
 
     /** Minor version number. */
-    public static readonly VERSION_MINOR = 2;
+    public static readonly VERSION_MINOR = 3;
 
     /** Patch version number. */
-    public static readonly VERSION_PATCH = 1;
+    public static readonly VERSION_PATCH = 0;
 
     /** Singleton instance of BTAPI. */
     private static _instance: BTAPI | null = null;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Released version 1.3.0 across package metadata and `BTAPI` version constants.
- Marked the 1.3.0 audio, music, sound, rendering, and synth APIs as stable.
- Started tracking unreleased version 1.3.1.
- Documented the engine overlay toggle fix, sampling key presses during fixed updates to prevent dropped presses on high-refresh displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->