### PR TITLE
fix(deps): website depends on the workspace engine, not npm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
               - 'packages/blit386/**'
             website:
               - 'packages/website/**'
-              - 'packages/blit386/docs/**'
+              - 'packages/blit386/**'
             kit:
               - 'packages/kit/**'
             # bump-lockstep.mjs/.test.mjs live under root scripts/, not packages/create-blit386/, but
@@ -695,9 +695,14 @@ jobs:
       - name: Set up workspace
         uses: ./.github/actions/setup
 
-      # No engine build needed: website resolves `blit386` from the npm registry, not
-      # from the workspace. `pnpm run build` sets CLOUDFLARE=1, which is what turns
-      # Twoslash on, and postbuild patches the generated wrangler config.
+      # website consumes the engine as workspace:*, and Twoslash resolves blit386's type
+      # declarations from packages/blit386/dist, so the engine must be built first - the
+      # same edge build-demos already handles for demos' workspace dependency.
+      - name: Build engine (workspace dependency)
+        run: pnpm --filter blit386 run build
+
+      # `pnpm run build` sets CLOUDFLARE=1, which is what turns Twoslash on, and
+      # postbuild patches the generated wrangler config.
       - name: Build site
         run: pnpm --filter blit386-website run build
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,8 +10,8 @@ name: Deploy
 # No path filter on the next.* jobs, on purpose - matches deploy-demos/deploy-website's
 # existing no-filter design. A wrong filter here means a preview site silently stays stale
 # rather than failing loudly, and the whole point of a preview channel is that it never lags
-# main. The website depends on packages/blit386/docs and demos depends on the engine, so a
-# path filter would also have to track those cross-package edges correctly, which a push-to-
+# main. Both the website and demos depend on the workspace engine (packages/blit386), so a
+# path filter would also have to track that cross-package edge correctly, which a push-to-
 # main preview channel should not have to get right to do its job.
 #
 # Each job builds its own site rather than downloading ci.yml's artifacts, same as before -
@@ -84,9 +84,12 @@ jobs:
       - name: Set up workspace
         uses: ./.github/actions/setup
 
-      # No engine build: website resolves `blit386` from npm, not the workspace.
-      # `build` sets CLOUDFLARE=1 (Twoslash) and its postbuild lifecycle patches
-      # dist/server/wrangler.json, which is the config deployed below.
+      # website consumes the engine as workspace:*, so the engine build is a
+      # prerequisite. `build` sets CLOUDFLARE=1 (Twoslash) and its postbuild lifecycle
+      # patches dist/server/wrangler.json, which is the config deployed below.
+      - name: Build engine (workspace dependency)
+        run: pnpm --filter blit386 run build
+
       - name: Build site
         run: pnpm --filter blit386-website run build
         env:
@@ -154,7 +157,11 @@ jobs:
       - name: Set up workspace
         uses: ./.github/actions/setup
 
-      # No engine build: website resolves `blit386` from npm, not the workspace.
+      # website consumes the engine as workspace:*, so the engine build is a
+      # prerequisite.
+      - name: Build engine (workspace dependency)
+        run: pnpm --filter blit386 run build
+
       - name: Build site (next channel)
         run: pnpm --filter blit386-website run build
         env:

--- a/packages/website/CLAUDE.md
+++ b/packages/website/CLAUDE.md
@@ -108,6 +108,13 @@ the generated JSON. Never add a symbol to that JSON here; fix `packages/blit386`
 block that fails compilation degrades to plain highlighting instead of crashing the build. Correctness is
 `packages/blit386`'s job – every twoslash block there must be self-contained or use a `// ---cut---` preamble.
 
+`blit386` is a `workspace:*` devDependency (BT-414), not a pinned npm version – Twoslash resolves its type declarations
+from `packages/blit386/dist`, so a doc can reference and validate unreleased engine API before it ships, and the engine
+must be built (`pnpm --filter blit386 run build`) before this package's `build` in every CI/deploy job that runs one.
+Because `throws: false` swallows a failing block into plain highlighting rather than an error, a regression here is
+silent: `grep -c twoslash-hover dist/public/docs/<page>/index.html` after a build is the fastest way to confirm a given
+block actually typechecked (0 means it silently degraded).
+
 Dev-mode skip (memory constraint): the transformer is gated on `!!process.env.CLOUDFLARE`. `blit386.d.ts` is ~192 KB and
 imports WebGPU types; across the several dozen MDX files the TypeScript language service accumulates over 4 GB during
 `waku dev` and OOMs. `NODE_ENV` is not a usable signal because `source.config.ts` is evaluated by the fumadocs-mdx Vite

--- a/packages/website/CLAUDE.md
+++ b/packages/website/CLAUDE.md
@@ -112,8 +112,11 @@ block that fails compilation degrades to plain highlighting instead of crashing 
 from `packages/blit386/dist`, so a doc can reference and validate unreleased engine API before it ships, and the engine
 must be built (`pnpm --filter blit386 run build`) before this package's `build` in every CI/deploy job that runs one.
 Because `throws: false` swallows a failing block into plain highlighting rather than an error, a regression here is
