### PR TITLE
docs(core): document engine hot reload (HMR) for the 1.4.0 release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -542,7 +542,7 @@ See `docs/developer-experience-guide.md` (File structure and member order) and `
 ## Commands
 
 ```bash
-pnpm run build              # Build library
+pnpm run build              # Build library (two Vite builds: the main dist/blit386.* plus dist/vite.* for the blit386/vite subpath)
 pnpm run lint               # ESLint
 pnpm run lint:fix           # ESLint with auto-fix
 pnpm run format             # Format all files (Biome + Prettier)

--- a/README.md
+++ b/README.md
@@ -192,8 +192,9 @@ You need an ESM bundler (Vite, esbuild, webpack, and friends) and Node 22+. The 
 quietly falls back to Canvas 2D when there is not one – see [Browser support](docs/api-browser-support.md) for the
 version details.
 
-On Vite, add the `blit386/vite` plugin to `vite.config.js` for hot reload during development – code and asset edits
-apply to the running game without a page reload. See the [Hot Reload guide](docs/guide-hot-reload.md).
+On Vite, add the `blit386/vite` plugin to `vite.config.js` for hot reload during development – most code and asset edits
+apply to the running game without a page reload (a hardware setting change or an unrecognized asset type still falls
+back to one). See the [Hot Reload guide](docs/guide-hot-reload.md).
 
 ## Demos
 

--- a/README.md
+++ b/README.md
@@ -192,6 +192,9 @@ You need an ESM bundler (Vite, esbuild, webpack, and friends) and Node 22+. The 
 quietly falls back to Canvas 2D when there is not one – see [Browser support](docs/api-browser-support.md) for the
 version details.
 
