### PR TITLE
feat(random): add Vector2i and Rect2i helpers on Random

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -95,7 +95,7 @@ src/
     Color32.ts             # 32-bit RGBA color
     Easing.ts              # Easing curves + interpolate() (number, Vector2i, Color32, Rect2i)
     AudioParamRamp.ts       # Shared AudioParam ramp scheduling (bus fades + per-voice fades)
-    Random.ts              # Seeded PRNG (mulberry32; exported; int/float/pick/shuffle/weighted/fork)
+    Random.ts              # Seeded PRNG (mulberry32; exported; int/float/pick/shuffle/weighted/fork; Vector2i/Rect2i helpers)
     Rng.ts                 # Deterministic PRNG (mulberry32-style; internal, backs the synth engine's noise generation)
     FrameCapture.ts        # GPU readback + PNG export
     Timer.ts               # Elapsed-time helper (exported; Timer.fireIfElapsed)

--- a/.cursor/rules/architecture.mdc
+++ b/.cursor/rules/architecture.mdc
@@ -99,7 +99,7 @@ src/
     Color32.ts             # 32-bit RGBA color
     Easing.ts              # Easing curves + interpolate() (number, Vector2i, Color32, Rect2i)
     AudioParamRamp.ts       # Shared AudioParam ramp scheduling (bus fades + per-voice fades)
-    Random.ts              # Seeded PRNG (mulberry32; exported; int/float/pick/shuffle/weighted/fork)
+    Random.ts              # Seeded PRNG (mulberry32; exported; int/float/pick/shuffle/weighted/fork; Vector2i/Rect2i helpers)
     Rng.ts                 # Deterministic PRNG (mulberry32-style; internal, backs the synth engine's noise generation)
     FrameCapture.ts        # GPU readback + PNG export
     Timer.ts               # Elapsed-time helper (exported; Timer.fireIfElapsed)

