### PR TITLE
feat(core): engine asset hot-replace (AssetLoader, SpriteSheet, AudioClip, BitmapFont)

### DIFF
--- a/docs/api-assets.md
+++ b/docs/api-assets.md
@@ -65,6 +65,9 @@ const images = await AssetLoader.loadImages(['sprites.png', 'tiles.png']);
 if (AssetLoader.isLoaded('sprites.png')) {
   // already cached
 }
+
+// Drop a single URL's cache entry (mainly for tests or explicit resets)
+AssetLoader.evict('sprites.png');
 ```
 
 ## Sprite setup – preferred path

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -36,7 +36,7 @@ notes, including dependency bumps and CI changes omitted here for brevity.
   runtime dependency on `vite` itself.
 - Engine-side asset hot-replace: `AssetLoader.evict`, plus internal routing in `HotRuntime.handleAssetChanged` for
   `blit386:asset-changed` events. A changed image, audio, or `.btfont` file under `public/` updates the running demo in
-  place - sprite sheets swap their texture (calling `reindexize()` against the active palette when needed), audio clips
+  place - sprite sheets swap their texture (calling `indexize()` against the active palette when needed), audio clips
   swap their decoded buffer (stopping SFX voices on the old buffer and restarting the music player if the replaced clip
   is the current track), and bitmap fonts rebuild their glyph tables and texture - all without a page reload. Adoption
   in `blit386-demos`/`create-blit386` ships in a follow-up release.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -27,13 +27,19 @@ notes, including dependency bumps and CI changes omitted here for brevity.
   `IBTDemo.onHotReload(context)` hook, and a tiered hot-swap - a method-only prototype swap when only method bodies
   changed, a full re-init when `init()` or the constructor changed, and a full page reload when hardware settings
   changed. Demo/game state persists across method and re-init swaps: ticks, camera, palette, and palette effects are
-  never reset. This lands the engine half of BLIT386's HMR support; asset hot-replace and adoption in
-  `blit386-demos`/`create-blit386` ship in follow-up releases.
+  never reset. This lands the engine half of BLIT386's HMR support; adoption in `blit386-demos`/`create-blit386` ships
+  in follow-up releases.
 - `blit386/vite` dev-server plugin: `import { blit386 } from 'blit386/vite'` in `vite.config.ts` appends the hot-reload
   registration snippet to a demo/game's entry module (skipped in production builds) and broadcasts asset changes under
   configured asset directories (default `public/`) as `blit386:asset-changed` HMR events, falling back to a full page
   reload for an unrecognized asset extension. Ships as a second build entry (`dist/vite.js`/`.cjs`/`.d.ts`) with zero
   runtime dependency on `vite` itself.
+- Engine-side asset hot-replace: `AssetLoader.evict`, plus internal routing in `HotRuntime.handleAssetChanged` for
+  `blit386:asset-changed` events. A changed image, audio, or `.btfont` file under `public/` updates the running demo in
+  place - sprite sheets swap their texture (calling `reindexize()` against the active palette when needed), audio clips
+  swap their decoded buffer (stopping SFX voices on the old buffer and restarting the music player if the replaced clip
+  is the current track), and bitmap fonts rebuild their glyph tables and texture - all without a page reload. Adoption
+  in `blit386-demos`/`create-blit386` ships in a follow-up release.
 
 ## 1.3.1 - 2026-07-19
 

--- a/src/assets/AssetLoader.test.ts
+++ b/src/assets/AssetLoader.test.ts
@@ -228,4 +228,119 @@ describe('AssetLoader', () => {
             );
         });
     });
+
+    describe('evict', () => {
+        beforeEach(() => {
+            vi.stubGlobal(
+                'Image',
+                class {
+                    onload: (() => void) | null = null;
+                    onerror: (() => void) | null = null;
+                    width = 100;
+                    height = 100;
+
+                    set src(_: string) {
+                        this.onload?.();
+                    }
+                },
+            );
+        });
+
+        afterEach(() => {
+            vi.unstubAllGlobals();
+        });
+
+        it('returns false when nothing is cached under the URL', () => {
+            expect(AssetLoader.evict('never-loaded.png')).toBe(false);
+        });
+
+        it('returns true and clears the cache entry when a cached image is evicted', async () => {
+            await AssetLoader.loadImage('evict-me.png');
+            expect(AssetLoader.isLoaded('evict-me.png')).toBe(true);
+
+            expect(AssetLoader.evict('evict-me.png')).toBe(true);
+            expect(AssetLoader.isLoaded('evict-me.png')).toBe(false);
+            expect(AssetLoader.getImage('evict-me.png')).toBeNull();
+        });
+
+        it('allows a fresh load after eviction', async () => {
+            const first = await AssetLoader.loadImage('reload-me.png');
+            AssetLoader.evict('reload-me.png');
+            const second = await AssetLoader.loadImage('reload-me.png');
+
+            expect(second).not.toBe(first);
+        });
+    });
+
+    describe('hotReloadImage', () => {
+        let requestedUrls: string[];
+
+        beforeEach(() => {
+            requestedUrls = [];
+
+            vi.stubGlobal(
+                'Image',
+                class {
+                    onload: (() => void) | null = null;
+                    onerror: (() => void) | null = null;
+                    width = 100;
+                    height = 100;
+
+                    set src(value: string) {
+                        requestedUrls.push(value);
+                        this.onload?.();
+                    }
+                },
+            );
+        });
+
+        afterEach(() => {
+            vi.unstubAllGlobals();
+        });
+
+        it('re-caches the result under the original URL, not the busted one', async () => {
+            await AssetLoader.loadImage('hot.png');
+
+            const reloaded = await AssetLoader.hotReloadImage('hot.png');
+
+            expect(reloaded).toBeDefined();
+            expect(AssetLoader.isLoaded('hot.png')).toBe(true);
+            expect(AssetLoader.getImage('hot.png')).toBe(reloaded);
+        });
+
+        it('requests the image with a cache-busting query parameter', async () => {
+            await AssetLoader.hotReloadImage('bust.png');
+
+            expect(requestedUrls).toHaveLength(1);
+            expect(requestedUrls[0]).toMatch(/^bust\.png\?blit386-hmr=\d+$/);
+        });
+
+        it('replaces a previously cached image with the freshly loaded one', async () => {
+            const before = await AssetLoader.loadImage('swap.png');
+            const after = await AssetLoader.hotReloadImage('swap.png');
+
+            expect(after).not.toBe(before);
+            expect(AssetLoader.getImage('swap.png')).toBe(after);
+        });
+
+        it('rejects with an error keyed to the original URL when the reload fails', async () => {
+            vi.stubGlobal(
+                'Image',
+                class {
+                    onload: (() => void) | null = null;
+                    onerror: (() => void) | null = null;
+                    width = 100;
+                    height = 100;
+
+                    set src(_: string) {
+                        this.onerror?.();
+                    }
+                },
+            );
+
+            await expect(AssetLoader.hotReloadImage('missing.png')).rejects.toThrow(
+                "Can't find the image 'missing.png'",
+            );
+        });
+    });
 });

--- a/src/assets/AssetLoader.test.ts
+++ b/src/assets/AssetLoader.test.ts
@@ -343,4 +343,64 @@ describe('AssetLoader', () => {
             );
         });
     });
+
+    describe('stale-completion safety', () => {
+        /** Image stub whose `onload`/`onerror` must be fired manually, so tests control resolution order. */
+        class DeferredImage {
+            onload: (() => void) | null = null;
+            onerror: (() => void) | null = null;
+            width = 100;
+            height = 100;
+            src = '';
+        }
+
+        let instances: DeferredImage[];
+
+        beforeEach(() => {
+            instances = [];
+
+            vi.stubGlobal(
+                'Image',
+                class extends DeferredImage {
+                    constructor() {
+                        super();
+                        instances.push(this);
+                    }
+                },
+            );
+        });
+
+        afterEach(() => {
+            vi.unstubAllGlobals();
+        });
+
+        it('keeps the newer hot-reloaded image when a superseded load resolves after it', async () => {
+            const firstPromise = AssetLoader.hotReloadImage('race.png');
+            const secondPromise = AssetLoader.hotReloadImage('race.png');
+
+            expect(instances).toHaveLength(2);
+
+            // The newer (second) request resolves first; the stale (first) one resolves after.
+            instances[1]?.onload?.();
+            const second = await secondPromise;
+
+            instances[0]?.onload?.();
+            await firstPromise;
+
+            expect(AssetLoader.getImage('race.png')).toBe(second);
+        });
+
+        it('does not repopulate the cache when a stale in-flight load resolves after evict()', async () => {
+            const promise = AssetLoader.loadImage('evicted.png');
+
+            expect(instances).toHaveLength(1);
+
+            AssetLoader.evict('evicted.png');
+
+            instances[0]?.onload?.();
+            await promise;
+
+            expect(AssetLoader.getImage('evicted.png')).toBeNull();
+        });
+    });
 });

--- a/src/assets/AssetLoader.test.ts
+++ b/src/assets/AssetLoader.test.ts
@@ -385,8 +385,11 @@ describe('AssetLoader', () => {
             const second = await secondPromise;
 
             instances[0]?.onload?.();
-            await firstPromise;
+            const first = await firstPromise;
 
+            // The superseded request still resolves its own caller with its own image - only
+            // the shared cache skips it.
+            expect(first).toBe(instances[0]);
             expect(AssetLoader.getImage('race.png')).toBe(second);
         });
 

--- a/src/assets/AssetLoader.ts
+++ b/src/assets/AssetLoader.ts
@@ -127,7 +127,48 @@ function clearInFlight(url: string): void {
 }
 
 /**
+ * Monotonic per-cache-key generation counter.
+ *
+ * Bumped whenever a fresh load starts for a key ({@link startLoading}) or the key is
+ * explicitly evicted ({@link AssetLoader.evict}), so a superseded in-flight request's
+ * `onload`/`onerror` handler can tell it is no longer the current request for that key and
+ * skip mutating the shared caches - otherwise a stale request that finishes after a newer one
+ * (or after an eviction) could silently overwrite the correct result with old data.
+ */
+const loadGenerations = new Map<string, number>();
+
+/**
+ * Advances and returns the generation for `cacheKey`.
+ *
+ * @param cacheKey - Cache key whose generation should advance.
+ * @returns The new, current generation number for `cacheKey`.
+ */
+function bumpGeneration(cacheKey: string): number {
+    const generation = (loadGenerations.get(cacheKey) ?? 0) + 1;
+
+    loadGenerations.set(cacheKey, generation);
+
+    return generation;
+}
+
+/**
+ * Reports whether `generation` is still the current one for `cacheKey`.
+ *
+ * @param cacheKey - Cache key to check.
+ * @param generation - Generation captured when the request being checked started.
+ * @returns `true` if no newer load or eviction has superseded `generation`.
+ */
+function isCurrentGeneration(cacheKey: string, generation: number): boolean {
+    return loadGenerations.get(cacheKey) === generation;
+}
+
+/**
  * Starts a browser image load and registers the in-flight promise.
+ *
+ * The returned promise always settles with this specific request's own outcome, even once
+ * superseded - only the shared `loadedImages`/`loadingPromises` caches are skipped for a
+ * superseded request, via the {@link loadGenerations} guard, so a stale completion can never
+ * clobber a newer load's result.
  *
  * @param fetchUrl - Path or URL to actually request (may carry a hot-reload cache-bust query).
  * @param cacheKey - Key to cache the result and track the in-flight load under. Defaults to
@@ -136,16 +177,24 @@ function clearInFlight(url: string): void {
  * @returns Promise that resolves to the loaded image element.
  */
 function startLoading(fetchUrl: string, cacheKey: string = fetchUrl): Promise<HTMLImageElement> {
+    const generation = bumpGeneration(cacheKey);
+
     const promise = new Promise<HTMLImageElement>((resolve, reject) => {
         const img = new Image();
 
         img.onload = () => {
-            clearInFlight(cacheKey);
+            const isCurrent = isCurrentGeneration(cacheKey, generation);
+
+            if (isCurrent) {
+                clearInFlight(cacheKey);
+            }
 
             try {
                 assertImageElementWithinLimits('image', img);
 
-                loadedImages.set(cacheKey, img);
+                if (isCurrent) {
+                    loadedImages.set(cacheKey, img);
+                }
 
                 resolve(img);
             } catch (error) {
@@ -154,7 +203,9 @@ function startLoading(fetchUrl: string, cacheKey: string = fetchUrl): Promise<HT
         };
 
         img.onerror = () => {
-            clearInFlight(cacheKey);
+            if (isCurrentGeneration(cacheKey, generation)) {
+                clearInFlight(cacheKey);
+            }
 
             reject(buildImageNotFoundError(cacheKey));
         };
@@ -228,11 +279,17 @@ export class AssetLoader {
      * Removes a URL's cached image and any in-flight load, so a later call to
      * {@link AssetLoader.loadImage} starts fresh.
      *
+     * Also bumps the URL's load generation, so an in-flight request that was already under way
+     * before this call can no longer repopulate the cache once it completes - see
+     * {@link isCurrentGeneration}.
+     *
      * @param url - Path or URL whose cache entry (and in-flight load, if any) should be evicted.
      * @returns `true` if a cached image was removed; `false` if nothing was cached under `url`.
      * @since 1.4.0
      */
     static evict(url: string): boolean {
+        bumpGeneration(url);
+
         const removed = loadedImages.delete(url);
 
         loadingPromises.delete(url);

--- a/src/assets/AssetLoader.ts
+++ b/src/assets/AssetLoader.ts
@@ -1,4 +1,5 @@
 import { assertImageElementWithinLimits } from '../utils/AssetLimits';
+import { appendCacheBustQuery } from '../utils/HotReloadUrl';
 
 /**
  * Successfully loaded images keyed by request URL.
@@ -128,20 +129,23 @@ function clearInFlight(url: string): void {
 /**
  * Starts a browser image load and registers the in-flight promise.
  *
- * @param url - Path or URL to load.
+ * @param fetchUrl - Path or URL to actually request (may carry a hot-reload cache-bust query).
+ * @param cacheKey - Key to cache the result and track the in-flight load under. Defaults to
+ *   `fetchUrl` for a normal load; a hot reload passes the original, un-busted URL here so the
+ *   result re-caches under the same key callers already hold.
  * @returns Promise that resolves to the loaded image element.
  */
-function startLoading(url: string): Promise<HTMLImageElement> {
+function startLoading(fetchUrl: string, cacheKey: string = fetchUrl): Promise<HTMLImageElement> {
     const promise = new Promise<HTMLImageElement>((resolve, reject) => {
         const img = new Image();
 
         img.onload = () => {
-            clearInFlight(url);
+            clearInFlight(cacheKey);
 
             try {
                 assertImageElementWithinLimits('image', img);
 
-                loadedImages.set(url, img);
+                loadedImages.set(cacheKey, img);
 
                 resolve(img);
             } catch (error) {
@@ -150,15 +154,15 @@ function startLoading(url: string): Promise<HTMLImageElement> {
         };
 
         img.onerror = () => {
-            clearInFlight(url);
+            clearInFlight(cacheKey);
 
-            reject(buildImageNotFoundError(url));
+            reject(buildImageNotFoundError(cacheKey));
         };
 
-        img.src = url;
+        img.src = fetchUrl;
     });
 
-    loadingPromises.set(url, promise);
+    loadingPromises.set(cacheKey, promise);
 
     return promise;
 }
@@ -218,6 +222,38 @@ export class AssetLoader {
      */
     static getImage(url: string): HTMLImageElement | null {
         return loadedImages.get(url) ?? null;
+    }
+
+    /**
+     * Removes a URL's cached image and any in-flight load, so a later call to
+     * {@link AssetLoader.loadImage} starts fresh.
+     *
+     * @param url - Path or URL whose cache entry (and in-flight load, if any) should be evicted.
+     * @returns `true` if a cached image was removed; `false` if nothing was cached under `url`.
+     * @since 1.4.0
+     */
+    static evict(url: string): boolean {
+        const removed = loadedImages.delete(url);
+
+        loadingPromises.delete(url);
+
+        return removed;
+    }
+
+    /**
+     * Re-loads an already-cached image with a cache-busted request, re-caching the
+     * result under the original `url` key so demo-held references from
+     * {@link AssetLoader.getImage} stay valid.
+     *
+     * Internal – routed from `HotRuntime.handleAssetChanged` when the dev asset
+     * watcher reports a changed image file.
+     *
+     * @param url - Cache key (and fetch URL) of the image to hot-reload.
+     * @returns The freshly loaded image element, cached under `url`.
+     * @throws Error if the cache-busted image fails to load.
+     */
+    static async hotReloadImage(url: string): Promise<HTMLImageElement> {
+        return startLoading(appendCacheBustQuery(url), url);
     }
 
     /**

--- a/src/assets/AudioClip.test.ts
+++ b/src/assets/AudioClip.test.ts
@@ -27,7 +27,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createMockAudioContext, type MockAudioContext } from '../__test__/webaudio-mock';
-import { setAudioClipUnloadHandler, setAudioDecodeContext } from '../audio/audioDecodeContext';
+import {
+    setAudioClipUnloadHandler,
+    setAudioDecodeContext,
+    setMusicHotReplaceHandler,
+} from '../audio/audioDecodeContext';
 import { AudioClip, type AudioClipProgress } from './AudioClip';
 import type { SynthParams } from './synth/SynthParams';
 
@@ -111,6 +115,7 @@ describe('AudioClip', () => {
     afterEach(() => {
         setAudioDecodeContext(null);
         setAudioClipUnloadHandler(() => {});
+        setMusicHotReplaceHandler(() => false);
         AudioClip.clear();
         vi.unstubAllGlobals();
     });
@@ -482,6 +487,97 @@ describe('AudioClip', () => {
                 clip.unload();
             }).not.toThrow();
             expect(clip.buffer).toBeNull();
+        });
+    });
+
+    describe('hotReload', () => {
+        it('returns false when no clip is cached under the URL', async () => {
+            vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockAudioFetchResponse()));
+
+            await expect(AudioClip.hotReload('never-loaded.mp3')).resolves.toBe(false);
+        });
+
+        it('returns false when the cached clip was already unloaded', async () => {
+            vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockAudioFetchResponse()));
+
+            const clip = await AudioClip.load('unloaded.mp3');
+            clip.unload();
+
+            await expect(AudioClip.hotReload('unloaded.mp3')).resolves.toBe(false);
+        });
+
+        it('swaps the buffer in place, keeping the same instance and cache key', async () => {
+            vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockAudioFetchResponse()));
+
+            const clip = await AudioClip.load('hot.mp3');
+            const oldBuffer = clip.buffer;
+
+            const nextBuffer = mockContext.decodeAudioDataImpl;
+            mockContext.decodeAudioDataImpl = () =>
+                Promise.resolve({ duration: 9, sampleRate: 48000 } as unknown as AudioBuffer);
+
+            const reloaded = await AudioClip.hotReload('hot.mp3');
+
+            expect(reloaded).toBe(true);
+            expect(AudioClip.getClip('hot.mp3')).toBe(clip);
+            expect(clip.buffer).not.toBe(oldBuffer);
+
+            mockContext.decodeAudioDataImpl = nextBuffer;
+        });
+
+        it('fetches with a cache-busting query parameter', async () => {
+            const fetchSpy = vi.fn().mockResolvedValue(mockAudioFetchResponse());
+            vi.stubGlobal('fetch', fetchSpy);
+
+            await AudioClip.load('bust.mp3');
+            fetchSpy.mockClear();
+
+            await AudioClip.hotReload('bust.mp3');
+
+            expect(fetchSpy).toHaveBeenCalledOnce();
+            const [requestedUrl] = fetchSpy.mock.calls[0] as [string];
+            expect(requestedUrl).toMatch(/^bust\.mp3\?blit386-hmr=\d+$/);
+        });
+
+        it('notifies the SFX unload seam with the old buffer', async () => {
+            vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockAudioFetchResponse()));
+
+            const clip = await AudioClip.load('sfx.mp3');
+            const oldBuffer = clip.buffer;
+            const unloadHandler = vi.fn();
+            setAudioClipUnloadHandler(unloadHandler);
+
+            await AudioClip.hotReload('sfx.mp3');
+
+            expect(unloadHandler).toHaveBeenCalledExactlyOnceWith(oldBuffer);
+        });
+
+        it('notifies the music hot-replace seam with the old and new buffers', async () => {
+            vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockAudioFetchResponse()));
+
+            const clip = await AudioClip.load('music.mp3');
+            const oldBuffer = clip.buffer;
+            const musicHandler = vi.fn().mockReturnValue(true);
+            setMusicHotReplaceHandler(musicHandler);
+
+            await AudioClip.hotReload('music.mp3');
+
+            expect(musicHandler).toHaveBeenCalledExactlyOnceWith(oldBuffer, clip.buffer);
+        });
+
+        it('rejects and leaves the old buffer in place when the re-fetch fails', async () => {
+            vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockAudioFetchResponse()));
+
+            const clip = await AudioClip.load('flaky.mp3');
+            const oldBuffer = clip.buffer;
+
+            vi.stubGlobal(
+                'fetch',
+                vi.fn().mockResolvedValue({ ok: false, status: 500, headers: { get: () => null }, body: null }),
+            );
+
+            await expect(AudioClip.hotReload('flaky.mp3')).rejects.toThrow();
+            expect(clip.buffer).toBe(oldBuffer);
         });
     });
 });

--- a/src/assets/AudioClip.ts
+++ b/src/assets/AudioClip.ts
@@ -224,7 +224,7 @@ export class AudioClip {
      * Hot-reloads a previously loaded clip's audio data in place, keeping the same
      * `AudioClip` instance and cache key so demo-held references stay valid.
      *
-     * Internal - routed from `HotRuntime.handleAssetChanged` when the dev asset
+     * Internal – routed from `HotRuntime.handleAssetChanged` when the dev asset
      * watcher reports a changed audio file. Fetches and decodes a cache-busted copy
      * of `url`, swaps the decoded buffer in place, notifies the SFX unload seam so
      * any voice still playing the old buffer stops safely, and restarts the music

--- a/src/assets/AudioClip.ts
+++ b/src/assets/AudioClip.ts
@@ -19,13 +19,14 @@
  * loading, caching, releasing, and synthesizing decoded buffers.
  */
 
-import { getAudioDecodeContext, notifyAudioClipUnload } from '../audio/audioDecodeContext';
+import { getAudioDecodeContext, notifyAudioClipUnload, notifyMusicHotReplace } from '../audio/audioDecodeContext';
 import {
     audioClipDecodeError,
     audioClipHttpError,
     audioClipNetworkError,
     audioClipNotReadyError,
 } from '../utils/errorMessages';
+import { appendCacheBustQuery } from '../utils/HotReloadUrl';
 import type { SynthParams } from './synth/SynthParams';
 import { renderSynthSamples } from './synth/synthRender';
 import { validateSynthParams } from './synth/synthValidation';
@@ -217,6 +218,41 @@ export class AudioClip {
     static clear(): void {
         resolvedClips.clear();
         inFlightLoads.clear();
+    }
+
+    /**
+     * Hot-reloads a previously loaded clip's audio data in place, keeping the same
+     * `AudioClip` instance and cache key so demo-held references stay valid.
+     *
+     * Internal - routed from `HotRuntime.handleAssetChanged` when the dev asset
+     * watcher reports a changed audio file. Fetches and decodes a cache-busted copy
+     * of `url`, swaps the decoded buffer in place, notifies the SFX unload seam so
+     * any voice still playing the old buffer stops safely, and restarts the music
+     * player if the replaced clip is the current track. `duration`/`sampleRate`
+     * reflect the buffer decoded at initial load time and are not updated by a
+     * hot reload.
+     *
+     * @param url - Cache key (and fetch URL) of the clip to hot-reload.
+     * @returns `true` if a cached clip was found and reloaded; `false` if no clip is
+     *   cached under `url` (never loaded, or already unloaded).
+     * @throws Error if the cache-busted fetch or decode fails.
+     */
+    static async hotReload(url: string): Promise<boolean> {
+        const clip = resolvedClips.get(url);
+
+        if (!clip || clip.decodedBuffer === null) {
+            return false;
+        }
+
+        const oldBuffer = clip.decodedBuffer;
+        const newBuffer = await AudioClip.fetchAndDecode(appendCacheBustQuery(url));
+
+        clip.decodedBuffer = newBuffer;
+
+        notifyAudioClipUnload(oldBuffer);
+        notifyMusicHotReplace(oldBuffer, newBuffer);
+
+        return true;
     }
 
     /**

--- a/src/assets/BitmapFont.test.ts
+++ b/src/assets/BitmapFont.test.ts
@@ -26,13 +26,13 @@ import { Rect2i } from '../utils/Rect2i';
 import { BitmapFont, getHotReloadFonts } from './BitmapFont';
 import { SpriteSheet } from './SpriteSheet';
 
-// registerFontForHotReload() normalizes the source url against `location.origin`
+// registerFontForHotReload() normalizes the source url against `document.baseURI`
 // whenever hot reload is active (see BitmapFont.ts). Real browsers always have
-// `location`; this file's default Node test environment does not, so - like the
+// `document`; this file's default Node test environment does not, so - like the
 // GPU/AudioContext stubs in src/__test__/setup.ts - install it once, only if
 // missing, so it survives every describe block's `vi.unstubAllGlobals()` call.
-if (typeof globalThis.location === 'undefined') {
-    (globalThis as unknown as { location?: URL }).location = new URL('http://localhost/');
+if (typeof globalThis.document === 'undefined') {
+    (globalThis as unknown as { document?: { baseURI: string } }).document = { baseURI: 'http://localhost/' };
 }
 
 type GlyphData = { x: number; y: number; w: number; h: number; ox: number; oy: number; adv: number };

--- a/src/assets/BitmapFont.test.ts
+++ b/src/assets/BitmapFont.test.ts
@@ -760,6 +760,17 @@ describe('BitmapFont', () => {
 
                 expect(imageSources[0]).toMatch(/^fonts\/atlas\.png\?blit386-hmr=\d+$/);
             });
+
+            it('does not cache-bust an embedded data URI texture', async () => {
+                vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockFontFetchResponse(MOCK_FONT_DATA)));
+
+                const imageSources: string[] = [];
+                vi.stubGlobal('Image', createStubImage({ onSrcSet: (src) => imageSources.push(src) }));
+
+                await font.hotReload('test.btfont', null);
+
+                expect(imageSources[0]).toBe(MOCK_FONT_DATA.texture);
+            });
         });
     });
 });

--- a/src/assets/BitmapFont.test.ts
+++ b/src/assets/BitmapFont.test.ts
@@ -14,6 +14,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { registerHotContext } from '../hot/HotRuntime';
 import {
     AssetLimitError,
     MAX_ASSET_DIMENSION,
@@ -22,8 +23,17 @@ import {
     MAX_GLYPH_COUNT,
 } from '../utils/AssetLimits';
 import { Rect2i } from '../utils/Rect2i';
-import { BitmapFont } from './BitmapFont';
+import { BitmapFont, getHotReloadFonts } from './BitmapFont';
 import { SpriteSheet } from './SpriteSheet';
+
+// registerFontForHotReload() normalizes the source url against `location.origin`
+// whenever hot reload is active (see BitmapFont.ts). Real browsers always have
+// `location`; this file's default Node test environment does not, so - like the
+// GPU/AudioContext stubs in src/__test__/setup.ts - install it once, only if
+// missing, so it survives every describe block's `vi.unstubAllGlobals()` call.
+if (typeof globalThis.location === 'undefined') {
+    (globalThis as unknown as { location?: URL }).location = new URL('http://localhost/');
+}
 
 type GlyphData = { x: number; y: number; w: number; h: number; ox: number; oy: number; adv: number };
 type FontData = {
@@ -660,6 +670,96 @@ describe('BitmapFont', () => {
             const font = BitmapFont.createFromGlyphs(sheet, glyphs, 'Test', 8, 8, 8);
 
             expect(font.measureText('Hi')).toBe(14); // 8 + 6
+        });
+    });
+
+    describe('hot reload', () => {
+        function activateHotReload() {
+            registerHotContext({
+                data: {},
+                on: vi.fn(),
+                invalidate: vi.fn(),
+                accept: vi.fn(),
+            });
+        }
+
+        it('does not register a loaded font when hot reload is inactive', () => {
+            expect(getHotReloadFonts('test.btfont')).toBeUndefined();
+        });
+
+        it('registers a loaded font under its normalized source URL once hot reload is active', async () => {
+            activateHotReload();
+            vi.stubGlobal('Image', createStubImage());
+            vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockFontFetchResponse(MOCK_FONT_DATA)));
+
+            const active = await BitmapFont.load('fonts/active.btfont');
+
+            expect(getHotReloadFonts('fonts/active.btfont')).toEqual(new Set([active]));
+        });
+
+        describe('hotReload', () => {
+            it('rebuilds glyph tables from the re-fetched .btfont data', async () => {
+                const updated = {
+                    ...MOCK_FONT_DATA,
+                    glyphs: { ...MOCK_FONT_DATA.glyphs, A: { x: 0, y: 0, w: 20, h: 12, ox: 0, oy: 0, adv: 21 } },
+                };
+                vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockFontFetchResponse(updated)));
+
+                await font.hotReload('test.btfont', null);
+
+                expect(font.getGlyph('A')?.advance).toBe(21);
+            });
+
+            it('fetches the .btfont JSON with a cache-busting query parameter', async () => {
+                const fetchSpy = vi.fn().mockResolvedValue(mockFontFetchResponse(MOCK_FONT_DATA));
+                vi.stubGlobal('fetch', fetchSpy);
+
+                await font.hotReload('test.btfont', null);
+
+                const [requestedUrl] = fetchSpy.mock.calls[0] as [string];
+                expect(requestedUrl).toMatch(/^test\.btfont\?blit386-hmr=\d+$/);
+            });
+
+            it('clears the measurement cache', async () => {
+                font.measureText('AB');
+                vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockFontFetchResponse(MOCK_FONT_DATA)));
+
+                const clearSpy = vi.spyOn(font, 'clearMeasureCache');
+                await font.hotReload('test.btfont', null);
+
+                expect(clearSpy).toHaveBeenCalledOnce();
+            });
+
+            it('replaces the underlying sprite sheet image', async () => {
+                vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockFontFetchResponse(MOCK_FONT_DATA)));
+                const replaceSpy = vi.spyOn(SpriteSheet.prototype, 'hotReplaceImage');
+
+                await font.hotReload('test.btfont', null);
+
+                expect(replaceSpy).toHaveBeenCalledOnce();
+            });
+
+            it('throws when the re-fetched .btfont file is missing', async () => {
+                vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 404, statusText: 'Not Found' }));
+
+                await expect(font.hotReload('test.btfont', null)).rejects.toThrow("Can't find the font file");
+            });
+
+            it('cache-busts a relative texture path but not an embedded data URI', async () => {
+                const relativeData = { ...MOCK_FONT_DATA, texture: 'atlas.png' };
+                vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockFontFetchResponse(relativeData)));
+
+                const imageSources: string[] = [];
+                vi.stubGlobal('Image', createStubImage({ onSrcSet: (src) => imageSources.push(src) }));
+
+                const relFont = await BitmapFont.load('fonts/rel.btfont');
+                imageSources.length = 0;
+
+                vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockFontFetchResponse(relativeData)));
+                await relFont.hotReload('fonts/rel.btfont', null);
+
+                expect(imageSources[0]).toMatch(/^fonts\/atlas\.png\?blit386-hmr=\d+$/);
+            });
         });
     });
 });

--- a/src/assets/BitmapFont.ts
+++ b/src/assets/BitmapFont.ts
@@ -1,3 +1,4 @@
+import { isHotActive } from '../hot/HotRuntime';
 import {
     assertImageElementWithinLimits,
     AssetLimitError,
@@ -9,8 +10,10 @@ import {
     validateGlyphCount,
 } from '../utils/AssetLimits';
 import { btfontGlyphEntryNotObjectError } from '../utils/errorMessages';
+import { appendCacheBustQuery, normalizeAssetUrl } from '../utils/HotReloadUrl';
 import { Rect2i } from '../utils/Rect2i';
 import { buildPathHint, extractExtension } from '../utils/urlHints';
+import type { Palette } from './Palette';
 import { SpriteSheet } from './SpriteSheet';
 
 /**
@@ -135,6 +138,48 @@ function populateAsciiGlyph(asciiGlyphs: (Glyph | null)[], char: string, glyph: 
             asciiGlyphs[code] = glyph;
         }
     }
+}
+
+/**
+ * Dev-only registry of live bitmap fonts keyed by normalized `.btfont` source URL,
+ * so `HotRuntime.handleAssetChanged` can find and hot-reload every font loaded from
+ * a changed font file. Populated only while {@link isHotActive} (no production
+ * memory cost). Entries are never pruned - unlike {@link SpriteSheet}, `BitmapFont`
+ * has no destroy/dispose lifecycle to hook; acceptable since the registry only
+ * exists in dev mode.
+ */
+const hotReloadRegistry = new Map<string, Set<BitmapFont>>();
+
+/**
+ * Registers `font` under its normalized source URL for hot-reload routing, when a
+ * Vite HMR context is active. Called by {@link BitmapFont.load}.
+ *
+ * @param url - Source URL the font was loaded from.
+ * @param font - Font to register.
+ */
+function registerFontForHotReload(url: string, font: BitmapFont): void {
+    if (!isHotActive()) {
+        return;
+    }
+
+    const key = normalizeAssetUrl(url);
+    const bucket = hotReloadRegistry.get(key) ?? new Set<BitmapFont>();
+
+    bucket.add(font);
+    hotReloadRegistry.set(key, bucket);
+}
+
+/**
+ * Returns every registered font loaded from a URL matching `url` after normalization.
+ *
+ * Internal - used by `HotRuntime.handleAssetChanged` to route a `'font'`
+ * asset-changed event to the fonts that need reloading.
+ *
+ * @param url - Changed asset URL to look up.
+ * @returns Matching fonts, or `undefined` when none are registered.
+ */
+export function getHotReloadFonts(url: string): ReadonlySet<BitmapFont> | undefined {
+    return hotReloadRegistry.get(normalizeAssetUrl(url));
 }
 
 /**
@@ -282,7 +327,7 @@ export class BitmapFont {
         const lineHeight = BitmapFont.resolvePositiveMetric(data.lineHeight, size);
         const baseline = BitmapFont.resolvePositiveMetric(data.baseline, size);
 
-        return new BitmapFont(
+        const font = new BitmapFont(
             spriteSheet,
             glyphs,
             asciiGlyphs,
@@ -291,6 +336,10 @@ export class BitmapFont {
             lineHeight,
             baseline,
         );
+
+        registerFontForHotReload(url, font);
+
+        return font;
     }
 
     /**
@@ -516,6 +565,19 @@ export class BitmapFont {
             : url.substring(0, url.lastIndexOf('/') + 1) + texture;
 
         return BitmapFont.loadImage(textureUrl);
+    }
+
+    /**
+     * Cache-busts a `.btfont` texture reference for a hot reload, unless it is an
+     * embedded data URI (always fresh from the just-re-fetched JSON, nothing to bust).
+     *
+     * @param texture - Raw `texture` field from the re-fetched `.btfont` JSON.
+     * @returns `texture` unchanged for a data URI; otherwise with a cache-bust query appended.
+     */
+    private static bustTextureUrl(texture: string): string {
+        return texture.toLowerCase().startsWith(BTFONT_EMBEDDED_TEXTURE_PREFIX)
+            ? texture
+            : appendCacheBustQuery(texture);
     }
 
     /**
@@ -821,5 +883,52 @@ export class BitmapFont {
      */
     clearMeasureCache(): void {
         this.measureCache.clear();
+    }
+
+    /**
+     * Hot-reloads this font's `.btfont` descriptor and texture in place, keeping the
+     * same `BitmapFont` instance so demo-held references stay valid.
+     *
+     * Internal - routed from `HotRuntime.handleAssetChanged` when the dev asset
+     * watcher reports a changed font file. Re-fetches a cache-busted copy of the
+     * `.btfont` JSON, rebuilds the glyph tables and measurement cache in place, and
+     * replaces the underlying sprite sheet's image via
+     * {@link SpriteSheet.hotReplaceImage} (which itself re-indexizes it when it was
+     * already indexized). `name`/`size`/`lineHeight`/`baseline` are not updated by a
+     * hot reload - only glyph data and the texture.
+     *
+     * @param url - `.btfont` URL this font was originally loaded from.
+     * @param palette - Active palette, forwarded to {@link SpriteSheet.hotReplaceImage}.
+     * @throws Error if the re-fetched `.btfont` file is missing or malformed (mirrors {@link BitmapFont.load}).
+     */
+    async hotReload(url: string, palette: Palette | null): Promise<void> {
+        const response = await fetch(appendCacheBustQuery(url));
+
+        if (!response.ok) {
+            throw new Error(BitmapFont.buildLoadErrorMessage(url, response.status));
+        }
+
+        const { data, glyphEntries } = BitmapFont.parseBtfontFile(url, await response.text());
+
+        BitmapFont.validateGlyphEntriesPreAtlas(glyphEntries);
+
+        const image = await BitmapFont.loadTexture(BitmapFont.bustTextureUrl(data.texture), url);
+
+        this.spriteSheet.hotReplaceImage(image, palette);
+
+        const { glyphs, asciiGlyphs } = BitmapFont.buildGlyphsFromEntries(
+            glyphEntries,
+            this.spriteSheet.width,
+            this.spriteSheet.height,
+        );
+
+        this.glyphs = glyphs;
+
+        for (let code = 0; code < this.asciiGlyphs.length; code++) {
+            // eslint-disable-next-line security/detect-object-injection -- code is a bounded loop index
+            this.asciiGlyphs[code] = asciiGlyphs[code] ?? null;
+        }
+
+        this.clearMeasureCache();
     }
 }

--- a/src/assets/BitmapFont.ts
+++ b/src/assets/BitmapFont.ts
@@ -144,7 +144,7 @@ function populateAsciiGlyph(asciiGlyphs: (Glyph | null)[], char: string, glyph: 
  * Dev-only registry of live bitmap fonts keyed by normalized `.btfont` source URL,
  * so `HotRuntime.handleAssetChanged` can find and hot-reload every font loaded from
  * a changed font file. Populated only while {@link isHotActive} (no production
- * memory cost). Entries are never pruned - unlike {@link SpriteSheet}, `BitmapFont`
+ * memory cost). Entries are never pruned – unlike {@link SpriteSheet}, `BitmapFont`
  * has no destroy/dispose lifecycle to hook; acceptable since the registry only
  * exists in dev mode.
  */
@@ -172,7 +172,7 @@ function registerFontForHotReload(url: string, font: BitmapFont): void {
 /**
  * Returns every registered font loaded from a URL matching `url` after normalization.
  *
- * Internal - used by `HotRuntime.handleAssetChanged` to route a `'font'`
+ * Internal – used by `HotRuntime.handleAssetChanged` to route a `'font'`
  * asset-changed event to the fonts that need reloading.
  *
  * @param url - Changed asset URL to look up.
@@ -889,13 +889,13 @@ export class BitmapFont {
      * Hot-reloads this font's `.btfont` descriptor and texture in place, keeping the
      * same `BitmapFont` instance so demo-held references stay valid.
      *
-     * Internal - routed from `HotRuntime.handleAssetChanged` when the dev asset
+     * Internal – routed from `HotRuntime.handleAssetChanged` when the dev asset
      * watcher reports a changed font file. Re-fetches a cache-busted copy of the
      * `.btfont` JSON, rebuilds the glyph tables and measurement cache in place, and
      * replaces the underlying sprite sheet's image via
      * {@link SpriteSheet.hotReplaceImage} (which itself re-indexizes it when it was
      * already indexized). `name`/`size`/`lineHeight`/`baseline` are not updated by a
-     * hot reload - only glyph data and the texture.
+     * hot reload – only glyph data and the texture.
      *
      * @param url - `.btfont` URL this font was originally loaded from.
      * @param palette - Active palette, forwarded to {@link SpriteSheet.hotReplaceImage}.

--- a/src/assets/SpriteSheet.test.ts
+++ b/src/assets/SpriteSheet.test.ts
@@ -26,14 +26,14 @@ import { AssetLoader } from './AssetLoader';
 import { Palette } from './Palette';
 import { getHotReloadSheets, SpriteSheet } from './SpriteSheet';
 
-// SpriteSheet.destroy() unconditionally normalizes `sourceUrl` against `location.origin`
+// SpriteSheet.destroy() unconditionally normalizes `sourceUrl` against `document.baseURI`
 // (see unregisterFromHotReload in SpriteSheet.ts) whenever a sheet was loaded via
 // SpriteSheet.load(), regardless of whether hot reload was ever active. Real browsers
-// always have `location`; this file's default Node test environment does not, so - like
+// always have `document`; this file's default Node test environment does not, so - like
 // the GPU/AudioContext stubs in src/__test__/setup.ts - install it once, only if missing,
 // so it survives every describe block's `vi.unstubAllGlobals()` call.
-if (typeof globalThis.location === 'undefined') {
-    (globalThis as unknown as { location?: URL }).location = new URL('http://localhost/');
+if (typeof globalThis.document === 'undefined') {
+    (globalThis as unknown as { document?: { baseURI: string } }).document = { baseURI: 'http://localhost/' };
 }
 
 /**

--- a/src/assets/SpriteSheet.test.ts
+++ b/src/assets/SpriteSheet.test.ts
@@ -18,12 +18,23 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { createMockGPUDevice } from '../__test__/webgpu-mock';
 import { collectUsedIndices, resetUsage } from '../core/RenderPaletteUsage';
+import { registerHotContext } from '../hot/HotRuntime';
 import { AssetLimitError, MAX_ASSET_DIMENSION, MAX_ASSET_PIXELS } from '../utils/AssetLimits';
 import { Color32 } from '../utils/Color32';
 import { Rect2i } from '../utils/Rect2i';
 import { AssetLoader } from './AssetLoader';
 import { Palette } from './Palette';
-import { SpriteSheet } from './SpriteSheet';
+import { getHotReloadSheets, SpriteSheet } from './SpriteSheet';
+
+// SpriteSheet.destroy() unconditionally normalizes `sourceUrl` against `location.origin`
+// (see unregisterFromHotReload in SpriteSheet.ts) whenever a sheet was loaded via
+// SpriteSheet.load(), regardless of whether hot reload was ever active. Real browsers
+// always have `location`; this file's default Node test environment does not, so - like
+// the GPU/AudioContext stubs in src/__test__/setup.ts - install it once, only if missing,
+// so it survives every describe block's `vi.unstubAllGlobals()` call.
+if (typeof globalThis.location === 'undefined') {
+    (globalThis as unknown as { location?: URL }).location = new URL('http://localhost/');
+}
 
 /**
  * Returns a minimal OffscreenCanvas mock whose getImageData yields the supplied
@@ -699,6 +710,124 @@ describe('SpriteSheet', () => {
             sheet.markPaletteIndicesInRect(new Rect2i(0, 0, 16, 16), 0, mask);
 
             expect(collectUsedIndices(mask, 16, scratch)).toEqual([]);
+        });
+    });
+
+    describe('hot reload', () => {
+        function activateHotReload() {
+            registerHotContext({
+                data: {},
+                on: vi.fn(),
+                invalidate: vi.fn(),
+                accept: vi.fn(),
+            });
+        }
+
+        afterEach(() => {
+            vi.restoreAllMocks();
+            vi.unstubAllGlobals();
+        });
+
+        it('does not register a loaded sheet when hot reload is inactive', async () => {
+            vi.stubGlobal('createImageBitmap', vi.fn().mockRejectedValue(new Error('n/a')));
+            vi.spyOn(AssetLoader, 'loadImage').mockResolvedValue(mockImage);
+
+            await SpriteSheet.load('inactive.png');
+
+            expect(getHotReloadSheets('inactive.png')).toBeUndefined();
+        });
+
+        it('registers a loaded sheet under its normalized source URL once hot reload is active', async () => {
+            activateHotReload();
+            vi.stubGlobal('createImageBitmap', vi.fn().mockRejectedValue(new Error('n/a')));
+            vi.spyOn(AssetLoader, 'loadImage').mockResolvedValue(mockImage);
+
+            const sheet = await SpriteSheet.load('images/hero.png');
+
+            expect(getHotReloadSheets('images/hero.png')).toEqual(new Set([sheet]));
+            expect(getHotReloadSheets('/images/hero.png')).toEqual(new Set([sheet]));
+        });
+
+        it('removes a sheet from the registry on destroy', async () => {
+            activateHotReload();
+            vi.stubGlobal('createImageBitmap', vi.fn().mockRejectedValue(new Error('n/a')));
+            vi.spyOn(AssetLoader, 'loadImage').mockResolvedValue(mockImage);
+
+            const sheet = await SpriteSheet.load('images/gone.png');
+            expect(getHotReloadSheets('images/gone.png')).toBeDefined();
+
+            sheet.destroy();
+
+            expect(getHotReloadSheets('images/gone.png')).toBeUndefined();
+        });
+
+        describe('hotReplaceImage', () => {
+            it('warns and does nothing for a raw-indexed sheet (no source image)', () => {
+                const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+                const sheet = SpriteSheet.fromIndexedPixels(2, 2, new Uint8Array(4) as Uint8Array<ArrayBuffer>);
+
+                sheet.hotReplaceImage(mockImage, null);
+
+                expect(warnSpy).toHaveBeenCalledOnce();
+            });
+
+            it('swaps the image and updates size for a non-indexized sheet', () => {
+                const sheet = new SpriteSheet(mockImage);
+                const newImage = { width: 64, height: 32 } as HTMLImageElement;
+
+                sheet.hotReplaceImage(newImage, null);
+
+                expect(sheet.getImage()).toBe(newImage);
+                expect(sheet.size.x).toBe(64);
+                expect(sheet.size.y).toBe(32);
+            });
+
+            it('invalidates the cached texture for a non-indexized sheet', () => {
+                const sheet = new SpriteSheet(mockImage);
+                const device = createMockGPUDevice();
+                const first = sheet.getTexture(device);
+
+                sheet.hotReplaceImage({ width: 64, height: 64 } as HTMLImageElement, null);
+                const second = sheet.getTexture(device);
+
+                expect(second).not.toBe(first);
+            });
+
+            it('re-indexizes an already-indexized sheet against the active palette', () => {
+                const pixels = new Uint8ClampedArray([255, 0, 0, 255]);
+                vi.stubGlobal('OffscreenCanvas', makeOffscreenCanvasMock(pixels, 1, 1));
+
+                const palette = new Palette(16);
+                palette.set(1, new Color32(255, 0, 0, 255));
+
+                const sheet = new SpriteSheet({ width: 1, height: 1 } as HTMLImageElement);
+                sheet.indexize(palette);
+
+                const nextPixels = new Uint8ClampedArray([0, 255, 0, 255]);
+                vi.stubGlobal('OffscreenCanvas', makeOffscreenCanvasMock(nextPixels, 1, 1));
+                palette.set(2, new Color32(0, 255, 0, 255));
+
+                expect(() => sheet.hotReplaceImage({ width: 1, height: 1 } as HTMLImageElement, palette)).not.toThrow();
+                expect(sheet.getIndexedPixels()[0]).toBe(2);
+            });
+
+            it('warns and skips when an indexized sheet has no active palette to reindex against', () => {
+                const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+                const pixels = new Uint8ClampedArray([0, 0, 0, 0]);
+                vi.stubGlobal('OffscreenCanvas', makeOffscreenCanvasMock(pixels, 1, 1));
+
+                const palette = new Palette(16);
+                const originalImage = { width: 1, height: 1 } as HTMLImageElement;
+                const sheet = new SpriteSheet(originalImage);
+                sheet.indexize(palette);
+
+                const newImage = { width: 1, height: 1 } as HTMLImageElement;
+                sheet.hotReplaceImage(newImage, null);
+
+                expect(warnSpy).toHaveBeenCalledOnce();
+                expect(sheet.getImage()).toBe(originalImage);
+                expect(sheet.getImage()).not.toBe(newImage);
+            });
         });
     });
 });

--- a/src/assets/SpriteSheet.ts
+++ b/src/assets/SpriteSheet.ts
@@ -32,7 +32,7 @@ const hotReloadRegistry = new Map<string, Set<SpriteSheet>>();
 /**
  * Returns every registered sheet loaded from a URL matching `url` after normalization.
  *
- * Internal - used by `HotRuntime.handleAssetChanged` to route an `'image'`
+ * Internal – used by `HotRuntime.handleAssetChanged` to route an `'image'`
  * asset-changed event to the sheets that need their texture replaced.
  *
  * @param url - Changed asset URL to look up.
@@ -299,7 +299,7 @@ export class SpriteSheet {
      * Gets the sprite-sheet dimensions in pixels.
      *
      * @returns Sheet dimensions. Changes after a hot-replace image swap with
-     *   different dimensions - any `srcRect` a demo holds onto is the demo's own
+     *   different dimensions – any `srcRect` a demo holds onto is the demo's own
      *   responsibility to reconcile.
      */
     get size(): Vector2i {
@@ -605,18 +605,18 @@ export class SpriteSheet {
      * Replaces this sheet's source image in place after a hot-reloaded asset change.
      *
      * Swaps the image reference, validates and updates {@link size} (dimension
-     * changes are allowed - buffers rebuild to match), re-runs `indexize` against
+     * changes are allowed – buffers rebuild to match), re-runs `indexize` against
      * `palette` when the sheet was already indexized so `indexedPixels` stays in
      * sync with the new pixels, and invalidates the cached GPU texture so the next
      * `getTexture()` call re-uploads it.
      *
-     * No-op (with a console warning) for sheets created from raw indexed data - there
-     * is no source image to replace - and for an already-indexized sheet when `palette`
+     * No-op (with a console warning) for sheets created from raw indexed data – there
+     * is no source image to replace – and for an already-indexized sheet when `palette`
      * is `null`, since there is nothing safe to reindex against.
      *
      * If `indexize()` throws partway (a pixel color from the new image is missing from
      * `palette`), this sheet is left with the new image/size but a stale, mismatched
-     * `indexedPixels`/texture until a subsequent successful hot reload - an accepted
+     * `indexedPixels`/texture until a subsequent successful hot reload – an accepted
      * dev-only-path risk, not a production code path.
      *
      * @param image - Newly loaded replacement image.

--- a/src/assets/SpriteSheet.ts
+++ b/src/assets/SpriteSheet.ts
@@ -1,7 +1,9 @@
 import { markIndexUsed } from '../core/RenderPaletteUsage';
+import { isHotActive } from '../hot/HotRuntime';
 import { assertDimensions, assertImageElementWithinLimits, assertIndexedPixelInput } from '../utils/AssetLimits';
 import { Color32 } from '../utils/Color32';
 import { spriteColorNotInPaletteError } from '../utils/errorMessages';
+import { normalizeAssetUrl } from '../utils/HotReloadUrl';
 import { Rect2i } from '../utils/Rect2i';
 import { Vector2i } from '../utils/Vector2i';
 import { AssetLoader } from './AssetLoader';
@@ -18,6 +20,27 @@ const RGBA_BYTES_PER_PIXEL = 4;
 
 /** Depth or array-layer count for a 2-D GPU texture descriptor. */
 const TEXTURE_LAYER_COUNT = 1;
+
+/**
+ * Dev-only registry of live sprite sheets keyed by normalized source URL, so
+ * `HotRuntime.handleAssetChanged` can find and hot-replace every sheet loaded
+ * from a changed image. Populated only while {@link isHotActive} (no production
+ * memory cost); entries are removed in {@link SpriteSheet.destroy}.
+ */
+const hotReloadRegistry = new Map<string, Set<SpriteSheet>>();
+
+/**
+ * Returns every registered sheet loaded from a URL matching `url` after normalization.
+ *
+ * Internal - used by `HotRuntime.handleAssetChanged` to route an `'image'`
+ * asset-changed event to the sheets that need their texture replaced.
+ *
+ * @param url - Changed asset URL to look up.
+ * @returns Matching sheets, or `undefined` when none are registered.
+ */
+export function getHotReloadSheets(url: string): ReadonlySet<SpriteSheet> | undefined {
+    return hotReloadRegistry.get(normalizeAssetUrl(url));
+}
 
 /**
  * Maps retained RGBA bytes to palette indices for one sprite sheet.
@@ -230,11 +253,14 @@ export type IndexedSpriteLoadResult = {
  * @since 0.1.0
  */
 export class SpriteSheet {
-    /** Sprite sheet dimensions in pixels. */
-    public readonly size: Vector2i;
-
     /** Source HTML image element (null for sheets created from raw indexed data). */
-    private readonly image: HTMLImageElement | null;
+    private image: HTMLImageElement | null;
+
+    /** Sprite sheet dimensions in pixels. Backing field for the public {@link size} getter. */
+    private sheetSize: Vector2i;
+
+    /** Source URL this sheet was loaded from via {@link SpriteSheet.load}, or `null` otherwise. */
+    private sourceUrl: string | null = null;
 
     /** Pre-decoded image bitmap for GPU upload (created by load()). */
     private imageBitmap: ImageBitmap | null = null;
@@ -260,13 +286,24 @@ export class SpriteSheet {
 
         if (image) {
             assertImageElementWithinLimits('sprite sheet', image);
-            this.size = new Vector2i(image.width, image.height);
+            this.sheetSize = new Vector2i(image.width, image.height);
         } else if (size) {
             assertDimensions('sprite sheet', size.x, size.y);
-            this.size = size;
+            this.sheetSize = size;
         } else {
             throw new Error('Either an image or explicit size must be provided.');
         }
+    }
+
+    /**
+     * Gets the sprite-sheet dimensions in pixels.
+     *
+     * @returns Sheet dimensions. Changes after a hot-replace image swap with
+     *   different dimensions - any `srcRect` a demo holds onto is the demo's own
+     *   responsibility to reconcile.
+     */
+    get size(): Vector2i {
+        return this.sheetSize;
     }
 
     /**
@@ -310,6 +347,9 @@ export class SpriteSheet {
     static async load(url: string): Promise<SpriteSheet> {
         const image = await AssetLoader.loadImage(url);
         const sheet = new SpriteSheet(image);
+
+        sheet.sourceUrl = url;
+        sheet.registerForHotReload();
 
         // Create ImageBitmap with explicit alpha handling.
         // - premultiplyAlpha: 'none' preserves original alpha values (avoids dark fringes)
@@ -562,6 +602,58 @@ export class SpriteSheet {
     }
 
     /**
+     * Replaces this sheet's source image in place after a hot-reloaded asset change.
+     *
+     * Swaps the image reference, validates and updates {@link size} (dimension
+     * changes are allowed - buffers rebuild to match), re-runs `indexize` against
+     * `palette` when the sheet was already indexized so `indexedPixels` stays in
+     * sync with the new pixels, and invalidates the cached GPU texture so the next
+     * `getTexture()` call re-uploads it.
+     *
+     * No-op (with a console warning) for sheets created from raw indexed data - there
+     * is no source image to replace - and for an already-indexized sheet when `palette`
+     * is `null`, since there is nothing safe to reindex against.
+     *
+     * If `indexize()` throws partway (a pixel color from the new image is missing from
+     * `palette`), this sheet is left with the new image/size but a stale, mismatched
+     * `indexedPixels`/texture until a subsequent successful hot reload - an accepted
+     * dev-only-path risk, not a production code path.
+     *
+     * @param image - Newly loaded replacement image.
+     * @param palette - Active palette, used to re-run `indexize` when the sheet was
+     *   already indexized.
+     */
+    hotReplaceImage(image: HTMLImageElement, palette: Palette | null): void {
+        if (!this.image) {
+            console.warn('[BT] Hot reload: sprite sheet has no source image (raw indexed data); skipping.');
+
+            return;
+        }
+
+        if (this.indexedPixels !== null && palette === null) {
+            console.warn(`[BT] Hot reload: ${this.sourceName} is indexized but no active palette is set; skipping.`);
+
+            return;
+        }
+
+        assertImageElementWithinLimits('sprite sheet', image);
+
+        this.image = image;
+        this.sheetSize = new Vector2i(image.width, image.height);
+
+        if (this.imageBitmap) {
+            this.imageBitmap.close();
+            this.imageBitmap = null;
+        }
+
+        if (this.indexedPixels !== null && palette !== null) {
+            this.indexize(palette);
+        } else {
+            this.invalidateTexture();
+        }
+    }
+
+    /**
      * Returns whether this sprite sheet has been converted to palette indices.
      *
      * @returns True if `indexize()` has been called successfully.
@@ -705,6 +797,7 @@ export class SpriteSheet {
      */
     destroy(): void {
         this.invalidateTexture();
+        this.unregisterFromHotReload();
 
         if (this.imageBitmap) {
             this.imageBitmap.close();
@@ -788,6 +881,45 @@ export class SpriteSheet {
         if (this.texture) {
             this.texture.destroy();
             this.texture = null;
+        }
+    }
+
+    /**
+     * Registers this sheet in the dev-only hot-reload registry under its normalized
+     * source URL, when a Vite HMR context is active. Called by {@link SpriteSheet.load}.
+     */
+    private registerForHotReload(): void {
+        if (this.sourceUrl === null || !isHotActive()) {
+            return;
+        }
+
+        const key = normalizeAssetUrl(this.sourceUrl);
+        const bucket = hotReloadRegistry.get(key) ?? new Set<SpriteSheet>();
+
+        bucket.add(this);
+        hotReloadRegistry.set(key, bucket);
+    }
+
+    /**
+     * Removes this sheet from the hot-reload registry, pruning an empty bucket.
+     * Called by {@link SpriteSheet.destroy}.
+     */
+    private unregisterFromHotReload(): void {
+        if (this.sourceUrl === null) {
+            return;
+        }
+
+        const key = normalizeAssetUrl(this.sourceUrl);
+        const bucket = hotReloadRegistry.get(key);
+
+        if (!bucket) {
+            return;
+        }
+
+        bucket.delete(this);
+
+        if (bucket.size === 0) {
+            hotReloadRegistry.delete(key);
         }
     }
 }

--- a/src/assets/SpriteSheet.ts
+++ b/src/assets/SpriteSheet.ts
@@ -257,7 +257,7 @@ export class SpriteSheet {
     private image: HTMLImageElement | null;
 
     /** Sprite sheet dimensions in pixels. Backing field for the public {@link size} getter. */
-    private sheetSize: Vector2i;
+    private _size: Vector2i;
 
     /** Source URL this sheet was loaded from via {@link SpriteSheet.load}, or `null` otherwise. */
     private sourceUrl: string | null = null;
@@ -286,10 +286,10 @@ export class SpriteSheet {
 
         if (image) {
             assertImageElementWithinLimits('sprite sheet', image);
-            this.sheetSize = new Vector2i(image.width, image.height);
+            this._size = new Vector2i(image.width, image.height);
         } else if (size) {
             assertDimensions('sprite sheet', size.x, size.y);
-            this.sheetSize = size;
+            this._size = size;
         } else {
             throw new Error('Either an image or explicit size must be provided.');
         }
@@ -303,7 +303,7 @@ export class SpriteSheet {
      *   responsibility to reconcile.
      */
     get size(): Vector2i {
-        return this.sheetSize;
+        return this._size;
     }
 
     /**
@@ -639,7 +639,7 @@ export class SpriteSheet {
         assertImageElementWithinLimits('sprite sheet', image);
 
         this.image = image;
-        this.sheetSize = new Vector2i(image.width, image.height);
+        this._size = new Vector2i(image.width, image.height);
 
         if (this.imageBitmap) {
             this.imageBitmap.close();

--- a/src/audio/AudioManager.test.ts
+++ b/src/audio/AudioManager.test.ts
@@ -24,6 +24,7 @@ import {
 } from '../__test__/webaudio-mock';
 import { BTAPI } from '../core/BTAPI';
 import type { HardwareSettings } from '../core/IBTDemo';
+import { notifyMusicHotReplace } from './audioDecodeContext';
 import { AudioManager } from './AudioManager';
 import { INVALID_SOUND_REF } from './VoicePool';
 
@@ -121,6 +122,23 @@ describe('AudioManager', () => {
 
             expect(() => audio.attach(canvas)).not.toThrow();
             expect(audio.isUnlocked()).toBe(false);
+        });
+    });
+
+    describe('music hot-replace wiring', () => {
+        it('registers a music hot-replace handler on attach that delegates to the music player', () => {
+            audio.attach(canvas);
+
+            const restarted = notifyMusicHotReplace(createMockAudioBuffer(), createMockAudioBuffer());
+
+            expect(restarted).toBe(false); // nothing playing yet, but the handler ran without throwing
+        });
+
+        it('resets the music hot-replace handler to a no-op on detach', () => {
+            audio.attach(canvas);
+            audio.detach();
+
+            expect(notifyMusicHotReplace(createMockAudioBuffer(), createMockAudioBuffer())).toBe(false);
         });
     });
 

--- a/src/audio/AudioManager.ts
+++ b/src/audio/AudioManager.ts
@@ -11,7 +11,7 @@
 import type { AudioBus } from '../core/IBTDemo';
 import { applyAudioParamRamp } from '../utils/AudioParamRamp';
 import type { EasingFunction } from '../utils/Easing';
-import { setAudioClipUnloadHandler, setAudioDecodeContext } from './audioDecodeContext';
+import { setAudioClipUnloadHandler, setAudioDecodeContext, setMusicHotReplaceHandler } from './audioDecodeContext';
 import { MusicPlayer, type MusicPlayOptions } from './MusicPlayer';
 import {
     DEFAULT_PAN,
@@ -155,6 +155,9 @@ export class AudioManager {
         setAudioClipUnloadHandler((buffer) => this.voicePool?.stopVoicesUsingBuffer(buffer));
 
         this.musicPlayer = new MusicPlayer(this.context, busNodes.music);
+        setMusicHotReplaceHandler(
+            (oldBuffer, newBuffer) => this.musicPlayer?.hotReplaceCurrentBuffer(oldBuffer, newBuffer) ?? false,
+        );
 
         this.target = target;
 
@@ -175,6 +178,7 @@ export class AudioManager {
         this.voicePool?.stopAll();
         this.voicePool = null;
         setAudioClipUnloadHandler(() => {});
+        setMusicHotReplaceHandler(() => false);
 
         this.musicPlayer?.stop();
         this.musicPlayer = null;

--- a/src/audio/MusicPlayer.test.ts
+++ b/src/audio/MusicPlayer.test.ts
@@ -787,4 +787,46 @@ describe('MusicPlayer', () => {
             expect(player.isPlaying()).toBe(true);
         });
     });
+
+    describe('hotReplaceCurrentBuffer', () => {
+        it('returns false when nothing is playing', () => {
+            const { player } = createPlayer();
+            const oldBuffer = createMockAudioBuffer();
+            const newBuffer = createMockAudioBuffer();
+
+            expect(player.hotReplaceCurrentBuffer(oldBuffer, newBuffer)).toBe(false);
+        });
+
+        it('returns false when the current track is a different buffer', () => {
+            const { player } = createPlayer();
+            player.play(createMockAudioBuffer());
+
+            expect(player.hotReplaceCurrentBuffer(createMockAudioBuffer(), createMockAudioBuffer())).toBe(false);
+        });
+
+        it('restarts the current track with the new buffer when it matches', () => {
+            const { player } = createPlayer();
+            const oldBuffer = createMockAudioBuffer();
+            const newBuffer = createMockAudioBuffer();
+            player.play(oldBuffer, { volume: 0.6, loop: false });
+
+            const restarted = player.hotReplaceCurrentBuffer(oldBuffer, newBuffer);
+
+            expect(restarted).toBe(true);
+            expect(player.isPlaying()).toBe(true);
+        });
+
+        it('restarts with fadeMs 0 regardless of the original play fadeMs', () => {
+            const { player, context } = createPlayer();
+            const context2 = context as unknown as { createBufferSourceCalls: AudioBufferSourceNode[] };
+            const oldBuffer = createMockAudioBuffer();
+            const newBuffer = createMockAudioBuffer();
+            player.play(oldBuffer, { fadeMs: 2000 });
+
+            const sourceCallsBefore = context2.createBufferSourceCalls.length;
+            player.hotReplaceCurrentBuffer(oldBuffer, newBuffer);
+
+            expect(context2.createBufferSourceCalls.length).toBe(sourceCallsBefore + 1);
+        });
+    });
 });

--- a/src/audio/MusicPlayer.test.ts
+++ b/src/audio/MusicPlayer.test.ts
@@ -828,5 +828,48 @@ describe('MusicPlayer', () => {
 
             expect(context2.createBufferSourceCalls.length).toBe(sourceCallsBefore + 1);
         });
+
+        it('restarts successfully when the old loop region no longer fits the new, shorter buffer', () => {
+            const { player } = createPlayer();
+            const oldBuffer = createMockAudioBuffer(1, 10, 10); // duration 1s at sampleRate 10
+            const newBuffer = createMockAudioBuffer(1, 5, 10); // duration 0.5s - shorter than the old loopEnd
+            player.play(oldBuffer, { loopStart: 0.2, loopEnd: 0.8 });
+
+            const restarted = player.hotReplaceCurrentBuffer(oldBuffer, newBuffer);
+
+            expect(restarted).toBe(true);
+            expect(player.isPlaying()).toBe(true);
+        });
+
+        it('drops the stale loop region instead of applying it to the new buffer', () => {
+            const { player, context } = createPlayer();
+            const context2 = context as unknown as { createBufferSourceCalls: AudioBufferSourceNode[] };
+            const oldBuffer = createMockAudioBuffer(1, 10, 10);
+            const newBuffer = createMockAudioBuffer(1, 5, 10);
+            player.play(oldBuffer, { loopStart: 0.2, loopEnd: 0.8 });
+
+            player.hotReplaceCurrentBuffer(oldBuffer, newBuffer);
+
+            // applyLoopOptions() never touches loopStart/loopEnd when both are absent from
+            // options, so an unset value here proves the stale region was dropped, not applied.
+            const source = context2.createBufferSourceCalls.at(-1) as AudioBufferSourceNode;
+            expect(source.loopStart).toBeUndefined();
+            expect(source.loopEnd).toBeUndefined();
+            expect(source.loop).toBe(true); // DEFAULT_LOOP
+        });
+
+        it('keeps a loop region that still fits the new buffer', () => {
+            const { player, context } = createPlayer();
+            const context2 = context as unknown as { createBufferSourceCalls: AudioBufferSourceNode[] };
+            const oldBuffer = createMockAudioBuffer(1, 10, 10);
+            const newBuffer = createMockAudioBuffer(1, 10, 10); // same duration - loop region still valid
+            player.play(oldBuffer, { loopStart: 0.2, loopEnd: 0.8 });
+
+            player.hotReplaceCurrentBuffer(oldBuffer, newBuffer);
+
+            const source = context2.createBufferSourceCalls.at(-1) as AudioBufferSourceNode;
+            expect(source.loopStart).toBe(0.2);
+            expect(source.loopEnd).toBe(0.8);
+        });
     });
 });

--- a/src/audio/MusicPlayer.ts
+++ b/src/audio/MusicPlayer.ts
@@ -99,6 +99,9 @@ export class MusicPlayer {
     /** Last requested target volume, reported by {@link volumeGet} regardless of fade state. */
     private volume = DEFAULT_VOLUME;
 
+    /** Options from the most recent {@link play} call, replayed (with `fadeMs` forced to `0`) by {@link hotReplaceCurrentBuffer}. */
+    private lastOptions: MusicPlayOptions = {};
+
     /**
      * Creates a player with no live voices.
      *
@@ -133,6 +136,8 @@ export class MusicPlayer {
      */
     public play(buffer: AudioBuffer, options: MusicPlayOptions = {}): void {
         validateLoopRegion(options, buffer.duration);
+
+        this.lastOptions = options;
 
         const now = this.context.currentTime;
         const fadeSeconds = Math.max(0, options.fadeMs ?? DEFAULT_FADE_MS) / 1000;
@@ -228,6 +233,27 @@ export class MusicPlayer {
      */
     public isPlaying(): boolean {
         return this.current !== null;
+    }
+
+    /**
+     * Hot-reload seam: if `oldBuffer` is the buffer of the currently playing track,
+     * restarts playback with `newBuffer` using the last {@link play} options but no
+     * crossfade (`fadeMs: 0`) so a hot-reloaded track picks up immediately. Same-
+     * position resume is out of scope - playback restarts from the beginning.
+     *
+     * @param oldBuffer - Buffer identity to match against the current track.
+     * @param newBuffer - Replacement buffer to play when `oldBuffer` matches.
+     * @returns `true` if the current track was restarted; `false` if it didn't
+     *   match, or nothing is currently playing.
+     */
+    public hotReplaceCurrentBuffer(oldBuffer: AudioBuffer, newBuffer: AudioBuffer): boolean {
+        if (this.currentBuffer() !== oldBuffer) {
+            return false;
+        }
+
+        this.play(newBuffer, { ...this.lastOptions, fadeMs: 0 });
+
+        return true;
     }
 
     /**
@@ -354,6 +380,15 @@ export class MusicPlayer {
         if (this.previous === voice) {
             this.previous = null;
         }
+    }
+
+    /**
+     * Returns the `AudioBuffer` backing the current track's sole source node.
+     *
+     * @returns The current track's buffer, or `null` when nothing is playing.
+     */
+    private currentBuffer(): AudioBuffer | null {
+        return this.current?.sources[0]?.buffer ?? null;
     }
 }
 

--- a/src/audio/MusicPlayer.ts
+++ b/src/audio/MusicPlayer.ts
@@ -251,7 +251,9 @@ export class MusicPlayer {
             return false;
         }
 
-        this.play(newBuffer, { ...this.lastOptions, fadeMs: 0 });
+        const options = sanitizeLoopRegion(this.lastOptions, newBuffer.duration);
+
+        this.play(newBuffer, { ...options, fadeMs: 0 });
 
         return true;
     }
@@ -421,6 +423,33 @@ function applyLoopOptions(source: AudioBufferSourceNode, options: MusicPlayOptio
     }
 
     source.loop = options.loop ?? DEFAULT_LOOP;
+}
+
+/**
+ * Drops `loopStart`/`loopEnd` from `options` when they no longer describe a valid region for
+ * `duration`, instead of letting an invalid region reach {@link validateLoopRegion} and throw.
+ *
+ * Used by {@link MusicPlayer.hotReplaceCurrentBuffer}: `lastOptions` was captured for the
+ * previous buffer's duration, and a hot-reloaded replacement can be shorter, so its old loop
+ * points may no longer fit. Falls back to whole-buffer looping via `options.loop` in that case,
+ * so a valid buffer replacement always restarts successfully instead of throwing.
+ *
+ * @param options - Options to sanitize.
+ * @param duration - Duration in seconds of the buffer these options are about to be replayed against.
+ * @returns `options` unchanged when its loop region already fits `duration`; otherwise `options`
+ *   with `loopStart`/`loopEnd` removed.
+ */
+function sanitizeLoopRegion(options: MusicPlayOptions, duration: number): MusicPlayOptions {
+    const { loopStart, loopEnd, ...rest } = options;
+
+    const isValidRegion =
+        loopStart !== undefined &&
+        loopEnd !== undefined &&
+        loopStart >= 0 &&
+        loopStart < loopEnd &&
+        loopEnd <= duration;
+
+    return isValidRegion ? options : rest;
 }
 
 /**

--- a/src/audio/audioDecodeContext.ts
+++ b/src/audio/audioDecodeContext.ts
@@ -61,3 +61,40 @@ export function setAudioClipUnloadHandler(handler: (buffer: AudioBuffer) => void
 export function notifyAudioClipUnload(buffer: AudioBuffer): void {
     audioClipUnloadHandler(buffer);
 }
+
+/**
+ * Handler invoked by `AudioClip.hotReload()` after swapping a clip's buffer in
+ * place, to restart the music player if the replaced buffer was the current track.
+ *
+ * `AudioManager.attach()` registers `MusicPlayer.hotReplaceCurrentBuffer` here (see
+ * BT-305) so a hot-reloaded music track keeps playing without a manual `BT.musicPlay`
+ * call; `AudioManager.detach()` restores the no-op default. Defaults to a no-op
+ * returning `false` before the first `attach()`.
+ *
+ * @returns Whether the handler restarted playback with the new buffer.
+ */
+let musicHotReplaceHandler: (oldBuffer: AudioBuffer, newBuffer: AudioBuffer) => boolean = () => false;
+
+/**
+ * Registers the handler invoked by `AudioClip.hotReload()` to restart the current
+ * music track when its buffer was just hot-replaced.
+ *
+ * @param handler - Handler to invoke; returns whether it restarted playback.
+ */
+export function setMusicHotReplaceHandler(handler: (oldBuffer: AudioBuffer, newBuffer: AudioBuffer) => boolean): void {
+    musicHotReplaceHandler = handler;
+}
+
+/**
+ * Invokes the registered music hot-replace handler with the old and new buffers.
+ *
+ * Called by `AudioClip.hotReload()`; a no-op (returns `false`) until a music player
+ * registers a handler via {@link setMusicHotReplaceHandler}.
+ *
+ * @param oldBuffer - Buffer being replaced.
+ * @param newBuffer - Replacement buffer.
+ * @returns Whether the music player restarted playback with `newBuffer`.
+ */
+export function notifyMusicHotReplace(oldBuffer: AudioBuffer, newBuffer: AudioBuffer): boolean {
+    return musicHotReplaceHandler(oldBuffer, newBuffer);
+}

--- a/src/hot/HotRuntime.test.ts
+++ b/src/hot/HotRuntime.test.ts
@@ -12,6 +12,28 @@ function makeFakeHotContext(onImpl?: (event: string, cb: (payload: unknown) => v
     };
 }
 
+function registerAndCaptureAssetHandler(
+    // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+    HotRuntimeModule: typeof import('./HotRuntime'),
+): (payload: unknown) => void {
+    let captured: ((payload: unknown) => void) | undefined;
+
+    HotRuntimeModule.registerHotContext({
+        data: {},
+        on: (_event, cb) => {
+            captured = cb;
+        },
+        invalidate: vi.fn(),
+        accept: vi.fn(),
+    });
+
+    if (!captured) {
+        throw new Error('asset-changed handler was not registered');
+    }
+
+    return captured;
+}
+
 describe('HotRuntime', () => {
     // Fresh module state per test - hot/generation/wired are module-scoped singletons
     // that mirror real page-load semantics (a fresh page load is a fresh module instance).
@@ -23,11 +45,23 @@ describe('HotRuntime', () => {
     let HotRuntime: typeof import('./HotRuntime');
     // eslint-disable-next-line @typescript-eslint/consistent-type-imports
     let BTAPI: typeof import('../core/BTAPI').BTAPI;
+    // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+    let AssetLoader: typeof import('../assets/AssetLoader').AssetLoader;
+    // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+    let AudioClip: typeof import('../assets/AudioClip').AudioClip;
+    // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+    let SpriteSheetModule: typeof import('../assets/SpriteSheet');
+    // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+    let BitmapFontModule: typeof import('../assets/BitmapFont');
 
     beforeEach(async () => {
         vi.resetModules();
         HotRuntime = await import('./HotRuntime');
         ({ BTAPI } = await import('../core/BTAPI'));
+        ({ AssetLoader } = await import('../assets/AssetLoader'));
+        ({ AudioClip } = await import('../assets/AudioClip'));
+        SpriteSheetModule = await import('../assets/SpriteSheet');
+        BitmapFontModule = await import('../assets/BitmapFont');
     });
 
     afterEach(() => {
@@ -156,6 +190,102 @@ describe('HotRuntime', () => {
             HotRuntime.announce('methods', 1, 1);
 
             expect(receivedDetail).toEqual({ reason: 'methods', generation: 1 });
+        });
+    });
+
+    describe('handleAssetChanged', () => {
+        afterEach(() => {
+            vi.restoreAllMocks();
+            vi.unstubAllGlobals();
+        });
+
+        it('ignores a malformed payload without throwing', () => {
+            const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+            const handler = registerAndCaptureAssetHandler(HotRuntime);
+
+            expect(() => handler({ not: 'a payload' })).not.toThrow();
+            expect(errorSpy).toHaveBeenCalled();
+        });
+
+        it('routes an image payload through AssetLoader.hotReloadImage', async () => {
+            const spy = vi.spyOn(AssetLoader, 'hotReloadImage').mockResolvedValue({} as HTMLImageElement);
+            const handler = registerAndCaptureAssetHandler(HotRuntime);
+
+            handler({ url: 'hero.png', type: 'image', timestamp: 1 });
+            await vi.waitFor(() => expect(spy).toHaveBeenCalledExactlyOnceWith('hero.png'));
+        });
+
+        it('replaces every registered sheet for a matching image URL', async () => {
+            vi.spyOn(AssetLoader, 'hotReloadImage').mockResolvedValue({ width: 8, height: 8 } as HTMLImageElement);
+            const fakeSheet = { hotReplaceImage: vi.fn() } as unknown as InstanceType<
+                typeof SpriteSheetModule.SpriteSheet
+            >;
+            vi.spyOn(SpriteSheetModule, 'getHotReloadSheets').mockReturnValue(new Set([fakeSheet]));
+            vi.spyOn(BTAPI.instance, 'getPalette').mockReturnValue(null);
+
+            const handler = registerAndCaptureAssetHandler(HotRuntime);
+            handler({ url: 'hero.png', type: 'image', timestamp: 1 });
+
+            await vi.waitFor(() =>
+                expect(fakeSheet.hotReplaceImage).toHaveBeenCalledExactlyOnceWith({ width: 8, height: 8 }, null),
+            );
+        });
+
+        it('routes an audio payload through AudioClip.hotReload', async () => {
+            const spy = vi.spyOn(AudioClip, 'hotReload').mockResolvedValue(true);
+            const handler = registerAndCaptureAssetHandler(HotRuntime);
+
+            handler({ url: 'music.mp3', type: 'audio', timestamp: 1 });
+            await vi.waitFor(() => expect(spy).toHaveBeenCalledExactlyOnceWith('music.mp3'));
+        });
+
+        it('routes a font payload to every registered font for that URL', async () => {
+            const fakeFont = { hotReload: vi.fn().mockResolvedValue(undefined) } as unknown as Awaited<
+                ReturnType<typeof BitmapFontModule.BitmapFont.load>
+            >;
+            vi.spyOn(BitmapFontModule, 'getHotReloadFonts').mockReturnValue(new Set([fakeFont]));
+            vi.spyOn(BTAPI.instance, 'getPalette').mockReturnValue(null);
+
+            const handler = registerAndCaptureAssetHandler(HotRuntime);
+            handler({ url: 'font.btfont', type: 'font', timestamp: 1 });
+
+            await vi.waitFor(() => expect(fakeFont.hotReload).toHaveBeenCalledExactlyOnceWith('font.btfont', null));
+        });
+
+        it('no-ops when a font payload matches no registered font', async () => {
+            vi.spyOn(BitmapFontModule, 'getHotReloadFonts').mockReturnValue(undefined);
+            const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+            const handler = registerAndCaptureAssetHandler(HotRuntime);
+            handler({ url: 'unmatched.btfont', type: 'font', timestamp: 1 });
+
+            await vi.waitFor(() => expect(errorSpy).not.toHaveBeenCalled());
+        });
+
+        it('requests a hard reload for an unrecognized asset type', () => {
+            // Capture the handler first, before anything has wired the listener - registerHotContext
+            // only calls context.on(...) once per module instance (guarded by the internal `wired`
+            // flag), so a second registerHotContext call updates which context requestHardReload
+            // targets without re-registering the listener.
+            const handler = registerAndCaptureAssetHandler(HotRuntime);
+            const invalidate = vi.fn();
+            HotRuntime.registerHotContext({ data: {}, on: vi.fn(), invalidate, accept: vi.fn() });
+
+            handler({ url: 'level.json', type: 'other', timestamp: 1 });
+
+            expect(invalidate).toHaveBeenCalledWith(expect.stringContaining('level.json'));
+        });
+
+        it('logs and swallows a thrown error instead of crashing', async () => {
+            vi.spyOn(AudioClip, 'hotReload').mockRejectedValue(new Error('decode failed'));
+            const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+            const handler = registerAndCaptureAssetHandler(HotRuntime);
+            handler({ url: 'broken.mp3', type: 'audio', timestamp: 1 });
+
+            await vi.waitFor(() =>
+                expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('broken.mp3'), expect.any(Error)),
+            );
         });
     });
 });

--- a/src/hot/HotRuntime.ts
+++ b/src/hot/HotRuntime.ts
@@ -7,8 +7,12 @@
  * `import.meta.hot`, not an import from the `vite` package.
  */
 
+import { AssetLoader } from '../assets/AssetLoader';
+import { AudioClip } from '../assets/AudioClip';
+import { getHotReloadFonts } from '../assets/BitmapFont';
+import { getHotReloadSheets } from '../assets/SpriteSheet';
 import { BTAPI } from '../core/BTAPI';
-import { ASSET_CHANGED_EVENT, HOT_RELOAD_DOM_EVENT } from './protocol';
+import { ASSET_CHANGED_EVENT, type AssetChangedPayload, HOT_RELOAD_DOM_EVENT } from './protocol';
 
 /**
  * Minimal structural shape of Vite's `import.meta.hot` context that the engine
@@ -44,14 +48,123 @@ let generation = 0;
  */
 let wired = false;
 
+/** Asset kinds routed to a hot-replace handler; anything else falls through to a hard reload. */
+const KNOWN_ASSET_TYPES = new Set(['image', 'audio', 'font', 'other']);
+
 /**
- * Placeholder asset-changed handler; replaced with real hot-replace routing to
- * `AssetLoader`/`SpriteSheet`/`AudioClip`/`BitmapFont` in BT-305.
+ * Narrows an unknown HMR event payload to {@link AssetChangedPayload}.
+ *
+ * @param payload - Raw payload received from the Vite plugin's custom HMR event.
+ * @returns `true` when the payload has the expected shape.
+ */
+function isAssetChangedPayload(payload: unknown): payload is AssetChangedPayload {
+    if (typeof payload !== 'object' || payload === null) {
+        return false;
+    }
+
+    const candidate = payload as Record<string, unknown>;
+
+    return (
+        typeof candidate.url === 'string' &&
+        typeof candidate.type === 'string' &&
+        KNOWN_ASSET_TYPES.has(candidate.type) &&
+        typeof candidate.timestamp === 'number'
+    );
+}
+
+/**
+ * Hot-reloads an image asset: refreshes the `AssetLoader` cache, then walks the
+ * `SpriteSheet` registry for any sheet loaded from the same URL and replaces its
+ * image in place against the active palette.
+ *
+ * @param url - Changed image URL, matching whatever the engine cached it under.
+ */
+async function hotReloadImageAsset(url: string): Promise<void> {
+    const image = await AssetLoader.hotReloadImage(url);
+    const sheets = getHotReloadSheets(url);
+
+    if (!sheets || sheets.size === 0) {
+        return;
+    }
+
+    const palette = BTAPI.instance.getPalette();
+
+    for (const sheet of sheets) {
+        sheet.hotReplaceImage(image, palette);
+    }
+}
+
+/**
+ * Hot-reloads a bitmap font asset: walks the `BitmapFont` registry for any font
+ * loaded from the same `.btfont` URL and reloads its descriptor and texture.
+ *
+ * No-ops when no font is registered under `url` - a benign miss, not an error.
+ *
+ * @param url - Changed `.btfont` URL, matching whatever the font was loaded from.
+ */
+async function hotReloadFontAsset(url: string): Promise<void> {
+    const fonts = getHotReloadFonts(url);
+
+    if (!fonts || fonts.size === 0) {
+        return;
+    }
+
+    const palette = BTAPI.instance.getPalette();
+
+    await Promise.all([...fonts].map((font) => font.hotReload(url, palette)));
+}
+
+/**
+ * Async body for {@link handleAssetChanged}, split out so its `await`s can run
+ * under one try/catch without leaving a floating, unhandled promise at the call site.
+ *
+ * Routes by `payload.type`: `AssetLoader`/`SpriteSheet` for `'image'`, `AudioClip`
+ * for `'audio'`, the `BitmapFont` registry for `'font'`, and {@link requestHardReload}
+ * for anything else (belt-and-suspenders - the plugin already full-reloads
+ * unrecognized asset extensions itself).
+ *
+ * @param payload - Asset-changed event payload from the Vite plugin.
+ */
+async function routeAssetChanged(payload: unknown): Promise<void> {
+    if (!isAssetChangedPayload(payload)) {
+        console.error('[BT] Ignoring a malformed asset-changed event:', payload);
+
+        return;
+    }
+
+    try {
+        switch (payload.type) {
+            case 'image':
+                await hotReloadImageAsset(payload.url);
+                break;
+
+            case 'audio':
+                await AudioClip.hotReload(payload.url);
+                break;
+
+            case 'font':
+                await hotReloadFontAsset(payload.url);
+                break;
+
+            default:
+                requestHardReload(`Unrecognized asset type '${payload.type}' for '${payload.url}'`);
+                break;
+        }
+    } catch (err) {
+        console.error(`[BT] Asset hot reload failed for '${payload.url}':`, err);
+    }
+}
+
+/**
+ * Routes a `blit386:asset-changed` payload to the right hot-replace handler by
+ * asset kind. Wrapped entirely in try/catch (inside {@link routeAssetChanged}) so a
+ * broken or unexpected asset event can never crash the game loop - on failure this
+ * logs and leaves the currently running state intact.
  *
  * @param payload - Asset-changed event payload from the Vite plugin.
  */
 function handleAssetChanged(payload: unknown): void {
-    void payload;
+    void routeAssetChanged(payload);
 }
 
 /**

--- a/src/utils/HotReloadUrl.test.ts
+++ b/src/utils/HotReloadUrl.test.ts
@@ -32,6 +32,16 @@ describe('HotReloadUrl', () => {
             expect(appendCacheBustQuery('a.png')).toBe('a.png?blit386-hmr=1');
             expect(appendCacheBustQuery('a.png')).toBe('a.png?blit386-hmr=2');
         });
+
+        it('inserts the query before a fragment identifier, not after it', () => {
+            expect(appendCacheBustQuery('sprites.png#atlas')).toBe('sprites.png?blit386-hmr=1700000000000#atlas');
+        });
+
+        it('inserts the query before a fragment even when a query string is already present', () => {
+            expect(appendCacheBustQuery('sprites.png?v=2#atlas')).toBe(
+                'sprites.png?v=2&blit386-hmr=1700000000000#atlas',
+            );
+        });
     });
 
     describe('normalizeAssetUrl', () => {
@@ -49,6 +59,27 @@ describe('HotReloadUrl', () => {
 
         it('treats equivalent relative and rooted forms as the same pathname', () => {
             expect(normalizeAssetUrl('./images/hero.png')).toBe(normalizeAssetUrl('/images/hero.png'));
+        });
+
+        it('resolves a relative URL against a nested document base, not just the origin', () => {
+            const originalBaseURI = document.baseURI;
+
+            Object.defineProperty(document, 'baseURI', {
+                value: 'http://localhost:3000/games/my-game/index.html',
+                configurable: true,
+            });
+
+            try {
+                // A browser resolves <img src="images/hero.png"> against the document's own
+                // directory, not the domain root - the normalized key must match that, or a
+                // sheet loaded on a nested page would never be found by the hot-reload registry.
+                expect(normalizeAssetUrl('images/hero.png')).toBe('/games/my-game/images/hero.png');
+            } finally {
+                Object.defineProperty(document, 'baseURI', {
+                    value: originalBaseURI,
+                    configurable: true,
+                });
+            }
         });
     });
 });

--- a/src/utils/HotReloadUrl.test.ts
+++ b/src/utils/HotReloadUrl.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment happy-dom
+
+/**
+ * Unit tests for the shared hot-reload URL helpers.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { appendCacheBustQuery, normalizeAssetUrl } from './HotReloadUrl';
+
+describe('HotReloadUrl', () => {
+    describe('appendCacheBustQuery', () => {
+        beforeEach(() => {
+            vi.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
+        });
+
+        afterEach(() => {
+            vi.restoreAllMocks();
+        });
+
+        it('appends a ? query when the URL has none', () => {
+            expect(appendCacheBustQuery('sprites/hero.png')).toBe('sprites/hero.png?blit386-hmr=1700000000000');
+        });
+
+        it('appends an & continuation when the URL already has a query string', () => {
+            expect(appendCacheBustQuery('sprites/hero.png?v=2')).toBe('sprites/hero.png?v=2&blit386-hmr=1700000000000');
+        });
+
+        it('uses the current timestamp on every call', () => {
+            vi.spyOn(Date, 'now').mockReturnValueOnce(1).mockReturnValueOnce(2);
+
+            expect(appendCacheBustQuery('a.png')).toBe('a.png?blit386-hmr=1');
+            expect(appendCacheBustQuery('a.png')).toBe('a.png?blit386-hmr=2');
+        });
+    });
+
+    describe('normalizeAssetUrl', () => {
+        it('resolves a rooted path to its pathname', () => {
+            expect(normalizeAssetUrl('/images/hero.png')).toBe('/images/hero.png');
+        });
+
+        it('resolves a relative path against the page origin', () => {
+            expect(normalizeAssetUrl('images/hero.png')).toBe('/images/hero.png');
+        });
+
+        it('strips a query string', () => {
+            expect(normalizeAssetUrl('/images/hero.png?v=2')).toBe('/images/hero.png');
+        });
+
+        it('treats equivalent relative and rooted forms as the same pathname', () => {
+            expect(normalizeAssetUrl('./images/hero.png')).toBe(normalizeAssetUrl('/images/hero.png'));
+        });
+    });
+});

--- a/src/utils/HotReloadUrl.ts
+++ b/src/utils/HotReloadUrl.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared URL helpers for the engine's dev-only asset hot-replace path.
+ *
+ * Used by `AssetLoader`, `SpriteSheet`, `AudioClip`, and `BitmapFont` to cache-bust
+ * a re-fetched asset while keeping its original cache key, and to canonicalize URLs
+ * for hot-reload registry lookups that may see slightly different-looking but
+ * equivalent URLs (relative vs. rooted, or a `blit386:asset-changed` payload URL
+ * that formats a path differently than a demo's original load call).
+ */
+
+/**
+ * Appends a cache-busting query parameter carrying the current timestamp, so a
+ * re-fetch of an unchanged URL bypasses the browser's HTTP cache.
+ *
+ * The busted URL is only ever used for the actual `fetch`/`Image.src` request -
+ * callers keep caching the result under the original, un-busted `url`.
+ *
+ * @param url - Original request URL.
+ * @returns `url` with a `blit386-hmr=<timestamp>` query parameter appended.
+ */
+export function appendCacheBustQuery(url: string): string {
+    return `${url}${url.includes('?') ? '&' : '?'}blit386-hmr=${Date.now()}`;
+}
+
+/**
+ * Normalizes a URL to its pathname against the page origin, so hot-reload registry
+ * lookups match regardless of superficial differences (relative vs. rooted paths,
+ * or a trailing query string).
+ *
+ * @param url - URL to normalize.
+ * @returns Normalized pathname, for example `/images/hero.png`.
+ */
+export function normalizeAssetUrl(url: string): string {
+    return new URL(url, location.origin).pathname;
+}

--- a/src/utils/HotReloadUrl.ts
+++ b/src/utils/HotReloadUrl.ts
@@ -12,24 +12,38 @@
  * Appends a cache-busting query parameter carrying the current timestamp, so a
  * re-fetch of an unchanged URL bypasses the browser's HTTP cache.
  *
+ * Inserted before any fragment identifier (`#...`) rather than after it - a query string
+ * appended past a fragment is invalid URL syntax and browsers treat it as part of the
+ * fragment, so the parameter would never actually reach the server.
+ *
  * The busted URL is only ever used for the actual `fetch`/`Image.src` request –
  * callers keep caching the result under the original, un-busted `url`.
  *
  * @param url - Original request URL.
