### PR TITLE
ci(github): add issue forms, chooser config, and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,104 @@
+name: Bug report
+description: Report a bug in blit386
+title: '[bug] '
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug. Check [the docs](https://blit386.dev/docs) and
+        [CONTRIBUTING.md](../../CONTRIBUTING.md) before opening.
+
+        For environment details, see [Browser Support](../../docs/api-browser-support.md).
+        `BT.activeBackend` is the backend that actually started (`webgpu` or `software`); WebGPU can
+        silently fall back to software when init fails.
+
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      description: One-line description of the bug
+      placeholder: Drawing a sprite at (0, 0) crashes under the software backend
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: Minimal steps to reproduce; include a short code snippet if helpful
+      placeholder: |
+        1. Create a demo with backend: 'software'
+        2. Call BT.drawSprite(...)
+        3. Observe the crash
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What you expected to happen
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened
+    validations:
+      required: true
+
+  - type: dropdown
+    id: backend
+    attributes:
+      label: Backend
+      description: >
+        Prefer the value of `BT.activeBackend` after init (not the requested backend). WebGPU can silently fall back to
+        software.
+      options:
+        - webgpu
+        - software
+    validations:
+      required: true
+
+  - type: input
+    id: browser
+    attributes:
+      label: Browser and version
+      description: >
+        e.g. Chrome 131, Firefox 145, Safari 26. See [Browser Support](../../docs/api-browser-support.md) for the
+        supported matrix.
+      placeholder: Chrome 131.0.6778.85
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      description: e.g. macOS 15.2, Windows 11, Ubuntu 24.04
+      placeholder: macOS 15.2
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: blit386 version
+      description: >
+        Installed npm package version from package.json or `npm ls blit386` (there is no runtime `BT.VERSION`).
+      placeholder: 1.2.1
+    validations:
+      required: true
+
+  - type: textarea
+    id: console
+    attributes:
+      label: Console output
+      description: Relevant browser console errors or warnings (optional)
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,17 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://blit386.dev/docs
+    about: API reference and guides for blit386
+  - name: Demos
+    url: https://demos.blit386.dev
+    about: Interactive demos covering rendering, input, audio, and more
+  - name: Report a vulnerability
+    url: https://github.com/blit386/blit386/security/advisories/new
+    about: Private vulnerability reporting (do not open a public issue)
+  - name: GitHub Discussions
+    url: https://github.com/blit386/blit386/discussions
+    about: Questions, ideas, and community conversation
+  - name: Discord
+    url: https://discord.gg/tC2wGt88Uj
+    about: Real-time chat with other blit386 users

--- a/.github/ISSUE_TEMPLATE/docs_issue.yml
+++ b/.github/ISSUE_TEMPLATE/docs_issue.yml
@@ -1,0 +1,37 @@
+name: Docs issue
+description: Report a docs problem, gap, or unclear page
+title: '[docs] '
+labels:
+  - documentation
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve the docs. Prefer a link to the live page on
+        [blit386.dev](https://blit386.dev/docs) or a path under `docs/` in this repo.
+
+  - type: input
+    id: page
+    attributes:
+      label: Affected page
+      description: >
+        blit386.dev URL (e.g. https://blit386.dev/docs/api/core) or source path (e.g. docs/api-core.md)
+      placeholder: https://blit386.dev/docs/api/core
+    validations:
+      required: true
+
+  - type: textarea
+    id: issue
+    attributes:
+      label: What is wrong, missing, or unclear?
+      description: Quote the confusing passage or describe the gap
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested correction
+      description: Optional rewrite, link, or outline of what should be there
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,58 @@
+name: Feature request
+description: Propose a new API or engine capability
+title: '[feature] '
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing a feature. Skim [the docs](https://blit386.dev/docs) first so the
+        request builds on existing APIs rather than duplicating them.
+
+        blit386 is palette-first: primitives, sprites, and bitmap text resolve through a shared
+        indexed palette before final RGBA output.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem being solved
+      description: What user or author pain does this address?
+      placeholder: There is no way to ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-api
+    attributes:
+      label: Proposed API shape
+      description: >
+        Sketch the public surface (BT getters/methods, HardwareSettings fields, types). Prefer getters for zero-arg
+        read-only snapshots and methods for actions or parameterized queries.
+      placeholder: |
+        BT.foo(bar: Vector2i): void
+        // or a HardwareSettings.isFooEnabled configure flag
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you tried or rejected, and why
+    validations:
+      required: false
+
+  - type: dropdown
+    id: palette-first
+    attributes:
+      label: Fits the palette-first model?
+      description: >
+        Does the proposal keep colors flowing through the indexed palette (or explicitly opt out with a documented
+        reason)?
+      options:
+        - 'Yes'
+        - 'No'
+        - Unsure
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Summary
+
+<!-- What does this PR change, and why? -->
+
+## Checklist
+
+1. Every commit is DCO signed off (`git commit -s`; each commit ends with `Signed-off-by: ...`).
+2. PR title follows Conventional Commits: `<type>(<scope>): <description>`
+   - Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
+   - Scope is optional; subject is lowercase with no trailing period
+3. `pnpm run preflight` passes locally.
+4. Documentation updated where this change touches public API or behavior:
+   - Public API: relevant `docs/api-*.md`
+   - Behavior: affected `docs/` guides
+   - Architecture / new subsystem: `CLAUDE.md` architecture map
+5. If renderer output could change, `pnpm run test:visual` was run (and baselines updated if the change is intentional).
+6. If AI tools helped write this change, each commit includes an AI trailer after `Signed-off-by`:
+   - `Co-Authored-By: Claude <noreply@anthropic.com>`
+   - or `Co-Authored-By: GitHub Copilot <noreply@github.com>`
+
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full contributor process.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 
 ## Checklist
 
-1. Every commit is DCO signed off (`git commit -s`; each commit ends with `Signed-off-by: ...`).
+1. Every commit is DCO signed off (`git commit -s` adds `Signed-off-by: ...`).
 2. PR title follows Conventional Commits: `<type>(<scope>): <description>`
    - Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
    - Scope is optional; subject is lowercase with no trailing period
@@ -14,7 +14,8 @@
    - Behavior: affected `docs/` guides
    - Architecture / new subsystem: `CLAUDE.md` architecture map
 5. If renderer output could change, `pnpm run test:visual` was run (and baselines updated if the change is intentional).
-6. If AI tools helped write this change, each commit includes an AI trailer after `Signed-off-by`:
+6. If AI tools helped write this change, each commit includes an AI trailer after `Signed-off-by` (as documented in
+   CONTRIBUTING.md):
    - `Co-Authored-By: Claude <noreply@anthropic.com>`
    - or `Co-Authored-By: GitHub Copilot <noreply@github.com>`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -205,6 +205,10 @@ pnpm run preflight        # Run all quality checks
 7. Push to your fork
 8. Open a pull request against `main`
 
+The pull request form is pre-filled from [`.github/pull_request_template.md`](.github/pull_request_template.md). Use
+that checklist for DCO sign-off, Conventional Commit titles, `pnpm run preflight`, documentation updates, and visual
+tests when renderer output could change.
+
 All pull requests will be reviewed by maintainers. The DCO check and other CI checks must pass before a PR can be
 merged.
 
@@ -233,7 +237,15 @@ project.
 
 ## Questions?
 
-If you have questions about the DCO or contributing process, please open an issue on GitHub.
+If you have questions about the DCO or contributing process, please open an issue on GitHub. Use the guided forms under
+[`.github/ISSUE_TEMPLATE/`](.github/ISSUE_TEMPLATE/):
+
+- [Bug report](.github/ISSUE_TEMPLATE/bug_report.yml) – reproduction, expected vs actual, backend, environment
+- [Feature request](.github/ISSUE_TEMPLATE/feature_request.yml) – problem, proposed API, palette-first fit
+- [Docs issue](.github/ISSUE_TEMPLATE/docs_issue.yml) – affected page and what is wrong or missing
+
+Blank issues are disabled; see `.github/ISSUE_TEMPLATE/config.yml` for docs, demos, and private vulnerability reporting
+links.
 
 ## Full Developer Certificate of Origin Text
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -237,15 +237,18 @@ project.
 
 ## Questions?
 
-If you have questions about the DCO or contributing process, please open an issue on GitHub. Use the guided forms under
+For questions about the DCO or contributing process, use
+[GitHub Discussions](https://github.com/blit386/blit386/discussions) or the [Discord](https://discord.gg/tC2wGt88Uj)
+community. Blank issues are disabled.
+
+To report a bug, propose a feature, or flag a docs problem, use the guided forms under
 [`.github/ISSUE_TEMPLATE/`](.github/ISSUE_TEMPLATE/):
 
 - [Bug report](.github/ISSUE_TEMPLATE/bug_report.yml) – reproduction, expected vs actual, backend, environment
 - [Feature request](.github/ISSUE_TEMPLATE/feature_request.yml) – problem, proposed API, palette-first fit
 - [Docs issue](.github/ISSUE_TEMPLATE/docs_issue.yml) – affected page and what is wrong or missing
 
-Blank issues are disabled; see `.github/ISSUE_TEMPLATE/config.yml` for docs, demos, and private vulnerability reporting
-links.
+See `.github/ISSUE_TEMPLATE/config.yml` for docs, demos, and private vulnerability reporting links.
 
 ## Full Developer Certificate of Origin Text
 


### PR DESCRIPTION
## Summary

- Add guided GitHub issue forms for bugs, feature requests, and docs issues, modeled on `security-risk-acceptance.yml`
- Add `config.yml` with `blank_issues_enabled: false` and contact links (docs, demos, private vuln reporting, Discussions, Discord)
- Add `pull_request_template.md` that surfaces DCO, Conventional Commits, preflight, docs-as-part-of-feature, and visual-test checklist
- Cross-link the templates from `CONTRIBUTING.md`

Closes BT-332.

## Test plan

- [x] `pnpm run format:check` passes on new YAML/Markdown
- [x] `pnpm run docs:links` green; `docs/security/*` still resolve `security-risk-acceptance.yml`
- [x] Manual check: relative `../../` links in new issue forms resolve; no emoji in templates
- [x] `security-risk-acceptance.yml` unchanged
- [ ] Confirm GitHub issue chooser shows the three forms + contact links after merge
- [ ] Confirm new PR form pre-fills the checklist

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guided issue templates for bug reports, feature requests, and documentation issues.
  * Updated issue handling to prevent blank submissions and added curated contact options (docs, demos, security, discussions, community).
  * Added a pull request template with required summary and checklist (including contributor sign-off and preflight validation).
  * Expanded contribution guidance to reference the guided forms and align with the pull request checklist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->