### PR TITLE
docs(repo): add the monorepo root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,71 @@
+# BLIT386
+
+[![CI](https://github.com/blit386/blit386/actions/workflows/ci.yml/badge.svg)](https://github.com/blit386/blit386/actions/workflows/ci.yml)
+[![npm version](https://img.shields.io/npm/v/blit386.svg)](https://www.npmjs.com/package/blit386)
+[![License: ISC](https://img.shields.io/badge/License-ISC-blue.svg)](LICENSE)
+
+BLIT386 is a palette-first retro game engine for the web, and this repository is the whole project – the engine, the
+scaffolder that writes you a running game in one command, a few dozen commented demos, and the site that documents them.
+Palette-first means you draw with numbered colors rather than RGBA pixels, so changing what color 3 _means_ recolors
+everything drawn in it at once: a few bytes of palette upload, and water flows or the sky goes dark without a single
+pixel being redrawn. TypeScript throughout, WebGPU where the browser has it, an automatic Canvas 2D fallback where it
+does not.
+
+![BLIT386 logo](https://github.com/blit386/blit386/raw/main/packages/blit386/assets/logo.png)
+
+## Quick start
+
+You do not need to know anything about this repository to start. One command writes a complete, running project:
+
+```bash
+npm create blit386@latest my-game
+cd my-game
+npm run dev
+```
+
+It works with npm, pnpm, yarn, or bun – whichever you ran it with. Open the address it prints, edit `src/game.js`, and
+the page updates as you type. The generated project comes with a starter game, local documentation, and the `blit` CLI.
+
+Already have a project and just want the engine in it? That path starts at
+[`packages/blit386`](packages/blit386/README.md).
+
+## What is in here
+
+| Package | npm | What it is |
+| --- | --- | --- |
+| [`packages/blit386`](packages/blit386) | [`blit386`](https://www.npmjs.com/package/blit386) | The engine: palette, sprites, text, input, audio, post-process effects |
+| [`packages/create-blit386`](packages/create-blit386) | [`create-blit386`](https://www.npmjs.com/package/create-blit386) | The scaffolder behind `npm create blit386@latest` |
+| [`packages/kit`](packages/kit) | [`@blit386/kit`](https://www.npmjs.com/package/@blit386/kit) | What a generated game gets: starter docs, game-author skills, the `blit` CLI |
+| [`packages/demos`](packages/demos) | not published | The examples running at demos.blit386.dev |
+| [`packages/website`](packages/website) | not published | The docs site at blit386.dev |
+
+The engine, the kit, and the scaffolder release together under one shared version number, so a scaffolded game always
+gets a kit that matches the engine it pins.
+
+## Where to go next
+
+- [blit386.dev](https://blit386.dev) – the project site
+- [blit386.dev/docs](https://blit386.dev/docs) – the full documentation, typeset and searchable
+- [demos.blit386.dev](https://demos.blit386.dev) – dozens of small examples, running in your browser
+- [awesome-blit386](https://github.com/blit386/awesome-blit386) – a curated list of games, tools, and resources
+
+## Community
+
+- [Discord](https://discord.gg/tC2wGt88Uj)
+- [GitHub Discussions](https://github.com/blit386/blit386/discussions)
+- [X](https://x.com/blit386)
+- [Bluesky](https://bsky.app/profile/blit386.bsky.social)
+- [Mastodon](https://mastodon.gamedev.place/@blit386)
+
+## Contributing
+
+BLIT386 is built by Václav Vančura ([@vancura](https://github.com/vancura)), and help is welcome. Start with
+[CONTRIBUTING.md](CONTRIBUTING.md) for the setup, the checks, and the commit conventions, and read
+[CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) before taking part. Security reports have their own channel –
+[SECURITY.md](SECURITY.md).
+
+Working inside a single package? Each one has its own `README.md` covering what only it does.
+
+## License
+
+ISC – see [LICENSE](LICENSE).

--- a/packages/blit386/README.md
+++ b/packages/blit386/README.md
@@ -12,7 +12,7 @@ does not.
 
 It is small, it is fast, and it is built to feel like a toy. That is the whole point.
 
-![BLIT386 logo](https://github.com/blit386/blit386/raw/main/assets/logo.png)
+![BLIT386 logo](https://github.com/blit386/blit386/raw/main/packages/blit386/assets/logo.png)
 
 ## Quick overview
 
@@ -175,8 +175,7 @@ npm run dev
 ```
 
 Works with npm, pnpm, yarn, or bun – it uses whichever you ran it with. Open the address it prints and edit
-`src/game.js`. See [create-blit386](https://github.com/blit386/create-blit386) for the options and what lands in the
-project.
+`src/game.js`. See [create-blit386](../create-blit386) for the options and what lands in the project.
 
 ### Add it to a project you already have
 


### PR DESCRIPTION
Closes [BT-412](https://linear.app/vancura/issue/BT-412/write-the-monorepo-root-readme-the-repo-landing-page-is-currently).

## Why

`github.com/blit386/blit386` has had no README since BT-402 moved the engine's to `packages/blit386/README.md`. Every package has one; the repository does not. BT-407 is about to add banners on three archived repos pointing here, and it is the page anyone reached by the announcement sees first.

npm is unaffected either way – the `blit386` package README stays where it is, which is where npm reads it.

## What this adds

A new root `README.md` that answers a different question than the engine's – what the project is, what is in here, where to start – rather than restoring the pre-BT-402 file:

- **Badges** – CI pointing at the current consolidated `ci.yml`, npm version for `blit386`, ISC license linked to the root `LICENSE`.
- **Opening paragraph** framing BLIT386 as a project rather than re-pitching the engine, with one concrete explanation of what palette-first buys you. Deliberately not the engine README's phrasing.
- **Quick start** leading with `npm create blit386@latest`, with `packages/blit386` as the secondary path for people who already have a project.
- **Packages table** adapted from `CLAUDE.md`, reader-facing rather than agent-facing, linking each directory and its npm page (demos and website marked "not published"), plus a line on lockstep versioning.
- **Links** – blit386.dev, /docs, demos.blit386.dev, awesome-blit386 – community links, contributing pointers (`CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`), license.

## Also fixed

Reading `packages/blit386/README.md` with fresh eyes, as the ticket asked: it does not describe itself as the repository root, but two links were left stale by the BT-402 move.

- The logo pointed at `raw/main/assets/logo.png`, which 404s since the asset moved to `packages/blit386/assets/`. This was a broken image on the npm listing as well. The link checker ignores `raw/` paths, so nothing caught it – verified with curl: 404 before, 302 after.
- The scaffolder link pointed at `github.com/blit386/create-blit386`; now `../create-blit386`, matching the file's existing relative-link convention (`../demos`, `../../CONTRIBUTING.md`).

## Left alone

`packages/kit/README.md:90`, `packages/create-blit386/README.md:56`, and `packages/demos/README.md:9` still point "Source and issues" at the soon-to-be-archived `blit386/create-blit386` repo. That is BT-407's archive-and-redirect work, not this PR's.

## Test plan

- [x] `README.md` exists at the repository root
- [x] Does not duplicate `packages/blit386/README.md` – the two have distinct purposes and no shared prose
- [x] `pnpm run docs:links` passes; the root README's 28 links all resolve or are on the config's ignore list
- [x] Badges point at live targets, including the current `ci.yml` workflow
- [x] `pnpm run format:check` passes, tables stay compact
- [x] `cspell` clean on both files (there is no root `spellcheck` script – it is per-package – so cspell was run directly)
- [x] Logo URL verified live: old path 404, new path 302
- [ ] After merge: `gh api repos/blit386/blit386/readme --jq .path` returns `README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive project README covering BLIT386, its rendering options, packages, quick-start workflow, documentation, demos, community resources, contribution guidance, and licensing.
  * Updated package documentation links for improved navigation to local assets and project resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->