### PR TITLE
fix(docs): resolve WebGPU globals in guide-post-process-effects.md's Twoslash example

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -25,7 +25,13 @@
       "project": ["src/**/*.css", "scripts/**/*.mjs"],
       "ignore": [".source/**", "src/pages.gen.ts", "dist/**", "scripts/prettier-plugin-compact-tables.mjs"],
       "ignoreFiles": ["src/app.css"],
-      "ignoreDependencies": ["@fuma-translate/react", "blit386", "react-server-dom-webpack", "tailwindcss"],
+      "ignoreDependencies": [
+        "@fuma-translate/react",
+        "@webgpu/types",
+        "blit386",
+        "react-server-dom-webpack",
+        "tailwindcss"
+      ],
       "ignoreBinaries": ["ffprobe"]
     },
     "packages/create-blit386": {

--- a/packages/website/content/docs/api/core.mdx
+++ b/packages/website/content/docs/api/core.mdx
@@ -3,7 +3,7 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Core"
 description: "Bootstrap, initialization, and default configuration."
-lastModified: "2026-08-06T19:11:45+02:00"
+lastModified: "2026-08-07T18:30:26+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/api-core.md"
 ---
 

--- a/packages/website/content/docs/guides/hot-reload.mdx
+++ b/packages/website/content/docs/guides/hot-reload.mdx
@@ -3,7 +3,7 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Hot Reload"
 description: "The three hot-reload swap tiers, onHotReload semantics, asset hot-replace, and the blit386/vite plugin."
-lastModified: "2026-08-05T19:53:12+02:00"
+lastModified: "2026-08-07T14:38:27+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/guide-hot-reload.md"
 ---
 

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -78,6 +78,7 @@
     "@types/node": "^25.9.5",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
+    "@webgpu/types": "^0.1.71",
     "blit386": "workspace:*",
     "cross-env": "^7.0.3",
     "cspell": "^10.0.1",
@@ -86,6 +87,7 @@
     "knip": "^6.29.0",
     "prettier": "^3.9.6",
     "tailwindcss": "^4.3.2",
+    "twoslash": "^0.3.9",
     "typescript": "^6.0.3",
     "wrangler": "^4.110.0"
   }

--- a/packages/website/scripts/__tests__/twoslash-webgpu-types.test.mjs
+++ b/packages/website/scripts/__tests__/twoslash-webgpu-types.test.mjs
@@ -1,0 +1,55 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { twoslasher } from 'twoslash';
+
+// Mirrors transformerTwoslash's twoslashOptions.compilerOptions in ../../source.config.ts.
+// Keep the two in sync - this locks in the config that lets Twoslash resolve WebGPU globals
+// (BT-431); if someone edits one without the other, this test is what catches the drift.
+const TWOSLASH_COMPILER_OPTIONS = { types: ['@webgpu/types', 'node'] };
+
+// The `Effect` interface example from packages/blit386/docs/guide-post-process-effects.md.
+const EFFECT_INTERFACE_EXAMPLE = `import type { Effect, EffectTier, Vector2i } from 'blit386';
+
+export class MyEffect implements Effect {
+  public readonly tier: EffectTier = 'display'; // or 'pixel'
+
+  init(device: GPUDevice, format: GPUTextureFormat, displaySize: Vector2i): void {
+    // Create pipeline, uniform buffer, sampler.
+  }
+
+  updateUniforms(deltaMs: number, sourceSize: Vector2i): void {
+    // Write per-frame uniform data to the GPU.
+  }
+
+  encodePass(encoder: GPUCommandEncoder, sourceView: GPUTextureView, destView: GPUTextureView): void {
+    // Begin a render pass against destView, sample sourceView, draw fullscreen triangle.
+  }
+
+  dispose?(): void {
+    // Optional: destroy GPU buffers.
+  }
+}`;
+
+describe('Twoslash WebGPU type resolution (BT-431)', () => {
+    test('compiles the Effect interface example with zero diagnostics', () => {
+        const result = twoslasher(EFFECT_INTERFACE_EXAMPLE, 'ts', { compilerOptions: TWOSLASH_COMPILER_OPTIONS });
+        assert.deepEqual(result.errors, []);
+    });
+
+    test('resolves GPUDevice and GPUTextureFormat in the init() hover', () => {
+        const result = twoslasher(EFFECT_INTERFACE_EXAMPLE, 'ts', { compilerOptions: TWOSLASH_COMPILER_OPTIONS });
+        const hover = result.nodes.find((node) => node.type === 'hover' && node.text.includes('init'));
+        assert.ok(hover && 'text' in hover && hover.text, 'expected a hover node for init()');
+        assert.match(hover.text, /device: GPUDevice/);
+        assert.match(hover.text, /format: GPUTextureFormat/);
+    });
+
+    test('resolves GPUCommandEncoder and GPUTextureView in the encodePass() hover', () => {
+        const result = twoslasher(EFFECT_INTERFACE_EXAMPLE, 'ts', { compilerOptions: TWOSLASH_COMPILER_OPTIONS });
+        const hover = result.nodes.find((node) => node.type === 'hover' && node.text.includes('encodePass'));
+        assert.ok(hover && 'text' in hover && hover.text, 'expected a hover node for encodePass()');
+        assert.match(hover.text, /encoder: GPUCommandEncoder/);
+        assert.match(hover.text, /sourceView: GPUTextureView/);
+        assert.match(hover.text, /destView: GPUTextureView/);
+    });
+});

--- a/packages/website/scripts/__tests__/twoslash-webgpu-types.test.mjs
+++ b/packages/website/scripts/__tests__/twoslash-webgpu-types.test.mjs
@@ -1,11 +1,7 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
 import { twoslasher } from 'twoslash';
