### PR TITLE
fix(demos): stop the shell emitting .html URLs in the production build

### DIFF
--- a/packages/demos/CLAUDE.md
+++ b/packages/demos/CLAUDE.md
@@ -21,9 +21,12 @@ tables, …) live in the root [`CLAUDE.md`](../../CLAUDE.md) – read together w
 
 One demo per file under `src/`, and that file is the single source of truth – no `demos/` directory exists on disk. The
 `virtual-demos` Vite plugin serves each at `/demos/<slug>.html` in dev; the production build flattens them to
-`https://demos.blit386.dev/<slug>`. `src/shared/` holds the UI kit and cross-demo helpers, `public/` static assets,
-`_partials/` the shared HTML template and shell scripts, `plugins/` the Vite plugin plus the order and vintage-URL
-registries, `scripts/` the check and generate scripts.
+`https://demos.blit386.dev/<slug>`. That difference is a build-time value, not runtime sniffing: `virtual-demos` stamps
+`data-page-suffix` onto `<body>` (`.html` in dev, empty in the build) and `_partials/demo-shell.js` appends it in
+`urlFor()`, so the shell's `history.pushState` URL and its iframe `?embed&source` src are extensionless in production.
+`src/shared/` holds the UI kit and cross-demo helpers, `public/` static assets, `_partials/` the shared HTML template
+and shell scripts, `plugins/` the Vite plugin plus the order and vintage-URL registries, `scripts/` the check and
+generate scripts.
 
 Filenames are number-free kebab-case (`basics.js`, `sprite-effects.js`); the first path segment must start with a
 letter, so legacy `001-topic.js` names are rejected. Navigation order is **not** derived from the filename – it comes
