### PR TITLE
docs: add Tier 1 hot-reload caveat for init()-baked constants

### DIFF
--- a/packages/blit386/docs/guide-hot-reload.md
+++ b/packages/blit386/docs/guide-hot-reload.md
@@ -75,6 +75,17 @@ The `SPEED` case is the detail worth understanding: a Tier 1 swap does not touch
 new module's top-level scope - so the new value of `SPEED` takes effect on the very next tick, even though no field on
 the instance changed. Module-level constants referenced from methods are effectively live-editable.
 
+<Callout type="warn" title="A constant baked into an instance field by init() is not live-editable">
+  The live-editable behavior above only holds while every reader of the constant is a method that runs fresh each
+  tick. If `init()` also reads the same constant to build data cached in an instance field - filling a scene buffer,
+  precomputing a lookup table, seeding a starting position - editing the constant is still a methods-only change as
+  far as the fingerprint in [Tier 2](#tier-2-initconstructor-change) is concerned: `init()`'s own source text did not
+  change, only the value an unrelated top-level `const` resolves to. So the swap stays Tier 1, `init()` does not
+  re-run, and the instance field keeps whatever it was built from before the edit - while methods swapped in by the
+  same save read the new value immediately. The two go out of sync until you force a Tier 2 path yourself (touch
+  `init()`, the constructor, or a class field initializer) or fall back to a full page reload / dev server restart.
+</Callout>
+
 ### Tier 2: init/constructor change
 
 If `init()`, the constructor, or a class field initializer changed, a Tier 1 swap is not safe - the running instance was

--- a/packages/demos/CLAUDE.md
+++ b/packages/demos/CLAUDE.md
@@ -146,6 +146,10 @@ are `filip-test-02` (a bare-bones starter with no demo UI at all) and `flurry`, 
 Still always full-reloads: `_partials/*` edits, a `blit386` dist rebuild (a changed engine bundle invalidates
 everything), and adding or removing a `src/<slug>.js` file.
 
+A module-level constant that `init()` also reads to build a cached instance field (not just one a method reads fresh
+each tick) does not get the "Method body" row's live-edit treatment – see the caveat in
+[the engine's hot-reload guide](../blit386/docs/guide-hot-reload.md#tier-1-method-only-change).
+
 Editing `src/shared/*.js` hot-swaps through Vite's own module graph rather than the engine's swap. That re-evaluates
 module-scope state: `ui.js`'s singleton `UiContext` is replaced, and `ui-dpad.js` / `ui-gestures.js` reset their D-pad
 and swipe state. So the D-pad can briefly hide, an in-flight swipe or keypress can drop, and `ui.hasTouch()` can revert

--- a/packages/website/content/docs/guides/hot-reload.mdx
+++ b/packages/website/content/docs/guides/hot-reload.mdx
@@ -3,7 +3,7 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Hot Reload"
 description: "The three hot-reload swap tiers, onHotReload semantics, asset hot-replace, and the blit386/vite plugin."
-lastModified: "2026-08-05T08:55:35+02:00"
+lastModified: "2026-08-05T19:53:12+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/guide-hot-reload.md"
 ---
 

--- a/packages/website/content/docs/guides/hot-reload.mdx
+++ b/packages/website/content/docs/guides/hot-reload.mdx
@@ -72,6 +72,17 @@ The `SPEED` case is the detail worth understanding: a Tier 1 swap does not touch
 new module's top-level scope - so the new value of `SPEED` takes effect on the very next tick, even though no field on
 the instance changed. Module-level constants referenced from methods are effectively live-editable.
 
+<Callout type="warn" title="A constant baked into an instance field by init() is not live-editable">
+  The live-editable behavior above only holds while every reader of the constant is a method that runs fresh each
+  tick. If `init()` also reads the same constant to build data cached in an instance field - filling a scene buffer,
+  precomputing a lookup table, seeding a starting position - editing the constant is still a methods-only change as
+  far as the fingerprint in [Tier 2](#tier-2-initconstructor-change) is concerned: `init()`'s own source text did not
+  change, only the value an unrelated top-level `const` resolves to. So the swap stays Tier 1, `init()` does not
+  re-run, and the instance field keeps whatever it was built from before the edit - while methods swapped in by the
+  same save read the new value immediately. The two go out of sync until you force a Tier 2 path yourself (touch
+  `init()`, the constructor, or a class field initializer) or fall back to a full page reload / dev server restart.
+</Callout>
+
 ### Tier 2: init/constructor change
 
 If `init()`, the constructor, or a class field initializer changed, a Tier 1 swap is not safe - the running instance was


### PR DESCRIPTION
## Summary
- Add a Callout to `guide-hot-reload.md`'s Tier 1 section: a module-level constant that `init()` also reads to build a cached instance field does not get live-edit treatment, because `initFingerprint()` only diffs method-body text, so the swap stays Tier 1 and `init()` never re-runs to pick up the new value.
- Add a matching one-line pointer under the hot-reload table in `packages/demos/CLAUDE.md`, since demo authors are the ones likely to hit this.
- Resync the `packages/website` docs mirror (`pnpm run sync:docs`).

Checked `.claude/rules/architecture.md`'s `HotSwap.ts` entry — it's a terse file-tree one-liner that stays accurate as-is, so no change needed there.

## Test plan
- [x] `pnpm run sync:doc-banners:check` (packages/blit386) — passes
- [x] `pnpm run sync:docs` && `pnpm run build` (packages/website) — MDX with the new Callout compiles cleanly
- [x] Pre-push preflight failures for `packages/website` (biome schema mismatch, `webmcp.js` template-literal lint) confirmed pre-existing on `origin/main`, unrelated to this docs-only change; `pnpm run test` in packages/website passes 168/168

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified a hot-reload limitation: constants cached during initialization may remain stale after certain live updates.
  * Noted that methods use updated constant values immediately, while cached fields update after a broader reload or qualifying change.
  * Added a link to the hot-reload guide for further details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->