### PR TITLE
refactor(api): version deprecated tags and drop dead internal aliases

### DIFF
--- a/docs/reference-deprecations.md
+++ b/docs/reference-deprecations.md
@@ -20,6 +20,8 @@ These aliases were introduced to preserve backward compatibility after the API n
 
 ### `BT` namespace
 
+Removal target: 2.0.0
+
 - `BT.pointerPosValid()` → `BT.isPointerActive()`
 - `BT.buttonDown()` → `BT.isDown()`
 - `BT.buttonPressed()` → `BT.isPressed()`
@@ -30,6 +32,8 @@ These aliases were introduced to preserve backward compatibility after the API n
 - `BT.keyReleased()` → `BT.isKeyReleased()`
 
 ### `HardwareSettings` compatibility fields
+
+Removal target: 2.0.0
 
 - `detectDroppedFrames` → `isDetectingDroppedFrames`
 - `overlayEnabled` → `isOverlayEnabled`
@@ -42,11 +46,15 @@ These aliases were introduced to preserve backward compatibility after the API n
 
 ### `BootstrapOptions` compatibility fields
 
+Removal target: 2.0.0
+
 - `canvasId` → `canvasID`
 - `containerId` → `containerID`
 - `waitForDOMReady` → `isWaitingForDOMReady`
 
 ### Class method aliases
+
+Removal target: 2.0.0
 
 - `SpriteSheet.isIndexized()` → `SpriteSheet.isIndexed()`
 - `Timer.tick()` → `Timer.fireIfElapsed()`
@@ -60,13 +68,14 @@ These aliases were introduced to preserve backward compatibility after the API n
 
 ### Removal checklist
 
-- Search for `@deprecated Deprecated since 2026-05-31` in `src/`.
+- Search for `@deprecated Deprecated since` in `src/` (every public alias uses that versioned form).
 - Remove aliases only after confirming downstream demos/apps have migrated.
 
 <Callout title="Public aliases only">
 
-This tracker lists public compatibility aliases only. Internal deprecated helpers (overlay layout functions,
-`RenderPaletteUsage` re-exports, etc.) are omitted – search `@deprecated` in `src/` for the full set.
+This tracker lists public compatibility aliases only. Internal deprecated helpers that used to live beside overlay
+layout functions and `RenderPaletteUsage` re-exports were removed rather than carried forward – search `@deprecated` in
+`src/` for anything that remains outside this list.
 
 </Callout>
 

--- a/knip.json
+++ b/knip.json
@@ -5,8 +5,6 @@
   "ignoreExportsUsedInFile": true,
   "tags": ["-deprecated"],
   "ignoreIssues": {
-    "src/core/RenderPaletteUsage.ts": ["duplicates"],
-    "src/overlay/palette/PaletteView.ts": ["duplicates"],
     "src/overlay/timing-chart/style.ts": ["duplicates"]
   },
   "ignoreDependencies": ["vite-plugin-istanbul"],