-silent: `grep -c twoslash-hover dist/public/docs/<page>/index.html` after a build is the fastest way to confirm a given
-block actually typechecked (0 means it silently degraded).
+silent. `grep -c twoslash-hover "dist/public/docs/<page>/index.html"` after a build (`<page>` is a placeholder, e.g.
+`api/random`; keep it quoted or the shell reads `<`/`>` as redirection) is only a page-wide smoke check, not proof a
+specific block typechecked – a page with several blocks can show a nonzero count while one block still silently failed
+(see BT-427). To confirm one block specifically, grep the built HTML for a distinctive identifier from that block's
+source and check whether it renders as a hoverable `twoslash-hover` token instead of plain syntax-highlighted text.
 
 Dev-mode skip (memory constraint): the transformer is gated on `!!process.env.CLOUDFLARE`. `blit386.d.ts` is ~192 KB and
 imports WebGPU types; across the several dozen MDX files the TypeScript language service accumulates over 4 GB during

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -78,7 +78,7 @@
     "@types/node": "^25.9.5",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
-    "blit386": "^1.4.0",
+    "blit386": "workspace:*",
     "cross-env": "^7.0.3",
     "cspell": "^10.0.1",
     "fumadocs-twoslash": "^3.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,8 +298,8 @@ importers:
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
       blit386:
-        specifier: ^1.4.0
-        version: 1.4.0
+        specifier: workspace:*
+        version: link:../blit386
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -3016,10 +3016,6 @@ packages:
 
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
-
-  blit386@1.4.0:
-    resolution: {integrity: sha512-GWW9Wqtf5BrExA1cNYFIy02LXSiS2xU/NuKNXOhOPwBZmOqAgI0Y6yPHdOSOusbzVh063Jv9qvKyyhu0pbCcFQ==}
-    engines: {node: '>=22.18.0'}
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
@@ -8374,8 +8370,6 @@ snapshots:
   binary-extensions@2.3.0: {}
 
   blake3-wasm@2.1.5: {}
-
-  blit386@1.4.0: {}
 
   boolbase@1.0.0: {}
 


### PR DESCRIPTION
## Summary

- `packages/website` now depends on `blit386` via `workspace:*` instead of a pinned npm version (`^1.4.0`), so Fumadocs Twoslash validates documentation against `packages/blit386` in this repo, not whatever happens to be published on npm.
- Widened the website CI path filter to `packages/blit386/**` (was `packages/blit386/docs/**`), and made `build-website` (`ci.yml`) and both `deploy-website` / `deploy-website-next` (`deploy.yml`) build the engine before the site - the same pattern `packages/demos` already uses.

## Why

Docs and npm currently happen to agree (both at `1.4.0`), so this was silently masking a real gap: `packages/blit386/docs/changelog.md`'s `## Unreleased` section (`Random`, noise/hashing helpers, `interpolate`) is already documented with Twoslash fences today, and those fences were silently degrading to plain syntax highlighting during the website build - `source.config.ts` sets `transformerTwoslash({ throws: false })`, so a failed block never fails CI. Confirmed before/after with a real example:

```bash
grep -c twoslash-hover dist/public/docs/api/easing/index.html
# before (npm blit386@1.4.0): 0  - interpolate() doesn't exist on npm yet
# after (workspace:*):        50 - now typechecks for real
```

Blocks BT-418 (1.5.0 release) per its own section 2 - at 1.5.0 this would have caused a build failure, or worse, published unvalidated examples.

## Unrelated finding (not fixed here, filed separately)

While building the before/after comparison, `api/camera`, `api/game-loop`, and part of `api/palette` showed `0` `twoslash-hover` occurrences both before and after this fix - not a workspace-vs-npm issue. Root cause: `packages/website/scripts/sync-docs-from-engine.mjs` strips Twoslash's `// ---cut---` preamble before compilation instead of letting Twoslash hide it natively, breaking every doc using that sanctioned fragment-block pattern (18 files, not just these 3 - some only partially, masked by other working blocks on the same page). Out of scope for this PR; filed as [BT-427](https://linear.app/vancura/issue/BT-427), milestone 1.5.0.

## Test plan

- [x] `packages/website/node_modules/blit386` resolves to `../blit386` (workspace symlink), confirmed from a clean install (`rm -rf node_modules && pnpm install --frozen-lockfile`)
- [x] `pnpm --filter blit386 run build` then `CLOUDFLARE=1 pnpm --filter blit386-website run build` succeeds
- [x] `pnpm --filter blit386-website run preflight` passes (format, typecheck, test, spellcheck, knip, build)
- [x] Real Twoslash proof: `api/easing` (interpolate) and `api/random` (Random) go from 0 to 50/210 `twoslash-hover` occurrences after the fix; `api/camera`/`api/game-loop`/`api/palette` stay at 0 both before and after, confirming that's a separate pre-existing bug, not this change regressing anything
- [x] `pnpm --filter blit386-demos run build` still succeeds (sanity check the shared engine build step didn't regress demos)
- [ ] **CI on this PR**: confirm `changes` job reports `website: true`, `build-website`'s log shows `Build engine (workspace dependency)` running before `Build site`, and `quality-website` + `build-website` both pass
- [ ] Recommended follow-up (not required to merge): a throwaway commit touching only `packages/blit386/**` to prove the widened path filter alone triggers the website jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LaBw2ygqhy9Z5522jM2afQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved website and demo builds by explicitly building the engine before deployment.
  * Updated change detection so relevant engine updates trigger website builds.

* **Documentation**
  * Added guidance for local engine usage, build requirements, and verifying website type checking.
  * Documented fallback behavior when interactive type-checking examples cannot be processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->