### PR TITLE
chore(preflight): deduplicate docs:links/agents:check across per-package preflight chains

### DIFF
--- a/.claude/skills/preflight/SKILL.md
+++ b/.claude/skills/preflight/SKILL.md
@@ -28,10 +28,12 @@ Where `<package>` is one of `blit386`, `demos`, `website`, `kit`, `create-blit38
 `docs:links` and `agents:check` are not package-scoped – each package's copy of the script
 (`node ../../scripts/check-markdown-links.mjs`) always walks the whole repo from the root, regardless of which package's
 `package.json` invoked it. They used to be listed in every package's `preflight` chain too, which meant
-`.husky/pre-push` (per-package preflight dispatch, then the root-level pass) ran the same full-repo check 2-4 times on
+`.husky/pre-push` (per-package preflight dispatch, then the root-level pass) ran the same full-repo check 2–4 times on
 one push – most of the "why does push take so long" feeling. They were removed from `packages/{blit386,demos,website}`'s
 `preflight` scripts for that reason; run them explicitly (`pnpm run docs:links`, `pnpm run agents:check`) or via
-`/preflight root` when checking a package in isolation, and trust the root-level pass for a push or CI run.
+`/preflight root` when checking a package in isolation. The root-level pass only runs when `PREFLIGHT_STATUS` is zero –
+a failed package preflight makes `.husky/pre-push` skip `format:check`, `docs:links`, and `agents:check` entirely, so a
+push or CI run only exercises them once the per-package checks are clean.
 
 ## Steps
 

--- a/.claude/skills/preflight/SKILL.md
+++ b/.claude/skills/preflight/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: preflight
 description:
-  Run all quality checks for a package (format, lint, typecheck, spellcheck, knip, docs:links, tests, build, and
-  package-specific gates) before committing or pushing. Use when the user wants to verify code is ready to commit or run
-  every check at once. Takes a package argument (blit386, demos, website, kit, create-blit386, or root).
+  Run all quality checks for a package (format, lint, typecheck, spellcheck, knip, tests, build, and package-specific
+  gates) before committing or pushing. Use when the user wants to verify code is ready to commit or run every check at
+  once. Takes a package argument (blit386, demos, website, kit, create-blit386, or root).
 ---
 
 # Preflight Checks
@@ -23,6 +23,16 @@ Where `<package>` is one of `blit386`, `demos`, `website`, `kit`, `create-blit38
 - Node.js >= 22.18.0 (`engines` in the root `package.json`)
 - pnpm 11.20.0 (`packageManager` in the root `package.json`)
 
+## docs:links and agents:check are root-only
+
+`docs:links` and `agents:check` are not package-scoped – each package's copy of the script
+(`node ../../scripts/check-markdown-links.mjs`) always walks the whole repo from the root, regardless of which package's
+`package.json` invoked it. They used to be listed in every package's `preflight` chain too, which meant
+`.husky/pre-push` (per-package preflight dispatch, then the root-level pass) ran the same full-repo check 2-4 times on
+one push – most of the "why does push take so long" feeling. They were removed from `packages/{blit386,demos,website}`'s
+`preflight` scripts for that reason; run them explicitly (`pnpm run docs:links`, `pnpm run agents:check`) or via
+`/preflight root` when checking a package in isolation, and trust the root-level pass for a push or CI run.
+
 ## Steps
 
 1. Run the package's preflight gate (see the per-package breakdown below)
@@ -41,8 +51,6 @@ Where `<package>` is one of `blit386`, `demos`, `website`, `kit`, `create-blit38
 - `typecheck` – TypeScript strict
 - `spellcheck` – cspell over `src/**/*.{ts,md,mdx}`, `docs/**/*.{md,mdx}`, `README.md`
 - `knip` – unused exports and dependencies
-- `docs:links` – Markdown link checker
-- `agents:check` – agent config drift (rules parity, skills symlinks, AGENTS.md <-> CLAUDE.md pointer)
 - `sync:doc-banners:check` – blit386.dev banner freshness on every published doc
 - `api:since:check` – every public export carries an `@since` tag
 - `api:history:check` – `docs/_api-history.json` matches the source version tags
@@ -57,7 +65,6 @@ Where `<package>` is one of `blit386`, `demos`, `website`, `kit`, `create-blit38
 - `lint` – ESLint
 - `spellcheck` – cspell over `src/**/*.{js,md,mdx}`, `docs/**/*.{md,mdx}`, `README.md`
 - `knip` – unused exports and dependencies
