### PR TITLE
fix(ci): split engine build so --watch reaches the browser bundle

### DIFF
--- a/packages/blit386/package.json
+++ b/packages/blit386/package.json
@@ -62,7 +62,9 @@
   },
   "sideEffects": false,
   "scripts": {
-    "build": "vite build && vite build --config vite.node.config.ts",
+    "build:browser": "vite build",
+    "build:node": "vite build --config vite.node.config.ts",
+    "build": "pnpm run build:browser && pnpm run build:node",
     "build:check-declarations": "node scripts/check-declaration-tooling.mjs",
     "test:declarations": "node --test scripts/check-declaration-tooling.test.mjs",
     "lint": "eslint . --max-warnings 0",

--- a/packages/demos/CLAUDE.md
+++ b/packages/demos/CLAUDE.md
@@ -164,8 +164,13 @@ change that hot-swaps cleanly under `webgpu`. That is a tier-detection parity ga
 not in this package's wiring – tracked against the engine. There is no automated coverage for hot reload; the
 `/test demos` skill carries the manual check script to run after touching the wiring.
 
-If you change the engine's `blit386/vite` plugin itself, `dev:watch`'s `build --watch` only rebuilds the browser bundle.
-Run a one-shot `pnpm run build` in `packages/blit386`, then restart `pnpm run dev` here.
+Editing engine source under `packages/blit386/src/` (anything feeding the browser bundle, `dist/blit386.js`) rebuilds
+automatically under `dev:watch` and full-reloads this page – no restart needed.
+
+If you change the engine's `blit386/vite` plugin itself (`packages/blit386/src/vite/**`, the Node-targeted
+`dist/vite.js` bundle), `dev:watch` does not watch it: `packages/demos/vite.config.js` loads that plugin once at its own
+server startup, so a rebuilt `dist/vite.js` is not picked up by a running server regardless. Run a one-shot
+`pnpm run build` in `packages/blit386`, then restart `pnpm run dev` here.
 
 ## File Organization
 

--- a/packages/demos/package.json
+++ b/packages/demos/package.json
@@ -34,7 +34,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "dev:watch": "pnpm --filter blit386 run build && concurrently -n \"lib,demos\" -c \"blue,green\" \"pnpm --filter blit386 run build --watch\" \"pnpm run dev\"",
+    "dev:watch": "pnpm --filter blit386 run build && concurrently -n \"lib,demos\" -c \"blue,green\" \"pnpm --filter blit386 run build:browser --watch\" \"pnpm run dev\"",
     "build": "vite build",
     "preview": "vite preview",
     "lint": "eslint .",


### PR DESCRIPTION
## Summary

pnpm forwards dev:watch's --watch flag to the end of blit386's chained `vite build && vite build --config vite.node.config.ts` script, so it only ever reached the second (Node/vite-plugin) build. The browser bundle demos actually alias and full-reload on never rebuilt, so dev:watch needed a restart to see any engine source change - including the splash logo regen from BT-390.

Split build into build:browser/build:node and point demos' dev:watch at build:browser --watch. Corrects demos/CLAUDE.md's hot-reload note, which had the bug backwards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added separate browser and Node build commands, while retaining a combined build option.
  - Improved development watch mode so browser engine changes rebuild automatically and trigger a full-page reload.

- **Documentation**
  - Clarified hot reload behavior, including when plugin changes require an engine rebuild and development server restart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->