### PR TITLE
test(renderer): raise src/render/effects unit coverage (BT-326)

### DIFF
--- a/docs/reference-testing.md
+++ b/docs/reference-testing.md
@@ -305,9 +305,15 @@ checks. It does not run unit or visual tests. There is no separate `docs-links` 
 
 <Callout type="warn" title="Visual tests run locally only">
 
-`pnpm run test:visual` requires Chrome with WebGPU and is not executed in GitHub Actions. Run it locally before merging
-renderer, palette, or post-process changes; use `pnpm run test:visual:update` when baselines change intentionally.
-`pnpm run preflight` does not include visual tests.
+`pnpm run test:visual` requires Chrome with WebGPU and is not executed in GitHub Actions. That is intentional: Actions
+minutes are a real cost for a solo project, so visual regression stays a manual gate (the decision recorded on
+[BT-319](https://linear.app/vancura/issue/BT-319/140-cleanup)). Run it locally before merging renderer, palette, or
+post-process changes; use `pnpm run test:visual:update` when baselines change intentionally. `pnpm run preflight` does
+not include visual tests.
+
+Unit-level coverage of `src/render/effects` (enforced by a per-directory Vitest threshold at 80%) is the primary
+automated protection for the post-process path. Visual snapshots remain the pixel-correctness check, but they are not
+what CI gates on.
 
 </Callout>
 

--- a/src/BLIT386.test.ts
+++ b/src/BLIT386.test.ts
@@ -17,6 +17,7 @@ import type { BitmapFont, HardwareSettings } from './BLIT386';
 import { BT, Palette, Rect2i, SpriteSheet, Vector2i } from './BLIT386';
 import { BTAPI } from './core/BTAPI';
 import type { FaceButtonCode } from './input/defaultKeyboardMap';
+import { SoftwareRenderer } from './render/SoftwareRenderer';
 import { DEFAULT_CONTAINER_ID } from './utils/BootstrapHelpers';
 
 const mockHardwareSettings = (displaySize = new Vector2i(320, 240), targetFPS = 60): HardwareSettings => ({
@@ -1494,6 +1495,49 @@ describe('BT.effectAdd / BT.effectRemove / BT.effectClear', () => {
         };
     }
 
+    /** Builds an initialized software renderer for effect-API facade tests. */
+    async function makeSoftwareRenderer(): Promise<SoftwareRenderer> {
+        const canvas = {
+            width: 0,
+            height: 0,
+            style: { width: '', height: '' },
+            getContext: () =>
+                ({
+                    imageSmoothingEnabled: false,
+                    createImageData: (w: number, h: number) =>
+                        ({
+                            data: new Uint8ClampedArray(w * h * 4),
+                            width: w,
+                            height: h,
+                        }) as ImageData,
+                    putImageData: () => {},
+                    clearRect: () => {},
+                    drawImage: () => {},
+                }) as unknown as CanvasRenderingContext2D,
+            toBlob: (_cb: (blob: Blob | null) => void) => {},
+        } as unknown as HTMLCanvasElement;
+        const renderer = new SoftwareRenderer(canvas, new Vector2i(4, 4));
+        await renderer.init();
+        return renderer;
+    }
+
+    /**
+     * Temporarily installs a software renderer on the BTAPI singleton so
+     * {@link BT.effectAdd} / friends reach the real unsupported-effects path.
+     */
+    async function withSoftwareRenderer(callback: () => void | Promise<void>): Promise<void> {
+        const renderer = await makeSoftwareRenderer();
+        const api = BTAPI.instance as unknown as { renderer: SoftwareRenderer | null };
+        const previous = api.renderer;
+        api.renderer = renderer;
+
+        try {
+            await callback();
+        } finally {
+            api.renderer = previous;
+        }
+    }
+
     beforeEach(() => {
         vi.restoreAllMocks();
     });
@@ -1562,50 +1606,36 @@ describe('BT.effectAdd / BT.effectRemove / BT.effectClear', () => {
 
     it('effectAdd shows a clear software-renderer unsupported message', async () => {
         await withErrorContainer(async () => {
-            vi.spyOn(BTAPI.instance, 'getRenderer').mockReturnValue({} as never);
-            vi.spyOn(BTAPI.instance, 'effectAdd').mockImplementation(() => {
-                throw new Error(
-                    "The software renderer doesn't support fullscreen effects. To use post-process effects, set backend to 'webgpu' in configure().",
-                );
+            await withSoftwareRenderer(() => {
+                BT.effectAdd(makeStubEffect());
+
+                const text = document.getElementById(DEFAULT_CONTAINER_ID)?.textContent ?? '';
+                expect(text).toContain("doesn't support fullscreen effects");
+                expect(text).toContain("set backend to 'webgpu' in configure()");
+                expect(text).toContain(SoftwareRenderer.EFFECTS_UNSUPPORTED_MESSAGE);
             });
-
-            BT.effectAdd(makeStubEffect());
-
-            const text = document.getElementById(DEFAULT_CONTAINER_ID)?.textContent ?? '';
-            expect(text).toContain("doesn't support fullscreen effects");
-            expect(text).toContain("set backend to 'webgpu' in configure()");
         });
     });
 
     it('effectRemove shows a clear software-renderer unsupported message', async () => {
         await withErrorContainer(async () => {
-            vi.spyOn(BTAPI.instance, 'getRenderer').mockReturnValue({} as never);
-            vi.spyOn(BTAPI.instance, 'effectRemove').mockImplementation(() => {
-                throw new Error(
-                    "The software renderer doesn't support fullscreen effects. To use post-process effects, set backend to 'webgpu' in configure().",
-                );
+            await withSoftwareRenderer(() => {
+                BT.effectRemove(makeStubEffect());
+
+                const text = document.getElementById(DEFAULT_CONTAINER_ID)?.textContent ?? '';
+                expect(text).toContain(SoftwareRenderer.EFFECTS_UNSUPPORTED_MESSAGE);
             });
-
-            BT.effectRemove(makeStubEffect());
-
-            const text = document.getElementById(DEFAULT_CONTAINER_ID)?.textContent ?? '';
-            expect(text).toContain("doesn't support fullscreen effects");
         });
     });
 
     it('effectClear shows a clear software-renderer unsupported message', async () => {
         await withErrorContainer(async () => {
-            vi.spyOn(BTAPI.instance, 'getRenderer').mockReturnValue({} as never);
-            vi.spyOn(BTAPI.instance, 'effectClear').mockImplementation(() => {
-                throw new Error(
-                    "The software renderer doesn't support fullscreen effects. To use post-process effects, set backend to 'webgpu' in configure().",
-                );
+            await withSoftwareRenderer(() => {
+                BT.effectClear();
+
+                const text = document.getElementById(DEFAULT_CONTAINER_ID)?.textContent ?? '';
+                expect(text).toContain(SoftwareRenderer.EFFECTS_UNSUPPORTED_MESSAGE);
             });
-
-            BT.effectClear();
-
-            const text = document.getElementById(DEFAULT_CONTAINER_ID)?.textContent ?? '';
-            expect(text).toContain("doesn't support fullscreen effects");
         });
     });
 });

--- a/src/render/PostProcessChain.test.ts
+++ b/src/render/PostProcessChain.test.ts
@@ -164,6 +164,14 @@ describe('add()', () => {
         expect(pixelChain.isActive()).toBe(false);
     });
 
+    it('throws when a pixel-tier effect is added to a display chain', () => {
+        const displayChain = new PostProcessChain(createMockGPUDevice(), FORMAT, DISPLAY_SIZE, 'display');
+        const pixelEffect = createStubEffect('pixel');
+
+        expect(() => displayChain.add(pixelEffect)).toThrow(/does not match chain tier/);
+        expect(displayChain.isActive()).toBe(false);
+    });
+
     it('reuses the existing texB when re-adding a second effect after a 2 -> 1 remove', () => {
         const device = createMockGPUDevice();
         const createTexture = vi.spyOn(device, 'createTexture');

--- a/src/render/SoftwareRenderer.test.ts
+++ b/src/render/SoftwareRenderer.test.ts
@@ -311,9 +311,9 @@ describe('SoftwareRenderer', () => {
 
         const effect: Effect = { tier: 'pixel', init: vi.fn(), updateUniforms: vi.fn(), encodePass: vi.fn() };
 
-        expect(() => renderer.addEffect(effect)).toThrow("doesn't support fullscreen effects");
-        expect(() => renderer.removeEffect(effect)).toThrow("doesn't support fullscreen effects");
-        expect(() => renderer.clearEffects()).toThrow("doesn't support fullscreen effects");
+        expect(() => renderer.addEffect(effect)).toThrow(SoftwareRenderer.EFFECTS_UNSUPPORTED_MESSAGE);
+        expect(() => renderer.removeEffect(effect)).toThrow(SoftwareRenderer.EFFECTS_UNSUPPORTED_MESSAGE);
+        expect(() => renderer.clearEffects()).toThrow(SoftwareRenderer.EFFECTS_UNSUPPORTED_MESSAGE);
     });
 
     it('resolves captureFrame on next endFrame', async () => {

--- a/src/render/SoftwareRenderer.ts
+++ b/src/render/SoftwareRenderer.ts
@@ -80,7 +80,12 @@ type Canvas2D = OffscreenCanvasRenderingContext2D | CanvasRenderingContext2D;
  * path, it does not use an `r8uint` index framebuffer.
  */
 export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
-    private static readonly EFFECTS_UNSUPPORTED_MESSAGE =
+    /**
+     * Shared error text for {@link addEffect}, {@link removeEffect}, and
+     * {@link clearEffects}. Kept public so unit tests can assert against the
+     * single source of truth.
+     */
+    static readonly EFFECTS_UNSUPPORTED_MESSAGE =
         "The software renderer doesn't support fullscreen effects. To use post-process effects, set backend to 'webgpu' in configure().";
 
     /** Vertices emitted for one filled rect or sprite quad (matches WebGPU batching). */

--- a/src/render/WebGPURenderer.test.ts
+++ b/src/render/WebGPURenderer.test.ts
@@ -994,7 +994,7 @@ describe('post-process effects', () => {
     });
 
     /** Minimal stub effect that records lifecycle calls. */
-    function createStubEffect(): Effect & {
+    function createStubEffect(tier: Effect['tier'] = 'pixel'): Effect & {
         initSpy: ReturnType<typeof vi.fn>;
         updateSpy: ReturnType<typeof vi.fn>;
         encodeSpy: ReturnType<typeof vi.fn>;
@@ -1010,7 +1010,7 @@ describe('post-process effects', () => {
             updateSpy,
             encodeSpy,
             disposeSpy,
-            tier: 'pixel',
+            tier,
             init: (device, format, displaySize) => initSpy(device, format, displaySize),
             updateUniforms: (deltaMs, sourceSize) => updateSpy(deltaMs, sourceSize),
             encodePass: (encoder, sourceView, destView) => encodeSpy(encoder, sourceView, destView),
@@ -1215,5 +1215,43 @@ describe('post-process effects', () => {
         const resolveAttachment = (resolvePass?.colorAttachments as GPURenderPassColorAttachment[])[0];
         expect(resolveAttachment?.view).toBe(swapView);
         expect(beginRenderPassCalls).toHaveLength(2);
+    });
+
+    it('addEffect throws for display-tier effects when drawingBufferSize is unset', async () => {
+        const r = new WebGPURenderer(createMockGPUDevice(), createMockGPUCanvasContext(), new Vector2i(320, 240));
+        await r.init();
+
+        expect(() => r.addEffect(createStubEffect('display'))).toThrow(
+            /display-tier effects require drawingBufferSize/,
+        );
+    });
+
+    it('routes pixel and display effects into their respective chains when drawingBufferSize is set', async () => {
+        const device = createMockGPUDevice();
+        const displaySize = new Vector2i(320, 240);
+        const drawingBufferSize = new Vector2i(640, 480);
+        const r = new WebGPURenderer(device, createMockGPUCanvasContext(), displaySize, drawingBufferSize);
+
+        await r.init();
+        r.setPalette(createTestPalette());
+
+        const pixelEffect = createStubEffect('pixel');
+        const displayEffect = createStubEffect('display');
+
+        r.addEffect(pixelEffect);
+        r.addEffect(displayEffect);
+
+        expect(pixelEffect.initSpy).toHaveBeenCalledOnce();
+        expect(displayEffect.initSpy).toHaveBeenCalledOnce();
+        expect(pixelEffect.initSpy.mock.calls[0]?.[1]).toBe('r8uint');
+        expect(displayEffect.initSpy.mock.calls[0]?.[1]).not.toBe('r8uint');
+
+        r.beginFrame();
+        r.endFrame();
+
+        expect(pixelEffect.encodeSpy).toHaveBeenCalledTimes(1);
+        expect(displayEffect.encodeSpy).toHaveBeenCalledTimes(1);
+        expect(pixelEffect.updateSpy).toHaveBeenCalledTimes(1);
+        expect(displayEffect.updateSpy).toHaveBeenCalledTimes(1);
     });
 });

--- a/src/render/effects/FullscreenEffect.test.ts
+++ b/src/render/effects/FullscreenEffect.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Unit tests for {@link FullscreenEffect}.
+ *
+ * Covers the shared display-tier base paths that concrete effect suites do not
+ * always hit: uninitialized encode/update early returns, bind-group caching,
+ * and the not-initialized bind-group throw.
+ */
+
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { createMockGPUDevice, installMockNavigatorGPU, uninstallMockNavigatorGPU } from '../../__test__/webgpu-mock';
+import { Vector2i } from '../../utils/Vector2i';
+import { FullscreenEffect } from './FullscreenEffect';
+
+const FORMAT: GPUTextureFormat = 'bgra8unorm';
+const SIZE = new Vector2i(1280, 960);
+
+const STUB_FRAGMENT = /* wgsl */ `
+@fragment
+fn fs_main(@location(0) uv: vec2<f32>) -> @location(0) vec4<f32> {
+    return vec4<f32>(uv, 0.0, 1.0);
+}
+`;
+
+/**
+ * Minimal concrete double for exercising the abstract base class.
+ */
+class StubFullscreenEffect extends FullscreenEffect {
+    readonly tier = 'display' as const;
+
+    protected readonly label = 'StubFullscreenEffect';
+
+    protected readonly uniformBytes = 16;
+
+    protected readonly fragmentShader = STUB_FRAGMENT;
+
+    protected writeUniforms(_deltaMs: number, _sourceSize: Vector2i): void {
+        // No-op: tests do not inspect uniform contents.
+    }
+}
+
+/** Runtime-only access to private GPU handles for guard-path tests. */
+type InternalAccess = {
+    pipeline: GPURenderPipeline | null;
+    device: GPUDevice | null;
+    uniformBuffer: GPUBuffer | null;
+    sampler: GPUSampler | null;
+    bindGroupLayout: GPUBindGroupLayout | null;
+};
+
+function asInternal(fx: FullscreenEffect): InternalAccess {
+    return fx as unknown as InternalAccess;
+}
+
+beforeAll(() => {
+    installMockNavigatorGPU();
+});
+
+afterAll(() => {
+    uninstallMockNavigatorGPU();
+});
+
+describe('FullscreenEffect', () => {
+    it('init creates a pipeline, uniform buffer, and sampler', () => {
+        const device = createMockGPUDevice();
+        const createPipeline = vi.spyOn(device, 'createRenderPipeline');
+        const createBuffer = vi.spyOn(device, 'createBuffer');
+        const createSampler = vi.spyOn(device, 'createSampler');
+        const fx = new StubFullscreenEffect();
+
+        fx.init(device, FORMAT, SIZE);
+
+        expect(createPipeline).toHaveBeenCalledTimes(1);
+        expect(createBuffer).toHaveBeenCalledTimes(1);
+        expect(createSampler).toHaveBeenCalledTimes(1);
+    });
+
+    it('updateUniforms and encodePass are no-ops before init', () => {
+        const device = createMockGPUDevice();
+        const writeBuffer = vi.spyOn(device.queue, 'writeBuffer');
+        const fx = new StubFullscreenEffect();
+        const encoder = device.createCommandEncoder();
+        const beginSpy = vi.spyOn(encoder, 'beginRenderPass');
+
+        fx.updateUniforms(16, SIZE);
+        fx.encodePass(
+            encoder,
+            { label: 'src' } as unknown as GPUTextureView,
+            { label: 'dst' } as unknown as GPUTextureView,
+        );
+
+        expect(writeBuffer).not.toHaveBeenCalled();
+        expect(beginSpy).not.toHaveBeenCalled();
+    });
+
+    it('caches bind groups by sourceView', () => {
+        const device = createMockGPUDevice();
+        const createBindGroup = vi.spyOn(device, 'createBindGroup');
+        const fx = new StubFullscreenEffect();
+        fx.init(device, FORMAT, SIZE);
+
+        const encoder = device.createCommandEncoder();
+        const sourceA = { label: 'src-a' } as unknown as GPUTextureView;
+        const sourceB = { label: 'src-b' } as unknown as GPUTextureView;
+        const dest = { label: 'dst' } as unknown as GPUTextureView;
+
+        fx.encodePass(encoder, sourceA, dest);
+        fx.encodePass(encoder, sourceA, dest);
+        expect(createBindGroup).toHaveBeenCalledTimes(1);
+
+        fx.encodePass(encoder, sourceB, dest);
+        expect(createBindGroup).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws when encodePass runs with a pipeline but missing GPU handles', () => {
+        const fx = new StubFullscreenEffect();
+        const internal = asInternal(fx);
+        internal.pipeline = { label: 'forced' } as unknown as GPURenderPipeline;
+
+        const encoder = createMockGPUDevice().createCommandEncoder();
+
+        expect(() =>
+            fx.encodePass(
+                encoder,
+                { label: 'src' } as unknown as GPUTextureView,
+                { label: 'dst' } as unknown as GPUTextureView,
+            ),
+        ).toThrow('StubFullscreenEffect.encodePass: effect was not initialized.');
+    });
+
+    it('throws when uniformBytes is not a positive multiple of 16', () => {
+        class BadBytesEffect extends FullscreenEffect {
+            readonly tier = 'display' as const;
+            protected readonly label = 'BadBytesEffect';
+            protected readonly uniformBytes = 8;
+            protected readonly fragmentShader = STUB_FRAGMENT;
+            protected writeUniforms(): void {}
+        }
+
+        expect(() => new BadBytesEffect().init(createMockGPUDevice(), FORMAT, SIZE)).toThrow(
+            /uniformBytes must be a positive multiple of 16/,
+        );
+    });
+
+    it('dispose is idempotent', () => {
+        const fx = new StubFullscreenEffect();
+        fx.init(createMockGPUDevice(), FORMAT, SIZE);
+
+        expect(() => {
+            fx.dispose();
+            fx.dispose();
+        }).not.toThrow();
+    });
+});

--- a/src/render/effects/FullscreenPixelEffect.test.ts
+++ b/src/render/effects/FullscreenPixelEffect.test.ts
@@ -17,10 +17,18 @@ const UINT_FORMAT: GPUTextureFormat = 'r8uint';
 const RGBA_FORMAT: GPUTextureFormat = 'rgba8unorm';
 const SIZE = new Vector2i(320, 240);
 
-const STUB_FRAGMENT = /* wgsl */ `
+const STUB_FRAGMENT_RGBA = /* wgsl */ `
 @fragment
 fn fs_main() -> @location(0) vec4<f32> {
     return vec4<f32>(0.0);
+}
+`;
+
+/** Matches the production `r8uint` contract (`fs_main` writes a palette index). */
+const STUB_FRAGMENT_UINT = /* wgsl */ `
+@fragment
+fn fs_main() -> @location(0) u32 {
+    return 0u;
 }
 `;
 
@@ -32,9 +40,9 @@ class StubPixelEffect extends FullscreenPixelEffect {
 
     protected readonly uniformBytes = 16;
 
-    protected readonly fragmentShaderRgba = STUB_FRAGMENT;
+    protected readonly fragmentShaderRgba = STUB_FRAGMENT_RGBA;
 
-    protected readonly fragmentShaderUint = STUB_FRAGMENT;
+    protected readonly fragmentShaderUint = STUB_FRAGMENT_UINT;
 
     protected writeUniforms(_deltaMs: number, _sourceSize: Vector2i): void {
         // No-op: tests do not inspect uniform contents.
@@ -251,8 +259,8 @@ describe('FullscreenPixelEffect uniformBytes validation', () => {
         class BadBytesEffect extends FullscreenPixelEffect {
             protected readonly label = 'BadBytesEffect';
             protected readonly uniformBytes = 8;
-            protected readonly fragmentShaderRgba = STUB_FRAGMENT;
-            protected readonly fragmentShaderUint = STUB_FRAGMENT;
+            protected readonly fragmentShaderRgba = STUB_FRAGMENT_RGBA;
+            protected readonly fragmentShaderUint = STUB_FRAGMENT_UINT;
             protected writeUniforms(): void {}
         }
 

--- a/src/render/effects/FullscreenPixelEffect.test.ts
+++ b/src/render/effects/FullscreenPixelEffect.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Unit tests for {@link FullscreenPixelEffect}.
+ *
+ * Covers the shared `r8uint` / RGBA init paths, bind-group caching, encode-pass
+ * clear values, disposal / re-init, and the defensive uninitialized / missing-
+ * sampler guards. Concrete pixel effects (`PixelGlitch`, `PixelMosaic`) have
+ * their own colocated suites for param layout.
+ */
+
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { createMockGPUDevice, installMockNavigatorGPU, uninstallMockNavigatorGPU } from '../../__test__/webgpu-mock';
+import { Vector2i } from '../../utils/Vector2i';
+import { FullscreenPixelEffect } from './FullscreenPixelEffect';
+
+const UINT_FORMAT: GPUTextureFormat = 'r8uint';
+const RGBA_FORMAT: GPUTextureFormat = 'rgba8unorm';
+const SIZE = new Vector2i(320, 240);
+
+const STUB_FRAGMENT = /* wgsl */ `
+@fragment
+fn fs_main() -> @location(0) vec4<f32> {
+    return vec4<f32>(0.0);
+}
+`;
+
+/**
+ * Minimal concrete double for exercising the abstract base class.
+ */
+class StubPixelEffect extends FullscreenPixelEffect {
+    protected readonly label = 'StubPixelEffect';
+
+    protected readonly uniformBytes = 16;
+
+    protected readonly fragmentShaderRgba = STUB_FRAGMENT;
+
+    protected readonly fragmentShaderUint = STUB_FRAGMENT;
+
+    protected writeUniforms(_deltaMs: number, _sourceSize: Vector2i): void {
+        // No-op: tests do not inspect uniform contents.
+    }
+}
+
+/** Runtime-only access to private GPU handles for guard-path tests. */
+type InternalAccess = {
+    pipeline: GPURenderPipeline | null;
+    device: GPUDevice | null;
+    uniformBuffer: GPUBuffer | null;
+    sampler: GPUSampler | null;
+    attachmentFormat: GPUTextureFormat | null;
+};
+
+function asInternal(fx: FullscreenPixelEffect): InternalAccess {
+    return fx as unknown as InternalAccess;
+}
+
+beforeAll(() => {
+    installMockNavigatorGPU();
+});
+
+afterAll(() => {
+    uninstallMockNavigatorGPU();
+});
+
+describe('FullscreenPixelEffect r8uint path', () => {
+    it('init creates a pipeline and uniform buffer but no sampler', () => {
+        const device = createMockGPUDevice();
+        const createPipeline = vi.spyOn(device, 'createRenderPipeline');
+        const createBuffer = vi.spyOn(device, 'createBuffer');
+        const createSampler = vi.spyOn(device, 'createSampler');
+        const fx = new StubPixelEffect();
+
+        fx.init(device, UINT_FORMAT, SIZE);
+
+        expect(createPipeline).toHaveBeenCalledTimes(1);
+        expect(createBuffer).toHaveBeenCalledTimes(1);
+        expect(createBuffer.mock.calls[0]?.[0]?.size).toBe(16);
+        expect(createSampler).not.toHaveBeenCalled();
+    });
+
+    it('encodePass clears into destView with alpha 0 and builds a uint bind group', () => {
+        const device = createMockGPUDevice();
+        const createBindGroup = vi.spyOn(device, 'createBindGroup');
+        const fx = new StubPixelEffect();
+        fx.init(device, UINT_FORMAT, SIZE);
+
+        const encoder = device.createCommandEncoder();
+        const beginSpy = vi.spyOn(encoder, 'beginRenderPass');
+        const sourceView = { label: 'src' } as unknown as GPUTextureView;
+        const destView = { label: 'dst' } as unknown as GPUTextureView;
+
+        fx.encodePass(encoder, sourceView, destView);
+
+        const passDescriptor = beginSpy.mock.calls[0]?.[0];
+        const firstColorAttachment = passDescriptor?.colorAttachments
+            ? [...passDescriptor.colorAttachments][0]
+            : undefined;
+        expect(firstColorAttachment?.view).toBe(destView);
+        expect(firstColorAttachment?.clearValue).toEqual({ r: 0, g: 0, b: 0, a: 0 });
+
+        expect(createBindGroup).toHaveBeenCalledTimes(1);
+        const entries = [...(createBindGroup.mock.calls[0]?.[0]?.entries ?? [])];
+        expect(entries).toHaveLength(2);
+        expect(entries[0]?.binding).toBe(0);
+        expect(entries[1]?.binding).toBe(1);
+        expect(entries[1]?.resource).toBe(sourceView);
+    });
+
+    it('caches uint bind groups by sourceView', () => {
+        const device = createMockGPUDevice();
+        const createBindGroup = vi.spyOn(device, 'createBindGroup');
+        const fx = new StubPixelEffect();
+        fx.init(device, UINT_FORMAT, SIZE);
+
+        const encoder = device.createCommandEncoder();
+        const sourceA = { label: 'src-a' } as unknown as GPUTextureView;
+        const sourceB = { label: 'src-b' } as unknown as GPUTextureView;
+        const dest = { label: 'dst' } as unknown as GPUTextureView;
+
+        fx.encodePass(encoder, sourceA, dest);
+        fx.encodePass(encoder, sourceA, dest);
+        expect(createBindGroup).toHaveBeenCalledTimes(1);
+
+        fx.encodePass(encoder, sourceB, dest);
+        expect(createBindGroup).toHaveBeenCalledTimes(2);
+    });
+});
+
+describe('FullscreenPixelEffect dispose and re-init', () => {
+    it('dispose is idempotent', () => {
+        const fx = new StubPixelEffect();
+        fx.init(createMockGPUDevice(), UINT_FORMAT, SIZE);
+
+        expect(() => {
+            fx.dispose();
+            fx.dispose();
+        }).not.toThrow();
+    });
+
+    it('re-init with a different format succeeds after dispose', () => {
+        const device = createMockGPUDevice();
+        const createSampler = vi.spyOn(device, 'createSampler');
+        const fx = new StubPixelEffect();
+
+        fx.init(device, UINT_FORMAT, SIZE);
+        expect(createSampler).not.toHaveBeenCalled();
+
+        fx.dispose();
+        fx.init(device, RGBA_FORMAT, SIZE);
+
+        expect(createSampler).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('FullscreenPixelEffect uninitialized guards', () => {
+    it('encodePass is a no-op when the pipeline is null', () => {
+        const device = createMockGPUDevice();
+        const fx = new StubPixelEffect();
+        const encoder = device.createCommandEncoder();
+        const beginSpy = vi.spyOn(encoder, 'beginRenderPass');
+
+        fx.encodePass(
+            encoder,
+            { label: 'src' } as unknown as GPUTextureView,
+            { label: 'dst' } as unknown as GPUTextureView,
+        );
+
+        expect(beginSpy).not.toHaveBeenCalled();
+    });
+
+    it('throws when encodePass runs with a pipeline but missing GPU handles', () => {
+        const fx = new StubPixelEffect();
+        const internal = asInternal(fx);
+        internal.pipeline = { label: 'forced' } as unknown as GPURenderPipeline;
+        internal.attachmentFormat = UINT_FORMAT;
+
+        const encoder = createMockGPUDevice().createCommandEncoder();
+
+        expect(() =>
+            fx.encodePass(
+                encoder,
+                { label: 'src' } as unknown as GPUTextureView,
+                { label: 'dst' } as unknown as GPUTextureView,
+            ),
+        ).toThrow('StubPixelEffect.encodePass: effect was not initialized.');
+    });
+});
+
+describe('FullscreenPixelEffect RGBA fallback path', () => {
+    it('init creates a nearest sampler for non-r8uint formats', () => {
+        const device = createMockGPUDevice();
+        const createSampler = vi.spyOn(device, 'createSampler');
+        const fx = new StubPixelEffect();
+
+        fx.init(device, RGBA_FORMAT, SIZE);
+
+        expect(createSampler).toHaveBeenCalledTimes(1);
+        expect(createSampler.mock.calls[0]?.[0]?.magFilter).toBe('nearest');
+        expect(createSampler.mock.calls[0]?.[0]?.minFilter).toBe('nearest');
+    });
+
+    it('encodePass uses float clear alpha 1 and includes the sampler at binding 2', () => {
+        const device = createMockGPUDevice();
+        const createBindGroup = vi.spyOn(device, 'createBindGroup');
+        const fx = new StubPixelEffect();
+        fx.init(device, RGBA_FORMAT, SIZE);
+
+        const encoder = device.createCommandEncoder();
+        const beginSpy = vi.spyOn(encoder, 'beginRenderPass');
+        const sourceView = { label: 'src' } as unknown as GPUTextureView;
+        const destView = { label: 'dst' } as unknown as GPUTextureView;
+
+        fx.encodePass(encoder, sourceView, destView);
+
+        const passDescriptor = beginSpy.mock.calls[0]?.[0];
+        const firstColorAttachment = passDescriptor?.colorAttachments
+            ? [...passDescriptor.colorAttachments][0]
+            : undefined;
+        expect(firstColorAttachment?.clearValue).toEqual({ r: 0, g: 0, b: 0, a: 1 });
+
+        const entries = [...(createBindGroup.mock.calls[0]?.[0]?.entries ?? [])];
+        expect(entries).toHaveLength(3);
+        expect(entries[0]?.binding).toBe(0);
+        expect(entries[1]?.binding).toBe(1);
+        expect(entries[1]?.resource).toBe(sourceView);
+        expect(entries[2]?.binding).toBe(2);
+        expect(entries[2]?.resource).toBe(asInternal(fx).sampler);
+    });
+
+    it('throws when the RGBA cache path is entered without a sampler', () => {
+        const device = createMockGPUDevice();
+        const fx = new StubPixelEffect();
+        fx.init(device, RGBA_FORMAT, SIZE);
+
+        asInternal(fx).sampler = null;
+
+        const encoder = device.createCommandEncoder();
+
+        expect(() =>
+            fx.encodePass(
+                encoder,
+                { label: 'src' } as unknown as GPUTextureView,
+                { label: 'dst' } as unknown as GPUTextureView,
+            ),
+        ).toThrow('StubPixelEffect.encodePass: sampler missing for RGBA pixel chain.');
+    });
+});
+
+describe('FullscreenPixelEffect uniformBytes validation', () => {
+    it('throws when uniformBytes is not a positive multiple of 16', () => {
+        class BadBytesEffect extends FullscreenPixelEffect {
+            protected readonly label = 'BadBytesEffect';
+            protected readonly uniformBytes = 8;
+            protected readonly fragmentShaderRgba = STUB_FRAGMENT;
+            protected readonly fragmentShaderUint = STUB_FRAGMENT;
+            protected writeUniforms(): void {}
+        }
+
+        expect(() => new BadBytesEffect().init(createMockGPUDevice(), UINT_FORMAT, SIZE)).toThrow(
+            /uniformBytes must be a positive multiple of 16/,
+        );
+    });
+});

--- a/src/render/effects/pixel/PixelGlitch.test.ts
+++ b/src/render/effects/pixel/PixelGlitch.test.ts
@@ -56,4 +56,33 @@ describe('PixelGlitch', () => {
         expect(buf[3]).toBeCloseTo(6);
         expect(buf[4]).toBeCloseTo(12);
     });
+
+    it('encodePass renders into destView with r8uint clear', () => {
+        const device = createMockGPUDevice();
+        const fx = new PixelGlitch();
+        fx.init(device, FORMAT, SIZE);
+
+        const encoder = device.createCommandEncoder();
+        const beginSpy = vi.spyOn(encoder, 'beginRenderPass');
+
+        fx.encodePass(
+            encoder,
+            { label: 'src' } as unknown as GPUTextureView,
+            { label: 'dst' } as unknown as GPUTextureView,
+        );
+
+        const passDescriptor = beginSpy.mock.calls[0]?.[0];
+        const firstColorAttachment = passDescriptor?.colorAttachments
+            ? [...passDescriptor.colorAttachments][0]
+            : undefined;
+        expect(firstColorAttachment?.view.label).toBe('dst');
+        expect(firstColorAttachment?.clearValue).toEqual({ r: 0, g: 0, b: 0, a: 0 });
+    });
+
+    it('dispose is safe to call multiple times', () => {
+        const fx = new PixelGlitch();
+        fx.init(createMockGPUDevice(), FORMAT, SIZE);
+        fx.dispose();
+        fx.dispose();
+    });
 });

--- a/src/render/effects/pixel/PixelGlitch.test.ts
+++ b/src/render/effects/pixel/PixelGlitch.test.ts
@@ -64,18 +64,15 @@ describe('PixelGlitch', () => {
 
         const encoder = device.createCommandEncoder();
         const beginSpy = vi.spyOn(encoder, 'beginRenderPass');
+        const destView = { label: 'dst' } as unknown as GPUTextureView;
 
-        fx.encodePass(
-            encoder,
-            { label: 'src' } as unknown as GPUTextureView,
-            { label: 'dst' } as unknown as GPUTextureView,
-        );
+        fx.encodePass(encoder, { label: 'src' } as unknown as GPUTextureView, destView);
 
         const passDescriptor = beginSpy.mock.calls[0]?.[0];
         const firstColorAttachment = passDescriptor?.colorAttachments
             ? [...passDescriptor.colorAttachments][0]
             : undefined;
-        expect(firstColorAttachment?.view.label).toBe('dst');
+        expect(firstColorAttachment?.view).toBe(destView);
         expect(firstColorAttachment?.clearValue).toEqual({ r: 0, g: 0, b: 0, a: 0 });
     });
 

--- a/src/render/effects/pixel/PixelMosaic.test.ts
+++ b/src/render/effects/pixel/PixelMosaic.test.ts
@@ -43,4 +43,33 @@ describe('PixelMosaic', () => {
         const buf = writeBuffer.mock.calls[0]?.[2] as Float32Array;
         expect(buf[2]).toBeCloseTo(8);
     });
+
+    it('encodePass renders into destView with r8uint clear', () => {
+        const device = createMockGPUDevice();
+        const fx = new PixelMosaic();
+        fx.init(device, FORMAT, SIZE);
+
+        const encoder = device.createCommandEncoder();
+        const beginSpy = vi.spyOn(encoder, 'beginRenderPass');
+
+        fx.encodePass(
+            encoder,
+            { label: 'src' } as unknown as GPUTextureView,
+            { label: 'dst' } as unknown as GPUTextureView,
+        );
+
+        const passDescriptor = beginSpy.mock.calls[0]?.[0];
+        const firstColorAttachment = passDescriptor?.colorAttachments
+            ? [...passDescriptor.colorAttachments][0]
+            : undefined;
+        expect(firstColorAttachment?.view.label).toBe('dst');
+        expect(firstColorAttachment?.clearValue).toEqual({ r: 0, g: 0, b: 0, a: 0 });
+    });
+
+    it('dispose is safe to call multiple times', () => {
+        const fx = new PixelMosaic();
+        fx.init(createMockGPUDevice(), FORMAT, SIZE);
+        fx.dispose();
+        fx.dispose();
+    });
 });

--- a/src/render/effects/pixel/PixelMosaic.test.ts
+++ b/src/render/effects/pixel/PixelMosaic.test.ts
@@ -51,18 +51,15 @@ describe('PixelMosaic', () => {
 
         const encoder = device.createCommandEncoder();
         const beginSpy = vi.spyOn(encoder, 'beginRenderPass');
+        const destView = { label: 'dst' } as unknown as GPUTextureView;
 
-        fx.encodePass(
-            encoder,
-            { label: 'src' } as unknown as GPUTextureView,
-            { label: 'dst' } as unknown as GPUTextureView,
-        );
+        fx.encodePass(encoder, { label: 'src' } as unknown as GPUTextureView, destView);
 
         const passDescriptor = beginSpy.mock.calls[0]?.[0];
         const firstColorAttachment = passDescriptor?.colorAttachments
             ? [...passDescriptor.colorAttachments][0]
             : undefined;
-        expect(firstColorAttachment?.view.label).toBe('dst');
+        expect(firstColorAttachment?.view).toBe(destView);
         expect(firstColorAttachment?.clearValue).toEqual({ r: 0, g: 0, b: 0, a: 0 });
     });
 

--- a/src/render/effects/writeUniformsGuards.test.ts
+++ b/src/render/effects/writeUniformsGuards.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Covers the defensive `writeUniforms` null-`uniformData` early return shared by
+ * every concrete pixel and display effect. That branch is unreachable through
+ * {@link FullscreenEffect.updateUniforms} / {@link FullscreenPixelEffect.updateUniforms}
+ * (those methods return earlier), so it is exercised here via a protected-method cast.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { Vector2i } from '../../utils/Vector2i';
+import { BarrelDistortion } from './display/BarrelDistortion';
+import { Bloom } from './display/Bloom';
+import { ChromaticAberration } from './display/ChromaticAberration';
+import { Flicker } from './display/Flicker';
+import { Interference } from './display/Interference';
+import { Noise } from './display/Noise';
+import { RGBMask } from './display/RGBMask';
+import { RollLine } from './display/RollLine';
+import { Scanlines } from './display/Scanlines';
+import { Vignette } from './display/Vignette';
+import type { Effect } from './Effect';
+import { PixelGlitch } from './pixel/PixelGlitch';
+import { PixelMosaic } from './pixel/PixelMosaic';
+
+type WritableUniforms = Effect & {
+    writeUniforms: (deltaMs: number, sourceSize: Vector2i) => void;
+};
+
+const SIZE = new Vector2i(320, 240);
+
+const EFFECTS: Array<{ name: string; create: () => WritableUniforms }> = [
+    { name: 'BarrelDistortion', create: () => new BarrelDistortion() as unknown as WritableUniforms },
+    { name: 'Bloom', create: () => new Bloom() as unknown as WritableUniforms },
+    { name: 'ChromaticAberration', create: () => new ChromaticAberration() as unknown as WritableUniforms },
+    { name: 'Flicker', create: () => new Flicker() as unknown as WritableUniforms },
+    { name: 'Interference', create: () => new Interference() as unknown as WritableUniforms },
+    { name: 'Noise', create: () => new Noise() as unknown as WritableUniforms },
+    { name: 'RGBMask', create: () => new RGBMask() as unknown as WritableUniforms },
+    { name: 'RollLine', create: () => new RollLine() as unknown as WritableUniforms },
+    { name: 'Scanlines', create: () => new Scanlines() as unknown as WritableUniforms },
+    { name: 'Vignette', create: () => new Vignette() as unknown as WritableUniforms },
+    { name: 'PixelGlitch', create: () => new PixelGlitch() as unknown as WritableUniforms },
+    { name: 'PixelMosaic', create: () => new PixelMosaic() as unknown as WritableUniforms },
+];
+
+describe('concrete effect writeUniforms null guards', () => {
+    it.each(EFFECTS)('$name writeUniforms no-ops when uniformData is null', ({ create }) => {
+        const fx = create();
+
+        expect(() => fx.writeUniforms(16, SIZE)).not.toThrow();
+    });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,6 +18,13 @@ export default defineConfig({
                 branches: 80,
                 functions: 80,
                 lines: 80,
+                // Glob thresholds do not inherit the global values above.
+                'src/render/effects/**': {
+                    statements: 80,
+                    branches: 80,
+                    functions: 80,
+                    lines: 80,
+                },
             },
             reporter: ['text', 'text-summary', 'lcov', 'json'],
             reportsDirectory: 'coverage',


### PR DESCRIPTION
## Summary
- Add base-class unit coverage for `FullscreenPixelEffect` / `FullscreenEffect` (r8uint + RGBA paths, bind-group caching, dispose/re-init, uninitialized guards) and extend `PixelGlitch` / `PixelMosaic` with `encodePass` + dispose cases.
- Cover pixel vs display tier dispatch in `WebGPURenderer` / `PostProcessChain`, and wire a real `SoftwareRenderer` through `BT.effectAdd` so the unsupported-effects message stays single-sourced via `SoftwareRenderer.EFFECTS_UNSUPPORTED_MESSAGE`.
- Enforce an 80% per-directory Vitest coverage threshold for `src/render/effects/**` and document why visual regression stays local-only (BT-319 / Actions minutes).

## Test plan
- [x] `pnpm run test:unit:coverage` passes global + `src/render/effects/**` thresholds
- [x] `pnpm run preflight` green
- [ ] CI green on this PR
- [ ] Optional local: `pnpm run test:visual` if reviewing renderer risk (not required for this test-only PR)

Fixes BT-326

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified local-only visual regression testing instructions, including pre-merge responsibilities for renderer/palette/post-process changes, plus explicit limits of `preflight` coverage.

* **Tests**
  * Expanded unit test coverage across rendering effects, including fullscreen effect base behavior, pixel and pixel-tier effects, uniform-guard no-ops, idempotent `dispose`, bind-group caching, and error handling for unsupported software-renderer fullscreen effects.
  * Added post-process chain tier-mismatch validation and multi-tier WebGPU post-process behavior.
  
* **Chores**
  * Set an 80% coverage threshold override for `src/render/effects/**`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->