### PR TITLE
fix(docs): stop stripping twoslash cut-preambles before compilation

### DIFF
--- a/packages/website/content/docs/api/assets.mdx
+++ b/packages/website/content/docs/api/assets.mdx
@@ -78,6 +78,8 @@ For a loading-screen indicator that covers both images and audio clips, use `BT.
 once every in-flight load has settled:
 
 ```ts twoslash
+import { BT } from 'blit386';
+// ---cut---
 if (BT.loadingAssetsCount > 0) {
   // show a spinner or progress bar
 }
@@ -139,6 +141,9 @@ Each call appends the image's colors starting at the given slot; chain them with
 into one palette.
 
 ```ts twoslash
+import { Palette, SpriteSheet } from 'blit386';
+const palette = new Palette(256);
+// ---cut---
 const colors = await SpriteSheet.loadColorsIntoPalette('hero.png', palette, 10);
 const tileColors = await SpriteSheet.loadColorsIntoPalette('tiles.png', palette, 10 + colors.length);
 ```
@@ -150,6 +155,8 @@ const tileColors = await SpriteSheet.loadColorsIntoPalette('tiles.png', palette,
 ### Load the image into a sprite sheet
 
 ```ts twoslash
+import { SpriteSheet } from 'blit386';
+// ---cut---
 const sheet = await SpriteSheet.load('hero.png');
 ```
 
@@ -162,6 +169,10 @@ const sheet = await SpriteSheet.load('hero.png');
 `indexize()` maps every pixel to its palette slot; activate the palette afterward.
 
 ```ts twoslash
+import { BT, Palette, SpriteSheet } from 'blit386';
+const palette = new Palette(256);
+declare const sheet: SpriteSheet;
+// ---cut---
 sheet.indexize(palette);
 BT.paletteSet(palette);
 ```
@@ -173,6 +184,11 @@ BT.paletteSet(palette);
 To create a sheet from raw palette-indexed pixel data (advanced / test use):
 
 ```ts twoslash
+import { SpriteSheet } from 'blit386';
+declare const width: number;
+declare const height: number;
+declare const indexedPixels: Uint8Array;
+// ---cut---
 const sheet = SpriteSheet.fromIndexedPixels(width, height, indexedPixels);
 ```
 
@@ -183,6 +199,11 @@ texel indices before palette lookup. Useful for team-color variations and damage
 [Palette addressing](/docs/api/palette#palette-addressing). Draw semantics: [API: Rendering](/docs/api/rendering).
 
 ```ts twoslash
+import { BT, Rect2i, SpriteSheet, Vector2i } from 'blit386';
+declare const sheet: SpriteSheet;
+const srcRect = new Rect2i(0, 0, 32, 32);
+const pos = new Vector2i(0, 0);
+// ---cut---
 BT.drawSprite(sheet, srcRect, pos, 16); // render in "blue team" color range
 ```
 
@@ -194,6 +215,9 @@ Load `.btfont` files for proportional, palette-indexed bitmap fonts. After loadi
 indexize the font's internal sprite sheet before drawing (same pattern as manual sprite setup).
 
 ```ts twoslash
+import { BitmapFont, BT, Palette, Vector2i } from 'blit386';
+declare const paletteOffset: number;
+// ---cut---
 const palette = new Palette(256);
 const font = await BitmapFont.load('fonts/MyFont.btfont');
 font.getSpriteSheet().indexize(palette);
@@ -233,6 +257,9 @@ replacement fetch while it's in flight - useful for a per-sheet loading indicato
 with `progress: 1.0`, since its image has already resolved by the time the sheet is constructed.
 
 ```ts twoslash
+import { SpriteSheet } from 'blit386';
+declare const sheet: SpriteSheet;
+// ---cut---
 sheet.status; // 'loading' | 'ready' | 'failed'
 sheet.progress; // 0 while loading, 1.0 once ready
 ```
@@ -251,6 +278,9 @@ fallback-to-full-reload behavior for unrecognized file types.
 A built-in 6×14 monospace font covering printable ASCII (characters 32–126). No load step needed.
 
 ```ts twoslash
+import { BT, Vector2i } from 'blit386';
+declare const paletteIndex: number;
+// ---cut---
 BT.systemPrint(new Vector2i(10, 10), paletteIndex, 'Score: 100');
 BT.systemPrintMeasure('Score: 100'); // → Vector2i (pixel width, height)
 ```

--- a/packages/website/content/docs/api/audio.mdx
+++ b/packages/website/content/docs/api/audio.mdx
@@ -25,6 +25,8 @@ music  ─┼─► main ─► destination
 <Since symbol="AudioBus" />
 
 ```ts twoslash
+import { type AudioBus } from 'blit386';
+// ---cut---
 declare const bus: AudioBus; // 'main' | 'music' | 'sfx'
 ```
 
@@ -36,6 +38,8 @@ declare const bus: AudioBus; // 'main' | 'music' | 'sfx'
 `BT.audioVolumeSet` sets a bus's volume, optionally fading to it. `BT.audioVolumeGet` reads it back.
 
 ```ts twoslash
+import { BT } from 'blit386';
+// ---cut---
 BT.audioVolumeSet('music', 0.5); // immediate change
 BT.audioVolumeSet('sfx', 0, { fadeMs: 300 }); // linear fade to silence over 300 ms
 BT.audioVolumeSet('main', 0.8, { fadeMs: 500, easing: 'ease-out' }); // eased fade
@@ -62,6 +66,8 @@ With no `fadeMs`, the bus gain changes immediately. With `fadeMs`, `'linear'` ea
 mute state.
 
 ```ts twoslash
+import { BT } from 'blit386';
+// ---cut---
 BT.audioVolumeSet('music', 0.75);
 
 BT.audioMuteSet('music', true); // silences the bus immediately (no fade)
@@ -85,6 +91,8 @@ Browsers block audio playback until a user gesture. `BT.isAudioUnlocked` is `fal
 session.
 
 ```ts twoslash
+import { BT } from 'blit386';
+// ---cut---
 if (!BT.isAudioUnlocked) {
   // Show a "click or press a key to enable audio" prompt.
 }
@@ -128,6 +136,8 @@ For a single loading-screen signal that also covers sprite sheet images, see
 Pass `onProgress` to report phased load progress:
 
 ```ts twoslash
+import { AudioClip } from 'blit386';
+// ---cut---
 await AudioClip.load('audio/theme.mp3', {
   onProgress: (progress) => {
     console.log(progress.phase, progress.ratio);
@@ -143,6 +153,9 @@ await AudioClip.load('audio/theme.mp3', {
 Release a clip's decoded buffer with `unload()` once you no longer need it:
 
 ```ts twoslash
+import { AudioClip } from 'blit386';
+declare const theme: AudioClip;
+// ---cut---
 theme.unload(); // releases the decoded buffer; safe to call more than once
 ```
 
@@ -357,6 +370,11 @@ Per-sound controls, all silent no-ops on a stale or invalid `SoundRef` (already 
 throws):
 
 ```ts twoslash
+import { AudioClip, BT } from 'blit386';
+
+const hit = await AudioClip.load('audio/hit.mp3');
+const ref = BT.soundPlay(hit);
+// ---cut---
 BT.soundVolumeSet(ref, 0.5, { fadeMs: 100 });
 BT.soundVolumeGet(ref); // 0.5
 
@@ -456,6 +474,11 @@ happen from normal play.
 requested target (not a mid-fade instantaneous value):
 
 ```ts twoslash
+import { AudioClip, BT } from 'blit386';
+
+const theme = await AudioClip.load('audio/theme.mp3');
+BT.musicPlay(theme);
+// ---cut---
 BT.musicVolumeSet(0.4, { fadeMs: 300 });
 BT.musicVolumeGet(); // 0.4
 ```

--- a/packages/website/content/docs/api/camera.mdx
+++ b/packages/website/content/docs/api/camera.mdx
@@ -17,6 +17,12 @@ The camera applies a global pixel offset to all subsequent draw calls. Integer o
 <Since symbol="BT.cameraClamp" />
 
 ```ts twoslash
+import { BT, Vector2i } from 'blit386';
+declare const scrollX: number;
+declare const scrollY: number;
+declare const desired: Vector2i;
+declare const worldSize: Vector2i;
+// ---cut---
 BT.cameraSet(new Vector2i(scrollX, scrollY)); // apply offset
 BT.camera; // Vector2i – current offset
 BT.cameraReset(); // set back to (0, 0)
@@ -42,6 +48,11 @@ Standalone helper (same math as `BT.cameraClamp`):
 <Since symbol="clampCameraToWorld" />
 
 ```ts twoslash
+import { clampCameraToWorld, Vector2i } from 'blit386';
+declare const desired: Vector2i;
+declare const worldSize: Vector2i;
+declare const viewSize: Vector2i;
+// ---cut---
 const clamped = clampCameraToWorld(desired, worldSize, viewSize);
 ```
 

--- a/packages/website/content/docs/api/core-types.mdx
+++ b/packages/website/content/docs/api/core-types.mdx
@@ -18,6 +18,14 @@ The integer-coordinate primitives shared across the engine: `Vector2i`, `Rect2i`
 Integer 2D vector. Constructor auto-truncates floats toward zero. Used for all positions, sizes, and camera offsets.
 
 ```ts twoslash
+import { Vector2i } from 'blit386';
+declare const x: number;
+declare const y: number;
+declare const a: Vector2i;
+declare const b: Vector2i;
+declare const t: number;
+declare const out: Vector2i;
+// ---cut---
 const v = new Vector2i(10, 20);
 v.x;
 v.y; // direct access
@@ -51,6 +59,29 @@ Instance methods: `.add()`, `.sub()`, `.mul()`, `.dot()`, `.clone()`, `.isEqual(
 Integer rectangle with `x, y, width, height` fields.
 
 ```ts twoslash
+import { Rect2i, Vector2i } from 'blit386';
+declare const x: number;
+declare const y: number;
+declare const width: number;
+declare const height: number;
+declare const min: Vector2i;
+declare const max: Vector2i;
+declare const minX: number;
+declare const minY: number;
+declare const maxX: number;
+declare const maxY: number;
+declare const center: Vector2i;
+declare const size: Vector2i;
+declare const cx: number;
+declare const cy: number;
+declare const w: number;
+declare const h: number;
+declare const point: Vector2i;
+declare const px: number;
+declare const py: number;
+declare const other: Rect2i;
+declare const out: Rect2i;
+// ---cut---
 const r = new Rect2i(x, y, width, height);
 
 // Static factories
@@ -81,6 +112,18 @@ r.max; // Vector2i getter (bottom-right)
 32-bit RGBA color (channels 0–255).
 
 ```ts twoslash
+import { Color32 } from 'blit386';
+declare const r: number;
+declare const g: number;
+declare const b: number;
+declare const a: number;
+declare const value: number;
+declare const newColor: Color32;
+declare const ca: Color32;
+declare const cb: Color32;
+declare const t: number;
+declare const other: Color32;
+// ---cut---
 const c = new Color32(r, g, b, a);
 
 // Cached color constants (static getters; frozen singletons)

--- a/packages/website/content/docs/api/core.mdx
+++ b/packages/website/content/docs/api/core.mdx
@@ -31,6 +31,10 @@ The `bootstrap()` function is the recommended entry point. It handles DOM ready,
 cold start or hot swap, `false` when init fails or a second call is rejected without a hot-reload context.
 
 ```ts twoslash
+import { bootstrap, type IBTDemo, type BootstrapOptions } from 'blit386';
+declare const MyDemo: new () => IBTDemo;
+declare function trackError(err: Error): void;
+// ---cut---
 // One-liner – canvas id defaults to 'blit386-canvas', container to 'canvas-container'
 const started = await bootstrap(MyDemo);
 
@@ -124,6 +128,10 @@ second call silently started another unstoppable `GameLoop`.
 <DemoEmbed demo="001-basics" title="BLIT386 basics demo" />
 
 ```ts twoslash
+import { BT, type IBTDemo } from 'blit386';
+declare const demo: IBTDemo;
+declare const canvas: HTMLCanvasElement;
+// ---cut---
 const ok = await BT.init(demo, canvas); // low-level init; prefer bootstrap()
 BT.displaySize; // Vector2i – configured logical resolution (clone per read)
 BT.drawingBufferSize; // Vector2i | null – output buffer when set in configure()
@@ -332,6 +340,8 @@ without hitting module-load errors from WebGPU-only code.
 Use `activeBackend`, not `requestedBackend`:
 
 ```ts twoslash
+import { BT } from 'blit386';
+// ---cut---
 // Correct: gate on the backend that actually started; BT.effectAdd takes one effect
 if (BT.activeBackend === 'webgpu') {
   for (const fx of BT.preset.crtPipBoy()) {
@@ -350,6 +360,8 @@ if (BT.requestedBackend === 'webgpu') {
 Forcing software up front avoids the fallback path entirely:
 
 ```ts twoslash
+import { type HardwareSettings } from 'blit386';
+// ---cut---
 function configure(): Partial<HardwareSettings> {
   return { backend: 'software' /* ... */ };
 }
@@ -424,6 +436,10 @@ otherwise. The useful thing it buys an `init()` is knowing that something is cov
 happen while the splash holds rather than after the first frame.
 
 ```ts twoslash
+import { BT } from 'blit386';
+
+declare function preloadOptionalAssets(): Promise<void>;
+// ---cut---
 async function init(): Promise<boolean> {
   if (BT.isSplashVisible) {
     // Something is covering for us – use the time to preload extras.

--- a/packages/website/content/docs/api/game-loop.mdx
+++ b/packages/website/content/docs/api/game-loop.mdx
@@ -25,6 +25,8 @@ step, for smoothing motion across that mismatch (see
 [Interpolating render state with renderAlpha](#interpolating-render-state-with-renderalpha) below).
 
 ```ts twoslash
+import { BT } from 'blit386';
+// ---cut---
 BT.deltaSeconds; // seconds per fixed tick (1 / BT.targetFPS)
 BT.timeSeconds; // elapsed seconds since init (ticks × deltaSeconds)
 BT.ticks; // current tick counter (increments each update)
@@ -86,6 +88,10 @@ the simulation has already progressed toward its next step - a fraction in `[0, 
 fraction: `0` means a fixed update just completed, values approaching `1` mean the next update is imminent.
 
 ```ts twoslash
+import { BT, Vector2i } from 'blit386';
+const previousPos = new Vector2i(0, 0);
+const currentPos = new Vector2i(0, 0);
+// ---cut---
 const alpha = BT.renderAlpha;
 const drawX = previousPos.x + (currentPos.x - previousPos.x) * alpha;
 const drawY = previousPos.y + (currentPos.y - previousPos.y) * alpha;
@@ -104,6 +110,9 @@ including a zero-allocation version and `Vector2i.lerp`, see [Guide: Game Loop](
 `intervalTicks / BT.targetFPS`. Use it in `update()` for periodic events: particle spawns, score ticks, palette swaps.
 
 ```ts twoslash
+import { Timer } from 'blit386';
+declare function spawnEnemy(): void;
+// ---cut---
 const spawn = new Timer(180); // every 180 ticks (3 s when BT.targetFPS === 60)
 
 // Inside update():

--- a/packages/website/content/docs/api/overlay.mdx
+++ b/packages/website/content/docs/api/overlay.mdx
@@ -180,6 +180,8 @@ right screen edges. Custom rows are user content, so a `|` in their text stays a
   allocations.
 
 ```ts twoslash
+import { type IBTDemo } from 'blit386';
+// ---cut---
 /** @implements {IBTDemo} */
 class Demo {
   readonly #overlayRows = [{ leftText: 'Position: 0, 0' }, { leftText: 'Score: 0', rightText: 'ready' }];
@@ -284,6 +286,8 @@ bottomReserve = paletteGridHeight + 1 + 13
   `resolveGridVisibleRows`).
 
 ```ts twoslash
+import { type HardwareSettings, Vector2i } from 'blit386';
+// ---cut---
 // Overlay off (release build or custom full-screen HUD).
 function configure(): Partial<HardwareSettings> {
   return {
@@ -296,6 +300,8 @@ function configure(): Partial<HardwareSettings> {
 <Since symbol="OverlayTimingChartStyle" />
 
 ```ts twoslash
+import { type HardwareSettings, Vector2i } from 'blit386';
+// ---cut---
 // Overlay on with palette grid and timing chart.
 function configure(): Partial<HardwareSettings> {
   return {

--- a/packages/website/content/docs/api/palette.mdx
+++ b/packages/website/content/docs/api/palette.mdx
@@ -31,6 +31,10 @@ Slot and `paletteIndex` mean the same integer: which entry in the active palette
 The draw call picks the slot directly. Slot `0` stays transparent (not drawn).
 
 ```ts twoslash
+import { BT, Rect2i, Vector2i } from 'blit386';
+const rect = new Rect2i(0, 0, 320, 240);
+const pos = new Vector2i(0, 0);
+// ---cut---
 BT.drawRectFill(rect, 6); // every pixel uses palette slot 6 (absolute)
 BT.systemPrint(pos, 3, 'Score'); // glyphs use absolute slot 3
 ```
@@ -42,6 +46,11 @@ draw time the WebGPU sprite shader computes `combined = storedIndex + paletteOff
 before palette lookup.
 
 ```ts twoslash
+import { BT, Rect2i, SpriteSheet, Vector2i } from 'blit386';
+declare const sheet: SpriteSheet;
+const src = new Rect2i(0, 0, 32, 32);
+const pos = new Vector2i(0, 0);
+// ---cut---
 BT.drawSprite(sheet, src, pos, 0); // stored 1 → palette[1], stored 2 → palette[2]
 BT.drawSprite(sheet, src, pos, 16); // stored 1 → palette[17], stored 2 → palette[18]
 ```
@@ -70,6 +79,8 @@ after a layout swap when colors moved to different slot numbers (then also call 
 <Since symbol="BT.palette" />
 
 ```ts twoslash
+import { BT, Color32, Palette } from 'blit386';
+// ---cut---
 // Create
 const palette = new Palette(256);
 // const palette2 = BT.paletteCreate(256); // equivalent BT-namespace shorthand
@@ -89,6 +100,8 @@ BT.palette; // → active Palette; throws if none set
 Each preset returns a fully populated `Palette` instance.
 
 ```ts twoslash
+import { Palette } from 'blit386';
+// ---cut---
 Palette.vga(); // VGA 256-color
 Palette.cga(); // CGA 16-color
 Palette.c64(); // Commodore 64 16-color
@@ -104,6 +117,9 @@ Palette.nes(); // NES 64-color
 Fills six consecutive UI-purpose slots into an existing palette and registers `hud_*` name aliases.
 
 ```ts twoslash
+import { BT, Palette } from 'blit386';
+const palette = new Palette(256);
+// ---cut---
 palette.applyHUD(); // fills slots 1-6 (default startSlot = 1)
 palette.applyHUD(10); // fills slots 10-15
 BT.paletteSet(palette);
@@ -123,6 +139,9 @@ The six slots in order, by alias:
 Override individual slots after `applyHUD()`:
 
 ```ts twoslash
+import { BT, Color32, Palette } from 'blit386';
+const palette = new Palette(256);
+// ---cut---
 palette.applyHUD(1);
 palette.set(2, new Color32(20, 16, 32)); // override hud_bg
 BT.paletteSet(palette);
@@ -131,6 +150,9 @@ BT.paletteSet(palette);
 ## Named slot aliases
 
 ```ts twoslash
+import { Palette } from 'blit386';
+const palette = new Palette(256);
+// ---cut---
 palette.setNamed('player', 3); // alias 'player' → slot 3
 palette.getNamed('player'); // → 3 (the slot index)
 palette.getNamedColor('player'); // → Color32 at that slot
@@ -141,6 +163,11 @@ palette.getNamedColor('player'); // → Color32 at that slot
 ## Serialization
 
 ```ts twoslash
+import { Color32, Palette } from 'blit386';
+const palette = new Palette(256);
+declare const out: Float32Array;
+declare const color: Color32;
+// ---cut---
 // JSON round-trip (preserves colors and named aliases)
 const json = palette.toJSON();
 const restored = Palette.fromJSON(json);
@@ -175,6 +202,15 @@ upload). Multiple effects can run simultaneously on different palette ranges and
 needed.
 
 ```ts twoslash
+import { BT, Color32, Palette } from 'blit386';
+declare const start: number;
+declare const end: number;
+declare const speed: number;
+const targetPalette = Palette.vga();
+declare const durationMs: number;
+declare const indexA: number;
+declare const indexB: number;
+// ---cut---
 // Cycle a range of slots (water, fire, plasma)
 BT.paletteCycle(start, end, speed);
 // speed: steps/second, positive = forward, negative = backward
@@ -242,6 +278,10 @@ and leaves the rest of the palette free for another effect.
   }} />
 
 ```ts twoslash
+import { BT, Palette } from 'blit386';
+const gamePalette = Palette.vga();
+const blackPalette = Palette.vga();
+// ---cut---
 // Cinematic fade up from black
 BT.paletteFadeExposure(gamePalette, 1500);
 

--- a/packages/website/content/docs/api/rendering.mdx
+++ b/packages/website/content/docs/api/rendering.mdx
@@ -25,6 +25,15 @@ optional `paletteOffset` added to stored texel indices. See [Palette addressing]
 <Since symbol="BT.drawRectFill" />
 
 ```ts twoslash
+import { BT, Rect2i, Vector2i } from 'blit386';
+declare const paletteIndex: number;
+const rect = new Rect2i(0, 0, 320, 240);
+const pos = new Vector2i(0, 0);
+declare const x: number;
+declare const y: number;
+const p0 = new Vector2i(0, 0);
+const p1 = new Vector2i(100, 100);
+// ---cut---
 BT.clear(paletteIndex); // fill entire display
 BT.clearRect(rect, paletteIndex); // fill rectangular region
 
@@ -53,6 +62,12 @@ Two more primitive-drawing demos: pixel art from number grids, and animated math
 <Since symbol="BT.drawSprite" />
 
 ```ts twoslash
+import { BT, Rect2i, SpriteSheet, Vector2i } from 'blit386';
+declare const sheet: SpriteSheet;
+const srcRect = new Rect2i(0, 0, 32, 32);
+const destPos = new Vector2i(0, 0);
+declare const paletteOffset: number;
+// ---cut---
 BT.drawSprite(sheet, srcRect, destPos);
 BT.drawSprite(sheet, srcRect, destPos, paletteOffset);
 ```
@@ -82,6 +97,10 @@ the palette without re-uploading texels.
   `index = min(combined, 255u)`, so any sum past `255` maps to palette slot `255`.
 
 ```ts twoslash
+import { BT, Rect2i, SpriteSheet, Vector2i } from 'blit386';
+declare const sheet: SpriteSheet;
+const srcRect = new Rect2i(0, 0, 32, 32);
+// ---cut---
 BT.drawSprite(sheet, srcRect, new Vector2i(10, 10)); // normal
 BT.drawSprite(sheet, srcRect, new Vector2i(10, 10), 16); // blue-team shift
 ```
@@ -101,6 +120,8 @@ Draws are auto-batched by texture. Group draws from the same sheet to minimize G
 The following flags are defined for future use. They are not yet accepted by `BT.drawSprite()`:
 
 ```ts twoslash
+import { BT } from 'blit386';
+// ---cut---
 BT.FLIP_H; // horizontal flip
 BT.FLIP_V; // vertical flip
 BT.ROT_90_CW; // rotate 90° clockwise
@@ -113,6 +134,9 @@ BT.ROT_270_CW; // rotate 270° clockwise
 <Since symbol="BT.spritesRefresh" />
 
 ```ts twoslash
+import { BT, Palette } from 'blit386';
+const newLayoutPalette = Palette.vga();
+// ---cut---
 BT.paletteSet(newLayoutPalette);
 BT.spritesRefresh(); // re-maps all tracked sheets to the new slot positions
 ```
@@ -136,6 +160,11 @@ RGBA values are gone.
 Built-in 6×14 monospace font covering printable ASCII (characters 32–126).
 
 ```ts twoslash
+import { BT, Vector2i } from 'blit386';
+const pos = new Vector2i(0, 0);
+declare const paletteIndex: number;
+declare const text: string;
+// ---cut---
 BT.systemPrint(pos, paletteIndex, text); // draw text at pos
 BT.systemPrintMeasure(text); // → Vector2i (pixel width × height)
 ```
@@ -149,6 +178,11 @@ BT.systemPrintMeasure(text); // → Vector2i (pixel width × height)
 Variable-width fonts from `.btfont` files. The font's sprite sheet must be indexized before use.
 
 ```ts twoslash
+import { BitmapFont, BT, Vector2i } from 'blit386';
+const pos = new Vector2i(0, 0);
+declare const text: string;
+declare const paletteOffset: number;
+// ---cut---
 const font = await BitmapFont.load('fonts/MyFont.btfont');
 BT.printFont(font, pos, text);
 BT.printFont(font, pos, text, paletteOffset); // palette-swap variant
@@ -186,6 +220,9 @@ error. Gate effect registration on `BT.activeBackend === 'webgpu'`.
 <Since symbol="green" />
 
 ```ts twoslash
+import { BT, BarrelDistortion, Scanlines, Bloom, PixelGlitch, type Effect } from 'blit386';
+declare const effect: Effect;
+// ---cut---
 // Add effect – routed to pixel or display chain by Effect.tier automatically
 BT.effectAdd(new BarrelDistortion());
 BT.effectAdd(new Scanlines());
@@ -229,6 +266,8 @@ See [Post-Process Effects Guide](/docs/guides/post-process-effects) for paramete
 Capture the current rendered frame as a PNG.
 
 ```ts twoslash
+import { BT } from 'blit386';
+// ---cut---
 // Resolves after the next render pass completes
 const blob = await BT.captureFrame();
 const url = URL.createObjectURL(blob);

--- a/packages/website/content/docs/guides/bitmap-fonts.mdx
+++ b/packages/website/content/docs/guides/bitmap-fonts.mdx
@@ -18,6 +18,8 @@ The engine includes a 6×14 monospace bitmap font covering printable ASCII (char
 loading and is available immediately after initialization:
 
 ```ts twoslash
+import { BT, Vector2i } from 'blit386';
+// ---cut---
 // Draw text with the system font (palette index selects the color)
 BT.systemPrint(new Vector2i(10, 10), 1, 'Hello World!');
 
@@ -310,6 +312,14 @@ Point it at the PNG filename, or embed it as base64.
 <Since symbol="TextSize" />
 
 ```ts twoslash
+import { type Rect2i, type TextSize, type SpriteSheet } from 'blit386';
+interface Glyph {
+  rect: Rect2i;
+  offsetX: number;
+  offsetY: number;
+  advance: number;
+}
+// ---cut---
 declare class BitmapFont {
   static load(url: string): Promise<BitmapFont>;
   readonly name: string;
@@ -331,6 +341,12 @@ Exported type `TextSize` is `{ width: number; height: number }`.
 ### BT.printFont()
 
 ```ts twoslash
+import { BT, type BitmapFont, type Vector2i } from 'blit386';
+declare const font: BitmapFont;
+declare const pos: Vector2i;
+declare const text: string;
+declare const paletteOffset: number;
+// ---cut---
 BT.printFont(font, pos, text);
 BT.printFont(font, pos, text, paletteOffset); // Per-draw index shift (default 0); not a Color32
 ```
@@ -340,6 +356,9 @@ BT.printFont(font, pos, text, paletteOffset); // Per-draw index shift (default 0
 ### Multi-line text
 
 ```ts twoslash
+import { BT, type BitmapFont, Vector2i } from 'blit386';
+declare const font: BitmapFont;
+// ---cut---
 const lines = ['Line 1', 'Line 2', 'Line 3'];
 let y = 10;
 
@@ -352,6 +371,9 @@ for (const line of lines) {
 ### Centered text
 
 ```ts twoslash
+import { BT, type BitmapFont, Vector2i } from 'blit386';
+declare const font: BitmapFont;
+// ---cut---
 const text = 'Centered';
 const textWidth = font.measureText(text);
 const screenWidth = BT.displaySize.x;
@@ -363,6 +385,10 @@ BT.printFont(font, new Vector2i(x, 10), text);
 ### Per-character palette offsets
 
 ```ts twoslash
+import { BT, type BitmapFont, Vector2i } from 'blit386';
+declare const font: BitmapFont;
+declare const text: string;
+// ---cut---
 let x = 10;
 for (let i = 0; i < text.length; i++) {
   const char = text[i];

--- a/packages/website/content/docs/guides/game-loop.mdx
+++ b/packages/website/content/docs/guides/game-loop.mdx
@@ -27,6 +27,10 @@ The fix is to interpolate: keep both the previous and current tick's position, a
 `BT.renderAlpha` as the blend factor. Store the previous position at the start of `update()`, before moving:
 
 ```ts twoslash
+import { BT, Rect2i, SpriteSheet, Vector2i } from 'blit386';
+declare const sheet: SpriteSheet;
+const srcRect = new Rect2i(0, 0, 16, 16);
+// ---cut---
 class Player {
   position = new Vector2i(0, 0);
   previousPosition = new Vector2i(0, 0);
@@ -59,6 +63,10 @@ for prototyping but worth tightening in a shipping demo. Reuse fixed vectors wit
 [Performance Best Practices](/docs/performance/best-practices)):
 
 ```ts twoslash
+import { BT, Rect2i, SpriteSheet, Vector2i } from 'blit386';
+declare const sheet: SpriteSheet;
+const srcRect = new Rect2i(0, 0, 16, 16);
+// ---cut---
 class Player {
   position = new Vector2i(0, 0);
   previousPosition = new Vector2i(0, 0);

--- a/packages/website/content/docs/guides/hot-reload.mdx
+++ b/packages/website/content/docs/guides/hot-reload.mdx
@@ -174,6 +174,8 @@ Every successful Tier 1 or Tier 2 swap also dispatches a `blit386:hot-reload` `C
 same `reason` and `generation` values passed to `onHotReload`:
 
 ```ts twoslash
+declare const canvas: HTMLCanvasElement;
+// ---cut---
 canvas.addEventListener('blit386:hot-reload', (event) => {
   const { reason, generation } = (event as CustomEvent).detail;
 

--- a/packages/website/content/docs/guides/input.mdx
+++ b/packages/website/content/docs/guides/input.mdx
@@ -50,6 +50,8 @@ The engine tracks four pointer slots (indices `0`–`3`). Overflow contacts beyo
 <Since symbol="BT.isPointerActive" />
 
 ```ts twoslash
+import { BT } from 'blit386';
+// ---cut---
 // Current position in display coordinates
 const pos = BT.pointerPos(); // slot 0 (mouse)
 const touch = BT.pointerPos(1); // slot 1 (first touch)
@@ -83,6 +85,8 @@ Use `BT.isDown()`, `BT.isPressed()`, and `BT.isReleased()` with the `BTN_POINTER
 the pointer slot (defaults to `0`):
 
 ```ts twoslash
+import { BT } from 'blit386';
+// ---cut---
 // Hold detection
 BT.isDown(BT.BTN_POINTER_A); // left mouse button held
 BT.isDown(BT.BTN_POINTER_B); // right mouse button held
@@ -144,6 +148,8 @@ not `event.key` layout text.
 Use these for direct key checks:
 
 ```ts twoslash
+import { BT } from 'blit386';
+// ---cut---
 // Held state
 if (BT.isKeyDown('KeyW')) {
   // W key held
@@ -201,6 +207,8 @@ For player 0 and player 1, face-button reads merge keyboard maps and gamepad sta
 `update()`-only edge timing as `BT.isKeyPressed` above.
 
 ```ts twoslash
+import { BT } from 'blit386';
+// ---cut---
 // Player 0 (default: WASD-style + Space / KeyB for A, etc.)
 BT.isDown(BT.BTN_UP, 0);
 BT.isPressed(BT.BTN_A, 0, 6); // edge + repeat every 6 ticks while held
@@ -229,6 +237,8 @@ Override bindings at runtime. The first argument is the zero-based player index 
 ignored). The second is the face button constant. Remaining arguments are `KeyboardEvent.code` strings.
 
 ```ts twoslash
+import { BT } from 'blit386';
+// ---cut---
 BT.inputMap(0, BT.BTN_A, 'Space');
 BT.inputMap(0, BT.BTN_UP, 'ArrowUp', 'KeyW'); // either key triggers UP for player 0
 BT.inputMap(1, BT.BTN_START, 'Enter', 'NumpadEnter');
@@ -240,6 +250,8 @@ BT.inputMapReset();
 Pass no key codes to clear keyboard bindings for that player and button until you map again:
 
 ```ts twoslash
+import { BT } from 'blit386';
+// ---cut---
 BT.inputMap(0, BT.BTN_X); // player 0 X has no keyboard keys until remapped
 ```
 
@@ -262,6 +274,8 @@ BT.inputMap(0, BT.BTN_X); // player 0 X has no keyboard keys until remapped
 <Since symbol="BT.PLAYER_FOUR" />
 
 ```ts twoslash
+import { BT } from 'blit386';
+// ---cut---
 BT.isGamepadConnected(0); // true when player 0 has a connected gamepad
 BT.gamepadCount; // number of connected gamepads (0..4)
 
@@ -307,6 +321,8 @@ details.
 <Since symbol="BT.pointerScrollDelta" />
 
 ```ts twoslash
+import { BT } from 'blit386';
+// ---cut---
 // Accumulated vertical scroll for the current frame, in pixels
 const scroll = BT.pointerScrollDelta;
 
@@ -372,6 +388,8 @@ function configure(): Partial<HardwareSettings> {
 <Since symbol="BT.showCursor" />
 
 ```ts twoslash
+import { BT } from 'blit386';
+// ---cut---
 // In init(): hide the OS cursor and draw your own crosshair / sprite
 BT.hideCursor();
 

--- a/packages/website/content/docs/guides/overlay.mdx
+++ b/packages/website/content/docs/guides/overlay.mdx
@@ -55,6 +55,8 @@ Demos may implement optional `overlayRows()` on `IBTDemo`. The engine calls it o
 overlay body is visible. Return a reused array of row objects when possible – avoid allocating new strings every frame.
 
 ```ts twoslash
+import { type IBTDemo } from 'blit386';
+// ---cut---
 /** @implements {IBTDemo} */
 class Demo {
   readonly #overlayRows = [{ leftText: 'Score: 0' }];
@@ -98,6 +100,8 @@ label, header, dim, FPS) and register `hud_*` name aliases. See
 [Palette Presets – HUD](/docs/guides/palette-presets#hud-preset).
 
 ```ts twoslash
+import { BT, Palette, Vector2i } from 'blit386';
+// ---cut---
 const palette = Palette.vga();
 palette.applyHUD(1); // slots 1-6 + hud_* aliases
 BT.paletteSet(palette);

--- a/packages/website/content/docs/guides/palette.mdx
+++ b/packages/website/content/docs/guides/palette.mdx
@@ -52,6 +52,11 @@ Primitive and clear APIs take an absolute `paletteIndex` (the exact slot written
 values. See [Palette addressing](/docs/api/palette#palette-addressing).
 
 ```ts twoslash
+import { BT, Rect2i, Vector2i } from 'blit386';
+const rect = new Rect2i(0, 0, 320, 240);
+const start = new Vector2i(0, 0);
+const end = new Vector2i(100, 100);
+// ---cut---
 BT.clear(1); // absolute paletteIndex 1
 BT.drawRectFill(rect, 6); // absolute paletteIndex 6
 BT.drawLine(start, end, 12); // absolute paletteIndex 12
@@ -72,6 +77,10 @@ When slot `6` changes in the active palette, every pixel drawn with absolute ind
 Use this when loading sprites for normal game/demo work.
 
 ```ts twoslash
+import { BT, Palette, SpriteSheet, Vector2i } from 'blit386';
+const palette = new Palette(256);
+const pos = new Vector2i(0, 0);
+// ---cut---
 const indexed = await SpriteSheet.loadIndexed('sprites/hero.png', palette, 32, { sort: 'luminance' });
 BT.paletteSet(palette);
 BT.drawSprite(indexed.sheet, indexed.srcRect, pos);
@@ -91,6 +100,9 @@ What it does:
 Use this when you need custom slot planning across multiple images.
 
 ```ts twoslash
+import { BT, Palette, SpriteSheet } from 'blit386';
+const palette = new Palette(256);
+// ---cut---
 await SpriteSheet.loadColorsIntoPalette('sprites/hero.png', palette, 32);
 const sheet = await SpriteSheet.load('sprites/hero.png');
 sheet.indexize(palette);
@@ -111,6 +123,12 @@ BT.paletteSet(palette);
 [Palette addressing](/docs/api/palette#palette-addressing).
 
 ```ts twoslash
+import { BT, Rect2i, SpriteSheet, Vector2i } from 'blit386';
+declare const heroSheet: SpriteSheet;
+const heroSrc = new Rect2i(0, 0, 32, 32);
+const leftTeamPos = new Vector2i(0, 0);
+const rightTeamPos = new Vector2i(100, 0);
+// ---cut---
 BT.drawSprite(heroSheet, heroSrc, leftTeamPos, 0); // base range
 BT.drawSprite(heroSheet, heroSrc, rightTeamPos, 16); // same art, shifted color range
 ```
@@ -133,6 +151,10 @@ No duplicate textures required.
 Palette effects mutate slots over time and are applied in the engine frame pipeline.
 
 ```ts twoslash
+import { BT, Color32, Palette } from 'blit386';
+const nightPalette = Palette.vga();
+const dangerPalette = Palette.vga();
+// ---cut---
 // Cycling: water/lava/plasma
 BT.paletteCycle(240, 248, 4);
 
@@ -219,6 +241,9 @@ Examples:
 If the same colors move to different slot indices, call:
 
 ```ts twoslash
+import { BT, Palette } from 'blit386';
+const newLayoutPalette = Palette.vga();
+// ---cut---
 BT.paletteSet(newLayoutPalette);
 BT.spritesRefresh();
 ```

--- a/packages/website/content/docs/guides/post-process-effects.mdx
+++ b/packages/website/content/docs/guides/post-process-effects.mdx
@@ -29,6 +29,8 @@ For how logical, drawing buffer, CSS cap, and effect tier map to `HardwareSettin
 ## Quick start
 
 ```ts twoslash
+import { BT, Vector2i, BarrelDistortion, Scanlines, RGBMask, Bloom, PixelGlitch } from 'blit386';
+// ---cut---
 class Demo {
   glitch: PixelGlitch | null = null;
 
@@ -151,6 +153,8 @@ vs. RGBA paths – see [Writing a custom effect](#writing-a-custom-effect) below
 ### `HardwareSettings`
 
 ```ts twoslash
+import type { Vector2i } from 'blit386';
+// ---cut---
 interface HardwareSettings {
   displaySize: Vector2i;
   drawingBufferSize?: Vector2i; // drives drawing buffer + CSS, enables display tier

--- a/packages/website/content/docs/guides/splash.mdx
+++ b/packages/website/content/docs/guides/splash.mdx
@@ -28,6 +28,8 @@ So with no configuration at all, a production build shows the splash and a dev s
 ### Turning it off
 
 ```ts twoslash
+import { type HardwareSettings, type IBTDemo } from 'blit386';
+// ---cut---
 class Game implements IBTDemo {
   configure(): Partial<HardwareSettings> {
     return { isSplashEnabled: false };
@@ -73,6 +75,10 @@ That is what `BT.isSplashVisible` is for inside `init()` – if something is alr
 can happen now instead of stuttering the first frames.
 
 ```ts twoslash
+import { BT } from 'blit386';
+
+declare function preloadOptionalAssets(): Promise<void>;
+// ---cut---
 async function init(): Promise<boolean> {
   if (BT.isSplashVisible) {
     await preloadOptionalAssets();
@@ -147,6 +153,8 @@ the value you drew it as, because the logo converter picks a step straight from 
 configurable:
 
 ```ts twoslash
+import { Color32, type HardwareSettings } from 'blit386';
+// ---cut---
 function configure(): Partial<HardwareSettings> {
   return {
     splashColorDark: new Color32(6, 8, 12),

--- a/packages/website/content/docs/performance/best-practices.mdx
+++ b/packages/website/content/docs/performance/best-practices.mdx
@@ -74,6 +74,11 @@ patterns for managing allocations:
 When to use: UI code, one-time operations, and anywhere readability matters more than performance.
 
 ```ts twoslash
+import { BT, type BitmapFont, Rect2i, Vector2i } from 'blit386';
+declare const x: number;
+declare const y: number;
+declare const font: BitmapFont;
+// ---cut---
 // Clear and readable – palette indices, not Color32
 const WHITE = 1;
 BT.drawPixel(new Vector2i(x, y), WHITE);
@@ -99,6 +104,11 @@ Cons:
 When to use: Tight loops that run 50+ times per frame.
 
 ```ts twoslash
+import { BT, type IBTDemo, Rect2i, Vector2i } from 'blit386';
+declare const x: number;
+declare const y: number;
+declare const color: number;
+// ---cut---
 class MyDemo implements IBTDemo {
   // Pre-allocate reusable objects
   private readonly tempVec = new Vector2i(0, 0);
@@ -155,6 +165,22 @@ BLIT386 automatically batches draw calls for optimal GPU performance:
 Optimization tips:
 
 ```ts twoslash
+import { BT, Rect2i, SpriteSheet, Vector2i } from 'blit386';
+declare const enemySheet: SpriteSheet;
+declare const playerSheet: SpriteSheet;
+interface Enemy {
+  sprite: Rect2i;
+  pos: Vector2i;
+  paletteOffset: number;
+}
+declare const enemies: Enemy[];
+const sprite1 = new Rect2i(0, 0, 16, 16);
+const sprite2 = new Rect2i(0, 0, 16, 16);
+const sprite3 = new Rect2i(0, 0, 16, 16);
+const pos1 = new Vector2i(0, 0);
+const pos2 = new Vector2i(16, 0);
+const pos3 = new Vector2i(32, 0);
+// ---cut---
 // Good: All sprites from same sheet
 for (const enemy of enemies) {
   BT.drawSprite(enemySheet, enemy.sprite, enemy.pos, enemy.paletteOffset);
@@ -186,6 +212,11 @@ Changing `paletteOffset` per draw is cheap – it shifts stored texel indices be
 multiplication:
 
 ```ts twoslash
+import { BT, Rect2i, SpriteSheet, Vector2i } from 'blit386';
+declare const sheet: SpriteSheet;
+const sprite = new Rect2i(0, 0, 16, 16);
+const pos = new Vector2i(0, 0);
+// ---cut---
 // Same performance – offset is a uniform add, not per-pixel color math
 BT.drawSprite(sheet, sprite, pos);
 BT.drawSprite(sheet, sprite, pos, 16); // team-color range
@@ -213,6 +244,11 @@ This produces the classic "staircase" look expected in retro demos but requires 
 Optimization tips for diagonal lines:
 
 ```ts twoslash
+import { BT, Vector2i } from 'blit386';
+declare const color: number;
+const p1 = new Vector2i(0, 0);
+const p2 = new Vector2i(100, 100);
+// ---cut---
 // GOOD: Grid lines (axis-aligned) are very cheap
 for (let x = 0; x < 800; x += 40) {
   BT.drawLine(new Vector2i(x, 0), new Vector2i(x, 600), color); // 6 vertices each
@@ -248,6 +284,12 @@ still runs at the browser's refresh rate. This provides:
 ### Using ticks for timing
 
 ```ts twoslash
+import { BT } from 'blit386';
+declare function performAction(): void;
+declare let lastActionTick: number;
+declare let elapsedTime: number;
+declare const deltaTime: number;
+// ---cut---
 // Frame-based timer (recommended)
 if (BT.ticks - lastActionTick >= 60) {
   performAction();
@@ -283,6 +325,9 @@ If your `update()` or `render()` takes too long:
 <Accordion title="1. Premature optimization">
 
 ```ts twoslash
+import { BT, type BitmapFont, Vector2i } from 'blit386';
+declare const font: BitmapFont;
+// ---cut---
 // BAD: Over-engineering simple UI code
 class BadDemo {
   private readonly uiVec = new Vector2i(0, 0);
@@ -317,6 +362,8 @@ Don't guess what's slow – measure it. Use:
 <Accordion title="3. Allocating in hot paths">
 
 ```ts twoslash
+import { BT, Vector2i } from 'blit386';
+// ---cut---
 // BAD: Allocating Vector2i in a tight loop (see pre-allocation section)
 for (let i = 0; i < 1000; i++) {
   BT.drawPixel(new Vector2i(i, 0), 1); // 60,000 Vector2i allocations/sec!
@@ -335,6 +382,10 @@ for (let i = 0; i < 1000; i++) {
 <Accordion title="4. Excessive string concatenation">
 
 ```ts twoslash
+import { BT, type BitmapFont, Vector2i } from 'blit386';
+declare const font: BitmapFont;
+const pos = new Vector2i(10, 10);
+// ---cut---
 // BAD: Creates new string every frame
 class BadStringDemo {
   score = 0;

--- a/packages/website/scripts/__fixtures__/sync-docs/_sitemap.json
+++ b/packages/website/scripts/__fixtures__/sync-docs/_sitemap.json
@@ -5,6 +5,7 @@
   },
   "pages": [
     { "src": "api/renderer.md", "path": "api/renderer", "description": "Renderer API" },
-    { "src": "guide/getting-started.md", "path": "guide/getting-started", "description": "Getting Started" }
+    { "src": "guide/getting-started.md", "path": "guide/getting-started", "description": "Getting Started" },
+    { "src": "api/with-twoslash.md", "path": "api/with-twoslash", "description": "Twoslash fixture." }
   ]
 }

--- a/packages/website/scripts/__fixtures__/sync-docs/api/with-twoslash.md
+++ b/packages/website/scripts/__fixtures__/sync-docs/api/with-twoslash.md
@@ -1,0 +1,11 @@
+# Twoslash Fixture
+
+Fragment-style twoslash block, the pattern documented in `packages/blit386/.claude/rules/twoslash-docs.md`: a hidden
+preamble followed by `// ---cut---`, then the code the reader actually sees.
+
+```ts twoslash
+import { BT, Palette } from 'blit386';
+const nightPalette = Palette.vga();
+// ---cut---
+BT.paletteFade(nightPalette, 2000, 'ease-in-out');
+```

--- a/packages/website/scripts/__tests__/sync-docs-from-engine.test.mjs
+++ b/packages/website/scripts/__tests__/sync-docs-from-engine.test.mjs
@@ -412,3 +412,19 @@ describe('renderPage frontmatter (lastModified, editUrl)', () => {
         assert.ok(contents.includes('<PageChangelog page="api/core-types" />'));
     });
 });
+
+describe('renderPage twoslash fragment blocks (BT-427)', () => {
+    const FIXTURE_PAGE = { src: 'api/with-twoslash.md', description: 'Twoslash fixture.' };
+
+    test('preserves the preamble before // ---cut--- so Twoslash can compile the fragment', () => {
+        // Twoslash type-checks the whole fenced block, including everything above
+        // `// ---cut---`, and only hides that part from the rendered output - it
+        // never sees the mirror's own markdown, only what this generator writes.
+        // Deleting the preamble here removes the imports/declarations the visible
+        // code depends on, so the block fails to compile (see BT-427).
+        const { contents } = renderPage(FIXTURE_PAGE);
+        assert.ok(contents.includes("import { BT, Palette } from 'blit386';"));
+        assert.ok(contents.includes('// ---cut---'));
+        assert.ok(contents.includes("BT.paletteFade(nightPalette, 2000, 'ease-in-out');"));
+    });
+});

--- a/packages/website/scripts/__tests__/sync-docs-from-engine.test.mjs
+++ b/packages/website/scripts/__tests__/sync-docs-from-engine.test.mjs
@@ -418,7 +418,7 @@ describe('renderPage twoslash fragment blocks (BT-427)', () => {
 
     test('preserves the preamble before // ---cut--- so Twoslash can compile the fragment', () => {
         // Twoslash type-checks the whole fenced block, including everything above
-        // `// ---cut---`, and only hides that part from the rendered output - it
+        // `// ---cut---`, and only hides that part from the rendered output – it
         // never sees the mirror's own markdown, only what this generator writes.
         // Deleting the preamble here removes the imports/declarations the visible
         // code depends on, so the block fails to compile (see BT-427).

--- a/packages/website/scripts/sync-docs-from-engine.mjs
+++ b/packages/website/scripts/sync-docs-from-engine.mjs
@@ -369,59 +369,6 @@ const SITE_BANNER_REGION = /\n*<!-- blit386\.dev-banner:start -->[\s\S]*?<!-- bl
 const stripSiteBanner = (markdown) => markdown.replace(SITE_BANNER_REGION, '\n').replace(/^\n+/u, '');
 
 /**
- * Strip preamble lines before `// ---cut---` in twoslash fenced code blocks.
- * Twoslash uses preamble lines only for TypeScript compilation context; readers
- * should never see them. When a cut marker is absent the block passes through
- * unchanged. Only blocks tagged `twoslash` are affected (e.g. ```ts twoslash);
- * plain language blocks (e.g. ```ts) are left untouched.
- */
-const stripTwoslashCutPreambles = (markdown) => {
-    const lines = markdown.split('\n');
-    const result = [];
-    let isInFence = false;
-    let isInTwoslashFence = false;
-    let fenceBuffer = [];
-
-    for (const line of lines) {
-        if (/^\s*```/u.test(line)) {
-            if (!isInFence) {
-                isInFence = true;
-                isInTwoslashFence = /```(?:ts|typescript)\s+twoslash/u.test(line);
-
-                if (isInTwoslashFence) {
-                    fenceBuffer = [];
-                }
-
-                result.push(line);
-            } else {
-                if (isInTwoslashFence) {
-                    const cutIndex = fenceBuffer.findIndex((l) => /^\/\/\s*---cut---\s*$/u.test(l));
-                    result.push(...(cutIndex === -1 ? fenceBuffer : fenceBuffer.slice(cutIndex + 1)));
-                    fenceBuffer = [];
-                }
-
-                isInFence = false;
-                isInTwoslashFence = false;
-                result.push(line);
-            }
-
-            continue;
-        }
-
-        if (isInTwoslashFence) {
-            fenceBuffer.push(line);
-        } else {
-            result.push(line);
-        }
-    }
-
-    // Malformed input: still inside a fence at EOF — flush the buffer as-is.
-    result.push(...fenceBuffer);
-
-    return result.join('\n');
-};
-
-/**
  * Look up the last commit date (ISO 8601, author date) that touched a source doc in
  * the engine repo. Returns `undefined` when git is unavailable, the repo has no
  * history for the path (e.g. a shallow clone), or the call otherwise fails, so a CI
@@ -472,7 +419,7 @@ const renderPage = ({ src, description }, { lastModifiedFor = getLastModified } 
     const { title, body } = extractTitleAndBody(raw, src);
     const sourceRepoDir = posix.dirname(`docs/${src}`);
     const trimmedBody = dropDuplicateIntro(stripSiteBanner(body), description);
-    const { body: rewritten, comments } = transformBody(stripTwoslashCutPreambles(trimmedBody), sourceRepoDir);
+    const { body: rewritten, comments } = transformBody(trimmedBody, sourceRepoDir);
     const banner = [
         `# Generated from blit386/docs/${src} by scripts/sync-docs-from-engine.mjs.`,
         '# Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.',
@@ -617,7 +564,6 @@ export {
     extractTitleAndBody,
     dropDuplicateIntro,
     stripSiteBanner,
-    stripTwoslashCutPreambles,
     isToolingDirective,
     summarizeComment,
     getLastModified,


### PR DESCRIPTION
## Summary

`stripTwoslashCutPreambles` deleted every line before `// ---cut---` in a fragment-style twoslash block before the mdx mirror ever reached Twoslash, removing the imports and declare-const context the visible code depends on. Twoslash's own source shows the opposite is true: it type-checks the whole block, including the preamble, and only strips the cut region from the rendered output afterward - so the preamble must survive into the mirror for the fragment to compile.

Because `source.config.ts` wires `throws: false`, a block that failed to compile silently degraded to plain syntax highlighting instead of failing the build, so this shipped unnoticed across all 18 fragment-style docs (BT-427).

Adds a fixture and a regression test asserting the preamble and the `// ---cut---` marker survive renderPage(). Regenerating the mirror (`pnpm run sync:docs`) is a separate, unstaged change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed documentation rendering for Twoslash code examples.
  * Preserved hidden preambles, separators, imports, and visible example code in generated pages.
  * Added coverage for Twoslash fragment rendering to prevent regressions.

* **Documentation**
  * Added a Twoslash API example demonstrating `BT.paletteFade`.
  * Updated the documentation sitemap to include the new API page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->