### PR TITLE
fix(scripts): guard checkFile against duplicate settle and add a timeout

### DIFF
--- a/scripts/check-markdown-links.mjs
+++ b/scripts/check-markdown-links.mjs
@@ -29,7 +29,8 @@ const IGNORED_DIRS = new Set([
     'playwright-report',
 ]);
 const CONCURRENCY = 8;
-const CHECK_TIMEOUT_MS = 120_000;
+// Exceeds the ~170s worst-case single-link retry chain in .github/markdown-link-check.json.
+const CHECK_TIMEOUT_MS = 300_000;
 
 /** @param {string} dir @param {string[]} files */
 function walkMarkdownFiles(dir, files) {
@@ -77,7 +78,10 @@ function checkFile(filePath) {
         }
 
         child.on('error', (err) => {
-            output += `\n[spawn error] ${err.message}\n`;
+            output +=
+                err.name === 'AbortError'
+                    ? `\n[spawn error] check timed out after ${CHECK_TIMEOUT_MS}ms\n`
+                    : `\n[spawn error] ${err.message}\n`;
             finish(false);
         });
 

--- a/scripts/check-markdown-links.mjs
+++ b/scripts/check-markdown-links.mjs
@@ -29,6 +29,7 @@ const IGNORED_DIRS = new Set([
     'playwright-report',
 ]);
 const CONCURRENCY = 8;
+const CHECK_TIMEOUT_MS = 120_000;
 
 /** @param {string} dir @param {string[]} files */
 function walkMarkdownFiles(dir, files) {
@@ -51,21 +52,37 @@ function checkFile(filePath) {
     const rel = relative(ROOT, filePath);
 
     return new Promise((settle) => {
-        const child = spawn(process.execPath, [MLC_BIN, rel, '-c', CONFIG], { cwd: ROOT });
+        const child = spawn(process.execPath, [MLC_BIN, rel, '-c', CONFIG], {
+            cwd: ROOT,
+            signal: AbortSignal.timeout(CHECK_TIMEOUT_MS),
+        });
         let output = '';
-        child.stdout.on('data', (chunk) => (output += chunk));
-        child.stderr.on('data', (chunk) => (output += chunk));
+        let settled = false;
 
-        child.on('error', () => {
+        child.stdout.on('data', (chunk) => {
+            output += chunk;
+        });
+        child.stderr.on('data', (chunk) => {
+            output += chunk;
+        });
+
+        function finish(ok) {
+            if (settled) {
+                return;
+            }
+            settled = true;
             console.log(`\nFILE: ./${rel}`);
             process.stdout.write(output);
-            settle(false);
+            settle(ok);
+        }
+
+        child.on('error', (err) => {
+            output += `\n[spawn error] ${err.message}\n`;
+            finish(false);
         });
 
         child.on('close', (code) => {
-            console.log(`\nFILE: ./${rel}`);
-            process.stdout.write(output);
-            settle(code === 0);
+            finish(code === 0);
         });
     });
 }


### PR DESCRIPTION
checkFile's error and close handlers could both fire for the same spawned markdown-link-check process (e.g. on an aborted child), each independently logging the file block and calling settle. Add a settled guard so only the first outcome is recorded. Also bound each check with a 120s timeout via AbortSignal so a hung child no longer blocks the run indefinitely, and log the spawn error's message instead of a generic failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Prevent duplicate `checkFile` results when the `error` and `close` handlers fire by using a `settled` guard around a centralized `finish(ok)` helper.
- Add a per-file execution timeout to abort hung `markdown-link-check` runs via `AbortSignal.timeout(CHECK_TIMEOUT_MS)` (currently `300_000ms`).
- Preserve stdout/stderr aggregation while refactoring subprocess completion logic to settle exactly once.
- Log the actual spawn error message (and a timeout-specific message when `err.name === 'AbortError'`) instead of a generic failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->