### PR TITLE
feat(core): add the engine hot-swap runtime

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ Before writing new code, reviewing existing code, or preflighting, check here fi
 | How does pointer wheel / keyboard scroll capture work?            | `HardwareSettings.isCapturingPointerScroll` (`src/input/PointerInput.ts`) and `isCapturingKeyboardScroll` (`src/input/KeyboardInput.ts`), both opt-in and default `false`; `docs/guide-input.md` (Scroll delta section), `docs/api-core.md` (Hardware settings table) |
 | How does the screen wake lock work?                               | `src/core/WakeLock.ts`; `HardwareSettings.isWakeLockEnabled` in `src/core/IBTDemo.ts`; `docs/api-core.md` (Hardware settings table), `docs/api-browser-support.md` (Screen wake lock section)                                                                         |
 | How does screen orientation detection / lock work?                | `src/core/Orientation.ts`; `HardwareSettings.preferredOrientation` + `IBTDemo.onOrientationChange` in `src/core/IBTDemo.ts`; `BT.screenOrientation` in `src/BLIT386.ts`; `docs/api-core.md` (Screen orientation), `docs/api-browser-support.md` (Screen orientation)  |
+| How does the engine hot-swap runtime work?                        | `src/hot/` (`protocol.ts`, `HotRuntime.ts`, `HotSwap.ts`); `BTAPI.hotReplaceDemo`/`getDemo`/`isInitialized` in `src/core/BTAPI.ts`; `IBTDemo.onHotReload` in `src/core/IBTDemo.ts`; hot-aware routing in `src/utils/Bootstrap.ts`                                     |
 
 ## Onboarding and the scaffolder
 
@@ -236,6 +237,10 @@ src/
     RenderPaletteUsage.ts  # Per-frame palette index usage mask for overlay grid
     WakeLock.ts             # Screen Wake Lock subsystem: acquire/release/re-acquire on visibilitychange (HardwareSettings.isWakeLockEnabled)
     Orientation.ts          # Screen orientation detection + optional lock (HardwareSettings.preferredOrientation, IBTDemo.onOrientationChange, BT.screenOrientation)
+  hot/
+    protocol.ts             # Shared types/constants for the hot-reload runtime (no value imports from src/; shared with the future src/vite/ plugin, BT-306)
+    HotRuntime.ts           # Vite HMR context registration, generation counter, hard-reload request, reload announce/broadcast
+    HotSwap.ts              # Tiered demo hot-swap: prototype swap (methods-only), re-init (init()/constructor changed), hard reload (hardware settings changed)
   overlay/
     Overlay.ts             # Orchestrator: sample, toggle, layout plan, delegate draws
     OverlayDrawTarget.ts   # Internal draw port (drawBarFill / drawLabel); not on IRenderer or BT

--- a/cspell.json
+++ b/cspell.json
@@ -73,6 +73,7 @@
     "rects",
     "reindexing",
     "reindexize",
+    "reinit",
     "retroblit",
     "RGBA",
     "rgba8unorm",

--- a/docs/_api-history.json
+++ b/docs/_api-history.json
@@ -11,7 +11,8 @@
     "1.1.1": "2026-06-07T14:08:44+02:00",
     "1.3.0": "2026-07-13T17:36:26+02:00",
     "1.3.1": "2026-07-19T18:11:00+02:00",
