### PR TITLE
fix(core): fix BT-318 hot-swap tier-3 backend override and vite overlay gap

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -46,6 +46,13 @@ notes, including dependency bumps and CI changes omitted here for brevity.
 - Calling `bootstrap()` a second time while already initialized no longer silently starts a second, unstoppable
   `GameLoop`. With the `blit386/vite` plugin installed and a hot-reload context registered, a second call now routes to
   a hot swap instead; without one, it logs an error and returns `false`.
+- Running under `?backend=software` no longer forces a full page reload on every hot-swappable edit. The Tier 3
+  hardware-settings check now accounts for the URL override on both sides of the comparison, so only a genuine
+  `configure()` change triggers a reload, matching the behavior already seen under the default `webgpu` backend.
+- The `blit386/vite` plugin now syntax-checks a plain `.js`/`.mjs` entry module before injecting the hot-reload snippet.
+  Vite's own default transform pipeline excludes those extensions from server-side parsing, so a broken entry module
+  previously surfaced only as a silently caught client-side error - Vite's error overlay never appeared. `.ts`/`.mts`
+  entries are unaffected; they already get real syntax validation from Vite's own transform.
 
 ## 1.3.1 - 2026-07-19
 

--- a/docs/guide-hot-reload.md
+++ b/docs/guide-hot-reload.md
@@ -155,6 +155,10 @@ class Demo implements IBTDemo {
 
 `onHotReload` never fires for a Tier 3 reload - the page is gone before there is anything left to notify.
 
+Running under `?backend=software` does not itself force a Tier 3 reload on every edit. The comparison accounts for the
+URL override on both sides, so only a genuine `configure()` change - not the override alone - triggers a full page
+reload.
+
 ## The `blit386:hot-reload` DOM event
 
 Every successful Tier 1 or Tier 2 swap also dispatches a `blit386:hot-reload` `CustomEvent` on the engine canvas
@@ -252,6 +256,11 @@ runtime cost or behavior change to ship):
   by static analysis, so an indirect call would not register self-acceptance and every edit would fall back to a full
   reload regardless of which tier should have applied. You never write or call `registerHotReload` yourself; the plugin
   injects it, and the engine handles everything from there.
