### PR TITLE
fix(docs): make performance-best-practices.md's MyDemo fully implement IBTDemo

### DIFF
--- a/packages/blit386/docs/performance-best-practices.md
+++ b/packages/blit386/docs/performance-best-practices.md
@@ -117,6 +117,12 @@ class MyDemo implements IBTDemo {
   private readonly tempVec = new Vector2i(0, 0);
   private readonly tempRect = new Rect2i(0, 0, 0, 0);
 
+  async init(): Promise<boolean> {
+    return true;
+  }
+
+  update(): void {}
+
   render(): void {
     // Reuse in tight loop
     for (let i = 0; i < 200; i++) {

--- a/packages/website/content/docs/performance/best-practices.mdx
+++ b/packages/website/content/docs/performance/best-practices.mdx
@@ -114,6 +114,12 @@ class MyDemo implements IBTDemo {
   private readonly tempVec = new Vector2i(0, 0);
   private readonly tempRect = new Rect2i(0, 0, 0, 0);
 
+  async init(): Promise<boolean> {
+    return true;
+  }
+
+  update(): void {}
+
   render(): void {
     // Reuse in tight loop
     for (let i = 0; i < 200; i++) {


### PR DESCRIPTION
## Summary

- `packages/blit386/docs/performance-best-practices.md`'s "Pre-allocation (performance)" tab declared `class MyDemo implements IBTDemo` but only defined `render()`, missing the required `init()` and `update()` methods (`configure` and `overlayRows` are the only optional members). Twoslash reported TS2420 once BT-427's fix let the block's `// ---cut---` preamble reach the compiler instead of being stripped.
- Added no-op `async init(): Promise<boolean> { return true; }` and `update(): void {}` stubs, matching the convention every other `implements IBTDemo` example in these docs already follows (`api-core.md`, `guide-hot-reload.md`, `guide-splash.md`, `guide-audio.md`).
- Checked the sibling "Inline (simple & clear)" tab on the same page: it doesn't declare a class at all, so it never had this problem.
- Regenerated the `packages/website` docs mirror (`content/docs/performance/best-practices.mdx`) to match.

Fixes BT-432.

## Test plan

- [x] `pnpm run sync:docs` (from repo root) — only the source doc and its mirror changed, no unrelated drift
- [x] `pnpm --filter blit386 run build` then `CLOUDFLARE=1 pnpm --filter blit386-website run build` — build succeeds
- [x] Per-block audit (not a page-level grep, per BT-427's method): grepped the built HTML around the `MyDemo` block specifically and confirmed `tempVec`/`tempRect` render as `twoslash-hover` tokens with resolved types (`MyDemo.tempVec: Vector2i`, `MyDemo.tempRect: Rect2i`) rather than degrading to plain highlighting, which is what `throws: false` produces on a TS2420 failure
- [x] `pnpm --filter blit386 run typecheck` — clean
- [x] `pnpm --filter blit386 run preflight` — passes
- [x] Pre-push hook (full cross-package preflight, `docs:links`, `agents:check`) — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzY2PVsMswCj31FtgUJd46