### PR TITLE
fix(ci): align Renovate commits with DCO and commitlint

### DIFF
--- a/docs/developer-experience-guide.md
+++ b/docs/developer-experience-guide.md
@@ -273,6 +273,8 @@ before 6 AM:
 - Major updates: manual review with `major-update` label
 - Vulnerability alerts are enabled
 - GitHub Actions stay digest-pinned (SHA plus trailing `# vN` comment) via `helpers:pinGitHubActionDigests`
+- Renovate commits use a lowercase subject (`commitMessageAction: "update"`) and the `:gitSignOff` preset so they pass
+  commitlint and the DCO check
 
 Dependabot remains enabled for security-only updates; Renovate owns version and Actions bumps. See
 [dependency-policy.md](security/dependency-policy.md#renovate-vs-dependabot).

--- a/docs/security/dependency-policy.md
+++ b/docs/security/dependency-policy.md
@@ -45,6 +45,10 @@ Dependabot stays enabled for security-only alerts and updates (no `.github/depen
 or GitHub Actions PRs). Renovate owns version bumps, grouping, automerge, and GitHub Actions digest pinning. That split
 keeps the two systems from opening competing PRs for the same dependency.
 
+Renovate commits are shaped for this repo's gates: lowercase subjects (`commitMessageAction: "update"`) for commitlint,
+and the `:gitSignOff` preset for the DCO workflow. Workflow `node` / `pnpm` version pins are left to the
+`packageManager` / `engines` managers so Actions PRs do not drift away from `package.json`.
+
 ## Supply-chain settings
 
 [`.npmrc`](../../.npmrc) enables `minimum-release-age` (7 days) and related pnpm 10 hardening. Security-patched packages

--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,18 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", ":dependencyDashboard", ":semanticCommits", "helpers:pinGitHubActionDigests"],
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommits",
+    "helpers:pinGitHubActionDigests",
+    ":gitSignOff"
+  ],
   "timezone": "Europe/Prague",
   "schedule": ["before 6am on Monday"],
   "rangeStrategy": "bump",
   "labels": ["dependencies"],
   "commitMessagePrefix": "chore(deps):",
+  "commitMessageAction": "update",
   "prConcurrentLimit": 5,
   "prHourlyLimit": 4,
   "automerge": false,
@@ -30,6 +37,12 @@
       "description": "TypeScript type definitions",
       "matchPackageNames": ["@types/*"],
       "groupName": "type definitions"
+    },
+    {
+      "description": "Do not bump workflow pnpm/node pins separately from packageManager/engines",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["node", "pnpm"],
+      "enabled": false
     },
     {
       "description": "GitHub Actions",


### PR DESCRIPTION
## Summary

- Follow-up to #395 / BT-329: Renovate's first PRs failed DCO (no `Signed-off-by`) and commitlint (`Update` sentence-case).
- Extend `:gitSignOff`, set `commitMessageAction: "update"`, and disable github-actions updates for `node`/`pnpm` workflow pins so Actions digests do not drift from `packageManager`.

## Test plan

- [x] `renovate-config-validator` passes
- [ ] Close first-batch Renovate PRs #397–#400 after merge
- [ ] Re-check Dependency Dashboard boxes and confirm new PRs pass DCO + commitlint
- [ ] Confirm Actions PR updates SHA + `# vN` without bumping workflow pnpm/node versions