### PR TITLE
chore(preflight): drop redundant lint step from website preflight chain

### DIFF
--- a/.claude/skills/preflight/SKILL.md
+++ b/.claude/skills/preflight/SKILL.md
@@ -76,8 +76,7 @@ No unit tests here by design – see `/test demos`.
 
 `cd packages/website && pnpm run preflight`, or `pnpm --filter blit386-website run preflight`. Runs:
 
-- `format:check` – Biome + Prettier
-- `lint` – Biome
+- `format:check` – Biome (lint + format) + Prettier
 - `typecheck` – fumadocs-mdx + tsc
 - `test` – `node --test scripts/__tests__/*.test.mjs`
 - `spellcheck` – cspell on `content/` and `src/`

--- a/packages/website/content/docs/api/palette.mdx
+++ b/packages/website/content/docs/api/palette.mdx
@@ -3,7 +3,7 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Palette"
 description: "Palette setup, built-in presets, HUD preset, serialization, and palette effects."
-lastModified: "2026-08-05T19:54:35+02:00"
+lastModified: "2026-08-05T20:32:58+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/api-palette.md"
 ---
 

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -55,7 +55,7 @@
     "security:audit:prod": "pnpm audit --prod --audit-level=moderate",
     "test": "node --test scripts/__tests__/*.test.mjs",
     "test:watch": "node --test --watch scripts/__tests__/*.test.mjs",
-    "preflight": "pnpm run format:check && pnpm run lint && pnpm run typecheck && pnpm run test && pnpm run spellcheck && pnpm run knip && pnpm run build",
+    "preflight": "pnpm run format:check && pnpm run typecheck && pnpm run test && pnpm run spellcheck && pnpm run knip && pnpm run build",
     "deploy": "wrangler deploy --config dist/server/wrangler.json --name blit386",
     "prepare": "husky"
   },


### PR DESCRIPTION
## Summary

Website's `lint` script is just `biome check .`, already covered by `format:check` (`biome check . && prettier ...`) — unlike blit386/demos, which run eslint as a separate lint step from biome's format check. Remove the duplicate `pnpm run lint` from website's preflight script chain and update the preflight skill doc to match.
