### PR TITLE
docs(kit): add random and noise skills, fix stale easing references

### DIFF
--- a/packages/blit386/docs/changelog.md
+++ b/packages/blit386/docs/changelog.md
@@ -23,6 +23,20 @@ notes, including dependency bumps and CI changes omitted here for brevity.
 
 ### Added
 
+- Seeded random: the `Random` class (a mulberry32 PRNG) plus `BT.random` and `BT.randomSeed(seed)` on the facade.
+  `BT.random` is a live reference to one shared instance, time-seeded at singleton creation, so the engine default is
+  deterministic the moment you seed it. Beyond `next()` / `float()` / `int()` / `intInclusive()` it carries the draws
+  games actually reach for – `bool`, `sign`, `pick`, `shuffle` / `shuffleInPlace`, `weighted`, `angle`, `gaussian` – and
+  spatial helpers `insideRect`, `pointInRange`, `direction4`, `direction8`, each with an allocation-free `*To(out)`
+  variant. Stream control is `seed`, `seedValue`, `getState`, `setState`, `clone`, and `fork`. Prefer it over
+  `Math.random()`, which cannot be seeded. See [Random](api-random.md) and [Random guide](guide-random.md).
+- Coordinate hashing: `hash1i` / `hash2i` / `hash3i` return an unsigned 32-bit value and `hash1` / `hash2` / `hash3`
+  return the same value scaled into `[0, 1)`. These are stateless spatial lookups – identical coordinates and seed
+  always give an identical result – so a chunked or procedural world needs no stored generator per chunk.
+- Pattern noise: `ValueNoise`, `PerlinNoise`, and `SimplexNoise`, each seedable and sampling to approximately `[-1, 1]`.
+  Value and Perlin expose `noise1D` / `noise2D` / `noise3D` and the matching `fbm*`; Simplex is 2D and 3D only. fBm
+  defaults to `octaves = 4`, `persistence = 0.5`, `lacunarity = 2`, with octave amplitudes normalized so the sum stays
+  in range. Distinct from the post-process `Noise` display effect, which is unrelated GPU grain.
 - Full easing curve library on `EasingFunction` / `applyEasing`: sine, cubic, quartic, quintic, expo, circ, back,
   elastic, and bounce families (in / out / in-out), alongside the existing linear and quadratic (`ease-*`) curves. Math
   matches RetroBlit's `Ease` class.

--- a/packages/create-blit386/templates/base/README.md
+++ b/packages/create-blit386/templates/base/README.md
@@ -72,5 +72,6 @@ the usual suspects: blank screens, "command not found," forgotten `await`, and m
 ## Learn more
 
 - `AGENTS.md` – a short home base for you or an AI assistant.
