### PR TITLE
feat(website,demos): add Mastodon rel=me verified link

### DIFF
--- a/packages/demos/_partials/layout.html
+++ b/packages/demos/_partials/layout.html
@@ -13,6 +13,8 @@
     <link rel="stylesheet" href="../styles/twoslash-rich.css"/>
     <link rel="stylesheet" href="../styles/demo-source.css"/>
 
+    <link rel="me" href="https://mastodon.gamedev.place/@blit386"/>
+
     <script>
         // Stamp shell vs embed on <html> before the first paint so layout.css sizing
         // (banner height, iframe vs canvas) is correct on the first frame.

--- a/packages/website/press.config.tsx
+++ b/packages/website/press.config.tsx
@@ -243,6 +243,7 @@ const GLOBAL_HEAD = (
 
         <script defer={true} src="/webmcp.js" />
         <link rel="alternate" type="application/rss+xml" title="BLIT386 Blog" href="/feed.xml" />
+        <link rel="me" href="https://mastodon.gamedev.place/@blit386" />
     </>
 );
 


### PR DESCRIPTION
## Summary

- Adds a sitewide `<link rel="me" href="https://mastodon.gamedev.place/@blit386">` to each package's global `<head>`, so Mastodon's link-verification crawler finds it regardless of which page is registered as the profile's website field.
- `packages/website`: added to `GLOBAL_HEAD` in `press.config.tsx`, alongside the existing favicon/feed head links.
- `packages/demos`: added to the shared `<head>` in `_partials/layout.html`, used by every demo page.

## Test plan

- [x] `pnpm run preflight` green for `packages/website` and `packages/demos`
- [x] Verified `<link rel="me">` renders in the demos dev server output (`/demos/basics.html`)
- [x] `packages/website` typecheck passes
- [ ] After merge: confirm the "Verified" badge appears on the Mastodon profile once Mastodon re-crawls both sites

## Follow-up (not in this PR)

Adding the Mastodon URL to the blit386 GitHub org's profile "Social accounts" setting is a manual account-settings step outside this PR's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)