### PR TITLE
refactor(scripts): dedupe helpers and fix prettier markdown plugin type import

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,6 @@ jobs:
               - 'prettier.config.js'
               - '.prettierignore'
               - 'commitlint.config.js'
-              - 'scripts/**'
               - '.husky/**'
             engine:
               - 'packages/blit386/**'
@@ -84,9 +83,16 @@ jobs:
               - 'packages/blit386/docs/**'
             kit:
               - 'packages/kit/**'
+            # bump-lockstep.mjs/.test.mjs live under root scripts/, not packages/create-blit386/, but
+            # build-test-scaffolder is the only CI job that exercises them (test:bump-lockstep). The rest of
+            # scripts/ (check-markdown-links.mjs, check-agent-config.mjs, prettier-plugin-compact-tables.mjs,
+            # ...) only feeds quality-root's format:check/docs:links/agents:check steps, which already run
+            # unconditionally - see quality-root's `if` below - so it deliberately has no filter entry here.
             scaffolder:
               - 'packages/create-blit386/**'
               - 'packages/kit/**'
+              - 'scripts/bump-lockstep.mjs'
+              - 'scripts/bump-lockstep.test.mjs'
 
   quality-root:
     name: Code Quality (root)

--- a/packages/create-blit386/templates/base/scripts/prettier-plugin-compact-tables.mjs
+++ b/packages/create-blit386/templates/base/scripts/prettier-plugin-compact-tables.mjs
@@ -15,7 +15,7 @@
  */
 
 import { doc } from 'prettier';
-import * as markdown from 'prettier/plugins/markdown.mjs';
+import * as markdown from 'prettier/plugins/markdown';
 
 /**
  * One column's alignment as mdast records it, read from the source delimiter row.

--- a/scripts/bump-lockstep.mjs
+++ b/scripts/bump-lockstep.mjs
@@ -18,11 +18,20 @@ import { fileURLToPath } from 'node:url';
 /** Repo root, resolved from this script's own location at repo-root `scripts/`. */
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
+/** The engine's `package.json` path, relative to `ROOT`. */
+export const ENGINE_PACKAGE_JSON_PATH = 'packages/blit386/package.json';
+
+/** The kit's `package.json` path, relative to `ROOT`. */
+export const KIT_PACKAGE_JSON_PATH = 'packages/kit/package.json';
+
+/** The scaffolder's `package.json` path, relative to `ROOT`. */
+export const CREATE_BLIT386_PACKAGE_JSON_PATH = 'packages/create-blit386/package.json';
+
 /** The three publishable packages' `package.json` paths, relative to `ROOT`. */
 export const LOCKSTEP_PACKAGE_JSON_PATHS = [
-    'packages/blit386/package.json',
-    'packages/kit/package.json',
-    'packages/create-blit386/package.json',
+    ENGINE_PACKAGE_JSON_PATH,
+    KIT_PACKAGE_JSON_PATH,
+    CREATE_BLIT386_PACKAGE_JSON_PATH,
 ];
 
 /** Source file holding the engine's own version constants, relative to `ROOT`. */
@@ -41,11 +50,13 @@ export const SEMVER_RE = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/u;
  */
 export function parseVersionArg(version) {
     const trimmed = version?.trim() ?? '';
+
     if (!SEMVER_RE.test(trimmed)) {
         throw new Error(
             `Expected a SemVer x.y.z version (got ${version === undefined ? '(missing)' : JSON.stringify(version)}).`,
         );
     }
+
     return trimmed;
 }
 