- * @returns `url` with a `blit386-hmr=<timestamp>` query parameter appended.
+ * @returns `url` with a `blit386-hmr=<timestamp>` query parameter inserted before any fragment.
  */
 export function appendCacheBustQuery(url: string): string {
-    return `${url}${url.includes('?') ? '&' : '?'}blit386-hmr=${Date.now()}`;
+    const fragmentIndex = url.indexOf('#');
+    const base = fragmentIndex === -1 ? url : url.slice(0, fragmentIndex);
+    const fragment = fragmentIndex === -1 ? '' : url.slice(fragmentIndex);
+    const separator = base.includes('?') ? '&' : '?';
+
+    return `${base}${separator}blit386-hmr=${Date.now()}${fragment}`;
 }
 
 /**
- * Normalizes a URL to its pathname against the page origin, so hot-reload registry
- * lookups match regardless of superficial differences (relative vs. rooted paths,
- * or a trailing query string).
+ * Normalizes a URL to its pathname against the document's base URL, so hot-reload registry
+ * lookups match regardless of superficial differences (relative vs. rooted paths, or a
+ * trailing query string).
+ *
+ * Resolves against `document.baseURI` rather than `location.origin` - a relative URL passed
+ * to `Image.src`/`fetch` is resolved by the browser against the document's base (the page's
+ * own URL, or an explicit `<base href>`), not just its origin, so a page served from a nested
+ * path (for example `/games/my-game/`) needs the same resolution here to produce a matching key.
  *
  * @param url - URL to normalize.
  * @returns Normalized pathname, for example `/images/hero.png`.
  */
 export function normalizeAssetUrl(url: string): string {
-    return new URL(url, location.origin).pathname;
+    return new URL(url, document.baseURI).pathname;
 }

