### PR TITLE
fix(docs): tolerate lastModified drift instead of requiring perfect commit order

### DIFF
--- a/packages/website/CLAUDE.md
+++ b/packages/website/CLAUDE.md
@@ -33,6 +33,7 @@ prefer `rtk read` / `rtk grep` over native Read/Grep for exploration.
 | Generated MDX loader | `.source/` (gitignored; run `fumadocs-mdx` or `pnpm run typecheck`) |
 | Engine API truth | `packages/blit386/docs/` in this monorepo – never this package |
 | How the mirror is built | `scripts/sync-docs-from-engine.mjs` via `pnpm run sync:docs` |
+| How mirror drift is checked in CI | `scripts/check-docs-sync.mjs` via `pnpm run sync:docs:check` |
 | Script test coverage | `scripts/__tests__/*.test.mjs` (`node --test`, via `pnpm run test`) |
 | MCP server | `src/mcp-server.ts`, `public/.well-known/mcp/server-card.json`, `content/mcp-server.mdx` |
 | Cloudflare security headers | `public/_headers` |
@@ -73,11 +74,14 @@ yourself after touching engine docs; CI is the backstop, not the workflow. The s
 That job checks out with `fetch-depth: 0`. The generator reads each page's `lastModified` with `git log --follow`, to
 see past the commit that moved the engine into `packages/blit386/`, and `--follow` finds nothing on a shallow clone.
 
-**Commit the engine doc before you sync.** `lastModified` comes from git, so a sync run before the commit records the
-doc's _previous_ date, and CI – which sees the commit – regenerates a different value and fails the check. The order is
-edit `packages/blit386/docs/…`, commit, then `pnpm run sync:docs`, then commit the mirror. Amending works too: the
-lookup reads the author date, which `git commit --amend` preserves. It converges after one extra sync either way, since
-the mirror commit does not touch the engine doc.
+**`lastModified` is always at most one commit behind, and that is by design, not a mistake to chase.** It comes from
+`git log` on the engine source doc, so a sync run before that doc's edit is committed embeds the _previous_ commit's
+date. Editing `packages/blit386/docs/…`, committing, then running `pnpm run sync:docs` narrows the window, but cannot
+close it: root CLAUDE.md's squash-merge policy collapses a PR's commits into one new commit with a new SHA and author
+date on `main`, and that commit does not exist yet when `sync:docs` runs, however carefully source and mirror commits
+are ordered within the PR. `pnpm run sync:docs:check` ([`scripts/check-docs-sync.mjs`](scripts/check-docs-sync.mjs))
+regenerates the mirror and inspects the diff: a change confined to `lastModified` lines passes – it self-corrects the
+next time anything syncs that page – and any other change (title, description, editUrl, body) still fails the build.
 
 What the generator does: drops the source H1 (the title comes from it), drops a lead paragraph duplicating the
 description, rewrites intra-doc links to site paths (`/docs/...`) and everything else to absolute GitHub URLs, adds

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -46,7 +46,7 @@
     "spellcheck": "cspell \"content/**/*.{md,mdx}\" \"src/**/*.{ts,tsx}\" \"*.{md,mdx}\" \"CLAUDE.md\" --no-progress",
     "docs:links": "node ../../scripts/check-markdown-links.mjs",
     "sync:docs": "node scripts/sync-docs-from-engine.mjs",
-    "sync:docs:check": "pnpm run sync:docs && git diff --exit-code -- content/docs",
+    "sync:docs:check": "node scripts/check-docs-sync.mjs",
     "sync:docs:watch": "node scripts/watch-engine-docs.mjs",
     "encode:video": "node scripts/encode-video.mjs",
     "knip": "cd ../.. && knip --workspace packages/website",

