### PR TITLE
fix(hooks): block every git clean that is not a dry run

### DIFF
--- a/.claude/hooks/shell-safety.sh
+++ b/.claude/hooks/shell-safety.sh
@@ -35,10 +35,31 @@ fi
 NORMALIZED_TEXT="$(printf '%s' "$COMMAND_TEXT" | tr -d "'" | tr -d '"' | tr -d '\\')"
 
 GIT_PREFIX='git([[:space:]]+(-[^[:space:]]+([[:space:]]+[^-][^[:space:]]*)?|--[^[:space:]]+([[:space:]]+[^-][^[:space:]]*)?))*[[:space:]]+'
-GIT_CLEAN_FLAGS='(-[^[:cntrl:]]*f[^[:cntrl:]]*d|-[^[:cntrl:]]*d[^[:cntrl:]]*f|-([^[:cntrl:]]|[[:space:]])*-f([^[:cntrl:]]|[[:space:]])*-d|-([^[:cntrl:]]|[[:space:]])*-d([^[:cntrl:]]|[[:space:]])*-f)'
 
-if printf '%s' "$NORMALIZED_TEXT" | grep -Eq "${GIT_PREFIX}reset[[:space:]]+--hard|${GIT_PREFIX}clean[[:space:]]+${GIT_CLEAN_FLAGS}|${GIT_PREFIX}checkout[[:space:]]+--"; then
-    printf '[BLOCKED] Destructive git command detected (reset --hard / clean -fd / checkout --). Use a safer git operation or ask for explicit approval.\n' >&2
+# `git clean` deletes untracked files, so treat every invocation as destructive
+# unless it is an explicit preview. Matching force flags alone was not enough:
+# `git -c clean.requireForce=false clean -d` deletes without ever naming a force
+# flag, and any other way around clean.requireForce would slip past the same way.
+# So only a dry run (`-n`, `--dry-run`) that carries no force flag is allowed
+# through; everything else, a bare `git clean` included, is denied. A preview
+# that still bundles an f (`git clean -nfd`) is denied too: over-matching is the
+# safe direction here, and the message says what to do instead. Each argument
+# scan stops at a shell separator, so flags belonging to a later command
+# (`git clean -n && rm -f build.log`) are never read as part of the clean.
+GIT_CLEAN='clean([[:space:]]|[;&|<>]|$)'
+GIT_CLEAN_FORCE='([[:space:]]+[^[:space:];&|<>]+)*[[:space:]]+(-[[:alnum:]]*f[[:alnum:]]*|--force)([[:space:]]|[;&|<>]|$)'
+GIT_CLEAN_DRY_RUN='([[:space:]]+[^[:space:];&|<>]+)*[[:space:]]+(-[[:alnum:]]*n[[:alnum:]]*|--dry-run)([[:space:]]|[;&|<>]|$)'
+
+# Exit status 0 when the command runs a `git clean` that is not a no-force dry run.
+is_destructive_clean() {
+    printf '%s' "$NORMALIZED_TEXT" | grep -Eq "${GIT_PREFIX}${GIT_CLEAN}" || return 1
+    printf '%s' "$NORMALIZED_TEXT" | grep -Eq "${GIT_PREFIX}clean${GIT_CLEAN_FORCE}" && return 0
+    printf '%s' "$NORMALIZED_TEXT" | grep -Eq "${GIT_PREFIX}clean${GIT_CLEAN_DRY_RUN}" && return 1
+    return 0
+}
+
+if printf '%s' "$NORMALIZED_TEXT" | grep -Eq "${GIT_PREFIX}reset[[:space:]]+--hard|${GIT_PREFIX}checkout[[:space:]]+--" || is_destructive_clean; then
+    printf '[BLOCKED] Destructive git command detected (reset --hard / clean without --dry-run / checkout --). Use a safer git operation or ask for explicit approval.\n' >&2
     exit 2
 fi
 

--- a/scripts/shell-safety.test.mjs
+++ b/scripts/shell-safety.test.mjs
@@ -66,6 +66,85 @@ describe('destructive command detection', () => {
     });
 });
 
+describe('git clean detection', () => {
+    it('blocks a bare -f, which already deletes untracked files', () => {
+        const result = runHook('git clean -f');
+
+        assert.equal(result.status, 2);
+        assert.match(result.stderr, /Destructive git command detected/);
+    });
+
+    it('blocks the long --force spelling', () => {
+        const result = runHook('git clean --force');
+
+        assert.equal(result.status, 2);
+        assert.match(result.stderr, /Destructive git command detected/);
+    });
+
+    it('blocks a bundled -xdf', () => {
+        const result = runHook('git clean -xdf');
+
+        assert.equal(result.status, 2);
+        assert.match(result.stderr, /Destructive git command detected/);
+    });
+
+    it('blocks a force flag in a later argument position', () => {
+        const result = runHook('git clean --exclude=build -d -f');
+
+        assert.equal(result.status, 2);
+        assert.match(result.stderr, /Destructive git command detected/);
+    });
+
+    it('blocks a clean behind a global git option', () => {
+        const result = runHook('git -C /tmp/repo clean -fd');
+
+        assert.equal(result.status, 2);
+        assert.match(result.stderr, /Destructive git command detected/);
+    });
+
+    it('blocks a quoted -f (quote-based bypass)', () => {
+        const result = runHook('git clean "-f"');
+
+        assert.equal(result.status, 2);
+        assert.match(result.stderr, /Destructive git command detected/);
+    });
+
+    it('blocks a clean that turns off requireForce instead of passing -f', () => {
+        const result = runHook('git -c clean.requireForce=false clean -d');
+
+        assert.equal(result.status, 2);
+        assert.match(result.stderr, /Destructive git command detected/);
+    });
+
+    it('blocks any clean that is not a preview, force flag or not', () => {
+        const result = runHook('git clean -d');
+
+        assert.equal(result.status, 2);
+        assert.match(result.stderr, /Destructive git command detected/);
+    });
+
+    it('allows a -n dry run', () => {
+        const result = runHook('git clean -n');
+
+        assert.equal(result.status, 0);
+        assert.equal(result.stdout, '');
+    });
+
+    it('allows a --dry-run preview with an exclude pattern', () => {
+        const result = runHook('git clean --dry-run --exclude=dist');
+
+        assert.equal(result.status, 0);
+        assert.equal(result.stdout, '');
+    });
+
+    it('does not trip on a force flag belonging to a later command', () => {
+        const result = runHook('git clean -n && rm -f build.log');
+
+        assert.equal(result.status, 0);
+        assert.equal(result.stdout, '');
+    });
+});
+
 describe('force-push detection', () => {
     it('asks before a short -f push', () => {
         const result = runHook('git push -f origin main');


### PR DESCRIPTION
## Summary

Force-flag matching alone missed `git -c clean.requireForce=false clean -d`, which deletes untracked files without ever naming -f/--force. Now only an explicit dry run (-n/--dry-run) with no force flag is allowed through; every other invocation, including a bare `git clean`, is denied. Adds regression tests for the requireForce bypass, bundled flags, quoted flags, and shell-separator boundaries.

Assisted-by: Claude Sonnet 5