-- `docs/` – friendly guides: getting started, the game loop, drawing, input, colors, hot reload, and fixing problems.
+- `docs/` – friendly guides: getting started, the game loop, drawing, input, colors, randomness and world generation,
+  hot reload, and fixing problems.
 - [blit386.dev](https://blit386.dev) – the full BLIT386 documentation site.

--- a/packages/kit/CLAUDE.md
+++ b/packages/kit/CLAUDE.md
@@ -15,12 +15,12 @@ The `blit` CLI is a project-local bin inside every generated game: `blit run`, `
 
 ## Kit content vs engine docs
 
-Generated games receive `AGENTS.md`, eight beginner docs from `content/docs/` (`getting-started`, `basics`, `drawing`,
-`input`, `palette`, `audio`, `hot-reload`, `when-something-breaks`), and the game-author skills in `content/skills/`.
-These are not copies of the engine's full `docs/` tree – they teach the starter game and point to GitHub for deep API
-reference.
+Generated games receive `AGENTS.md`, nine beginner docs from `content/docs/` (`getting-started`, `basics`, `drawing`,
+`input`, `palette`, `random`, `audio`, `hot-reload`, `when-something-breaks`), and the game-author skills in
+`content/skills/`. These are not copies of the engine's full `docs/` tree – they teach the starter game and point to
+GitHub for deep API reference.
 
-The whole of `content/` is the shipped IR, not just `AGENTS.md` + `docs/`: it also carries `rules/`, `skills/` (21
+The whole of `content/` is the shipped IR, not just `AGENTS.md` + `docs/`: it also carries `rules/`, `skills/` (24
 game-author capability skills plus the `run`, `fix`, and `migrate` workflow skills), `hooks/shell-safety.sh` +
 `hooks.manifest.json`, and `agents.config.json`. Skills and rules are discovered by directory scan in `src/adapters.ts`
 – adding a skill folder is enough, nothing registers it by name.
@@ -30,9 +30,10 @@ kit files. Do not reference the `packages/demos` package, its demo slugs, or its
 favor of kit-based demos, and shipped content must not break with it.
 
 The engine has no physics, collision, entity, or scene system. Say so; do not invent one. What the kit does teach:
-drawing (primitives, sprites, text), palette and effects, input (keyboard, pointer, gamepad), timing, audio (bus mixer,
-`AudioClip`, procedural synth – engine 1.3.0), hot reload / `blit386/vite` / asset hot-replace / `BT.loadingAssetsCount`
-(engine 1.4.0), the debug overlay, screenshots, and WebGPU-only post-process effects.
+drawing (primitives, sprites, text), palette and effects, input (keyboard, pointer, gamepad), timing and easing, audio
+(bus mixer, `AudioClip`, procedural synth – engine 1.3.0), hot reload / `blit386/vite` / asset hot-replace /
+`BT.loadingAssetsCount` (engine 1.4.0), `BT.isDevMode` dev/release detection plus `BT.random` and the noise/hash world
+generation surface (engine 1.5.0), the debug overlay, screenshots, and WebGPU-only post-process effects.
 
 ### Drift is the standing risk here
 
@@ -48,6 +49,7 @@ here – review in the same pass, not later. Run `/kit-audit` to walk the checkl
 | `content/docs/drawing.md` | `BT.clear`, primitives, text APIs |
 | `content/docs/input.md` | `BT.isDown`, edges, keyboard, pointer, gamepad, scroll-capture / touch-action |
 | `content/docs/palette.md` | `paletteCreate`, slots, `Color32` |
+| `content/docs/random.md` | `BT.random` / `BT.randomSeed`, seeding a run, noise and hash world generation |
 | `content/docs/audio.md` | `AudioClip`, `BT.synthPreset`, buses, the unlock rule |
 | `content/docs/hot-reload.md` | `blit386/vite`, swap tiers, `onHotReload`, asset hot-replace |
 | `content/docs/when-something-breaks.md` | Common errors, `await`, palette slot 0, silent audio, hot-reload surprises |
@@ -55,6 +57,10 @@ here – review in the same pass, not later. Run `/kit-audit` to walk the checkl
 | `content/rules/blit-api-names.md` | `BT` getters, configure flags, wake lock, `onHotReload` / never `registerHotReload` |
 | `content/rules/blit-integer-coords.md` | Integer-coordinate rule (`Vector2i` / `Rect2i`) |
 | `content/skills/use-hot-reload/SKILL.md` | Swap tiers, `onHotReload`, vite plugin opt-in for older games |
+| `content/skills/use-dev-mode/SKILL.md` | `BT.isDevMode` resolution order, cheat-key / debug-HUD gating examples |
+| `content/skills/use-random/SKILL.md` | `BT.random` / `BT.randomSeed`, `Random` methods, state and stream helpers |
+| `content/skills/use-noise/SKILL.md` | `hash*` functions, `ValueNoise` / `PerlinNoise` / `SimplexNoise`, fBm defaults |
+| `content/skills/move-and-time/SKILL.md` | Clock getters, `Timer`, the `EasingFunction` curve list, `interpolate` |
 | `content/skills/*/SKILL.md` | Other game-author skills; each demonstrates a slice of the `BT` surface |
 | `content/hooks/shell-safety.sh` | Shell commands the hook blocks in a generated game (Cursor + Claude protocols) |
 | `content/hooks.manifest.json` | Canonical hook intent; Cursor `hooks.json` and Claude `settings.json` derive from it |

--- a/packages/kit/README.md
+++ b/packages/kit/README.md
@@ -50,7 +50,9 @@ there you can also invoke one by name (`/add-sprite`).
 | `add-text` | Scores, labels, and titles with the built-in or a bitmap font |
 | `use-palette` | Set up colors as numbered palette slots |
 | `animate-the-palette` | Cycle, fade, flash, and swap colors for motion and mood |
-| `move-and-time` | The frame clock, timers, cooldowns, and easing |
+| `move-and-time` | The frame clock, timers, cooldowns, easing curves, and `interpolate` |
+| `use-random` | Dice, picks, shuffles, weighted drops, and seeds that replay the same game |
+| `use-noise` | Terrain, caves, clouds, and procedural textures from noise and coordinate hashing |
 | `smooth-the-motion` | Make movement look smooth instead of stepped, with `BT.renderAlpha` |
 | `scroll-with-camera` | Scroll a world bigger than the screen, clamped to its bounds |
 | `read-keyboard` | Keys, face buttons, typed text, and remapping |

--- a/packages/kit/content/AGENTS.md
+++ b/packages/kit/content/AGENTS.md
@@ -60,6 +60,8 @@ bootstrap(Game);
 | Clear the screen, draw rectangles, lines, text | `docs/drawing.md` |
 | Read the keyboard, mouse, or a gamepad | `docs/input.md` |
 | Make and use colors (palette, slots) | `docs/palette.md` |
+| Roll dice, pick, shuffle, or seed a run so it repeats | `docs/random.md` |
+| Generate terrain, caves, or patterns you can walk back to | `docs/random.md` (Terrain and patterns) |
 | Play sound effects and music, or fix a silent game | `docs/audio.md` |
 | Keep playing while you edit code or assets | `docs/hot-reload.md` |
 | Show a loading screen while assets load | `docs/basics.md` (Waiting for assets) |

--- a/packages/kit/content/docs/basics.md
+++ b/packages/kit/content/docs/basics.md
@@ -129,4 +129,5 @@ coarse `sheet.progress` (`0` or `1.0`). Prefer `BT.loadingAssetsCount` for one e
 New projects include the `blit386` Vite plugin, so most saves keep the running game alive. Optional
 `onHotReload(context)` on your game class can restore fields after an `init()` edit. Full detail: `docs/hot-reload.md`.
 
-Next: `docs/drawing.md` to put things on screen, `docs/input.md` to react to the player, `docs/palette.md` for colors.
+Next: `docs/drawing.md` to put things on screen, `docs/input.md` to react to the player, `docs/palette.md` for colors,
+`docs/random.md` for dice rolls and generated worlds.

--- a/packages/kit/content/docs/random.md
+++ b/packages/kit/content/docs/random.md
@@ -1,0 +1,97 @@
+# Random numbers and world generation
+
+Games need surprise: which enemy appears, where the coin lands, how the ground is shaped. BLIT386 gives you two tools
+for that, and picking the right one saves a lot of trouble.
+
+- `BT.random` – a generator you ask for the next value. Ask twice, get two different answers. Use it for dice rolls,
+  picks, and shuffles.
+- Noise and hashing – lookups by coordinate. Ask about the same spot twice, get the same answer twice. Use them for
+  terrain, caves, and anything the player can walk away from and come back to.
+
+## Rolling and picking
+
+`BT.random` is a property, not a call – no parentheses on `BT.random` itself, only on the method after it.
+
+```js
+update() {
+    const lane = BT.random.int(3); // 0, 1, or 2 - the top number is excluded
+    const damage = BT.random.intInclusive(1, 6); // 1 to 6, like a die - both ends included
+    const speed = BT.random.float(0.5, 2.0); // a decimal in between
+
+    if (BT.random.bool(0.3)) {
+        this.spawnEnemy(); // happens 30% of the time
+    }
+
+    const enemy = BT.random.pick(['bat', 'slime', 'ghost']); // one item from a list
+    const deck = BT.random.shuffle(this.cards); // a new array, shuffled
+    const drop = BT.random.weighted(['coin', 'gem', 'crown'], [70, 25, 5]); // rarer things, less often
+}
+```
+
+`int` and `intInclusive` give whole numbers, so you can use them as screen coordinates directly. `float` gives decimals,
+so round it with `Math.floor` before drawing anything with it.
+
+Use `BT.random` instead of `Math.random()`. It does more, and unlike the built-in one it can be seeded – which is the
+next section.
+
+## Making a run repeat exactly
+
+Normally every run differs, because the generator starts from the clock. Give it a seed and the same numbers come back
+in the same order:
+
+```js
+async init() {
+    BT.randomSeed(1234); // this run now plays out identically every time
+    return true;
+}
+```
+
+That is how daily challenges, shareable level codes, and reproducible bug reports work: store one number, rebuild the
+same world from it.
+
+`BT.random` is shared, so everything draws from the same sequence. If you want your level layout to stay identical no
+matter how many shots the player fires, give it a private generator:
+
+```js
+import { Random } from 'blit386';
+
+// in init():
+this.levelRng = new Random(1234); // unaffected by anything else
+```
+
+## Terrain and patterns
+
+For a world you generate rather than roll, use noise. It gives a smooth value that changes gradually across space, which
+is what makes hills look like hills:
+
+```js
+import { PerlinNoise } from 'blit386';
+
+// in init():
+this.terrain = new PerlinNoise(9001);
+for (let x = 0; x < 320; x++) {
+  const n = this.terrain.noise2D(x * 0.02, 0); // about -1 to 1
+  this.groundY.push(Math.floor(120 + n * 40)); // round: screen coordinates are whole numbers
+}
+```
+
+The `0.02` controls the size of the features – smaller means broader, smoother hills. `ValueNoise` and `SimplexNoise`
+are alternatives with slightly different looks.
+
+When you want an unrelated yes-or-no answer per tile instead of a smooth slope, use a hash:
+
+```js
+import { hash2 } from 'blit386';
+
+hasTreeAt(tileX, tileY) {
+    return hash2(tileX, tileY, 9001) < 0.15; // 15% of tiles, always the same ones
+}
+```
+
+Because the answer depends only on the coordinates and the seed, the trees are still there when the player walks back –
+without you storing a single one of them.
+
+Generate this kind of thing once, into an array, in `init()` or when the player enters a new area. Sampling noise for
+every pixel on every frame is slow.
+
+Next: `docs/basics.md` for the game loop, or `docs/drawing.md` for what you can draw with these numbers.

--- a/packages/kit/content/docs/random.md
+++ b/packages/kit/content/docs/random.md
@@ -3,8 +3,8 @@
 Games need surprise: which enemy appears, where the coin lands, how the ground is shaped. BLIT386 gives you two tools
 for that, and picking the right one saves a lot of trouble.
 
-- `BT.random` – a generator you ask for the next value. Ask twice, get two different answers. Use it for dice rolls,
-  picks, and shuffles.
+- `BT.random` – a getter that returns a shared generator. Reading `BT.random` alone does nothing; call a method on it
+  (`BT.random.int()`, `BT.random.float()`, ...) to draw the next value. Use it for dice rolls, picks, and shuffles.
 - Noise and hashing – lookups by coordinate. Ask about the same spot twice, get the same answer twice. Use them for
   terrain, caves, and anything the player can walk away from and come back to.
 

--- a/packages/kit/content/rules/blit-api-names.md
+++ b/packages/kit/content/rules/blit-api-names.md
@@ -27,6 +27,10 @@ These are read-only values; access them as properties, not function calls.
 - Audio: `BT.isAudioUnlocked`, `BT.isMusicPlaying`
 - Input: `BT.inputString`, `BT.pointerScrollDelta`, `BT.gamepadCount`
 - Scene: `BT.camera`, `BT.palette` (throws if no palette has been set yet)
+- Random: `BT.random` (engine 1.5.0+) – the shared seedable generator; a live reference, like `BT.palette`. See
+  `skills/use-random/`
+- Build mode: `BT.isDevMode` (engine 1.5.0+) – gate debug HUDs, cheat keys, and verbose logging; see
+  `skills/use-dev-mode/`
 
 ```js
 const w = BT.displaySize.x; // correct
@@ -45,7 +49,13 @@ BT.isPressed(BT.BTN_A, 0); // check just-pressed edge
 BT.isKeyDown('ArrowLeft'); // keyboard hold
 BT.isPointerActive(0); // mouse or touch slot 0 is active
 BT.pointerPos(0); // pointer position (Vector2i)
+BT.randomSeed(1234); // reseed the shared generator (engine 1.5.0+)
 ```
+
+`BT.random` is the getter, `BT.randomSeed(n)` is the method – the pair works like `BT.palette` / `BT.paletteSet`. Draws
+go through the getter: `BT.random.int(0, 320)`, `BT.random.pick(list)`. Prefer it over `Math.random()`, which cannot be
+seeded. Import `Random` from `blit386` for an independent stream, and `hash2` / `PerlinNoise` and friends for
+coordinate-based world generation; see `skills/use-random/` and `skills/use-noise/`.
 
 ## Configure flags
 

--- a/packages/kit/content/skills/animate-the-palette/SKILL.md
+++ b/packages/kit/content/skills/animate-the-palette/SKILL.md
@@ -45,7 +45,8 @@ BT.paletteClearEffects();
 - `BT.paletteFlash(color, durationMs)`
 - `BT.paletteSwap(indexA, indexB)`
 - `BT.paletteClearEffects()`
-- Easing names: `'linear'`, `'ease-in'`, `'ease-out'`, `'ease-in-out'`.
+- Easing names: `'linear'`, `'ease-in'`, `'ease-out'`, `'ease-in-out'`, plus the full curve library on blit386 1.5.0+
+  (`'sine-*'`, `'cubic-*'`, `'expo-*'`, `'bounce-*'`, and more – see the `move-and-time` skill).
 
 ## Notes
 

--- a/packages/kit/content/skills/move-and-time/SKILL.md
+++ b/packages/kit/content/skills/move-and-time/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: move-and-time
 description:
-  Move things smoothly and schedule actions using the engine frame clock, the Timer helper, and easing. Use for
-  movement, timers, cooldowns, spawn intervals, animation frames, or anything that should happen 'every N frames' or
-  'over N seconds'.
+  Move things smoothly and schedule actions using the engine frame clock, the Timer helper, and the easing curve library
+  (`applyEasing`, `interpolate`). Use for movement, timers, cooldowns, spawn intervals, animation frames, tweening a
+  position or color between two values, or anything that should happen 'every N frames' or 'over N seconds'.
 ---
 
 # Move and time things
@@ -48,6 +48,8 @@ if (this.fireTimer.fireIfElapsed(BT.ticks)) {
 
 ## Easing for smooth motion
 
+Easing bends a straight 0..1 progress value into something that accelerates, overshoots, or bounces.
+
 ```js
 import { applyEasing } from 'blit386';
 
@@ -55,6 +57,41 @@ const t = (BT.ticks % 60) / 60; // 0..1
 const eased = applyEasing(t, 'ease-in-out');
 this.y = Math.floor(100 + eased * 50); // round before drawing
 ```
+
+### Which curve
+
+Every family below comes in three versions: `-in` (slow start), `-out` (slow finish), and `-in-out` (both). So
+`'sine-in'`, `'sine-out'`, and `'sine-in-out'` all exist, and the same for the rest.
+
+| Name | Feels like |
+| --- | --- |
+| `'linear'` | No easing – constant speed |
+| `'ease-in'` / `'ease-out'` / `'ease-in-out'` | The gentle default (quadratic) |
+| `'sine-*'` | Very soft, barely noticeable |
+| `'cubic-*'`, `'quartic-*'`, `'quintic-*'` | Progressively sharper acceleration |
+| `'expo-*'` | Extreme – near-still, then a rush |
+| `'circ-*'` | Slow, then a sudden hard pull |
+| `'back-*'` | Overshoots slightly and settles – good for menus popping in |
+| `'elastic-*'` | Springs past the target and wobbles |
+| `'bounce-*'` | Bounces like a dropped ball |
+
+`'back-*'` and `'elastic-*'` deliberately leave the 0..1 range mid-animation, so leave room around whatever you are
+moving.
+
+### Interpolating between two values
+
+`interpolate` applies a curve and blends two values in one call, so you do not do the arithmetic yourself. It works on
+plain numbers and on `Vector2i`, `Color32`, and `Rect2i`, rounding integer types for you:
+
+```js
+import { interpolate, Vector2i } from 'blit386';
+
+const t = (BT.ticks % 90) / 90; // 0..1
+this.pos = interpolate('bounce-out', new Vector2i(20, 20), new Vector2i(200, 180), t);
+```
+
+Watch the argument order – it is the reverse of `applyEasing`: `interpolate(easing, start, end, t)` but
+`applyEasing(t, easing)`.
 
 ## Notes
 

--- a/packages/kit/content/skills/move-and-time/SKILL.md
+++ b/packages/kit/content/skills/move-and-time/SKILL.md
@@ -86,7 +86,7 @@ plain numbers and on `Vector2i`, `Color32`, and `Rect2i`, rounding integer types
 ```js
 import { interpolate, Vector2i } from 'blit386';
 
-const t = (BT.ticks % 90) / 90; // 0..1
+const t = (BT.ticks % 90) / 89; // 0..1, reaching 1 on the last frame of the cycle
 this.pos = interpolate('bounce-out', new Vector2i(20, 20), new Vector2i(200, 180), t);
 ```
 

--- a/packages/kit/content/skills/use-noise/SKILL.md
+++ b/packages/kit/content/skills/use-noise/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: use-noise
+description:
+  Generate terrain, caves, clouds, and procedural textures with the seedable noise classes (`ValueNoise`, `PerlinNoise`,
+  `SimplexNoise`) and the coordinate hash functions (`hash2i`, `hash2`) from blit386 1.5.0+. Use for procedurally
+  generated levels, infinite or chunked worlds, height maps, cave layouts, cloud and water patterns, or scattering
+  decoration that must stay put between visits.
+---
+
+# Use noise
+
+Noise and coordinate hashing answer the question "what is at this spot in the world" without storing a map. Same
+coordinates and same seed always give the same answer, so a world can be enormous, generated on demand, and still
+identical every time the player walks back.
+
+## When to use
+
+Use for terrain height, cave layouts, clouds, water, procedural textures, tile variation, or scattering trees and rocks
+across a world larger than memory.
+
+This is the opposite tool to the `use-random` skill. `BT.random` gives you the _next_ value in a sequence, so calling it
+twice gives two different answers. Noise and hashing are _stateless lookups_ by coordinate – ask for tile `(12, -3)` a
+thousand times and you get the same answer a thousand times.
+
+(Not to be confused with the `Noise` post-process effect from the `add-crt-effect` skill – that one is a fullscreen
+grain filter on the GPU, nothing to do with world generation.)
+
+## Yes or no per tile: coordinate hashing
+
+Use a hash when you want a hard, unrelated answer per coordinate – is there a tree here, which tile variant is this.
+
+```js
+import { hash2 } from 'blit386';
+
+const WORLD_SEED = 9001;
+
+hasTreeAt(tileX, tileY) {
+    return hash2(tileX, tileY, WORLD_SEED) < 0.15; // 15% of tiles, always the same ones
+}
+```
+
+| Function | Gives you |
+| --- | --- |
+| `hash1(x, seed?)`, `hash2(x, y, seed?)`, `hash3(x, y, z, seed?)` | A decimal from 0 up to (not including) 1 |
+| `hash1i(x, seed?)`, `hash2i(x, y, seed?)`, `hash3i(x, y, z, seed?)` | A big whole number – good with `%` to pick a variant |
+
+```js
+import { hash2i } from 'blit386';
+
+const variant = hash2i(tileX, tileY, WORLD_SEED) % 4; // 0..3, stable per tile
+```
+
+## Smooth landscapes: noise
+
+Hashing is jagged – neighboring tiles are unrelated. Noise is smooth, so neighbors resemble each other, which is what
+makes hills look like hills.
+
+```js
+import { PerlinNoise } from 'blit386';
+
+// in init():
+this.terrain = new PerlinNoise(9001);
+
+// anywhere:
+const height = this.terrain.noise2D(x * 0.05, y * 0.05); // about -1..1
+```
+
+The multiplier is the important part. Coordinates go in raw and neighboring whole numbers would land on completely
+different values, so scale them down: **smaller multiplier means larger, smoother features**. Start at `0.05` and adjust
+– `0.01` gives broad continents, `0.2` gives tight ripples.
+
+Turning the result into something you can draw. Sample once into an array, then draw from that array every frame:
+
+```js
+import { PerlinNoise, Vector2i } from 'blit386';
+
+// in init(): work out the ground height for every screen column, one time only
+this.terrain = new PerlinNoise(9001);
+this.groundY = [];
+for (let x = 0; x < 320; x++) {
+    const n = this.terrain.noise2D(x * 0.02, 0); // -1..1
+    this.groundY.push(Math.floor(120 + n * 40)); // round: screen coordinates are whole numbers
+}
+
+// in init() as well: two reusable points, so render() allocates nothing
+this.top = new Vector2i();
+this.bottom = new Vector2i();
+
+// in render(): just read the array back
+render() {
+    for (let x = 0; x < 320; x++) {
+        this.top.set(x, this.groundY[x]);
+        this.bottom.set(x, 239);
+        BT.drawLine(this.top, this.bottom, COLOR_DIRT);
+    }
+}
+```
+
+### Which class
+
+| Class | Use it for |
+| --- | --- |
+| `ValueNoise` | Cheapest. Fine for clouds and soft blobs; can look blocky at large scales |
+| `PerlinNoise` | The usual choice for terrain and height maps |
+| `SimplexNoise` | Fewer square-grid artifacts; `noise2D` / `noise3D` only, no 1D |
+
+All three take a seed in the constructor (`new PerlinNoise(9001)`) and have a `seed(n)` method to switch worlds later.
+All return roughly `-1` to `1`.
+
+### More detail with fbm
+
+One noise call gives smooth rolling hills. `fbm` ("fractal Brownian motion") layers several calls at increasing
+frequency to add roughness on top of the big shapes – this is what makes terrain look natural instead of like a duvet.
+
+```js
+const h = this.terrain.fbm2D(x * 0.02, y * 0.02); // 4 layers by default, still about -1..1
+const rougher = this.terrain.fbm2D(x * 0.02, y * 0.02, 6); // more layers, more fine detail
+```
+
+Extra arguments are `(x, y, octaves, persistence, lacunarity)`, defaulting to `4`, `0.5`, and `2`. Raising `octaves`
+adds detail and costs more; the other two are worth leaving alone until the shape is right.
+
+## Notes
+
+- Generate once, not every frame. Sampling noise for all 320x240 pixels every frame will drop your frame rate. Build the
+  height map or tile map into an array in `init()` (or when the player enters a chunk) and draw from that – see the
+  `keep-it-fast` skill.
+- Keep one world seed in a constant and pass it to every hash call, so the whole world regenerates as a unit when you
+  change it.
+- Omit the seed (or pass `0`) and you get a fixed default world – handy while experimenting, but two different features
+  will then share a pattern. Give each its own seed once the game is real.
+- Noise returns decimals around `-1..1`. Screen coordinates are whole numbers, so `Math.floor` the result before
+  drawing.
+- Chunked worlds need no bookkeeping: because the answer depends only on coordinates and seed, a chunk regenerates
+  identically when the player returns. Only store what the player _changed_.
+- Needs blit386 `^1.5.0`.

--- a/packages/kit/content/skills/use-noise/SKILL.md
+++ b/packages/kit/content/skills/use-noise/SKILL.md
@@ -18,9 +18,9 @@ identical every time the player walks back.
 Use for terrain height, cave layouts, clouds, water, procedural textures, tile variation, or scattering trees and rocks
 across a world larger than memory.
 
-This is the opposite tool to the `use-random` skill. `BT.random` gives you the _next_ value in a sequence, so calling it
-twice gives two different answers. Noise and hashing are _stateless lookups_ by coordinate – ask for tile `(12, -3)` a
-thousand times and you get the same answer a thousand times.
+This is the opposite tool to the `use-random` skill. `BT.random` is a getter for a shared generator – calling a method
+on it (`BT.random.int()`, ...) draws the _next_ value in a sequence. Noise and hashing are _stateless lookups_ by
+coordinate – ask for tile `(12, -3)` a thousand times and you get the same answer a thousand times.
 
 (Not to be confused with the `Noise` post-process effect from the `add-crt-effect` skill – that one is a fullscreen
 grain filter on the GPU, nothing to do with world generation.)

--- a/packages/kit/content/skills/use-random/SKILL.md
+++ b/packages/kit/content/skills/use-random/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: use-random
+description:
+  Roll dice, pick from a list, shuffle, and scatter things with the engine's seedable random generator `BT.random`
+  (engine 1.5.0+) instead of `Math.random()`. Use for enemy spawns, loot drops, damage rolls, screen shake, card
+  shuffles, scattering stars or particles, or whenever the user wants a game that plays out the same way twice from a
+  seed.
+---
+
+# Use random
+
+`BT.random` is the engine's random number generator. It does everything `Math.random()` does, plus the things games
+actually need – pick from a list, shuffle, weighted drops, a random direction – and it can be seeded so a run plays out
+identically every time.
+
+## When to use
+
+Use for spawn positions, enemy choice, loot drops, damage rolls, screen shake, shuffling a deck, scattering stars, or
+any "pick something at random". Also use when the user wants a daily challenge, a shareable level code, or a replay –
+anything where the same seed must produce the same game.
+
+For terrain, caves, clouds, or procedural textures, use the `use-noise` skill instead. That is a different tool: `noise`
+answers "what is at this coordinate", `random` answers "give me the next value".
+
+## How to do it
+
+`BT.random` is a getter (no parentheses), and it is the same generator every time you read it.
+
+```js
+update() {
+    // whole numbers, high end excluded: 0, 1, or 2
+    const lane = BT.random.int(3);
+
+    // whole numbers in a range, high end excluded: 10..319
+    const x = BT.random.int(10, 320);
+
+    // whole numbers, both ends included: 1..6, like a die
+    const damage = BT.random.intInclusive(1, 6);
+
+    // a decimal between two values
+    const speed = BT.random.float(0.5, 2.0);
+
+    // true 30% of the time
+    if (BT.random.bool(0.3)) {
+        this.spawnEnemy();
+    }
+}
+```
+
+`int` and `intInclusive` give you whole numbers already, so they are safe to use as screen coordinates directly. `float`
+is not – round it with `Math.floor` before drawing.
+
+## Picking and shuffling
+
+```js
+const enemy = BT.random.pick(['bat', 'slime', 'ghost']); // one item
+const deck = BT.random.shuffle(this.cards); // a new shuffled array
+
+// weights do not have to add up to anything in particular
+const drop = BT.random.weighted(['coin', 'gem', 'crown'], [70, 25, 5]);
+```
+
+`pick` throws on an empty array, so check `length` first if the list can run out. `shuffle` returns a new array and
+leaves the original alone; use `shuffleInPlace` only when you deliberately want the original changed.
+
+## Scattering things around
+
+```js
+import { Rect2i, Vector2i } from 'blit386';
+
+const spot = BT.random.insideRect(new Rect2i(0, 0, 320, 240)); // Vector2i
+const step = BT.random.direction4(); // (1,0), (-1,0), (0,1), or (0,-1)
+const drift = BT.random.direction8(); // the four above plus diagonals
+const heading = BT.random.angle(); // 0..2*PI radians
+const shake = BT.random.gaussian(0, 2); // clustered near 0, occasionally far
+```
+
+`gaussian` is the one to reach for when "mostly small, sometimes big" looks better than an even spread – screen shake,
+scatter, enemy speed variation.
+
+## Same seed, same game
+
+By default the generator is seeded from the clock, so every run differs. Seed it yourself to make a run repeatable:
+
+```js
+async init() {
+    BT.randomSeed(1234); // this level now generates identically every time
+    // ...
+    return true;
+}
+```
+
+That is what makes daily challenges, level codes, and bug reports you can actually reproduce possible. Store the seed
+with the save and you can rebuild the same world from a single number.
+
+## Your own generator
+
+`BT.random` is shared, so anything that draws from it shifts what everything else gets next. When you need one part of
+the game to be reproducible on its own, give it a private generator:
+
+```js
+import { Random } from 'blit386';
+
+// in init():
+this.levelRng = new Random(1234); // level layout, unaffected by combat rolls
+this.combatRng = new Random(99); // damage rolls, unaffected by layout
+```
+
+A `Random` instance has exactly the same methods as `BT.random`. Useful extras when you need them:
+
+| Call | What it does |
+| --- | --- |
+| `rng.seed(n)` | Restart the sequence from seed `n` |
+| `rng.getState()` | The current position, as a number you can save |
+| `rng.setState(n)` | Jump back to a saved position and replay from there |
+| `rng.clone()` | A copy that will produce the identical sequence from here |
+| `rng.fork()` | A new independent stream (advances the parent once) |
+| `rng.seedValue` | The seed it was last given (`undefined` after `setState` or `fork`) |
+
+## Notes
+
+- Prefer `BT.random` over `Math.random()` everywhere. Same convenience, plus seeding – there is no reason to keep the
+  built-in one.
+- `BT.random` is a getter with no parentheses; `BT.randomSeed(n)` is a method with them.
+- Draw random values in `update()`, not `render()`. `render()` can run a different number of times per update, so
+  rolling there makes things flicker and breaks reproducibility.
+- In a per-frame loop over many items, `insideRectTo(rect, out)` and `pointInRangeTo(min, max, out)` write into a
+  `Vector2i` you already own instead of making a new one each call – see the `keep-it-fast` skill.
+- Ranges are half-open where you would expect: `int(1, 5)` never returns `5`. Use `intInclusive(1, 5)` when you want it
+  to. Inverted or empty ranges throw rather than returning nonsense.
+- Needs blit386 `^1.5.0`.

--- a/packages/website/content/docs/reference/changelog.mdx
+++ b/packages/website/content/docs/reference/changelog.mdx
@@ -3,7 +3,7 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Changelog"
 description: "Release history in Keep a Changelog style: what shipped, what broke, and when."
-lastModified: "2026-08-05T08:35:31+02:00"
+lastModified: "2026-08-05T08:47:46+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/changelog.md"
 ---
 
@@ -20,6 +20,20 @@ notes, including dependency bumps and CI changes omitted here for brevity.
 
 ### Added
 
+- Seeded random: the `Random` class (a mulberry32 PRNG) plus `BT.random` and `BT.randomSeed(seed)` on the facade.
+  `BT.random` is a live reference to one shared instance, time-seeded at singleton creation, so the engine default is
+  deterministic the moment you seed it. Beyond `next()` / `float()` / `int()` / `intInclusive()` it carries the draws
+  games actually reach for – `bool`, `sign`, `pick`, `shuffle` / `shuffleInPlace`, `weighted`, `angle`, `gaussian` – and
+  spatial helpers `insideRect`, `pointInRange`, `direction4`, `direction8`, each with an allocation-free `*To(out)`
+  variant. Stream control is `seed`, `seedValue`, `getState`, `setState`, `clone`, and `fork`. Prefer it over
+  `Math.random()`, which cannot be seeded. See [Random](/docs/api/random) and [Random guide](/docs/guides/random).
+- Coordinate hashing: `hash1i` / `hash2i` / `hash3i` return an unsigned 32-bit value and `hash1` / `hash2` / `hash3`
+  return the same value scaled into `[0, 1)`. These are stateless spatial lookups – identical coordinates and seed
+  always give an identical result – so a chunked or procedural world needs no stored generator per chunk.
+- Pattern noise: `ValueNoise`, `PerlinNoise`, and `SimplexNoise`, each seedable and sampling to approximately `[-1, 1]`.
+  Value and Perlin expose `noise1D` / `noise2D` / `noise3D` and the matching `fbm*`; Simplex is 2D and 3D only. fBm
+  defaults to `octaves = 4`, `persistence = 0.5`, `lacunarity = 2`, with octave amplitudes normalized so the sum stays
+  in range. Distinct from the post-process `Noise` display effect, which is unrelated GPU grain.
 - Full easing curve library on `EasingFunction` / `applyEasing`: sine, cubic, quartic, quintic, expo, circ, back,
   elastic, and bounce families (in / out / in-out), alongside the existing linear and quadratic (`ease-*`) curves. Math
   matches RetroBlit's `Ease` class.


### PR DESCRIPTION
## Summary

`BT.random` and the hash/noise functions had no corresponding kit skill, doc, or API-names entry, leaving generated-game agents with no guidance on either API. move-and-time and animate-the-palette also referenced an incomplete set of easing curves.

- Add use-random and use-noise skills covering `BT.random`'s seeded PRNG (state get/set/clone/fork) and the hash/noise helpers
- Add content/docs/random.md and register both skills in blit-api-names.md, AGENTS.md, CLAUDE.md, and README.md
- Fix stale easing curve references in move-and-time and animate-the-palette skills
- Add matching changelog entries and a create-blit386 template README tweak


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance for seeded random generation, independent random streams, and deterministic world generation.
  - Documented Value, Perlin, and Simplex noise utilities, coordinate hashing, terrain sampling, and chunk regeneration.
  - Expanded easing and interpolation guidance for movement, tweening, and palette effects.
  - Updated beginner documentation and skill listings to include randomization, noise, and world generation topics.
  - Added guidance on random state management, performance considerations, and selecting noise techniques.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->