--- a/src/utils/HotReloadUrl.ts
+++ b/src/utils/HotReloadUrl.ts
@@ -12,7 +12,7 @@
  * Appends a cache-busting query parameter carrying the current timestamp, so a
  * re-fetch of an unchanged URL bypasses the browser's HTTP cache.
  *
- * The busted URL is only ever used for the actual `fetch`/`Image.src` request -
+ * The busted URL is only ever used for the actual `fetch`/`Image.src` request –
  * callers keep caching the result under the original, un-busted `url`.
  *
  * @param url - Original request URL.


### PR DESCRIPTION
## Summary

Implements BT-305 (HMR 2 of the BT-303 hot-reload epic): in-place asset hot-replace so a changed image, audio, or `.btfont` file under `public/` updates the running demo/game without a page reload, wiring the `AssetLoader`/`SpriteSheet`/`AudioClip`/`BitmapFont`/`MusicPlayer` asset classes into the `blit386:asset-changed` event `src/hot/HotRuntime.ts` already broadcasts (from the already-merged `blit386/vite` plugin).

- `AssetLoader.evict(url)` (new public API, `@since 1.4.0`) + internal `hotReloadImage(url)` – cache-busted re-fetch, re-cached under the original URL key.
- `SpriteSheet.hotReplaceImage(image, palette)` – swaps a sheet's image in place (dimension changes allowed), re-indexizes against the active palette when previously indexized. Backed by a dev-only registry keyed by normalized source URL, gated on `isHotActive()` (zero production cost).
- `AudioClip.hotReload(url)` – swaps a clip's decoded buffer in place (same instance, same cache key), stops SFX voices on the old buffer, and restarts the music player if the replaced clip is the current track.
- `MusicPlayer.hotReplaceCurrentBuffer` + `AudioManager` wiring – completes the music-restart seam.
- `BitmapFont.hotReload(url, palette)` – rebuilds glyph tables in place and delegates to `SpriteSheet.hotReplaceImage` for the texture.
- `HotRuntime.handleAssetChanged` – routes a `blit386:asset-changed` payload by kind to the handlers above, wrapped in try/catch so a broken asset event can never crash the game loop.
- New shared `src/utils/HotReloadUrl.ts` (`appendCacheBustQuery`, `normalizeAssetUrl`) used by all of the above.
- Changelog entry under `1.4.0 - Unreleased` and a brief `AssetLoader.evict` mention in `docs/api-assets.md`. Comprehensive HMR guide-level docs are deferred to the already-planned BT-307 follow-up, per the parent epic's sequencing.

