### PR TITLE
test(ci): move shell-safety suite to root and filter .claude changes

### DIFF
--- a/.claude/skills/preflight/SKILL.md
+++ b/.claude/skills/preflight/SKILL.md
@@ -125,3 +125,7 @@ The following are not part of that pre-push gate – run them directly when audi
 - `pnpm run test:dash-typography` – unit tests for `check-dash-typography.mjs`
 - `pnpm run test:bump-lockstep` – unit tests for `scripts/bump-lockstep.mjs`, the lockstep version-bump script covering
   `blit386`, `@blit386/kit`, and `create-blit386` (see `/release`)
+- `pnpm run test:shell-safety` – unit tests for `.claude/hooks/shell-safety.sh`. Unlike its neighbors above, this one
+  does run in CI: `quality-root` in `.github/workflows/ci.yml` runs it unconditionally, since `.claude/**` is in the
+  `shared` path filter (BT-439). `test:agent-config` and `test:dash-typography` are not yet wired into any CI job –
+  tracked separately in BT-445

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
           filters: |
             shared:
               - '.github/**'
+              - '.claude/**'
               - 'package.json'
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
@@ -86,8 +87,9 @@ jobs:
             # bump-lockstep.mjs/.test.mjs live under root scripts/, not packages/create-blit386/, but
             # build-test-scaffolder is the only CI job that exercises them (test:bump-lockstep). The rest of
             # scripts/ (check-markdown-links.mjs, check-agent-config.mjs, prettier-plugin-compact-tables.mjs,
-            # ...) only feeds quality-root's format:check/docs:links/agents:check steps, which already run
-            # unconditionally - see quality-root's `if` below - so it deliberately has no filter entry here.
+            # shell-safety.test.mjs, ...) only feeds quality-root's format:check/docs:links/agents:check/
+            # test:shell-safety steps, which already run unconditionally – see quality-root's `if` below – so
+            # it deliberately has no filter entry here.
             scaffolder:
               - 'packages/create-blit386/**'
               - 'packages/kit/**'
@@ -124,6 +126,10 @@ jobs:
 
       - name: Check agent config drift
         run: pnpm run agents:check
+        background: true
+
+      - name: Run shell-safety hook tests
+        run: pnpm run test:shell-safety
         background: true
 
       - wait-all:

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:agent-config": "node --test scripts/check-agent-config.test.mjs",
     "check-dash-typography": "node scripts/check-dash-typography.mjs",
     "test:dash-typography": "node --test scripts/check-dash-typography.test.mjs",
+    "test:shell-safety": "node --test scripts/shell-safety.test.mjs",
     "bump": "node scripts/bump-lockstep.mjs",
     "test:bump-lockstep": "node --test scripts/bump-lockstep.test.mjs",
     "security:audit": "pnpm audit --audit-level=moderate",

--- a/scripts/shell-safety.test.mjs
+++ b/scripts/shell-safety.test.mjs
@@ -13,7 +13,7 @@ import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
 const here = dirname(fileURLToPath(import.meta.url));
-const hookPath = join(here, '..', '..', '..', '..', '.claude', 'hooks', 'shell-safety.sh');
+const hookPath = join(here, '..', '.claude', 'hooks', 'shell-safety.sh');
 
 /**
  * @param {string} command The raw shell command text to run the hook against.


### PR DESCRIPTION
## Summary

- Move `packages/website/scripts/__tests__/shell-safety.test.mjs` to `scripts/shell-safety.test.mjs` at the repo root, alongside `check-agent-config.test.mjs` and `check-dash-typography.test.mjs`. It tests the root `.claude/hooks/shell-safety.sh`, not anything website-specific.
- Add a root `package.json` script, `test:shell-safety`, following the `test:agent-config` / `test:dash-typography` naming convention.
- Wire `test:shell-safety` into the unconditional `quality-root` CI job.
- Add `.claude/**` to the `shared` path filter in the `changes` job, so a hook change now reaches every package's quality job, not just `quality-root` and `security-audit`.
- Update `.claude/skills/preflight/SKILL.md` to document the new script and its CI wiring (and note that its `test:agent-config` / `test:dash-typography` neighbors are still not CI-wired - tracked separately in BT-445).

Fixes BT-439 (sub-issue of the BT-322 website package cleanup umbrella).

## Test plan

- [x] `pnpm run test:shell-safety` passes from the new root location: 27/27 tests, unchanged from the pre-move baseline
- [x] `pnpm --filter blit386-website run test` passes with its remaining suites: 155/155 tests
- [x] `node scripts/check-dash-typography.mjs`, biome, prettier, and cspell all clean on touched files
- [x] Verified from a real CI run (https://github.com/blit386/blit386/actions/runs/31249484359), not inferred from the YAML: the `quality-root` job's "Run shell-safety hook tests" step actually executed `node --test scripts/shell-safety.test.mjs` and printed `# tests 27 / # pass 27 / # fail 0` in the job log. The same run also confirms the `shared` filter reaches every package: `Code Quality (website/root/kit/demos/scaffolder/engine)` all completed successfully in that run.

Note: this run's `shared=true` is attributable to several shared-listed paths changing together in this PR (`.github/workflows/ci.yml`, `package.json`, and `.claude/skills/preflight/SKILL.md`), so it isn't a diff confined to only `.claude/`. A perfectly isolated "only `.claude/` changed" CI run needs this PR's filter change to already be on `main`; happy to run that follow-up check right after merge if wanted.