### PR TITLE
fix(ci): repair Renovate config and align release-age policy

### DIFF
--- a/docs/developer-experience-guide.md
+++ b/docs/developer-experience-guide.md
@@ -267,10 +267,15 @@ job in `ci.yml`) and a retired skill's stale command file is removed automatical
 Renovate is configured (`renovate.json` at the project root). Dependency update PRs open automatically each Monday
 before 6 AM:
 
-- Patch updates and GitHub Actions updates: auto-merge after 3 days
+- Patch updates and GitHub Actions updates: auto-merge after 7 days (`minimumReleaseAge`, aligned with `.npmrc`
+  `minimum-release-age`)
 - Minor updates: manual review required
 - Major updates: manual review with `major-update` label
 - Vulnerability alerts are enabled
+- GitHub Actions stay digest-pinned (SHA plus trailing `# vN` comment) via `helpers:pinGitHubActionDigests`
+
+Dependabot remains enabled for security-only updates; Renovate owns version and Actions bumps. See
+[dependency-policy.md](security/dependency-policy.md#renovate-vs-dependabot).
 
 CI workflows pin third-party actions by commit SHA (not `@vN` tags). See
 [dependency-policy.md](security/dependency-policy.md#github-actions-pinning) for bumping SHAs and job permissions.

--- a/docs/security/dependency-policy.md
+++ b/docs/security/dependency-policy.md
@@ -35,8 +35,15 @@ re-running both commands.
 | Manual (monthly)    | Review `pnpm outdated`; run the [security runbook](./security-runbook.md) MCP preflight and audits                                      |
 | Per release         | Run `pnpm run security:audit` and `pnpm run security:audit:prod` before tagging                                                         |
 
-Patch updates for GitHub Actions and npm patches may automerge per [renovate.json](../../renovate.json). Minor and major
-updates require manual review.
+Patch updates for GitHub Actions and npm patches may automerge after 7 days (`minimumReleaseAge`), matching
+[`.npmrc`](../../.npmrc) `minimum-release-age` (10080 minutes), per [renovate.json](../../renovate.json). Minor and
+major updates require manual review.
+
+### Renovate vs Dependabot
+
+Dependabot stays enabled for security-only alerts and updates (no `.github/dependabot.yml`, so it does not open version
+or GitHub Actions PRs). Renovate owns version bumps, grouping, automerge, and GitHub Actions digest pinning. That split
+keeps the two systems from opening competing PRs for the same dependency.
 
 ## Supply-chain settings
 
@@ -56,10 +63,13 @@ job adds `actions: read` and `pull-requests: write` only where artifact lookup a
 
 ### Bumping pinned actions
 
-| Path    | Who updates SHAs                                                                                                      |
-| ------- | --------------------------------------------------------------------------------------------------------------------- |
-| Routine | [Renovate](../../renovate.json) `github-actions` manager – grouped PRs, 3-day `minimumReleaseAge`, patch automerge    |
-| Manual  | Resolve the release tag commit on the action repo, replace the SHA in the workflow, keep or update the `# vN` comment |
+Renovate extends `helpers:pinGitHubActionDigests`, so action references stay pinned to a 40-character commit SHA with a
+trailing `# vN` comment, and routine bumps update the SHA and comment together.
+
+| Path    | Who updates SHAs                                                                                                                   |
+| ------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Routine | [Renovate](../../renovate.json) `github-actions` manager – grouped PRs, 7-day `minimumReleaseAge`, patch automerge, digest pinning |
+| Manual  | Resolve the release tag commit on the action repo, replace the SHA in the workflow, keep or update the `# vN` comment              |
 
 After any workflow edit, confirm the affected jobs still pass in CI (artifact upload, Codecov, benchmark baseline
 lookup, PR benchmark comments).

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", ":dependencyDashboard", ":semanticCommits"],
+  "extends": ["config:recommended", ":dependencyDashboard", ":semanticCommits", "helpers:pinGitHubActionDigests"],
   "timezone": "Europe/Prague",
   "schedule": ["before 6am on Monday"],
   "rangeStrategy": "bump",
@@ -9,6 +9,7 @@
   "prConcurrentLimit": 5,
   "prHourlyLimit": 4,
   "automerge": false,
+  "internalChecksFilter": "strict",
   "packageRules": [
     {
       "description": "Core build tools",
@@ -17,17 +18,17 @@
     },
     {
       "description": "Vite plugins",
-      "matchPackageNames": ["^vite-plugin-"],
+      "matchPackageNames": ["vite-plugin-*"],
       "groupName": "vite plugins"
     },
     {
       "description": "Linting and formatting tools",
-      "matchPackageNames": ["eslint", "prettier", "biome"],
+      "matchPackageNames": ["eslint", "prettier", "@biomejs/biome"],
       "groupName": "linting and formatting"
     },
     {
       "description": "TypeScript type definitions",
-      "matchPackageNames": ["^@types/"],
+      "matchPackageNames": ["@types/*"],
       "groupName": "type definitions"
     },
     {
@@ -36,7 +37,7 @@
       "groupName": "github actions",
       "automerge": true,
       "automergeType": "pr",
-      "minimumReleaseAge": "3 days"
+      "minimumReleaseAge": "7 days"
     },
     {
       "description": "All patches - automerge",
@@ -44,7 +45,7 @@
       "matchPackageNames": ["*"],
       "automerge": true,
       "automergeType": "pr",
-      "minimumReleaseAge": "3 days"
+      "minimumReleaseAge": "7 days"
     },
     {
       "description": "Minor updates - manual review",
@@ -56,19 +57,6 @@
       "matchUpdateTypes": ["major"],
       "automerge": false,
       "labels": ["dependencies", "major-update"]
-    },
-    {
-      "description": "GitHub Actions",
-      "matchManagers": ["github-actions"],
-      "groupName": "github actions",
-      "automerge": true,
-      "automergeType": "pr",
-      "minimumReleaseAge": "3 days"
-    },
-    {
-      "description": "Pin pnpm version",
-      "matchPackageNames": ["pnpm"],
-      "rangeStrategy": "pin"
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## Summary

- Repair dormant `renovate.json`: drop the duplicated GitHub Actions rule and inert `pnpm` pin, rewrite vite/`@types`/`@biomejs/biome` matchers so they match real packages, raise `minimumReleaseAge` to 7 days (aligned with `.npmrc`), and extend `helpers:pinGitHubActionDigests` plus `internalChecksFilter: "strict"`.
- Document the Dependabot (security-only) vs Renovate (versions + Actions digests) split in `docs/security/dependency-policy.md` and update the DX guide automerge wording.

Closes BT-329.

## Test plan

- [x] `npx --yes --package renovate renovate-config-validator renovate.json` (config validated successfully)
- [x] `pnpm run preflight`
- [ ] Install Renovate GitHub App on `blit386/blit386`
- [ ] Confirm Dependency Dashboard issue + `renovate/*` branches after first run
- [ ] Confirm Dependabot security updates remain enabled (no `.github/dependabot.yml`)
- [ ] Review/merge first Renovate PR batch (vite plugins, `@types/*`, `@biomejs/biome`, Actions SHA + `# vN`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified dependency update policies, including review requirements for minor and major updates.
  * Documented the separation between routine dependency updates and security-only alerts.
  * Added guidance on keeping GitHub Actions securely pinned to specific versions.

* **Chores**
  * Updated automated dependency management to allow eligible patch updates after a seven-day release period.
  * Improved dependency grouping and validation to reduce conflicting or unnecessary update requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->