+On Vite, add the `blit386/vite` plugin to `vite.config.js` for hot reload during development – code and asset edits
+apply to the running game without a page reload. See the [Hot Reload guide](docs/guide-hot-reload.md).
+
 ## Demos
 
 Play the [hosted demos at demos.blit386.dev](https://demos.blit386.dev), or read the source in the

--- a/docs/_api-history.json
+++ b/docs/_api-history.json
@@ -1462,12 +1462,14 @@
       "BT.targetFPS",
       "BootstrapOptions",
       "HardwareSettings",
+      "HotReloadContext",
       "PreferredOrientation",
       "bootstrap",
       "defaultConfig",
       "displayError",
       "getCanvas",
-      "mergeHardwareSettings"
+      "mergeHardwareSettings",
+      "registerHotReload"
     ],
     "api/easing": [
       "EasingFunction",

--- a/docs/_sitemap.json
+++ b/docs/_sitemap.json
@@ -103,6 +103,11 @@
       "description": "The audio subsystem layout, locked vs. unlocked gesture state, and web audio constraints."
     },
     {
+      "src": "guide-hot-reload.md",
+      "path": "guides/hot-reload",
+      "description": "The three hot-reload swap tiers, onHotReload semantics, asset hot-replace, and the blit386/vite plugin."
+    },
+    {
       "src": "performance-best-practices.md",
       "path": "performance/best-practices",
       "description": "When and how to optimize demos: object allocation, batching, and hot-path guidance."

--- a/docs/api-assets.md
+++ b/docs/api-assets.md
@@ -70,6 +70,9 @@ if (AssetLoader.isLoaded('sprites.png')) {
 AssetLoader.evict('sprites.png');
 ```
 
+`AssetLoader.evict()` is also the manual escape hatch for forcing a fresh load outside the `blit386/vite` plugin's
+automatic asset watcher - see [Hot Reload](guide-hot-reload.md#asset-hot-replace-matrix).
+
 ## Sprite setup – preferred path
 
 <Since symbol="SpriteSheet" />
@@ -221,6 +224,24 @@ BT.printFont(font, new Vector2i(10, 10), 'Hello!', paletteOffset); // per-draw i
 
 <DemoEmbed demo="022-bitmap-font" title="BLIT386 bitmap font demo" />
 
+## Hot-replacing assets
+
+Under a Vite dev server with the `blit386/vite` plugin installed, editing a sprite sheet's source image or a `.btfont`
+file under a watched asset directory (`public/` by default) updates the already-loaded asset in place - no page reload,
+and demo-held references (a `SpriteSheet` or `BitmapFont` instance, or an `IndexedSpriteLoadResult.sheet`) stay valid. A
+sprite sheet re-runs `indexize()` against the active palette when it was already indexized; a bitmap font rebuilds its
+glyph tables and texture.
+
+<Callout title="Demo-held srcRects and dimension changes">
+  If the replacement image has different dimensions, the sheet's `size` updates to match, but any `Rect2i` a demo is
+  holding onto as a `srcRect` into that sheet does not update itself - reconciling it is the demo's own
+  responsibility. Keep sprite sheet dimensions stable during a hot-reload session, or recompute `srcRect`s from the
+  sheet's current `width`/`height` when that matters.
+</Callout>
+
+See [Hot Reload](guide-hot-reload.md#asset-hot-replace-matrix) for the full asset type matrix, including audio and the
+fallback-to-full-reload behavior for unrecognized file types.
+
 ## System font
 
 A built-in 6×14 monospace font covering printable ASCII (characters 32–126). No load step needed.
@@ -251,6 +272,7 @@ BT.systemPrintMeasure('Score: 100'); // → Vector2i (pixel width, height)
   <Card title="Palette Guide" href="/docs/guides/palette">Palette-first setup, offsets, refresh.</Card>
   <Card title="Palette Presets" href="/docs/guides/palette-presets">Built-in preset reference.</Card>
   <Card title="Bitmap Fonts" href="/docs/guides/bitmap-fonts">.btfont format, BMFont conversion.</Card>
+  <Card title="Hot Reload Guide" href="/docs/guides/hot-reload">Asset hot-replace matrix and srcRect caveats.</Card>
   <Card title="Overlay Guide" href="/docs/guides/overlay">System font for HUD text.</Card>
   <Card title="Testing" href="/docs/reference/testing">SpriteSheet and BitmapFont tests.</Card>
 </Cards>

--- a/docs/api-audio.md
+++ b/docs/api-audio.md
@@ -163,6 +163,13 @@ theme.unload(); // releases the decoded buffer; safe to call more than once
 - Playing a loaded clip back as SFX is covered in [Playback (SFX)](#playback-sfx) below; as looping, crossfading music
   in [Playback (Music)](#playback-music).
 
+Under a Vite dev server with the `blit386/vite` plugin installed, editing an audio file under a watched asset directory
+(`public/` by default) swaps the decoded buffer inside the same `AudioClip` instance - demo-held references stay valid.
+Any SFX voice still playing the old buffer is stopped; if the replaced clip is the currently playing music track,
+playback restarts immediately (`fadeMs: 0`, no crossfade). `duration`/`sampleRate` reflect the buffer decoded at initial
+load and are not updated by a hot reload. See [Hot Reload](guide-hot-reload.md#asset-hot-replace-matrix) for the full
+asset type matrix.
+
 ## Synth
 
 <Since symbol="SynthParams" />
@@ -504,4 +511,5 @@ allocation and stealing policy. Documented in [Hardware settings](api-core.md#ha
   <Card title="API: Core" href="/docs/api/core">Hardware settings, including audioVoices.</Card>
   <Card title="API: Overlay" href="/docs/api/overlay#audio-meters-optional">Live bus level bars and voices/steal/drop readout.</Card>
   <Card title="API: Browser Support" href="/docs/api/browser-support">Browser/build support matrix.</Card>
+  <Card title="Hot Reload Guide" href="/docs/guides/hot-reload">Audio clip hot-replace: SFX voices and music restart.</Card>
 </Cards>

--- a/docs/api-core.md
+++ b/docs/api-core.md
@@ -77,6 +77,48 @@ displayError('Init Failed', 'WebGPU unavailable.', 'my-container');
 - `bootstrap()` applies canvas layout CSS custom properties via `CanvasLayoutStyles` (logical size, CSS cap, pixelated
   scaling). Custom hosts can reuse the same helper when not using `bootstrap()`.
 
+### Hot reload
+
+<Since symbol="registerHotReload" />
+<Since symbol="HotReloadContext" />
+
+Under a Vite dev server with the `blit386/vite` plugin installed, calling `bootstrap()` again after the engine is
+already initialized - exactly what happens on every hot-reloaded save - routes to a hot swap instead of starting a
+second, unstoppable game loop. `registerHotReload(hot)` registers the active `import.meta.hot` context so the engine
+knows a swap is possible; the plugin injects the call to it automatically into the demo/game's entry module, so you
+never call it by hand.
+
+Depending on what changed, the swap is a prototype-only method swap, a full re-init, or a full page reload - see
+[Hot Reload](guide-hot-reload.md) for the three tiers with worked examples. `IBTDemo` has an optional
+`onHotReload(context: HotReloadContext)` hook for reacting to a swap:
+
+```ts twoslash
+import { type IBTDemo, type HotReloadContext } from 'blit386';
+
+class Demo implements IBTDemo {
+  onHotReload(context: HotReloadContext): void {
+    console.log(`hot reload #${context.generation} (${context.reason})`);
+  }
+
+  async init(): Promise<boolean> {
+    return true;
+  }
+
+  update(): void {}
+  render(): void {}
+}
+```
+
+<TypeTable type={{
+    reason: { type: "'methods' | 'reinit'", description: "Which swap tier ran: 'methods' swapped the prototype in place, 'reinit' re-ran init() on a fresh instance" },
+    generation: { type: 'number', description: 'Hot-swap generation number, incremented on every successful swap since page load' },
+    snapshot: { type: 'Record<string, unknown>', description: "Previous instance's own enumerable fields, captured just before init() ran on the new one. Present only when reason is 'reinit'" },
+  }} />
+
+`onHotReload` never fires for a hardware-settings change - that always triggers a full page reload instead. Without the
+`blit386/vite` plugin, `bootstrap()` behaves as before: calling it a second time while already initialized logs an error
+and returns `false` rather than starting a second loop.
+
 ## Initialization
 
 <Since symbol="BT.init" />
@@ -355,5 +397,6 @@ enabled, WebGPU backend, `16` SFX voices, and other defaults documented in the t
   <Card title="API: Audio" href="/docs/api/audio">Bus volume, mute, and the unlock getter.</Card>
   <Card title="Overlay Guide" href="/docs/guides/overlay">Engine HUD subsystem, toggle, layout.</Card>
   <Card title="Post-Process Effects" href="/docs/guides/post-process-effects">Effect chain and tiers.</Card>
+  <Card title="Hot Reload Guide" href="/docs/guides/hot-reload">Swap tiers, onHotReload, asset hot-replace, blit386/vite.</Card>
   <Card title="Deprecation Timeline" href="/docs/reference/deprecations">Renamed configure flags and getters.</Card>
 </Cards>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -41,6 +41,12 @@ notes, including dependency bumps and CI changes omitted here for brevity.
   is the current track), and bitmap fonts rebuild their glyph tables and texture - all without a page reload. Adoption
   in `blit386-demos`/`create-blit386` ships in a follow-up release.
 
+### Fixed
+
+- Calling `bootstrap()` a second time while already initialized no longer silently starts a second, unstoppable
+  `GameLoop`. With the `blit386/vite` plugin installed and a hot-reload context registered, a second call now routes to
+  a hot swap instead; without one, it logs an error and returns `false`.
+
 ## 1.3.1 - 2026-07-19
 
 ### Added

--- a/docs/guide-hot-reload.md
+++ b/docs/guide-hot-reload.md
@@ -1,0 +1,330 @@
+# Hot Reload
+
+<!-- blit386.dev-banner:start -->
+
+<!-- prettier-ignore -->
+> [!TIP]
+> You're reading the raw source on GitHub. The same page lives at https://blit386.dev/docs/guides/hot-reload, typeset like an
+> actual docs site and easier on the eyes. Probably the nicer place to read it, but same
+> words either way.
+
+<!-- blit386.dev-banner:end -->
+
+`registerHotReload`, `HotReloadContext`, and `IBTDemo.onHotReload` live in [API: Core](api-core.md#hot-reload). This
+guide covers the dev-loop hot reload enables, the three swap tiers with worked examples, the asset hot-replace matrix,
+and the `blit386/vite` plugin that wires it all up.
+
+<ApiAvailability page="guides/hot-reload" />
+
+## What hot reload replaces
+
+Without it, every saved change to a demo or game source file triggers a full page reload: the whole module graph
+re-evaluates, `bootstrap()` runs cold again, and every piece of runtime state is lost - the player's position, score,
+current level, whatever was on screen. Editing an asset under `public/` (a sprite, a sound, a font) does nothing at all;
+the running instance keeps using whatever it already loaded.
+
+With the `blit386/vite` plugin installed, both of those become live updates instead. A code change injects new behavior
+into the already-running demo, preserving as much state as the change allows. An asset change replaces the
+already-loaded resource in place. A page reload still happens, but only for the handful of changes that are genuinely
+incompatible with swapping in place - see [What always forces a full reload](#what-always-forces-a-full-reload) below.
+
+This is engine-side infrastructure. Nothing about it requires demo code to change - `onHotReload` is optional, and a
+demo that never implements it still gets prototype swaps and re-inits for free. It only affects local development;
+`import.meta.hot` never exists outside a Vite dev server, so every part of this is a no-op in a production build.
+
+## The three tiers
+
+`bootstrap()` decides which tier applies by comparing the newly re-evaluated demo class against the one currently
+running, every time Vite's HMR boundary re-evaluates the entry module. The decision is entirely mechanical - it is not
+configurable, and there is no way to force a different tier from demo code.
+
+### Tier 1: method-only change
+
+If the constructor, class field initializers, and `init()` are all unchanged (compared by source text), the running
+instance's prototype is swapped onto the new class. Every field on the instance is left exactly as it was - `init()`
+does not re-run, music keeps playing, and the game loop keeps ticking without a hitch.
+
+```ts twoslash
+import { BT, type IBTDemo, Vector2i } from 'blit386';
+
+const SPEED = 120; // change this number and save - the running instance picks it up immediately
+
+class Demo implements IBTDemo {
+  private pos = new Vector2i(0, 0);
+
+  async init() {
+    return true;
+  }
+
+  update() {
+    this.pos = new Vector2i(this.pos.x + SPEED * BT.deltaSeconds, this.pos.y);
+  }
+
+  render() {
+    BT.drawRectFill(this.pos, new Vector2i(16, 16), 1);
+  }
+}
+```
+
+Editing `update()`, `render()`, or the module-level `SPEED` constant only changes method bodies - `init()` and the
+constructor are untouched, so this is a Tier 1 swap. `this.pos` keeps whatever value it already had; the sprite does not
+jump back to the origin.
+
+The `SPEED` case is the detail worth understanding: a Tier 1 swap does not touch `this.pos`, but it does replace
+`update` with a brand new function, freshly defined in the newly re-evaluated module. That new function closes over the
+new module's top-level scope - so the new value of `SPEED` takes effect on the very next tick, even though no field on
+the instance changed. Module-level constants referenced from methods are effectively live-editable.
+
+### Tier 2: init/constructor change
+
+If `init()`, the constructor, or a class field initializer changed, a Tier 1 swap is not safe - the running instance was
+built by code that no longer exists. Instead, a fresh instance is constructed and its `init()` runs while the previous
+instance keeps driving the loop. Only once that succeeds does the engine swap the new instance in; a failed `init()`
+(returns `false`, or throws) leaves the previous instance running untouched, so a broken save never crashes your game.
+
+Just before the new instance's `init()` runs, the previous instance's own enumerable fields are captured into a
+`snapshot` and handed to the new instance's `onHotReload`, so you can restore whatever state matters to you:
+
+```ts twoslash
+import { BT, type IBTDemo, type HotReloadContext, Vector2i } from 'blit386';
+
+class Demo implements IBTDemo {
+  private score = 0;
+  private pos = new Vector2i(0, 0);
+
+  async init() {
+    // Editing this method (or the constructor, or a class field initializer)
+    // changes the class's init fingerprint, so a save here takes the Tier 2 path.
+    this.pos = new Vector2i(160, 120);
+
+    return true;
+  }
+
+  onHotReload(context: HotReloadContext) {
+    if (context.reason !== 'reinit' || !context.snapshot) {
+      return;
+    }
+
+    // snapshot holds the previous instance's own enumerable fields, captured
+    // right before this fresh instance's init() ran.
+    if (typeof context.snapshot.score === 'number') {
+      this.score = context.snapshot.score;
+    }
+    if (context.snapshot.pos instanceof Vector2i) {
+      this.pos = context.snapshot.pos;
+    }
+  }
+
+  update() {}
+
+  render() {
+    BT.systemPrint(new Vector2i(8, 8), 1, `score: ${this.score}`);
+  }
+}
+```
+
+Without the `onHotReload` hook, a Tier 2 swap still works - it just means every field resets to whatever `init()` sets
+it to, same as a cold boot. Implementing `onHotReload` is how you opt into carrying state across a re-init.
+
+### Tier 3: hardware settings change
+
+If `configure()`'s return value differs from what is currently running - a different `displaySize`, backend, target
+frame rate, or any other field listed in [Hardware settings](api-core.md#hardware-settings) - neither swap is safe. Some
+of those changes mean recreating the canvas, the WebGPU device, or the audio graph, and there is no in-place path for
+that. The engine requests a full page reload instead, through Vite's `import.meta.hot.invalidate()`.
+
+```ts twoslash
+import { type IBTDemo, type HardwareSettings, Vector2i } from 'blit386';
+
+class Demo implements IBTDemo {
+  configure(): Partial<HardwareSettings> {
+    // Changing displaySize, drawingBufferSize, backend, targetFPS, audioVoices,
+    // outputUpscaleFilter, maxCanvasSize, or any overlay flag forces a full page
+    // reload on save - there is no partial-swap path for hardware settings.
+    return { displaySize: new Vector2i(320, 240) };
+  }
+
+  async init() {
+    return true;
+  }
+
+  update() {}
+  render() {}
+}
+```
+
+`onHotReload` never fires for a Tier 3 reload - the page is gone before there is anything left to notify.
+
+## The `blit386:hot-reload` DOM event
+
+Every successful Tier 1 or Tier 2 swap also dispatches a `blit386:hot-reload` `CustomEvent` on the engine canvas
+(falling back to `window` if the canvas does not exist yet). It bubbles and is composed, and its `detail` carries the
+same `reason` and `generation` values passed to `onHotReload`:
+
+```ts twoslash
+declare const canvas: HTMLCanvasElement;
+// ---cut---
+canvas.addEventListener('blit386:hot-reload', (event) => {
+  const { reason, generation } = (event as CustomEvent).detail;
+
+  console.log(`hot reload #${generation} (${reason})`);
+});
+```
+
+This is a DOM event rather than a second `BT` callback API on purpose: `onHotReload` is for the demo class itself to
+react to its own state; the DOM event is for anything outside the demo class that wants to know a reload happened - a
+browser extension, an in-page dev overlay, a Playwright test waiting for the swap to settle, or any other tooling that
+has no reason to import `blit386` at all. It fires whether or not the demo implements `onHotReload`.
+
+## Asset hot-replace matrix
+
+The plugin also watches configured asset directories (`public/` by default) and broadcasts a `blit386:asset-changed` HMR
+event for anything it recognizes. The engine routes that event by file type:
+
+| Asset type                                       | What happens                                                                                                                                                                                                                                                                                                                                                            |
+| ------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Image (`.png`, `.gif`, `.webp`, `.jpg`, `.jpeg`) | Every registered `SpriteSheet` built from that URL swaps its texture in place, re-running `indexize()` against the active palette when the sheet was already indexized. See the dimension-change caveat below.                                                                                                                                                          |
+| Audio (`.wav`, `.mp3`, `.ogg`, `.flac`)          | The same `AudioClip` instance swaps its decoded buffer in place - demo-held references stay valid. Any SFX voice still playing the old buffer is stopped; if the replaced clip is the currently playing music track, playback restarts immediately (`fadeMs: 0`, no crossfade). `duration`/`sampleRate` reflect the buffer decoded at initial load and are not updated. |
+| Bitmap font (`.btfont`)                          | The same `BitmapFont` instance rebuilds its glyph tables and texture in place. `name`/`size`/`lineHeight`/`baseline` are frozen at their original values - only glyph data and the texture update.                                                                                                                                                                      |
+| Palette                                          | Nothing hot-reload-specific needed - `BT.palette` is already a live reference, so mutating a slot with `palette.set()` takes effect on the very next frame regardless of how the change was triggered.                                                                                                                                                                  |
+| Anything else                                    | Falls back to a full page reload (`fullReloadOnUnknownAssets`, default `true` - see [Plugin options](#plugin-options)).                                                                                                                                                                                                                                                 |
+
+<Callout title="Demo-held srcRects and dimension changes">
+  If a hot-replaced image has different dimensions than the one it replaced, the sprite sheet's `size` updates to
+  match and its internal buffers rebuild accordingly - but any `Rect2i` a demo is holding onto as a `srcRect` into
+  that sheet does not update itself. Reconciling a stale `srcRect` after a dimension change is the demo's own
+  responsibility; keep sprite sheet dimensions stable during a hot-reload session, or recompute `srcRect`s from the
+  sheet's current `width`/`height` in `onHotReload`.
+</Callout>
+
+You can also force a fresh load by hand with `AssetLoader.evict(url)` - it removes a URL's cached image (and any
+in-flight load) so the next `loadImage()` call starts over. The automatic asset watcher does not call it; it fetches a
+cache-busted copy directly. `evict` is there for cases the watcher does not cover, like a CDN-hosted image that changed
+outside the watched directories. See [Loading assets](api-assets.md#loading-assets).
+
+## What always forces a full reload
+
+Beyond the Tier 3 hardware-settings case above, three other situations always mean a full page reload rather than a
+swap:
+
+- Editing the engine's own source (a `blit386` dist rebuild). The hot-reload boundary lives in the demo/game's entry
+  module, not inside the engine bundle itself - a changed `blit386` dist is a different module identity as far as Vite's
+  module graph is concerned, so there is nothing to swap into.
+- An asset change with an unrecognized extension, when `fullReloadOnUnknownAssets` is left at its default `true`.
+- Calling `bootstrap()` a second time with no Vite HMR context registered at all (for example, calling it twice by
+  mistake outside of a dev server) logs an error and does nothing, rather than silently starting a second, unstoppable
+  game loop.
+
+This is a deliberate design choice, not a current limitation: a hard reload is always a full page reload, so there is
+never a point in the engine's lifetime where a renderer needs to tear itself down and rebuild in place - the whole page,
+canvas, and WebGPU device go away and come back fresh instead. That is why `IRenderer` has no `dispose` method. Adding
+one would mean maintaining a teardown path that a real page reload already gives you for free.
+
+## The `blit386/vite` plugin
+
+Everything above only runs once the plugin is installed in your Vite config:
+
+```js
+// vite.config.js
+import { defineConfig } from 'vite';
+import { blit386 } from 'blit386/vite';
+
+export default defineConfig({
+  plugins: [blit386()],
+});
+```
+
+The plugin does two things, both dev-server only (`apply: 'serve'` - a production build never sees it, so there is zero
+runtime cost or behavior change to ship):
+
+- Appends a small hot-reload registration snippet to any served module that imports `blit386` and calls
+  `bootstrap(...)`:
+
+  ```js
+  import { registerHotReload } from 'blit386';
+  if (import.meta.hot) {
+    import.meta.hot.accept();
+    registerHotReload(import.meta.hot);
+  }
+  ```
+
+  The literal `import.meta.hot.accept()` call has to appear in the emitted source - Vite marks a module self-accepting
+  by static analysis, so an indirect call would not register self-acceptance and every edit would fall back to a full
+  reload regardless of which tier should have applied. You never write or call `registerHotReload` yourself; the plugin
+  injects it, and the engine handles everything from there.
+
+- Watches the configured asset directories and broadcasts `blit386:asset-changed` events for recognized file types (see
+  the [asset matrix](#asset-hot-replace-matrix) above), falling back to a full reload for anything else.
+
+### Plugin options
+
+<TypeTable type={{
+    include: {
+      description: 'Predicate selecting which modules get the hot-reload snippet appended.',
+      type: '(id: string) => boolean',
+      default: "a module under /src/ ending .js, .ts, .mjs, or .mts",
+    },
+    assetDirs: {
+      description: 'Directories to watch for asset changes, resolved against the Vite root.',
+      type: 'string[]',
+      default: "['public']",
+    },
+    assetTypes: {
+      description: 'Maps a lowercased file extension (with leading dot) to an asset kind. Merged over, not replacing, the defaults.',
+      type: "Record<string, 'image' | 'audio' | 'font' | 'other'>",
+      default: '.png/.gif/.webp/.jpg/.jpeg -> image, .wav/.mp3/.ogg/.flac -> audio, .btfont -> font',
+    },
+    fullReloadOnUnknownAssets: {
+      description: 'Whether an asset change with an unrecognized extension triggers a full page reload.',
+      type: 'boolean',
+      default: 'true',
+    },
+  }} />
+
+A game that keeps level data or animation descriptors under `public/levels/` can watch that directory too, and treat
+`.json` as its own asset kind (routed through the `'other'` fallback today, so this only changes what the console log
+attributes the reload to until a dedicated handler exists):
+
+```js
+// vite.config.js
+import { defineConfig } from 'vite';
+import { blit386 } from 'blit386/vite';
+
+export default defineConfig({
+  plugins: [
+    blit386({
+      assetDirs: ['public', 'public/levels'],
+      assetTypes: { '.json': 'other' },
+    }),
+  ],
+});
+```
+
+## Future ideas
+
+Not implemented yet - notes for where this could go next:
+
+- An overlay badge showing the current reload count and the last file that triggered it.
+- A `?hardreload` query parameter or a keyboard chord that forces a clean Tier 2 re-init on demand, without waiting for
+  a source edit.
+- Live `.btfont` glyph-metric editing (today only the texture and glyph tables hot-reload; metrics come from the
+  descriptor JSON, which does already reload - this is about interactively nudging metrics from a tool, not a gap in
+  what already reloads).
+- Hot-editing a palette file directly, rather than only palette slot mutations already being live.
+- Resuming music at its previous playback position across a hot-reload restart, instead of restarting from the top.
+- Persisting a demo's own state (via `sessionStorage` or similar) across a full page reload, so a Tier 3 change does not
+  lose progress the way a Tier 1/2 swap preserves it.
+- Verifying compatibility with StackBlitz/WebContainers. The plugin is built entirely on Vite's public dev-server plugin
+  API with no Node-only assumptions beyond what any Vite plugin already requires, so this is expected to work, but it
+  has not been verified hands-on yet.
+
+<PageChangelog page="guides/hot-reload" />
+
+## See also
+
+<Cards>
+  <Card title="API: Core" href="/docs/api/core#hot-reload">registerHotReload, HotReloadContext, and IBTDemo.onHotReload.</Card>
+  <Card title="API: Assets" href="/docs/api/assets">Sprite sheets and bitmap fonts, including hot-replace behavior.</Card>
+  <Card title="API: Audio" href="/docs/api/audio">Audio clips, including hot-replace behavior for SFX and music.</Card>
+  <Card title="Changelog" href="/docs/reference/changelog">1.4.0 release notes for the full HMR feature set.</Card>
+</Cards>


### PR DESCRIPTION
Add docs/guide-hot-reload.md covering the three swap tiers with worked examples, onHotReload/HotReloadContext semantics, the blit386:hot-reload DOM event, the asset hot-replace matrix, what forces a full reload, and the blit386/vite plugin. Sitemap and blit386.dev banner updated to publish it.

Tag registerHotReload and HotReloadContext with `@since` in docs/api-core.md and regenerate docs/_api-history.json. Cross-link asset hot-replace behavior (srcRect caveat, SFX/music restart) from docs/api-assets.md and docs/api-audio.md. Add the missing Fixed entry for the double-bootstrap() guard to the 1.4.0 changelog. Note the second build entry in CLAUDE.md and mention the blit386/vite plugin in the README quick start.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added a comprehensive hot reload guide covering swap tiers and state preservation (`onHotReload`, `HotReloadContext.snapshot`), full reload conditions (including hardware/settings changes), the `blit386:hot-reload` DOM event, and the `blit386/vite` Vite plugin (with worked examples and worked matrix-style asset hot-replace rules).
- Documented hot-replace behavior across assets and audio, including `AssetLoader.evict()` as a manual escape hatch and audio/music restart/voice swapping semantics during asset replacement.
- Updated documentation navigation and references by adding the new guide to the sitemap and cross-linking it from the relevant API pages; also updated the README quick start and qualified the hot-reload claim with the cases that still require a full page reload.
- Refreshed supporting docs and release notes: updated the 1.4.0 changelog for the double-`bootstrap()` guard, regenerated API history (including `HotReloadContext`/`registerHotReload`), added `@since` tags, updated `CLAUDE.md`, and updated site banner content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->