### PR TITLE
chore(rules): scope always-loaded rule files to their relevant paths

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,3 +1,7 @@
+---
+paths: [src/**]
+---
+
 # Architecture
 
 Paired with `.cursor/rules/architecture.mdc` (same annotated tree).

--- a/.claude/rules/docs-authoring.md
+++ b/.claude/rules/docs-authoring.md
@@ -1,3 +1,7 @@
+---
+paths: [docs/**/*.md]
+---
+
 # Docs authoring
 
 Condensed mirror of `.cursor/rules/docs-authoring.mdc`. How to write, rename, and split published `docs/*.md` pages

--- a/.claude/rules/docs-sync-required.md
+++ b/.claude/rules/docs-sync-required.md
@@ -1,5 +1,6 @@
 ---
-paths: [src/**/*.ts, docs/**/*.md]
+paths:
+  [src/**/*.ts, docs/**/*.md, docs/_sitemap.json, README.md, CLAUDE.md, .claude/skills/**/SKILL.md, .cursor/rules/*.mdc]
 ---
 
 # Docs sync required

--- a/.claude/rules/docs-sync-required.md
+++ b/.claude/rules/docs-sync-required.md
@@ -1,3 +1,7 @@
+---
+paths: [src/**/*.ts, docs/**/*.md]
+---
+
 # Docs sync required
 
 Condensed mirror of `.cursor/rules/docs-sync-required.mdc`.

--- a/.claude/rules/environment-bootstrap.md
+++ b/.claude/rules/environment-bootstrap.md
@@ -1,3 +1,7 @@
+---
+paths: [scripts/session-start-bootstrap.sh, .claude/settings.json, .cursor/hooks.json, .devcontainer/devcontainer.json]
+---
+
 # Environment bootstrap
 
 Condensed mirror of `.cursor/rules/environment-bootstrap.mdc`. How a fresh remote/web/cloud checkout warms its toolchain

--- a/.claude/rules/ts-file-structure.md
+++ b/.claude/rules/ts-file-structure.md
@@ -1,3 +1,7 @@
+---
+paths: [src/**/*.ts]
+---
+
 # TypeScript file structure
 
 This file (and `.cursor/rules/ts-file-structure.mdc`) is the full policy for TypeScript file structure;

--- a/.claude/rules/twoslash-docs.md
+++ b/.claude/rules/twoslash-docs.md
@@ -1,3 +1,7 @@
+---
+paths: [docs/api-*.md, docs/guide-*.md, docs/performance-*.md, docs/reference-*.md]
+---
+
 # Twoslash in published docs
 
 Condensed mirror of `.cursor/rules/twoslash-docs.mdc`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,8 +255,8 @@ Full file layout and class member order: `.claude/rules/ts-file-structure.md` (C
 
 ## Commands
 
-All commands are `pnpm run <script>` (see `package.json` for the full script list; `pnpm run preflight` runs the gating
-checks listed under Testing below).
+All commands are `pnpm run <script>` (see `package.json` for the full script list; `pnpm run preflight` runs the
+repository's gating checks — its exact definition lives in `package.json`).
 
 RTK: Shell commands are rewritten via `rtk hook cursor` (Cursor) / `rtk hook claude` (Claude Code). Use `pnpm run …` for
 scripts. Prefer `rtk read` / `rtk grep` / shell over native Read/Grep for exploration. See `~/.claude/RTK.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,39 +255,17 @@ Full file layout and class member order: `.claude/rules/ts-file-structure.md` (C
 
 ## Commands
 
-```bash
-pnpm run build              # Build library (two Vite builds: the main dist/blit386.* plus dist/vite.* for the blit386/vite subpath)
-pnpm run lint               # ESLint
-pnpm run lint:fix           # ESLint with auto-fix
-pnpm run format             # Format all files (Biome + Prettier)
-pnpm run format:check       # Check formatting (Biome + Prettier)
-pnpm run typecheck          # TypeScript type checking
-pnpm run spellcheck         # cspell check
-pnpm run knip               # Find unused exports/deps
-pnpm run docs:links         # Check Markdown links (all repo-root *.md / *.mdx)
-pnpm run agents:check       # Check agent config drift (rules parity, skills symlinks, AGENTS.md pointer, Copilot, Zed)
-pnpm run preflight          # All checks (format + lint + typecheck + spellcheck + knip + docs:links + agents:check + sync:doc-banners:check + sync:cursor-commands:check + api:since:check + api:history:check + test:unit + test:declarations + test:agent-config + test:cursor-commands + test:api-history + test:security-preflight)
-```
+All commands are `pnpm run <script>` (see `package.json` for the full script list; `pnpm run preflight` runs the gating
+checks listed under Testing below).
 
 RTK: Shell commands are rewritten via `rtk hook cursor` (Cursor) / `rtk hook claude` (Claude Code). Use `pnpm run …` for
 scripts. Prefer `rtk read` / `rtk grep` / shell over native Read/Grep for exploration. See `~/.claude/RTK.md`.
 
 ## Testing
 
-Test files are colocated next to source: `src/utils/Vector2i.test.ts`.
-
-```bash
-pnpm run test                # Run all unit tests (alias for test:unit)
-pnpm run test:unit           # Run all unit tests
-pnpm run test:unit:watch     # Watch mode for development
-pnpm run test:unit:coverage  # Coverage report (80% minimum threshold)
-pnpm run test:declarations   # Declaration tooling log checker (Node test)
-pnpm run test:agent-config   # Agent config drift checker tests (Node test)
-pnpm run test:visual         # Playwright visual regression tests (requires Chrome with WebGPU)
-pnpm run test:visual:update  # Update visual test baselines
-pnpm run bench               # Run CPU benchmarks (Vitest bench)
-pnpm run bench:json          # Run benchmarks and write benchmark-results.json
-```
+Test files are colocated next to source: `src/utils/Vector2i.test.ts`. Test-related scripts (`test`, `test:unit`,
+`test:unit:watch`, `test:unit:coverage`, `test:declarations`, `test:agent-config`, `test:visual`, `test:visual:update`,
+`bench`, `bench:json`) are all `pnpm run <script>` — see `package.json` for exact invocations.
 
 Test tiers:
 


### PR DESCRIPTION
Add `paths:` frontmatter to architecture.md, ts-file-structure.md, docs-authoring.md, twoslash-docs.md, docs-sync-required.md, and environment-bootstrap.md so Claude Code loads them only when working under matching files, mirroring the Cursor `alwaysApply: false` glob scoping these rules already carry. Also trim CLAUDE.md's Commands/Testing sections to point at package.json instead of re-listing every script inline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added path-based metadata/front-matter to multiple documentation rules to scope when they apply (architecture, docs authoring, docs sync requirements, environment bootstrap, TypeScript file structure, and Twoslash docs).
  * Updated the “Commands” and “Testing” sections in the main guidance to reference the project’s `pnpm run <script>` pattern and point to the script catalog in the project configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->