-    "1.3.2": null
+    "1.3.2": null,
+    "1.4.0": null
   },
   "symbols": {
     "AssetLoader": {
@@ -1077,6 +1078,20 @@
       "deprecated": null,
       "status": "stable"
     },
+    "HotContext": {
+      "kind": "interface",
+      "since": "1.4.0",
+      "changes": [],
+      "deprecated": null,
+      "status": "unreleased"
+    },
+    "HotReloadContext": {
+      "kind": "interface",
+      "since": "1.4.0",
+      "changes": [],
+      "deprecated": null,
+      "status": "unreleased"
+    },
     "IBTDemo": {
       "kind": "interface",
       "since": "0.1.0",
@@ -1084,6 +1099,10 @@
         {
           "version": "1.3.1",
           "note": "Added optional {@link IBTDemo.onOrientationChange} hook."
+        },
+        {
+          "version": "1.4.0",
+          "note": "Added optional {@link IBTDemo.onHotReload} hook."
         }
       ],
       "deprecated": null,
@@ -1368,6 +1387,13 @@
       "changes": [],
       "deprecated": null,
       "status": "stable"
+    },
+    "registerHotReload": {
+      "kind": "function",
+      "since": "1.4.0",
+      "changes": [],
+      "deprecated": null,
+      "status": "unreleased"
     }
   },
   "pages": {

--- a/docs/_api-history.json
+++ b/docs/_api-history.json
@@ -1335,7 +1335,12 @@
     "bootstrap": {
       "kind": "function",
       "since": "0.2.0",
-      "changes": [],
+      "changes": [
+        {
+          "version": "1.4.0",
+          "note": "Calling `bootstrap()` again while already initialized now routes to a hot\nswap (via {@link registerHotReload}) when a Vite HMR context is registered, or logs a\ndouble-bootstrap guard and returns `false` otherwise - previously it silently started a\nsecond, unstoppable `GameLoop`."
+        }
+      ],
       "deprecated": null,
       "status": "stable"
     },

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -19,6 +19,17 @@ This page is editorial – release highlights and migration notes, not an exhaus
 `guides/*` reference page, or [GitHub Releases](https://github.com/blit386/blit386/releases) for the full PR-by-PR
 notes, including dependency bumps and CI changes omitted here for brevity.
 
+## 1.4.0 - Unreleased
+
+### Added
+
+- Engine-side hot-reload runtime: `registerHotReload` (wired automatically by the upcoming `blit386/vite` plugin), an
+  optional `IBTDemo.onHotReload(context)` hook, and a tiered hot-swap - a method-only prototype swap when only method
+  bodies changed, a full re-init when `init()` or the constructor changed, and a full page reload when hardware settings
+  changed. Demo/game state persists across method and re-init swaps: ticks, camera, palette, and palette effects are
+  never reset. This lands the engine half of BLIT386's HMR support; the `blit386/vite` plugin, asset hot-replace, and
+  adoption in `blit386-demos`/`create-blit386` ship in follow-up releases.
+
 ## 1.3.1 - 2026-07-19
 
 ### Added

--- a/src/BLIT386.ts
+++ b/src/BLIT386.ts
@@ -34,6 +34,7 @@ import {
     type Backend,
     defaultConfig,
     type HardwareSettings,
+    type HotReloadContext,
     type IBTDemo,
     mergeHardwareSettings,
     type OverlayAudioMeterStyle,
@@ -42,6 +43,8 @@ import {
     type OverlayTimingChartStyle,
     type PreferredOrientation,
 } from './core/IBTDemo';
+import type { HotContext } from './hot/HotRuntime';
+import { registerHotReload } from './hot/HotRuntime';
 import {
     createDefaultKeyboardRuntimeMaps,
     DEFAULT_KEYBOARD_PLAYER1,
@@ -2111,6 +2114,7 @@ export {
     PixelGlitch,
     PixelMosaic,
     Rect2i,
+    registerHotReload,
     RGBMask,
     RollLine,
     Scanlines,
@@ -2127,6 +2131,8 @@ export type {
     Effect,
     EffectTier,
     HardwareSettings,
+    HotContext,
+    HotReloadContext,
     IBTDemo,
     MusicPlayOptions,
     OverlayAudioMeterStyle,

--- a/src/core/BTAPI.test.ts
+++ b/src/core/BTAPI.test.ts
@@ -2659,6 +2659,10 @@ describe('BTAPI', () => {
         });
 
         describe('hotReplaceDemo', () => {
+            afterEach(() => {
+                Reflect.deleteProperty(globalThis, 'screen');
+            });
+
             it('swaps in the new demo and returns true when init() succeeds', async () => {
                 const oldDemo = makeMockDemo();
                 await BTAPI.instance.init(oldDemo, makeMockCanvas());
@@ -2716,6 +2720,41 @@ describe('BTAPI', () => {
 
                 expect(result).toBe(false);
                 expect(BTAPI.instance.getDemo()).toBe(oldDemo);
+            });
+
+            it('rebinds orientation change events to the new demo after a successful swap', async () => {
+                const target = new EventTarget();
+                const mockOrientation = {
+                    type: 'landscape-primary',
+                    lock: vi.fn(async () => undefined),
+                    unlock: vi.fn(),
+                    addEventListener: vi.fn((event: string, listener: EventListener) =>
+                        target.addEventListener(event, listener),
+                    ),
+                    removeEventListener: vi.fn((event: string, listener: EventListener) =>
+                        target.removeEventListener(event, listener),
+                    ),
+                    dispatchEvent: (event: Event) => target.dispatchEvent(event),
+                };
+
+                Object.defineProperty(globalThis, 'screen', {
+                    configurable: true,
+                    value: { orientation: mockOrientation },
+                });
+
+                const oldOnOrientationChange = vi.fn();
+                const oldDemo = { ...makeMockDemo(), onOrientationChange: oldOnOrientationChange };
+                await BTAPI.instance.init(oldDemo, makeMockCanvas());
+
+                const newOnOrientationChange = vi.fn();
+                const newDemo = { ...makeMockDemo(), onOrientationChange: newOnOrientationChange };
+                await BTAPI.instance.hotReplaceDemo(newDemo);
+
+                mockOrientation.type = 'portrait-primary';
+                mockOrientation.dispatchEvent(new Event('change'));
+
+                expect(newOnOrientationChange).toHaveBeenCalledWith('portrait-primary');
+                expect(oldOnOrientationChange).not.toHaveBeenCalled();
             });
         });
     });

--- a/src/core/BTAPI.test.ts
+++ b/src/core/BTAPI.test.ts
@@ -2630,4 +2630,93 @@ describe('BTAPI', () => {
             expect(removeSpy).toHaveBeenCalledWith(effect);
         });
     });
+
+    describe('hot reload', () => {
+        describe('getDemo', () => {
+            it('returns null before initialization', () => {
+                expect(BTAPI.instance.getDemo()).toBeNull();
+            });
+
+            it('returns the active demo instance after initialization', async () => {
+                const demo = makeMockDemo();
+
+                await BTAPI.instance.init(demo, makeMockCanvas());
+
+                expect(BTAPI.instance.getDemo()).toBe(demo);
+            });
+        });
+
+        describe('isInitialized', () => {
+            it('returns false before initialization', () => {
+                expect(BTAPI.instance.isInitialized()).toBe(false);
+            });
+
+            it('returns true after a successful initialization', async () => {
+                await BTAPI.instance.init(makeMockDemo(), makeMockCanvas());
+
+                expect(BTAPI.instance.isInitialized()).toBe(true);
+            });
+        });
+
+        describe('hotReplaceDemo', () => {
+            it('swaps in the new demo and returns true when init() succeeds', async () => {
+                const oldDemo = makeMockDemo();
+                await BTAPI.instance.init(oldDemo, makeMockCanvas());
+
+                const newDemo = makeMockDemo();
+                const result = await BTAPI.instance.hotReplaceDemo(newDemo);
+
+                expect(result).toBe(true);
+                expect(BTAPI.instance.getDemo()).toBe(newDemo);
+            });
+
+            it('keeps the previous demo and returns false when init() returns false', async () => {
+                const oldDemo = makeMockDemo();
+                await BTAPI.instance.init(oldDemo, makeMockCanvas());
+
+                const newDemo = makeMockDemo(60, false);
+                const result = await BTAPI.instance.hotReplaceDemo(newDemo);
+
+                expect(result).toBe(false);
+                expect(BTAPI.instance.getDemo()).toBe(oldDemo);
+            });
+
+            it('keeps the previous demo and returns false when init() throws', async () => {
+                const oldDemo = makeMockDemo();
+                await BTAPI.instance.init(oldDemo, makeMockCanvas());
+
+                const newDemo = { ...makeMockDemo(), init: vi.fn().mockRejectedValue(new Error('boom')) };
+                const result = await BTAPI.instance.hotReplaceDemo(newDemo);
+
+                expect(result).toBe(false);
+                expect(BTAPI.instance.getDemo()).toBe(oldDemo);
+            });
+
+            it('never touches input/audio subsystems on failure (unlike cold-boot init failure)', async () => {
+                const oldDemo = makeMockDemo();
+                await BTAPI.instance.init(oldDemo, makeMockCanvas());
+
+                const clearSpy = vi.spyOn(
+                    BTAPI.instance as unknown as { clearInputSubsystems: () => void },
+                    'clearInputSubsystems',
+                );
+
+                const newDemo = makeMockDemo(60, false);
+                await BTAPI.instance.hotReplaceDemo(newDemo);
+
+                expect(clearSpy).not.toHaveBeenCalled();
+            });
+
+            it('returns false without swapping when the candidate is missing update()/render()', async () => {
+                const oldDemo = makeMockDemo();
+                await BTAPI.instance.init(oldDemo, makeMockCanvas());
+
+                const broken = { ...makeMockDemo(), update: undefined } as unknown as IBTDemo;
+                const result = await BTAPI.instance.hotReplaceDemo(broken);
+
+                expect(result).toBe(false);
+                expect(BTAPI.instance.getDemo()).toBe(oldDemo);
+            });
+        });
+    });
 });

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -521,6 +521,11 @@ export class BTAPI {
      * loop while this candidate's `init()` runs. A failed hot reload must leave the running
      * engine untouched.
      *
+     * On success, also rebinds the orientation subsystem's change callback to the new
+     * instance via {@link Orientation.setOnChange} - the listener installed at {@link init}
+     * closes over the *previous* demo's bound `onOrientationChange`, so without this,
+     * orientation events would keep reaching stale code after the swap.
+     *
      * @param newDemo - Freshly constructed candidate demo instance.
      * @returns `true` when `newDemo.init()` succeeds and {@link demo} was swapped to it.
      */
@@ -551,6 +556,7 @@ export class BTAPI {
         }
 
         this.demo = newDemo;
+        this.orientation?.setOnChange(newDemo.onOrientationChange?.bind(newDemo) ?? null);
 
         return true;
     }

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -511,6 +511,51 @@ export class BTAPI {
     }
 
     /**
+     * Runs a Tier 2 hot-swap candidate's `init()` while the previous demo instance keeps
+     * driving the loop, swapping {@link demo} to it only on success.
+     *
+     * Deliberately does not delegate to {@link runDemoInit}: that method calls
+     * {@link clearInputSubsystems} on failure, which is correct for a cold-boot failure
+     * (nothing else is running yet) but would tear down the pointer/keyboard/gamepad/audio
+     * subsystems out from under the *previous* demo instance, which is still driving the
+     * loop while this candidate's `init()` runs. A failed hot reload must leave the running
+     * engine untouched.
+     *
+     * @param newDemo - Freshly constructed candidate demo instance.
+     * @returns `true` when `newDemo.init()` succeeds and {@link demo} was swapped to it.
+     */
+    public async hotReplaceDemo(newDemo: IBTDemo): Promise<boolean> {
+        if (typeof newDemo.update !== 'function' || typeof newDemo.render !== 'function') {
+            console.error(
+                '[BT] Hot reload failed; keeping the previous version running: ' +
+                    'the new demo is missing update() or render()',
+            );
+
+            return false;
+        }
+
+        try {
+            const ok = await newDemo.init();
+
+            if (!ok) {
+                console.error(
+                    '[BT] Hot reload failed; keeping the previous version running: demo initialization failed',
+                );
+
+                return false;
+            }
+        } catch (err) {
+            console.error('[BT] Hot reload failed; keeping the previous version running:', err);
+
+            return false;
+        }
+
+        this.demo = newDemo;
+
+        return true;
+    }
+
+    /**
      * Gets the current tick count.
      * Ticks increment once per fixed update step (target rate set by `targetFPS`).
      *
@@ -583,6 +628,24 @@ export class BTAPI {
      */
     public getCanvas(): HTMLCanvasElement | null {
         return this.canvas;
+    }
+
+    /**
+     * Gets the active demo instance.
+     *
+     * @returns Current demo, or null if not initialized.
+     */
+    public getDemo(): IBTDemo | null {
+        return this.demo;
+    }
+
+    /**
+     * Reports whether the engine has completed initialization.
+     *
+     * @returns `true` when both a demo and the game loop are live.
+     */
+    public isInitialized(): boolean {
+        return this.demo !== null && this.loop !== null;
     }
 
     /**

--- a/src/core/IBTDemo.ts
+++ b/src/core/IBTDemo.ts
@@ -610,7 +610,8 @@ export interface IBTDemo {
      * this hook is only ever called during local development.
      *
      * @since 1.4.0
-     * @param context - Which tier ran, the new generation number, and (for `'reinit'`) a field snapshot of the previous instance.
+     * @param context - Which tier ran, the new generation number, and (for
+     *   `'reinit'`) a field snapshot of the previous instance.
      */
     onHotReload?(context: HotReloadContext): void;
 }

--- a/src/core/IBTDemo.ts
+++ b/src/core/IBTDemo.ts
@@ -42,6 +42,25 @@ export type AudioBus = 'main' | 'music' | 'sfx';
 export type PreferredOrientation = 'landscape' | 'portrait' | 'any';
 
 /**
+ * Passed to {@link IBTDemo.onHotReload} after a hot reload swaps in new code.
+ *
+ * @since 1.4.0
+ */
+export interface HotReloadContext {
+    /** Which swap tier ran: `'methods'` swapped the prototype in place; `'reinit'` re-ran `init()` on a fresh instance. */
+    reason: 'methods' | 'reinit';
+
+    /** Hot-swap generation number, incremented on every successful swap since page load. */
+    generation: number;
+
+    /**
+     * Own enumerable fields of the previous demo instance, captured just before `init()` ran on
+     * the new one. Present only when `reason` is `'reinit'`.
+     */
+    snapshot?: Record<string, unknown>;
+}
+
+/**
  * Engine-facing hardware configuration returned by `configure()` when a demo
  * implements that optional hook, or by {@link defaultConfig} otherwise.
  *
@@ -487,6 +506,7 @@ export interface OverlayRow {
  *
  * @since 0.1.0
  * @changed 1.3.1 Added optional {@link IBTDemo.onOrientationChange} hook.
+ * @changed 1.4.0 Added optional {@link IBTDemo.onHotReload} hook.
  */
 export interface IBTDemo {
     /**
@@ -576,6 +596,23 @@ export interface IBTDemo {
      *   `'landscape-primary'` or `'portrait-secondary'`).
      */
     onOrientationChange?(type: string): void;
+
+    /**
+     * Optional hook called after a hot reload swaps in new code for this demo.
+     *
+     * Fires for both swap tiers: `'methods'` (the prototype was swapped in place; this
+     * instance and its fields are untouched) and `'reinit'` (a fresh instance was
+     * constructed and its `init()` re-run; `snapshot` carries the previous instance's own
+     * enumerable fields so state can be restored). Never fires for a hardware-settings
+     * change, which triggers a full page reload instead.
+     *
+     * No-op in production - `import.meta.hot` never exists outside a Vite dev server, so
+     * this hook is only ever called during local development.
+     *
+     * @since 1.4.0
+     * @param context - Which tier ran, the new generation number, and (for `'reinit'`) a field snapshot of the previous instance.
+     */
+    onHotReload?(context: HotReloadContext): void;
 }
 
 /**

--- a/src/core/Orientation.ts
+++ b/src/core/Orientation.ts
@@ -147,6 +147,21 @@ export class Orientation {
     }
 
     /**
+     * Rebinds the demo callback for subsequent orientation changes, without touching the
+     * live listener, lock state, or attach/detach generation.
+     *
+     * Used when a hot reload swaps in a new demo instance ({@link BTAPI.hotReplaceDemo}):
+     * the `change` listener installed by {@link attach} closes over `this.onChange`, so
+     * without this, orientation events would keep reaching the *previous* demo's bound
+     * handler after the swap.
+     *
+     * @param onChange - Replacement demo callback, or `null` to stop forwarding events.
+     */
+    public setOnChange(onChange: ChangeHandler | null): void {
+        this.onChange = onChange;
+    }
+
+    /**
      * Removes the `change` listener and unlocks only when this instance holds a lock.
      *
      * Safe to call repeatedly or when {@link attach} was never called (for example

--- a/src/hot/HotRuntime.test.ts
+++ b/src/hot/HotRuntime.test.ts
@@ -1,0 +1,153 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ASSET_CHANGED_EVENT, HOT_RELOAD_DOM_EVENT } from './protocol';
+
+function makeFakeHotContext(onImpl?: (event: string, cb: (payload: unknown) => void) => void) {
+    return {
+        data: {},
+        on: vi.fn(onImpl),
+        invalidate: vi.fn(),
+        accept: vi.fn(),
+    };
+}
+
+describe('HotRuntime', () => {
+    // Fresh module state per test - hot/generation/wired are module-scoped singletons
+    // that mirror real page-load semantics (a fresh page load is a fresh module instance).
+    // BTAPI is re-imported through the SAME vi.resetModules() epoch as HotRuntime so
+    // `BTAPI.instance` in the test is the identical singleton HotRuntime's internal
+    // `import { BTAPI } from '../core/BTAPI'` resolves to - spying on the test's copy
+    // then actually intercepts the call HotRuntime.announce() makes.
+    // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+    let HotRuntime: typeof import('./HotRuntime');
+    // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+    let BTAPI: typeof import('../core/BTAPI').BTAPI;
+
+    beforeEach(async () => {
+        vi.resetModules();
+        HotRuntime = await import('./HotRuntime');
+        ({ BTAPI } = await import('../core/BTAPI'));
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe('registerHotContext', () => {
+        it('wires the asset-changed listener once, across repeated registrations', () => {
+            const first = makeFakeHotContext();
+            const second = makeFakeHotContext();
+
+            HotRuntime.registerHotContext(first);
+            expect(first.on).toHaveBeenCalledExactlyOnceWith(ASSET_CHANGED_EVENT, expect.any(Function));
+
+            HotRuntime.registerHotContext(second);
+            expect(second.on).not.toHaveBeenCalled();
+        });
+
+        it('is inactive before any registration, and active immediately after', () => {
+            expect(HotRuntime.isHotActive()).toBe(false);
+
+            HotRuntime.registerHotContext(makeFakeHotContext());
+
+            expect(HotRuntime.isHotActive()).toBe(true);
+        });
+
+        it('swallows a throw from a broken hot context and logs it', () => {
+            const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+            const broken = {
+                data: {},
+                on: vi.fn(() => {
+                    throw new Error('broken context');
+                }),
+                invalidate: vi.fn(),
+                accept: vi.fn(),
+            };
+
+            expect(() => HotRuntime.registerHotContext(broken)).not.toThrow();
+            expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to register'), expect.any(Error));
+        });
+    });
+
+    describe('registerHotReload', () => {
+        it('delegates to registerHotContext', () => {
+            const hot = makeFakeHotContext();
+
+            HotRuntime.registerHotReload(hot);
+
+            expect(HotRuntime.isHotActive()).toBe(true);
+            expect(hot.on).toHaveBeenCalledExactlyOnceWith(ASSET_CHANGED_EVENT, expect.any(Function));
+        });
+    });
+
+    describe('nextGeneration', () => {
+        it('increments on every call, starting from 1', () => {
+            expect(HotRuntime.nextGeneration()).toBe(1);
+            expect(HotRuntime.nextGeneration()).toBe(2);
+            expect(HotRuntime.nextGeneration()).toBe(3);
+        });
+    });
+
+    describe('requestHardReload', () => {
+        it('calls invalidate on the registered hot context', () => {
+            const hot = makeFakeHotContext();
+            HotRuntime.registerHotContext(hot);
+
+            HotRuntime.requestHardReload('settings changed');
+
+            expect(hot.invalidate).toHaveBeenCalledExactlyOnceWith('settings changed');
+        });
+
+        it('falls back to location.reload when no hot context is registered', () => {
+            const reloadSpy = vi.fn();
+            Object.defineProperty(globalThis, 'location', {
+                value: { ...globalThis.location, reload: reloadSpy },
+                configurable: true,
+            });
+
+            HotRuntime.requestHardReload('settings changed');
+
+            expect(reloadSpy).toHaveBeenCalledOnce();
+        });
+    });
+
+    describe('announce', () => {
+        it('logs a console line with the reason, generation, and elapsed time', () => {
+            const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+            HotRuntime.announce('methods', 3, 12.5);
+
+            expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('#3'));
+            expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('methods'));
+            expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('12.5'));
+        });
+
+        it('dispatches a CustomEvent with reason/generation detail on the engine canvas', () => {
+            const canvas = document.createElement('canvas');
+            vi.spyOn(BTAPI.instance, 'getCanvas').mockReturnValue(canvas);
+
+            let receivedDetail: unknown;
+            canvas.addEventListener(HOT_RELOAD_DOM_EVENT, (event) => {
+                receivedDetail = (event as CustomEvent).detail;
+            });
+
+            HotRuntime.announce('reinit', 7, 3.2);
+
+            expect(receivedDetail).toEqual({ reason: 'reinit', generation: 7 });
+        });
+
+        it('falls back to window when no canvas is available', () => {
+            vi.spyOn(BTAPI.instance, 'getCanvas').mockReturnValue(null);
+
+            let receivedDetail: unknown;
+            window.addEventListener(HOT_RELOAD_DOM_EVENT, (event) => {
+                receivedDetail = (event as CustomEvent).detail;
+            });
+
+            HotRuntime.announce('methods', 1, 1);
+
+            expect(receivedDetail).toEqual({ reason: 'methods', generation: 1 });
+        });
+    });
+});

--- a/src/hot/HotRuntime.test.ts
+++ b/src/hot/HotRuntime.test.ts
@@ -54,7 +54,7 @@ describe('HotRuntime', () => {
             expect(HotRuntime.isHotActive()).toBe(true);
         });
 
-        it('swallows a throw from a broken hot context and logs it', () => {
+        it('swallows a throw from a broken hot context and logs it, without permanently blocking future wiring', () => {
             const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
             const broken = {
                 data: {},
@@ -67,6 +67,14 @@ describe('HotRuntime', () => {
 
             expect(() => HotRuntime.registerHotContext(broken)).not.toThrow();
             expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to register'), expect.any(Error));
+            expect(HotRuntime.isHotActive()).toBe(false);
+
+            const working = makeFakeHotContext();
+
+            HotRuntime.registerHotContext(working);
+
+            expect(working.on).toHaveBeenCalledExactlyOnceWith(ASSET_CHANGED_EVENT, expect.any(Function));
+            expect(HotRuntime.isHotActive()).toBe(true);
         });
     });
 

--- a/src/hot/HotRuntime.ts
+++ b/src/hot/HotRuntime.ts
@@ -67,12 +67,12 @@ function handleAssetChanged(payload: unknown): void {
  */
 export function registerHotContext(context: HotContext): void {
     try {
-        hot = context;
-
         if (!wired) {
+            context.on(ASSET_CHANGED_EVENT, handleAssetChanged);
             wired = true;
-            hot.on(ASSET_CHANGED_EVENT, handleAssetChanged);
         }
+
+        hot = context;
     } catch (err) {
         console.error('[BT] Failed to register the hot-reload context:', err);
     }

--- a/src/hot/HotRuntime.ts
+++ b/src/hot/HotRuntime.ts
@@ -1,0 +1,169 @@
+/**
+ * Vite HMR context registration, hot-swap generation counter, hard-reload
+ * request, and hot-reload broadcast for the engine's hot-reload runtime.
+ *
+ * Depends on `BTAPI` (for the canvas to dispatch the broadcast on) but never
+ * on `vite` itself - {@link HotContext} is a structural type matching Vite's
+ * `import.meta.hot`, not an import from the `vite` package.
+ */
+
+import { BTAPI } from '../core/BTAPI';
+import { ASSET_CHANGED_EVENT, HOT_RELOAD_DOM_EVENT } from './protocol';
+
+/**
+ * Minimal structural shape of Vite's `import.meta.hot` context that the engine
+ * depends on. Kept structural (not imported from `vite`) so the published
+ * engine bundle never depends on Vite's types or runtime.
+ *
+ * @since 1.4.0
+ */
+export interface HotContext {
+    /** Persistent data bag Vite preserves across a module's hot replacement. */
+    data: Record<string, unknown>;
+
+    /** Subscribes to a Vite custom HMR event (for example an asset-changed broadcast). */
+    on(event: string, callback: (payload: unknown) => void): void;
+
+    /** Requests Vite fall back to a full page reload, with an optional reason string. */
+    invalidate(message?: string): void;
+
+    /** Marks the current module as self-accepting; called once by the injected snippet. */
+    accept(): void;
+}
+
+/** Registered Vite HMR context, or `null` before {@link registerHotContext} runs. */
+let hot: HotContext | null = null;
+
+/** Hot-swap generation counter; advanced only through {@link nextGeneration}. */
+let generation = 0;
+
+/**
+ * True once {@link registerHotContext} has wired the asset-changed listener, so a
+ * re-evaluated entry module (every hot reload re-runs top-level module code) does
+ * not attach the listener a second time.
+ */
+let wired = false;
+
+/**
+ * Placeholder asset-changed handler; replaced with real hot-replace routing to
+ * `AssetLoader`/`SpriteSheet`/`AudioClip`/`BitmapFont` in BT-305.
+ *
+ * @param payload - Asset-changed event payload from the Vite plugin.
+ */
+function handleAssetChanged(payload: unknown): void {
+    void payload;
+}
+
+/**
+ * Registers the active Vite HMR context and wires the asset-changed listener
+ * exactly once.
+ *
+ * The entire body runs in try/catch: this function executes synchronously at
+ * the entry module's top level (via the snippet the `blit386/vite` plugin
+ * injects), so a throw here (for example from an incompatible or broken `hot`
+ * object) must not abort loading the game.
+ *
+ * @param context - Vite's `import.meta.hot` context.
+ */
+export function registerHotContext(context: HotContext): void {
+    try {
+        hot = context;
+
+        if (!wired) {
+            wired = true;
+            hot.on(ASSET_CHANGED_EVENT, handleAssetChanged);
+        }
+    } catch (err) {
+        console.error('[BT] Failed to register the hot-reload context:', err);
+    }
+}
+
+/**
+ * Registers the active Vite HMR context so the engine can hot-swap the demo
+ * class in place instead of reloading the page.
+ *
+ * Wired automatically by the snippet the `blit386/vite` plugin (BT-306)
+ * injects into a demo/game's entry module, immediately after the
+ * `bootstrap(Game)` call:
+ *
+ * ```js
+ * import { registerHotReload } from 'blit386';
+ * if (import.meta.hot) {
+ *     import.meta.hot.accept();
+ *     registerHotReload(import.meta.hot);
+ * }
+ * ```
+ *
+ * Never called by hand - it does nothing useful without the plugin's matching
+ * asset watcher and snippet injection.
+ *
+ * @since 1.4.0
+ * @param hot - Vite's `import.meta.hot` context (or a structurally compatible object).
+ */
+export function registerHotReload(hot: HotContext): void {
+    registerHotContext(hot);
+}
+
+/**
+ * Reports whether a Vite HMR context is registered.
+ *
+ * Gates dev-only registries and logic so production builds (no
+ * `import.meta.hot`, so {@link registerHotContext} never runs) pay nothing for
+ * hot reload.
+ *
+ * @returns `true` once {@link registerHotContext} has run.
+ */
+export function isHotActive(): boolean {
+    return hot !== null;
+}
+
+/**
+ * Advances and returns the module-level hot-swap generation counter.
+ *
+ * @returns The new generation number after incrementing.
+ */
+export function nextGeneration(): number {
+    generation += 1;
+
+    return generation;
+}
+
+/**
+ * Requests a full page reload through Vite's invalidation API, falling back to
+ * a direct reload when no HMR context is registered.
+ *
+ * @param reason - Human-readable reason surfaced in Vite's overlay/log.
+ */
+export function requestHardReload(reason: string): void {
+    if (hot) {
+        hot.invalidate(reason);
+
+        return;
+    }
+
+    globalThis.location.reload();
+}
+
+/**
+ * Logs and broadcasts a completed hot reload.
+ *
+ * Dispatches on the engine canvas so games can add a listener scoped to their
+ * own canvas element; falls back to `window` before the canvas exists.
+ *
+ * @param reason - Which swap tier ran (`'methods'` mutated the prototype in place; `'reinit'` re-ran `init()`).
+ * @param generationValue - Generation number after this swap.
+ * @param elapsedMs - Wall-clock duration of the swap, for the console line.
+ */
+export function announce(reason: 'methods' | 'reinit', generationValue: number, elapsedMs: number): void {
+    console.log(`[BT] Hot reload #${generationValue} (${reason}) in ${elapsedMs.toFixed(1)}ms`);
+
+    const target: EventTarget = BTAPI.instance.getCanvas() ?? globalThis.window;
+
+    target.dispatchEvent(
+        new CustomEvent(HOT_RELOAD_DOM_EVENT, {
+            detail: { reason, generation: generationValue },
+            bubbles: true,
+            composed: true,
+        }),
+    );
+}

--- a/src/hot/HotSwap.test.ts
+++ b/src/hot/HotSwap.test.ts
@@ -1,0 +1,319 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { BTAPI } from '../core/BTAPI';
+import type { HardwareSettings, IBTDemo } from '../core/IBTDemo';
+import type { DemoConstructor } from '../utils/Bootstrap';
+import * as HotRuntime from './HotRuntime';
+import { hasHardReloadDiff, hotSwapDemo, initFingerprint } from './HotSwap';
+
+function resetSingleton(): void {
+    (BTAPI as unknown as { _instance: BTAPI | null })._instance = null;
+}
+
+function makeMockCanvas(): HTMLCanvasElement {
+    return {
+        width: 0,
+        height: 0,
+        style: { setProperty: vi.fn(), getPropertyValue: vi.fn(() => '') },
+        getContext: () => null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+    } as unknown as HTMLCanvasElement;
+}
+
+describe('initFingerprint', () => {
+    it('is equal when only a non-init method body changes', () => {
+        class A {
+            init() {
+                return Promise.resolve(true);
+            }
+            update() {
+                return 1;
+            }
+            render() {}
+        }
+        class B {
+            init() {
+                return Promise.resolve(true);
+            }
+            update() {
+                return 2;
+            }
+            render() {}
+        }
+
+        expect(initFingerprint(A as unknown as DemoConstructor)).toBe(initFingerprint(B as unknown as DemoConstructor));
+    });
+
+    it('differs when init() changes', () => {
+        class A {
+            init() {
+                return Promise.resolve(true);
+            }
+            update() {}
+            render() {}
+        }
+        class B {
+            init() {
+                return Promise.resolve(false);
+            }
+            update() {}
+            render() {}
+        }
+
+        expect(initFingerprint(A as unknown as DemoConstructor)).not.toBe(
+            initFingerprint(B as unknown as DemoConstructor),
+        );
+    });
+
+    it('differs when a class-field initializer changes', () => {
+        class A {
+            speed = 1;
+            init() {
+                return Promise.resolve(true);
+            }
+            update() {}
+            render() {}
+        }
+        class B {
+            speed = 2;
+            init() {
+                return Promise.resolve(true);
+            }
+            update() {}
+            render() {}
+        }
+
+        expect(initFingerprint(A as unknown as DemoConstructor)).not.toBe(
+            initFingerprint(B as unknown as DemoConstructor),
+        );
+    });
+
+    // initFingerprint is documented as exact-string comparison (not AST-aware): per the
+    // ECMAScript spec, a real browser's Function.prototype.toString() returns a function's
+    // literal source text verbatim when available, so a whitespace-only edit (an extra blank
+    // line, extra spaces) there WOULD change the fingerprint. That specific claim cannot be
+    // exercised here, though: Vitest's esbuild-based TS transform re-serializes the parsed AST
+    // rather than preserving literal source text, and this repo's Biome formatter would also
+    // collapse any such whitespace-only edit on the next `pnpm run format` pass regardless.
+    // Verified empirically (blank lines, extra inter-token spacing) - both are normalized away
+    // before Function.prototype.toString() ever sees them in this environment. This test
+    // documents that behavior directly instead of asserting the untestable production claim.
+    it('is unaffected by a whitespace-only edit inside init() under this test transform', () => {
+        class A {
+            init() {
+                return Promise.resolve(true);
+            }
+            update() {}
+            render() {}
+        }
+        class B {
+            init() {
+                return Promise.resolve(true);
+            }
+            update() {}
+            render() {}
+        }
+
+        expect(initFingerprint(A as unknown as DemoConstructor)).toBe(initFingerprint(B as unknown as DemoConstructor));
+    });
+});
+
+describe('hasHardReloadDiff', () => {
+    const base = {
+        displaySize: { x: 320, y: 240, isEqual: (o: { x: number; y: number }) => o.x === 320 && o.y === 240 },
+        targetFPS: 60,
+        backend: 'webgpu',
+        audioVoices: 16,
+        outputUpscaleFilter: 'nearest',
+        isOverlayEnabled: true,
+    } as unknown as HardwareSettings;
+
+    it('is false when settings are unchanged', () => {
+        expect(hasHardReloadDiff(base, { ...base })).toBe(false);
+    });
+
+    const CHANGED_VALUES: Record<string, unknown> = {
+        targetFPS: 30,
+        backend: 'software',
+        audioVoices: 8,
+        outputUpscaleFilter: 'linear',
+        isOverlayEnabled: false,
+    };
+
+    it.each(Object.keys(CHANGED_VALUES))('is true when %s changes', (field) => {
+        // eslint-disable-next-line security/detect-object-injection -- field iterates CHANGED_VALUES' own keys, not external input
+        const changed = { ...base, [field]: CHANGED_VALUES[field] };
+        expect(hasHardReloadDiff(base, changed)).toBe(true);
+    });
+});
+
+describe('hotSwapDemo', () => {
+    beforeEach(() => {
+        resetSingleton();
+        vi.spyOn(HotRuntime, 'requestHardReload').mockImplementation(() => {});
+        vi.spyOn(HotRuntime, 'announce').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        resetSingleton();
+        vi.restoreAllMocks();
+    });
+
+    function makeDemo(overrides: Partial<IBTDemo> = {}): IBTDemo {
+        return {
+            // No overrides: mergeHardwareSettings() treats an omitted displaySize identically
+            // to an explicit `undefined` value, so this is behaviorally the same as
+            // `{ displaySize: undefined }` while satisfying exactOptionalPropertyTypes.
+            configure: () => ({}),
+            init: vi.fn().mockResolvedValue(true),
+            update: vi.fn(),
+            render: vi.fn(),
+            ...overrides,
+        };
+    }
+
+    it('requests a hard reload when hardware settings changed (Tier 3)', async () => {
+        const oldDemo = makeDemo();
+        await BTAPI.instance.init(oldDemo, makeMockCanvas());
+
+        class NewClass {
+            configure() {
+                return { targetFPS: 30 };
+            }
+            async init() {
+                return true;
+            }
+            update() {}
+            render() {}
+        }
+
+        const result = await hotSwapDemo(NewClass as unknown as DemoConstructor);
+
+        expect(result).toBe(true);
+        expect(HotRuntime.requestHardReload).toHaveBeenCalledOnce();
+    });
+
+    it('re-initializes and swaps the instance when init() changed (Tier 2), passing a snapshot to onHotReload', async () => {
+        class OldClass {
+            score = 42;
+            async init() {
+                return true;
+            }
+            update() {}
+            render() {}
+        }
+
+        const oldDemo = new OldClass();
+        await BTAPI.instance.init(oldDemo, makeMockCanvas());
+
+        const onHotReload = vi.fn();
+
+        class NewClass {
+            onHotReload = onHotReload;
+
+            async init() {
+                // Different body than OldClass.init() on purpose, so initFingerprint differs
+                // and this test actually exercises Tier 2 rather than Tier 1.
+                return Promise.resolve(true);
+            }
+            update() {}
+            render() {}
+        }
+
+        const result = await hotSwapDemo(NewClass as unknown as DemoConstructor);
+
+        expect(result).toBe(true);
+        expect(BTAPI.instance.getDemo()).not.toBe(oldDemo);
+        expect(onHotReload).toHaveBeenCalledWith(
+            expect.objectContaining({ reason: 'reinit', snapshot: expect.objectContaining({ score: 42 }) }),
+        );
+        expect(HotRuntime.announce).toHaveBeenCalledWith('reinit', expect.any(Number), expect.any(Number));
+    });
+
+    it('keeps the old demo running when Tier 2 re-init fails', async () => {
+        class OldClass {
+            async init() {
+                return true;
+            }
+            update() {}
+            render() {}
+        }
+
+        const oldDemo = new OldClass();
+        await BTAPI.instance.init(oldDemo, makeMockCanvas());
+
+        class NewClass {
+            async init() {
+                // Different body than OldClass.init() on purpose, so initFingerprint differs
+                // and this test actually exercises Tier 2 rather than Tier 1.
+                return Promise.resolve(false);
+            }
+            update() {}
+            render() {}
+        }
+
+        const result = await hotSwapDemo(NewClass as unknown as DemoConstructor);
+
+        expect(result).toBe(false);
+        expect(BTAPI.instance.getDemo()).toBe(oldDemo);
+    });
+
+    it('swaps the prototype in place and preserves fields when only methods changed (Tier 1)', async () => {
+        class Original {
+            score = 7;
+            async init() {
+                return true;
+            }
+            update() {
+                return 'old';
+            }
+            render() {}
+        }
+
+        const oldDemo = new Original();
+        await BTAPI.instance.init(oldDemo, makeMockCanvas());
+
+        // score stays 7, matching Original: initFingerprint treats a class-field initializer
+        // change as a Tier 2 signal (see the initFingerprint describe block above), so this
+        // test - which isolates a methods-only change - must not vary it. Its value would be
+        // moot at runtime either way, since Tier 1 never re-runs a constructor.
+        class NewClass {
+            score = 7;
+            async init() {
+                return true;
+            }
+            update() {
+                return 'new';
+            }
+            render() {}
+        }
+
+        const result = await hotSwapDemo(NewClass as unknown as DemoConstructor);
+
+        expect(result).toBe(true);
+        expect(BTAPI.instance.getDemo()).toBe(oldDemo); // same instance, not the new one
+        expect((BTAPI.instance.getDemo() as unknown as { score: number }).score).toBe(7); // field preserved
+        expect((BTAPI.instance.getDemo() as unknown as { update: () => string }).update()).toBe('new'); // method rebound
+        expect(HotRuntime.announce).toHaveBeenCalledWith('methods', expect.any(Number), expect.any(Number));
+    });
+
+    it('returns false and logs when the candidate class throws on construction', async () => {
+        const oldDemo = makeDemo();
+        await BTAPI.instance.init(oldDemo, makeMockCanvas());
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        class Throws {
+            constructor() {
+                throw new Error('boom');
+            }
+        }
+
+        const result = await hotSwapDemo(Throws as unknown as DemoConstructor);
+
+        expect(result).toBe(false);
+        expect(BTAPI.instance.getDemo()).toBe(oldDemo);
+        expect(errorSpy).toHaveBeenCalled();
+    });
+});

--- a/src/hot/HotSwap.test.ts
+++ b/src/hot/HotSwap.test.ts
@@ -147,6 +147,24 @@ describe('hasHardReloadDiff', () => {
         const changed = { ...base, [field]: CHANGED_VALUES[field] };
         expect(hasHardReloadDiff(base, changed)).toBe(true);
     });
+
+    // These five fields are deliberately excluded from the hard-reload comparison (per the
+    // originating issue's own field list): they are applied live by their own subsystems
+    // (PointerInput, KeyboardInput, WakeLock, Orientation) rather than requiring a fresh
+    // init(), so changing any of them must never force a Tier 3 hard reload.
+    const EXCLUDED_CHANGED_VALUES: Record<string, unknown> = {
+        isCapturingPointerScroll: true,
+        isCapturingKeyboardScroll: true,
+        isWakeLockEnabled: true,
+        preferredOrientation: 'landscape',
+        isDetectingDroppedFrames: true,
+    };
+
+    it.each(Object.keys(EXCLUDED_CHANGED_VALUES))('is false when excluded field %s changes', (field) => {
+        // eslint-disable-next-line security/detect-object-injection -- field iterates EXCLUDED_CHANGED_VALUES' own keys, not external input
+        const changed = { ...base, [field]: EXCLUDED_CHANGED_VALUES[field] };
+        expect(hasHardReloadDiff(base, changed)).toBe(false);
+    });
 });
 
 describe('hotSwapDemo', () => {

--- a/src/hot/HotSwap.test.ts
+++ b/src/hot/HotSwap.test.ts
@@ -118,6 +118,26 @@ describe('initFingerprint', () => {
 
         expect(initFingerprint(A as unknown as DemoConstructor)).toBe(initFingerprint(B as unknown as DemoConstructor));
     });
+
+    it('never invokes a getter defined on the prototype', () => {
+        const getterCalls = vi.fn();
+
+        class WithGetter {
+            get currentScore(): number {
+                getterCalls();
+
+                return 0;
+            }
+            init() {
+                return Promise.resolve(true);
+            }
+            update() {}
+            render() {}
+        }
+
+        expect(() => initFingerprint(WithGetter as unknown as DemoConstructor)).not.toThrow();
+        expect(getterCalls).not.toHaveBeenCalled();
+    });
 });
 
 describe('hasHardReloadDiff', () => {
@@ -211,6 +231,34 @@ describe('hotSwapDemo', () => {
 
         expect(result).toBe(true);
         expect(HotRuntime.requestHardReload).toHaveBeenCalledOnce();
+    });
+
+    it('aborts without swapping when configure() throws, keeping the previous demo running', async () => {
+        const oldDemo = makeDemo();
+        await BTAPI.instance.init(oldDemo, makeMockCanvas());
+
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        class NewClass {
+            configure(): never {
+                throw new Error('boom');
+            }
+            async init() {
+                return true;
+            }
+            update() {}
+            render() {}
+        }
+
+        const result = await hotSwapDemo(NewClass as unknown as DemoConstructor);
+
+        expect(result).toBe(false);
+        expect(BTAPI.instance.getDemo()).toBe(oldDemo);
+        expect(HotRuntime.requestHardReload).not.toHaveBeenCalled();
+        expect(errorSpy).toHaveBeenCalledWith(
+            expect.stringContaining('keeping the previous version running'),
+            expect.any(Error),
+        );
     });
 
     it('re-initializes and swaps the instance when init() changed (Tier 2), passing a snapshot to onHotReload', async () => {

--- a/src/hot/HotSwap.ts
+++ b/src/hot/HotSwap.ts
@@ -118,19 +118,17 @@ export function initFingerprint(cls: DemoConstructor): string {
 
     let classSource = cls.toString().replace(CLASS_NAME_HEADER_PATTERN, 'class');
 
-    /* eslint-disable security/detect-object-injection -- name comes from Object.getOwnPropertyNames(cls.prototype), not external input */
     for (const name of Object.getOwnPropertyNames(cls.prototype)) {
         if (name === 'constructor') {
             continue;
         }
 
-        const member = prototype[name];
+        const member = Object.getOwnPropertyDescriptor(cls.prototype, name)?.value;
 
         if (typeof member === 'function') {
             classSource = classSource.replace(member.toString(), '');
         }
     }
-    /* eslint-enable security/detect-object-injection */
 
     return initSource + classSource;
 }
@@ -151,13 +149,34 @@ function constructCandidate(NewClass: DemoConstructor): IBTDemo | null {
     }
 }
 
+/** {@link tryHardReload} could not run at all because the candidate's `configure()` threw. */
+const HARD_RELOAD_OUTCOME_ABORTED = 'aborted';
+
+/** {@link tryHardReload} ran to completion and found no init-only hardware-settings diff. */
+const HARD_RELOAD_OUTCOME_NO_DIFF = 'no-diff';
+
+/** {@link tryHardReload} ran to completion, found a diff, and requested a hard reload. */
+const HARD_RELOAD_OUTCOME_RELOAD = 'reload';
+
+/**
+ * Outcome of the Tier 3 hardware-settings check. {@link HARD_RELOAD_OUTCOME_RELOAD} and
+ * {@link HARD_RELOAD_OUTCOME_NO_DIFF} mean the check itself ran to completion (settings
+ * differed, or they didn't); {@link HARD_RELOAD_OUTCOME_ABORTED} means the check could not
+ * run at all, so {@link hotSwapDemo} must stop without attempting any swap - a hard-reload
+ * result and an aborted check are not interchangeable "no swap happened" outcomes.
+ */
+type HardReloadOutcome =
+    | typeof HARD_RELOAD_OUTCOME_ABORTED
+    | typeof HARD_RELOAD_OUTCOME_NO_DIFF
+    | typeof HARD_RELOAD_OUTCOME_RELOAD;
+
 /**
  * Runs the Tier 3 check: a hardware-settings change forces a full page reload.
  *
  * @param newDemo - Constructed candidate instance.
- * @returns `true` when a hard reload was requested; the caller should stop and return `true`.
+ * @returns The check's outcome; see {@link HardReloadOutcome}.
  */
-function tryHardReload(newDemo: IBTDemo): boolean {
+function tryHardReload(newDemo: IBTDemo): HardReloadOutcome {
     let nextSettings: HardwareSettings;
 
     try {
@@ -165,7 +184,7 @@ function tryHardReload(newDemo: IBTDemo): boolean {
     } catch (err) {
         console.error('[BT] Hot reload failed; keeping the previous version running:', err);
 
-        return false;
+        return HARD_RELOAD_OUTCOME_ABORTED;
     }
 
     const previousSettings = BTAPI.instance.getHardwareSettings();
@@ -173,10 +192,10 @@ function tryHardReload(newDemo: IBTDemo): boolean {
     if (previousSettings && hasHardReloadDiff(previousSettings, nextSettings)) {
         requestHardReload('Hardware settings changed');
 
-        return true;
+        return HARD_RELOAD_OUTCOME_RELOAD;
     }
 
-    return false;
+    return HARD_RELOAD_OUTCOME_NO_DIFF;
 }
 
 /**
@@ -258,8 +277,14 @@ export async function hotSwapDemo(NewClass: DemoConstructor): Promise<boolean> {
         return false;
     }
 
-    if (tryHardReload(newDemo)) {
+    const hardReloadOutcome = tryHardReload(newDemo);
+
+    if (hardReloadOutcome === HARD_RELOAD_OUTCOME_RELOAD) {
         return true;
+    }
+
+    if (hardReloadOutcome === HARD_RELOAD_OUTCOME_ABORTED) {
+        return false;
     }
 
     if (initFingerprint(oldDemo.constructor as unknown as DemoConstructor) !== initFingerprint(NewClass)) {

--- a/src/hot/HotSwap.ts
+++ b/src/hot/HotSwap.ts
@@ -1,0 +1,272 @@
+/**
+ * Tiered demo hot-swap: constructs a candidate instance from the newly evaluated
+ * demo class and swaps it into the running engine using the cheapest tier that is
+ * safe for what changed, preserving state whenever possible.
+ *
+ * Called only by `bootstrap()` (`src/utils/Bootstrap.ts`) when the engine is already
+ * initialized and a Vite HMR context is registered ({@link isHotActive}); never
+ * called directly by demo/game code.
+ */
+
+import { BTAPI } from '../core/BTAPI';
+import type { HardwareSettings, IBTDemo } from '../core/IBTDemo';
+import { mergeHardwareSettings } from '../core/IBTDemo';
+import type { DemoConstructor } from '../utils/Bootstrap';
+import type { Vector2i } from '../utils/Vector2i';
+import { announce, nextGeneration, requestHardReload } from './HotRuntime';
+
+/** HardwareSettings vector fields that force a hard reload when they change. */
+const HARD_RELOAD_VECTOR_FIELDS = ['displaySize', 'drawingBufferSize', 'maxCanvasSize'] as const;
+
+/** HardwareSettings scalar/string fields that force a hard reload when they change. */
+const HARD_RELOAD_SCALAR_FIELDS = ['targetFPS', 'backend', 'audioVoices', 'outputUpscaleFilter'] as const;
+
+/** HardwareSettings overlay scalar/boolean/count flags that force a hard reload when they change. */
+const HARD_RELOAD_OVERLAY_FLAG_FIELDS = [
+    'isOverlayEnabled',
+    'isOverlayVisibleAtStart',
+    'isOverlayToggleHintVisible',
+    'isOverlayToggleEnabled',
+    'isOverlayToggleHitDebugVisible',
+    'isOverlayPaletteEnabled',
+    'overlayPaletteColumns',
+    'overlayPaletteRowsVisible',
+    'isOverlayTimingChartEnabled',
+    'overlayTimingChartHeight',
+    'overlayTimingChartDiagnostics',
+    'isOverlayRendererDiagnosticsBarEnabled',
+    'isOverlayAudioMetersEnabled',
+    'overlayAudioMeterHeight',
+] as const;
+
+/** HardwareSettings style-object fields compared by JSON projection. */
+const HARD_RELOAD_STYLE_FIELDS = ['overlayStyle', 'overlayTimingChartStyle', 'overlayAudioMeterStyle'] as const;
+
+/**
+ * Matches the `class Name` (or anonymous `class`) header token at the very start of a
+ * {@link Function.prototype.toString} dump of a class declaration, so {@link initFingerprint}
+ * can normalize it away. Vite HMR always re-evaluates the same class declaration under the
+ * same name across a hot reload, so the identifier itself carries no signal about whether a
+ * reinit is needed - keeping it would only make two structurally identical classes fingerprint
+ * differently because a test double (or a renamed export) happens to use a different name.
+ */
+const CLASS_NAME_HEADER_PATTERN = /^class\s+[$A-Za-z_][$\w]*/;
+
+/**
+ * Compares two optional {@link Vector2i} hardware-settings fields.
+ *
+ * @param previous - Value from the currently running settings.
+ * @param next - Value from the candidate demo's resolved `configure()`.
+ * @returns `true` when both are undefined or equal; `false` otherwise.
+ */
+function isVectorFieldEqual(previous: Vector2i | undefined, next: Vector2i | undefined): boolean {
+    if (previous === undefined || next === undefined) {
+        return previous === next;
+    }
+
+    return previous.isEqual(next);
+}
+
+/**
+ * Reports whether any init-only hardware-settings field differs between the running
+ * settings and a hot-swap candidate's resolved `configure()` output.
+ *
+ * @param previous - Currently active hardware settings.
+ * @param next - Candidate demo's resolved hardware settings.
+ * @returns `true` when a hard reload is required.
+ */
+export function hasHardReloadDiff(previous: HardwareSettings, next: HardwareSettings): boolean {
+    /* eslint-disable security/detect-object-injection -- fields are literal keyof HardwareSettings, not external input */
+    for (const field of HARD_RELOAD_VECTOR_FIELDS) {
+        if (!isVectorFieldEqual(previous[field], next[field])) {
+            return true;
+        }
+    }
+
+    for (const field of [...HARD_RELOAD_SCALAR_FIELDS, ...HARD_RELOAD_OVERLAY_FLAG_FIELDS]) {
+        if (previous[field] !== next[field]) {
+            return true;
+        }
+    }
+
+    for (const field of HARD_RELOAD_STYLE_FIELDS) {
+        if (JSON.stringify(previous[field]) !== JSON.stringify(next[field])) {
+            return true;
+        }
+    }
+    /* eslint-enable security/detect-object-injection */
+
+    return false;
+}
+
+/**
+ * Builds a fingerprint that changes only when a class's constructor, class-field
+ * initializers, or `init()` change - not when an unrelated method body is edited or
+ * the class itself is declared under a different name.
+ *
+ * Concatenates `init()`'s own source with the class's full source (its declared name
+ * normalized away, see {@link CLASS_NAME_HEADER_PATTERN}), with every prototype
+ * method's source (other than `constructor`) stripped out. What remains covers the
+ * constructor and class-field initializers.
+ *
+ * @param cls - Demo class to fingerprint.
+ * @returns Fingerprint string; equal fingerprints mean a Tier 1 (methods-only) swap is safe.
+ */
+export function initFingerprint(cls: DemoConstructor): string {
+    const prototype = cls.prototype as Record<string, unknown>;
+    const initSource = typeof prototype.init === 'function' ? prototype.init.toString() : '';
+
+    let classSource = cls.toString().replace(CLASS_NAME_HEADER_PATTERN, 'class');
+
+    /* eslint-disable security/detect-object-injection -- name comes from Object.getOwnPropertyNames(cls.prototype), not external input */
+    for (const name of Object.getOwnPropertyNames(cls.prototype)) {
+        if (name === 'constructor') {
+            continue;
+        }
+
+        const member = prototype[name];
+
+        if (typeof member === 'function') {
+            classSource = classSource.replace(member.toString(), '');
+        }
+    }
+    /* eslint-enable security/detect-object-injection */
+
+    return initSource + classSource;
+}
+
+/**
+ * Constructs a candidate instance from `NewClass` in try/catch.
+ *
+ * @param NewClass - Newly evaluated demo class.
+ * @returns The constructed instance, or `null` on throw (logged).
+ */
+function constructCandidate(NewClass: DemoConstructor): IBTDemo | null {
+    try {
+        return new NewClass();
+    } catch (err) {
+        console.error('[BT] Hot reload failed; keeping the previous version running:', err);
+
+        return null;
+    }
+}
+
+/**
+ * Runs the Tier 3 check: a hardware-settings change forces a full page reload.
+ *
+ * @param newDemo - Constructed candidate instance.
+ * @returns `true` when a hard reload was requested; the caller should stop and return `true`.
+ */
+function tryHardReload(newDemo: IBTDemo): boolean {
+    let nextSettings: HardwareSettings;
+
+    try {
+        nextSettings = mergeHardwareSettings(newDemo.configure?.());
+    } catch (err) {
+        console.error('[BT] Hot reload failed; keeping the previous version running:', err);
+
+        return false;
+    }
+
+    const previousSettings = BTAPI.instance.getHardwareSettings();
+
+    if (previousSettings && hasHardReloadDiff(previousSettings, nextSettings)) {
+        requestHardReload('Hardware settings changed');
+
+        return true;
+    }
+
+    return false;
+}
+
+/**
+ * Runs the Tier 2 check: re-creates the instance and re-runs `init()` while the previous
+ * instance keeps driving the loop, swapping in the new instance only on success.
+ *
+ * @param oldDemo - Currently running instance.
+ * @param newDemo - Constructed candidate instance.
+ * @param startedAt - `performance.now()` when this swap attempt began, for the announce timing.
+ * @returns `true` once the swap completed; `false` when `hotReplaceDemo` reported failure (already logged there).
+ */
+async function tryReinit(oldDemo: IBTDemo, newDemo: IBTDemo, startedAt: number): Promise<boolean> {
+    const snapshot = Object.fromEntries(Object.entries(oldDemo));
+
+    const success = await BTAPI.instance.hotReplaceDemo(newDemo);
+
+    if (!success) {
+        return false;
+    }
+
+    const generationValue = nextGeneration();
+
+    try {
+        newDemo.onHotReload?.({ reason: 'reinit', generation: generationValue, snapshot });
+    } catch (err) {
+        console.error('[BT] onHotReload threw:', err);
+    }
+
+    announce('reinit', generationValue, performance.now() - startedAt);
+
+    return true;
+}
+
+/**
+ * Runs the Tier 1 (default) swap: rebinds the running instance's prototype to the new
+ * class in place, keeping every field untouched.
+ *
+ * @param oldDemo - Currently running instance, mutated in place.
+ * @param NewClass - Newly evaluated demo class.
+ * @param startedAt - `performance.now()` when this swap attempt began, for the announce timing.
+ */
+function applyMethodSwap(oldDemo: IBTDemo, NewClass: DemoConstructor, startedAt: number): void {
+    Object.setPrototypeOf(oldDemo, NewClass.prototype);
+
+    const generationValue = nextGeneration();
+
+    try {
+        oldDemo.onHotReload?.({ reason: 'methods', generation: generationValue });
+    } catch (err) {
+        console.error('[BT] onHotReload threw:', err);
+    }
+
+    announce('methods', generationValue, performance.now() - startedAt);
+}
+
+/**
+ * Hot-swaps the running demo in place with a newly evaluated demo class, using the
+ * cheapest tier that is safe for what changed.
+ *
+ * @param NewClass - Newly evaluated demo class from the re-run entry module.
+ * @returns `true` when a swap tier ran (including a requested hard reload); `false` only
+ *   when construction or the Tier 2 re-init failed and the previous demo instance is
+ *   still running unmodified.
+ */
+export async function hotSwapDemo(NewClass: DemoConstructor): Promise<boolean> {
+    const startedAt = performance.now();
+
+    const oldDemo = BTAPI.instance.getDemo();
+
+    if (!oldDemo) {
+        console.error('[BT] Hot reload failed; keeping the previous version running: no active demo instance');
+
+        return false;
+    }
+
+    const newDemo = constructCandidate(NewClass);
+
+    if (!newDemo) {
+        return false;
+    }
+
+    if (tryHardReload(newDemo)) {
+        return true;
+    }
+
+    if (initFingerprint(oldDemo.constructor as unknown as DemoConstructor) !== initFingerprint(NewClass)) {
+        return tryReinit(oldDemo, newDemo, startedAt);
+    }
+
+    applyMethodSwap(oldDemo, NewClass, startedAt);
+
+    return true;
+}

--- a/src/hot/protocol.test.ts
+++ b/src/hot/protocol.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { ASSET_CHANGED_EVENT, HOT_RELOAD_DOM_EVENT } from './protocol';
+
+describe('protocol', () => {
+    it('exposes a distinct, namespaced event name for asset changes', () => {
+        expect(ASSET_CHANGED_EVENT).toBe('blit386:asset-changed');
+    });
+
+    it('exposes a distinct, namespaced event name for hot reload broadcasts', () => {
+        expect(HOT_RELOAD_DOM_EVENT).toBe('blit386:hot-reload');
+    });
+
+    it('uses two different event names', () => {
+        expect(ASSET_CHANGED_EVENT).not.toBe(HOT_RELOAD_DOM_EVENT);
+    });
+});

--- a/src/hot/protocol.test.ts
+++ b/src/hot/protocol.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import type { AssetChangedPayload } from './protocol';
 import { ASSET_CHANGED_EVENT, HOT_RELOAD_DOM_EVENT } from './protocol';
 
 describe('protocol', () => {
@@ -13,5 +14,11 @@ describe('protocol', () => {
 
     it('uses two different event names', () => {
         expect(ASSET_CHANGED_EVENT).not.toBe(HOT_RELOAD_DOM_EVENT);
+    });
+
+    it('describes the expected payload shape', () => {
+        const payload: AssetChangedPayload = { url: 'sprites/hero.png', type: 'image', timestamp: 1700000000000 };
+
+        expect(payload).toEqual({ url: 'sprites/hero.png', type: 'image', timestamp: 1700000000000 });
     });
 });

--- a/src/hot/protocol.ts
+++ b/src/hot/protocol.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared types and DOM/HMR event names for the engine hot-reload runtime.
+ *
+ * Value-free (types and string constants only) so it can be imported from both the
+ * browser-facing `src/hot/` runtime and the future `src/vite/` plugin package (BT-306)
+ * without pulling `vite` into the published engine bundle.
+ */
+
+/**
+ * Payload describing a changed asset, broadcast by the `blit386/vite` plugin's asset
+ * watcher (BT-306) as a Vite custom HMR event.
+ *
+ * `type` is an open string union: today's values are the asset kinds the engine can
+ * hot-replace (BT-305); future kinds (levels, maps, animations) can extend this union
+ * without changing the event name or the envelope shape.
+ */
+export interface AssetChangedPayload {
+    /** URL of the changed asset, matching whatever the engine cached it under. */
+    url: string;
+
+    /** Asset kind, used to route to the right hot-replace handler. */
+    type: 'image' | 'audio' | 'font' | 'other';
+
+    /** `Date.now()` when the plugin observed the change, for logging/ordering. */
+    timestamp: number;
+}
+
+/** Vite custom HMR event name for asset changes; shared between the plugin and the engine. */
+export const ASSET_CHANGED_EVENT = 'blit386:asset-changed';
+
+/** DOM `CustomEvent` name dispatched on the engine canvas after a hot reload. */
+export const HOT_RELOAD_DOM_EVENT = 'blit386:hot-reload';

--- a/src/utils/Bootstrap.test.ts
+++ b/src/utils/Bootstrap.test.ts
@@ -19,8 +19,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { BTAPI } from '../core/BTAPI';
 import type { IBTDemo } from '../core/IBTDemo';
+import type * as HotRuntimeModule from '../hot/HotRuntime';
 import { bootstrap } from './Bootstrap';
 import { DEFAULT_CANVAS_ID, DEFAULT_CONTAINER_ID } from './BootstrapHelpers';
+
+vi.mock('../hot/HotRuntime', async (importOriginal) => {
+    const actual = await importOriginal<typeof HotRuntimeModule>();
+
+    return { ...actual, isHotActive: vi.fn(() => false) };
+});
+
+vi.mock('../hot/HotSwap', () => ({
+    hotSwapDemo: vi.fn(async () => true),
+}));
 
 class MockDemo implements IBTDemo {
     async init() {
@@ -257,6 +268,51 @@ describe('bootstrap', () => {
 
             expect(result).toBe(false);
             expect(onError).toHaveBeenCalledOnce();
+        });
+    });
+
+    describe('hot reload routing', () => {
+        it('routes to hotSwapDemo when already initialized and a hot context is registered', async () => {
+            const { isHotActive } = await import('../hot/HotRuntime');
+            const { hotSwapDemo } = await import('../hot/HotSwap');
+
+            vi.spyOn(BTAPI.instance, 'isInitialized').mockReturnValue(true);
+            vi.mocked(isHotActive).mockReturnValue(true);
+            vi.mocked(hotSwapDemo).mockResolvedValue(true);
+
+            const result = await bootstrap(MockDemo, { isWaitingForDOMReady: false });
+
+            expect(result).toBe(true);
+            expect(hotSwapDemo).toHaveBeenCalledExactlyOnceWith(MockDemo);
+        });
+
+        it('does not touch the canvas when routing to hotSwapDemo', async () => {
+            const { isHotActive } = await import('../hot/HotRuntime');
+
+            vi.spyOn(BTAPI.instance, 'isInitialized').mockReturnValue(true);
+            vi.mocked(isHotActive).mockReturnValue(true);
+
+            const initSpy = vi.spyOn(BTAPI.instance, 'init');
+
+            await bootstrap(MockDemo, { isWaitingForDOMReady: false });
+
+            expect(initSpy).not.toHaveBeenCalled();
+        });
+
+        it('logs an error and returns false when already initialized with no hot context (double-bootstrap guard)', async () => {
+            const { isHotActive } = await import('../hot/HotRuntime');
+
+            vi.spyOn(BTAPI.instance, 'isInitialized').mockReturnValue(true);
+            vi.mocked(isHotActive).mockReturnValue(false);
+
+            const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+            const initSpy = vi.spyOn(BTAPI.instance, 'init');
+
+            const result = await bootstrap(MockDemo, { isWaitingForDOMReady: false });
+
+            expect(result).toBe(false);
+            expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('bootstrap()'));
+            expect(initSpy).not.toHaveBeenCalled();
         });
     });
 });

--- a/src/utils/Bootstrap.ts
+++ b/src/utils/Bootstrap.ts
@@ -238,6 +238,10 @@ async function routeIfAlreadyInitialized(DemoClass: DemoConstructor): Promise<bo
  * while allowing customization through options.
  *
  * @since 0.2.0
+ * @changed 1.4.0 Calling `bootstrap()` again while already initialized now routes to a hot
+ *   swap (via {@link registerHotReload}) when a Vite HMR context is registered, or logs a
+ *   double-bootstrap guard and returns `false` otherwise - previously it silently started a
+ *   second, unstoppable `GameLoop`.
  * @param DemoClass - Demo class constructor implementing `IBTDemo` (optional `configure()` for hardware settings).
  * @param options - Optional configuration for IDs and callbacks.
  * @returns `true` when the demo boots successfully; otherwise `false`.

--- a/src/utils/Bootstrap.ts
+++ b/src/utils/Bootstrap.ts
@@ -8,6 +8,8 @@
 
 import { BTAPI } from '../core/BTAPI';
 import type { IBTDemo } from '../core/IBTDemo';
+import { isHotActive } from '../hot/HotRuntime';
+import { hotSwapDemo } from '../hot/HotSwap';
 import type { ErrorContent } from './BootstrapHelpers';
 import { DEFAULT_CANVAS_ID, DEFAULT_CONTAINER_ID, displayError, getCanvas } from './BootstrapHelpers';
 import { CANVAS_NOT_FOUND_MESSAGE, INIT_FAILED_MESSAGE } from './errorMessages';
@@ -203,6 +205,31 @@ async function initDemo(
 }
 
 /**
+ * Routes an already-running engine's `bootstrap()` call to the hot-swap path, or logs a
+ * double-bootstrap guard error when no hot-reload context is registered.
+ *
+ * @param DemoClass - Newly evaluated demo class constructor.
+ * @returns The bootstrap result when the engine is already initialized (hot-swapped or
+ *   guarded); `null` when a cold boot should proceed instead.
+ */
+async function routeIfAlreadyInitialized(DemoClass: DemoConstructor): Promise<boolean | null> {
+    if (!BTAPI.instance.isInitialized()) {
+        return null;
+    }
+
+    if (isHotActive()) {
+        return hotSwapDemo(DemoClass);
+    }
+
+    console.error(
+        '[BT] bootstrap() was called again while already initialized, with no hot-reload context ' +
+            'registered. Reload the page instead of calling bootstrap() a second time.',
+    );
+
+    return false;
+}
+
+/**
  * One-liner bootstrap function for BLIT386 demos.
  * Handles canvas retrieval and engine initialization. Backend selection
  * (WebGPU or software fallback) is managed internally by BTAPI.
@@ -236,6 +263,20 @@ async function initDemo(
  * }
  */
 export async function bootstrap(DemoClass: DemoConstructor, options: BootstrapOptions = {}): Promise<boolean> {
+    // One microtask yield before anything else runs. Module top-level evaluation is
+    // synchronous and this function is async, so the snippet's un-awaited
+    // `registerHotReload(import.meta.hot)` call - which runs synchronously right after a
+    // demo's own un-awaited `bootstrap(Game);` call, at the same module top level - always
+    // completes before this function proceeds past this line, regardless of
+    // `isWaitingForDOMReady`.
+    await Promise.resolve();
+
+    const routedResult = await routeIfAlreadyInitialized(DemoClass);
+
+    if (routedResult !== null) {
+        return routedResult;
+    }
+
     const {
         canvasID: providedCanvasID,
         canvasId,


### PR DESCRIPTION
Implements the engine-side hot-reload runtime (`src/hot/`), a hot-aware `bootstrap()`, and the optional `onHotReload` demo hook. This is step 1 of 8 in the true-hot-reload (HMR) epic for demos and scaffolded games (BT-303/BT-304); target release 1.4.0.

Nothing here is reachable yet: `hotSwapDemo` only runs once a Vite HMR context is registered via `registerHotReload`, and no plugin calls that today (the `blit386/vite` plugin ships in a follow-up issue, BT-306). Cold boot and production builds are unaffected.

## Summary

- New `src/hot/` module:
  - `protocol.ts` - shared types/event names (`AssetChangedPayload`, `ASSET_CHANGED_EVENT`, `HOT_RELOAD_DOM_EVENT`), no value imports from `src/` so it can be shared with the future Vite plugin package without pulling `vite` into the engine bundle.
  - `HotRuntime.ts` - Vite HMR context registration (`registerHotReload`), hot-swap generation counter, hard-reload request (`hot.invalidate()` with a `location.reload()` fallback), and a console + `CustomEvent` broadcast on the engine canvas after each swap.
  - `HotSwap.ts` - the tiered swap orchestrator (`hotSwapDemo`): a hardware-settings diff forces a full page reload (Tier 3); an `init()`/constructor/class-field change re-runs `init()` on a fresh instance while the old instance keeps driving the loop, swapping in only on success (Tier 2); everything else rebinds the prototype in place, preserving every field (Tier 1, the default). Ticks, camera, palette, and palette effects are never reset.
- `IBTDemo.onHotReload?(context)` optional hook + `HotReloadContext` type (`src/core/IBTDemo.ts`).
- Three new internal `BTAPI` methods: `getDemo()`, `isInitialized()`, `hotReplaceDemo(newDemo)` - the last one deliberately does not reuse the existing `runDemoInit`, since that tears down input/audio subsystems on failure, which would break the still-running previous demo mid-swap.
- Hot-aware `bootstrap()` (`src/utils/Bootstrap.ts`): a leading microtask yield so the injected snippet's `registerHotReload(import.meta.hot)` call always registers before the routing check runs, then routes to cold boot, a hot-swap, or a double-bootstrap guard.
- New public exports: `registerHotReload`, `HotContext`, `HotReloadContext` (all `@since 1.4.0`). Nothing added to the `BT` namespace - this is plugin-facing plumbing, not a game-facing API.
- `docs/changelog.md` 1.4.0 entry, `docs/_api-history.json` regeneration, `CLAUDE.md` architecture map update. Full `docs/guide-*`/`docs/api-*` prose for the HMR surface is intentionally deferred to a later issue (BT-307) once the plugin and asset hot-replace pieces exist too.

## Test plan

- [x] `pnpm run preflight` (format, lint, typecheck, spellcheck, knip, docs:links, doc banners, api:since/api:history checks, unit tests, declaration tests) - all green.
- [x] Unit tests: 2262/2262 passing across 84 files, including full tier-selection coverage in `HotSwap.test.ts` (method-only, init-changed, hardware-changed, and a negative test proving the five deliberately-excluded hardware fields never force a reload).
- [x] Verified the production/cold-boot gating directly: `bootstrap()` checks `BTAPI.instance.isInitialized()` before ever consulting `isHotActive()`, so a normal first boot never touches the hot-swap path, and `isHotActive()` stays `false` in any build where nothing calls `registerHotReload`.
- [ ] `pnpm run test:visual` - not run in this environment (Chromium is not installed here); this change makes no rendering-path changes, so no visual regression is expected, but a maintainer with a Playwright-capable environment should confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BYSebmXRXEGFvhJ1U9dBX5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds an engine-side hot-reload runtime for the true-HMR effort, introducing a new `src/hot/` subsystem that handles Vite HMR context registration, swap generation tracking, hard-reload fallback, and engine-canvas event broadcasts.

Implements tiered demo hot-swapping:
- Hardware/settings diffs trigger a full page reload.
- `init()`/constructor/field-initializer changes reinitialize and swap in a fresh demo instance (with optional `IBTDemo.onHotReload` support and state snapshots).
- Method-only changes swap by rebinding the running instance’s prototype in place.

Extends the engine API with hot-aware demo management:
- `BTAPI` now exposes `getDemo()` and `isInitialized()`, and adds `hotReplaceDemo()` to validate candidates, safely swap the active demo, and rebind orientation change handling to the new demo.
- A hot-aware `bootstrap()` routes to hot swapping when already initialized under an active HMR context, and includes cold-boot and double-bootstrap guards to prevent accidental double game-loop startup.

Publishes public exports for `registerHotReload`, `HotContext`, and `HotReloadContext`, and documents the behavior in the changelog, API history, and architecture docs. Adds protocol/event type definitions plus comprehensive unit tests covering HotRuntime, HotSwap, protocol constants, BTAPI hot-replace behavior, and hot-routing bootstrap behavior (visual tests were not run due to Chromium unavailability).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->