### PR TITLE
fix(deploy): resolve wrangler via pnpm workspace, not a bare npm install

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,6 +65,7 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: packages/demos
           command: pages deploy dist/ --project-name=blit386-demos
+          packageManager: pnpm
 
   deploy-website:
     name: Deploy Website to Cloudflare Workers
@@ -98,7 +99,7 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: packages/website
           command: deploy --config dist/server/wrangler.json --name blit386
-          wranglerVersion: '4.67.0'
+          wranglerVersion: '4.114.0'
 
   deploy-demos-next:
     name: Deploy Demos to Cloudflare Pages (next preview)
@@ -134,6 +135,7 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: packages/demos
           command: pages deploy dist/ --project-name=blit386-demos-next
+          packageManager: pnpm
 
   deploy-website-next:
     name: Deploy Website to Cloudflare Workers (next preview)
@@ -166,4 +168,4 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: packages/website
           command: deploy --config dist/server/wrangler.json --name blit386-next
-          wranglerVersion: '4.67.0'
+          wranglerVersion: '4.114.0'


### PR DESCRIPTION
## Summary

- `deploy-demos` and `deploy-demos-next` installed wrangler with a bare `npm i` inside `packages/demos`, which fails because that package depends on `blit386` via `workspace:*` - a protocol only pnpm understands. Every deploy run since this morning has failed on this (5 in a row); `demos.blit386.dev` has been stale all day.
- Fix: pass `packageManager: pnpm` to `wrangler-action` on both demos jobs, so it installs/execs wrangler through the workspace instead of a bare npm install.
- Also repoints the website jobs' `wranglerVersion` pin from a stale `4.67.0` to `4.114.0`, matching the `wrangler` devDependency actually resolved in `packages/website/package.json` (`^4.110.0`) - the pin and the dependency had drifted apart since the pin was never read from the project's own dependency.
- Found while rehearsing the release path for BT-407.

## Test plan

- [x] Verified root cause against `wrangler-action`'s bundled source at the pinned SHA: `detectPackageManager` only checks `workingDirectory` for a lockfile, finds none in `packages/demos` or `packages/website` (the lockfile lives at repo root), and falls back to `npm`.
- [x] Confirmed `pnpm exec wrangler --version` resolves `4.114.0` locally in `packages/website`, matching the lockfile.
- [ ] After merge, re-trigger `workflow_dispatch` on `deploy.yml` and confirm both `deploy-demos` and `deploy-website` succeed.

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated demo deployment workflows to use pnpm explicitly.
  * Updated the Wrangler deployment tool version for website and preview deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->