@@ -185,7 +188,10 @@ Commit scopes (convention only – prefer one already in this package's history)
 `skills`, `deps`. Husky runs lint-staged on pre-commit, commitlint on commit-msg, and `pnpm run preflight` on pre-push.
 
 The build copies each virtual demo to `dist/<slug>.html` at the site root and generates `dist/_redirects` from
-`VINTAGE_URLS` plus a site-index rule, so vintage numbered paths (`/001-basics`) 301 to the current slug everywhere.
+`VINTAGE_URLS` plus a site-index rule, so vintage numbered paths (`/001-basics` and `/001-basics.html`) 301 to the
+current extensionless slug everywhere. The site-index rule is the one entry that still names `dist/<slug>.html`, because
+a `200` rewrite has to name the asset. Cloudflare Pages serves each `dist/<slug>.html` at `/<slug>` and 308s
+`/<slug>.html` to it, which is why nothing else should emit the extension.
 
 `.github/workflows/deploy.yml` runs two jobs against this package: `deploy-demos` deploys to the `blit386-demos` Pages
 project (`demos.blit386.dev`) on a release tag push (`x.y.z`, no `v` prefix, no prerelease suffix) or a manual

--- a/packages/demos/_partials/demo-shell.js
+++ b/packages/demos/_partials/demo-shell.js
@@ -76,10 +76,17 @@ function findCurrentIndex(demos) {
 // "javascript:" or other unexpected URL scheme.
 const SLUG_PATTERN = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
 
+// Stamped into <body> by plugins/virtual-demos.js: '.html' in dev, where the Vite
+// middleware routes only /demos/<slug>.html, and empty in the production build, where
+// Cloudflare Pages serves dist/<slug>.html at the extensionless /<slug>. Nullish (not
+// truthy) fallback: an empty attribute is a real "no suffix", only an absent one falls
+// back to the dev form.
+const PAGE_SUFFIX = document.body.dataset.pageSuffix ?? '.html';
+
 /**
  * Build a same-directory link to another demo page. The directory is derived from
  * the current page's own pathname, so this resolves correctly under both dev
- * (/demos/<slug>.html) and the flattened production build (/<slug>.html).
+ * (/demos/<slug>.html) and the flattened production build (/<slug>).
  * @param {string} slug - Demo slug, e.g. "basics"
  * @returns {string}
  */
@@ -90,7 +97,7 @@ function urlFor(slug) {
 
     const dir = location.pathname.slice(0, location.pathname.lastIndexOf('/') + 1);
 
-    return `${dir + slug}.html`;
+    return `${dir + slug}${PAGE_SUFFIX}`;
 }
 
 /**
@@ -968,7 +975,7 @@ function renderShell() {
     syncArrowDisabled(demos, currentIndex);
 
     // Initial iframe src: this demo with source (dev: /demos/<slug>.html?embed&source,
-    // prod: /<slug>.html?embed&source). Same relative-path derivation as urlFor().
+    // prod: /<slug>?embed&source). Same relative-path derivation as urlFor().
     if (initialSlug) {
         frame.src = embedUrlFor(initialSlug);
     }

--- a/packages/demos/_partials/layout.html
+++ b/packages/demos/_partials/layout.html
@@ -41,7 +41,7 @@
     </script>
 </head>
 
-<body data-slug="{{slug}}">
+<body data-slug="{{slug}}" data-page-suffix="{{pageSuffix}}">
 {{channelBanner}}
 
 <script id="demo-list" type="application/json">{{demoList}}</script>
@@ -49,8 +49,11 @@
 <!--
   Shell mode (default): persistent banner + content iframe. The banner hosts a
   fuzzy-searchable combobox (plus prev/next). Demo swaps change the iframe src and
-  history.pushState the clean number-free demo URL (e.g. /demos/basics.html); the
-  banner never reloads. Vintage numbered paths 301 to the current slug.
+  history.pushState the number-free demo URL; the banner never reloads. That URL
+  carries data-page-suffix above: `.html` in dev (/demos/basics.html, the only path
+  the Vite middleware routes) and empty in the production build (/basics, which is
+  how Cloudflare Pages serves dist/basics.html). Vintage numbered paths 301 to the
+  current slug.
 
   Embed mode (?embed): #canvas-container only (no banner; source hidden). Used by
   external embeds on blit386.dev. The shell iframe loads ?embed&source so the

--- a/packages/demos/plugins/virtual-demos.js
+++ b/packages/demos/plugins/virtual-demos.js
@@ -139,10 +139,14 @@ export function virtualDemos() {
 </script>`
             : '';
 
+        // `pageSuffix` is what the shell appends when it builds navigation targets: dev serves
+        // only /demos/<slug>.html (see URL_PATTERN), while the production build flattens pages
+        // to dist/<slug>.html, which Cloudflare Pages serves at the extensionless /<slug>.
         return layoutTemplate
             .replaceAll('{{title}}', escapeHtml(entry.title))
             .replaceAll('{{scriptFile}}', entry.scriptFile)
             .replaceAll('{{slug}}', entry.slug)
+            .replaceAll('{{pageSuffix}}', isDevMode ? '.html' : '')
             .replace('{{demoList}}', () => demoListJson)
             .replace('{{sourceHtml}}', () => sourceHtml)
             .replace('{{sourcePanelScript}}', () => sourcePanelScript)

--- a/packages/demos/vite.config.js
+++ b/packages/demos/vite.config.js
@@ -80,6 +80,9 @@ function demoRedirectsPlugin() {
             ];
 
             if (firstVisible) {
+                // A 200 rewrite names the asset, so this one keeps `.html`. Pages then applies
+                // its own clean-URL handling on top and 308s `/` to `/basics`, which is where
+                // the visitor should land anyway.
                 lines.push('# Serve the first nav-visible demo as the site index.');
                 lines.push(`/ /${firstVisible.slug}.html 200`);
                 lines.push('');
@@ -92,8 +95,10 @@ function demoRedirectsPlugin() {
                     continue;
                 }
 
+                // Both forms target the extensionless slug. Pages 308s /<slug>.html to /<slug>
+                // anyway, so a `.html` target here would only chain a second hop.
                 lines.push(`/${vintageSlug} /${currentSlug} 301`);
-                lines.push(`/${vintageSlug}.html /${currentSlug}.html 301`);
+                lines.push(`/${vintageSlug}.html /${currentSlug} 301`);
             }
 
             writeFileSync(join(distDir, '_redirects'), `${lines.join('\n')}\n`);


### PR DESCRIPTION
## Summary

Closes BT-423.

The demo shell built every navigation target with a hard-coded `.html` suffix. That is correct in dev, where the
`virtual-demos` middleware routes only `/demos/<slug>.html`, but wrong in production: the build flattens pages to
`dist/<slug>.html` and Cloudflare Pages serves them at the extensionless `/<slug>`.

Two consequences on demos.blit386.dev:

1. Using the dropdown or prev/next left `https://demos.blit386.dev/basics.html` in the address bar. `pushState` issues
   no request, so the URL was never corrected. This is what the issue reports.
2. The shell's iframe fetched `/<slug>.html?embed&source`, which Pages answered with a `308` to the clean form on every
   demo swap.

The README already advertised the clean form and `packages/website/src/components/demo-embed.tsx` already embedded it,
so the shell was the odd one out.

## Approach

The suffix is now a build-time value, injected like the existing `{{slug}}` / `{{channelBanner}}` substitutions rather
than sniffed at runtime:

- `plugins/virtual-demos.js` substitutes `{{pageSuffix}}` – `.html` when serving, empty when building.
- `_partials/layout.html` stamps it as `data-page-suffix` on `<body>`.
- `_partials/demo-shell.js` reads it once into `PAGE_SUFFIX` and appends it in `urlFor()`. The nullish fallback matters:
  an empty attribute is a real "no suffix", only an absent one falls back to the dev form. `embedUrlFor()` builds on
  `urlFor()`, so the iframe goes clean too.
- `vite.config.js` points the vintage `.html` redirects at the extensionless slug, so a bookmarked vintage URL no
  longer chains `/001-basics.html` -> `/basics.html` -> `/basics`. The site-index rule keeps `.html`, because a `200`
  rewrite has to name the asset.

Dev behavior is unchanged.

## Test plan

No test changes: `packages/demos` has no test runner by design. Verified manually.

- [x] `pnpm run preflight` in `packages/demos` (format, lint, spellcheck, knip, demo-registry, build) – exit 0
- [x] Dev (`vite`) still serves `data-page-suffix=".html"`; dropdown keeps `/demos/<slug>.html`
- [x] Build output has `data-page-suffix=""` and no leftover template placeholders
- [x] Against `wrangler pages dev dist` (real Pages routing, `_redirects` honored), driving the UI in a browser:
      dropdown -> `/sprite-effects`, next -> `/starfield`, back -> `/sprite-effects`, forward -> `/starfield`, all
      without `.html`
- [x] Iframe still loads embed mode (source panel present), and the request log shows only direct `200`/`304` – the
      `308` hop is gone
- [x] `/001-basics` and `/001-basics.html` both `301` straight to `/basics`

### Note for reviewers

`pnpm run preview` cannot verify this. Vite's `htmlFallbackMiddleware` resolves `/basics` to `/basics.html` but strips
the query string doing so, so the iframe would load shell-in-shell locally. Real Pages preserves it (confirmed:
`/basics.html?embed&source` `308`s to `/basics?embed&source`). Use `wrangler pages dev dist` instead – note `wrangler`
is not on `packages/demos`' bin path.

`/` returning a `308` to `/basics` rather than serving the rewrite in place is pre-existing and unchanged here;
production behaves identically today.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Demo navigation now uses `.html` URLs in development and extensionless URLs in production.
  * Iframe loading and generated links consistently follow the active environment’s URL format.
  * Updated legacy redirects to point from `.html` pages to extensionless URLs.

* **Documentation**
  * Clarified URL suffix handling, deployment behavior, redirects, and production routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->