### PR TITLE
fix(website): correct the stale agent-skills digest and guard it against drift

### DIFF
--- a/packages/website/public/.well-known/agent-skills/index.json
+++ b/packages/website/public/.well-known/agent-skills/index.json
@@ -6,7 +6,7 @@
       "type": "skill-md",
       "description": "Navigate and query the BLIT386 documentation site at blit386.dev. Use when helping a developer learn the BLIT386 JavaScript/TypeScript library, find API references, or locate guides.",
       "url": "/.well-known/agent-skills/blit386-docs/SKILL.md",
-      "digest": "sha256:c827d5df8883e7ad542d60a4f87477684ab8efa5319250210ed9632cf3c9d3a2"
+      "digest": "sha256:01f04847f296716f1b4f51fa24eab0b15fc85ca9195fad21ea43aadf5e1a499c"
     }
   ]
 }

--- a/packages/website/scripts/__tests__/agent-skills-manifest.test.mjs
+++ b/packages/website/scripts/__tests__/agent-skills-manifest.test.mjs
@@ -1,0 +1,29 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+
+const PUBLIC_DIR = fileURLToPath(new URL('../../public/', import.meta.url));
+const MANIFEST_PATH = fileURLToPath(new URL('../../public/.well-known/agent-skills/index.json', import.meta.url));
+
+describe('agent-skills manifest digests', () => {
+    test('every entry digest matches a fresh hash of its url target', async () => {
+        const manifest = JSON.parse(await readFile(MANIFEST_PATH, 'utf8'));
+
+        assert.ok(Array.isArray(manifest.skills), 'manifest.skills must be an array');
+        assert.ok(manifest.skills.length > 0, 'manifest.skills must not be empty');
+
+        for (const skill of manifest.skills) {
+            const targetPath = fileURLToPath(new URL(`.${skill.url}`, `file://${PUBLIC_DIR}`));
+            const content = await readFile(targetPath);
+            const actualDigest = `sha256:${createHash('sha256').update(content).digest('hex')}`;
+
+            assert.equal(
+                skill.digest,
+                actualDigest,
+                `stale digest for '${skill.name}' (${skill.url}): manifest declares '${skill.digest}', file hashes to '${actualDigest}'`,
+            );
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- Correct the stale SHA-256 digest in `packages/website/public/.well-known/agent-skills/index.json` for `blit386-docs/SKILL.md`, which last changed in 9e2b6e64 without a matching digest update
- Add `packages/website/scripts/__tests__/agent-skills-manifest.test.mjs`, a regression test that reads the manifest and recomputes the hash of every entry's `url` target, driven off the manifest so a second skill is covered automatically
- Fixes BT-434 (sub-issue of BT-322)

## Test plan
- [x] Wrote the test first against the stale digest and watched it fail
- [x] Corrected the digest and watched the test pass
- [x] Edited `SKILL.md` and confirmed the test fails, then reverted and confirmed it passes again
- [x] `pnpm --filter blit386-website run test` (183/183 passing)
- [x] `pnpm --filter blit386-website run preflight` (green)
- [x] Push-time root preflight passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)