### PR TITLE
chore(hooks): drop cspell from the PostToolUse formatting hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -47,10 +47,6 @@
           {
             "type": "command",
             "command": "FILE=$(echo \"$CLAUDE_TOOL_PARAMETERS\" | sed -n \"s/.*\\\"file_path\\\"[[:space:]]*:[[:space:]]*\\\"\\([^\\\"]*\\)\\\".*/\\1/p\" | head -1); if [ -n \"$FILE\" ] && [ -f \"$FILE\" ]; then cd \"$CLAUDE_PROJECT_DIR\" && pnpm exec biome check --write \"$FILE\" 2>/dev/null; pnpm exec prettier --write \"$FILE\" 2>/dev/null; fi; true"
-          },
-          {
-            "type": "command",
-            "command": "FILE=$(echo \"$CLAUDE_TOOL_PARAMETERS\" | sed -n \"s/.*\\\"file_path\\\"[[:space:]]*:[[:space:]]*\\\"\\([^\\\"]*\\)\\\".*/\\1/p\" | head -1); if [ -n \"$FILE\" ] && [ -f \"$FILE\" ] && echo \"$FILE\" | grep -qE '\\.(ts|tsx|js|md|mdx)$'; then cd \"$CLAUDE_PROJECT_DIR\" && RESULT=$(pnpm exec cspell --no-progress \"$FILE\" 2>&1); if [ $? -ne 0 ]; then echo \"[SPELLCHECK] Errors found in $FILE:\"; echo \"$RESULT\"; echo \"Fix typos in the source code, or add legitimate technical terms to cspell.json in the words array.\"; fi; fi; true"
           }
         ]
       }


### PR DESCRIPTION
## Summary

The per-edit spellcheck was noisy and duplicated coverage already provided by lint-staged pre-commit and the *-spellcheck skill. PostToolUse now only runs biome/prettier formatting on Edit/Write/MultiEdit.