### PR TITLE
fix(ci): build the engine in quality-website and patch the nanoid advisory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -647,6 +647,15 @@ jobs:
       - name: Set up workspace
         uses: ./.github/actions/setup
 
+      # Must precede the parallel block, not sit inside it: `pnpm run test` includes
+      # scripts/__tests__/twoslash-webgpu-types.test.mjs, which runs the real twoslasher
+      # over a sample importing `blit386`. The engine is a workspace:* dependency whose
+      # types resolve from packages/blit386/dist, so on a fresh checkout that import is
+      # TS2307 until the engine is built. build-website already does this for the same
+      # reason; this job needs it too, and did not have it.
+      - name: Build engine (workspace dependency)
+        run: pnpm --filter blit386 run build
+
       - name: Lint code
         run: pnpm --filter blit386-website run lint
         background: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   js-yaml@>=3.0.0 <3.15.1: ^3.15.1
   js-yaml@>=4.0.0 <4.3.1: ^4.3.1
   undici@>=7.0.0 <7.29.0: ^7.29.0
+  nanoid@<3.3.17: ^3.3.17
 
 importers:
 
@@ -4753,8 +4754,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -10451,7 +10452,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -10760,7 +10761,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -43,9 +43,10 @@ minimumReleaseAgeExclude:
   - '@types/node'
   - '@commitlint/cli'
   # Security patch for GHSA-2v37-7h3g-55p8, published 2026-08-03 and so still inside the
-  # 7-day window. Excluded so the override above can resolve; drop this entry once the
-  # patch ages past the gate.
-  - nanoid
+  # 7-day window. Pinned to the exact vetted version rather than a bare `nanoid`, which
+  # would exempt every future release from the supply-chain gate permanently. Drop this
+  # entry once the patch ages past the gate.
+  - nanoid@3.3.18
   - '@commitlint/config-conventional'
   - cspell
   - knip

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,6 +15,10 @@ overrides:
   js-yaml@>=3.0.0 <3.15.1: ^3.15.1
   js-yaml@>=4.0.0 <4.3.1: ^4.3.1
   undici@>=7.0.0 <7.29.0: ^7.29.0
+  # GHSA-2v37-7h3g-55p8 (high): custom generators loop indefinitely when size is zero.
+  # Dev-only, reached through postcss via vite and vitest, so it never enters a runtime
+  # bundle - but `security:audit` covers dev + prod, so it fails CI. 3.3.17 is the patch.
+  nanoid@<3.3.17: ^3.3.17
 
 allowBuilds:
   esbuild: true
@@ -38,6 +42,10 @@ minimumReleaseAgeExclude:
   - undici
   - '@types/node'
   - '@commitlint/cli'
+  # Security patch for GHSA-2v37-7h3g-55p8, published 2026-08-03 and so still inside the
+  # 7-day window. Excluded so the override above can resolve; drop this entry once the
+  # patch ages past the gate.
+  - nanoid
   - '@commitlint/config-conventional'
   - cspell
   - knip


### PR DESCRIPTION
`main` is currently red on two unrelated checks. Both are fixed here so dependent work (BT-455 / #489) can land.

## 1. Code Quality (website) – red since #485

#485 added `scripts/__tests__/twoslash-webgpu-types.test.mjs`, which runs the real twoslasher over a sample importing `blit386`. The engine is a `workspace:*` dependency whose types resolve from `packages/blit386/dist`, and **`quality-website` never built it** – so on a fresh checkout the import is `TS2307` and three subtests fail. It passes locally only because a previous build left `dist` behind.

`build-website` already carries a `Build engine (workspace dependency)` step for exactly this reason. `quality-website` now does too, placed **before** the parallel block, since `pnpm run test` runs inside it.

Reproduced by moving `packages/blit386/dist` aside:

```
[2307] 50 - Cannot find module 'blit386' or its corresponding type declarations.
not ok 1 - compiles the Effect interface example with zero diagnostics
not ok 2 - resolves GPUDevice and GPUTextureFormat in the init() hover
not ok 3 - resolves GPUCommandEncoder and GPUTextureView in the encodePass() hover
```

With the engine built: `tests 182 / pass 182 / fail 0`.

## 2. Dependency Security Audit – newly published advisory

[GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) (high) against `nanoid` `<3.3.17`. It was published recently, so it started failing every branch at once – `nanoid@3.3.16` is identical on `main` and on every open branch.

It is reached only through `postcss` via `vite` and `vitest`, so it never enters a runtime bundle, but `security:audit` covers dev and prod together and the policy is moderate-and-above fails.

Fixed with a bounded override in the same shape the existing `js-yaml` and `undici` entries use:

```yaml
nanoid@<3.3.17: ^3.3.17
```

The 3.3.17 patch was published 2026-08-03 and is still inside the 7-day `minimumReleaseAge` window, so `nanoid` also gets a `minimumReleaseAgeExclude` entry – the exception `packages/blit386/docs/security/dependency-policy.md` explicitly sanctions for security patches blocked by release age, with the reason documented in the PR. It resolves to **3.3.18** and `pnpm audit --audit-level=moderate` reports **no known vulnerabilities**.

That exclude entry is temporary: drop it once the patch ages past the gate.

## Test plan

- [x] `pnpm --filter blit386-website run test` → 182/182 with the engine built; the three twoslash subtests fail without it, confirming the diagnosis
- [x] `pnpm audit --audit-level=moderate` → no known vulnerabilities
- [x] `pnpm install` resolves `nanoid` to 3.3.18

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Updated a component to address a known security vulnerability.
  * Allowed the security fix to become available sooner despite release-age safeguards.
  * Reduced exposure to the reported vulnerability while preserving standard update controls.

* **Chores**
  * Improved automated website quality checks by ensuring required components are built before validation.
  * Increased reliability of testing and related tooling in continuous integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->