@@ -60,6 +71,7 @@ export function parseVersionArg(version) {
  */
 export function deriveCaretRange(version) {
     const [major, minor] = parseVersionArg(version).split('.');
+
     return `^${major}.${minor}.0`;
 }
 
@@ -73,17 +85,22 @@ export function deriveCaretRange(version) {
  */
 function endOfStringLiteral(raw, start) {
     let index = start + 1;
+
     while (index < raw.length) {
         const char = raw[index];
+
         if (char === '\\') {
             index += 2;
             continue;
         }
+
         if (char === '"') {
             return index + 1;
         }
+
         index += 1;
     }
+
     throw new Error('Invalid JSON: unterminated string literal');
 }
 
@@ -110,25 +127,33 @@ function findTopLevelVersionSpan(raw) {
 
         if (char === '"') {
             const literalEnd = endOfStringLiteral(raw, index);
+
             if (depth !== 1) {
                 index = literalEnd;
                 continue;
             }
+
             let cursor = literalEnd;
+
             while (cursor < raw.length && /\s/u.test(raw[cursor])) {
                 cursor += 1;
             }
+
             if (raw[cursor] !== ':') {
                 index = literalEnd;
                 continue;
             }
+
             cursor += 1;
+
             while (cursor < raw.length && /\s/u.test(raw[cursor])) {
                 cursor += 1;
             }
+
             if (raw.slice(index, literalEnd) === '"version"' && raw[cursor] === '"') {
                 span = { start: cursor, end: endOfStringLiteral(raw, cursor) };
             }
+
             // Resume at the value so it is never re-read as a key.
             index = cursor;
             continue;
@@ -139,12 +164,14 @@ function findTopLevelVersionSpan(raw) {
         } else if (char === '}' || char === ']') {
             depth -= 1;
         }
+
         index += 1;
     }
 
     if (span === undefined) {
         throw new Error('package.json is missing a string "version" field');
     }
+
     return span;
 }
 
@@ -164,27 +191,34 @@ function findStringFieldSpan(raw, key) {
 
     while (index < raw.length) {
         const char = raw[index];
+
         if (char !== '"') {
             index += 1;
             continue;
         }
 
         const literalEnd = endOfStringLiteral(raw, index);
+
         if (raw.slice(index, literalEnd) === keyLiteral) {
             let cursor = literalEnd;
+
             while (cursor < raw.length && /\s/u.test(raw[cursor])) {
                 cursor += 1;
             }
+
             if (raw[cursor] === ':') {
                 cursor += 1;
+
                 while (cursor < raw.length && /\s/u.test(raw[cursor])) {
                     cursor += 1;
                 }
+
                 if (raw[cursor] === '"') {
                     return { start: cursor, end: endOfStringLiteral(raw, cursor) };
                 }
             }
         }
+
         index = literalEnd;
     }
 
@@ -206,21 +240,26 @@ function findStringFieldSpan(raw, key) {
 export function applyVersion(raw, version) {
     /** @type {unknown} */
     let parsed;
+
     try {
         parsed = JSON.parse(raw);
     } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         throw new Error(`Invalid JSON: ${message}`);
     }
+
     if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
         throw new Error('package.json must be a JSON object');
     }
+
     const record = /** @type {Record<string, unknown>} */ (parsed);
+
     if (typeof record.version !== 'string') {
         throw new Error('package.json is missing a string "version" field');
     }
 
     const { start, end } = findTopLevelVersionSpan(raw);
+
     return {
         next: `${raw.slice(0, start)}${JSON.stringify(version)}${raw.slice(end)}`,
         previous: record.version,
@@ -238,6 +277,7 @@ export function applyVersion(raw, version) {
 export function applyEngineRange(raw, range) {
     const { start, end } = findStringFieldSpan(raw, 'engineRange');
     const previous = JSON.parse(raw.slice(start, end));
+
     return {
         next: `${raw.slice(0, start)}${JSON.stringify(range)}${raw.slice(end)}`,
         previous,
@@ -260,6 +300,7 @@ export function applyEngineVersionConstants(raw, version) {
     const majorMatch = raw.match(VERSION_MAJOR_RE);
     const minorMatch = raw.match(VERSION_MINOR_RE);
     const patchMatch = raw.match(VERSION_PATCH_RE);
+
     if (!majorMatch || !minorMatch || !patchMatch) {
         throw new Error('BTAPI.ts is missing one of VERSION_MAJOR / VERSION_MINOR / VERSION_PATCH');
     }
@@ -286,11 +327,14 @@ const BLIT386_RANGE_RE = /(const BLIT386_RANGE = ')([^']+)(';)/u;
  */
 export function applyBlit386Range(raw, range) {
     const match = raw.match(BLIT386_RANGE_RE);
+
     if (!match) {
         throw new Error('scaffold.ts is missing the BLIT386_RANGE constant');
     }
+
     const previous = match[2];
     const next = raw.replace(BLIT386_RANGE_RE, `$1${range}$3`);
+
     return { next, previous };
 }
 
@@ -302,15 +346,26 @@ export function applyBlit386Range(raw, range) {
  * @typedef {{ path: string, apply: (raw: string, version: string) => { next: string, results: { path: string, previous: string, next: string }[] } }} LockstepTarget
  */
 
-/** @type {LockstepTarget[]} */
-const LOCKSTEP_TARGETS = [
-    {
-        path: LOCKSTEP_PACKAGE_JSON_PATHS[0],
+/**
+ * A lockstep target whose `apply` only rewrites its `package.json`'s top-level `version` – no
+ * derived fields. Shared by the engine's and scaffolder's manifests, which are otherwise identical.
+ *
+ * @param {string} path Package.json path, relative to `ROOT`.
+ * @returns {LockstepTarget}
+ */
+function versionOnlyTarget(path) {
+    return {
+        path,
         apply: (raw, version) => {
             const { next, previous } = applyVersion(raw, version);
-            return { next, results: [{ path: LOCKSTEP_PACKAGE_JSON_PATHS[0], previous, next: version }] };
+            return { next, results: [{ path, previous, next: version }] };
         },
-    },
+    };
+}
+
+/** @type {LockstepTarget[]} */
+const LOCKSTEP_TARGETS = [
+    versionOnlyTarget(ENGINE_PACKAGE_JSON_PATH),
     {
         path: ENGINE_VERSION_FILE,
         apply: (raw, version) => {
@@ -322,7 +377,7 @@ const LOCKSTEP_TARGETS = [
         },
     },
     {
-        path: LOCKSTEP_PACKAGE_JSON_PATHS[1],
+        path: KIT_PACKAGE_JSON_PATH,
         apply: (raw, version) => {
             const versionResult = applyVersion(raw, version);
             const range = deriveCaretRange(version);
@@ -330,9 +385,9 @@ const LOCKSTEP_TARGETS = [
             return {
                 next: rangeResult.next,
                 results: [
-                    { path: LOCKSTEP_PACKAGE_JSON_PATHS[1], previous: versionResult.previous, next: version },
+                    { path: KIT_PACKAGE_JSON_PATH, previous: versionResult.previous, next: version },
                     {
-                        path: `${LOCKSTEP_PACKAGE_JSON_PATHS[1]} (blit386.engineRange)`,
+                        path: `${KIT_PACKAGE_JSON_PATH} (blit386.engineRange)`,
                         previous: rangeResult.previous,
                         next: range,
                     },
@@ -340,13 +395,7 @@ const LOCKSTEP_TARGETS = [
             };
         },
     },
-    {
-        path: LOCKSTEP_PACKAGE_JSON_PATHS[2],
-        apply: (raw, version) => {
-            const { next, previous } = applyVersion(raw, version);
-            return { next, results: [{ path: LOCKSTEP_PACKAGE_JSON_PATHS[2], previous, next: version }] };
-        },
-    },
+    versionOnlyTarget(CREATE_BLIT386_PACKAGE_JSON_PATH),
     {
         path: SCAFFOLD_RANGE_FILE,
         apply: (raw, version) => {
@@ -386,17 +435,21 @@ export function bumpLockstep(options) {
 
     /** @type {{ absolute: string, previousContents: string }[]} */
     const written = [];
+
     try {
         for (const entry of staged) {
             if (entry.next === entry.previousContents) {
                 continue;
             }
+
             writeFile(entry.absolute, entry.next);
+
             written.push({ absolute: entry.absolute, previousContents: entry.previousContents });
         }
     } catch (error) {
         /** @type {{ absolute: string, error: unknown }[]} */
         const rollbackFailures = [];
+
         for (const entry of written.reverse()) {
             try {
                 writeFile(entry.absolute, entry.previousContents);
@@ -416,6 +469,7 @@ export function bumpLockstep(options) {
                     `  ${failure.absolute}: ${failure.error instanceof Error ? failure.error.message : String(failure.error)}`,
             )
             .join('\n');
+
         throw new Error(
             `${originalMessage}\nAdditionally, rollback failed for ${rollbackFailures.length} file(s), left at the bumped version:\n${rollbackMessage}`,
         );
@@ -426,21 +480,23 @@ export function bumpLockstep(options) {
 
 /**
  * @param {string[]} argv Process argv (including node + script path).
- * @returns {{ version: string, dryRun: boolean }}
+ * @returns {{ version: string, dryRun: boolean }} The parsed command-line arguments.
  */
 export function parseArgv(argv) {
     const args = argv.slice(2).filter((arg) => arg !== '--');
     const dryRun = args.includes('--dry-run');
     const positional = args.filter((arg) => arg !== '--dry-run');
+
     if (positional.length !== 1) {
         throw new Error('Usage: node scripts/bump-lockstep.mjs <x.y.z> [--dry-run]');
     }
+
     return { version: parseVersionArg(positional[0]), dryRun };
 }
 
 /**
- * @param {string[]} argv
- * @param {{ log?: (message: string) => void, bump?: typeof bumpLockstep }} [hooks]
+ * @param {string[]} argv Process argv (including node + script path).
+ * @param {{ log?: (message: string) => void, bump?: typeof bumpLockstep }} [hooks] Optional hooks for logging and bumping.
  * @returns {number} Process exit code.
  */
 export function main(argv, hooks = {}) {
@@ -451,9 +507,11 @@ export function main(argv, hooks = {}) {
         const { version, dryRun } = parseArgv(argv);
         const results = bump({ version, dryRun });
         const label = dryRun ? 'Would set' : 'Set';
+
         for (const result of results) {
             log(`${label} ${result.path}: ${result.previous} -> ${result.next}`);
         }
+
         if (dryRun) {
             log('(dry-run; no files written)');
         }
@@ -466,6 +524,7 @@ export function main(argv, hooks = {}) {
 }
 
 const isDirectRun = process.argv[1] !== undefined && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
 if (isDirectRun) {
     process.exitCode = main(process.argv);
 }

--- a/scripts/bump-lockstep.test.mjs
+++ b/scripts/bump-lockstep.test.mjs
@@ -8,8 +8,11 @@ import {
     applyEngineVersionConstants,
     applyVersion,
     bumpLockstep,
+    CREATE_BLIT386_PACKAGE_JSON_PATH,
     deriveCaretRange,
+    ENGINE_PACKAGE_JSON_PATH,
     ENGINE_VERSION_FILE,
+    KIT_PACKAGE_JSON_PATH,
     LOCKSTEP_PACKAGE_JSON_PATHS,
     main,
     parseArgv,
@@ -22,7 +25,7 @@ import {
 function makeFixtureFiles() {
     return new Map([
         [
-            join('/repo', LOCKSTEP_PACKAGE_JSON_PATHS[0]),
+            join('/repo', ENGINE_PACKAGE_JSON_PATH),
             `${JSON.stringify({ name: 'blit386', version: '1.2.1' }, null, 4)}\n`,
         ],
         [
@@ -37,7 +40,7 @@ function makeFixtureFiles() {
             ].join('\n'),
         ],
         [
-            join('/repo', LOCKSTEP_PACKAGE_JSON_PATHS[1]),
+            join('/repo', KIT_PACKAGE_JSON_PATH),
             `${JSON.stringify(
                 { name: '@blit386/kit', version: '1.2.1', blit386: { engineRange: '^1.2.0' } },
                 null,
@@ -45,7 +48,7 @@ function makeFixtureFiles() {
             )}\n`,
         ],
         [
-            join('/repo', LOCKSTEP_PACKAGE_JSON_PATHS[2]),
+            join('/repo', CREATE_BLIT386_PACKAGE_JSON_PATH),
             `${JSON.stringify({ name: 'create-blit386', version: '1.2.1' }, null, 4)}\n`,
         ],
         [
@@ -406,9 +409,9 @@ describe('bump-lockstep', () => {
             );
 
             // Rolled back successfully: entries written after the engine file, and the one written before it.
-            assert.equal(JSON.parse(files.get(join('/repo', LOCKSTEP_PACKAGE_JSON_PATHS[1]))).version, '1.2.1');
-            assert.equal(JSON.parse(files.get(join('/repo', LOCKSTEP_PACKAGE_JSON_PATHS[2]))).version, '1.2.1');
-            assert.equal(JSON.parse(files.get(join('/repo', LOCKSTEP_PACKAGE_JSON_PATHS[0]))).version, '1.2.1');
+            assert.equal(JSON.parse(files.get(join('/repo', KIT_PACKAGE_JSON_PATH))).version, '1.2.1');
+            assert.equal(JSON.parse(files.get(join('/repo', CREATE_BLIT386_PACKAGE_JSON_PATH))).version, '1.2.1');
+            assert.equal(JSON.parse(files.get(join('/repo', ENGINE_PACKAGE_JSON_PATH))).version, '1.2.1');
             // Left at the bumped value: its own rollback write failed.
             assert.match(files.get(engineVersionPath), /VERSION_MINOR = 5;/);
         });

--- a/scripts/check-agent-config.mjs
+++ b/scripts/check-agent-config.mjs
@@ -258,22 +258,19 @@ function readClaudeSkillDirNames(claudeSkillsDir) {
  * @param {string} root Absolute path to the repo root.
  * @returns {string[]} Human-readable failure messages.
  */
-function checkRootSkillsLayout(root) {
+export function checkRootSkillsLayout(root) {
     const agentsSkillsDir = join(root, '.agents', 'skills');
     const claudeSkillsDir = join(root, '.claude', 'skills');
     const zedSettingsPath = join(root, '.zed', 'settings.json');
     const claudeSkillsDirExists = existsSync(claudeSkillsDir);
 
-    if (!claudeSkillsDirExists) {
-        return ['.claude/skills directory is missing'];
-    }
-
     const agentsSkillsLayoutExists = existsSync(agentsSkillsDir);
     const agentsSkillEntries = agentsSkillsLayoutExists ? readAgentsSkillEntries(agentsSkillsDir, claudeSkillsDir) : [];
-    const claudeSkillDirNames = readClaudeSkillDirNames(claudeSkillsDir);
+    const claudeSkillDirNames = claudeSkillsDirExists ? readClaudeSkillDirNames(claudeSkillsDir) : [];
     const zedSettingsContent = readFileIfExists(zedSettingsPath);
 
     return [
+        ...(claudeSkillsDirExists ? [] : ['.claude/skills directory is missing']),
         ...(agentsSkillsLayoutExists
             ? findSkillsSymlinkFailures(agentsSkillEntries, claudeSkillDirNames)
             : ['.agents/skills directory is missing']),

--- a/scripts/check-agent-config.mjs
+++ b/scripts/check-agent-config.mjs
@@ -32,6 +32,24 @@ import { fileURLToPath } from 'node:url';
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
+/** @param {string} path @returns {string | null} File contents, or `null` when the file does not exist. */
+function readFileIfExists(path) {
+    return existsSync(path) ? readFileSync(path, 'utf8') : null;
+}
+
+/**
+ * Pushes each failure onto `failures`, tagged with `[prefix]`.
+ *
+ * @param {string[]} failures Accumulator array, mutated in place.
+ * @param {string} prefix Root label to prefix each failure with (e.g. `.` or `packages/blit386`).
+ * @param {string[]} newFailures Failure messages to prefix and append.
+ */
+function collect(failures, prefix, newFailures) {
+    for (const failure of newFailures) {
+        failures.push(`[${prefix}] ${failure}`);
+    }
+}
+
 /**
  * Verifies every `.agents/skills/*` entry is a working symlink that resolves
  * to a same-named `.claude/skills/*` directory, and that every
@@ -197,8 +215,11 @@ export function resolveSkillSymlinkTarget(resolvedTargetPath, targetIsDirectory,
     return basename(resolvedTargetPath);
 }
 
-/** @param {string} agentsSkillsDir @param {string} claudeSkillsDir
- * @returns {Array<{ name: string, isSymlink: boolean, resolvedName: string | null }>} */
+/**
+ * @param {string} agentsSkillsDir
+ * @param {string} claudeSkillsDir
+ * @returns {Array<{ name: string, isSymlink: boolean, resolvedName: string | null }>}
+ */
 function readAgentsSkillEntries(agentsSkillsDir, claudeSkillsDir) {
     return readdirSync(agentsSkillsDir, { withFileTypes: true }).map((entry) => {
         if (!entry.isSymbolicLink()) {
@@ -241,8 +262,8 @@ function checkRootSkillsLayout(root) {
     const agentsSkillsDir = join(root, '.agents', 'skills');
     const claudeSkillsDir = join(root, '.claude', 'skills');
     const zedSettingsPath = join(root, '.zed', 'settings.json');
-
     const claudeSkillsDirExists = existsSync(claudeSkillsDir);
+
     if (!claudeSkillsDirExists) {
         return ['.claude/skills directory is missing'];
     }
@@ -250,7 +271,7 @@ function checkRootSkillsLayout(root) {
     const agentsSkillsLayoutExists = existsSync(agentsSkillsDir);
     const agentsSkillEntries = agentsSkillsLayoutExists ? readAgentsSkillEntries(agentsSkillsDir, claudeSkillsDir) : [];
     const claudeSkillDirNames = readClaudeSkillDirNames(claudeSkillsDir);
-    const zedSettingsContent = existsSync(zedSettingsPath) ? readFileSync(zedSettingsPath, 'utf8') : null;
+    const zedSettingsContent = readFileIfExists(zedSettingsPath);
 
     return [
         ...(agentsSkillsLayoutExists
@@ -271,7 +292,7 @@ function checkAgentsPointer(root) {
     const agentsMdPath = join(root, 'AGENTS.md');
     const claudeMdPath = join(root, 'CLAUDE.md');
 
-    const agentsMdContent = existsSync(agentsMdPath) ? readFileSync(agentsMdPath, 'utf8') : null;
+    const agentsMdContent = readFileIfExists(agentsMdPath);
     const claudeMdExists = existsSync(claudeMdPath);
 
     return findAgentsPointerFailures(agentsMdContent, claudeMdExists);
@@ -306,27 +327,20 @@ export function discoverPackageAgentRoots(packagesDir) {
 function runAllChecks() {
     const failures = [];
 
-    for (const failure of checkRootSkillsLayout(REPO_ROOT)) {
-        failures.push(`[.] ${failure}`);
-    }
-
-    for (const failure of checkAgentsPointer(REPO_ROOT)) {
-        failures.push(`[.] ${failure}`);
-    }
+    collect(failures, '.', checkRootSkillsLayout(REPO_ROOT));
+    collect(failures, '.', checkAgentsPointer(REPO_ROOT));
 
     const copilotInstructionsPath = join(REPO_ROOT, '.github', 'copilot-instructions.md');
-    const copilotContent = existsSync(copilotInstructionsPath) ? readFileSync(copilotInstructionsPath, 'utf8') : null;
+    const copilotContent = readFileIfExists(copilotInstructionsPath);
+
     const agentsMdExists = existsSync(join(REPO_ROOT, 'AGENTS.md'));
     const claudeMdExists = existsSync(join(REPO_ROOT, 'CLAUDE.md'));
-    for (const failure of findCopilotPointerFailures(copilotContent, agentsMdExists, claudeMdExists)) {
-        failures.push(`[.] ${failure}`);
-    }
+
+    collect(failures, '.', findCopilotPointerFailures(copilotContent, agentsMdExists, claudeMdExists));
 
     for (const packageName of discoverPackageAgentRoots(join(REPO_ROOT, 'packages'))) {
         const root = join(REPO_ROOT, 'packages', packageName);
-        for (const failure of checkAgentsPointer(root)) {
-            failures.push(`[packages/${packageName}] ${failure}`);
-        }
+        collect(failures, `packages/${packageName}`, checkAgentsPointer(root));
     }
 
     return failures;
@@ -337,9 +351,11 @@ function main() {
 
     if (failures.length > 0) {
         console.error('Agent config drift check failed:');
+
         for (const failure of failures) {
             console.error(`  - ${failure}`);
         }
+
         process.exit(1);
     }
 

--- a/scripts/check-agent-config.test.mjs
+++ b/scripts/check-agent-config.test.mjs
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { describe, it } from 'node:test';
 
 import {
+    checkRootSkillsLayout,
     discoverPackageAgentRoots,
     findAgentsPointerFailures,
     findCopilotPointerFailures,
@@ -179,6 +180,29 @@ describe('check-agent-config', () => {
             const failures = findZedSettingsFailures(content, false);
             assert.equal(failures.length, 1);
             assert.match(failures[0], /\.agents\/skills layout is missing while \.zed\/settings\.json exists/);
+        });
+    });
+
+    describe('checkRootSkillsLayout', () => {
+        it('reports .agents/skills and .zed/settings.json failures even when .claude/skills is missing', () => {
+            const root = mkdtempSync(join(tmpdir(), 'agent-config-test-'));
+            const agentsSkillsDir = join(root, '.agents', 'skills');
+            const zedDir = join(root, '.zed');
+
+            mkdirSync(agentsSkillsDir, { recursive: true });
+            writeFileSync(join(agentsSkillsDir, 'bt-format'), 'not a symlink');
+            mkdirSync(zedDir, { recursive: true });
+            writeFileSync(join(zedDir, 'settings.json'), '{not json');
+
+            try {
+                const failures = checkRootSkillsLayout(root);
+                assert.equal(failures.length, 3);
+                assert.ok(failures.some((failure) => /\.claude\/skills directory is missing/.test(failure)));
+                assert.ok(failures.some((failure) => /\.agents\/skills\/bt-format is not a symlink/.test(failure)));
+                assert.ok(failures.some((failure) => /\.zed\/settings\.json is not parseable as JSON/.test(failure)));
+            } finally {
+                rmSync(root, { recursive: true, force: true });
+            }
         });
     });
 

--- a/scripts/check-agent-config.test.mjs
+++ b/scripts/check-agent-config.test.mjs
@@ -186,15 +186,16 @@ describe('check-agent-config', () => {
     describe('checkRootSkillsLayout', () => {
         it('reports .agents/skills and .zed/settings.json failures even when .claude/skills is missing', () => {
             const root = mkdtempSync(join(tmpdir(), 'agent-config-test-'));
-            const agentsSkillsDir = join(root, '.agents', 'skills');
-            const zedDir = join(root, '.zed');
-
-            mkdirSync(agentsSkillsDir, { recursive: true });
-            writeFileSync(join(agentsSkillsDir, 'bt-format'), 'not a symlink');
-            mkdirSync(zedDir, { recursive: true });
-            writeFileSync(join(zedDir, 'settings.json'), '{not json');
 
             try {
+                const agentsSkillsDir = join(root, '.agents', 'skills');
+                const zedDir = join(root, '.zed');
+
+                mkdirSync(agentsSkillsDir, { recursive: true });
+                writeFileSync(join(agentsSkillsDir, 'bt-format'), 'not a symlink');
+                mkdirSync(zedDir, { recursive: true });
+                writeFileSync(join(zedDir, 'settings.json'), '{not json');
+
                 const failures = checkRootSkillsLayout(root);
                 assert.equal(failures.length, 3);
                 assert.ok(failures.some((failure) => /\.claude\/skills directory is missing/.test(failure)));

--- a/scripts/check-markdown-links.mjs
+++ b/scripts/check-markdown-links.mjs
@@ -30,15 +30,11 @@ const MLC_BIN = require.resolve('markdown-link-check/markdown-link-check');
 const CONFIG = join(ROOT, '.github/markdown-link-check.json');
 const HOSTED_DEMOS_PATTERN = '^https://demos\\.blit386\\.dev(/|$)';
 const CONCURRENCY = 8;
+
 // Exceeds the ~170s worst-case single-link retry chain in .github/markdown-link-check.json.
 const CHECK_TIMEOUT_MS = 300_000;
 
-/**
- * Repo-relative path patterns to skip. Generated doc pages
- * (`packages/website/content/docs/<section>/**`) are mirrored from
- * `packages/blit386/docs/`, where they are already link-checked; the hand-authored hub
- * (`content/docs/index.mdx`) and root meta stay in scope.
- */
+/** Repo-relative path patterns to skip; see the file header for what and why. */
 const IGNORED_PATH_PATTERNS = [/^packages\/website\/content\/docs\/[^/]+\//u];
 
 /** @param {string} rel @returns {string} */
@@ -55,10 +51,11 @@ export function isIgnoredFile(filePath) {
  * Lists git-tracked markdown files under the repo root as absolute paths, excluding
  * generated doc-mirror pages (see `isIgnoredFile`).
  *
- * @returns {string[]}
+ * @returns {string[]} Absolute paths to tracked markdown files.
  */
 function listTrackedMarkdownFiles() {
     let output;
+
     try {
         output = execFileSync('git', ['ls-files', '*.md', '*.mdx'], {
             cwd: ROOT,
@@ -88,7 +85,7 @@ function listTrackedMarkdownFiles() {
  * Cloudflare returns 403 to GitHub Actions datacenter IPs for the hosted demos site.
  * Keep local link checks; skip those URLs only in CI.
  *
- * @returns {string}
+ * @returns {string} Path to the markdown-link-check config file.
  */
 function resolveConfigPath() {
     if (process.env.GITHUB_ACTIONS !== 'true') {
@@ -96,11 +93,8 @@ function resolveConfigPath() {
     }
 
     const config = JSON.parse(readFileSync(CONFIG, 'utf8'));
-    const alreadyIgnored = config.ignorePatterns.some(({ pattern }) => pattern === HOSTED_DEMOS_PATTERN);
 
-    if (!alreadyIgnored) {
-        config.ignorePatterns.push({ pattern: HOSTED_DEMOS_PATTERN });
-    }
+    config.ignorePatterns.push({ pattern: HOSTED_DEMOS_PATTERN });
 
     const tempDir = mkdtempSync(join(tmpdir(), 'mlc-config-'));
     const tempConfig = join(tempDir, 'markdown-link-check.json');
@@ -112,7 +106,15 @@ function resolveConfigPath() {
     return tempConfig;
 }
 
-/** @param {string} filePath @param {string} configPath @returns {Promise<boolean>} */
+/**
+ * Runs markdown-link-check on one file and resolves whether it passed. Never rejects
+ * (spawn errors and timeouts resolve `false`), and buffers stdout/stderr to print as a
+ * single block on completion so concurrent workers don't interleave output.
+ *
+ * @param {string} filePath File path to check.
+ * @param {string} configPath Path to the markdown-link-check config file.
+ * @returns {Promise<boolean>} Whether the file passed the link check.
+ */
 function checkFile(filePath, configPath) {
     const rel = relative(ROOT, filePath);
 
@@ -121,23 +123,27 @@ function checkFile(filePath, configPath) {
             cwd: ROOT,
             signal: AbortSignal.timeout(CHECK_TIMEOUT_MS),
         });
+
         let output = '';
         let settled = false;
 
-        child.stdout.on('data', (chunk) => {
+        const collect = (chunk) => {
             output += chunk;
-        });
-        child.stderr.on('data', (chunk) => {
-            output += chunk;
-        });
+        };
+
+        child.stdout.on('data', collect);
+        child.stderr.on('data', collect);
 
         function finish(ok) {
             if (settled) {
                 return;
             }
+
             settled = true;
+
             console.log(`\nFILE: ./${rel}`);
             process.stdout.write(output);
+
             settle(ok);
         }
 
@@ -146,6 +152,7 @@ function checkFile(filePath, configPath) {
                 err.name === 'AbortError'
                     ? `\n[spawn error] check timed out after ${CHECK_TIMEOUT_MS}ms\n`
                     : `\n[spawn error] ${err.message}\n`;
+
             finish(false);
         });
 
@@ -155,7 +162,15 @@ function checkFile(filePath, configPath) {
     });
 }
 
-/** @param {string[]} files @param {string} configPath @returns {Promise<number>} */
+/**
+ * Checks all files concurrently via a fixed-size worker pool (bounded by CONCURRENCY)
+ * pulling from a shared index, so output order follows completion order rather than
+ * `files` order.
+ *
+ * @param {string[]} files
+ * @param {string} configPath
+ * @returns {Promise<number>} the number of files that failed
+ */
 async function checkAll(files, configPath) {
     let nextIndex = 0;
     let failed = 0;
@@ -163,8 +178,11 @@ async function checkAll(files, configPath) {
     async function worker() {
         while (nextIndex < files.length) {
             const filePath = files.at(nextIndex);
+
             nextIndex += 1;
+
             const ok = await checkFile(filePath, configPath);
+
             if (!ok) {
                 failed += 1;
             }
@@ -178,6 +196,7 @@ async function checkAll(files, configPath) {
 
 async function main() {
     const files = listTrackedMarkdownFiles();
+
     files.sort((a, b) => a.localeCompare(b));
 
     const configPath = resolveConfigPath();

--- a/scripts/prettier-plugin-compact-tables.mjs
+++ b/scripts/prettier-plugin-compact-tables.mjs
@@ -19,7 +19,7 @@
  */
 
 import { doc } from 'prettier';
-import * as markdown from 'prettier/plugins/markdown.mjs';
+import * as markdown from 'prettier/plugins/markdown';
 
 /**
  * One column's alignment as mdast records it, read from the source delimiter row.
@@ -54,7 +54,7 @@ const basePrinter = markdown.printers.mdast;
  * Three dashes is the form every Markdown renderer accepts, so the output stays portable. A column with no explicit
  * alignment is absent from this map on purpose and falls through to the `---` default at the call site.
  *
- * @type {Record<Exclude<ColumnAlignment, null>, string>}
+ * @type {Record<Exclude<ColumnAlignment, null>, string>} The delimiter row cell for each alignment value.
  */
 const DELIMITERS = {
     left: ':---',
@@ -100,12 +100,12 @@ const printTable = (path, options, print) => {
     const columns = Math.max(node.align?.length ?? 0, ...rows.map((row) => row.length));
 
     /** Pad (or trim) one row's rendered cells to the table's column count. */
-    const cellsOf = (row) => Array.from({ length: columns }, (_unused, index) => row.at(index) ?? '');
+    const cellsOf = (row) => Array.from({ length: columns }, (_, index) => row.at(index) ?? '');
 
     /** Wrap one row's cells in pipes with exactly one space of padding on each side. */
     const lineOf = (row) => `| ${cellsOf(row).join(' | ')} |`;
 
-    const delimiters = Array.from({ length: columns }, (_unused, index) => DELIMITERS[node.align?.at(index)] ?? '---');
+    const delimiters = Array.from({ length: columns }, (_, index) => DELIMITERS[node.align?.at(index)] ?? '---');
     const [head, ...body] = rows;
 
     return join(hardline, [lineOf(head), `| ${delimiters.join(' | ')} |`, ...body.map(lineOf)]);
@@ -117,7 +117,7 @@ const printTable = (path, options, print) => {
  * Everything else - paragraphs, lists, code fences, prose wrapping - delegates to {@link basePrinter}, so this plugin
  * can only ever change table layout.
  *
- * @type {import('prettier').Printer}
+ * @type {import('prettier').Printer} The custom printer implementation.
  */
 const printer = {
     ...basePrinter,
@@ -146,7 +146,7 @@ const printer = {
  * `markdown-compact` is Prettier's own Markdown parser pointed at the `mdast-compact` printer below. Naming it in a
  * config's `overrides` is what opts a file into compact tables; nothing changes for anyone who does not ask.
  *
- * @type {Record<string, import('prettier').Parser>}
+ * @type {Record<string, import('prettier').Parser>} The custom parser implementation.
  */
 export const parsers = {
     'markdown-compact': { ...markdown.parsers.markdown, astFormat: 'mdast-compact' },
@@ -155,7 +155,7 @@ export const parsers = {
 /**
  * Printers this plugin contributes, keyed by the `astFormat` the parsers above declare.
  *
- * @type {Record<string, import('prettier').Printer>}
+ * @type {Record<string, import('prettier').Printer>} The custom printer implementation.
  */
 export const printers = {
     'mdast-compact': printer,


### PR DESCRIPTION
## Summary

- bump-lockstep.mjs: extract ENGINE_PACKAGE_JSON_PATH / KIT_PACKAGE_JSON_PATH / CREATE_BLIT386_PACKAGE_JSON_PATH constants and a versionOnlyTarget() factory, replacing magic-index lookups into LOCKSTEP_PACKAGE_JSON_PATHS[0..2]; bump-lockstep.test.mjs follows the renamed exports.
- check-agent-config.mjs: extract readFileIfExists() and collect() helpers, removing the repeated existsSync(...) ? readFileSync(...) : null and failures.push(`[prefix] ...`) patterns.
- check-markdown-links.mjs: expand compressed one-line JSDoc into full blocks with return descriptions, and drop the dead alreadyIgnored guard in resolveConfigPath() (the config is parsed fresh from disk on every call, so the pattern was never already present).
- prettier-plugin-compact-tables.mjs (root and create-blit386's base template): import from 'prettier/plugins/markdown' instead of '.../markdown.mjs' - prettier's package.json exports map only declares a types entry for the extensionless subpath, so the .mjs import silently resolved to any under TypeScript's checker despite working fine at runtime.
- Consistent blank-line breathing room after control-flow statements (early returns, before/after loops) across all four scripts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown formatting compatibility with Prettier.
  * Ensured hosted-demo links are consistently excluded during CI checks.
  * Improved handling of optional configuration files and missing skill directories.

* **Maintenance**
  * Made package version updates and rollback validation more consistent.
  * Improved reliability and clarity of validation output.
  * Refined CI change detection so affected checks run more accurately.

* **Documentation**
  * Clarified internal tooling guidance and maintenance documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->