### PR TITLE
feat(assets): add asset loading progress instrumentation and public API access

### DIFF
--- a/docs/_api-history.json
+++ b/docs/_api-history.json
@@ -666,6 +666,13 @@
       },
       "status": "deprecated"
     },
+    "BT.loadingAssetsCount": {
+      "kind": "getter",
+      "since": "1.4.0",
+      "changes": [],
+      "deprecated": null,
+      "status": "unreleased"
+    },
     "BT.musicPlay": {
       "kind": "method",
       "since": "1.3.0",
@@ -1404,6 +1411,7 @@
   "pages": {
     "api/assets": [
       "AssetLoader",
+      "BT.loadingAssetsCount",
       "BitmapFont",
       "IndexedSpriteLoadResult",
       "SpriteSheet"

--- a/docs/api-assets.md
+++ b/docs/api-assets.md
@@ -256,10 +256,24 @@ glyph tables and texture.
   sheet's current `width`/`height` when that matters.
 </Callout>
 
-Each `SpriteSheet` also exposes `status` (`'loading' | 'ready' | 'failed'`) and `progress` (`0` or `1` -
-`HTMLImageElement` reports no byte-level progress) tracking a replacement fetch while it's in flight. A normally loaded
-sheet is always `'ready'` with `progress: 1.0`, since its image has already resolved by the time the sheet is
-constructed.
+Each `SpriteSheet` also exposes `status` (`'loading' | 'ready' | 'failed'`) and `progress` (`0` or `1`) tracking a
+replacement fetch while it's in flight - useful for a per-sheet loading indicator, or combine with
+[`BT.loadingAssetsCount`](#loading-assets) for a single engine-wide signal. A normally loaded sheet is always `'ready'`
+with `progress: 1.0`, since its image has already resolved by the time the sheet is constructed.
+
+```ts twoslash
+import { SpriteSheet } from 'blit386';
+declare const sheet: SpriteSheet;
+// ---cut---
+sheet.status; // 'loading' | 'ready' | 'failed'
+sheet.progress; // 0 while loading, 1.0 once ready
+```
+
+<Callout title="Coarse-grained progress">
+  `progress` is `0` or `1.0`, never a value in between - `HTMLImageElement` reports no byte-level download progress the
+  way `AudioClip`'s `onProgress` callback does (see [API: Audio](api-audio.md#loading)). Use `status`/`progress` to show
+  or hide a loading indicator, not to drive a percentage bar.
+</Callout>
 
 See [Hot Reload](guide-hot-reload.md#asset-hot-replace-matrix) for the full asset type matrix, including audio and the
 fallback-to-full-reload behavior for unrecognized file types.

--- a/docs/api-assets.md
+++ b/docs/api-assets.md
@@ -68,6 +68,9 @@ if (AssetLoader.isLoaded('sprites.png')) {
 
 // Drop a single URL's cache entry (mainly for tests or explicit resets)
 AssetLoader.evict('sprites.png');
+
+// Number of image loads currently in flight
+AssetLoader.loadingCount;
 ```
 
 `AssetLoader.evict()` is also the manual escape hatch for forcing a fresh load outside the `blit386/vite` plugin's
@@ -238,6 +241,11 @@ glyph tables and texture.
   responsibility. Keep sprite sheet dimensions stable during a hot-reload session, or recompute `srcRect`s from the
   sheet's current `width`/`height` when that matters.
 </Callout>
+
+Each `SpriteSheet` also exposes `status` (`'loading' | 'ready' | 'failed'`) and `progress` (`0` or `1` -
+`HTMLImageElement` reports no byte-level progress) tracking a replacement fetch while it's in flight. A normally loaded
+sheet is always `'ready'` with `progress: 1.0`, since its image has already resolved by the time the sheet is
+constructed.
 
 See [Hot Reload](guide-hot-reload.md#asset-hot-replace-matrix) for the full asset type matrix, including audio and the
 fallback-to-full-reload behavior for unrecognized file types.

--- a/docs/api-assets.md
+++ b/docs/api-assets.md
@@ -76,6 +76,20 @@ AssetLoader.loadingCount;
 `AssetLoader.evict()` is also the manual escape hatch for forcing a fresh load outside the `blit386/vite` plugin's
 automatic asset watcher - see [Hot Reload](guide-hot-reload.md#asset-hot-replace-matrix).
 
+<Since symbol="BT.loadingAssetsCount" />
+
+For a loading-screen indicator that covers both images and audio clips, use `BT.loadingAssetsCount` - it sums
+`AssetLoader.loadingCount` and `AudioClip.loadingCount` (see [API: Audio](api-audio.md#loading)) and drops back to `0`
+once every in-flight load has settled:
+
+```ts twoslash
+import { BT } from 'blit386';
+// ---cut---
+if (BT.loadingAssetsCount > 0) {
+  // show a spinner or progress bar
+}
+```
+
 ## Sprite setup – preferred path
 
 <Since symbol="SpriteSheet" />

--- a/docs/api-audio.md
+++ b/docs/api-audio.md
@@ -128,6 +128,9 @@ const clips = await AudioClip.loadAll(['audio/theme.mp3', ['audio/hit.ogg', 'aud
 if (AudioClip.isLoaded('audio/theme.mp3')) {
   // already cached
 }
+
+// Number of clip loads currently in flight
+AudioClip.loadingCount;
 ```
 
 Pass `onProgress` to report phased load progress:

--- a/docs/api-audio.md
+++ b/docs/api-audio.md
@@ -133,6 +133,9 @@ if (AudioClip.isLoaded('audio/theme.mp3')) {
 AudioClip.loadingCount;
 ```
 
+For a single loading-screen signal that also covers sprite sheet images, see
+[`BT.loadingAssetsCount`](api-assets.md#loading-assets).
+
 Pass `onProgress` to report phased load progress:
 
 ```ts twoslash

--- a/src/BLIT386.test.ts
+++ b/src/BLIT386.test.ts
@@ -1666,3 +1666,24 @@ describe('BT.activeBackend', () => {
         expect(BT.activeBackend).toBe('software');
     });
 });
+
+describe('BT.loadingAssetsCount', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('delegates to BTAPI.instance.getLoadingAssetsCount', () => {
+        const spy = vi.spyOn(BTAPI.instance, 'getLoadingAssetsCount').mockReturnValue(3);
+
+        const result = BT.loadingAssetsCount;
+
+        expect(spy).toHaveBeenCalled();
+        expect(result).toBe(3);
+    });
+
+    it('returns 0 when nothing is loading', () => {
+        vi.spyOn(BTAPI.instance, 'getLoadingAssetsCount').mockReturnValue(0);
+
+        expect(BT.loadingAssetsCount).toBe(0);
+    });
+});

--- a/src/BLIT386.test.ts
+++ b/src/BLIT386.test.ts
@@ -10,6 +10,7 @@
 
 import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
 
+import { AssetLoader } from './assets/AssetLoader';
 import type { AudioClip } from './assets/AudioClip';
 import { blip, explosion, hit, jump, laser, pickup } from './assets/synth/synthPresets';
 import type { BitmapFont, HardwareSettings } from './BLIT386';
@@ -1685,5 +1686,44 @@ describe('BT.loadingAssetsCount', () => {
         vi.spyOn(BTAPI.instance, 'getLoadingAssetsCount').mockReturnValue(0);
 
         expect(BT.loadingAssetsCount).toBe(0);
+    });
+
+    it('reflects a real pending AssetLoader image load, without mocking BTAPI', async () => {
+        /** Image stub whose `onload`/`onerror` must be fired manually, so the test controls timing. */
+        class DeferredImage {
+            onload: (() => void) | null = null;
+            onerror: (() => void) | null = null;
+            width = 10;
+            height = 10;
+            src = '';
+        }
+
+        const instances: DeferredImage[] = [];
+
+        vi.stubGlobal(
+            'Image',
+            class extends DeferredImage {
+                constructor() {
+                    super();
+                    instances.push(this);
+                }
+            },
+        );
+
+        try {
+            expect(BT.loadingAssetsCount).toBe(0);
+
+            const promise = AssetLoader.loadImage('pending-bt-aggregate.png');
+
+            expect(BT.loadingAssetsCount).toBe(1);
+
+            instances[0]?.onload?.();
+            await promise;
+
+            expect(BT.loadingAssetsCount).toBe(0);
+        } finally {
+            vi.unstubAllGlobals();
+            AssetLoader.clear();
+        }
     });
 });

--- a/src/BLIT386.ts
+++ b/src/BLIT386.ts
@@ -715,6 +715,19 @@ export const BT = {
     },
 
     /**
+     * Total number of asset loads currently in flight (images and audio clips combined).
+     *
+     * Useful for a loading-screen progress indicator: poll this each frame and show a
+     * spinner or bar until it drops back to `0`.
+     *
+     * @since 1.4.0
+     * @returns Combined count of in-flight `AssetLoader` and `AudioClip` loads.
+     */
+    get loadingAssetsCount(): number {
+        return BTAPI.instance.getLoadingAssetsCount();
+    },
+
+    /**
      * Current screen orientation type from the Screen Orientation API.
      *
      * Examples: `'landscape-primary'`, `'portrait-secondary'`. Returns `null` when

--- a/src/assets/AssetLoader.test.ts
+++ b/src/assets/AssetLoader.test.ts
@@ -344,6 +344,63 @@ describe('AssetLoader', () => {
         });
     });
 
+    describe('loadingCount', () => {
+        /** Image stub whose `onload`/`onerror` must be fired manually, so tests control timing. */
+        class DeferredImage {
+            onload: (() => void) | null = null;
+            onerror: (() => void) | null = null;
+            width = 100;
+            height = 100;
+            src = '';
+        }
+
+        let instances: DeferredImage[];
+
+        beforeEach(() => {
+            instances = [];
+
+            vi.stubGlobal(
+                'Image',
+                class extends DeferredImage {
+                    constructor() {
+                        super();
+                        instances.push(this);
+                    }
+                },
+            );
+        });
+
+        afterEach(() => {
+            vi.unstubAllGlobals();
+        });
+
+        it('is zero when nothing is loading', () => {
+            expect(AssetLoader.loadingCount).toBe(0);
+        });
+
+        it('increments while a load is in flight and drops to zero once it resolves', async () => {
+            const promise = AssetLoader.loadImage('pending.png');
+
+            expect(AssetLoader.loadingCount).toBe(1);
+
+            instances[0]?.onload?.();
+            await promise;
+
+            expect(AssetLoader.loadingCount).toBe(0);
+        });
+
+        it('drops to zero once an in-flight load rejects', async () => {
+            const promise = AssetLoader.loadImage('pending-fail.png');
+
+            expect(AssetLoader.loadingCount).toBe(1);
+
+            instances[0]?.onerror?.();
+            await expect(promise).rejects.toThrow();
+
+            expect(AssetLoader.loadingCount).toBe(0);
+        });
+    });
+
     describe('stale-completion safety', () => {
         /** Image stub whose `onload`/`onerror` must be fired manually, so tests control resolution order. */
         class DeferredImage {

--- a/src/assets/AssetLoader.ts
+++ b/src/assets/AssetLoader.ts
@@ -231,6 +231,16 @@ function startLoading(fetchUrl: string, cacheKey: string = fetchUrl): Promise<HT
  */
 export class AssetLoader {
     /**
+     * Gets the number of image loads currently in flight.
+     *
+     * @returns Count of URLs with a pending {@link AssetLoader.loadImage} or
+     *   {@link AssetLoader.hotReloadImage} request.
+     */
+    static get loadingCount(): number {
+        return loadingPromises.size;
+    }
+
+    /**
      * Loads an image and caches the resolved element by URL.
      *
      * Reuses an already-cached image immediately and shares a single in-flight

--- a/src/assets/AssetLoader.ts
+++ b/src/assets/AssetLoader.ts
@@ -233,6 +233,7 @@ export class AssetLoader {
     /**
      * Gets the number of image loads currently in flight.
      *
+     * @since 1.4.0
      * @returns Count of URLs with a pending {@link AssetLoader.loadImage} or
      *   {@link AssetLoader.hotReloadImage} request.
      */

--- a/src/assets/AudioClip.test.ts
+++ b/src/assets/AudioClip.test.ts
@@ -136,6 +136,34 @@ describe('AudioClip', () => {
         });
     });
 
+    describe('loadingCount', () => {
+        it('is zero when nothing is loading', () => {
+            expect(AudioClip.loadingCount).toBe(0);
+        });
+
+        it('increments while a load is in flight and drops to zero once it resolves', async () => {
+            vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockAudioFetchResponse()));
+
+            const promise = AudioClip.load('pending.mp3');
+
+            expect(AudioClip.loadingCount).toBe(1);
+            await promise;
+
+            expect(AudioClip.loadingCount).toBe(0);
+        });
+
+        it('drops to zero once an in-flight load rejects', async () => {
+            vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')));
+
+            const promise = AudioClip.load('pending-fail.mp3');
+
+            expect(AudioClip.loadingCount).toBe(1);
+            await expect(promise).rejects.toThrow();
+
+            expect(AudioClip.loadingCount).toBe(0);
+        });
+    });
+
     describe('loading a single URL', () => {
         beforeEach(() => {
             vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockAudioFetchResponse()));

--- a/src/assets/AudioClip.ts
+++ b/src/assets/AudioClip.ts
@@ -110,6 +110,7 @@ export class AudioClip {
     /**
      * Gets the number of clip loads currently in flight.
      *
+     * @since 1.4.0
      * @returns Count of URLs with a pending {@link AudioClip.load} (or
      *   {@link AudioClip.loadAll}) request.
      */

--- a/src/assets/AudioClip.ts
+++ b/src/assets/AudioClip.ts
@@ -108,6 +108,16 @@ export class AudioClip {
     }
 
     /**
+     * Gets the number of clip loads currently in flight.
+     *
+     * @returns Count of URLs with a pending {@link AudioClip.load} (or
+     *   {@link AudioClip.loadAll}) request.
+     */
+    static get loadingCount(): number {
+        return inFlightLoads.size;
+    }
+
+    /**
      * Returns the decoded audio buffer.
      *
      * @returns The decoded buffer, or `null` after {@link unload}.

--- a/src/assets/SpriteSheet.test.ts
+++ b/src/assets/SpriteSheet.test.ts
@@ -104,6 +104,40 @@ describe('SpriteSheet', () => {
         });
     });
 
+    describe('status and progress', () => {
+        it('defaults to ready/1.0 for a normally constructed sheet', () => {
+            const sheet = new SpriteSheet(mockImage);
+
+            expect(sheet.status).toBe('ready');
+            expect(sheet.progress).toBe(1.0);
+        });
+
+        it('defaults to ready/1.0 for a sheet created from raw indexed pixels', () => {
+            const sheet = SpriteSheet.fromIndexedPixels(2, 2, new Uint8Array(4) as Uint8Array<ArrayBuffer>);
+
+            expect(sheet.status).toBe('ready');
+            expect(sheet.progress).toBe(1.0);
+        });
+
+        it('beginHotReplace marks the sheet loading with zero progress', () => {
+            const sheet = new SpriteSheet(mockImage);
+
+            sheet.beginHotReplace();
+
+            expect(sheet.status).toBe('loading');
+            expect(sheet.progress).toBe(0);
+        });
+
+        it('failHotReplace marks the sheet failed', () => {
+            const sheet = new SpriteSheet(mockImage);
+
+            sheet.beginHotReplace();
+            sheet.failHotReplace();
+
+            expect(sheet.status).toBe('failed');
+        });
+    });
+
     describe('getTexture', () => {
         it('should return a texture object from a mock device', () => {
             const sheet = new SpriteSheet(mockImage);
@@ -769,17 +803,31 @@ describe('SpriteSheet', () => {
                 sheet.hotReplaceImage(mockImage, null);
 
                 expect(warnSpy).toHaveBeenCalledOnce();
+                expect(sheet.status).toBe('failed');
             });
 
             it('swaps the image and updates size for a non-indexized sheet', () => {
                 const sheet = new SpriteSheet(mockImage);
                 const newImage = { width: 64, height: 32 } as HTMLImageElement;
 
+                sheet.beginHotReplace();
                 sheet.hotReplaceImage(newImage, null);
 
                 expect(sheet.getImage()).toBe(newImage);
                 expect(sheet.size.x).toBe(64);
                 expect(sheet.size.y).toBe(32);
+                expect(sheet.status).toBe('ready');
+                expect(sheet.progress).toBe(1.0);
+            });
+
+            it('marks the sheet failed and rethrows when the replacement image exceeds size limits', () => {
+                const sheet = new SpriteSheet(mockImage);
+                const oversized = { width: MAX_ASSET_DIMENSION + 1, height: 16 } as HTMLImageElement;
+
+                sheet.beginHotReplace();
+
+                expect(() => sheet.hotReplaceImage(oversized, null)).toThrow(AssetLimitError);
+                expect(sheet.status).toBe('failed');
             });
 
             it('invalidates the cached texture for a non-indexized sheet', () => {
@@ -807,8 +855,11 @@ describe('SpriteSheet', () => {
                 vi.stubGlobal('OffscreenCanvas', makeOffscreenCanvasMock(nextPixels, 1, 1));
                 palette.set(2, new Color32(0, 255, 0, 255));
 
+                sheet.beginHotReplace();
+
                 expect(() => sheet.hotReplaceImage({ width: 1, height: 1 } as HTMLImageElement, palette)).not.toThrow();
                 expect(sheet.getIndexedPixels()[0]).toBe(2);
+                expect(sheet.status).toBe('ready');
             });
 
             it('warns and skips when an indexized sheet has no active palette to reindex against', () => {
@@ -822,11 +873,13 @@ describe('SpriteSheet', () => {
                 sheet.indexize(palette);
 
                 const newImage = { width: 1, height: 1 } as HTMLImageElement;
+                sheet.beginHotReplace();
                 sheet.hotReplaceImage(newImage, null);
 
                 expect(warnSpy).toHaveBeenCalledOnce();
                 expect(sheet.getImage()).toBe(originalImage);
                 expect(sheet.getImage()).not.toBe(newImage);
+                expect(sheet.status).toBe('failed');
             });
         });
     });

--- a/src/assets/SpriteSheet.test.ts
+++ b/src/assets/SpriteSheet.test.ts
@@ -14,7 +14,7 @@
  * stubbed asset-loading/browser APIs.
  */
 
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createMockGPUDevice } from '../__test__/webgpu-mock';
 import { collectUsedIndices, resetUsage } from '../core/RenderPaletteUsage';
@@ -392,6 +392,60 @@ describe('SpriteSheet', () => {
             const sheet = await SpriteSheet.load('test.png');
             sheet.destroy();
             expect(closeSpy).toHaveBeenCalledOnce();
+        });
+
+        describe('AssetLoader.loadingCount via SpriteSheet.load', () => {
+            /** Image stub whose `onload`/`onerror` must be fired manually, so tests control timing. */
+            class DeferredImage {
+                onload: (() => void) | null = null;
+                onerror: (() => void) | null = null;
+                width = 100;
+                height = 100;
+                src = '';
+            }
+
+            let instances: DeferredImage[];
+
+            beforeEach(() => {
+                instances = [];
+
+                vi.stubGlobal(
+                    'Image',
+                    class extends DeferredImage {
+                        constructor() {
+                            super();
+                            instances.push(this);
+                        }
+                    },
+                );
+                vi.stubGlobal('createImageBitmap', vi.fn().mockRejectedValue(new Error('n/a')));
+            });
+
+            afterEach(() => {
+                AssetLoader.clear();
+            });
+
+            it('rises while the underlying image fetch is pending and drops to zero once it resolves', async () => {
+                const loadPromise = SpriteSheet.load('pending-sheet.png');
+
+                expect(AssetLoader.loadingCount).toBe(1);
+
+                instances[0]?.onload?.();
+                await loadPromise;
+
+                expect(AssetLoader.loadingCount).toBe(0);
+            });
+
+            it('drops to zero when the underlying image fetch rejects', async () => {
+                const loadPromise = SpriteSheet.load('pending-fail-sheet.png');
+
+                expect(AssetLoader.loadingCount).toBe(1);
+
+                instances[0]?.onerror?.();
+                await expect(loadPromise).rejects.toThrow();
+
+                expect(AssetLoader.loadingCount).toBe(0);
+            });
         });
     });
 
