### PR TITLE
fix(docs): correct drawRectFill arity in guide-hot-reload.md's Tier 1 example

### DIFF
--- a/packages/blit386/docs/guide-hot-reload.md
+++ b/packages/blit386/docs/guide-hot-reload.md
@@ -45,7 +45,7 @@ instance's prototype is swapped onto the new class. Every field on the instance 
 does not re-run, music keeps playing, and the game loop keeps ticking without a hitch.
 
 ```ts twoslash
-import { BT, type IBTDemo, Vector2i } from 'blit386';
+import { BT, type IBTDemo, Rect2i, Vector2i } from 'blit386';
 
 const SPEED = 120; // change this number and save - the running instance picks it up immediately
 
@@ -61,7 +61,7 @@ class Demo implements IBTDemo {
   }
 
   render() {
-    BT.drawRectFill(this.pos, new Vector2i(16, 16), 1);
+    BT.drawRectFill(new Rect2i(this.pos.x, this.pos.y, 16, 16), 1);
   }
 }
 ```

--- a/packages/website/content/docs/guides/hot-reload.mdx
+++ b/packages/website/content/docs/guides/hot-reload.mdx
@@ -42,7 +42,7 @@ instance's prototype is swapped onto the new class. Every field on the instance 
 does not re-run, music keeps playing, and the game loop keeps ticking without a hitch.
 
 ```ts twoslash
-import { BT, type IBTDemo, Vector2i } from 'blit386';
+import { BT, type IBTDemo, Rect2i, Vector2i } from 'blit386';
 
 const SPEED = 120; // change this number and save - the running instance picks it up immediately
 
@@ -58,7 +58,7 @@ class Demo implements IBTDemo {
   }
 
   render() {
-    BT.drawRectFill(this.pos, new Vector2i(16, 16), 1);
+    BT.drawRectFill(new Rect2i(this.pos.x, this.pos.y, 16, 16), 1);
   }
 }
 ```


### PR DESCRIPTION
## Summary

- `guide-hot-reload.md`'s first `Demo implements IBTDemo` twoslash example called `BT.drawRectFill(this.pos, new Vector2i(16, 16), 1)` - three arguments, as if it took the same `(pos, size, color)` shape as `drawSprite`. The real signature (`BLIT386.ts`) is `drawRectFill: (rect: Rect2i, paletteIndex: number): void` - two arguments. TS2554.
- This block has no `// ---cut---` preamble, so it predates and is unrelated to BT-427's mirror-generator fix - it had been silently degrading to plain highlighting on its own (`transformerTwoslash({ throws: false })`), unnoticed until BT-427's per-block audit surfaced it.
- Fix: construct a `Rect2i` from the demo's position and a fixed 16x16 size, and add `Rect2i` to the block's import line.
- Regenerated the `packages/website` mirror (`pnpm run sync:docs`) so both copies stay in sync.

Fixes BT-430 (found during BT-427's per-block Twoslash audit).

## Test plan

- [x] `pnpm --filter blit386 run preflight` - format, lint, typecheck, spellcheck, knip, doc-banner/`@since`/api-history checks, unit tests all pass
- [x] `pnpm --filter blit386-website run preflight` - format, typecheck, tests, spellcheck, knip, build all pass
- [x] Per-block audit (not just page-level grep, per BT-427's method): built the site (`pnpm --filter blit386 run build && pnpm --filter blit386-website run build`) and inspected `dist/public/docs/guides/hot-reload/index.html` - both `drawRectFill` and `Rect2i` in this specific block render as `class="twoslash-hover"` tokens with real popup content (e.g. the actual `paletteIndex - Palette color index.` param doc), confirming a clean compile rather than the silent plain-text fallback. No `twoslash-error` / `twoslash-fallback` markers on the page.
- [x] `.husky/pre-push` full check suite (package preflights + root `docs:links` + `agents:check`) passed on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzY2PVsMswCj31FtgUJd46