### PR TITLE
feat(core): add engine-level dev vs. release mode detection

### DIFF
--- a/packages/blit386/.claude/rules/architecture.md
+++ b/packages/blit386/.claude/rules/architecture.md
@@ -92,6 +92,7 @@ src/
     RenderLimits.ts        # Render dimension validation (8192 px per axis; 16,777,216 total pixels)
     AssetLimits.ts         # Asset dimension validation, btfont/glyph limits, sprite-blit clipping
     HotReloadUrl.ts        # Cache-bust/normalize URL helpers (appendCacheBustQuery, normalizeAssetUrl) for the dev-only asset hot-replace path; used by AssetLoader, SpriteSheet, AudioClip, BitmapFont
+    devMode.ts             # Dev vs. release build detection (resolveDevMode pure resolver + isDevMode reader); backs BT.isDevMode
     Vector2i.ts            # Integer 2D vector
     Rect2i.ts              # Integer rectangle
     Color32.ts             # 32-bit RGBA color

--- a/packages/blit386/CLAUDE.md
+++ b/packages/blit386/CLAUDE.md
@@ -28,6 +28,7 @@ Routing that is not obvious from the file tree. For "how does subsystem X work",
 | How do I smooth motion between fixed `update()` steps? | `BT.renderAlpha`; worked `Vector2i.lerp` pattern in `docs/guide-game-loop.md` |
 | Seeded / deterministic random? | `BT.random` / `BT.randomSeed`; `src/utils/Random.ts`, coordinate hashes in `src/utils/hash.ts`, `docs/api-random.md` |
 | How does hot-reload / HMR work? | `docs/guide-hot-reload.md` is canonical; runtime in `src/hot/`, dev plugin in `src/vite/` |
+| How does dev vs. release detection work? | `BT.isDevMode`; `src/utils/devMode.ts`, dev marker set by `src/vite/transform.ts`, `docs/api-core.md#dev-vs-release-mode` |
 | How is agent config drift checked? | `scripts/check-agent-config.mjs` (root), wired into `pnpm run agents:check` and the `quality` CI job |
 | Where is the public docs site? | `packages/website` builds it from this package's `docs/`; `docs/_sitemap.json` controls what publishes |
 | Dependency security policy / CI audit gate? | `docs/security/dependency-policy.md`, `docs/security/audit-exceptions.md` |

--- a/packages/blit386/docs/_api-history.json
+++ b/packages/blit386/docs/_api-history.json
@@ -563,6 +563,13 @@
       "deprecated": null,
       "status": "stable"
     },