-- `docs:links` – Markdown link checker
 - `check:demo-registry` – `DEMO_ORDER` / `VINTAGE_URLS` / `RETIRED_SLUGS` / `NAV_HIDDEN_SLUGS` / `src/*.js` consistency
 - `build` – production build succeeds (CI and Cloudflare Pages depend on this)
 
@@ -73,7 +80,6 @@ No unit tests here by design – see `/test demos`.
 - `test` – `node --test scripts/__tests__/*.test.mjs`
 - `spellcheck` – cspell on `content/` and `src/`
 - `knip` – unused exports/deps
-- `docs:links` – Markdown link checker
 - `build` – `CLOUDFLARE=1 waku build`
 
 No MCP security preflight here (unlike `blit386` – see `/security-run`).

--- a/packages/blit386/.claude/rules/environment-gotchas.md
+++ b/packages/blit386/.claude/rules/environment-gotchas.md
@@ -11,10 +11,12 @@ network). These are environment artifacts, not code bugs – do not "fix" them b
 - `docs:links` needs outbound network. It fails only on external `https://` URLs (the `blit386.dev` banner links, the
   Keep a Changelog and WebKit-bug references) returning 403 through a sandbox proxy; every relative/internal link still
   resolves. Confirm all failures are external before treating one as real.
-- Hooks amplify those two artifacts. The pre-push hook runs `typecheck` + `lint` + `docs:links`; the lint-staged
-  pre-commit hook runs `biome` / `prettier` / `eslint --fix` / `cspell` on staged files. When the only failures are the
-  tag-less / no-network artifacts above, push with `--no-verify` after confirming the real checks (`typecheck`, `lint`,
-  `format:check`, `spellcheck`) pass on their own.
+- Hooks amplify those two artifacts. The pre-push hook runs each changed package's `preflight` (which includes
+  `typecheck` + `lint`), then a root-level pass that includes `docs:links` once for the whole push (`docs:links` and
+  `agents:check` are not package-scoped, so they were removed from every package's own `preflight` chain to stop running
+  2-4x per push – see the `preflight` skill). The lint-staged pre-commit hook runs `biome` / `prettier` / `eslint --fix`
+  / `cspell` on staged files. When the only failures are the tag-less / no-network artifacts above, push with
+  `--no-verify` after confirming the real checks (`typecheck`, `lint`, `format:check`, `spellcheck`) pass on their own.
 - `.agents/skills/*` are symlinks to `.claude/skills/*`. Edit the `.claude` copy once and both update; do not treat them
   as two files to patch.
 - `pnpm run spellcheck` (from `packages/blit386`) scopes to `src/`, `docs/`, and `README.md`, so it does not scan the

--- a/packages/blit386/.claude/rules/environment-gotchas.md
+++ b/packages/blit386/.claude/rules/environment-gotchas.md
@@ -12,11 +12,13 @@ network). These are environment artifacts, not code bugs – do not "fix" them b
   Keep a Changelog and WebKit-bug references) returning 403 through a sandbox proxy; every relative/internal link still
   resolves. Confirm all failures are external before treating one as real.
 - Hooks amplify those two artifacts. The pre-push hook runs each changed package's `preflight` (which includes
-  `typecheck` + `lint`), then a root-level pass that includes `docs:links` once for the whole push (`docs:links` and
-  `agents:check` are not package-scoped, so they were removed from every package's own `preflight` chain to stop running
-  2-4x per push – see the `preflight` skill). The lint-staged pre-commit hook runs `biome` / `prettier` / `eslint --fix`
-  / `cspell` on staged files. When the only failures are the tag-less / no-network artifacts above, push with
-  `--no-verify` after confirming the real checks (`typecheck`, `lint`, `format:check`, `spellcheck`) pass on their own.
+  `typecheck` + `lint`), then – only if that succeeds – a root-level pass that includes `docs:links` once for the whole
+  push (`docs:links` and `agents:check` are not package-scoped, so they were removed from every package's own
+  `preflight` chain to stop running 2–4x per push – see the `preflight` skill). A failed package preflight skips the
+  root-level `format:check` / `docs:links` / `agents:check` pass entirely. The lint-staged pre-commit hook runs `biome`
+  / `prettier` / `eslint --fix` / `cspell` on staged files. When the only failures are the tag-less / no-network
+  artifacts above, push with `--no-verify` after confirming the real checks (`typecheck`, `lint`, `format:check`,
+  `spellcheck`) pass on their own.
 - `.agents/skills/*` are symlinks to `.claude/skills/*`. Edit the `.claude` copy once and both update; do not treat them
   as two files to patch.
 - `pnpm run spellcheck` (from `packages/blit386`) scopes to `src/`, `docs/`, and `README.md`, so it does not scan the

