### PR TITLE
feat(demos): generate sitemap.xml at build time

### DIFF
--- a/packages/demos/CLAUDE.md
+++ b/packages/demos/CLAUDE.md
@@ -205,4 +205,6 @@ every push to main, no path filter. The `-next` job sets `BLIT386_CHANNEL=next` 
 `plugins/virtual-demos.js` and `plugins/channel-headers.js` read directly (Node context, at build time – no client-side
 env var involved) to render the unreleased-work banner and a `noindex` meta tag into every page, append
 `X-Robots-Tag: noindex` to `dist/_headers`, and write a disallow-all `dist/robots.txt`. Production gets none of that –
-no banner, no noindex header, and (same as before this) no `robots.txt` at all.
+no banner, no noindex header, and `_headers` stays exactly what `viteStaticCopy` copied. Production's `robots.txt`
+instead allows everything and points crawlers at `dist/sitemap.xml`, which `plugins/sitemap.js` writes from the live
+demo registry (site root plus every demo's canonical extensionless URL, skipped entirely on the `next` channel).

--- a/packages/demos/plugins/channel-headers.js
+++ b/packages/demos/plugins/channel-headers.js
@@ -2,18 +2,21 @@ import { appendFileSync, existsSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { SITE_URL } from './sitemap.js';
+
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const rootDir = resolve(__dirname, '..');
 
 /**
  * On the `next.demos.blit386.dev` preview channel (`BLIT386_CHANNEL=next`, set only in the
- * `deploy-demos-next` CI job — see `.github/workflows/deploy.yml`), appends an
+ * `deploy-demos-next` CI job – see `.github/workflows/deploy.yml`), appends an
  * `X-Robots-Tag: noindex` block to `dist/_headers` and writes a disallow-all `dist/robots.txt`.
- * Production gets neither: `_headers` stays exactly what `viteStaticCopy` copied from
- * `public/_headers`, and no `robots.txt` is written at all, same as today.
+ * Production gets neither `_headers` addition: it stays exactly what `viteStaticCopy` copied
+ * from `public/_headers`. Production's `robots.txt` instead allows everything and points
+ * crawlers at `sitemapPlugin`'s `dist/sitemap.xml`.
  *
  * Runs in `closeBundle`, which fires after every plugin's `writeBundle` hook across the whole
- * build (Rollup runs the hooks in phases, not by plugin array order) — so `dist/_headers` from
+ * build (Rollup runs the hooks in phases, not by plugin array order) – so `dist/_headers` from
  * `viteStaticCopy` already exists by the time this reads/appends to it.
  * @returns {import('vite').Plugin}
  */
@@ -22,11 +25,16 @@ export function channelHeadersPlugin() {
         name: 'channel-headers',
         apply: 'build',
         closeBundle() {
+            const distDir = resolve(rootDir, 'dist');
+
             if (process.env.BLIT386_CHANNEL !== 'next') {
+                writeFileSync(
+                    join(distDir, 'robots.txt'),
+                    `User-agent: *\nAllow: /\n\nSitemap: ${SITE_URL}/sitemap.xml\n`,
+                );
                 return;
             }
 
-            const distDir = resolve(rootDir, 'dist');
             const headersPath = join(distDir, '_headers');
             const noindexBlock =
                 '\n# BT-406: next.demos.blit386.dev preview channel — never index.\n/*\n  X-Robots-Tag: noindex\n';

--- a/packages/demos/plugins/sitemap.js
+++ b/packages/demos/plugins/sitemap.js
@@ -7,8 +7,9 @@ import { buildRegistry } from './demo-registry.js';
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const rootDir = resolve(__dirname, '..');
 
-// Mirrors package.json's "homepage" field – the canonical production origin.
-const SITE_URL = 'https://demos.blit386.dev';
+// Mirrors package.json's "homepage" field – the canonical production origin. Also consumed by
+// channel-headers.js to point production's robots.txt at this file.
+export const SITE_URL = 'https://demos.blit386.dev';
 
 /**
  * Writes `dist/sitemap.xml` from the live demo registry: the site root plus every demo's

--- a/packages/demos/plugins/sitemap.js
+++ b/packages/demos/plugins/sitemap.js
@@ -1,0 +1,46 @@
+import { writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { buildRegistry } from './demo-registry.js';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const rootDir = resolve(__dirname, '..');
+
+// Mirrors package.json's "homepage" field – the canonical production origin.
+const SITE_URL = 'https://demos.blit386.dev';
+
+/**
+ * Writes `dist/sitemap.xml` from the live demo registry: the site root plus every demo's
+ * canonical, extensionless URL. Cloudflare Pages serves `/<slug>` and 308s `/<slug>.html` to
+ * it, so only the extensionless form belongs here – same rule `demoRedirectsPlugin` follows
+ * for `_redirects`.
+ *
+ * Skipped entirely on the `next.demos.blit386.dev` preview channel (`BLIT386_CHANNEL=next`):
+ * that channel already disallows all crawling via `channelHeadersPlugin`'s disallow-all
+ * `robots.txt`, so a sitemap there would contradict it.
+ * @returns {import('vite').Plugin}
+ */
+export function sitemapPlugin() {
+    return {
+        name: 'demo-sitemap',
+        apply: 'build',
+        closeBundle() {
+            if (process.env.BLIT386_CHANNEL === 'next') {
+                return;
+            }
+
+            const registry = buildRegistry(rootDir);
+            const urls = [`${SITE_URL}/`, ...registry.map((entry) => `${SITE_URL}/${entry.slug}`)];
+            const body = urls.map((url) => `    <url>\n        <loc>${url}</loc>\n    </url>`).join('\n');
+
+            const xml =
+                '<?xml version="1.0" encoding="UTF-8"?>\n' +
+                '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n' +
+                `${body}\n` +
+                '</urlset>\n';
+
+            writeFileSync(join(resolve(rootDir, 'dist'), 'sitemap.xml'), xml);
+        },
+    };
+}

--- a/packages/demos/vite.config.js
+++ b/packages/demos/vite.config.js
@@ -9,6 +9,7 @@ import { viteStaticCopy } from 'vite-plugin-static-copy';
 import { buildRegistry } from './plugins/demo-registry.js';
 import { channelHeadersPlugin } from './plugins/channel-headers.js';
 import { VINTAGE_URLS } from './plugins/demo-vintage-urls.js';
+import { sitemapPlugin } from './plugins/sitemap.js';
 import { virtualDemos } from './plugins/virtual-demos.js';
 
 /**
@@ -168,6 +169,7 @@ export default defineConfig(({ command }) => {
             }),
             flattenDemosPlugin(),
             demoRedirectsPlugin(),
+            sitemapPlugin(),
             channelHeadersPlugin(),
         ],
 


### PR DESCRIPTION
## Summary

- Adds `sitemapPlugin` (`packages/demos/plugins/sitemap.js`), wired into `vite.config.js` alongside `demoRedirectsPlugin`/`channelHeadersPlugin`
- Writes `dist/sitemap.xml` from the live demo registry: the site root (`/`) plus every demo's canonical, extensionless URL (`https://demos.blit386.dev/<slug>`)
- Skipped entirely on the `next.demos.blit386.dev` preview channel (`BLIT386_CHANNEL=next`), which already disallows all crawling via `channelHeadersPlugin`'s disallow-all `robots.txt` — a sitemap there would contradict it
- `channelHeadersPlugin` now also writes production's `robots.txt` (previously none at all): allow-all plus a `Sitemap:` directive pointing at `dist/sitemap.xml`, so crawlers can auto-discover it instead of relying solely on manual Search Console submission. `SITE_URL` is exported from `sitemap.js` so both plugins share one source of truth for the origin
- `packages/demos/CLAUDE.md` updated to describe the new production `robots.txt` behavior

Closes BT-380.

## Test plan

`packages/demos` has no unit test runner by design (see its `CLAUDE.md`), so this was verified by hand:

- [x] `pnpm run build` (production) writes `dist/sitemap.xml` (site root + all 46 demo slugs) and an allow-all `dist/robots.txt` with a `Sitemap:` directive
- [x] `BLIT386_CHANNEL=next pnpm run build` writes disallow-all `dist/robots.txt`, no `sitemap.xml`
- [x] `pnpm run preflight` (format, lint, spellcheck, knip, `check:demo-registry`, build) passes
- [x] Pre-push gate passes

Still worth doing manually: submit `https://demos.blit386.dev/sitemap.xml` in Google Search Console for the property, since discovery via `robots.txt` alone can take a while.

🤖 Generated with [Claude Code](https://claude.com/claude-code)