+    "BT.isDevMode": {
+      "kind": "getter",
+      "since": "1.5.0",
+      "changes": [],
+      "deprecated": null,
+      "status": "unreleased"
+    },
     "BT.isDown": {
       "kind": "method",
       "since": "1.1.1",
@@ -1565,6 +1572,7 @@
       "BT.displaySize",
       "BT.drawingBufferSize",
       "BT.init",
+      "BT.isDevMode",
       "BT.outputSize",
       "BT.requestedBackend",
       "BT.screenOrientation",

--- a/packages/blit386/docs/api-core.md
+++ b/packages/blit386/docs/api-core.md
@@ -370,6 +370,55 @@ function configure(): Partial<HardwareSettings> {
 // requestedBackend === activeBackend === 'software' after init
 ```
 
+### Dev vs. release mode
+
+<Since symbol="BT.isDevMode" />
+
+`BT.isDevMode` answers one question: is this a development build. Games and demos can gate debug HUDs, cheat keys,
+verbose logging, or test fixtures on it instead of inventing a build-mode signal of their own.
+
+```ts twoslash
+import { BT } from 'blit386';
+// ---cut---
+if (BT.isDevMode) {
+  console.log('dev build - verbose logging enabled');
+}
+```
+
+Resolution order, first match wins:
+
+1. `globalThis.__BLIT386_DEV__`, set at runtime by the
+   [`blit386/vite` plugin](guide-hot-reload.md#the-blit386vite-plugin)'s injected snippet. A runtime assignment, not a
+   bundler define, so it works regardless of how the engine itself was built or bundled.
+2. A live Vite HMR context, as a late fallback (see [Hot Reload](guide-hot-reload.md)).
+3. Otherwise, release.
+
+The underlying resolver also accepts an explicit override that always wins over both signals above; nothing in the
+public `BT` surface offers one today, so this only matters if you call the internal resolver directly.
+
+Neither `import.meta.env.DEV` nor a bundler `define` can back this getter: the engine ships both ESM and CJS builds and
+is pre-built into `dist` before a consumer's bundler ever sees it, so a define declared in the consumer's config does
+not reliably reach a pre-bundled dependency.
+
+<Callout title="This is DX gating, not DRM">
+
+Any consumer can flip `globalThis.__BLIT386_DEV__` by hand. `BT.isDevMode` exists to make ordinary dev-vs-release
+decisions easy, not to make release builds tamper-proof.
+
+</Callout>
+
+<Callout type="warn" title="Read it from update()/render(), not module scope">
+
+The `blit386/vite` plugin's snippet is appended after the rest of the entry module, so it runs after that module's own
+top-level code but before `update()`/`render()` ever run. A module-scope `BT.isDevMode` read (for example a
+`const isDev = BT.isDevMode;` at the top of a file the entry module imports) can observe `false` even in a dev build.
+Read it inside a lifecycle method instead.
+
+</Callout>
+
+A consumer who skips the `blit386/vite` plugin reads as release everywhere the plugin's marker would otherwise apply –
+see [The `blit386/vite` plugin](guide-hot-reload.md#the-blit386vite-plugin) for what installing it actually does.
+
 ## Default configuration
 
 <Since symbol="defaultConfig" />

--- a/packages/blit386/docs/api-core.md
+++ b/packages/blit386/docs/api-core.md
@@ -378,10 +378,20 @@ function configure(): Partial<HardwareSettings> {
 verbose logging, or test fixtures on it instead of inventing a build-mode signal of their own.
 
 ```ts twoslash
-import { BT } from 'blit386';
-// ---cut---
-if (BT.isDevMode) {
-  console.log('dev build - verbose logging enabled');
+import { BT, type IBTDemo } from 'blit386';
+
+class Demo implements IBTDemo {
+  async init(): Promise<boolean> {
+    return true;
+  }
+
+  update(): void {
+    if (BT.isDevMode) {
+      console.log('dev build – verbose logging enabled');
+    }
+  }
+
+  render(): void {}
 }
 ```
 

--- a/packages/blit386/docs/changelog.md
+++ b/packages/blit386/docs/changelog.md
@@ -28,6 +28,10 @@ notes, including dependency bumps and CI changes omitted here for brevity.
   matches RetroBlit's `Ease` class.
 - `interpolate(easing, start, end, t)` for `number`, `Vector2i`, `Color32`, and `Rect2i`. Integer types round to the
   nearest component; `Color32` channels also clamp to `[0, 255]`.
+- `BT.isDevMode`: engine-level dev vs. release build detection. Resolves from the `blit386/vite` plugin's runtime
+  marker, falling back to a live Vite HMR context, otherwise release. The plugin now sets that marker as a second
+  responsibility beyond hot reload. See [Core](api-core.md#dev-vs-release-mode) and
+  [Hot Reload](guide-hot-reload.md#the-blit386vite-plugin).
 
 ## 1.4.0 - 2026-07-23
 

--- a/packages/blit386/docs/guide-hot-reload.md
+++ b/packages/blit386/docs/guide-hot-reload.md
@@ -238,7 +238,7 @@ export default defineConfig({
 });
 ```
 
-The plugin does two things, both dev-server only (`apply: 'serve'` - a production build never sees it, so there is zero
+The plugin does three things, all dev-server only (`apply: 'serve'` - a production build never sees it, so there is zero
 runtime cost or behavior change to ship):
 
 - Appends a small hot-reload registration snippet to any served module that imports `blit386` and calls
@@ -247,6 +247,7 @@ runtime cost or behavior change to ship):
   ```js
   /* blit386:hot-reload-snippet */
   import { registerHotReload as __blit386_registerHotReload } from 'blit386';
+  globalThis.__BLIT386_DEV__ = true;
   if (import.meta.hot) {
     import.meta.hot.accept();
     __blit386_registerHotReload(import.meta.hot);
@@ -265,6 +266,15 @@ runtime cost or behavior change to ship):
   transform pipeline excludes those extensions from server-side parsing, so without this a broken entry module would
   surface only as a silently caught client-side error - Vite's error overlay would never appear. A `.ts`/`.mts` entry is
   unaffected; it already gets real syntax validation from Vite's own transform.
+
+- Marks the build as dev for [`BT.isDevMode`](api-core.md#dev-vs-release-mode) via the snippet's
+  `globalThis.__BLIT386_DEV__ = true` line – a responsibility this plugin has beyond hot reload itself. It runs
+  unconditionally, not only inside the `import.meta.hot` guard, because the snippet as a whole is only ever injected by
+  this dev-server-only plugin. A consumer who skips this plugin gets release behavior from `BT.isDevMode` everywhere
+  this marker would otherwise apply – there is no other way for the engine to learn it is running under a dev server.
+  Because the snippet is appended after the rest of the entry module, a module-scope `BT.isDevMode` read (rather than
+  one inside `update()`/`render()`) can still observe `false` in a dev build – see the callout on
+  [Dev vs. release mode](api-core.md#dev-vs-release-mode).
 
 - Watches the configured asset directories and broadcasts `blit386:asset-changed` events for recognized file types (see
   the [asset matrix](#asset-hot-replace-matrix) above), falling back to a full reload for anything else.

--- a/packages/blit386/docs/guide-hot-reload.md
+++ b/packages/blit386/docs/guide-hot-reload.md
@@ -238,7 +238,7 @@ export default defineConfig({
 });
 ```
 
-The plugin does three things, all dev-server only (`apply: 'serve'` - a production build never sees it, so there is zero
+The plugin does three things, all dev-server only (`apply: 'serve'` – a production build never sees it, so there is zero
 runtime cost or behavior change to ship):
 
 - Appends a small hot-reload registration snippet to any served module that imports `blit386` and calls
@@ -270,11 +270,12 @@ runtime cost or behavior change to ship):
 - Marks the build as dev for [`BT.isDevMode`](api-core.md#dev-vs-release-mode) via the snippet's
   `globalThis.__BLIT386_DEV__ = true` line – a responsibility this plugin has beyond hot reload itself. It runs
   unconditionally, not only inside the `import.meta.hot` guard, because the snippet as a whole is only ever injected by
-  this dev-server-only plugin. A consumer who skips this plugin gets release behavior from `BT.isDevMode` everywhere
-  this marker would otherwise apply – there is no other way for the engine to learn it is running under a dev server.
-  Because the snippet is appended after the rest of the entry module, a module-scope `BT.isDevMode` read (rather than
-  one inside `update()`/`render()`) can still observe `false` in a dev build – see the callout on
-  [Dev vs. release mode](api-core.md#dev-vs-release-mode).
+  this dev-server-only plugin. This is the standard, automatic signal `BT.isDevMode` looks for; the same snippet's
+  `registerHotReload(import.meta.hot)` call also registers a live Vite HMR context, which `BT.isDevMode` checks as a
+  late fallback (see [Dev vs. release mode](api-core.md#dev-vs-release-mode)). A consumer who skips this plugin gets
+  neither signal, so `BT.isDevMode` reads as release. Because the snippet is appended after the rest of the entry
+  module, a module-scope `BT.isDevMode` read (rather than one inside `update()`/`render()`) can still observe `false` in
+  a dev build.
 
 - Watches the configured asset directories and broadcasts `blit386:asset-changed` events for recognized file types (see
   the [asset matrix](#asset-hot-replace-matrix) above), falling back to a full reload for anything else.

--- a/packages/blit386/eslint.config.js
+++ b/packages/blit386/eslint.config.js
@@ -42,6 +42,7 @@ export default [
                 ecmaVersion: 'latest',
                 sourceType: 'module',
                 project: TSCONFIG_PATH,
+                tsconfigRootDir: import.meta.dirname,
             },
             globals: {
                 ...globals.browser,

--- a/packages/blit386/src/BLIT386.test.ts
+++ b/packages/blit386/src/BLIT386.test.ts
@@ -529,6 +529,19 @@ describe('BT.isMusicPlaying', () => {
     });
 });
 
+describe('BT.isDevMode', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('delegates to BTAPI.instance.isDevMode', () => {
+        const spy = vi.spyOn(BTAPI.instance, 'isDevMode').mockReturnValue(true);
+
+        expect(BT.isDevMode).toBe(true);
+        expect(spy).toHaveBeenCalledWith();
+    });
+});
+
 describe('BT.musicVolumeSet / BT.musicVolumeGet', () => {
     beforeEach(() => {
         vi.restoreAllMocks();

--- a/packages/blit386/src/BLIT386.ts
+++ b/packages/blit386/src/BLIT386.ts
@@ -720,6 +720,21 @@ export const BT = {
     },
 
     /**
+     * Whether this is a development build, not a release build.
+     *
+     * Resolves from the `blit386/vite` plugin's injected runtime marker, falling back to a live
+     * Vite HMR context, otherwise release. (The underlying resolver also accepts an explicit
+     * override that always wins over both; nothing in the public `BT` surface supplies one today.)
+     * This is UX/DX gating, not DRM – any consumer can flip the underlying global by hand.
+     *
+     * @since 1.5.0
+     * @returns `true` for a dev build, `false` for release.
+     */
+    get isDevMode(): boolean {
+        return BTAPI.instance.isDevMode();
+    },
+
+    /**
      * Total number of asset loads currently in flight (images and audio clips combined).
      *
      * Useful for a loading-screen progress indicator: poll this each frame and show a

--- a/packages/blit386/src/core/BTAPI.test.ts
+++ b/packages/blit386/src/core/BTAPI.test.ts
@@ -2676,6 +2676,20 @@ describe('BTAPI', () => {
             });
         });
 
+        describe('isDevMode', () => {
+            afterEach(() => {
+                Reflect.deleteProperty(globalThis, '__BLIT386_DEV__');
+            });
+
+            it('delegates to devMode.isDevMode', () => {
+                expect(BTAPI.instance.isDevMode()).toBe(false);
+
+                globalThis.__BLIT386_DEV__ = true;
+
+                expect(BTAPI.instance.isDevMode()).toBe(true);
+            });
+        });
+
         describe('hotReplaceDemo', () => {
             afterEach(() => {
                 Reflect.deleteProperty(globalThis, 'screen');

--- a/packages/blit386/src/core/BTAPI.ts
+++ b/packages/blit386/src/core/BTAPI.ts
@@ -26,6 +26,7 @@ import { SoftwareRenderer } from '../render/SoftwareRenderer';
 import { WebGPURenderer } from '../render/WebGPURenderer';
 import { applyCanvasLayoutStyles, DEFAULT_MAX_CANVAS_SIZE } from '../utils/CanvasLayoutStyles';
 import type { Color32 } from '../utils/Color32';
+import { isDevMode } from '../utils/devMode';
 import type { EasingFunction } from '../utils/Easing';
 import * as errorMessages from '../utils/errorMessages';
 import {
@@ -661,6 +662,15 @@ export class BTAPI {
      */
     public isInitialized(): boolean {
         return this.demo !== null && this.loop !== null;
+    }
+
+    /**
+     * Reports whether this is a development build; see {@link isDevMode}.
+     *
+     * @returns `true` for a dev build, `false` for release.
+     */
+    public isDevMode(): boolean {
+        return isDevMode();
     }
 
     /**

--- a/packages/blit386/src/utils/devMode.test.ts
+++ b/packages/blit386/src/utils/devMode.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Unit tests for {@link resolveDevMode} and {@link isDevMode}.
+ *
+ * `resolveDevMode` is a pure function taking its inputs as parameters, so its
+ * tests run in the default Node vitest environment with no `happy-dom`
+ * opt-in – this property is load-bearing for BT-416, which needs `BT`
+ * assignment guards to stay testable outside a DOM.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type * as HotRuntimeModule from '../hot/HotRuntime';
+import { isDevMode, resolveDevMode } from './devMode';
+
+vi.mock('../hot/HotRuntime', async (importOriginal) => {
+    const actual = await importOriginal<typeof HotRuntimeModule>();
+
+    return { ...actual, isHotActive: vi.fn(() => false) };
+});
+
+describe('resolveDevMode', () => {
+    it('returns the override when true, regardless of other signals', () => {
+        expect(resolveDevMode({ override: true, globalDevFlag: false, hotActive: false })).toBe(true);
+    });
+
+    it('returns the override when false, regardless of other signals', () => {
+        expect(resolveDevMode({ override: false, globalDevFlag: true, hotActive: true })).toBe(false);
+    });
+
+    it('falls back to the global dev flag when no override is given', () => {
+        expect(resolveDevMode({ globalDevFlag: true, hotActive: false })).toBe(true);
+    });
+
+    it('falls back to hot-active when no override and no global dev flag', () => {
+        expect(resolveDevMode({ globalDevFlag: false, hotActive: true })).toBe(true);
+    });
+
+    it('resolves to release when no signal indicates dev', () => {
+        expect(resolveDevMode({ globalDevFlag: false, hotActive: false })).toBe(false);
+    });
+});
+
+describe('isDevMode', () => {
+    afterEach(() => {
+        Reflect.deleteProperty(globalThis, '__BLIT386_DEV__');
+    });
+
+    it('returns false when nothing indicates a dev build', () => {
+        expect(isDevMode()).toBe(false);
+    });
+
+    it('returns true when globalThis.__BLIT386_DEV__ is set', () => {
+        globalThis.__BLIT386_DEV__ = true;
+
+        expect(isDevMode()).toBe(true);
+    });
+
+    it('treats a missing globalThis.__BLIT386_DEV__ as release, not a crash', () => {
+        expect(typeof globalThis.__BLIT386_DEV__).toBe('undefined');
+        expect(isDevMode()).toBe(false);
+    });
+
+    it('lets an explicit override win over the global dev flag', () => {
+        globalThis.__BLIT386_DEV__ = true;
+
+        expect(isDevMode(false)).toBe(false);
+    });
+});

--- a/packages/blit386/src/utils/devMode.ts
+++ b/packages/blit386/src/utils/devMode.ts
@@ -1,0 +1,75 @@
+/**
+ * Engine-level dev vs. release mode detection.
+ *
+ * `import.meta.env.DEV` cannot be used – the engine ships both ESM and CJS, and
+ * the engine is pre-built into `dist` before a consumer's bundler ever sees it,
+ * so a bundler `define` cannot reach this module either. The only signal that
+ * survives being pre-built is a runtime global, assigned by the `blit386/vite`
+ * plugin's injected snippet (see `src/vite/transform.ts`).
+ *
+ * Split into a pure resolver ({@link resolveDevMode}) and a thin reader
+ * ({@link isDevMode}) so the precedence logic is unit-testable in the default
+ * Node vitest environment, with no `happy-dom` opt-in – BT-416 depends on that
+ * property holding.
+ *
+ * This is UX/DX gating, not DRM: any consumer can flip `globalThis.__BLIT386_DEV__`
+ * by hand, and that is fine.
+ */
+
+import { isHotActive } from '../hot/HotRuntime';
+
+declare global {
+    // `var` is required here – `let`/`const` cannot ambient-declare a globalThis property.
+    var __BLIT386_DEV__: boolean | undefined;
+}
+
+/** Inputs to {@link resolveDevMode}, gathered by {@link isDevMode}. */
+export interface DevModeSignals {
+    /** Explicit override from config, if one is offered. Always wins when defined. */
+    override?: boolean | undefined;
+
+    /** Whether the `blit386/vite` plugin's injected snippet marked this build as dev. */
+    globalDevFlag: boolean;
+
+    /** Whether a Vite HMR context is registered ({@link isHotActive}); a late fallback signal. */
+    hotActive: boolean;
+}
+
+/**
+ * Resolves dev vs. release from already-gathered signals, in priority order: explicit
+ * override, then the runtime dev global, then hot-reload activity, otherwise release.
+ *
+ * @param signals - See {@link DevModeSignals}.
+ * @returns `true` for a dev build, `false` for release.
+ */
+export function resolveDevMode(signals: DevModeSignals): boolean {
+    if (signals.override !== undefined) {
+        return signals.override;
+    }
+
+    if (signals.globalDevFlag) {
+        return true;
+    }
+
+    return signals.hotActive;
+}
+
+/**
+ * Reports whether this is a development build, gathering signals from `globalThis` (never a
+ * bare `window` reference).
+ *
+ * @param override - Explicit override, if a caller offers one; always wins when defined.
+ * @returns `true` for a dev build, `false` for release.
+ */
+export function isDevMode(override?: boolean): boolean {
+    return resolveDevMode({
+        override,
+
+        // No `typeof ... !== 'undefined'` guard needed here: unlike `screen.orientation` or
+        // `navigator.wakeLock`, nothing drills into a second property, so a missing global just
+        // reads as `undefined` and `=== true` already treats that as release.
+        globalDevFlag: globalThis.__BLIT386_DEV__ === true,
+
+        hotActive: isHotActive(),
+    });
+}

--- a/packages/blit386/src/vite/transform.test.ts
+++ b/packages/blit386/src/vite/transform.test.ts
@@ -108,6 +108,16 @@ describe('injectSnippet', () => {
         expect(injectedPortion).not.toMatch(/import\s*\{\s*registerHotReload\s*\}\s*from\s*'blit386'/);
     });
 
+    it('marks the build as dev via globalThis.__BLIT386_DEV__, unconditionally on import.meta.hot', () => {
+        const result = injectSnippet('bootstrap(Demo);\n');
+        const injectedPortion = result.code.slice(result.code.indexOf(INJECTION_MARKER));
+        const devMarkerIndex = injectedPortion.indexOf('globalThis.__BLIT386_DEV__ = true;');
+        const hotGuardIndex = injectedPortion.indexOf('if (import.meta.hot)');
+
+        expect(devMarkerIndex).toBeGreaterThan(-1);
+        expect(devMarkerIndex).toBeLessThan(hotGuardIndex);
+    });
+
     it('appends after the original code rather than prepending', () => {
         const result = injectSnippet('bootstrap(Demo);\n');
 

--- a/packages/blit386/src/vite/transform.ts
+++ b/packages/blit386/src/vite/transform.ts
@@ -23,10 +23,16 @@ export const INJECTION_MARKER = '/* blit386:hot-reload-snippet */';
  * be a duplicate lexical declaration - a hard `SyntaxError` - if the entry module already imports or
  * declares a `registerHotReload` binding of its own (for example, a game that wired hot reload by hand
  * before adopting this plugin).
+ *
+ * The `globalThis.__BLIT386_DEV__ = true` assignment is this plugin's second responsibility beyond hot
+ * reload: marking the build as dev for `BT.isDevMode` (`src/utils/devMode.ts`). It runs unconditionally
+ * (not gated on `import.meta.hot`), because the plugin itself is dev-server only (`apply: 'serve'`) – a
+ * production build never sees this snippet at all.
  */
 const SNIPPET = `
 ${INJECTION_MARKER}
 import { registerHotReload as __blit386_registerHotReload } from 'blit386';
+globalThis.__BLIT386_DEV__ = true;
 if (import.meta.hot) {
     import.meta.hot.accept();
     __blit386_registerHotReload(import.meta.hot);

--- a/packages/kit/CLAUDE.md
+++ b/packages/kit/CLAUDE.md
@@ -20,7 +20,7 @@ Generated games receive `AGENTS.md`, eight beginner docs from `content/docs/` (`
 These are not copies of the engine's full `docs/` tree – they teach the starter game and point to GitHub for deep API
 reference.
 
-The whole of `content/` is the shipped IR, not just `AGENTS.md` + `docs/`: it also carries `rules/`, `skills/` (21
+The whole of `content/` is the shipped IR, not just `AGENTS.md` + `docs/`: it also carries `rules/`, `skills/` (22
 game-author capability skills plus the `run`, `fix`, and `migrate` workflow skills), `hooks/shell-safety.sh` +
 `hooks.manifest.json`, and `agents.config.json`. Skills and rules are discovered by directory scan in `src/adapters.ts`
 – adding a skill folder is enough, nothing registers it by name.
@@ -32,7 +32,8 @@ favor of kit-based demos, and shipped content must not break with it.
 The engine has no physics, collision, entity, or scene system. Say so; do not invent one. What the kit does teach:
 drawing (primitives, sprites, text), palette and effects, input (keyboard, pointer, gamepad), timing, audio (bus mixer,
 `AudioClip`, procedural synth – engine 1.3.0), hot reload / `blit386/vite` / asset hot-replace / `BT.loadingAssetsCount`
-(engine 1.4.0), the debug overlay, screenshots, and WebGPU-only post-process effects.
+(engine 1.4.0), `BT.isDevMode` dev/release detection (engine 1.5.0), the debug overlay, screenshots, and WebGPU-only
+post-process effects.
 
 ### Drift is the standing risk here
 
@@ -49,12 +50,13 @@ here – review in the same pass, not later. Run `/kit-audit` to walk the checkl
 | `content/docs/input.md` | `BT.isDown`, edges, keyboard, pointer, gamepad, scroll-capture / touch-action |
 | `content/docs/palette.md` | `paletteCreate`, slots, `Color32` |
 | `content/docs/audio.md` | `AudioClip`, `BT.synthPreset`, buses, the unlock rule |
-| `content/docs/hot-reload.md` | `blit386/vite`, swap tiers, `onHotReload`, asset hot-replace |
+| `content/docs/hot-reload.md` | `blit386/vite`, swap tiers, `onHotReload`, asset hot-replace, `BT.isDevMode` |
 | `content/docs/when-something-breaks.md` | Common errors, `await`, palette slot 0, silent audio, hot-reload surprises |
 | `content/AGENTS.md` | Overall game shape, hard rules, doc routing, hot-reload tiers |
 | `content/rules/blit-api-names.md` | `BT` getters, configure flags, wake lock, `onHotReload` / never `registerHotReload` |
 | `content/rules/blit-integer-coords.md` | Integer-coordinate rule (`Vector2i` / `Rect2i`) |
 | `content/skills/use-hot-reload/SKILL.md` | Swap tiers, `onHotReload`, vite plugin opt-in for older games |
+| `content/skills/use-dev-mode/SKILL.md` | `BT.isDevMode` resolution order, cheat-key / debug-HUD gating examples |
 | `content/skills/*/SKILL.md` | Other game-author skills; each demonstrates a slice of the `BT` surface |
 | `content/hooks/shell-safety.sh` | Shell commands the hook blocks in a generated game (Cursor + Claude protocols) |
 | `content/hooks.manifest.json` | Canonical hook intent; Cursor `hooks.json` and Claude `settings.json` derive from it |

--- a/packages/kit/README.md
+++ b/packages/kit/README.md
@@ -44,6 +44,7 @@ there you can also invoke one by name (`/add-sprite`).
 | `run` | Start the dev server and see the game |
 | `fix` | The game crashes, shows a black screen, or behaves oddly |
 | `use-hot-reload` | Keep playing while you edit code or assets (`blit386/vite`, `onHotReload`) |
+| `use-dev-mode` | Gate debug HUDs, cheat keys, and verbose logging on `BT.isDevMode` |
 | `draw-shapes` | Rectangles, lines, pixels, and clearing the screen |
 | `add-sprite` | Load a PNG sprite sheet and draw it, whole or frame by frame |
 | `show-a-loading-screen` | Wait for sprites and audio with `BT.loadingAssetsCount` |

--- a/packages/kit/content/AGENTS.md
+++ b/packages/kit/content/AGENTS.md
@@ -62,6 +62,7 @@ bootstrap(Game);
 | Make and use colors (palette, slots) | `docs/palette.md` |
 | Play sound effects and music, or fix a silent game | `docs/audio.md` |
 | Keep playing while you edit code or assets | `docs/hot-reload.md` |
+| Tell a dev build from a release build (debug HUDs, cheat keys) | `docs/hot-reload.md` (Telling a dev build from a release build) |
 | Show a loading screen while assets load | `docs/basics.md` (Waiting for assets) |
 | Fix a blank screen, an error, a broken change | `docs/when-something-breaks.md` |
 

--- a/packages/kit/content/docs/hot-reload.md
+++ b/packages/kit/content/docs/hot-reload.md
@@ -90,7 +90,7 @@ game, `false` once you `npm run build` it. Use it to gate things you only want w
 ```js
 update() {
     if (BT.isDevMode) {
-        console.log('dev build - extra logging on');
+        console.log('dev build – extra logging on');
     }
 }
 ```

--- a/packages/kit/content/docs/hot-reload.md
+++ b/packages/kit/content/docs/hot-reload.md
@@ -82,4 +82,22 @@ The plugin needs blit386 1.4.0 or newer.
 - Editing a file under `public/` that the plugin does not recognize as an image, audio, or `.btfont` (by default that
   reloads the page).
 
+## Telling a dev build from a release build
+
+Installing the plugin above also gets you `BT.isDevMode` (blit386 1.5.0+) – `true` while `npm run dev` is running the
+game, `false` once you `npm run build` it. Use it to gate things you only want while developing:
+
+```js
+update() {
+    if (BT.isDevMode) {
+        console.log('dev build - extra logging on');
+    }
+}
+```
+
+Read it inside `update()` or `render()`, not at the top of a file – the plugin marks the build as dev after the rest of
+your entry file has already run, so a check outside those methods can see `false` even while developing.
+
+See the use-dev-mode skill for cheat-key and debug-HUD examples.
+
 Next: `docs/basics.md` for the game loop, `docs/when-something-breaks.md` if a save did something unexpected.

--- a/packages/kit/content/rules/blit-api-names.md
+++ b/packages/kit/content/rules/blit-api-names.md
@@ -27,6 +27,8 @@ These are read-only values; access them as properties, not function calls.
 - Audio: `BT.isAudioUnlocked`, `BT.isMusicPlaying`
 - Input: `BT.inputString`, `BT.pointerScrollDelta`, `BT.gamepadCount`
 - Scene: `BT.camera`, `BT.palette` (throws if no palette has been set yet)
+- Build mode: `BT.isDevMode` (engine 1.5.0+) – gate debug HUDs, cheat keys, and verbose logging; see
+  `skills/use-dev-mode/`
 
 ```js
 const w = BT.displaySize.x; // correct

--- a/packages/kit/content/skills/use-dev-mode/SKILL.md
+++ b/packages/kit/content/skills/use-dev-mode/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: use-dev-mode
+description:
+  Gate debug HUDs, cheat keys, verbose logging, and test fixtures on `BT.isDevMode` (engine 1.5.0+) instead of a
+  hand-rolled flag. Use when the user asks how to tell a dev build from a release build, wants a feature to only run
+  while developing, or wants something like a cheat key to disappear once the game ships.
+---
+
+# Use dev mode
+
+`BT.isDevMode` tells you whether the game is running as a development build or a release build, so you do not have to
+invent your own signal for it.
+
+## When to use
+
+Use when the user wants a debug HUD, cheat key, verbose console logging, or a test fixture (a level-select shortcut, a
+god-mode toggle) to work while developing but disappear from a shipped build.
+
+## How to do it
+
+```js
+update() {
+    if (BT.isDevMode && BT.isKeyPressed('KeyG')) {
+        this.godMode = !this.godMode; // dev-only cheat key
+    }
+}
+
+render() {
+    // ...
+    if (BT.isDevMode) {
+        console.log('player', this.player.x, this.player.y); // dev-only verbose logging
+    }
+}
+```
+
+`BT.isDevMode` is a getter (no parentheses) and needs no setup beyond having `blit386/vite` installed – every scaffold
+has it already (see `use-hot-reload`). It reads `true` while `npm run dev` is running the game through that plugin, and
+`false` in a built/shipped game (`npm run build`).
+
+## Notes
+
+- `BT.isDevMode` is tied to the dev server, not to `NODE_ENV` or any bundler define – there is nothing else to
+  configure.
+- It answers exactly one question: is this a dev build. It has nothing to do with your own game state (paused, in a
+  menu, level number) – keep those as your own fields.
+- This is a convenience for you, the developer, not a security boundary. A player who really wants to could still flip
+  it on in a shipped build; do not rely on it to hide content you actually need to protect.
+- Needs blit386 `^1.5.0`.

--- a/packages/website/content/docs/api/core.mdx
+++ b/packages/website/content/docs/api/core.mdx
@@ -3,7 +3,7 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Core"
 description: "Bootstrap, initialization, and default configuration."
-lastModified: "2026-07-28T16:49:29+02:00"
+lastModified: "2026-08-05T08:55:35+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/api-core.md"
 ---
 
@@ -352,6 +352,65 @@ function configure(): Partial<HardwareSettings> {
 }
 // requestedBackend === activeBackend === 'software' after init
 ```
+
+### Dev vs. release mode
+
+<Since symbol="BT.isDevMode" />
+
+`BT.isDevMode` answers one question: is this a development build. Games and demos can gate debug HUDs, cheat keys,
+verbose logging, or test fixtures on it instead of inventing a build-mode signal of their own.
+
+```ts twoslash
+import { BT, type IBTDemo } from 'blit386';
+
+class Demo implements IBTDemo {
+  async init(): Promise<boolean> {
+    return true;
+  }
+
+  update(): void {
+    if (BT.isDevMode) {
+      console.log('dev build – verbose logging enabled');
+    }
+  }
+
+  render(): void {}
+}
+```
+
+Resolution order, first match wins:
+
+1. `globalThis.__BLIT386_DEV__`, set at runtime by the
+   [`blit386/vite` plugin](/docs/guides/hot-reload#the-blit386vite-plugin)'s injected snippet. A runtime assignment, not a
+   bundler define, so it works regardless of how the engine itself was built or bundled.
+2. A live Vite HMR context, as a late fallback (see [Hot Reload](/docs/guides/hot-reload)).
+3. Otherwise, release.
+
+The underlying resolver also accepts an explicit override that always wins over both signals above; nothing in the
+public `BT` surface offers one today, so this only matters if you call the internal resolver directly.
+
+Neither `import.meta.env.DEV` nor a bundler `define` can back this getter: the engine ships both ESM and CJS builds and
+is pre-built into `dist` before a consumer's bundler ever sees it, so a define declared in the consumer's config does
+not reliably reach a pre-bundled dependency.
+
+<Callout title="This is DX gating, not DRM">
+
+Any consumer can flip `globalThis.__BLIT386_DEV__` by hand. `BT.isDevMode` exists to make ordinary dev-vs-release
+decisions easy, not to make release builds tamper-proof.
+
+</Callout>
+
+<Callout type="warn" title="Read it from update()/render(), not module scope">
+
+The `blit386/vite` plugin's snippet is appended after the rest of the entry module, so it runs after that module's own
+top-level code but before `update()`/`render()` ever run. A module-scope `BT.isDevMode` read (for example a
+`const isDev = BT.isDevMode;` at the top of a file the entry module imports) can observe `false` even in a dev build.
+Read it inside a lifecycle method instead.
+
+</Callout>
+
+A consumer who skips the `blit386/vite` plugin reads as release everywhere the plugin's marker would otherwise apply –
+see [The `blit386/vite` plugin](/docs/guides/hot-reload#the-blit386vite-plugin) for what installing it actually does.
 
 ## Default configuration
 

--- a/packages/website/content/docs/guides/hot-reload.mdx
+++ b/packages/website/content/docs/guides/hot-reload.mdx
@@ -3,7 +3,7 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Hot Reload"
 description: "The three hot-reload swap tiers, onHotReload semantics, asset hot-replace, and the blit386/vite plugin."
-lastModified: "2026-07-28T16:49:29+02:00"
+lastModified: "2026-08-05T08:55:35+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/guide-hot-reload.md"
 ---
 
@@ -233,7 +233,7 @@ export default defineConfig({
 });
 ```
 
-The plugin does two things, both dev-server only (`apply: 'serve'` - a production build never sees it, so there is zero
+The plugin does three things, all dev-server only (`apply: 'serve'` – a production build never sees it, so there is zero
 runtime cost or behavior change to ship):
 
 - Appends a small hot-reload registration snippet to any served module that imports `blit386` and calls
@@ -242,6 +242,7 @@ runtime cost or behavior change to ship):
   ```js
   /* blit386:hot-reload-snippet */
   import { registerHotReload as __blit386_registerHotReload } from 'blit386';
+  globalThis.__BLIT386_DEV__ = true;
   if (import.meta.hot) {
     import.meta.hot.accept();
     __blit386_registerHotReload(import.meta.hot);
@@ -260,6 +261,16 @@ runtime cost or behavior change to ship):
   transform pipeline excludes those extensions from server-side parsing, so without this a broken entry module would
   surface only as a silently caught client-side error - Vite's error overlay would never appear. A `.ts`/`.mts` entry is
   unaffected; it already gets real syntax validation from Vite's own transform.
+
+- Marks the build as dev for [`BT.isDevMode`](/docs/api/core#dev-vs-release-mode) via the snippet's
+  `globalThis.__BLIT386_DEV__ = true` line – a responsibility this plugin has beyond hot reload itself. It runs
+  unconditionally, not only inside the `import.meta.hot` guard, because the snippet as a whole is only ever injected by
+  this dev-server-only plugin. This is the standard, automatic signal `BT.isDevMode` looks for; the same snippet's
+  `registerHotReload(import.meta.hot)` call also registers a live Vite HMR context, which `BT.isDevMode` checks as a
+  late fallback (see [Dev vs. release mode](/docs/api/core#dev-vs-release-mode)). A consumer who skips this plugin gets
+  neither signal, so `BT.isDevMode` reads as release. Because the snippet is appended after the rest of the entry
+  module, a module-scope `BT.isDevMode` read (rather than one inside `update()`/`render()`) can still observe `false` in
+  a dev build.
 
 - Watches the configured asset directories and broadcasts `blit386:asset-changed` events for recognized file types (see
   the [asset matrix](#asset-hot-replace-matrix) above), falling back to a full reload for anything else.

--- a/packages/website/content/docs/reference/changelog.mdx
+++ b/packages/website/content/docs/reference/changelog.mdx
@@ -3,7 +3,7 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Changelog"
 description: "Release history in Keep a Changelog style: what shipped, what broke, and when."
-lastModified: "2026-07-25T13:36:33+02:00"
+lastModified: "2026-08-05T08:35:31+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/changelog.md"
 ---
 
@@ -25,6 +25,10 @@ notes, including dependency bumps and CI changes omitted here for brevity.
   matches RetroBlit's `Ease` class.
 - `interpolate(easing, start, end, t)` for `number`, `Vector2i`, `Color32`, and `Rect2i`. Integer types round to the
   nearest component; `Color32` channels also clamp to `[0, 255]`.
+- `BT.isDevMode`: engine-level dev vs. release build detection. Resolves from the `blit386/vite` plugin's runtime
+  marker, falling back to a live Vite HMR context, otherwise release. The plugin now sets that marker as a second
+  responsibility beyond hot reload. See [Core](/docs/api/core#dev-vs-release-mode) and
+  [Hot Reload](/docs/guides/hot-reload#the-blit386vite-plugin).
 
 ## 1.4.0 - 2026-07-23
 

--- a/packages/website/src/data/api-history.generated.json
+++ b/packages/website/src/data/api-history.generated.json
@@ -563,6 +563,13 @@
       "deprecated": null,
       "status": "stable"
     },
+    "BT.isDevMode": {
+      "kind": "getter",
+      "since": "1.5.0",
+      "changes": [],
+      "deprecated": null,
+      "status": "unreleased"
+    },
     "BT.isDown": {
       "kind": "method",
       "since": "1.1.1",
@@ -1565,6 +1572,7 @@
       "BT.displaySize",
       "BT.drawingBufferSize",
       "BT.init",
+      "BT.isDevMode",
       "BT.outputSize",
       "BT.requestedBackend",
       "BT.screenOrientation",


### PR DESCRIPTION
## Summary

Add `BT.isDevMode`, resolving from the `blit386/vite` plugin's runtime marker (`globalThis.__BLIT386_DEV__`, set by its injected snippet), with a live Vite HMR context as a late fallback, otherwise release. The resolver is split into a pure `resolveDevMode` and a thin `isDevMode` reader so the precedence logic stays unit-testable in the default Node vitest environment, with no `happy-dom` opt-in.

Also ships the `use-dev-mode` kit skill plus matching kit/engine doc and rule updates so generated games know how to gate debug HUDs, cheat keys, and verbose logging on the new getter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `BT.isDevMode` to identify development builds at runtime.
  * Development mode now activates automatically during hot-reload sessions.
  * Added guidance for using development mode to enable debug HUDs, cheat keys, and verbose logging.

* **Documentation**
  * Documented development and release behavior, usage examples, limitations, and lifecycle considerations.
  * Added a new development-mode skill for game authors.

* **Tests**
  * Added coverage for development-mode detection, runtime behavior, and hot-reload integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->