Deliberate, documented scope decisions (not gaps): `AudioClip.duration`/`sampleRate` and `BitmapFont.name`/`size`/`lineHeight`/`baseline` are not updated by a hot reload (only buffer/glyph/texture data); music hot-replace restarts from the beginning (no same-position resume); with hot reload inactive, all new dev-only registries stay empty and behavior is unchanged from `main`.

Built via subagent-driven development: 8 planned tasks, each independently implemented and reviewed (two required one fix round), plus a final whole-branch review (caught and fixed one changelog inaccuracy — the doc named `reindexize()` where the code correctly calls `indexize()`).

## Test plan

- [x] `pnpm run preflight` – format, lint, typecheck, spellcheck, knip, docs:links, sync:doc-banners:check, api:since:check, api:history:check, test:unit (2358/2358), test:declarations (16/16) – all green
- [x] Full whole-branch review (opus) covering cross-task consistency: the three deliberate circular imports (`hot/HotRuntime.ts <-> assets/SpriteSheet.ts`, `<-> assets/BitmapFont.ts`, one-way `-> assets/AudioClip.ts`) verified safe and confirmed working under a real `pnpm run build`, not just Vitest
- [x] "Hot inactive → zero registries populated, zero behavior change" verified directly by dedicated tests in `SpriteSheet.test.ts`/`BitmapFont.test.ts`
- [ ] `pnpm run test:visual` – not run in this environment (no Chrome binary available); this branch makes zero rendering-path changes (asset-loading code only), matching the same reasoning used on the prior BT-304/BT-306 branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F8WmM5WaaBk2cT67P7YZhz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Implements in-place hot replacement for image, audio, and `.btfont` assets under `public/` without reloading the page.