@@ -793,6 +847,37 @@ describe('SpriteSheet', () => {
             sheet.destroy();
 
             expect(getHotReloadSheets('images/gone.png')).toBeUndefined();
+        });
+
+        it('reports ready/1.0 on a resolved sheet, then loading/0 and back to ready/1.0 across a hot-reload transition', async () => {
+            activateHotReload();
+            vi.stubGlobal('createImageBitmap', vi.fn().mockRejectedValue(new Error('n/a')));
+            vi.spyOn(AssetLoader, 'loadImage').mockResolvedValue(mockImage);
+
+            const sheet = await SpriteSheet.load('images/hot-status.png');
+
+            expect(sheet.status).toBe('ready');
+            expect(sheet.progress).toBe(1.0);
+
+            const registered = getHotReloadSheets('images/hot-status.png');
+            expect(registered).toEqual(new Set([sheet]));
+
+            for (const registeredSheet of registered ?? []) {
+                registeredSheet.beginHotReplace();
+            }
+
+            expect(sheet.status).toBe('loading');
+            expect(sheet.progress).toBe(0);
+
+            const replacementImage = { width: 32, height: 32 } as HTMLImageElement;
+
+            for (const registeredSheet of registered ?? []) {
+                registeredSheet.hotReplaceImage(replacementImage, null);
+            }
+
+            expect(sheet.status).toBe('ready');
+            expect(sheet.progress).toBe(1.0);
+            expect(sheet.getImage()).toBe(replacementImage);
         });
 
         describe('hotReplaceImage', () => {

--- a/src/assets/SpriteSheet.ts
+++ b/src/assets/SpriteSheet.ts
@@ -343,6 +343,7 @@ export class SpriteSheet {
     /**
      * Gets the lifecycle status of this sheet's backing image data.
      *
+     * @since 1.4.0
      * @returns `'ready'` once constructed (an image has always already resolved by
      *   then); `'loading'` or `'failed'` only while and after a hot-reload
      *   replacement image is in flight, respectively.
@@ -354,6 +355,7 @@ export class SpriteSheet {
     /**
      * Gets the load progress of this sheet's backing image data, in `[0, 1]`.
      *
+     * @since 1.4.0
      * @returns `1.0` once ready; `0.0` while a hot-reload replacement image is in
      *   flight. Coarse-grained - `HTMLImageElement` reports no byte-level progress.
      */

--- a/src/assets/SpriteSheet.ts
+++ b/src/assets/SpriteSheet.ts
@@ -22,6 +22,16 @@ const RGBA_BYTES_PER_PIXEL = 4;
 const TEXTURE_LAYER_COUNT = 1;
 
 /**
+ * Lifecycle status of a sprite sheet's backing image data.
+ *
+ * A sheet only ever reports `'loading'` or `'failed'` while a hot-reload
+ * replacement image is in flight - normal construction always resolves an
+ * image beforehand, so a sheet starts (and, once reloaded, settles back to)
+ * `'ready'`.
+ */
+type SpriteSheetStatus = 'loading' | 'ready' | 'failed';
+
+/**
  * Dev-only registry of live sprite sheets keyed by normalized source URL, so
  * `HotRuntime.handleAssetChanged` can find and hot-replace every sheet loaded
  * from a changed image. Populated only while {@link isHotActive} (no production
@@ -274,6 +284,12 @@ export class SpriteSheet {
     /** Palette index per pixel (set by indexize, uploaded as r8uint texture). */
     private indexedPixels: Uint8Array<ArrayBuffer> | null = null;
 
+    /** Lifecycle status. Backing field for the public {@link status} getter. */
+    private _status: SpriteSheetStatus = 'ready';
+
+    /** Load progress in `[0, 1]`. Backing field for the public {@link progress} getter. */
+    private _progress = 1.0;
+
     /**
      * Creates a sprite sheet from a loaded image.
      * Use the static load() method for easier loading from URL.
@@ -322,6 +338,27 @@ export class SpriteSheet {
      */
     get height(): number {
         return this.size.y;
+    }
+
+    /**
+     * Gets the lifecycle status of this sheet's backing image data.
+     *
+     * @returns `'ready'` once constructed (an image has always already resolved by
+     *   then); `'loading'` or `'failed'` only while and after a hot-reload
+     *   replacement image is in flight, respectively.
+     */
+    get status(): SpriteSheetStatus {
+        return this._status;
+    }
+
+    /**
+     * Gets the load progress of this sheet's backing image data, in `[0, 1]`.
+     *
+     * @returns `1.0` once ready; `0.0` while a hot-reload replacement image is in
+     *   flight. Coarse-grained - `HTMLImageElement` reports no byte-level progress.
+     */
+    get progress(): number {
+        return this._progress;
     }
 
     /**
@@ -602,54 +639,91 @@ export class SpriteSheet {
     }
 
     /**
+     * Marks this sheet as loading a hot-reloaded replacement image.
+     *
+     * Internal – called by `HotRuntime.handleAssetChanged` immediately before it
+     * starts fetching the changed image, so {@link status}/{@link progress} reflect
+     * the fetch while it's in flight. Followed by either {@link hotReplaceImage}
+     * (the fetch resolved) or {@link failHotReplace} (the fetch itself threw).
+     */
+    beginHotReplace(): void {
+        this._status = 'loading';
+        this._progress = 0;
+    }
+
+    /**
+     * Marks this sheet's in-flight hot-reload replacement as failed.
+     *
+     * Internal – called by `HotRuntime.handleAssetChanged` when the replacement
+     * image fetch itself throws, before {@link hotReplaceImage} is ever reached.
+     */
+    failHotReplace(): void {
+        this._status = 'failed';
+    }
+
+    /**
      * Replaces this sheet's source image in place after a hot-reloaded asset change.
      *
      * Swaps the image reference, validates and updates {@link size} (dimension
      * changes are allowed – buffers rebuild to match), re-runs `indexize` against
      * `palette` when the sheet was already indexized so `indexedPixels` stays in
      * sync with the new pixels, and invalidates the cached GPU texture so the next
-     * `getTexture()` call re-uploads it.
+     * `getTexture()` call re-uploads it. Sets {@link status} to `'ready'` on success.
      *
-     * No-op (with a console warning) for sheets created from raw indexed data – there
-     * is no source image to replace – and for an already-indexized sheet when `palette`
-     * is `null`, since there is nothing safe to reindex against.
+     * No-op (with a console warning, and {@link status} set to `'failed'`) for sheets
+     * created from raw indexed data – there is no source image to replace – and for
+     * an already-indexized sheet when `palette` is `null`, since there is nothing safe
+     * to reindex against.
      *
      * If `indexize()` throws partway (a pixel color from the new image is missing from
      * `palette`), this sheet is left with the new image/size but a stale, mismatched
      * `indexedPixels`/texture until a subsequent successful hot reload – an accepted
-     * dev-only-path risk, not a production code path.
+     * dev-only-path risk, not a production code path. {@link status} is set to
+     * `'failed'` and the error is rethrown.
      *
      * @param image - Newly loaded replacement image.
      * @param palette - Active palette, used to re-run `indexize` when the sheet was
      *   already indexized.
+     * @throws If the replacement image exceeds engine size limits, or `indexize()` throws.
      */
     hotReplaceImage(image: HTMLImageElement, palette: Palette | null): void {
         if (!this.image) {
             console.warn('[BT] Hot reload: sprite sheet has no source image (raw indexed data); skipping.');
+            this._status = 'failed';
 
             return;
         }
 
         if (this.indexedPixels !== null && palette === null) {
             console.warn(`[BT] Hot reload: ${this.sourceName} is indexized but no active palette is set; skipping.`);
+            this._status = 'failed';
 
             return;
         }
 
-        assertImageElementWithinLimits('sprite sheet', image);
+        try {
+            assertImageElementWithinLimits('sprite sheet', image);
 
-        this.image = image;
-        this._size = new Vector2i(image.width, image.height);
+            this.image = image;
+            this._size = new Vector2i(image.width, image.height);
 
-        if (this.imageBitmap) {
-            this.imageBitmap.close();
-            this.imageBitmap = null;
-        }
+            if (this.imageBitmap) {
+                this.imageBitmap.close();
+                this.imageBitmap = null;
+            }
 
-        if (this.indexedPixels !== null && palette !== null) {
-            this.indexize(palette);
-        } else {
-            this.invalidateTexture();
+            if (this.indexedPixels !== null && palette !== null) {
+                this.indexize(palette);
+            } else {
+                this.invalidateTexture();
+            }
+
+            this._status = 'ready';
+            this._progress = 1.0;
+        } catch (error) {
+            this._status = 'failed';
+
+            throw error;
         }
     }
 

--- a/src/core/BTAPI.test.ts
+++ b/src/core/BTAPI.test.ts
@@ -25,7 +25,8 @@ import {
     installMockNavigatorGPU,
     uninstallMockNavigatorGPU,
 } from '../__test__/webgpu-mock';
-import type { AudioClip } from '../assets/AudioClip';
+import { AssetLoader } from '../assets/AssetLoader';
+import { AudioClip } from '../assets/AudioClip';
 import type { BitmapFont } from '../assets/BitmapFont';
 import { Palette } from '../assets/Palette';
 import type { SpriteSheet } from '../assets/SpriteSheet';
@@ -2628,6 +2629,23 @@ describe('BTAPI', () => {
             BTAPI.instance.effectRemove(effect);
 
             expect(removeSpy).toHaveBeenCalledWith(effect);
+        });
+    });
+
+    describe('getLoadingAssetsCount', () => {
+        afterEach(() => {
+            vi.restoreAllMocks();
+        });
+
+        it('returns 0 when nothing is loading', () => {
+            expect(BTAPI.instance.getLoadingAssetsCount()).toBe(0);
+        });
+
+        it('sums the AssetLoader and AudioClip in-flight counts', () => {
+            vi.spyOn(AssetLoader, 'loadingCount', 'get').mockReturnValue(2);
+            vi.spyOn(AudioClip, 'loadingCount', 'get').mockReturnValue(3);
+
+            expect(BTAPI.instance.getLoadingAssetsCount()).toBe(5);
         });
     });
 

--- a/src/core/BTAPI.ts
+++ b/src/core/BTAPI.ts
@@ -1,4 +1,5 @@
-import type { AudioClip } from '../assets/AudioClip';
+import { AssetLoader } from '../assets/AssetLoader';
+import { AudioClip } from '../assets/AudioClip';
 import type { BitmapFont } from '../assets/BitmapFont';
 import type { Palette } from '../assets/Palette';
 import {
@@ -656,6 +657,18 @@ export class BTAPI {
      */
     public isInitialized(): boolean {
         return this.demo !== null && this.loop !== null;
+    }
+
+    /**
+     * Gets the total number of asset loads currently in flight across all loaders.
+     *
+     * Computed fresh on each read by summing {@link AssetLoader.loadingCount} and
+     * {@link AudioClip.loadingCount} - stateless, no subscription or extra bookkeeping.
+     *
+     * @returns Combined count of in-flight image and audio clip loads.
+     */
+    public getLoadingAssetsCount(): number {
+        return AssetLoader.loadingCount + AudioClip.loadingCount;
     }
 
     /**

--- a/src/hot/HotRuntime.test.ts
+++ b/src/hot/HotRuntime.test.ts
@@ -217,9 +217,11 @@ describe('HotRuntime', () => {
 
         it('replaces every registered sheet for a matching image URL', async () => {
             vi.spyOn(AssetLoader, 'hotReloadImage').mockResolvedValue({ width: 8, height: 8 } as HTMLImageElement);
-            const fakeSheet = { hotReplaceImage: vi.fn() } as unknown as InstanceType<
-                typeof SpriteSheetModule.SpriteSheet
-            >;
+            const fakeSheet = {
+                beginHotReplace: vi.fn(),
+                failHotReplace: vi.fn(),
+                hotReplaceImage: vi.fn(),
+            } as unknown as InstanceType<typeof SpriteSheetModule.SpriteSheet>;
             vi.spyOn(SpriteSheetModule, 'getHotReloadSheets').mockReturnValue(new Set([fakeSheet]));
             vi.spyOn(BTAPI.instance, 'getPalette').mockReturnValue(null);
 
@@ -229,6 +231,42 @@ describe('HotRuntime', () => {
             await vi.waitFor(() =>
                 expect(fakeSheet.hotReplaceImage).toHaveBeenCalledExactlyOnceWith({ width: 8, height: 8 }, null),
             );
+        });
+
+        it('marks every registered sheet loading before the replacement image is fetched', async () => {
+            vi.spyOn(AssetLoader, 'hotReloadImage').mockResolvedValue({ width: 8, height: 8 } as HTMLImageElement);
+            const fakeSheet = {
+                beginHotReplace: vi.fn(),
+                failHotReplace: vi.fn(),
+                hotReplaceImage: vi.fn(),
+            } as unknown as InstanceType<typeof SpriteSheetModule.SpriteSheet>;
+            vi.spyOn(SpriteSheetModule, 'getHotReloadSheets').mockReturnValue(new Set([fakeSheet]));
+            vi.spyOn(BTAPI.instance, 'getPalette').mockReturnValue(null);
+
+            const handler = registerAndCaptureAssetHandler(HotRuntime);
+            handler({ url: 'hero.png', type: 'image', timestamp: 1 });
+
+            await vi.waitFor(() => expect(fakeSheet.hotReplaceImage).toHaveBeenCalledOnce());
+            expect(fakeSheet.beginHotReplace).toHaveBeenCalledOnce();
+            expect(fakeSheet.failHotReplace).not.toHaveBeenCalled();
+        });
+
+        it('marks every registered sheet failed when the replacement fetch itself throws', async () => {
+            vi.spyOn(AssetLoader, 'hotReloadImage').mockRejectedValue(new Error('404'));
+            const fakeSheet = {
+                beginHotReplace: vi.fn(),
+                failHotReplace: vi.fn(),
+                hotReplaceImage: vi.fn(),
+            } as unknown as InstanceType<typeof SpriteSheetModule.SpriteSheet>;
+            vi.spyOn(SpriteSheetModule, 'getHotReloadSheets').mockReturnValue(new Set([fakeSheet]));
+            const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+            const handler = registerAndCaptureAssetHandler(HotRuntime);
+            handler({ url: 'hero.png', type: 'image', timestamp: 1 });
+
+            await vi.waitFor(() => expect(fakeSheet.failHotReplace).toHaveBeenCalledOnce());
+            expect(fakeSheet.hotReplaceImage).not.toHaveBeenCalled();
+            expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('hero.png'), expect.any(Error));
         });
 
         it('routes an audio payload through AudioClip.hotReload', async () => {

--- a/src/hot/HotRuntime.test.ts
+++ b/src/hot/HotRuntime.test.ts
@@ -233,8 +233,14 @@ describe('HotRuntime', () => {
             );
         });
 
-        it('marks every registered sheet loading before the replacement image is fetched', async () => {
-            vi.spyOn(AssetLoader, 'hotReloadImage').mockResolvedValue({ width: 8, height: 8 } as HTMLImageElement);
+        it('marks every registered sheet loading before the replacement image is fetched, then replaces once it resolves', async () => {
+            let resolveFetch: ((image: HTMLImageElement) => void) | undefined;
+            vi.spyOn(AssetLoader, 'hotReloadImage').mockImplementation(
+                () =>
+                    new Promise((resolve) => {
+                        resolveFetch = resolve;
+                    }),
+            );
             const fakeSheet = {
                 beginHotReplace: vi.fn(),
                 failHotReplace: vi.fn(),
@@ -246,13 +252,27 @@ describe('HotRuntime', () => {
             const handler = registerAndCaptureAssetHandler(HotRuntime);
             handler({ url: 'hero.png', type: 'image', timestamp: 1 });
 
-            await vi.waitFor(() => expect(fakeSheet.hotReplaceImage).toHaveBeenCalledOnce());
+            // The fetch is still pending here - beginHotReplace already ran, hotReplaceImage/failHotReplace have not.
             expect(fakeSheet.beginHotReplace).toHaveBeenCalledOnce();
+            expect(fakeSheet.hotReplaceImage).not.toHaveBeenCalled();
+            expect(fakeSheet.failHotReplace).not.toHaveBeenCalled();
+
+            resolveFetch?.({ width: 8, height: 8 } as HTMLImageElement);
+
+            await vi.waitFor(() =>
+                expect(fakeSheet.hotReplaceImage).toHaveBeenCalledExactlyOnceWith({ width: 8, height: 8 }, null),
+            );
             expect(fakeSheet.failHotReplace).not.toHaveBeenCalled();
         });
 
-        it('marks every registered sheet failed when the replacement fetch itself throws', async () => {
-            vi.spyOn(AssetLoader, 'hotReloadImage').mockRejectedValue(new Error('404'));
+        it('marks every registered sheet failed only once the replacement fetch itself rejects', async () => {
+            let rejectFetch: ((error: Error) => void) | undefined;
+            vi.spyOn(AssetLoader, 'hotReloadImage').mockImplementation(
+                () =>
+                    new Promise((_resolve, reject) => {
+                        rejectFetch = reject;
+                    }),
+            );
             const fakeSheet = {
                 beginHotReplace: vi.fn(),
                 failHotReplace: vi.fn(),
@@ -263,6 +283,13 @@ describe('HotRuntime', () => {
 
             const handler = registerAndCaptureAssetHandler(HotRuntime);
             handler({ url: 'hero.png', type: 'image', timestamp: 1 });
+
+            // The fetch is still pending here - beginHotReplace already ran, failHotReplace has not (yet).
+            expect(fakeSheet.beginHotReplace).toHaveBeenCalledOnce();
+            expect(fakeSheet.failHotReplace).not.toHaveBeenCalled();
+            expect(fakeSheet.hotReplaceImage).not.toHaveBeenCalled();
+
+            rejectFetch?.(new Error('404'));
 
             await vi.waitFor(() => expect(fakeSheet.failHotReplace).toHaveBeenCalledOnce());
             expect(fakeSheet.hotReplaceImage).not.toHaveBeenCalled();

--- a/src/hot/HotRuntime.ts
+++ b/src/hot/HotRuntime.ts
@@ -77,11 +77,34 @@ function isAssetChangedPayload(payload: unknown): payload is AssetChangedPayload
  * `SpriteSheet` registry for any sheet loaded from the same URL and replaces its
  * image in place against the active palette.
  *
+ * Every registered sheet is marked loading before the fetch starts and either
+ * failed (the fetch itself threw) or handed to `hotReplaceImage` (the fetch
+ * resolved), so `SpriteSheet.status`/`progress` track the replacement in flight.
+ *
  * @param url - Changed image URL, matching whatever the engine cached it under.
  */
 async function hotReloadImageAsset(url: string): Promise<void> {
-    const image = await AssetLoader.hotReloadImage(url);
     const sheets = getHotReloadSheets(url);
+
+    if (sheets) {
+        for (const sheet of sheets) {
+            sheet.beginHotReplace();
+        }
+    }
+
+    let image: HTMLImageElement;
+
+    try {
+        image = await AssetLoader.hotReloadImage(url);
+    } catch (error) {
+        if (sheets) {
+            for (const sheet of sheets) {
+                sheet.failHotReplace();
+            }
+        }
+
+        throw error;
+    }
 
     if (!sheets || sheets.size === 0) {
         return;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `BT.loadingAssetsCount` to display an engine-wide count of in-flight image and audio loads.
  - Added per-loader loading counters: `AssetLoader.loadingCount` and `AudioClip.loadingCount`.
  - Added `SpriteSheet.status` (`'loading' | 'ready' | 'failed'`) and coarse `SpriteSheet.progress`, plus lifecycle controls for hot-replacement.
  - Hot-reloading image replacement now updates these `SpriteSheet` lifecycle states on start and failure.

- **Documentation**
  - Updated loading and hot-reload API docs with new counters, status/progress, and usage guidance.

- **Tests**
  - Expanded test coverage for loading counters and sprite-sheet hot-reload state transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->