-
-// Mirrors transformerTwoslash's twoslashOptions.compilerOptions in ../../source.config.ts.
-// Keep the two in sync - this locks in the config that lets Twoslash resolve WebGPU globals
-// (BT-431); if someone edits one without the other, this test is what catches the drift.
-const TWOSLASH_COMPILER_OPTIONS = { types: ['@webgpu/types', 'node'] };
+import { TWOSLASH_COMPILER_OPTIONS } from '../twoslash-compiler-options.mjs';
 
 // The `Effect` interface example from packages/blit386/docs/guide-post-process-effects.md.
 const EFFECT_INTERFACE_EXAMPLE = `import type { Effect, EffectTier, Vector2i } from 'blit386';

--- a/packages/website/scripts/twoslash-compiler-options.mjs
+++ b/packages/website/scripts/twoslash-compiler-options.mjs
@@ -1,0 +1,5 @@
+// Shared between source.config.ts's transformerTwoslash call and
+// scripts/__tests__/twoslash-webgpu-types.test.mjs, so the regression test
+// exercises the same compiler options the production build uses (BT-431)
+// instead of a copy that could drift out of sync.
+export const TWOSLASH_COMPILER_OPTIONS = { types: ['@webgpu/types', 'node'] };

--- a/packages/website/source.config.ts
+++ b/packages/website/source.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, defineDocs } from 'fumadocs-mdx/config';
 import { blogMetaSchema, blogPageSchema, metaSchema, pageSchema } from 'fumapress/adapters/mdx/schema';
 import { transformerTwoslash } from 'fumadocs-twoslash';
 import { z } from 'zod';
+import { TWOSLASH_COMPILER_OPTIONS } from './scripts/twoslash-compiler-options.mjs';
 
 // Twoslash spins up a TypeScript language service that loads blit386.d.ts plus
 // WebGPU types for every MDX file. Across the 35 MDX files in content/ the
@@ -22,7 +23,7 @@ export default defineConfig({
                 ? [
                       transformerTwoslash({
                           throws: false,
-                          twoslashOptions: { compilerOptions: { types: ['@webgpu/types', 'node'] } },
+                          twoslashOptions: { compilerOptions: TWOSLASH_COMPILER_OPTIONS },
                       }),
                   ]
                 : [],

--- a/packages/website/source.config.ts
+++ b/packages/website/source.config.ts
@@ -18,7 +18,14 @@ export default defineConfig({
             themes: { light: 'github-light', dark: 'github-dark' },
             defaultColor: false,
             langs: ['js', 'jsx', 'ts', 'tsx'],
-            transformers: isProductionBuild ? [transformerTwoslash({ throws: false })] : [],
+            transformers: isProductionBuild
+                ? [
+                      transformerTwoslash({
+                          throws: false,
+                          twoslashOptions: { compilerOptions: { types: ['@webgpu/types', 'node'] } },
+                      }),
+                  ]
+                : [],
         },
     },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,6 +297,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
+      '@webgpu/types':
+        specifier: ^0.1.71
+        version: 0.1.71
       blit386:
         specifier: workspace:*
         version: link:../blit386
@@ -321,6 +324,9 @@ importers:
       tailwindcss:
         specifier: ^4.3.2
         version: 4.3.3
+      twoslash:
+        specifier: ^0.3.9
+        version: 0.3.9(supports-color@10.2.2)(typescript@6.0.3)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3


### PR DESCRIPTION
## Summary

- `packages/website/source.config.ts`'s `transformerTwoslash` call now passes `types: ['@webgpu/types', 'node']` through `twoslashOptions.compilerOptions`, matching `packages/blit386/tsconfig.json`'s own WebGPU types config, so Twoslash's isolated TypeScript environment can resolve `GPUDevice`, `GPUTextureFormat`, `GPUTextureView`, and `GPUCommandEncoder` in the `Effect` interface example.
- Adds `@webgpu/types` as a `packages/website` devDependency, a `knip.json` `ignoreDependencies` entry for it (only referenced as a config string, not imported), and a regression test (`scripts/__tests__/twoslash-webgpu-types.test.mjs`) locking in the compiler options.

**Important nuance** (also posted as a comment on BT-431): verification showed the TS2304 symptom described in the issue doesn't currently reproduce. `packages/website`'s pinned `typescript@6.0.3` already bundles WebGPU declarations in `lib.dom.d.ts`, so Twoslash resolved these types even with the original, unfixed config (confirmed via a differential build – reverted the config, rebuilt, same result). This change lands as hardening against a TypeScript downgrade or a future `lib.dom.d.ts` scope change, not a fix for a currently-failing build.

Fixes BT-431.

## Test plan

- [x] `pnpm run preflight` (packages/website): format, typecheck, tests (182 passing), spellcheck, knip, build – all green
- [x] `pnpm run sync:docs && pnpm run build`, then targeted grep on the built HTML for `docs/guides/post-process-effects`: `GPUDevice`, `GPUTextureFormat`, `GPUTextureView`, `GPUCommandEncoder` all render as `twoslash-hover` tokens with resolved signatures, zero `twoslash-error` markers
- [x] Repo-wide before/after `twoslash-hover` count diff across all 35 built doc pages (differential build with/without the fix) to rule out the narrower `types` list silently breaking another page – no regressions
- [x] `pnpm run sync:docs:check` – only the expected, self-correcting `lastModified` drift
- [x] Pre-push hook (root-level preflight incl. `docs:links`, `agents:check`) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzY2PVsMswCj31FtgUJd46

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved WebGPU code examples on the website with more accurate type information.
  * Added reliable recognition for common WebGPU types, including devices, textures, command encoders, and texture views.
  * Enhanced inline guidance and hover details for WebGPU examples, helping prevent misleading diagnostics.
  * Improved the consistency of type checking across supported WebGPU documentation examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
