### PR TITLE
fix(docs): correct indexedPixels type in api-assets.md's twoslash example

### DIFF
--- a/packages/blit386/docs/api-assets.md
+++ b/packages/blit386/docs/api-assets.md
@@ -74,7 +74,7 @@ AssetLoader.loadingCount;
 ```
 
 `AssetLoader.evict()` is also the manual escape hatch for forcing a fresh load outside the `blit386/vite` plugin's
-automatic asset watcher - see [Hot Reload](guide-hot-reload.md#asset-hot-replace-matrix).
+automatic asset watcher – see [Hot Reload](guide-hot-reload.md#asset-hot-replace-matrix).
 
 <Since symbol="BT.loadingAssetsCount" />
 
@@ -192,7 +192,7 @@ To create a sheet from raw palette-indexed pixel data (advanced / test use):
 import { SpriteSheet } from 'blit386';
 declare const width: number;
 declare const height: number;
-declare const indexedPixels: Uint8Array;
+declare const indexedPixels: Uint8Array<ArrayBuffer>;
 // ---cut---
 const sheet = SpriteSheet.fromIndexedPixels(width, height, indexedPixels);
 ```
@@ -244,20 +244,20 @@ BT.printFont(font, new Vector2i(10, 10), 'Hello!', paletteOffset); // per-draw i
 ## Hot-replacing assets
 
 Under a Vite dev server with the `blit386/vite` plugin installed, editing a sprite sheet's source image or a `.btfont`
-file under a watched asset directory (`public/` by default) updates the already-loaded asset in place - no page reload,
+file under a watched asset directory (`public/` by default) updates the already-loaded asset in place – no page reload,
 and demo-held references (a `SpriteSheet` or `BitmapFont` instance, or an `IndexedSpriteLoadResult.sheet`) stay valid. A
 sprite sheet re-runs `indexize()` against the active palette when it was already indexized; a bitmap font rebuilds its
 glyph tables and texture.
 
 <Callout title="Demo-held srcRects and dimension changes">
   If the replacement image has different dimensions, the sheet's `size` updates to match, but any `Rect2i` a demo is
-  holding onto as a `srcRect` into that sheet does not update itself - reconciling it is the demo's own
+  holding onto as a `srcRect` into that sheet does not update itself – reconciling it is the demo's own
   responsibility. Keep sprite sheet dimensions stable during a hot-reload session, or recompute `srcRect`s from the
   sheet's current `width`/`height` when that matters.
 </Callout>
 
 Each `SpriteSheet` also exposes `status` (`'loading' | 'ready' | 'failed'`) and `progress` (`0` or `1`) tracking a
-replacement fetch while it's in flight - useful for a per-sheet loading indicator, or combine with
+replacement fetch while it's in flight – useful for a per-sheet loading indicator, or combine with
 [`BT.loadingAssetsCount`](#loading-assets) for a single engine-wide signal. A normally loaded sheet is always `'ready'`
 with `progress: 1.0`, since its image has already resolved by the time the sheet is constructed.
 

--- a/packages/website/content/docs/api/assets.mdx
+++ b/packages/website/content/docs/api/assets.mdx
@@ -69,7 +69,7 @@ AssetLoader.loadingCount;
 ```
 
 `AssetLoader.evict()` is also the manual escape hatch for forcing a fresh load outside the `blit386/vite` plugin's
-automatic asset watcher - see [Hot Reload](/docs/guides/hot-reload#asset-hot-replace-matrix).
+automatic asset watcher – see [Hot Reload](/docs/guides/hot-reload#asset-hot-replace-matrix).
 
 <Since symbol="BT.loadingAssetsCount" />
 
@@ -187,7 +187,7 @@ To create a sheet from raw palette-indexed pixel data (advanced / test use):
 import { SpriteSheet } from 'blit386';
 declare const width: number;
 declare const height: number;
-declare const indexedPixels: Uint8Array;
+declare const indexedPixels: Uint8Array<ArrayBuffer>;
 // ---cut---
 const sheet = SpriteSheet.fromIndexedPixels(width, height, indexedPixels);
 ```
@@ -239,20 +239,20 @@ BT.printFont(font, new Vector2i(10, 10), 'Hello!', paletteOffset); // per-draw i
 ## Hot-replacing assets
 
 Under a Vite dev server with the `blit386/vite` plugin installed, editing a sprite sheet's source image or a `.btfont`
-file under a watched asset directory (`public/` by default) updates the already-loaded asset in place - no page reload,
+file under a watched asset directory (`public/` by default) updates the already-loaded asset in place – no page reload,
 and demo-held references (a `SpriteSheet` or `BitmapFont` instance, or an `IndexedSpriteLoadResult.sheet`) stay valid. A
 sprite sheet re-runs `indexize()` against the active palette when it was already indexized; a bitmap font rebuilds its
 glyph tables and texture.
 
 <Callout title="Demo-held srcRects and dimension changes">
   If the replacement image has different dimensions, the sheet's `size` updates to match, but any `Rect2i` a demo is
-  holding onto as a `srcRect` into that sheet does not update itself - reconciling it is the demo's own
+  holding onto as a `srcRect` into that sheet does not update itself – reconciling it is the demo's own
   responsibility. Keep sprite sheet dimensions stable during a hot-reload session, or recompute `srcRect`s from the
   sheet's current `width`/`height` when that matters.
 </Callout>
 
 Each `SpriteSheet` also exposes `status` (`'loading' | 'ready' | 'failed'`) and `progress` (`0` or `1`) tracking a
-replacement fetch while it's in flight - useful for a per-sheet loading indicator, or combine with
+replacement fetch while it's in flight – useful for a per-sheet loading indicator, or combine with
 [`BT.loadingAssetsCount`](#loading-assets) for a single engine-wide signal. A normally loaded sheet is always `'ready'`
 with `progress: 1.0`, since its image has already resolved by the time the sheet is constructed.
 


### PR DESCRIPTION
## Summary

- `packages/blit386/docs/api-assets.md`'s `fromIndexedPixels` Twoslash example declared `indexedPixels: Uint8Array` with no generic argument, which does not structurally satisfy the real signature's `Uint8Array<ArrayBuffer>` under TypeScript's newer generic typed-array types (TS 5.7+) - Twoslash reported TS2345, silently degrading to plain highlighting instead of failing the build (`throws: false`).
- Fixes the `declare const` to match the test fixtures' own pattern (`SpriteSheet.test.ts`), and regenerates the `packages/website` mirror.
- Also fixes four pre-existing hyphen-as-dash violations elsewhere in the same file, surfaced by staging it under the repo's new dash-typography pre-commit check (#486) - unrelated to the type fix but blocking without it.

Fixes BT-428.

## Test plan

- [x] `node scripts/check-dash-typography.mjs packages/blit386/docs/api-assets.md` - clean
- [x] `packages/blit386`: `pnpm run preflight` (format, lint, typecheck, spellcheck, knip, doc-banner/api-history checks, unit tests) - all green
- [x] `packages/website`: `pnpm run sync:docs && pnpm run test` (182 tests) - all green
- [x] `packages/website`: `pnpm run build`, then inspected `dist/public/docs/api/assets/index.html` - `indexedPixels` and `height` in the `fromIndexedPixels(...)` call render as `twoslash-hover` tokens with a popup showing `const indexedPixels: Uint8Array<ArrayBuffer>`, confirming the block now typechecks (per-block audit, not just a page-level grep, per BT-427's method)
- [x] Full `.husky/pre-push` gate (per-package preflight + root `docs:links` + `agents:check`) passed on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzY2PVsMswCj31FtgUJd46