### PR TITLE
ci: close preflight and CI gate gaps

### DIFF
--- a/.claude/rules/rtk-and-pnpm.md
+++ b/.claude/rules/rtk-and-pnpm.md
@@ -6,7 +6,8 @@ Condensed mirror of `.cursor/rules/rtk-and-pnpm.mdc`.
   rewrite.
 - **`pnpm run preflight`** runs: `format:check`, `lint`, `typecheck`, `spellcheck`, `knip`, `docs:links`,
   `agents:check`, `sync:doc-banners:check`, `sync:cursor-commands:check`, `api:since:check`, `api:history:check`,
-  `test:unit`, `test:declarations`, `test:agent-config`, `test:cursor-commands`.
+  `test:unit`, `test:declarations`, `test:agent-config`, `test:cursor-commands`, `test:api-history`,
+  `test:security-preflight`.
 - Built-ins without `run`: `pnpm install`, `pnpm audit`, `pnpm exec`, `pnpm add`, `pnpm --filter …`.
 - Claude Code: `PreToolUse` → `rtk hook claude` on the Bash matcher; `PostToolUse` on Edit/MultiEdit/Write runs Biome
   and Prettier formatting, then a cspell check (see `.claude/settings.json`).

--- a/.cursor/rules/rtk-and-pnpm.mdc
+++ b/.cursor/rules/rtk-and-pnpm.mdc
@@ -8,7 +8,8 @@ alwaysApply: true
 - Package scripts: **`pnpm run <script>`** only (e.g. `pnpm run preflight`). Bare `pnpm preflight` skips RTK rewrite.
 - **`pnpm run preflight`** runs: `format:check`, `lint`, `typecheck`, `spellcheck`, `knip`, `docs:links`,
   `agents:check`, `sync:doc-banners:check`, `sync:cursor-commands:check`, `api:since:check`, `api:history:check`,
-  `test:unit`, `test:declarations`, `test:agent-config`, `test:cursor-commands`.
+  `test:unit`, `test:declarations`, `test:agent-config`, `test:cursor-commands`, `test:api-history`,
+  `test:security-preflight`.
 - Built-ins without `run`: `pnpm install`, `pnpm audit`, `pnpm exec`, `pnpm add`, `pnpm --filter …`.
 - Cursor: `preToolUse` → `rtk hook cursor` on Shell; `afterFileEdit` → `.cursor/hooks/format-and-check.sh` (see
   `.cursor/hooks.json`).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   security-audit:
     name: Dependency Security Audit
@@ -115,6 +119,14 @@ jobs:
         run: pnpm run knip
         background: true
 
+      - name: Check API @since tags
+        run: pnpm run api:since:check
+        background: true
+
+      - name: Check API history manifest
+        run: pnpm run api:history:check
+        background: true
+
       - wait-all:
 
   build-library:
@@ -149,7 +161,7 @@ jobs:
           NODE_ENV: production
 
       - name: Verify declaration tooling alignment
-        run: node scripts/check-declaration-tooling.mjs build.log
+        run: pnpm run build:check-declarations build.log
 
       - name: Upload library artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -438,6 +450,12 @@ jobs:
 
       - name: Run unit tests with coverage
         run: pnpm run test:unit:coverage
+
+      - name: Run API history generator tests
+        run: pnpm run test:api-history
+
+      - name: Run security preflight tests
+        run: pnpm run test:security-preflight
 
       - name: Upload coverage
         uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,9 @@ on:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  # Prefer PR number over head_ref so two forks/PRs with the same branch name do not
+  # cancel each other. Mirrors the benchmark job group below.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # api:history:check resolves release dates from git tags; without them dates go null and the
+          # committed docs/_api-history.json versions map looks drifted.
+          fetch-tags: true
 
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
@@ -433,6 +437,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # test:api-history's resolveTagDate integration cases need real release tags present.
+          fetch-tags: true
 
       - name: Setup pnpm
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -378,7 +378,7 @@ pnpm run spellcheck         # cspell check
 pnpm run knip               # Find unused exports/deps
 pnpm run docs:links         # Check Markdown links (all repo-root *.md / *.mdx)
 pnpm run agents:check       # Check agent config drift (rules parity, skills symlinks, AGENTS.md <-> CLAUDE.md pointer)