--- a/src/assets/SpriteSheet.ts
+++ b/src/assets/SpriteSheet.ts
@@ -741,7 +741,7 @@ export class SpriteSheet {
     /**
      * Backward-compatible alias for {@link isIndexed}.
      *
-     * @deprecated Deprecated since 2026-05-31. Use {@link isIndexed} instead.
+     * @deprecated Deprecated since 0.1.0 (2026-05-31). Use {@link isIndexed} instead.
      * @returns True if `indexize()` has been called successfully.
      */
     isIndexized(): boolean {

--- a/src/core/IBTDemo.ts
+++ b/src/core/IBTDemo.ts
@@ -153,7 +153,7 @@ export interface HardwareSettings {
     isDetectingDroppedFrames?: boolean;
 
     /**
-     * @deprecated Deprecated since 2026-05-31. Use {@link isDetectingDroppedFrames} instead.
+     * @deprecated Deprecated since 0.1.0 (2026-05-31). Use {@link isDetectingDroppedFrames} instead.
      */
     detectDroppedFrames?: boolean;
 
@@ -240,7 +240,7 @@ export interface HardwareSettings {
     isOverlayEnabled?: boolean;
 
     /**
-     * @deprecated Deprecated since 2026-05-31. Use {@link isOverlayEnabled} instead.
+     * @deprecated Deprecated since 0.1.0 (2026-05-31). Use {@link isOverlayEnabled} instead.
      */
     overlayEnabled?: boolean;
 
@@ -252,7 +252,7 @@ export interface HardwareSettings {
     isOverlayVisibleAtStart?: boolean;
 
     /**
-     * @deprecated Deprecated since 2026-05-31. Use {@link isOverlayVisibleAtStart} instead.
+     * @deprecated Deprecated since 0.1.0 (2026-05-31). Use {@link isOverlayVisibleAtStart} instead.
      */
     overlayVisibleAtStart?: boolean;
 
@@ -264,7 +264,7 @@ export interface HardwareSettings {
     isOverlayToggleHintVisible?: boolean;
 
     /**
-     * @deprecated Deprecated since 2026-05-31. Use {@link isOverlayToggleHintVisible} instead.
+     * @deprecated Deprecated since 0.1.0 (2026-05-31). Use {@link isOverlayToggleHintVisible} instead.
      */
     overlayToggleHintVisible?: boolean;
 
@@ -276,7 +276,7 @@ export interface HardwareSettings {
     isOverlayToggleEnabled?: boolean;
 
     /**
-     * @deprecated Deprecated since 2026-05-31. Use {@link isOverlayToggleEnabled} instead.
+     * @deprecated Deprecated since 0.1.0 (2026-05-31). Use {@link isOverlayToggleEnabled} instead.
      */
     overlayToggleEnabled?: boolean;
 
@@ -298,7 +298,7 @@ export interface HardwareSettings {
     isOverlayPaletteEnabled?: boolean;
 
     /**
-     * @deprecated Deprecated since 2026-05-31. Use {@link isOverlayPaletteEnabled} instead.
+     * @deprecated Deprecated since 0.1.0 (2026-05-31). Use {@link isOverlayPaletteEnabled} instead.
      */
     overlayPaletteView?: boolean;
 
@@ -333,7 +333,7 @@ export interface HardwareSettings {
     isOverlayTimingChartEnabled?: boolean;
 
     /**
-     * @deprecated Deprecated since 2026-05-31. Use {@link isOverlayTimingChartEnabled} instead.
+     * @deprecated Deprecated since 0.1.0 (2026-05-31). Use {@link isOverlayTimingChartEnabled} instead.
      */
     overlayTimingChart?: boolean;
 
@@ -366,7 +366,7 @@ export interface HardwareSettings {
     isOverlayRendererDiagnosticsBarEnabled?: boolean;
 
     /**
-     * @deprecated Deprecated since 2026-05-31. Use {@link isOverlayRendererDiagnosticsBarEnabled} instead.
+     * @deprecated Deprecated since 0.1.0 (2026-05-31). Use {@link isOverlayRendererDiagnosticsBarEnabled} instead.
      */
     overlayRendererDiagnosticsBar?: boolean;
 

--- a/src/core/RenderPaletteUsage.ts
+++ b/src/core/RenderPaletteUsage.ts
@@ -9,27 +9,12 @@
 export const USAGE_CAPACITY = 256;
 
 /**
- * @deprecated Deprecated since 2026-05-31. Use {@link USAGE_CAPACITY} instead.
- */
-export const RENDER_PALETTE_USAGE_CAPACITY = USAGE_CAPACITY;
-
-/**
  * Clears a palette usage bitmask.
  *
  * @param usedMask - Mutable usage mask cleared in place.
  */
 export function resetUsage(usedMask: Uint8Array): void {
     usedMask.fill(0);
-}
-
-/**
- * Backward-compatible alias for {@link resetUsage}.
- *
- * @deprecated Deprecated since 2026-05-31. Use {@link resetUsage} instead.
- * @param usedMask - Mutable usage mask cleared in place.
- */
-export function resetRenderPaletteUsage(usedMask: Uint8Array): void {
-    resetUsage(usedMask);
 }
 
 /**
@@ -47,17 +32,6 @@ export function markIndexUsed(usedMask: Uint8Array, index: number): void {
 
     // eslint-disable-next-line security/detect-object-injection -- index bounds checked above
     usedMask[index] = 1;
-}
-
-/**
- * Backward-compatible alias for {@link markIndexUsed}.
- *
- * @deprecated Deprecated since 2026-05-31. Use {@link markIndexUsed} instead.
- * @param usedMask - Mutable usage mask.
- * @param index - Palette index referenced by a draw call.
- */
-export function markRenderPaletteIndexUsed(usedMask: Uint8Array, index: number): void {
-    markIndexUsed(usedMask, index);
 }
 
 /**
@@ -81,21 +55,4 @@ export function collectUsedIndices(usedMask: Uint8Array, paletteSize: number, sc
     }
 
     return scratch;
-}
-
-/**
- * Backward-compatible alias for {@link collectUsedIndices}.
- *
- * @deprecated Deprecated since 2026-05-31. Use {@link collectUsedIndices} instead.
- * @param usedMask - Usage mask populated during the current frame.
- * @param paletteSize - Active palette size upper bound.
- * @param scratch - Reusable output buffer mutated in place.
- * @returns The same scratch array containing sorted used indices.
- */
-export function collectUsedRenderPaletteIndices(
-    usedMask: Uint8Array,
-    paletteSize: number,
-    scratch: number[],
-): readonly number[] {
-    return collectUsedIndices(usedMask, paletteSize, scratch);
 }

--- a/src/input/KeyboardInput.ts
+++ b/src/input/KeyboardInput.ts
@@ -167,7 +167,7 @@ export class KeyboardInput {
     /**
      * Alias for {@link endUpdate}; kept for tests and callers that still use the old name.
      *
-     * @deprecated Call {@link endUpdate} once per fixed update instead.
+     * @deprecated Deprecated since 1.0.3 (2026-05-31). Call {@link endUpdate} once per fixed update instead.
      * @param currentTick - Passed through to {@link endUpdate}.
      */
     public endFrame(currentTick: number): void {

--- a/src/overlay/Overlay.ts
+++ b/src/overlay/Overlay.ts
@@ -334,7 +334,7 @@ export class Overlay {
     /**
      * Handles toggle input (Backquote and bottom-left corner press).
      *
-     * @deprecated Deprecated since 2026-05-31. Use {@link handleFrameInput} instead. Unlike
+     * @deprecated Deprecated since 1.1.0 (2026-05-31). Use {@link handleFrameInput} instead. Unlike
      * `handleFrameInput`, this reads the keyboard directly at call time, so it remains susceptible to
      * missing a Backquote press that a fixed-update tick already consumed this frame.
      *

--- a/src/overlay/OverlayToggleIcon.ts
+++ b/src/overlay/OverlayToggleIcon.ts
@@ -26,17 +26,6 @@ export function hintIconY(hintBarTopY: number): number {
 }
 
 /**
- * Backward-compatible alias for {@link hintIconY}.
- *
- * @deprecated Deprecated since 2026-05-31. Use {@link hintIconY} instead.
- * @param hintBarTopY - Top Y of the bottom hint bar from the layout plan.
- * @returns Icon top Y in display pixels.
- */
-export function overlayToggleHintIconY(hintBarTopY: number): number {
-    return hintIconY(hintBarTopY);
-}
-
-/**
  * Returns the top-left screen position for the toggle hint icon inside the hint bar.
  *
  * @param hintBarTopY - Top Y of the bottom hint bar from the layout plan.
@@ -47,17 +36,6 @@ export function hintIconPos(hintBarTopY: number): Vector2i {
 }
 
 /**
- * Backward-compatible alias for {@link hintIconPos}.
- *
- * @deprecated Deprecated since 2026-05-31. Use {@link hintIconPos} instead.
- * @param hintBarTopY - Top Y of the bottom hint bar from the layout plan.
- * @returns Icon anchor in display pixels.
- */
-export function overlayToggleHintIconPos(hintBarTopY: number): Vector2i {
-    return hintIconPos(hintBarTopY);
-}
-
-/**
  * Returns the screen-space rect reserved for the toggle hint icon (palette swatch exclusion).
  *
  * @param hintBarTopY - Top Y of the bottom hint bar from the layout plan.
@@ -65,17 +43,6 @@ export function overlayToggleHintIconPos(hintBarTopY: number): Vector2i {
  */
 export function hintIconExclusionRect(hintBarTopY: number): Rect2i {
     return new Rect2i(overlayToggleHintIconX(), hintIconY(hintBarTopY), ICON_WIDTH, ICON_HEIGHT);
-}
-
-/**
- * Backward-compatible alias for {@link hintIconExclusionRect}.
- *
- * @deprecated Deprecated since 2026-05-31. Use {@link hintIconExclusionRect} instead.
- * @param hintBarTopY - Top Y of the bottom hint bar from the layout plan.
- * @returns Icon bounding rect in display pixels.
- */
-export function overlayToggleHintIconExclusionRect(hintBarTopY: number): Rect2i {
-    return hintIconExclusionRect(hintBarTopY);
 }
 
 /**
@@ -124,24 +91,6 @@ export function toggleIcon(
             target.drawBarFillOnTop(run, textPaletteIndex);
         }
     }
-}
-
-/**
- * Backward-compatible alias for {@link toggleIcon}.
- *
- * @deprecated Deprecated since 2026-05-31. Use {@link toggleIcon} instead.
- * @param target - Overlay draw target.
- * @param hintBarTopY - Top Y of the bottom hint bar from the layout plan.
- * @param textPaletteIndex - Overlay text palette index (`OverlayStyle.textPaletteIndex`, default `2`).
- * @param inverted - Legacy parameter name forwarded to `isInverted`.
- */
-export function drawOverlayToggleIcon(
-    target: OverlayDrawTarget,
-    hintBarTopY: number,
-    textPaletteIndex: number,
-    inverted = false,
-): void {
-    toggleIcon(target, hintBarTopY, textPaletteIndex, inverted);
 }
 
 /**

--- a/src/overlay/index.ts
+++ b/src/overlay/index.ts
@@ -32,13 +32,9 @@ export type { OverlayLayout, OverlayLayoutConfig, OverlayLayoutPlan } from './la
 export { Overlay } from './Overlay';
 export type { OverlayDrawTarget, OverlayRenderer } from './OverlayDrawTarget';
 export {
-    drawOverlayToggleIcon,
     hintIconExclusionRect,
     hintIconPos,
     hintIconY,
-    overlayToggleHintIconExclusionRect,
-    overlayToggleHintIconPos,
-    overlayToggleHintIconY,
     toggleIcon,
 } from './OverlayToggleIcon';
 export { PaletteInteraction } from './palette/PaletteInteraction';

--- a/src/overlay/input/Toggle.ts
+++ b/src/overlay/input/Toggle.ts
@@ -81,7 +81,7 @@ export class Toggle {
     /**
      * Backward-compatible alias for {@link handleInput}.
      *
-     * @deprecated Deprecated since 2026-05-31. Use {@link handleInput} instead.
+     * @deprecated Deprecated since 1.1.0 (2026-05-31). Use {@link handleInput} instead.
      * @param pointer - Pointer subsystem, or `null` when unavailable.
      * @param keyboard - Keyboard subsystem, or `null` when unavailable.
      * @param currentTick - Current fixed-update tick for keyboard edge detection.

--- a/src/overlay/palette/PaletteView.ts
+++ b/src/overlay/palette/PaletteView.ts
@@ -57,15 +57,6 @@ export function gridRowWidth(cols: number, swatchSize: number, gap: number): num
 }
 
 /**
- * @deprecated Deprecated since 2026-05-31. Use {@link gridRowWidth} instead.
- * @param cols - Column count.
- * @param swatchSize - Side length of each swatch.
- * @param gap - Gap between swatches.
- * @returns Row width in pixels.
- */
-export const paletteGridRowWidth = gridRowWidth;
-
-/**
  * Computes the vertical span of the full grid.
  *
  * @param rows - Row count.
@@ -80,15 +71,6 @@ export function gridRowStackHeight(rows: number, swatchSize: number, gap: number
 
     return rows * swatchSize + (rows - 1) * gap;
 }
-
-/**
- * @deprecated Deprecated since 2026-05-31. Use {@link gridRowStackHeight} instead.
- * @param rows - Row count.
- * @param swatchSize - Side length of each swatch.
- * @param gap - Gap between swatches.
- * @returns Grid height in pixels.
- */
-export const paletteGridRowStackHeight = gridRowStackHeight;
 
 /**
  * Picks the widest column count that fits the display while halving from the palette size.
@@ -126,17 +108,6 @@ export function pickGridColumnCount(
 }
 
 /**
- * @deprecated Deprecated since 2026-05-31. Use {@link pickGridColumnCount} instead.
- * @param displayWidth - Logical display width in pixels.
- * @param swatchSize - Side length of each swatch.
- * @param gap - Gap between swatches.
- * @param colorCount - Active palette slot count.
- * @param maxColumns - Optional cap from {@link HardwareSettings.overlayPaletteColumns}.
- * @returns Column count (at least 1).
- */
-export const pickPaletteGridColumnCount = pickGridColumnCount;
-
-/**
  * Resolves the visible row count for a palette grid viewport.
  *
  * @param totalRows - Full palette row count.
@@ -156,14 +127,6 @@ export function resolveGridVisibleRows(totalRows: number, maxVisibleRows?: numbe
 
     return Math.min(totalRows, parsedMax);
 }
-
-/**
- * @deprecated Deprecated since 2026-05-31. Use {@link resolveGridVisibleRows} instead.
- * @param totalRows - Full palette row count.
- * @param maxVisibleRows - Optional cap from {@link HardwareSettings.overlayPaletteRowsVisible}.
- * @returns Visible rows (0 when `totalRows` is 0; otherwise clamped to `[1, totalRows]`).
- */
-export const resolvePaletteGridVisibleRows = resolveGridVisibleRows;
 
 /**
  * Computes palette grid layout for the bottom band.
@@ -195,18 +158,6 @@ export function computeGrid(
 
     return { cols, rows, visibleRows, swatchSize, gap, totalHeight };
 }
-
-/**
- * @deprecated Deprecated since 2026-05-31. Use {@link computeGrid} instead.
- * @param displayWidth - Logical display width in pixels.
- * @param swatchSize - Side length of each swatch.
- * @param colorCount - Number of palette slots to show.
- * @param gap - Gap between swatches.
- * @param maxColumns - Optional cap from {@link HardwareSettings.overlayPaletteColumns}.
- * @param maxVisibleRows - Optional cap from {@link HardwareSettings.overlayPaletteRowsVisible}.
- * @returns Grid dimensions and viewport band height.
- */
-export const computePaletteGrid = computeGrid;
 
 /**
  * Returns whether two axis-aligned rects overlap (zero allocation).
@@ -275,14 +226,6 @@ export function resolveHintExclusionRect(hintBarTopY: number, displayWidth: numb
 
     return hintExclusionCache.rect;
 }
-
-/**
- * @deprecated Deprecated since 2026-05-31. Use {@link resolveHintExclusionRect} instead.
- * @param hintBarTopY - Top Y of the bottom hint bar from the layout plan.
- * @param displayWidth - Logical display width (cache key only; icon X is margin-based).
- * @returns Exclusion rect for swatch placement and hit testing.
- */
-export const resolvePaletteHintExclusionRect = resolveHintExclusionRect;
 
 /** Preferred side length for the filled marker drawn inside unused swatches. */
 const UNUSED_SWATCH_MARKER_SIZE = 3;
@@ -439,16 +382,6 @@ export function writeSwatchTopLeft(
 }
 
 /**
- * @deprecated Deprecated since 2026-05-31. Use {@link writeSwatchTopLeft} instead.
- * @param target - Reusable rect mutated in place.
- * @param index - Palette slot index.
- * @param paletteBand - Palette band rect from layout plan.
- * @param grid - Precomputed grid layout.
- * @param scrollRowOffset - First visible grid row (default `0`).
- */
-export const writePaletteSwatchTopLeft = writeSwatchTopLeft;
-
-/**
  * Draws the visible palette swatch window inside the bottom band.
  *
  * @param target - Overlay draw target.
@@ -511,14 +444,6 @@ export function computeScrollbarThumbHeight(trackHeight: number, grid: PaletteGr
 }
 
 /**
- * @deprecated Deprecated since 2026-05-31. Use {@link computeScrollbarThumbHeight} instead.
- * @param trackHeight - Full palette band height in pixels.
- * @param grid - Precomputed grid layout.
- * @returns Thumb height in pixels, or `0` when inputs are invalid.
- */
-export const computePaletteScrollbarThumbHeight = computeScrollbarThumbHeight;
-
-/**
  * Writes the palette scrollbar track and thumb rects for the bottom band.
  *
  * The track is inset 1 px from the palette band top, right, and bottom edges. Only the
@@ -571,18 +496,6 @@ export function writeScrollbarRects(
 
     return true;
 }
-
-/**
- * @deprecated Deprecated since 2026-05-31. Use {@link writeScrollbarRects} instead.
- * @param trackTarget - Reusable track rect mutated in place.
- * @param thumbTarget - Reusable thumb rect mutated in place.
- * @param paletteBand - Palette band rect from layout plan.
- * @param grid - Precomputed grid layout.
- * @param scrollRowOffset - First visible grid row.
- * @param trackWidth - Scrollbar track width in pixels.
- * @returns `true` when scrolling is possible and rects were written.
- */
-export const writePaletteScrollbarRects = writeScrollbarRects;
 
 /**
  * Draws the palette scrollbar thumb inside the bottom band (no track fill).

--- a/src/overlay/timing-chart/style.ts
+++ b/src/overlay/timing-chart/style.ts
@@ -186,7 +186,7 @@ export function isTimingChartGridLineAtY(y: number, chartRect: Rect2i): boolean 
 /**
  * Backward-compatible alias for {@link isTimingChartGridLineAtY}.
  *
- * @deprecated Deprecated since 2026-05-31. Use {@link isTimingChartGridLineAtY} instead.
+ * @deprecated Deprecated since 1.1.0 (2026-05-31). Use {@link isTimingChartGridLineAtY} instead.
  * @param y - Screen Y from {@link computeTimingChartGridLineY}.
  * @param chartRect - Chart band bounds.
  * @returns `true` when the row is strictly inside the band and not the baseline.

--- a/src/utils/AssetLimits.ts
+++ b/src/utils/AssetLimits.ts
@@ -90,18 +90,6 @@ export function formatSize(width: number, height: number): string {
 }
 
 /**
- * Backward-compatible alias for {@link formatSize}.
- *
- * @deprecated Deprecated since 2026-05-31. Use {@link formatSize} instead.
- * @param width - Width in pixels.
- * @param height - Height in pixels.
- * @returns Size formatted as `WIDTHxHEIGHT`.
- */
-export function formatAssetSize(width: number, height: number): string {
-    return formatSize(width, height);
-}
-
-/**
  * Computes a safe pixel count when width and height are valid asset dimensions.
  *
  * @param width - Width in pixels.
@@ -178,19 +166,6 @@ export function validateDimensions(context: string, width: number, height: numbe
 }
 
 /**
- * Backward-compatible alias for {@link validateDimensions}.
- *
- * @deprecated Deprecated since 2026-05-31. Use {@link validateDimensions} instead.
- * @param context - Asset label used in error text (for example `'sprite sheet'`).
- * @param width - Width in pixels.
- * @param height - Height in pixels.
- * @returns A user-facing error message when invalid, otherwise `null`.
- */
-export function validateAssetDimensions(context: string, width: number, height: number): string | null {
-    return validateDimensions(context, width, height);
-}
-
-/**
  * Validates decoded image dimensions and throws when they exceed engine limits.
  *
  * @param context - Asset label used in error text.
@@ -204,19 +179,6 @@ export function assertDimensions(context: string, width: number, height: number)
     if (error) {
         throw new AssetLimitError(error);
     }
-}
-
-/**
- * Backward-compatible alias for {@link assertDimensions}.
- *
- * @deprecated Deprecated since 2026-05-31. Use {@link assertDimensions} instead.
- * @param context - Asset label used in error text.
- * @param width - Width in pixels.
- * @param height - Height in pixels.
- * @throws {@link AssetLimitError} when the dimensions are invalid.
- */
-export function assertAssetDimensions(context: string, width: number, height: number): void {
-    assertDimensions(context, width, height);
 }
 
 /**

--- a/src/utils/Bootstrap.ts
+++ b/src/utils/Bootstrap.ts
@@ -27,7 +27,7 @@ export interface BootstrapOptions {
     canvasID?: string;
 
     /**
-     * @deprecated Deprecated since 2026-05-31. Use `canvasID` instead.
+     * @deprecated Deprecated since 0.2.0 (2026-05-31). Use `canvasID` instead.
      */
     canvasId?: string;
 
@@ -38,7 +38,7 @@ export interface BootstrapOptions {
     containerID?: string;
 
     /**
-     * @deprecated Deprecated since 2026-05-31. Use `containerID` instead.
+     * @deprecated Deprecated since 0.2.0 (2026-05-31). Use `containerID` instead.
      */
     containerId?: string;
 
@@ -55,7 +55,7 @@ export interface BootstrapOptions {
     isWaitingForDOMReady?: boolean;
 
     /**
-     * @deprecated Deprecated since 2026-05-31. Use `isWaitingForDOMReady` instead.
+     * @deprecated Deprecated since 0.2.0 (2026-05-31). Use `isWaitingForDOMReady` instead.
      */
     waitForDOMReady?: boolean;
 }

--- a/src/utils/Color32.ts
+++ b/src/utils/Color32.ts
@@ -631,7 +631,7 @@ export class Color32 {
     /**
      * Backward-compatible alias for {@link isEqual}.
      *
-     * @deprecated Deprecated since 2026-05-31. Use {@link isEqual} instead.
+     * @deprecated Deprecated since 0.1.0 (2026-05-31). Use {@link isEqual} instead.
      * @param other - Color to compare with.
      * @returns True if all RGBA channels are identical.
      */

--- a/src/utils/Rect2i.ts
+++ b/src/utils/Rect2i.ts
@@ -325,7 +325,7 @@ export class Rect2i {
     /**
      * Backward-compatible alias for {@link isContaining}.
      *
-     * @deprecated Deprecated since 2026-05-31. Use {@link isContaining} instead.
+     * @deprecated Deprecated since 0.1.0 (2026-05-31). Use {@link isContaining} instead.
      * @param point - Point to test.
      * @returns True if point is inside the rectangle.
      */
@@ -347,7 +347,7 @@ export class Rect2i {
     /**
      * Backward-compatible alias for {@link isContainingXY}.
      *
-     * @deprecated Deprecated since 2026-05-31. Use {@link isContainingXY} instead.
+     * @deprecated Deprecated since 0.1.0 (2026-05-31). Use {@link isContainingXY} instead.
      * @param px - X coordinate to test.
      * @param py - Y coordinate to test.
      * @returns True if point is inside the rectangle.
@@ -374,7 +374,7 @@ export class Rect2i {
     /**
      * Backward-compatible alias for {@link isIntersecting}.
      *
-     * @deprecated Deprecated since 2026-05-31. Use {@link isIntersecting} instead.
+     * @deprecated Deprecated since 0.1.0 (2026-05-31). Use {@link isIntersecting} instead.
      * @param other - Rectangle to test against.
      * @returns True if rectangles overlap.
      */
@@ -428,7 +428,7 @@ export class Rect2i {
     /**
      * Backward-compatible alias for {@link intersectTo}.
      *
-     * @deprecated Deprecated since 2026-05-31. Use {@link intersectTo} instead.
+     * @deprecated Deprecated since 0.1.0 (2026-05-31). Use {@link intersectTo} instead.
      * @param other - Rectangle to intersect with.
      * @param out - Rectangle to write the result to.
      * @returns True if intersection exists (out is valid), false otherwise (out unchanged).
@@ -503,7 +503,7 @@ export class Rect2i {
     /**
      * Backward-compatible alias for {@link isEqual}.
      *
-     * @deprecated Deprecated since 2026-05-31. Use {@link isEqual} instead.
+     * @deprecated Deprecated since 0.1.0 (2026-05-31). Use {@link isEqual} instead.
      * @param other - Rectangle to compare with.
      * @returns True if position and size are identical.
      */

--- a/src/utils/Timer.ts
+++ b/src/utils/Timer.ts
@@ -56,7 +56,7 @@ export class Timer {
     /**
      * Backward-compatible alias for {@link fireIfElapsed}.
      *
-     * @deprecated Deprecated since 2026-05-31. Use {@link fireIfElapsed} instead.
+     * @deprecated Deprecated since 1.0.3 (2026-05-31). Use {@link fireIfElapsed} instead.
      * @param currentTick - Tick to evaluate against; defaults to engine tick counter.
      * @returns True when at least `intervalTicks` have elapsed since the last fire/reset.
      */

--- a/src/utils/Vector2i.ts
+++ b/src/utils/Vector2i.ts
@@ -1000,7 +1000,7 @@ export class Vector2i {
     /**
      * Backward-compatible alias for {@link isEqual}.
      *
-     * @deprecated Deprecated since 2026-05-31. Use {@link isEqual} instead.
+     * @deprecated Deprecated since 0.1.0 (2026-05-31). Use {@link isEqual} instead.
      * @param other - Vector to compare with.
      * @returns True if both x and y components are equal.
      */


### PR DESCRIPTION
## Summary
- Upgrade every remaining date-only `@deprecated` JSDoc tag in `src/` to the versioned form `Deprecated since <version> (2026-05-31).`, and fix the malformed `KeyboardInput.endFrame` tag.
- Remove dead internal-only compatibility aliases (`PaletteView`, `RenderPaletteUsage`, `AssetLimits`, `OverlayToggleIcon`) that had no public reachability and no callers.
- Rework `docs/reference-deprecations.md` with a `Removal target: 2.0.0` per alias group and a checklist that greps the versioned `@deprecated Deprecated since` form (BT-331).

## Test plan
- [x] `pnpm run api:since:check`
- [x] `pnpm run api:history:check`
- [x] `pnpm run preflight`
- [ ] CI green on the PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed several deprecated compatibility aliases for palette utilities, overlay toggle icons, render palette usage, and asset validation.
  * Use the current, non-deprecated API names instead.

* **Documentation**
  * Standardized deprecation notices to include the relevant library version and date.
  * Clarified deprecation removal targets and updated the removal checklist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->