### PR TITLE
docs(changelog): document asset loading progress API (BT-327)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -40,6 +40,10 @@ notes, including dependency bumps and CI changes omitted here for brevity.
   swap their decoded buffer (stopping SFX voices on the old buffer and restarting the music player if the replaced clip
   is the current track), and bitmap fonts rebuild their glyph tables and texture - all without a page reload. Adoption
   in `blit386-demos`/`create-blit386` ships in a follow-up release.
+- Asset loading progress: `BT.loadingAssetsCount` is polled once per frame as a combined image+audio signal (the sum of
+  `AssetLoader.loadingCount` and `AudioClip.loadingCount`) to drive a loading spinner or progress bar until it returns
+  to `0`. `SpriteSheet.status` (`'loading' | 'ready' | 'failed'`) and `SpriteSheet.progress` expose per-sheet hot-reload
+  replacement state; `progress` is coarse-grained (`0` or `1.0`, not a percentage).
 
 ### Fixed
 


### PR DESCRIPTION
## Summary
- Add the missing `## 1.4.0 - Unreleased` → `### Added` changelog entry for the asset-loading-progress API from BT-274 / #388
- Document `BT.loadingAssetsCount`, `AssetLoader.loadingCount`, `AudioClip.loadingCount`, and `SpriteSheet.status`/`SpriteSheet.progress` in the section's editorial voice (poll once per frame for a loading screen; coarse-grained per-sheet hot-reload progress)
- Completes coverage of the 14 `@since 1.4.0` symbols alongside the existing hot-reload / `blit386/vite` / `AssetLoader.evict` bullets

Closes BT-327

## Test plan
- [x] `pnpm run docs:links`
- [x] `pnpm run spellcheck`
- [x] `pnpm run preflight`
- [ ] Confirm the new bullet sits after the three existing `Added` bullets and before `### Fixed`
- [ ] Spot-check voice against neighboring 1.4.0 entries (subsystem label, inline code, ~120-char wrap)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added changelog details for asset loading progress.
  - Documented aggregated image and audio loading progress reporting.
  - Documented sprite sheet hot-reload status and progress indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->