-pnpm run preflight          # All checks (format + lint + typecheck + spellcheck + knip + docs:links + agents:check + sync:doc-banners:check + sync:cursor-commands:check + api:since:check + api:history:check + test:unit + test:declarations + test:agent-config + test:cursor-commands)
+pnpm run preflight          # All checks (format + lint + typecheck + spellcheck + knip + docs:links + agents:check + sync:doc-banners:check + sync:cursor-commands:check + api:since:check + api:history:check + test:unit + test:declarations + test:agent-config + test:cursor-commands + test:api-history + test:security-preflight)
 ```
 
 RTK: Shell commands are rewritten via `rtk hook cursor` (Cursor) / `rtk hook claude` (Claude Code). Use `pnpm run …` for

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,6 +165,8 @@ This runs:
 - Declaration tooling tests (`test:declarations`)
 - Agent config drift checker tests (`test:agent-config`)
 - Cursor commands drift checker tests (`test:cursor-commands`)
+- API history generator tests (`test:api-history`)
+- Security preflight tests (`test:security-preflight`)
 
 ### Available Commands
 
@@ -185,6 +187,8 @@ pnpm run test:unit        # Run unit tests
 pnpm run test:declarations # Declaration tooling checker tests
 pnpm run test:agent-config # Agent config drift checker tests
 pnpm run test:cursor-commands # Cursor commands drift checker tests
+pnpm run test:api-history # API history generator tests
+pnpm run test:security-preflight # Security preflight tests
 pnpm run test:visual      # Playwright visual regression (local; not in preflight)
 pnpm run bench            # CPU benchmarks (Vitest bench)
 pnpm run preflight        # Run all quality checks

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "test:visual": "playwright test",
     "test:visual:update": "playwright test --update-snapshots",
     "test:visual:coverage": "VISUAL_COVERAGE=1 playwright test && nyc report --reporter=lcov --reporter=text-summary --temp-dir=.nyc_output --report-dir=coverage-visual",
-    "preflight": "pnpm run format:check && pnpm run lint && pnpm run typecheck && pnpm run spellcheck && pnpm run knip && pnpm run docs:links && pnpm run agents:check && pnpm run sync:doc-banners:check && pnpm run sync:cursor-commands:check && pnpm run api:since:check && pnpm run api:history:check && pnpm run test:unit && pnpm run test:declarations && pnpm run test:agent-config && pnpm run test:cursor-commands",
+    "preflight": "pnpm run format:check && pnpm run lint && pnpm run typecheck && pnpm run spellcheck && pnpm run knip && pnpm run docs:links && pnpm run agents:check && pnpm run sync:doc-banners:check && pnpm run sync:cursor-commands:check && pnpm run api:since:check && pnpm run api:history:check && pnpm run test:unit && pnpm run test:declarations && pnpm run test:agent-config && pnpm run test:cursor-commands && pnpm run test:api-history && pnpm run test:security-preflight",
     "clean": "rm -rf dist node_modules/.vite",
     "release": "pnpm run build && pnpm publish",
     "knip": "knip",


### PR DESCRIPTION
## Summary
- Align `preflight` with its docs mirrors by appending `test:api-history` and `test:security-preflight`, and update `CONTRIBUTING.md`, `CLAUDE.md`, and the RTK/pnpm rule mirrors.
- Close CI coverage gaps: run `api:since:check` / `api:history:check` in `quality`, run the two new suites in `test`, route declaration verify through `pnpm run build:check-declarations build.log`, and add PR-scoped top-level concurrency so duplicate PR runs cancel while push-to-main baseline uploads never do.
- SHA-pin `actions/checkout` in `dco.yml` to match the rest of the workflows.
- Follow-ups on the same branch: `fetch-tags: true` for api-history jobs (BT-337); concurrency group keyed by PR number (CodeRabbit).

Closes BT-328 (sub-issue of BT-319). Also covers BT-337.

## Test plan
- [x] `pnpm run agents:check` green
- [x] `pnpm run test:api-history` and `pnpm run test:security-preflight` green
- [x] `pnpm run preflight` green (includes the two new suites)
- [x] Confirmed `pnpm run build:check-declarations <log>` forwards the log path
- [x] CI green on this PR (`quality` shows the two API checks; `test` shows the two new suites; `build-library` uses the npm script; concurrency present)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded `preflight` checks to include API history and security validation.
* **CI Improvements**
  * CI now runs API history and security preflight checks during test/quality workflows.
  * Quality checks fetch repository tags to resolve release-date information correctly.
  * Added workflow concurrency to prevent overlapping runs.
* **Documentation**
  * Updated contributor and run-convention guidance to reflect the expanded `preflight` suite.
* **Security**
  * Added/covered security preflight validation in automated checks.
* **Chores**
  * Pinned the DCO workflow checkout action for consistent verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->