--- a/packages/blit386/package.json
+++ b/packages/blit386/package.json
@@ -93,7 +93,7 @@
     "test:visual": "playwright test",
     "test:visual:update": "playwright test --update-snapshots",
     "test:visual:coverage": "VISUAL_COVERAGE=1 playwright test && nyc report --reporter=lcov --reporter=text-summary --temp-dir=.nyc_output --report-dir=coverage-visual",
-    "preflight": "pnpm run format:check && pnpm run lint && pnpm run typecheck && pnpm run spellcheck && pnpm run knip && pnpm run docs:links && pnpm run agents:check && pnpm run sync:doc-banners:check && pnpm run api:since:check && pnpm run api:history:check && pnpm run test:unit && pnpm run test:declarations && pnpm run test:agent-config && pnpm run test:api-history && pnpm run test:compact-tables && pnpm run test:shell-safety && pnpm run test:security-preflight",
+    "preflight": "pnpm run format:check && pnpm run lint && pnpm run typecheck && pnpm run spellcheck && pnpm run knip && pnpm run sync:doc-banners:check && pnpm run api:since:check && pnpm run api:history:check && pnpm run test:unit && pnpm run test:declarations && pnpm run test:agent-config && pnpm run test:api-history && pnpm run test:compact-tables && pnpm run test:shell-safety && pnpm run test:security-preflight",
     "clean": "rm -rf dist node_modules/.vite",
     "release": "pnpm run build && pnpm publish",
     "knip": "cd ../.. && knip --workspace packages/blit386 --exclude exports,types",

--- a/packages/demos/package.json
+++ b/packages/demos/package.json
@@ -47,7 +47,7 @@
     "docs:links": "node ../../scripts/check-markdown-links.mjs",
     "check:demo-registry": "node scripts/check-demo-registry.mjs",
     "generate:audio-loops": "node scripts/generate-audio-loops.mjs",
-    "preflight": "pnpm run format:check && pnpm run lint && pnpm run spellcheck && pnpm run knip && pnpm run docs:links && pnpm run check:demo-registry && pnpm run build",
+    "preflight": "pnpm run format:check && pnpm run lint && pnpm run spellcheck && pnpm run knip && pnpm run check:demo-registry && pnpm run build",
     "knip": "cd ../.. && knip --workspace packages/demos",
     "knip:fix": "knip --fix",
     "clean": "rm -rf dist node_modules/.vite",

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -55,7 +55,7 @@
     "security:audit:prod": "pnpm audit --prod --audit-level=moderate",
     "test": "node --test scripts/__tests__/*.test.mjs",
     "test:watch": "node --test --watch scripts/__tests__/*.test.mjs",
-    "preflight": "pnpm run format:check && pnpm run lint && pnpm run typecheck && pnpm run test && pnpm run spellcheck && pnpm run knip && pnpm run docs:links && pnpm run build",
+    "preflight": "pnpm run format:check && pnpm run lint && pnpm run typecheck && pnpm run test && pnpm run spellcheck && pnpm run knip && pnpm run build",
     "deploy": "wrangler deploy --config dist/server/wrangler.json --name blit386",
     "prepare": "husky"
   },


### PR DESCRIPTION
## Summary

Root-scoped scripts were listed in every package's preflight, so .husky/pre-push ran the full-repo markdown-link and agent-config checks 2-4x per push. Drop them from packages/{blit386,demos,website} and document the root-only convention in the preflight skill and the blit386 environment-gotchas rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified which validation checks run at the package level versus the repository level.
  - Added guidance for explicitly running repository-wide documentation and agent checks.
  - Updated pre-push guidance to describe the revised validation sequence and environment-only failure handling.

- **Chores**
  - Simplified package-specific preflight workflows by removing checks that are now handled centrally.
  - Preserved all other existing validation steps and pre-commit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->