+
+  For a plain `.js`/`.mjs` entry, the plugin also syntax-checks the module before injecting. Vite's own default
+  transform pipeline excludes those extensions from server-side parsing, so without this a broken entry module would
+  surface only as a silently caught client-side error - Vite's error overlay would never appear. A `.ts`/`.mts` entry is
+  unaffected; it already gets real syntax validation from Vite's own transform.
 
 - Watches the configured asset directories and broadcasts `blit386:asset-changed` events for recognized file types (see
   the [asset matrix](#asset-hot-replace-matrix) above), falling back to a full reload for anything else.

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "@typescript-eslint/parser": "^8.62.1",
     "@vitest/coverage-v8": "^4.1.10",
     "@webgpu/types": "^0.1.71",
+    "acorn": "^8.17.0",
     "cspell": "^10.0.1",
     "eslint": "^10.6.0",
     "eslint-config-prettier": "^10.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       '@webgpu/types':
         specifier: ^0.1.71
         version: 0.1.71
+      acorn:
+        specifier: ^8.17.0
+        version: 8.17.0
       cspell:
         specifier: ^10.0.1
         version: 10.0.1

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -251,9 +251,13 @@ export class BTAPI {
     /**
      * Reads backend override from the current URL query string.
      *
+     * Also called by the hot-swap runtime ({@link tryHardReload} in `src/hot/HotSwap.ts`) so a
+     * hot-swap candidate's resolved settings can be normalized the same way `init()` normalizes
+     * the running settings, before the two are diffed for a Tier 3 hard reload.
+     *
      * @returns Supported backend override, or null when absent/invalid.
      */
-    private static getBackendQueryOverride(): Backend | null {
+    public static getBackendQueryOverride(): Backend | null {
         const search =
             typeof globalThis.location?.search === 'string'
                 ? globalThis.location.search

--- a/src/hot/HotSwap.test.ts
+++ b/src/hot/HotSwap.test.ts
@@ -197,7 +197,49 @@ describe('hotSwapDemo', () => {
     afterEach(() => {
         resetSingleton();
         vi.restoreAllMocks();
+        vi.unstubAllGlobals();
     });
+
+    /** Minimal 2D-context canvas mock, enough for {@link SoftwareRenderer.init} to succeed. */
+    function makeMock2DCanvas(): HTMLCanvasElement {
+        return {
+            ...makeMockCanvas(),
+            getContext: (type: string) =>
+                type === '2d'
+                    ? {
+                          imageSmoothingEnabled: false,
+                          createImageData: (w: number, h: number) =>
+                              ({ data: new Uint8ClampedArray(w * h * 4), width: w, height: h }) as ImageData,
+                          putImageData: vi.fn(),
+                          clearRect: vi.fn(),
+                          drawImage: vi.fn(),
+                      }
+                    : null,
+        } as unknown as HTMLCanvasElement;
+    }
+
+    /** Stubs `OffscreenCanvas` with a 2D-context mock, matching {@link makeMock2DCanvas}. */
+    function stubOffscreenCanvas(): void {
+        vi.stubGlobal(
+            'OffscreenCanvas',
+            class MockOffscreenCanvas {
+                constructor(
+                    public width: number,
+                    public height: number,
+                ) {}
+                getContext(contextType?: string) {
+                    return contextType === '2d'
+                        ? {
+                              imageSmoothingEnabled: false,
+                              createImageData: (w: number, h: number) =>
+                                  ({ data: new Uint8ClampedArray(w * h * 4), width: w, height: h }) as ImageData,
+                              putImageData: vi.fn(),
+                          }
+                        : null;
+                }
+            },
+        );
+    }
 
     function makeDemo(overrides: Partial<IBTDemo> = {}): IBTDemo {
         return {
@@ -231,6 +273,56 @@ describe('hotSwapDemo', () => {
 
         expect(result).toBe(true);
         expect(HotRuntime.requestHardReload).toHaveBeenCalledOnce();
+    });
+
+    it('does not request a hard reload for a render()-only edit when ?backend=software overrides configure()', async () => {
+        stubOffscreenCanvas();
+        vi.stubGlobal('location', { search: '?backend=software' });
+        // The software backend inits successfully here, unlike the other tests in this
+        // describe block (their makeMockCanvas() 2D/WebGPU contexts both return null, so
+        // init() fails before the loop starts). Stub rAF so GameLoop never actually ticks -
+        // no palette is set, and a real tick would throw after this test already returned.
+        vi.stubGlobal('requestAnimationFrame', vi.fn());
+
+        // configure() never mentions backend - mergeHardwareSettings() alone would default it to
+        // 'webgpu'; only the URL override (applied during init, see applyBackendQueryOverride())
+        // makes the running settings 'software'.
+        class OriginalClass {
+            async init() {
+                return true;
+            }
+            update() {}
+            render() {}
+            configure() {
+                return {};
+            }
+        }
+
+        const oldDemo = new OriginalClass();
+        await BTAPI.instance.init(oldDemo, makeMock2DCanvas());
+
+        expect(BTAPI.instance.getHardwareSettings()?.backend).toBe('software');
+
+        class NewClass {
+            async init() {
+                return true;
+            }
+            update() {}
+            render() {
+                // A pure render()-body edit - the exact BT-318 repro (changing a BT.clear
+                // argument). Must swap in place, not force a full reload.
+                return 'edited';
+            }
+            configure() {
+                return {};
+            }
+        }
+
+        const result = await hotSwapDemo(NewClass as unknown as DemoConstructor);
+
+        expect(result).toBe(true);
+        expect(HotRuntime.requestHardReload).not.toHaveBeenCalled();
+        expect(BTAPI.instance.getDemo()).toBe(oldDemo); // same instance: Tier 1 methods-only swap, not a reload
     });
 
     it('aborts without swapping when configure() throws, keeping the previous demo running', async () => {

--- a/src/hot/HotSwap.ts
+++ b/src/hot/HotSwap.ts
@@ -187,6 +187,17 @@ function tryHardReload(newDemo: IBTDemo): HardReloadOutcome {
         return HARD_RELOAD_OUTCOME_ABORTED;
     }
 
+    // The running settings already have any `?backend=software` URL override baked in (applied
+    // once at init by BTAPI.applyBackendQueryOverride). The candidate's configure() output never
+    // sees that override, so without reapplying it here `backend` would mismatch on every single
+    // check under an override - forcing a hard reload on every edit, not just a real configure()
+    // change.
+    const backendOverride = BTAPI.getBackendQueryOverride();
+
+    if (backendOverride) {
+        nextSettings.backend = backendOverride;
+    }
+
     const previousSettings = BTAPI.instance.getHardwareSettings();
 
     if (previousSettings && hasHardReloadDiff(previousSettings, nextSettings)) {

--- a/src/vite/index.test.ts
+++ b/src/vite/index.test.ts
@@ -50,6 +50,34 @@ describe('blit386', () => {
 
             expect(result).toBeNull();
         });
+
+        it('reports a syntax error through this.error() for a broken .js entry, instead of injecting', () => {
+            const plugin = blit386();
+            const brokenCode = "import { bootstrap } from 'blit386';\nconst x = ;\nbootstrap(Demo);\n";
+            const error = vi.fn(() => {
+                throw new Error('mocked this.error()');
+            });
+
+            expect(() => invokeHook(plugin.transform, { error }, brokenCode, '/project/src/001-basics.js')).toThrow(
+                'mocked this.error()',
+            );
+            expect(error).toHaveBeenCalledExactlyOnceWith(
+                expect.stringContaining('Unexpected token'),
+                expect.any(Number),
+            );
+        });
+
+        it('still injects a syntactically valid .ts entry without calling this.error()', () => {
+            const plugin = blit386();
+            const error = vi.fn();
+
+            const result = invokeHook(plugin.transform, { error }, code, '/project/src/main.ts') as {
+                code: string;
+            } | null;
+
+            expect(error).not.toHaveBeenCalled();
+            expect(result?.code).toContain(INJECTION_MARKER);
+        });
     });
 
     describe('hotUpdate', () => {

--- a/src/vite/index.ts
+++ b/src/vite/index.ts
@@ -15,7 +15,7 @@ import type { Plugin } from 'vite';
 import { handleAssetHotUpdate } from './assets';
 import type { Blit386PluginOptions } from './options';
 import { resolveOptions } from './options';
-import { injectSnippet, shouldInjectSnippet } from './transform';
+import { checkPlainJsSyntax, injectSnippet, shouldInjectSnippet } from './transform';
 
 export type { AssetKind, Blit386PluginOptions, ResolvedBlit386PluginOptions } from './options';
 
@@ -46,9 +46,17 @@ export function blit386(options?: Blit386PluginOptions): Plugin {
             resolved = resolveOptions(options, config.root);
         },
 
+        // Method shorthand, not an arrow function - `this.error()` below needs Vite's own plugin
+        // context bound here, same reason as `hotUpdate` below.
         transform(code, id) {
             if (!shouldInjectSnippet(code, id, resolved.include)) {
                 return null;
+            }
+
+            const syntaxError = checkPlainJsSyntax(code, id);
+
+            if (syntaxError) {
+                this.error(syntaxError.message, syntaxError.pos);
             }
 
             return injectSnippet(code);

--- a/src/vite/transform.test.ts
+++ b/src/vite/transform.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { INJECTION_MARKER, injectSnippet, shouldInjectSnippet } from './transform';
+import { checkPlainJsSyntax, INJECTION_MARKER, injectSnippet, shouldInjectSnippet } from './transform';
 
 const INCLUDE_ALL = () => true;
 const INCLUDE_NONE = () => false;
@@ -36,6 +36,45 @@ describe('shouldInjectSnippet', () => {
         const injected = injectSnippet(validCode).code;
 
         expect(shouldInjectSnippet(injected, '/project/src/main.ts', INCLUDE_ALL)).toBe(false);
+    });
+});
+
+describe('checkPlainJsSyntax', () => {
+    it('is null for syntactically valid code in a .js module', () => {
+        const code = "import { bootstrap } from 'blit386';\nbootstrap(Demo);\n";
+
+        expect(checkPlainJsSyntax(code, '/project/src/001-basics.js')).toBeNull();
+    });
+
+    it('is null for syntactically valid code in a .mjs module', () => {
+        expect(checkPlainJsSyntax('export const x = 1;\n', '/project/src/main.mjs')).toBeNull();
+    });
+
+    it('reports the syntax error and its character offset for invalid code in a .js module', () => {
+        // The exact BT-318 repro: a dangling assignment.
+        const result = checkPlainJsSyntax('const x = ;\n', '/project/src/001-basics.js');
+
+        expect(result).not.toBeNull();
+        expect(result?.message).toContain('Unexpected token');
+        expect(result?.pos).toBe(10);
+    });
+
+    it('ignores a query suffix when matching the module id extension', () => {
+        const result = checkPlainJsSyntax('const x = ;\n', '/project/src/001-basics.js?t=1700000000000');
+
+        expect(result).not.toBeNull();
+    });
+
+    it('is null (skipped) for a .ts module even with invalid plain-JS/TypeScript-only syntax', () => {
+        // Valid TypeScript, invalid as plain ES - acorn (an ES-only parser) would reject this if it
+        // ran, which is exactly why .ts/.mts must be skipped rather than checked.
+        const code = 'const x: number = 1;\n';
+
+        expect(checkPlainJsSyntax(code, '/project/src/game.ts')).toBeNull();
+    });
+
+    it('is null (skipped) for a .mts module', () => {
+        expect(checkPlainJsSyntax('const x: number = ;\n', '/project/src/game.mts')).toBeNull();
     });
 });
 

--- a/src/vite/transform.ts
+++ b/src/vite/transform.ts
@@ -1,8 +1,14 @@
 /**
  * Hot-reload snippet injection for the `blit386` Vite plugin: appends a tiny snippet to a
  * demo/game's entry module so it registers with the engine's hot-swap runtime (`src/hot/`).
+ *
+ * Also does a plain-JS entry's only syntax check (see {@link checkPlainJsSyntax}): Vite's own
+ * default transform pipeline excludes `.js`/`.mjs` from server-side parsing, so without this a
+ * broken entry module surfaces only as a caught client-side `import()` rejection - logged, but
+ * never shown in Vite's error overlay (BT-318).
  */
 
+import { parse } from 'acorn';
 import MagicString from 'magic-string';
 
 /** Marker comment guarding injection against running twice on the same module (idempotency). */
@@ -34,6 +40,26 @@ const BOOTSTRAP_CALL_TOKEN = 'bootstrap(';
 const BLIT386_IMPORT_PATTERN = /from\s*['"]blit386['"]/;
 
 /**
+ * Matches a plain JS module id (ignoring any query suffix) - the extensions Vite's own default
+ * transform pipeline excludes from server-side parsing. `.ts`/`.mts` are deliberately not matched:
+ * they already get real syntax validation from Vite's own transform, and acorn (a plain-ES parser)
+ * would reject valid TypeScript-only syntax as a false positive.
+ */
+const PLAIN_JS_MODULE_ID_PATTERN = /\.m?js$/;
+
+/**
+ * A syntax error found by {@link checkPlainJsSyntax}, shaped for a Rollup/Vite plugin context's
+ * `this.error(message, pos)` call.
+ */
+export interface PlainJsSyntaxError {
+    /** Parser error message. */
+    message: string;
+
+    /** Character offset into `code` where the error was raised. */
+    pos: number;
+}
+
+/**
  * Reports whether a module should get the hot-reload snippet appended.
  *
  * @param code - Module source, pre-transform.
@@ -52,6 +78,39 @@ export function shouldInjectSnippet(code: string, id: string, include: (id: stri
     }
 
     return code.includes(BOOTSTRAP_CALL_TOKEN) && BLIT386_IMPORT_PATTERN.test(code);
+}
+
+/**
+ * Syntax-checks a plain `.js`/`.mjs` module id's source. No-ops (`null`) for any other extension -
+ * `.ts`/`.mts` entries are already validated by Vite's own transform pipeline before this plugin's
+ * `transform` hook ever runs, and acorn cannot parse TypeScript-only syntax.
+ *
+ * A non-`SyntaxError` parse failure (acorn hitting something unexpected in valid-looking code) is
+ * treated as a no-op rather than surfaced: this check exists to close a gap in Vite's own error
+ * reporting, not to become a second, stricter parser gate on top of it.
+ *
+ * @param code - Module source, pre-transform.
+ * @param id - Module id (path, possibly with a query suffix).
+ * @returns The first syntax error found, or `null` when `id` isn't plain JS or `code` parses cleanly.
+ */
+export function checkPlainJsSyntax(code: string, id: string): PlainJsSyntaxError | null {
+    const [pathWithoutQuery = id] = id.split('?');
+
+    if (!PLAIN_JS_MODULE_ID_PATTERN.test(pathWithoutQuery)) {
+        return null;
+    }
+
+    try {
+        parse(code, { ecmaVersion: 'latest', sourceType: 'module' });
+
+        return null;
+    } catch (err) {
+        if (err instanceof SyntaxError && 'pos' in err && typeof err.pos === 'number') {
+            return { message: err.message, pos: err.pos };
+        }
+
+        return null;
+    }
 }
 
 /**


### PR DESCRIPTION
Two independent hot-swap runtime issues found during BT-308's manual verification:

- Tier 3's hardware-settings diff compared the running settings (which already have any `?backend=software` URL override baked in by BTAPI.applyBackendQueryOverride) against a hot-swap candidate's raw mergeHardwareSettings(configure()) output, which never saw that override. Under `?backend=software`, `backend` mismatched on every single check, forcing a full page reload on every edit regardless of what actually changed. tryHardReload now reapplies the same override to the candidate's settings before diffing.
- The blit386 Vite plugin's transform hook now syntax-checks a plain `.js`/`.mjs` entry with acorn before injecting the hot-reload snippet, surfacing a real error through Vite's plugin context (`this.error`) instead of silently no-oping. Vite's own default transform pipeline excludes those extensions from server-side parsing, so a broken entry previously surfaced only as a client-side import() rejection caught and console-logged by Vite's HMR client - never Vite's error overlay. `.ts`/`.mts` entries are unaffected; acorn cannot parse TypeScript-only syntax, so the check is scoped to extensions Vite's own transform already excludes. acorn is bundled into dist/vite.js/.cjs, not a new runtime dependency for consumers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed Tier 3 hot-swap comparisons when `?backend=software` is active, avoiding unnecessary full-page reloads.
- Added Acorn syntax validation for plain `.js`/`.mjs` Vite entries so syntax errors appear in Vite’s overlay; TypeScript entries remain unchanged.
- Added regression tests and updated documentation/changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->