### PR TITLE
docs(rules): add missing .claude/rules mirrors for BT-241

### DIFF
--- a/.claude/rules/claude-canonical.md
+++ b/.claude/rules/claude-canonical.md
@@ -1,0 +1,16 @@
+# blit386 CLAUDE.md is canonical
+
+Condensed mirror of `.cursor/rules/claude-canonical.mdc`.
+
+- Treat the repo-root `CLAUDE.md` as canonical for implementation in this repo; it is loaded automatically into every
+  Claude Code session.
+- Follow its API conventions (especially BT getters vs methods), architecture map, command set, internal scoped naming,
+  and docs-update rules.
+- Subsystem guides: `docs/guide-overlay.md` (engine HUD), `docs/api-*.md` (public API), `docs/reference-deprecations.md`
+  (aliases).
+- Cursor-specific policy lives in `.cursor/rules/*.mdc` and `.cursor/hooks/`; this directory (`.claude/rules/`) holds
+  condensed mirrors of the always-applied `.mdc` rules for Claude Code.
+- Do not invent alternate conventions when `CLAUDE.md` provides project-specific direction.
+- Public API or behavior changes must include matching docs updates in `docs/` as described in `CLAUDE.md`.
+- Keep performance-first and strict TypeScript standards from `CLAUDE.md` (no `any`, use type-only imports, integer
+  coordinates where required).

--- a/.claude/rules/rtk-and-pnpm.md
+++ b/.claude/rules/rtk-and-pnpm.md
@@ -1,0 +1,13 @@
+# RTK and pnpm
+
+Condensed mirror of `.cursor/rules/rtk-and-pnpm.mdc`.
+
+- Package scripts: **`pnpm run <script>`** only (e.g. `pnpm run preflight`). Bare `pnpm preflight` skips the RTK
+  rewrite.
+- **`pnpm run preflight`** runs: `format:check`, `lint`, `typecheck`, `spellcheck`, `knip`, `docs:links`,
+  `sync:doc-banners:check`, `api:since:check`, `api:history:check`, `test:unit`, `test:declarations`.
+- Built-ins without `run`: `pnpm install`, `pnpm audit`, `pnpm exec`, `pnpm add`, `pnpm --filter …`.
+- Claude Code: `PreToolUse` → `rtk hook claude` on the Bash matcher; `PostToolUse` on Edit/MultiEdit/Write runs Biome
+  and Prettier formatting, then a cspell check (see `.claude/settings.json`).
+- Prefer shell + RTK (`rtk read`, `rtk grep`, `git`, `pnpm run …`) over native Read/Grep for exploration.
+- Full policy: `~/.claude/RTK.md`.


### PR DESCRIPTION
`.cursor/rules` had 8 files but `.claude/rules` only had 6 - claude-canonical.mdc and rtk-and-pnpm.mdc had no condensed Claude Code twin despite CLAUDE.md describing them as such. Adds both, restoring parity between the two directories ahead of the CI drift check that will enforce it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds missing `.claude/rules` mirrors for `claude-canonical.mdc` and `rtk-and-pnpm.mdc`, restoring parity with `.cursor/rules`.

- Documents `CLAUDE.md` as the authoritative source for Claude Code conventions, architecture, APIs, documentation, and TypeScript standards.
- Documents pnpm script usage, preflight checks, RTK command handling, and exploration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->