- Adds `AssetLoader.evict()` and hot-reload support via cache-busted image re-fetching (`AssetLoader.hotReloadImage`), including generation-based stale-load protection so newer cache state can’t be overwritten by older completions; also ensures eviction cancels the chance of in-flight stale repopulation.
- Adds dev-only registries (gated by hot runtime activation) for `SpriteSheet`, `AudioClip`, and `BitmapFont`, enabling in-place texture/buffer/font glyph rebuild updates while preserving object and cache-key identity; `BitmapFont.hotReload` rebuilds glyph tables without updating font metadata.
- Updates `MusicPlayer`/`AudioManager` so replaced music restarts immediately from the beginning (forcing `fadeMs: 0`) and sanitizes loop regions to avoid invalid/overflowing loop points; wires hot-replace callbacks so music buffers swap safely while other audio remains consistent.
- Routes `blit386:asset-changed` events through `HotRuntime` with type-specific handling for images, audio, and fonts, safe ignoring of malformed payloads, and try/catch logging so hot-reload failures cannot crash the game loop; unknown asset types fall back to hard reload.
- Adds shared hot-reload URL utilities (`normalizeAssetUrl`, `appendCacheBustQuery`) to normalize registry keys and apply cache-busting timestamps (including correct placement before `#fragment`), with additional semantics for relative texture paths vs embedded data URIs.
- Updates API docs and changelog to document the new asset hot-replace behavior and demo/game state persistence across hot-swap modes.

All preflight checks passed: 2,358 unit tests and 16 declaration tests. Visual tests were not run because Chrome was unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->