### PR TITLE
fix(docs): correct mergeHardwareSettings arity in api-core.md's twoslash example

### DIFF
--- a/packages/blit386/docs/api-core.md
+++ b/packages/blit386/docs/api-core.md
@@ -480,12 +480,13 @@ Full behavior – the three gating layers, the loading-screen hold, the palette 
 <Since symbol="defaultConfig" />
 <Since symbol="mergeHardwareSettings" />
 
-Import `defaultConfig` and `mergeHardwareSettings` when building custom configure flows outside `bootstrap()`:
+Import `mergeHardwareSettings` when building custom configure flows outside `bootstrap()` – it merges its argument with
+`defaultConfig()` internally, so a partial override is enough to get a full settings object back:
 
 ```ts twoslash
-import { defaultConfig, mergeHardwareSettings } from 'blit386';
+import { mergeHardwareSettings } from 'blit386';
 
-const settings = mergeHardwareSettings(defaultConfig(), { targetFPS: 30 });
+const settings = mergeHardwareSettings({ targetFPS: 30 });
 ```
 
 `defaultConfig()` returns a full `HardwareSettings` object (`320×240` logical, `640×480` drawing buffer, overlay

--- a/packages/website/content/docs/api/core.mdx
+++ b/packages/website/content/docs/api/core.mdx
@@ -475,12 +475,13 @@ Full behavior – the three gating layers, the loading-screen hold, the palette 
 <Since symbol="defaultConfig" />
 <Since symbol="mergeHardwareSettings" />
 
-Import `defaultConfig` and `mergeHardwareSettings` when building custom configure flows outside `bootstrap()`:
+Import `mergeHardwareSettings` when building custom configure flows outside `bootstrap()` – it merges its argument with
+`defaultConfig()` internally, so a partial override is enough to get a full settings object back:
 
 ```ts twoslash
-import { defaultConfig, mergeHardwareSettings } from 'blit386';
+import { mergeHardwareSettings } from 'blit386';
 
-const settings = mergeHardwareSettings(defaultConfig(), { targetFPS: 30 });
+const settings = mergeHardwareSettings({ targetFPS: 30 });
 ```
 
 `defaultConfig()` returns a full `HardwareSettings` object (`320×240` logical, `640×480` drawing buffer, overlay


### PR DESCRIPTION
## Summary

- `api-core.md`'s "Default configuration" twoslash example called `mergeHardwareSettings` with two arguments (`defaultConfig(), { targetFPS: 30 }`); the real signature (`packages/blit386/src/core/IBTDemo.ts:1265`) takes a single optional partial and merges it against `defaultConfig()` internally (TS2554).
- This block has no `// ---cut---` preamble, so it was never touched by BT-427's mirror-generator fix - it had been silently degrading to plain highlighting on its own (`transformerTwoslash({ throws: false })`), unnoticed.
- Dropped the redundant `defaultConfig()` argument and its now-unused import, matching the prose already on this page ("The engine merges them with `defaultConfig()` via `mergeHardwareSettings()`").

Fixes BT-429.

## Test plan

- [x] `pnpm run sync:docs && pnpm run sync:docs:check && pnpm run build` (in `packages/website`) - build completes with no Twoslash compile error
- [x] Per-block audit (per BT-427's method, not just a page-level grep): inspected the built `dist/public/docs/api/core/index.html` directly and confirmed `mergeHardwareSettings`, `settings`, and `targetFPS` all render as `<button class="twoslash-hover">` tokens with real popup content, not the plain-text fallback
- [x] `pnpm run preflight` green in both `packages/blit386` and `packages/website`
- [x] `pnpm run spellcheck` (blit386) and `prettier --check` on touched files
- [x] `packages/website` test suite: 179/179 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzY2PVsMswCj31FtgUJd46