### PR TITLE
feat(random): read back the last seed via Random.seedValue

### DIFF
--- a/docs/api-random.md
+++ b/docs/api-random.md
@@ -210,6 +210,13 @@ rng.setState(saved); // restore and replay
 | `setState(n)` | Restore a saved state |
 | `clone()` | New instance with identical state (identical subsequent draws) |
 | `fork()` | Advance this instance once; seed a child so the two streams diverge |
+| `seedValue` | Last seed passed to the constructor or `seed()`; `undefined` after `setState()`, or on a forked child |
+
+`seedValue` reads back the seed itself, not the current position in the sequence – the value `getState()` returns keeps
+changing as you draw, but `seedValue` stays put until the generator is genuinely reseeded. `setState()` clears it, since
+jumping to an arbitrary saved state does not correspond to any known seed. `clone()` copies it verbatim (including
+`undefined`), matching the identical stream a clone produces. `fork()`'s child always reports `undefined` – a fork is a
+new stream and should not claim a seed its caller never chose.
 
 <PageChangelog page="api/random" />
 

--- a/docs/api-random.md
+++ b/docs/api-random.md
@@ -213,10 +213,11 @@ rng.setState(saved); // restore and replay
 | `seedValue` | Last seed passed to the constructor or `seed()`; `undefined` after `setState()`, or on a forked child |
 
 `seedValue` reads back the seed itself, not the current position in the sequence – the value `getState()` returns keeps
-changing as you draw, but `seedValue` stays put until the generator is genuinely reseeded. `setState()` clears it, since
-jumping to an arbitrary saved state does not correspond to any known seed. `clone()` copies it verbatim (including
-`undefined`), matching the identical stream a clone produces. `fork()`'s child always reports `undefined` – a fork is a
-new stream and should not claim a seed its caller never chose.
+changing as you draw, but `seedValue` stays put until the generator is genuinely reseeded. It is normalized to an
+unsigned 32-bit value, the same representation `getState()` uses, not necessarily the raw number passed in. `setState()`
+clears it, since jumping to an arbitrary saved state does not correspond to any known seed. `clone()` copies it verbatim
+(including `undefined`), matching the identical stream a clone produces. `fork()`'s child always reports `undefined` – a
+fork is a new stream and should not claim a seed its caller never chose.
 
 <PageChangelog page="api/random" />
 

--- a/docs/guide-random.md
+++ b/docs/guide-random.md
@@ -58,6 +58,7 @@ a.pick(['fire', 'water', 'earth']) === b.pick(['fire', 'water', 'earth']); // tr
 
 a.seed(42); // rewind a to the beginning
 a.int(0, 1000); // same first value as before
+a.seedValue; // 42 – the seed itself, readable back after the fact
 ```
 
 The order of draws is part of the state. Adding a `rng.bool()` call between two `rng.int()` calls shifts every value
@@ -100,6 +101,14 @@ rng.int(0, 6); // advance
 
 rng.setState(checkpoint); // rewind and replay the same draws
 ```
+
+`seedValue` answers a different question than `getState()`: not "where am I in the sequence" but "what seed got me
+here." It reports the last seed passed to the constructor or `seed()`, for exactly as long as that claim stays true.
+`setState()` breaks the claim – an arbitrary saved state is not a seed – so it clears `seedValue` to `undefined` rather
+than report something misleading. `clone()` and `fork()` diverge for the same opposite reasons as before: a clone is
+defined to replay the parent's exact sequence, so it copies `seedValue` along with the state; a fork is defined to
+diverge, so its child never claims a seed the caller didn't choose, even though `fork()` seeds the child internally from
+a drawn value.
 
 ## Procedural patterns from coordinates
 

--- a/docs/guide-random.md
+++ b/docs/guide-random.md
@@ -4,8 +4,8 @@
 
 <!-- prettier-ignore -->
 > [!TIP]
-> You're reading the raw source on GitHub. The same page lives at <https://blit386.dev/docs/guides/random>, typeset like
-> an actual docs site and easier on the eyes. Probably the nicer place to read it, but same
+> You're reading the raw source on GitHub. The same page lives at https://blit386.dev/docs/guides/random, typeset like an
+> actual docs site and easier on the eyes. Probably the nicer place to read it, but same
 > words either way.
 
 <!-- blit386.dev-banner:end -->

--- a/src/utils/Random.test.ts
+++ b/src/utils/Random.test.ts
@@ -43,6 +43,32 @@ describe('Random', () => {
             expect(rng.next()).toBeGreaterThanOrEqual(0);
             expect(rng.next()).toBeLessThan(1);
         });