--- a/docs/_sitemap.json
+++ b/docs/_sitemap.json
@@ -35,7 +35,7 @@
     {
       "src": "api-random.md",
       "path": "api/random",
-      "description": "Seeded Random PRNG: ints, floats, pick, shuffle, weighted choice, and stream control."
+      "description": "Seeded Random PRNG: ints, floats, Vector2i/Rect2i helpers, pick, shuffle, weighted choice, and stream control."
     },
     {
       "src": "api-core-types.md",

--- a/docs/api-random.md
+++ b/docs/api-random.md
@@ -33,6 +33,7 @@ rng.pick(['a', 'b', 'c']);
 rng.shuffle([1, 2, 3, 4]);
 rng.angle(); // [0, 2π) radians
 rng.gaussian(0, 1); // Box-Muller sample
+rng.direction4(); // cardinal unit vector
 ```
 
 Omit the constructor seed to time-seed from `Date.now()` (lower 32 bits). Call `seed(n)` later to restart from a known
@@ -40,24 +41,51 @@ value.
 
 ## Generators
 
-| Method                     | Range / behavior                                 |
-| -------------------------- | ------------------------------------------------ |
-| `next()`                   | Float in `[0, 1)`                                |
-| `float(min, max)`          | Float in `[min, max)`                            |
-| `int(maxExclusive)`        | Integer in `[0, maxExclusive)`                   |
-| `int(min, maxExclusive)`   | Integer in `[min, maxExclusive)`                 |
-| `intInclusive(min, max)`   | Integer in `[min, max]`                          |
-| `bool(probability?)`       | `true` with the given chance (default `0.5`)     |
-| `sign()`                   | `-1` or `1`                                      |
-| `pick(arr)`                | One element from a non-empty array               |
-| `shuffle(arr)`             | New shuffled copy (Fisher-Yates)                 |
-| `shuffleInPlace(arr)`      | Shuffle the array in place and return it         |
-| `weighted(items, weights)` | One item by relative non-negative weights        |
-| `angle()`                  | Float in `[0, 2π)` radians                       |
-| `gaussian(mean?, stddev?)` | Approximate normal sample (Box-Muller, no spare) |
+| Method                          | Range / behavior                                 |
+| ------------------------------- | ------------------------------------------------ |
+| `next()`                        | Float in `[0, 1)`                                |
+| `float(min, max)`               | Float in `[min, max)`                            |
+| `int(maxExclusive)`             | Integer in `[0, maxExclusive)`                   |
+| `int(min, maxExclusive)`        | Integer in `[min, maxExclusive)`                 |
+| `intInclusive(min, max)`        | Integer in `[min, max]`                          |
+| `bool(probability?)`            | `true` with the given chance (default `0.5`)     |
+| `sign()`                        | `-1` or `1`                                      |
+| `pick(arr)`                     | One element from a non-empty array               |
+| `shuffle(arr)`                  | New shuffled copy (Fisher-Yates)                 |
+| `shuffleInPlace(arr)`           | Shuffle the array in place and return it         |
+| `weighted(items, weights)`      | One item by relative non-negative weights        |
+| `angle()`                       | Float in `[0, 2π)` radians                       |
+| `gaussian(mean?, stddev?)`      | Approximate normal sample (Box-Muller, no spare) |
+| `insideRect(rect)`              | Integer point in half-open `rect`                |
+| `insideRectTo(rect, out)`       | Same as `insideRect`, writes into `out`          |
+| `pointInRange(min, max)`        | Integer point; per-axis `[min, max)`             |
+| `pointInRangeTo(min, max, out)` | Same as `pointInRange`, writes into `out`        |
+| `direction4()`                  | One of four cardinal unit vectors (Y-down)       |
+| `direction8()`                  | One of eight king-move unit vectors (Y-down)     |
 
 Integer helpers return true integers (`| 0` truncation), matching the engine's `Vector2i` philosophy. Half-open `int`
 ranges match the demo helpers (`randInt` / `randFloat`).
+
+## Spatial helpers
+
+`insideRect` / `insideRectTo` sample the same half-open region as `Rect2i.isContaining`: `x` in `[rect.x, rect.right)`,
+`y` in `[rect.y, rect.bottom)`. `pointInRange` / `pointInRangeTo` use `int` per axis (`[min.x, max.x)` and
+`[min.y, max.y)`). Empty or inverted ranges throw the same `RangeError` as `int`. Prefer the `*To(out)` variants in
+`update()` / `render()` loops to avoid per-frame allocation.
+
+```ts twoslash
+import { Random, Rect2i, Vector2i } from 'blit386';
+
+const rng = new Random(7);
+const rect = new Rect2i(0, 0, 320, 240);
+const out = new Vector2i();
+
+rng.insideRect(rect);
+rng.insideRectTo(rect, out);
+rng.pointInRange(new Vector2i(10, 10), new Vector2i(20, 30));
+rng.direction4(); // (1,0) | (-1,0) | (0,1) | (0,-1)
+rng.direction8(); // cardinals plus diagonals
+```
 
 ## State and streams
 

--- a/src/utils/Random.bench.ts
+++ b/src/utils/Random.bench.ts
@@ -1,9 +1,13 @@
 import { bench, describe } from 'vitest';
 
 import { Random } from './Random';
+import { Rect2i } from './Rect2i';
+import { Vector2i } from './Vector2i';
 
 const SEED = 12345;
 const PICK_ITEMS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+const BENCH_RECT = new Rect2i(0, 0, 64, 64);
+const BENCH_OUT = new Vector2i();
 const BENCH_OPTIONS = {
     iterations: 500,
     time: 100,
@@ -58,6 +62,22 @@ describe('Random hot-path benchmarks', () => {
         'bool()',
         () => {
             rng.bool();
+        },
+        BENCH_OPTIONS,
+    );
+
+    bench(
+        'insideRectTo(64x64)',
+        () => {
+            rng.insideRectTo(BENCH_RECT, BENCH_OUT);
+        },
+        BENCH_OPTIONS,
+    );
+
+    bench(
+        'direction4()',
+        () => {
+            rng.direction4();
         },
         BENCH_OPTIONS,
     );

--- a/src/utils/Random.test.ts
+++ b/src/utils/Random.test.ts
@@ -5,7 +5,9 @@
 import { describe, expect, it } from 'vitest';
 
 import { Random } from './Random';
+import { Rect2i } from './Rect2i';
 import { Rng } from './Rng';
+import { Vector2i } from './Vector2i';
 
 describe('Random', () => {
     describe('constructor and seed', () => {
@@ -229,6 +231,110 @@ describe('Random', () => {
             for (let i = 0; i < 100; i++) {
                 expect(Number.isFinite(rng.gaussian(10, 2))).toBe(true);
             }
+        });
+    });
+
+    describe('insideRect and pointInRange', () => {
+        it('should keep insideRect points inside the half-open rectangle', () => {
+            const rng = new Random(11);
+            const rect = new Rect2i(10, 20, 5, 7);
+
+            for (let i = 0; i < 500; i++) {
+                expect(rect.isContaining(rng.insideRect(rect))).toBe(true);
+            }
+        });
+
+        it('should keep pointInRange points in the half-open per-axis range', () => {
+            const rng = new Random(12);
+            const min = new Vector2i(3, -2);
+            const max = new Vector2i(8, 4);
+
+            for (let i = 0; i < 500; i++) {
+                const point = rng.pointInRange(min, max);
+
+                expect(point.x).toBeGreaterThanOrEqual(min.x);
+                expect(point.x).toBeLessThan(max.x);
+                expect(point.y).toBeGreaterThanOrEqual(min.y);
+                expect(point.y).toBeLessThan(max.y);
+            }
+        });
+
+        it('should mutate and return out from insideRectTo and pointInRangeTo', () => {
+            const rng = new Random(13);
+            const rect = new Rect2i(0, 0, 4, 4);
+            const min = new Vector2i(1, 2);
+            const max = new Vector2i(5, 6);
+            const outRect = new Vector2i(99, 99);
+            const outRange = new Vector2i(99, 99);
+
+            expect(rng.insideRectTo(rect, outRect)).toBe(outRect);
+            expect(rect.isContaining(outRect)).toBe(true);
+
+            expect(rng.pointInRangeTo(min, max, outRange)).toBe(outRange);
+            expect(outRange.x).toBeGreaterThanOrEqual(min.x);
+            expect(outRange.x).toBeLessThan(max.x);
+            expect(outRange.y).toBeGreaterThanOrEqual(min.y);
+            expect(outRange.y).toBeLessThan(max.y);
+        });
+
+        it('should draw the same sequence for allocating and *To variants', () => {
+            const rect = new Rect2i(2, 3, 6, 5);
+            const min = new Vector2i(-1, 0);
+            const max = new Vector2i(4, 3);
+            const a = new Random(42);
+            const b = new Random(42);
+            const out = new Vector2i();
+
+            for (let i = 0; i < 20; i++) {
+                const allocatedRect = a.insideRect(rect);
+                const writtenRect = b.insideRectTo(rect, out);
+
+                expect(writtenRect.x).toBe(allocatedRect.x);
+                expect(writtenRect.y).toBe(allocatedRect.y);
+
+                const allocatedRange = a.pointInRange(min, max);
+                const writtenRange = b.pointInRangeTo(min, max, out);
+
+                expect(writtenRange.x).toBe(allocatedRange.x);
+                expect(writtenRange.y).toBe(allocatedRange.y);
+            }
+        });
+
+        it('should throw when the rectangle or range is empty', () => {
+            const rng = new Random(1);
+
+            expect(() => rng.insideRect(new Rect2i(0, 0, 0, 4))).toThrow(RangeError);
+            expect(() => rng.pointInRange(new Vector2i(5, 0), new Vector2i(5, 3))).toThrow(RangeError);
+        });
+    });
+
+    describe('direction4 and direction8', () => {
+        it('should only return the four cardinal unit vectors from direction4', () => {
+            const rng = new Random(21);
+            const expected = new Set(['1,0', '-1,0', '0,1', '0,-1']);
+            const seen = new Set<string>();
+
+            for (let i = 0; i < 200; i++) {
+                const d = rng.direction4();
+
+                seen.add(`${d.x},${d.y}`);
+            }
+
+            expect(seen).toEqual(expected);
+        });
+
+        it('should only return the eight king-move unit vectors from direction8', () => {
+            const rng = new Random(22);
+            const expected = new Set(['1,0', '-1,0', '0,1', '0,-1', '1,1', '1,-1', '-1,1', '-1,-1']);
+            const seen = new Set<string>();
+
+            for (let i = 0; i < 400; i++) {
+                const d = rng.direction8();
+
+                seen.add(`${d.x},${d.y}`);
+            }
+
+            expect(seen).toEqual(expected);
         });
     });
 

--- a/src/utils/Random.ts
+++ b/src/utils/Random.ts
@@ -1,9 +1,9 @@
 /**
  * Seeded, deterministic pseudo-random number generator (mulberry32).
  *
- * Integer-first helpers for demos and games: ints, floats, picks, shuffles, and
- * weighted choice. Same seed always produces the same sequence across platforms
- * (pure `>>> 0` integer ops in the core).
+ * Integer-first helpers for demos and games: ints, floats, picks, shuffles,
+ * weighted choice, and Vector2i/Rect2i spatial draws. Same seed always produces
+ * the same sequence across platforms (pure `>>> 0` integer ops in the core).
  *
  * @since 1.5.0
  */
@@ -16,12 +16,34 @@ import {
     randomWeightedLengthError,
     randomWeightedTotalError,
 } from './errorMessages';
+import type { Rect2i } from './Rect2i';
+import { Vector2i } from './Vector2i';
 
 /** Reciprocal of 2^32, used to map a uint32 into [0, 1). */
 const INV_2_32 = 1 / 4294967296;
 
 /** Two pi, used by {@link Random.angle}. */
 const TWO_PI = Math.PI * 2;
+
+/** Cardinal unit offsets for {@link Random.direction4} (Y-down). */
+const CARDINALS: readonly (readonly [number, number])[] = [
+    [1, 0],
+    [-1, 0],
+    [0, 1],
+    [0, -1],
+];
+
+/** Eight king-move unit offsets for {@link Random.direction8} (Y-down). */
+const DIRECTIONS8: readonly (readonly [number, number])[] = [
+    [1, 0],
+    [-1, 0],
+    [0, 1],
+    [0, -1],
+    [1, 1],
+    [1, -1],
+    [-1, 1],
+    [-1, -1],
+];
 
 /**
  * Seeded PRNG with integer-first generators and stream control (`seed` / `clone` / `fork`).
@@ -316,6 +338,95 @@ export class Random {
         const mag = Math.sqrt(-2 * Math.log(u)) * Math.cos(TWO_PI * v);
 
         return mean + mag * stddev;
+    }
+
+    /**
+     * Returns a random integer point inside a rectangle (half-open, like {@link Rect2i.isContaining}).
+     *
+     * @param rect - Rectangle to sample; must have positive width and height.
+     * @returns New point with `x` in `[rect.x, rect.right)` and `y` in `[rect.y, rect.bottom)`.
+     * @since 1.5.0
+     */
+    public insideRect(rect: Rect2i): Vector2i {
+        return this.insideRectTo(rect, new Vector2i());
+    }
+
+    /**
+     * Writes a random integer point inside a rectangle into `out` (zero-alloc).
+     *
+     * Half-open bounds match {@link Rect2i.isContaining}: `x` in `[rect.x, rect.right)`,
+     * `y` in `[rect.y, rect.bottom)`.
+     *
+     * @param rect - Rectangle to sample; must have positive width and height.
+     * @param out - Vector to write into.
+     * @returns The same `out` reference.
+     * @since 1.5.0
+     */
+    public insideRectTo(rect: Rect2i, out: Vector2i): Vector2i {
+        out.x = this.int(rect.x, rect.right);
+        out.y = this.int(rect.y, rect.bottom);
+
+        return out;
+    }
+
+    /**
+     * Returns a random integer point with each axis drawn from a half-open range.
+     *
+     * Per axis uses {@link int}: `x` in `[min.x, max.x)`, `y` in `[min.y, max.y)`.
+     *
+     * @param min - Inclusive lower bound per axis.
+     * @param max - Exclusive upper bound per axis.
+     * @returns New point in the half-open range.
+     * @since 1.5.0
+     */
+    public pointInRange(min: Vector2i, max: Vector2i): Vector2i {
+        return this.pointInRangeTo(min, max, new Vector2i());
+    }
+
+    /**
+     * Writes a random integer point from a half-open per-axis range into `out` (zero-alloc).
+     *
+     * Per axis uses {@link int}: `x` in `[min.x, max.x)`, `y` in `[min.y, max.y)`.
+     *
+     * @param min - Inclusive lower bound per axis.
+     * @param max - Exclusive upper bound per axis.
+     * @param out - Vector to write into.
+     * @returns The same `out` reference.
+     * @since 1.5.0
+     */
+    public pointInRangeTo(min: Vector2i, max: Vector2i, out: Vector2i): Vector2i {
+        out.x = this.int(min.x, max.x);
+        out.y = this.int(min.y, max.y);
+
+        return out;
+    }
+
+    /**
+     * Returns one of the four cardinal unit directions (Y-down).
+     *
+     * Possible values: `(1, 0)`, `(-1, 0)`, `(0, 1)`, `(0, -1)`.
+     *
+     * @returns New unit vector.
+     * @since 1.5.0
+     */
+    public direction4(): Vector2i {
+        const [x, y] = CARDINALS[this.int(4)] as readonly [number, number];
+
+        return Vector2i.fromXYUnchecked(x, y);
+    }
+
+    /**
+     * Returns one of the eight king-move unit directions (Y-down).
+     *
+     * Cardinals plus diagonals: `(±1, 0)`, `(0, ±1)`, `(±1, ±1)`.
+     *
+     * @returns New unit vector.
+     * @since 1.5.0
+     */
+    public direction8(): Vector2i {
+        const [x, y] = DIRECTIONS8[this.int(8)] as readonly [number, number];
+
+        return Vector2i.fromXYUnchecked(x, y);
     }
 
     /**


### PR DESCRIPTION
## Summary

Add insideRect/pointInRange with *To zero-alloc variants and direction4/direction8 (Y-down), matching half-open int bounds. Includes tests, benches, and api-random docs.