### PR TITLE
feat(dx): add SessionStart hook and devcontainer for remote/web bootstrap

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,17 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact|fork",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh \"${CLAUDE_PROJECT_DIR}/scripts/session-start-bootstrap.sh\"",
+            "timeout": 300
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,6 +1,12 @@
 {
   "version": 1,
   "hooks": {
+    "sessionStart": [
+      {
+        "command": "sh scripts/session-start-bootstrap.sh",
+        "timeout": 300
+      }
+    ],
     "preToolUse": [
       {
         "command": "rtk hook cursor",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+{
+  "name": "blit386",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:22-bookworm",
+  "postCreateCommand": "sh scripts/session-start-bootstrap.sh",
+  "remoteEnv": {
+    "COREPACK_ENABLE_DOWNLOAD_PROMPT": "0"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "biomejs.biome-vscode",
+        "editorconfig.editorconfig",
+        "ms-playwright.playwright",
+        "vitest.explorer",
+        "esbenp.prettier-vscode",
+        "streetsidesoftware.code-spell-checker"
+      ],
+      "settings": {
+        "typescript.tsdk": "node_modules/typescript/lib"
+      }
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ Before writing new code, reviewing existing code, or preflighting, check here fi
 | How does screen orientation detection / lock work?                                    | `src/core/Orientation.ts`; `HardwareSettings.preferredOrientation` + `IBTDemo.onOrientationChange` in `src/core/IBTDemo.ts`; `BT.screenOrientation` in `src/BLIT386.ts`; `docs/api-core.md` (Screen orientation), `docs/api-browser-support.md` (Screen orientation)                                                                                                                           |
 | How does the engine hot-swap runtime work?                                            | `src/hot/` (`protocol.ts`, `HotRuntime.ts`, `HotSwap.ts`); `BTAPI.hotReplaceDemo`/`getDemo`/`isInitialized` in `src/core/BTAPI.ts`; `IBTDemo.onHotReload` in `src/core/IBTDemo.ts`; hot-aware routing in `src/utils/Bootstrap.ts`                                                                                                                                                              |
 | How does the `blit386/vite` dev plugin work?                                          | `src/vite/` (`options.ts`, `transform.ts`, `assets.ts`, `index.ts`); `package.json` `"./vite"` subpath export; dev-only (`apply: 'serve'`) – injects the hot-reload snippet and broadcasts `blit386:asset-changed`/full-reload for asset dir changes; `vite.node.config.ts` sets `root: '/'` to avoid collision with the main build's `dist/blit386.d.ts` (see inline comment for explanation) |
+| How does a fresh remote/web session bootstrap its toolchain?                          | Environment bootstrap below; `scripts/session-start-bootstrap.sh`; `.claude/settings.json` (`SessionStart`), `.cursor/hooks.json` (`sessionStart`), `.devcontainer/devcontainer.json`                                                                                                                                                                                                          |
 
 ## Onboarding and the scaffolder
 
@@ -662,6 +663,27 @@ Claude Code reusable skill:
   `CLAUDE.md` architecture map and the `## Where to Find Information` table; update `README.md` only if the change
   affects the Quick Start, prerequisites, features list, or browser compatibility. Never treat documentation as a
   separate step the user must request.
+
+## Environment bootstrap (SessionStart hook and devcontainer)
+
+A fresh remote/web/cloud checkout (Claude Code on the web, a Codespace, any ephemeral agent sandbox) starts with no
+`node_modules` and no warmed toolchain. `scripts/session-start-bootstrap.sh` fixes that: it runs
+`pnpm install --frozen-lockfile` (enabling `corepack` first if `pnpm` is not yet on `PATH`) so `pnpm run preflight` and
+the test suite work without manual setup. It stamps `node_modules/.session-start-lockfile.cksum` with a `cksum` of
+`pnpm-lock.yaml` and skips the install on the next call when the lockfile has not changed, so it stays a fast no-op on a
+machine that already has dependencies installed.
+
+The same script is wired into three places, all pointing at this one file so the bootstrap logic is never duplicated:
+
+- `.claude/settings.json` – a `SessionStart` hook (`matcher: "startup|resume|clear|compact|fork"`) runs it at the start
+  of every Claude Code session.
+- `.cursor/hooks.json` – a `sessionStart` hook runs it when a new Cursor composer conversation begins (fire-and-forget;
+  it does not block the first prompt).
+- `.devcontainer/devcontainer.json` – an optional devcontainer (`typescript-node:22-bookworm`) for reproducible
+  Codespaces/cloud environments; `postCreateCommand` runs the same script once the container is created.
+
+None of the three block or fail the session/container on a bootstrap error – a missing `pnpm`/network failure is logged
+and the script exits `0`, since a `SessionStart` hook cannot prevent a session from starting anyway.
 
 ## Environment and tooling gotchas
 

--- a/cspell.json
+++ b/cspell.json
@@ -27,6 +27,7 @@
     "Chebyshev",
     "chrom",
     "Cietwierkowski",
+    "cksum",
     "commitlint",
     "daafu",
     "dbaeumer",

--- a/scripts/session-start-bootstrap.sh
+++ b/scripts/session-start-bootstrap.sh
@@ -7,6 +7,8 @@
 
 set -u
 
+export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT" || exit 0
 
@@ -28,8 +30,12 @@ if [ -d node_modules ] && [ -f "$LOCKFILE_STAMP" ] && [ "$(cat "$LOCKFILE_STAMP"
     exit 0
 fi
 
-if ! pnpm install --frozen-lockfile; then
+INSTALL_OUTPUT="$(pnpm install --frozen-lockfile 2>&1)"
+INSTALL_STATUS=$?
+
+if [ "$INSTALL_STATUS" -ne 0 ]; then
     echo "[session-start] pnpm install failed; the session will continue without a warmed toolchain." >&2
+    printf '%s\n' "$INSTALL_OUTPUT" >&2
     exit 0
 fi
 

--- a/scripts/session-start-bootstrap.sh
+++ b/scripts/session-start-bootstrap.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+# Bootstraps the pnpm toolchain for ephemeral remote/web/cloud sessions (Claude Code SessionStart
+# hook, Cursor sessionStart hook, and the devcontainer postCreateCommand). Installs dependencies
+# only when pnpm-lock.yaml has changed since the last successful install here, so it is a fast
+# no-op on a machine that already has node_modules set up.
+
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT" || exit 0
+
+if ! command -v pnpm >/dev/null 2>&1; then
+    if command -v corepack >/dev/null 2>&1; then
+        corepack enable >/dev/null 2>&1 || true
+    fi
+fi
+
+if ! command -v pnpm >/dev/null 2>&1; then
+    echo "[session-start] pnpm not found on PATH; skipping dependency bootstrap." >&2
+    exit 0
+fi
+
+LOCKFILE_STAMP="node_modules/.session-start-lockfile.cksum"
+CURRENT_CKSUM="$(cksum pnpm-lock.yaml 2>/dev/null)"
+
+if [ -d node_modules ] && [ -f "$LOCKFILE_STAMP" ] && [ "$(cat "$LOCKFILE_STAMP" 2>/dev/null)" = "$CURRENT_CKSUM" ]; then
+    exit 0
+fi
+
+if ! pnpm install --frozen-lockfile; then
+    echo "[session-start] pnpm install failed; the session will continue without a warmed toolchain." >&2
+    exit 0
+fi
+
+mkdir -p node_modules
+printf '%s' "$CURRENT_CKSUM" >"$LOCKFILE_STAMP"
+
+exit 0


### PR DESCRIPTION
Fresh remote/web sessions (Claude Code on the web, Codespaces, or any ephemeral agent sandbox) had no node_modules and no warmed toolchain, so an agent had to discover and run pnpm install by hand before tests or linters worked.

Add scripts/session-start-bootstrap.sh, wired into three places: a Claude Code SessionStart hook, a Cursor sessionStart hook, and an optional .devcontainer/devcontainer.json postCreateCommand. It runs pnpm install --frozen-lockfile (enabling corepack first if pnpm is missing) and stamps a cksum of pnpm-lock.yaml so repeat runs on an already-set-up machine are a fast no-op. Document the setup in CLAUDE.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added automatic dependency bootstrapping for ephemeral/remote development sessions via a new `scripts/session-start-bootstrap.sh`.
- The script enables Corepack when `pnpm` isn’t on `PATH`, disables interactive Corepack download prompts, and runs `pnpm install --frozen-lockfile`.
- Implemented checksum-based install deduplication using `pnpm-lock.yaml` to skip repeat installs when `node_modules` is already current.
- Ensured install failures surface the captured install output on stderr while still exiting successfully to avoid breaking the session startup.
- Wired the bootstrap to Claude Code `SessionStart` and Cursor `sessionStart` hooks (each with a 300-second timeout), plus an optional `.devcontainer/devcontainer.json` `postCreateCommand`.
- Updated `CLAUDE.md` with environment bootstrap documentation and updated `cspell.json` to allow the checksum stamp filename term (`cksum`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->