+
+        it('should report the seed passed to the constructor as seedValue', () => {
+            const rng = new Random(1234);
+
+            expect(rng.seedValue).toBe(1234);
+        });
+
+        it('should report the seed passed to seed() as seedValue', () => {
+            const rng = new Random(1234);
+
+            rng.seed(99);
+
+            expect(rng.seedValue).toBe(99);
+        });
+
+        it('should report a reproducible seedValue for a time-seeded generator', () => {
+            const timeSeeded = new Random();
+            const reported = timeSeeded.seedValue;
+            const firstSequence = Array.from({ length: 10 }, () => timeSeeded.next());
+
+            expect(reported).toBeDefined();
+
+            const reseeded = new Random(reported as number);
+
+            expect(Array.from({ length: 10 }, () => reseeded.next())).toEqual(firstSequence);
+        });
     });
 
     describe('next', () => {
@@ -353,6 +379,14 @@ describe('Random', () => {
             expect(Array.from({ length: 5 }, () => rng.next())).toEqual(afterSave);
         });
 
+        it('should clear seedValue after setState', () => {
+            const rng = new Random(50);
+
+            rng.setState(rng.getState());
+
+            expect(rng.seedValue).toBeUndefined();
+        });
+
         it('should clone to an identical stream', () => {
             const parent = new Random(77);
 
@@ -363,6 +397,24 @@ describe('Random', () => {
             expect(Array.from({ length: 10 }, () => parent.next())).toEqual(
                 Array.from({ length: 10 }, () => child.next()),
             );
+        });
+
+        it('should copy seedValue on clone', () => {
+            const parent = new Random(77);
+            const child = parent.clone();
+
+            expect(child.seedValue).toBe(parent.seedValue);
+        });
+
+        it('should copy an undefined seedValue on clone', () => {
+            const parent = new Random(77);
+
+            parent.setState(parent.getState());
+
+            const child = parent.clone();
+
+            expect(parent.seedValue).toBeUndefined();
+            expect(child.seedValue).toBeUndefined();
         });
 
         it('should fork to an independent stream and advance the parent', () => {
@@ -377,6 +429,16 @@ describe('Random', () => {
             const childSeq = Array.from({ length: 10 }, () => child.next());
 
             expect(parentSeq).not.toEqual(childSeq);
+        });
+
+        it('should never report a seedValue on a forked child, and should not affect the parent', () => {
+            const parent = new Random(88);
+            const parentSeedBefore = parent.seedValue;
+
+            const child = parent.fork();
+
+            expect(child.seedValue).toBeUndefined();
+            expect(parent.seedValue).toBe(parentSeedBefore);
         });
 
         it('should make fork reproducible for the same parent state', () => {

--- a/src/utils/Random.test.ts
+++ b/src/utils/Random.test.ts
@@ -58,6 +58,20 @@ describe('Random', () => {
             expect(rng.seedValue).toBe(99);
         });
 
+        it('should normalize a negative constructor seed to unsigned 32-bit', () => {
+            const rng = new Random(-1);
+
+            expect(rng.seedValue).toBe(0xffff_ffff);
+        });
+
+        it('should normalize an overflowing seed() value to unsigned 32-bit', () => {
+            const rng = new Random(0);
+
+            rng.seed(2 ** 32 + 1);
+
+            expect(rng.seedValue).toBe(1);
+        });
+
         it('should report a reproducible seedValue for a time-seeded generator', () => {
             const timeSeeded = new Random();
             const reported = timeSeeded.seedValue;

--- a/src/utils/Random.test.ts
+++ b/src/utils/Random.test.ts
@@ -64,6 +64,7 @@ describe('Random', () => {
             const firstSequence = Array.from({ length: 10 }, () => timeSeeded.next());
 
             expect(reported).toBeDefined();
+            expect(timeSeeded.seedValue).toBe(reported);
 
             const reseeded = new Random(reported as number);
 

--- a/src/utils/Random.ts
+++ b/src/utils/Random.ts
@@ -54,6 +54,9 @@ export class Random {
     /** Internal 32-bit generator state, mutated on every draw. */
     private state: number;
 
+    /** Last seed passed to the constructor or {@link seed}; `undefined` when not known. */
+    private lastSeed: number | undefined;
+
     /**
      * Creates a PRNG. Omit `seed` to time-seed from `Date.now()` (lower 32 bits).
      *
@@ -62,6 +65,20 @@ export class Random {
      */
     public constructor(seed: number = Date.now()) {
         this.state = seed >>> 0;
+        this.lastSeed = this.state;
+    }
+
+    /**
+     * The last seed passed to the constructor or {@link seed}. `undefined` after {@link setState} (the
+     * stream position no longer corresponds to a known seed) or on a {@link fork}ed child (a fork is a new
+     * stream and should not claim to have been seeded by its caller). {@link clone} copies whatever value
+     * the parent currently holds.
+     *
+     * @returns Last known seed, or `undefined` if the origin seed is not known.
+     * @since 1.5.0
+     */
+    public get seedValue(): number | undefined {
+        return this.lastSeed;
     }
 
     /**
@@ -72,6 +89,7 @@ export class Random {
      */
     public seed(seed: number): void {
         this.state = seed >>> 0;
+        this.lastSeed = this.state;
     }
 
     /**
@@ -92,6 +110,7 @@ export class Random {
      */
     public setState(state: number): void {
         this.state = state >>> 0;
+        this.lastSeed = undefined;
     }
 
     /**
@@ -104,6 +123,7 @@ export class Random {
         const copy = new Random(0);
 
         copy.state = this.state;
+        copy.lastSeed = this.lastSeed;
 
         return copy;
     }
@@ -115,7 +135,11 @@ export class Random {
      * @since 1.5.0
      */
     public fork(): Random {
-        return new Random(this.nextUint32());
+        const child = new Random(this.nextUint32());
+
+        child.lastSeed = undefined;
+
+        return child;
     }
 
     /**

--- a/src/utils/Random.ts
+++ b/src/utils/Random.ts
@@ -69,10 +69,11 @@ export class Random {
     }
 
     /**
-     * The last seed passed to the constructor or {@link seed}. `undefined` after {@link setState} (the
-     * stream position no longer corresponds to a known seed) or on a {@link fork}ed child (a fork is a new
-     * stream and should not claim to have been seeded by its caller). {@link clone} copies whatever value
-     * the parent currently holds.
+     * The last seed passed to the constructor or {@link seed}, normalized to an unsigned 32-bit value (the
+     * same representation {@link getState} uses, not necessarily the raw number passed in). `undefined`
+     * after {@link setState} (the stream position no longer corresponds to a known seed) or on a
+     * {@link fork}ed child (a fork is a new stream and should not claim to have been seeded by its caller).
+     * {@link clone} copies whatever value the parent currently holds.
      *
      * @returns Last known seed, or `undefined` if the origin seed is not known.
      * @since 1.5.0
@@ -82,7 +83,8 @@ export class Random {
     }
 
     /**
-     * Reseeds the generator. Same seed restarts the same sequence.
+     * Reseeds the generator. Same seed restarts the same sequence. Updates {@link seedValue} to the
+     * normalized `seed`.
      *
      * @param seed - Any finite number; only its lower 32 bits are used.
      * @since 1.5.0
@@ -103,7 +105,8 @@ export class Random {
     }
 
     /**
-     * Restores a previously saved 32-bit generator state.
+     * Restores a previously saved 32-bit generator state. Clears {@link seedValue} to `undefined`, since an
+     * arbitrary saved state does not correspond to a known seed.
      *
      * @param state - Value from {@link getState} (lower 32 bits used).
      * @since 1.5.0
@@ -114,7 +117,8 @@ export class Random {
     }
 
     /**
-     * Returns a new generator with the same state (identical stream from this point).
+     * Returns a new generator with the same state (identical stream from this point). The copy also shares
+     * this generator's {@link seedValue}, including `undefined`.
      *
      * @returns Independent copy that will produce the same subsequent values.
      * @since 1.5.0
@@ -129,7 +133,8 @@ export class Random {
     }
 
     /**
-     * Returns an independent sub-stream. Advances this generator once to seed the child.
+     * Returns an independent sub-stream. Advances this generator once to seed the child. The child's
+     * {@link seedValue} is always `undefined` - a fork should not claim a caller-chosen seed.
      *
      * @returns New generator whose sequence diverges from this one.
      * @since 1.5.0


### PR DESCRIPTION
## Summary

BT.randomSeed(n) had no way to ask the engine what n was: getState() returns the live, advancing state, not the seed, so callers had to track a seed separately to display, share, or persist it (BT-398).

Adds a read-only Random.seedValue getter reporting the last seed passed to the constructor or seed(). setState() clears it (a restored state isn't a seed), clone() copies it, and a forked child always reports undefined, since a fork shouldn't claim a seed its caller never chose.

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `Random.seedValue` getter to report the generator’s originating seed when known (normalized to the same unsigned 32-bit representation used by `getState()`).
  * Seed tracking updates on reseeding, is cleared by `setState()`, persists via `clone()`, and is always `undefined` for forked child streams.

* **Documentation**
  * Updated the API reference and guide examples to reflect `seedValue` semantics, including behavior after reseeding/state changes.

* **Tests**
  * Extended the `Random` test suite to verify `seedValue` across constructor, `seed()`, `setState()`, `clone()`, and `fork()`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->