### PR TITLE
chore(husky): guard pre-commit and pre-push against placeholder git identity

### DIFF
--- a/.husky/check-author.sh
+++ b/.husky/check-author.sh
@@ -1,0 +1,31 @@
+# Guards against a placeholder/sandbox git identity (e.g. "Test <test@example.com>")
+# getting baked into commit authorship. A local (non --global) `git config user.*`
+# override in this repo's .git/config once came from a sandboxed session and
+# silently overrode the correct ~/.gitconfig identity for every commit made here.
+#
+# Sourced by pre-commit and pre-push - not standalone, no shebang needed.
+
+check_author_identity() {
+    name="$1"
+    email="$2"
+    label="$3"
+
+    bad=0
+
+    case "$name" in
+        "" | [Tt]est | "Your Name") bad=1 ;;
+    esac
+
+    case "$email" in
+        "" | *@example.com | you@example.com) bad=1 ;;
+    esac
+
+    if [ "$bad" = "1" ]; then
+        echo ""
+        echo "[FAIL] $label looks like a placeholder identity: \"$name <$email>\"."
+        echo "       This is usually a LOCAL .git/config override, not your ~/.gitconfig."
+        echo "       Check: git config --local --get-regexp '^user\\.'"
+        echo "       Fix:   git config --local --unset user.name && git config --local --unset user.email"
+        exit 1
+    fi
+}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,5 +2,8 @@
 
 # Load Node.js environment and ensure pnpm is available
 . "$(dirname "$0")/ensure-pnpm.sh"
+. "$(dirname "$0")/check-author.sh"
+
+check_author_identity "$(git config user.name)" "$(git config user.email)" "Configured git identity"
 
 pnpm lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,6 +4,11 @@
 . "$(dirname "$0")/ensure-pnpm.sh"
 . "$(dirname "$0")/check-author.sh"
 
-check_author_identity "$(git config user.name)" "$(git config user.email)" "Configured git identity"
+author_ident=$(git var GIT_AUTHOR_IDENT)
+author_name=${author_ident%% <*}
+author_rest=${author_ident#*<}
+author_email=${author_rest%%>*}
+
+check_author_identity "$author_name" "$author_email" "Configured git identity"
 
 pnpm lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,9 +1,35 @@
 #!/bin/sh
 
 . "$(dirname "$0")/ensure-pnpm.sh"
+. "$(dirname "$0")/check-author.sh"
 
 echo "Running pre-push checks..."
 echo ""
+
+# Reject any commit about to be pushed whose author/committer is a placeholder
+# identity (see check-author.sh). Catches commits that bypassed pre-commit -
+# rebase, cherry-pick, amend --no-verify, or a commit made in another
+# worktree/session with a bad local .git/config override.
+ZERO_SHA="0000000000000000000000000000000000000000"
+while read -r local_ref local_sha remote_ref remote_sha; do
+    [ "$local_sha" = "$ZERO_SHA" ] && continue # deleting the remote ref
+
+    if [ "$remote_sha" = "$ZERO_SHA" ]; then
+        push_range="$local_sha"
+    else
+        push_range="$remote_sha..$local_sha"
+    fi
+
+    # Written to a temp file rather than piped into the while loop: a piped
+    # while runs in a subshell, so check_author_identity's `exit 1` would only
+    # kill the subshell and the push would proceed anyway.
+    author_log=$(mktemp)
+    git log "$push_range" --format='%H%x09%an%x09%ae' >"$author_log"
+    while IFS="$(printf '\t')" read -r sha an ae; do
+        check_author_identity "$an" "$ae" "Commit $sha"
+    done <"$author_log"
+    rm -f "$author_log"
+done
 
 # Monorepo: dispatch preflight per changed package rather than running everything.
 # pnpm's "...[ref]" filter selects a package plus anything downstream of it that


### PR DESCRIPTION
## Summary

A local (non --global) `git config user.*` override in this repo's .git/config silently baked "Test <test@example.com>" into commit authorship instead of the correct ~/.gitconfig identity, likely from a sandboxed session that ran a local (not --global) git config command.

- Add check-author.sh: shared check_author_identity, blocklists known placeholder names/emails (Test, empty, *@example.com, Your Name)
- pre-commit: check the resolved identity before lint-staged runs, so a bad override blocks the commit immediately with a fix command
- pre-push: scan every commit in the push range (parsed from git's stdin ref info) for a placeholder author, catching anything that bypassed pre-commit - rebase, cherry-pick, --no-verify, or a commit made elsewhere with the override already in place

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent commits with missing or placeholder author names or email addresses.
  * Pre-commit and pre-push checks now provide clear remediation guidance when invalid author information is detected.
  * Push validation covers new branches, incremental updates, and deleted references without interrupting valid operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->