--- a/packages/website/scripts/__tests__/check-docs-sync.test.mjs
+++ b/packages/website/scripts/__tests__/check-docs-sync.test.mjs
@@ -86,9 +86,39 @@ describe('classifyDocsDiff', () => {
     test('does not mistake a removed frontmatter delimiter line for a diff file header', () => {
         // A removed "---" content line renders as "----" (the diff marker plus the
         // three literal dashes), which must NOT be swallowed by the `--- ` /
-        // `+++ ` file-header exclusion - only real header lines carry the trailing
+        // `+++ ` file-header exclusion – only real header lines carry the trailing
         // space before the path.
         const diff = [FILE_HEADER, '@@ -1,3 +1,2 @@', '-title: "Page"', '----'].join('\n');
+
+        assert.equal(classifyDocsDiff(diff), 'drift');
+    });
+
+    test('returns drift for a rename-only diff with no content lines at all', () => {
+        // A pure rename (no content change) has no `---`/`+++`/`@@` lines, so the
+        // old, unguarded `[].every(...)` on an empty changed-lines array was
+        // vacuously true and misclassified this as lastModifiedOnly.
+        const diff = [
+            'diff --git a/packages/website/content/docs/guides/old-name.mdx b/packages/website/content/docs/guides/new-name.mdx',
+            'similarity index 100%',
+            'rename from packages/website/content/docs/guides/old-name.mdx',
+            'rename to packages/website/content/docs/guides/new-name.mdx',
+        ].join('\n');
+
+        assert.equal(classifyDocsDiff(diff), 'drift');
+    });
+
+    test('returns drift for a body addition that happens to start with "lastModified:"', () => {
+        // A code example demonstrating frontmatter, deep in the body, must not be
+        // trusted just because the added line is lexically shaped like the real
+        // field - only a hunk starting near the file's top counts as frontmatter.
+        const diff = [
+            FILE_HEADER,
+            '@@ -42,3 +42,4 @@',
+            ' Example frontmatter shape:',
+            ' ```yaml',
+            '+lastModified: "2026-01-01T00:00:00Z"',
+            ' ```',
+        ].join('\n');
 
         assert.equal(classifyDocsDiff(diff), 'drift');
     });

--- a/packages/website/scripts/__tests__/check-docs-sync.test.mjs
+++ b/packages/website/scripts/__tests__/check-docs-sync.test.mjs
@@ -1,0 +1,95 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const { classifyDocsDiff } = await import('../check-docs-sync.mjs');
+
+const FILE_HEADER = [
+    'diff --git a/packages/website/content/docs/guides/splash.mdx b/packages/website/content/docs/guides/splash.mdx',
+    'index fb5235d2..f0ab1f8e 100644',
+    '--- a/packages/website/content/docs/guides/splash.mdx',
+    '+++ b/packages/website/content/docs/guides/splash.mdx',
+].join('\n');
+
+describe('classifyDocsDiff', () => {
+    test('returns clean for an empty diff', () => {
+        assert.equal(classifyDocsDiff(''), 'clean');
+    });
+
+    test('returns clean for a diff that is only whitespace', () => {
+        assert.equal(classifyDocsDiff('\n  \n'), 'clean');
+    });
+
+    test('returns lastModifiedOnly when every changed line is a lastModified value', () => {
+        const diff = [
+            FILE_HEADER,
+            '@@ -3,7 +3,7 @@',
+            ' title: "The BLIT386 Splash"',
+            '-lastModified: "2026-08-06T19:00:45+02:00"',
+            '+lastModified: "2026-08-06T19:21:58+02:00"',
+            ' editUrl: "https://github.com/blit386/blit386/blob/main/docs/guide-splash.md"',
+        ].join('\n');
+
+        assert.equal(classifyDocsDiff(diff), 'lastModifiedOnly');
+    });
+
+    test('returns lastModifiedOnly across multiple changed files', () => {
+        const diff = [
+            FILE_HEADER,
+            '@@ -3,7 +3,7 @@',
+            '-lastModified: "2026-08-06T19:00:45+02:00"',
+            '+lastModified: "2026-08-06T19:21:58+02:00"',
+            FILE_HEADER,
+            '@@ -3,7 +3,7 @@',
+            '-lastModified: "2026-08-06T19:00:45+02:00"',
+            '+lastModified: "2026-08-06T20:02:11+02:00"',
+        ].join('\n');
+
+        assert.equal(classifyDocsDiff(diff), 'lastModifiedOnly');
+    });
+
+    test('returns drift when body content changed alongside lastModified', () => {
+        const diff = [
+            FILE_HEADER,
+            '@@ -3,9 +3,9 @@',
+            '-lastModified: "2026-08-06T19:00:45+02:00"',
+            '+lastModified: "2026-08-06T19:21:58+02:00"',
+            ' ---',
+            '-The splash palette is spaced evenly.',
+            '+The splash palette is spaced evenly in encoded sRGB.',
+        ].join('\n');
+
+        assert.equal(classifyDocsDiff(diff), 'drift');
+    });
+
+    test('returns drift when only non-lastModified content changed', () => {
+        const diff = [FILE_HEADER, '@@ -10,1 +10,1 @@', '-old body text', '+new body text'].join('\n');
+
+        assert.equal(classifyDocsDiff(diff), 'drift');
+    });
+
+    test('returns drift for a brand-new page (title and body differ, not just lastModified)', () => {
+        const diff = [
+            'diff --git a/packages/website/content/docs/guides/new-page.mdx b/packages/website/content/docs/guides/new-page.mdx',
+            'new file mode 100644',
+            'index 00000000..abcdef01',
+            '--- /dev/null',
+            '+++ b/packages/website/content/docs/guides/new-page.mdx',
+            '@@ -0,0 +1,5 @@',
+            '+title: "New Page"',
+            '+lastModified: "2026-08-06T19:21:58+02:00"',
+            '+Some new body text.',
+        ].join('\n');
+
+        assert.equal(classifyDocsDiff(diff), 'drift');
+    });
+
+    test('does not mistake a removed frontmatter delimiter line for a diff file header', () => {
+        // A removed "---" content line renders as "----" (the diff marker plus the
+        // three literal dashes), which must NOT be swallowed by the `--- ` /
+        // `+++ ` file-header exclusion - only real header lines carry the trailing
+        // space before the path.
+        const diff = [FILE_HEADER, '@@ -1,3 +1,2 @@', '-title: "Page"', '----'].join('\n');
+
+        assert.equal(classifyDocsDiff(diff), 'drift');
+    });
+});

--- a/packages/website/scripts/check-docs-sync.mjs
+++ b/packages/website/scripts/check-docs-sync.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+// @ts-nocheck
+/**
+ * Verify the generated docs mirror matches its source, tolerating the
+ * one-commit lag inherent to `lastModified`.
+ *
+ * `lastModified` (see `getLastModified` in sync-docs-from-engine.mjs) comes from
+ * `git log` on the engine source doc. This repo squash-merges every PR
+ * (root CLAUDE.md), which collapses a PR's commits into one new commit with a
+ * new SHA and author date on `main`. A PR that both edits an engine doc and
+ * regenerates its mirror can never embed that final, squashed commit's date -
+ * that commit does not exist yet when `sync:docs` runs, however carefully the
+ * source and mirror commits are ordered within the PR. So the mirror's
+ * `lastModified` is always exactly one commit behind until the *next* sync
+ * touches the same page, regardless of author discipline.
+ *
+ * A byte-exact `git diff --exit-code` therefore fails on every such PR without
+ * any real content drift to fix. This script regenerates the mirror and then
+ * inspects the diff: a change confined to `lastModified` lines passes (it will
+ * self-correct on the next sync); any other change - title, description,
+ * editUrl, or body - still fails the build.
+ */
+import { execFileSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+
+const DIFF_FILE_HEADER_PATTERN = /^(?:\+\+\+ |--- )/u;
+const LAST_MODIFIED_LINE_PATTERN = /^[+-]lastModified: /u;
+
+/**
+ * Classify a `git diff -- content/docs` unified diff: `'clean'` (no diff),
+ * `'lastModifiedOnly'` (every changed line is a `lastModified` frontmatter
+ * value), or `'drift'` (at least one other line changed). Diff file-header
+ * lines (`--- a/...`, `+++ b/...`) are ignored - they always change alongside
+ * any edit and carry no content of their own.
+ */
+const classifyDocsDiff = (diffText) => {
+    if (diffText.trim() === '') {
+        return 'clean';
+    }
+
+    const changedLines = diffText
+        .split('\n')
+        .filter((line) => /^[+-]/u.test(line) && !DIFF_FILE_HEADER_PATTERN.test(line));
+
+    return changedLines.every((line) => LAST_MODIFIED_LINE_PATTERN.test(line)) ? 'lastModifiedOnly' : 'drift';
+};
+
+const main = () => {
+    execFileSync('pnpm', ['run', 'sync:docs'], { stdio: 'inherit' });
+
+    const diff = execFileSync('git', ['diff', '--no-color', '--', 'content/docs'], { encoding: 'utf8' });
+    const verdict = classifyDocsDiff(diff);
+
+    if (verdict === 'clean') {
+        console.log('Docs mirror matches the engine source.');
+
+        return;
+    }
+
+    if (verdict === 'lastModifiedOnly') {
+        console.log(
+            'Docs mirror lastModified timestamp(s) are one commit behind the engine source (expected: this repo ' +
+                'squash-merges PRs, so a PR that edits an engine doc and regenerates its mirror cannot embed the ' +
+                "final squashed commit's date). Not failing the build - the next sync will pick it up.",
+        );
+
+        return;
+    }
+
+    console.error(
+        'Docs mirror is out of sync with the engine source. Run `pnpm run sync:docs` and commit the result.\n',
+    );
+    console.error(diff);
+    process.exitCode = 1;
+};
+
+export { classifyDocsDiff };
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    main();
+}

--- a/packages/website/scripts/check-docs-sync.mjs
+++ b/packages/website/scripts/check-docs-sync.mjs
@@ -8,7 +8,7 @@
  * `git log` on the engine source doc. This repo squash-merges every PR
  * (root CLAUDE.md), which collapses a PR's commits into one new commit with a
  * new SHA and author date on `main`. A PR that both edits an engine doc and
- * regenerates its mirror can never embed that final, squashed commit's date -
+ * regenerates its mirror can never embed that final, squashed commit's date –
  * that commit does not exist yet when `sync:docs` runs, however carefully the
  * source and mirror commits are ordered within the PR. So the mirror's
  * `lastModified` is always exactly one commit behind until the *next* sync
@@ -16,33 +16,64 @@
  *
  * A byte-exact `git diff --exit-code` therefore fails on every such PR without
  * any real content drift to fix. This script regenerates the mirror and then
- * inspects the diff: a change confined to `lastModified` lines passes (it will
- * self-correct on the next sync); any other change - title, description,
- * editUrl, or body - still fails the build.
+ * inspects the diff: a change confined to the `lastModified` frontmatter field
+ * passes (it will self-correct on the next sync); any other change – title,
+ * description, editUrl, body, or a rename – still fails the build.
  */
 import { execFileSync } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
 
 const DIFF_FILE_HEADER_PATTERN = /^(?:\+\+\+ |--- )/u;
+const HUNK_HEADER_PATTERN = /^@@ -(\d+)(?:,\d+)? \+\d+(?:,\d+)? @@/u;
 const LAST_MODIFIED_LINE_PATTERN = /^[+-]lastModified: /u;
+
+/**
+ * A generated page's frontmatter (see `renderPage` in sync-docs-from-engine.mjs)
+ * is always the opening `---`, a two-line banner, up to four fields, and the
+ * closing `---` – 8 lines at most. A hunk whose pre-image starts beyond that is
+ * necessarily body content, never frontmatter, however its lines read.
+ */
+const FRONTMATTER_HUNK_START_LIMIT = 8;
 
 /**
  * Classify a `git diff -- content/docs` unified diff: `'clean'` (no diff),
  * `'lastModifiedOnly'` (every changed line is a `lastModified` frontmatter
- * value), or `'drift'` (at least one other line changed). Diff file-header
- * lines (`--- a/...`, `+++ b/...`) are ignored - they always change alongside
- * any edit and carry no content of their own.
+ * value, and at least one such line exists), or `'drift'` (anything else,
+ * including a rename or mode change with no matching content lines). Diff
+ * file-header lines (`--- a/...`, `+++ b/...`) are ignored – they always
+ * change alongside any edit and carry no content of their own.
+ *
+ * `lastModified`-shaped text is only trusted inside a hunk that starts within
+ * `FRONTMATTER_HUNK_START_LIMIT` of the file's top, so a coincidentally
+ * matching line added to prose or a code example – never actually frontmatter
+ * – still counts as drift.
  */
 const classifyDocsDiff = (diffText) => {
     if (diffText.trim() === '') {
         return 'clean';
     }
 
-    const changedLines = diffText
-        .split('\n')
-        .filter((line) => /^[+-]/u.test(line) && !DIFF_FILE_HEADER_PATTERN.test(line));
+    let isFrontmatterHunk = false;
+    const changedLines = [];
 
-    return changedLines.every((line) => LAST_MODIFIED_LINE_PATTERN.test(line)) ? 'lastModifiedOnly' : 'drift';
+    for (const line of diffText.split('\n')) {
+        const hunkHeader = HUNK_HEADER_PATTERN.exec(line);
+
+        if (hunkHeader) {
+            isFrontmatterHunk = Number(hunkHeader[1]) <= FRONTMATTER_HUNK_START_LIMIT;
+            continue;
+        }
+
+        if (/^[+-]/u.test(line) && !DIFF_FILE_HEADER_PATTERN.test(line)) {
+            changedLines.push({ line, isFrontmatterHunk });
+        }
+    }
+
+    const isSafe =
+        changedLines.length > 0 &&
+        changedLines.every(({ line, isFrontmatterHunk }) => isFrontmatterHunk && LAST_MODIFIED_LINE_PATTERN.test(line));
+
+    return isSafe ? 'lastModifiedOnly' : 'drift';
 };
 
 const main = () => {
@@ -61,7 +92,7 @@ const main = () => {
         console.log(
             'Docs mirror lastModified timestamp(s) are one commit behind the engine source (expected: this repo ' +
                 'squash-merges PRs, so a PR that edits an engine doc and regenerates its mirror cannot embed the ' +
-                "final squashed commit's date). Not failing the build - the next sync will pick it up.",
+                "final squashed commit's date). Not failing the build – the next sync will pick it up.",
         );
 
         return;


### PR DESCRIPTION
## Summary

- `sync:docs:check` used a byte-exact `git diff --exit-code` against the regenerated mirror, so any drift in the `lastModified` frontmatter field failed the build.
- That drift is structurally unavoidable in this repo: `lastModified` comes from `git log` on the engine source doc, and root CLAUDE.md's squash-merge policy collapses a PR's commits into one new commit with a new SHA and author date on `main`. That commit doesn't exist yet when `sync:docs` runs, so a PR that both edits an engine doc and regenerates its mirror can never embed the final squashed date — no matter how carefully the source and mirror commits are ordered within the PR. This is exactly what happened to `guide-splash.md`'s mirror after PR #475 merged, and needed a one-off manual fix in PR #477 to unblock CI.
- `scripts/check-docs-sync.mjs` replaces the plain diff check: it still regenerates the mirror, but classifies the resulting diff and only fails when something other than a `lastModified` line changed. A drifted timestamp now passes (self-correcting the next time anything syncs that page); real content drift — title, description, editUrl, body — still fails exactly as before.
- Updated `packages/website/CLAUDE.md` (mechanism explanation + "Where to Find Information" table) to describe the real cause and the new tolerant checker.

## Test plan

- [x] 8 new unit tests on the pure `classifyDocsDiff` function: empty diff, timestamp-only diff (single and multi-file), real content drift, brand-new page, and a deliberate edge case where a removed `---` frontmatter delimiter line must not be mistaken for a diff file header
- [x] `pnpm --filter blit386-website run test` — 176/176 pass (168 existing + 8 new)
- [x] `pnpm --filter blit386-website run sync:docs:check` — passes against the current (clean) tree
- [x] `pnpm --filter blit386-website run preflight` — format, lint, typecheck, spellcheck, knip, test, build all pass

Co-Authored-By: Claude <noreply@anthropic.com>

https://claude.ai/code/session_019oqjmUwnS6wKjQbGDNqWGB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved documentation synchronization checks to distinguish harmless timestamp differences from actual content drift.
  * CI now continues to pass when only `lastModified` metadata differs, while still flagging meaningful documentation changes.

* **Tests**
  * Added coverage for empty diffs, metadata-only changes, content changes, new pages, and frontmatter edge cases.

* **Documentation**
  * Clarified documentation synchronization guidance, including behavior after squash merges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->