### PR TITLE
chore(agents): dedupe bt-* skill checklists and sharpen descriptions

### DIFF
--- a/.claude/skills/bt-deep-review/SKILL.md
+++ b/.claude/skills/bt-deep-review/SKILL.md
@@ -27,9 +27,7 @@ pushing significant changes or creating pull requests.
 
 2. Run preflight checks
 
-- Execute `pnpm run preflight` (format, lint, typecheck, spellcheck, knip, docs:links, agents:check,
-  sync:doc-banners:check, sync:cursor-commands:check, api:since:check, api:history:check, test:unit, test:declarations,
-  test:agent-config, test:cursor-commands, test:api-history, test:security-preflight)
+- Run `/bt-preflight` (or `pnpm run preflight` directly) – see that skill for the full breakdown of what it checks
 - If any check fails, report issues and stop
 - All automated checks must pass before AI review
 
@@ -58,12 +56,8 @@ pushing significant changes or creating pull requests.
 
 6. Check project-specific rules
 
-- No emoji anywhere (code, comments, docs, commits)
-- Integer coordinates (Vector2i, Rect2i) for all rendering
-- TypeScript strict types (no `any`)
-- Type imports use `import type` syntax
-- Internal scoped naming: private/protected/module-local names must not repeat class or file; public `BT.*` and exports
-  unchanged (`CLAUDE.md` Internal scoped naming)
+- Apply the same project-rule checklist as `/bt-review` (full detail: `CLAUDE.md` Critical Rules, BT API getters vs
+  methods, Internal scoped naming, plus the paired rule files – `.claude/rules/*.md`, Cursor: `.cursor/rules/*.mdc`)
 
 7. Generate PR-ready summary
 
@@ -82,23 +76,7 @@ pushing significant changes or creating pull requests.
 
 ### Automated Checks
 
-- [PASS/FAIL] Format check
-- [PASS/FAIL] Lint check
-- [PASS/FAIL] Type check
-- [PASS/FAIL] Spell check
-- [PASS/FAIL] Unused exports (knip)
-- [PASS/FAIL] Markdown links (docs:links)
-- [PASS/FAIL] Agent config drift (agents:check)
-- [PASS/FAIL] Doc banners (sync:doc-banners:check)
-- [PASS/FAIL] Cursor commands drift (sync:cursor-commands:check)
-- [PASS/FAIL] Cursor command tests (test:cursor-commands)
-- [PASS/FAIL] API @since coverage (api:since:check)
-- [PASS/FAIL] API history manifest (api:history:check)
-- [PASS/FAIL] Unit tests (test:unit)
-- [PASS/FAIL] Declaration tooling (test:declarations)
-- [PASS/FAIL] Agent config tests (test:agent-config)
-- [PASS/FAIL] API history tests (test:api-history)
-- [PASS/FAIL] Security preflight tests (test:security-preflight)
+- One [PASS/FAIL] line per check `pnpm run preflight` runs (see `/bt-preflight` for the current list)
 - [PASS/FAIL] Security audit
 
 ### Code Review Findings

--- a/.claude/skills/bt-format/SKILL.md
+++ b/.claude/skills/bt-format/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: bt-format
 description:
-  Format all code with Biome and Prettier, then verify formatting passes. Use when the user asks to format, reformat, or
-  clean up code style, or to fix a failing format check.
+  Format all code with Biome and Prettier and verify the result with format:check. Use when the user wants formatting
+  done and confirmed – before a commit or PR, when a format check has failed in CI or a hook, or any time the result
+  needs to be trustworthy rather than just fast. For a no-verification quick pass, use bt-quick-format instead.
 ---
 
 # Format Code

--- a/.claude/skills/bt-perf/SKILL.md
+++ b/.claude/skills/bt-perf/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: bt-perf
-description: Add or update BLIT386 CPU benchmarks and explain the CI benchmark workflow.
+description:
+  Add or update BLIT386 CPU benchmarks (`*.bench.ts`) and explain the CI benchmark workflow. Use when adding a benchmark
+  for a new hot method or allocation pattern, or when a `perf`-labeled PR's benchmark comparison or regression threshold
+  needs explaining.
 ---
 
 # Performance Testing

--- a/.claude/skills/bt-pr/SKILL.md
+++ b/.claude/skills/bt-pr/SKILL.md
@@ -41,7 +41,7 @@ The description after `/bt-pr` becomes the commit subject.
 - Stage relevant files with `git add`
 - Generate a conventional commit message:
   - Format: `<type>(<scope>): <description>`
