### PR TITLE
fix(ci): disable dts rollup under --watch to stop the api-extractor crash

### DIFF
--- a/packages/blit386/tsconfig.json
+++ b/packages/blit386/tsconfig.json
@@ -12,6 +12,7 @@
     "src/**/*",
     "tests/visual/**/*.ts",
     "vite.config.ts",
+    "vite.config.test.ts",
     "vite.node.config.ts",
     "vitest.config.ts",
     "playwright.config.ts",

--- a/packages/blit386/vite.config.test.ts
+++ b/packages/blit386/vite.config.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Unit tests for {@link resolveDtsRollupTypes}.
+ *
+ * Guards the BT-426 fix: `vite build --watch` must never enable api-extractor's
+ * declaration rollup, since it crashes intermittently mid-watch-rebuild. Only the
+ * final, non-watch production build may roll up `dist/blit386.d.ts`.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { resolveDtsRollupTypes } from './vite.config';
+
+describe('resolveDtsRollupTypes', () => {
+    it('disables rollupTypes when --watch is present', () => {
+        expect(resolveDtsRollupTypes(['vite', 'build', '--watch'])).toBe(false);
+    });
+
+    it('enables rollupTypes for a normal production build', () => {
+        expect(resolveDtsRollupTypes(['vite', 'build'])).toBe(true);
+    });
+
+    it('enables rollupTypes when argv is empty', () => {
+        expect(resolveDtsRollupTypes([])).toBe(true);
+    });
+
+    it('disables rollupTypes regardless of --watch position in argv', () => {
+        expect(resolveDtsRollupTypes(['--watch', 'vite', 'build'])).toBe(false);
+    });
+});

--- a/packages/blit386/vite.config.ts
+++ b/packages/blit386/vite.config.ts
@@ -4,6 +4,18 @@ import type { LibraryFormats } from 'vite';
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
 
+/**
+ * Whether the dts plugin should run api-extractor's declaration rollup.
+ *
+ * Api-extractor's rollup crashes intermittently when a watch rebuild's per-file `.d.ts`
+ * tree is still being rewritten as it starts reading it - see BT-426. It only ever needs
+ * to run for the final, non-watch production build.
+ *
+ * @param argv - The process argv to check for a `--watch` flag.
+ * @returns `false` under `--watch`, `true` otherwise.
+ */
+export const resolveDtsRollupTypes = (argv: readonly string[]): boolean => !argv.includes('--watch');
+
 export default defineConfig(() => {
     const isWatch = process.argv.includes('--watch');
 
@@ -13,7 +25,7 @@ export default defineConfig(() => {
         plugins: [
             dts({
                 include: ['src/**/*.ts'],
-                rollupTypes: true,
+                rollupTypes: resolveDtsRollupTypes(process.argv),
                 beforeWriteFile: (filePath, content) => ({
                     filePath: filePath.replace(/BLIT386\.d\.ts$/, 'blit386.d.ts'),
                     content,

--- a/packages/blit386/vitest.config.ts
+++ b/packages/blit386/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
     test: {
-        include: ['src/**/*.test.ts'],
+        include: ['src/**/*.test.ts', 'vite.config.test.ts'],
         exclude: ['node_modules', 'dist'],
 
         // Default environment is node. Tests needing DOM use


### PR DESCRIPTION
## Summary

- `vite build --watch` on `packages/blit386` crashed `vite-plugin-dts`'s api-extractor-backed declaration rollup on every rebuild after the first, throwing an internal `api-extractor` error (`Unable to determine module for: ...` / `referenced path was not found: ...`) and printing a stack trace on every save.
- Root cause: api-extractor's rollup step re-reads the just-emitted per-file `dist/*.d.ts` tree straight off disk on every cycle, but `vite-plugin-dts` keeps rebuild state as mutable, plugin-instance-scoped closure state shared across the `es`/`cjs` sub-builds in one watch session. A second `watchChange` firing for the same file - which happens routinely, since an editor's atomic-write save is two filesystem events, not one - can land while the previous cycle's declaration tree is still being rewritten, so api-extractor reads a transiently inconsistent file and throws.
- Reproduced directly (instrumented `vite-plugin-dts` with timing traces to confirm the double `watchChange` firing and the crash site, then reverted the instrumentation) rather than guessing at a fix.
- Fix: `rollupTypes` now resolves to `false` under `--watch` (extracted into the testable, exported `resolveDtsRollupTypes`) and stays `true` for the final production build - the only place anything actually reads the bundled `dist/blit386.d.ts`; `packages/demos`'s `dev:watch` only consumes the JS bundle. Per-file `.d.ts` emission (the half that doesn't crash) still runs every watch cycle.
- Not a regression from BT-425 - the `isWatch` branch already existed; BT-425 just made `--watch` actually reach this build for the first time, exposing this latent bug.

Linear: BT-426

## Test plan

- [x] Stress-tested the actual fix against real `vite build --watch`: rapid consecutive edits (the pattern that reliably crashed within 2-3 cycles before) now run clean across 10+ rebuild cycles with the api-extractor rollup step confirmed skipped.
- [x] Confirmed a normal non-watch `vite build` still produces a correctly rolled-up, full-size `dist/blit386.d.ts`.
- [x] Added `packages/blit386/vite.config.test.ts` (4 cases) covering `resolveDtsRollupTypes`.
- [x] `pnpm run test:unit` - 104 files, 2737 tests pass.
- [x] `pnpm run test:declarations`, `typecheck`, `lint`, `format:check`, `spellcheck`, `knip` all pass.
- [x] Pre-push preflight (including root-level `docs:links`/`agents:check`) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved watch-mode builds by disabling declaration rollups, helping changes rebuild more reliably.
  * Declaration rollups remain enabled for standard production builds.

* **Tests**
  * Added coverage for watch-mode detection, production builds, empty arguments, and watch flags in any position.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->