-  - Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`
+  - Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
   - Scopes (convention only): prefer an existing one – `docs`, `audio`, `assets`, `overlay`, `core`, `api`, `ci`,
     `renderer`, `tests`, `utils`, `rules`, `release`, `security`, `input`, `deps` / `deps-dev`, `visual`, `camera`
     (rare/legacy: `examples`)

--- a/.claude/skills/bt-quick-format/SKILL.md
+++ b/.claude/skills/bt-quick-format/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: bt-quick-format
 description:
-  Quickly format all code with Biome and Prettier, skipping the verification step. Use for a fast cleanup after edits or
-  to fix formatting flagged by CI or a hook.
+  Quickly format all code with Biome and Prettier, skipping the format:check verification step. Use for a fast cleanup
+  right after edits, or as a lightweight pre-step before other checks, when you don't need confirmation that formatting
+  actually passed. If the result needs to be verified (before a commit or PR), use bt-format instead.
 ---
 
 # Quick Format
@@ -20,18 +21,10 @@ verification steps for maximum speed.
 
 1. Run formatters
 
-- Execute `pnpm run format` which runs:
-  - Biome for TypeScript/JavaScript/JSON/JSONC/CSS
-  - Prettier for Markdown/YAML/Cursor rules (`.md`, `.mdx`, `.mdc`, `.yml`, `.yaml`)
+- Execute `pnpm run format` (Biome for TS/JS/JSON/JSONC/CSS, Prettier for MD/YAML/Cursor rules – see `/bt-format` for
+  the full file-type table)
 
 2. Brief confirmation
 
 - Report completion
 - Note any files that couldn't be formatted (usually indicate syntax errors)
-
-## When to Use
-
-- A quick cleanup after manual edits
-- Before running other checks
-- When you know you just need formatting (not verification)
-- To fix formatting issues reported by CI or hooks

--- a/.claude/skills/bt-review/SKILL.md
+++ b/.claude/skills/bt-review/SKILL.md
@@ -31,18 +31,20 @@ Review current changes against project rules and quality standards.
 
 3. Check against project rules
 
+Full detail lives in `CLAUDE.md` (Critical Rules, BT API: getters vs methods, Internal scoped naming, Boolean naming)
+and the paired rule files (`.claude/rules/*.md`, Cursor: `.cursor/rules/*.mdc`) – read those for the exact getter list,
+naming exceptions, and edge cases rather than relying on a paraphrase here. Rules below are cited by basename, which is
+the same in both directories. Quick checklist:
+
 - No emoji anywhere (code, comments, docs, commits)
 - Integer coordinates (Vector2i, Rect2i) for rendering
-- TypeScript strict types (no `any`)
-- Type imports use `import type` syntax
-- Proper error handling (guard clauses, null checks)
-- Consistent naming conventions
-- Internal scoped naming: private/protected/module-local names must not repeat class or file name (`request()` on
-  `FrameCapture`, not `requestCapture()`). Public `BT.*` and barrel exports stay unchanged. See `CLAUDE.md` (Internal
-  scoped naming).
-- BT API shape: read-only zero-arg snapshots use getters (`BT.displaySize`, `BT.targetFPS`), not `BT.foo()`. Actions and
-  parameterized queries stay methods. New configure mirrors use `HardwareSettings` field names (`targetFPS`, not `fps`).
-  Derived getters (e.g. `outputSize`) have no matching field. See `CLAUDE.md` (BT API: getters vs methods).
+- TypeScript strict types (no `any`); type-only imports for types
+- Proper error handling (guard clauses, null checks); consistent naming
+- Internal scoped naming: private/protected/module-local names don't repeat the class or file name (`request()` on
+  `FrameCapture`, not `requestCapture()`); public `BT.*` and barrel exports stay unchanged (`internal-scoped-naming`
+  rule)
+- BT API shape: read-only zero-arg snapshots are getters (`BT.displaySize`, `BT.targetFPS`), not `BT.foo()`; actions and
+  parameterized queries stay methods (`bt-api-getters` rule)
 
 4. Summarize findings
 

--- a/.claude/skills/bt-security-run/SKILL.md
+++ b/.claude/skills/bt-security-run/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: bt-security-run
-description: Run MCP security preflight, governance checks, and documented fallbacks for BLIT386 security workflows.
+description:
+  Run MCP security preflight, governance checks, and documented fallbacks for BLIT386 security workflows. Use before
+  comprehensive security scans or hardening passes, or whenever MCP security-scanner availability (Opsera, JFrog,
+  Semgrep) is uncertain and scans still need to happen via a documented fallback.
 ---
 
 # Security Run

--- a/.cursor/commands/bt-deep-review.md
+++ b/.cursor/commands/bt-deep-review.md
@@ -20,9 +20,7 @@ pushing significant changes or creating pull requests.
 
 2. Run preflight checks
 
-- Execute `pnpm run preflight` (format, lint, typecheck, spellcheck, knip, docs:links, agents:check,
-  sync:doc-banners:check, sync:cursor-commands:check, api:since:check, api:history:check, test:unit, test:declarations,
-  test:agent-config, test:cursor-commands, test:api-history, test:security-preflight)
+- Run `/bt-preflight` (or `pnpm run preflight` directly) – see that skill for the full breakdown of what it checks
 - If any check fails, report issues and stop
 - All automated checks must pass before AI review
 
@@ -51,12 +49,8 @@ pushing significant changes or creating pull requests.
 
 6. Check project-specific rules
 
-- No emoji anywhere (code, comments, docs, commits)
-- Integer coordinates (Vector2i, Rect2i) for all rendering
-- TypeScript strict types (no `any`)
-- Type imports use `import type` syntax
-- Internal scoped naming: private/protected/module-local names must not repeat class or file; public `BT.*` and exports
-  unchanged (`CLAUDE.md` Internal scoped naming)
+- Apply the same project-rule checklist as `/bt-review` (full detail: `CLAUDE.md` Critical Rules, BT API getters vs
+  methods, Internal scoped naming, plus the paired rule files – `.claude/rules/*.md`, Cursor: `.cursor/rules/*.mdc`)
 
 7. Generate PR-ready summary
 
@@ -75,23 +69,7 @@ pushing significant changes or creating pull requests.
 
 ### Automated Checks
 
-- [PASS/FAIL] Format check
-- [PASS/FAIL] Lint check
-- [PASS/FAIL] Type check
-- [PASS/FAIL] Spell check
-- [PASS/FAIL] Unused exports (knip)
-- [PASS/FAIL] Markdown links (docs:links)
-- [PASS/FAIL] Agent config drift (agents:check)
-- [PASS/FAIL] Doc banners (sync:doc-banners:check)
-- [PASS/FAIL] Cursor commands drift (sync:cursor-commands:check)
-- [PASS/FAIL] Cursor command tests (test:cursor-commands)
-- [PASS/FAIL] API @since coverage (api:since:check)
-- [PASS/FAIL] API history manifest (api:history:check)
-- [PASS/FAIL] Unit tests (test:unit)
-- [PASS/FAIL] Declaration tooling (test:declarations)
-- [PASS/FAIL] Agent config tests (test:agent-config)
-- [PASS/FAIL] API history tests (test:api-history)
-- [PASS/FAIL] Security preflight tests (test:security-preflight)
+- One [PASS/FAIL] line per check `pnpm run preflight` runs (see `/bt-preflight` for the current list)
 - [PASS/FAIL] Security audit
 
 ### Code Review Findings

--- a/.cursor/commands/bt-pr.md
+++ b/.cursor/commands/bt-pr.md
@@ -34,7 +34,7 @@ The description after `/bt-pr` becomes the commit subject.
 - Stage relevant files with `git add`
 - Generate a conventional commit message:
   - Format: `<type>(<scope>): <description>`
-  - Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`
+  - Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
   - Scopes (convention only): prefer an existing one – `docs`, `audio`, `assets`, `overlay`, `core`, `api`, `ci`,
     `renderer`, `tests`, `utils`, `rules`, `release`, `security`, `input`, `deps` / `deps-dev`, `visual`, `camera`
     (rare/legacy: `examples`)

--- a/.cursor/commands/bt-quick-format.md
+++ b/.cursor/commands/bt-quick-format.md
@@ -13,18 +13,10 @@ verification steps for maximum speed.
 
 1. Run formatters
 
-- Execute `pnpm run format` which runs:
-  - Biome for TypeScript/JavaScript/JSON/JSONC/CSS
-  - Prettier for Markdown/YAML/Cursor rules (`.md`, `.mdx`, `.mdc`, `.yml`, `.yaml`)
+- Execute `pnpm run format` (Biome for TS/JS/JSON/JSONC/CSS, Prettier for MD/YAML/Cursor rules – see `/bt-format` for
+  the full file-type table)
 
 2. Brief confirmation
 
 - Report completion
 - Note any files that couldn't be formatted (usually indicate syntax errors)
-
-## When to Use
-
-- A quick cleanup after manual edits
-- Before running other checks
-- When you know you just need formatting (not verification)
-- To fix formatting issues reported by CI or hooks

--- a/.cursor/commands/bt-review.md
+++ b/.cursor/commands/bt-review.md
@@ -24,18 +24,20 @@ Review current changes against project rules and quality standards.
 
 3. Check against project rules
 
+Full detail lives in `CLAUDE.md` (Critical Rules, BT API: getters vs methods, Internal scoped naming, Boolean naming)
+and the paired rule files (`.claude/rules/*.md`, Cursor: `.cursor/rules/*.mdc`) – read those for the exact getter list,
+naming exceptions, and edge cases rather than relying on a paraphrase here. Rules below are cited by basename, which is
+the same in both directories. Quick checklist:
+
 - No emoji anywhere (code, comments, docs, commits)
 - Integer coordinates (Vector2i, Rect2i) for rendering
-- TypeScript strict types (no `any`)
-- Type imports use `import type` syntax
-- Proper error handling (guard clauses, null checks)
-- Consistent naming conventions
-- Internal scoped naming: private/protected/module-local names must not repeat class or file name (`request()` on
-  `FrameCapture`, not `requestCapture()`). Public `BT.*` and barrel exports stay unchanged. See `CLAUDE.md` (Internal
-  scoped naming).
-- BT API shape: read-only zero-arg snapshots use getters (`BT.displaySize`, `BT.targetFPS`), not `BT.foo()`. Actions and
-  parameterized queries stay methods. New configure mirrors use `HardwareSettings` field names (`targetFPS`, not `fps`).
-  Derived getters (e.g. `outputSize`) have no matching field. See `CLAUDE.md` (BT API: getters vs methods).
+- TypeScript strict types (no `any`); type-only imports for types
+- Proper error handling (guard clauses, null checks); consistent naming
+- Internal scoped naming: private/protected/module-local names don't repeat the class or file name (`request()` on
+  `FrameCapture`, not `requestCapture()`); public `BT.*` and barrel exports stay unchanged (`internal-scoped-naming`
+  rule)
+- BT API shape: read-only zero-arg snapshots are getters (`BT.displaySize`, `BT.targetFPS`), not `BT.foo()`; actions and
+  parameterized queries stay methods (`bt-api-getters` rule)
 
 4. Summarize findings
 


### PR DESCRIPTION
## Summary

Housekeeping on the `bt-*` agent skills and their generated Cursor commands. Net -48 lines, but the removals are duplicated lists rather than content – every dropped detail still lives in exactly one authoritative place.

### Deduplicated the preflight check list

`bt-deep-review` carried a 17-item inline copy of what `pnpm run preflight` runs, in two places (the step and the report template). It had already drifted out of order relative to `package.json`. Both now point at `/bt-preflight`, whose `SKILL.md` carries the annotated list. The list still exists in `package.json`, `CLAUDE.md`, and `.claude/rules/rtk-and-pnpm.md` – this removes the fifth copy, the only one nobody was maintaining.

### Condensed the `bt-review` project-rule checklist

Replaced the paraphrased long form with a short checklist plus pointers to `CLAUDE.md` and the paired rule files. Rules are cited by basename (`internal-scoped-naming`, `bt-api-getters`) so the generated Cursor command resolves them against `.cursor/rules/*.mdc` just as well as the skill resolves them against `.claude/rules/*.md`.

Nothing is lost: the dropped `targetFPS`-not-`fps` and `outputSize`-has-no-field detail is verbatim in `.claude/rules/bt-api-getters.md`, which is always applied in this repo. `bt-deep-review` step 6 now defers to this checklist, which is strictly more complete than the subset it replaces (the old one omitted error handling and BT API shape).

### Sharpened four frontmatter descriptions

Skill selection runs entirely off the description, and `bt-perf` and `bt-security-run` had bare one-liners with no use-when trigger at all. All four now state when to reach for them; `bt-format` and `bt-quick-format` additionally name each other as the alternative, which was a real ambiguity.

### Fixed the `bt-pr` commit-type list

Added the missing `revert`. It is in the `type-enum` in `commitlint.config.js`, so the skill was steering away from a type the repo has always accepted.

## Test plan

- [x] `pnpm run preflight` – full pass, including `sync:cursor-commands:check` (12/12 up to date), `agents:check`, `test:cursor-commands` (21/21), and `spellcheck`
- [x] `pnpm run format:check` – clean
- [x] Pre-push hook (`typecheck` + `lint` + `docs:links`) – clean, 44 links checked
- [x] Verified `revert` against the `type-enum` in `commitlint.config.js`
- [x] Verified `/bt-preflight` and `/bt-format` actually contain the lists the new pointers promise
- [x] `.cursor/commands/*` regenerated via `pnpm run sync:cursor-commands`, never hand-edited

No engine code, public API, or behavior changed, so no `docs/` update is owed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development skill guidance for preflight checks, code reviews, formatting, performance benchmarking, security scans, and pull-request workflows.
  * Clarified when to use standard and quick formatting workflows, including verification expectations.
  * Centralized review and preflight rules by directing readers to the authoritative project rule documentation.
  * Added support for `revert` as a conventional commit type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->