### PR TITLE
fix(demos): point walkthrough article links at docs.blit386.dev

### DIFF
--- a/packages/demos/src/animation.js
+++ b/packages/demos/src/animation.js
@@ -27,7 +27,7 @@
 // Each particle gets its own palette slot at the moment it is spawned.
 // In update(), we compute the color (hue from spawn time, alpha from age)
 // and write it into that slot with palette.set(). In render(), we just
-// use the particle's slot number - no Color32 objects needed there.
+// use the particle's slot number – no Color32 objects needed there.
 //
 // Palette Animation demo explores this palette-animation idea in depth:
 // https://demos.blit386.dev/palette-animation
@@ -69,22 +69,22 @@ const SPRITE_BASE = 20;
 const WALK_FRAME_W = 18;
 const WALK_FRAME_COUNT = 4;
 
-// Scene color slots (low palette slots - text and panels use the shared UI theme instead).
+// Scene color slots (low palette slots – text and panels use the shared UI theme instead).
 const C_GROUND = 1; // (40, 60, 40) dark green ground strip.
 const C_SHADOW = 2; // (0, 0, 0, 100) semi-transparent shadow under the rock.
-const C_STATE_IDLE = 3; // (150, 150, 150) calm gray - the Idle state color.
-const C_STATE_WALK = 4; // (100, 255, 100) "go" green - the Walking state color.
-const C_STATE_JUMP = 5; // (255, 100, 100) alert red - the Jumping state color.
+const C_STATE_IDLE = 3; // (150, 150, 150) calm gray – the Idle state color.
+const C_STATE_WALK = 4; // (100, 255, 100) "go" green – the Walking state color.
+const C_STATE_JUMP = 5; // (255, 100, 100) alert red – the Jumping state color.
 
 // Palette slots of the shared UI theme. applyTheme() in init() writes the twelve UI kit
 // colors into slots 240-251 (its default start slot). configure() runs BEFORE init(), so
-// the overlay styles below cannot read this.theme yet - these constants spell out where
+// the overlay styles below cannot read this.theme yet – these constants spell out where
 // each theme color will land once init() runs.
-const UI_BG = 240; // 'ui_bg' - deep navy screen background.
-const UI_HEADER = 246; // 'ui_header' - warm amber (render bars, chart tags).
-const UI_ACCENT = 247; // 'ui_accent' - phosphor green (update bars).
-const UI_WARM = 248; // 'ui_accent_warm' - orange (chart warning and error frames).
-const UI_INFO = 249; // 'ui_info' - light blue (overlay row text).
+const UI_BG = 240; // 'ui_bg' – deep navy screen background.
+const UI_HEADER = 246; // 'ui_header' – warm amber (render bars, chart tags).
+const UI_ACCENT = 247; // 'ui_accent' – phosphor green (update bars).
+const UI_WARM = 248; // 'ui_accent_warm' – orange (chart warning and error frames).
+const UI_INFO = 249; // 'ui_info' – light blue (overlay row text).
 
 /**
  * Draws one character pose into a walk-strip cell.
@@ -224,15 +224,15 @@ class Demo {
             // Show the scrolling timing chart in the overlay so each frame's update/render cost is visible.
             isOverlayTimingChartEnabled: true,
             overlayTimingChartStyle: {
-                // Theme green - used for update() bars, matching the "ready" cooldown color.
+                // Theme green – used for update() bars, matching the "ready" cooldown color.
                 updateBarPaletteIndex: UI_ACCENT,
-                // Theme amber - used for render() bars.
+                // Theme amber – used for render() bars.
                 renderBarPaletteIndex: UI_HEADER,
-                // Theme orange - flags frames that are close to the frame budget.
+                // Theme orange – flags frames that are close to the frame budget.
                 warningPaletteIndex: UI_WARM,
-                // Theme orange again - the old palette also shared one red for warning and error.
+                // Theme orange again – the old palette also shared one red for warning and error.
                 errorPaletteIndex: UI_WARM,
-                // Theme amber - used for milestone labels such as "Start" or BT.assignTag() calls.
+                // Theme amber – used for milestone labels such as "Start" or BT.assignTag() calls.
                 tagPaletteIndex: UI_HEADER,
             },
         };
@@ -328,11 +328,11 @@ class Demo {
 
             // applyEasing(t, 'ease-in') starts slow and accelerates toward the end.
             // Subtracting from 1 flips it: alpha stays high for most of the particle's life,
-            // then drops quickly right before it disappears - like a real spark that glows
+            // then drops quickly right before it disappears – like a real spark that glows
             // brightly, then winks out all at once instead of fading evenly.
             const alpha = Math.floor(255 * (1 - applyEasing(t, 'ease-in')));
 
-            // Hue is based on when the particle was spawned - no two batches look the same.
+            // Hue is based on when the particle was spawned – no two batches look the same.
             const hue = (p.spawnTick * 3) % 360;
 
             // Compute the color and write it into this particle's reserved palette slot.
@@ -346,7 +346,7 @@ class Demo {
 
     /**
      * Runs once per screen refresh to draw the rock, particles, and UI.
-     * Notice: NO Color32 objects appear in draw calls - only palette indices and offsets.
+     * Notice: NO Color32 objects appear in draw calls – only palette indices and offsets.
      */
     render() {
         // Clear the whole screen with the shared UI theme's background color.
@@ -385,7 +385,7 @@ class Demo {
      * Automatically cycles through Idle -> Walking -> Jumping every 2 seconds each.
      * The full cycle is 6 seconds (360 ticks at 60 FPS).
      *
-     * @param {number} tick - Current tick count.
+     * @param {number} tick – Current tick count.
      */
     autoCycleStates(tick) {
         // cyclePos goes 0..359, repeating.
@@ -507,10 +507,10 @@ class Demo {
         this.nextParticleSlot++;
 
         // Scatter the particle around the rock. BT.random is the engine's shared random number generator, and int()
-        // returns a whole number starting at the first value and stopping just before the second - so int(-5, 25)
+        // returns a whole number starting at the first value and stopping just before the second – so int(-5, 25)
         // gives anything from -5 to 24, and 25 itself never comes up.
         // Both ranges are deliberately lopsided. Most of the x offsets are positive, so dust trails off to the right,
-        // and most of the y offsets are negative, which on screen means upward - the dust rises off the rock.
+        // and most of the y offsets are negative, which on screen means upward – the dust rises off the rock.
         const x = this.charPos.x + BT.random.int(-5, 25);
         const y = this.charPos.y + BT.random.int(-15, 5);
 
@@ -524,7 +524,7 @@ class Demo {
     /**
      * Draws all active particles as small colored squares.
      * The color for each particle was already updated in update() via palette.set().
-     * Here we just use the slot number - no Color32 needed.
+     * Here we just use the slot number – no Color32 needed.
      */
     renderParticles() {
         for (const p of this.particles) {

--- a/packages/demos/src/animation.js
+++ b/packages/demos/src/animation.js
@@ -2,7 +2,7 @@
 //
 // Prerequisites: Basics (https://demos.blit386.dev/basics),
 // Sprites (https://demos.blit386.dev/sprites).
-// Live article: https://vancura.dev/articles/blit386-animation
+// Guide: https://blit386.dev/docs/api/game-loop
 //
 // In BLIT386, the tick counter goes up once per update() call at a fixed rate (targetFPS),
 // not once per screen refresh. render() can run more often than update() on a high refresh

--- a/packages/demos/src/basics-enhanced.js
+++ b/packages/demos/src/basics-enhanced.js
@@ -16,7 +16,7 @@
 //   1. Pixel tier – runs ON the logical index buffer (320x240, palette indices, BEFORE
 //      the palette is resolved into RGB). Effects here distort the indexed image itself.
 //      Only PixelGlitch sits here. See:
-//      https://vancura.dev/articles/blit386-crt-toggle
+//      https://blit386.dev/docs/guides/post-process-effects
 //
 //   2. Display tier – runs AFTER the palette is resolved and the image is upscaled to
 //      the canvas. Effects here work in full-color RGB and can blur, warp, tint, and

--- a/packages/demos/src/basics-enhanced.js
+++ b/packages/demos/src/basics-enhanced.js
@@ -13,18 +13,18 @@
 // The pipeline has two tiers. Both come from the engine's post-process system we
 // explored in crt-pipboy and crt-toggle:
 //
-//   1. Pixel tier - runs ON the logical index buffer (320x240, palette indices, BEFORE
+//   1. Pixel tier – runs ON the logical index buffer (320x240, palette indices, BEFORE
 //      the palette is resolved into RGB). Effects here distort the indexed image itself.
 //      Only PixelGlitch sits here. See:
 //      https://vancura.dev/articles/blit386-crt-toggle
 //
-//   2. Display tier - runs AFTER the palette is resolved and the image is upscaled to
+//   2. Display tier – runs AFTER the palette is resolved and the image is upscaled to
 //      the canvas. Effects here work in full-color RGB and can blur, warp, tint, and
 //      bloom the final image. The other ten effects in this demo live here.
 //
 // Why ten separate display-tier effects instead of one ready-made preset (like
 // BT.preset.crtPipBoy used in crt-toggle)? Because hand-composing the chain makes it possible
-// to drive individual uniforms from a state machine - the glitch state machine below
+// to drive individual uniforms from a state machine – the glitch state machine below
 // picks ONE of five glitch styles, ramps it up for a few frames, and ramps it down again.
 //
 // SOFTWARE FALLBACK: when the engine uses the software renderer, the bouncing sprite
@@ -111,7 +111,7 @@ const GLITCH_LABELS = {
     interference: 'INTERFERENCE',
 };
 
-// The shared fallback note is one long sentence - too wide for this 320-pixel screen in
+// The shared fallback note is one long sentence – too wide for this 320-pixel screen in
 // the 6-pixel-wide system font. split('. ') cuts the string at the sentence break, giving
 // us an array of two shorter lines the UI kit can draw one under the other.
 const FALLBACK_LINES = SOFTWARE_FALLBACK_NOTE.split('. ');
@@ -132,7 +132,7 @@ class Demo {
 
     // Logo position at the START of the most recent update() tick, before that tick
     // moved it. render() blends between this and pos using BT.renderAlpha so the logo
-    // glides smoothly between ticks instead of jumping - same fix and same reason as
+    // glides smoothly between ticks instead of jumping – same fix and same reason as
     // Basics demo (see the big comment above its render() for the full
     // explanation, including why targetFPS 30 makes the stutter especially visible).
     prevPos = new Vector2i(160, 120);
@@ -203,7 +203,7 @@ class Demo {
     // True when WebGPU post-process is available; false in software fallback.
     effectsAvailable = false;
 
-    // Reused every frame for overlayRows() - position, bounces, CRT status, glitch readout.
+    // Reused every frame for overlayRows() – position, bounces, CRT status, glitch readout.
     overlayRowData = [
         { leftText: 'Position (0, 0)', textPaletteIndex: C_OVERLAY_GREEN },
         { leftText: 'Bounces 0', textPaletteIndex: C_OVERLAY_AMBER },
@@ -267,7 +267,7 @@ class Demo {
 
         // Install the shared UI kit colors. The scene owns slots 1-5 and the logo owns
         // slots 10-12, so the kit's default range (240-251, at the top of the palette)
-        // is provably free. The scene keeps its own PipBoy colors - the kit colors are
+        // is provably free. The scene keeps its own PipBoy colors – the kit colors are
         // only for the on-canvas hint and fallback note drawn in render().
         applyTheme(this.palette);
 
@@ -367,11 +367,11 @@ class Demo {
         // draw a smooth in-between position instead of a pop.
         this.prevPos = this.pos;
 
-        // Move the logo by adding speed to position - one step per tick.
+        // Move the logo by adding speed to position – one step per tick.
         this.pos = this.pos.add(this.speed);
 
         // Left/right wall test. pos is the sprite's top-left corner, so the right
-        // edge is at pos.x + size.x. We compare against displaySize.x - size.x.
+        // edge is at pos.x + size.x. We compare against displaySize.x – size.x.
         if (this.pos.x <= 0 || this.pos.x >= BT.displaySize.x - this.size.x) {
             // Flip horizontal direction (multiply speed.x by -1).
             this.speed.x = -this.speed.x;
@@ -406,7 +406,7 @@ class Demo {
 
             this.glitchTicksLeft--;
             if (this.glitchTicksLeft <= 0) {
-                // Burst finished - return effect uniforms to calm resting values.
+                // Burst finished – return effect uniforms to calm resting values.
                 this.resetGlitchUniforms();
 
                 this.glitchCooldown = BT.random.int(GLITCH_COOLDOWN_MIN, GLITCH_COOLDOWN_MAX);
@@ -431,12 +431,12 @@ class Demo {
 
     render() {
         // Clear the logical framebuffer to the PipBoy background color.
-        // C_BG is palette index 1 set in init() - almost black with a faint green tint.
+        // C_BG is palette index 1 set in init() – almost black with a faint green tint.
         BT.clear(C_BG);
 
         // Blend prevPos toward pos by BT.renderAlpha to get the logo's true position at
         // this exact render moment, instead of only its last-tick position. Same fix,
-        // same reason, as the Basics demo - see the big comment above its render().
+        // same reason, as the Basics demo – see the big comment above its render().
         const drawPos = Vector2i.lerp(this.prevPos, this.pos, BT.renderAlpha);
 
         // Draw the bouncing logo at its smoothed position (updated in update(), not here).

--- a/packages/demos/src/camera.js
+++ b/packages/demos/src/camera.js
@@ -8,13 +8,13 @@
 //
 // How BT.cameraSet() works: a positive camera offset shifts the view to the right, so the
 // world appears to scroll left on the screen. A positive X offset means the camera is
-// looking that many pixels to the right of the world's left edge - for example, an X
+// looking that many pixels to the right of the world's left edge – for example, an X
 // offset of 200 shows the world starting 200 pixels in from the left (like the camera
 // moved 200 steps east along the map).
 //
 // Imagine looking through a window: the window doesn't move, but you can shift
 // what part of the outside world you see through it. That's exactly what a camera
-// does in a game. The "camera" here is just an offset - how far we've scrolled
+// does in a game. The "camera" here is just an offset – how far we've scrolled
 // the view to the right and down.
 //
 // This demo creates a 800x600 pixel world (bigger than the 320x240 screen),
@@ -79,7 +79,7 @@ class Demo {
     // Where the camera was at the START of the most recent update() tick, before this
     // tick's sine/cosine math moved it. render() blends between cameraPrevPos and
     // cameraPos using BT.renderAlpha so the camera pans smoothly between physics ticks
-    // instead of jumping - see "Interpolating render state with renderAlpha" in the
+    // instead of jumping – see "Interpolating render state with renderAlpha" in the
     // engine's docs/api-game-loop.md.
     cameraPrevPos = new Vector2i(0, 0);
 
@@ -87,7 +87,7 @@ class Demo {
     // so we do not allocate a new Vector2i every frame.
     cameraRenderPos = new Vector2i(0, 0);
 
-    // A stationary red square we call the "player" - it stays in place
+    // A stationary red square we call the "player" – it stays in place
     // while the camera moves around it.
     playerPos = new Vector2i(400, 300);
 
@@ -163,7 +163,7 @@ class Demo {
         // first, then add the 20 random building colors when we generate the buildings.
         this.palette = BT.paletteCreate(256);
 
-        // Static colors - these are the same every time the demo runs.
+        // Static colors – these are the same every time the demo runs.
         this.palette.set(C_SKY, new Color32(135, 206, 235)); // sky blue background
         this.palette.set(C_GRID, new Color32(100, 180, 100)); // medium green for the ground grid
         this.palette.set(C_WORLD_BORDER, new Color32(255, 0, 0)); // red world boundary rectangle
@@ -224,7 +224,7 @@ class Demo {
         this.cameraPos = BT.cameraClamp(this.cameraPos, this.worldSize, BT.displaySize);
 
         // BT.cameraSet() now happens in render(), using a position blended between
-        // cameraPrevPos and cameraPos - see renderWorld() below.
+        // cameraPrevPos and cameraPos – see renderWorld() below.
     }
 
     /**
@@ -237,7 +237,7 @@ class Demo {
         // Clear the screen to sky blue.
         BT.clear(C_SKY);
 
-        // Blend cameraPrevPos toward cameraPos by BT.renderAlpha - a fraction from 0
+        // Blend cameraPrevPos toward cameraPos by BT.renderAlpha – a fraction from 0
         // (a tick just finished) to just under 1 (the next tick is about to happen) -
         // so the camera's on-screen position matches this exact render moment instead
         // of only its last-tick position. Set it here, right before any world drawing,
@@ -293,7 +293,7 @@ class Demo {
             // Give each building a slightly different blue-gray tint by randomizing R, G, B.
             // BT.random is the engine's shared random number generator.
             // Its int() method gives a whole number from the first value up to (but not including) the second, so
-            // int(100, 200) can be 100, 101, ... 199 - but never 200.
+            // int(100, 200) can be 100, 101, ... 199 – but never 200.
             const r = BT.random.int(100, 200);
             const g = BT.random.int(100, 200);
             const b = BT.random.int(150, 250);
@@ -331,7 +331,7 @@ class Demo {
      */
     generateTrees() {
         // renderTree() draws foliage as a 12x12 square centered on pos, sitting 16 px above
-        // the ground point - so keep a 6 px side margin and a 16 px top margin.
+        // the ground point – so keep a 6 px side margin and a 16 px top margin.
         const treeMarginX = 6;
         const treeMarginTop = 16;
 
@@ -346,7 +346,7 @@ class Demo {
 
         for (let i = 0; i < 50; i++) {
             this.trees.push({
-                // insideRect() hands back a Vector2i somewhere inside that rectangle - like closing your eyes and
+                // insideRect() hands back a Vector2i somewhere inside that rectangle – like closing your eyes and
                 // pointing at a spot on a map.
                 pos: BT.random.insideRect(treeArea),
             });
@@ -404,7 +404,7 @@ class Demo {
     /**
      * Draws a single tree: a brown trunk below a green leafy top.
      *
-     * @param {Vector2i} pos - The center-bottom of the tree in world coordinates.
+     * @param {Vector2i} pos – The center-bottom of the tree in world coordinates.
      */
     renderTree(pos) {
         // Brown trunk: 4 pixels wide, 8 pixels tall, centered on pos.x.
@@ -424,7 +424,7 @@ class Demo {
      * The building's color is identified by its colorIndex (a palette slot number),
      * so no Color32 object is created during drawing.
      *
-     * @param {{pos: Vector2i, size: Vector2i, colorIndex: number}} building - The building data.
+     * @param {{pos: Vector2i, size: Vector2i, colorIndex: number}} building – The building data.
      */
     renderBuilding(building) {
         // Draw the filled body of the building using its stored palette index.
@@ -467,7 +467,7 @@ class Demo {
         // between ui.begin() and ui.end() stacks into one anchored group; the kit
         // measures the rows, draws the panel background, and places it for us.
         // The kit draws in whatever camera space is active, so this must run AFTER
-        // BT.cameraReset() - otherwise the panel would scroll away with the world.
+        // BT.cameraReset() – otherwise the panel would scroll away with the world.
         ui.begin('topLeft');
         ui.panel('Camera Demo');
         ui.label('Auto-scrolling camera', { color: 'dim' });
@@ -495,7 +495,7 @@ class Demo {
         const mapH = 70;
 
         // Background and border for the mini-map frame. The kit has no mini-map
-        // widget, so we draw this panel by hand - but we borrow the shared theme's
+        // widget, so we draw this panel by hand – but we borrow the shared theme's
         // panel and border slots so it matches the kit's look exactly.
         this.tempRect.set(mapX, mapY, mapW, mapH);
         BT.drawRectFill(this.tempRect, this.theme.panel);

--- a/packages/demos/src/camera.js
+++ b/packages/demos/src/camera.js
@@ -4,7 +4,7 @@
 // (https://demos.blit386.dev/basics) and shapes in Primitives demo
 // (https://demos.blit386.dev/primitives).
 //
-// Live walkthrough: https://vancura.dev/articles/blit386-camera
+// Guide: https://blit386.dev/docs/api/camera
 //
 // How BT.cameraSet() works: a positive camera offset shifts the view to the right, so the
 // world appears to scroll left on the screen. A positive X offset means the camera is

--- a/packages/demos/src/colors.js
+++ b/packages/demos/src/colors.js
@@ -13,7 +13,7 @@
 // https://demos.blit386.dev/basics
 //
 // Live version: https://demos.blit386.dev/colors
-// Walkthrough article: https://vancura.dev/articles/blit386-colors
+// Guide: https://blit386.dev/docs/api/core-types#color32
 //
 // IMPORTANT – palettes and how they changed from older demos:
 //

--- a/packages/demos/src/colors.js
+++ b/packages/demos/src/colors.js
@@ -1,9 +1,9 @@
-// Colors Demo - a deep dive into Color32 and palettes in BLIT386.
+// Colors Demo – a deep dive into Color32 and palettes in BLIT386.
 //
 // Part of the BLIT386 demo series, written for young learners (around 12)
 // who are getting comfortable with code. You will see:
 //
-//   - Named shortcut colors (Color32.red and friends - static properties, not function calls)
+//   - Named shortcut colors (Color32.red and friends – static properties, not function calls)
 //   - How red, green, and blue light mix to make new colors
 //   - HSL: another way to pick colors (hue, saturation, lightness) and a scrolling rainbow
 //   - Alpha: the fourth number that makes colors see-through
@@ -15,9 +15,9 @@
 // Live version: https://demos.blit386.dev/colors
 // Walkthrough article: https://vancura.dev/articles/blit386-colors
 //
-// IMPORTANT - palettes and how they changed from older demos:
+// IMPORTANT – palettes and how they changed from older demos:
 //
-//   The engine now uses a "palette" - a table of up to 256 numbered colors.
+//   The engine now uses a "palette" – a table of up to 256 numbered colors.
 //   Instead of passing a Color32 to every draw call, you pick a number (an "index")
 //   from the palette. Think of it like numbered paint cans: you choose which can to use,
 //   not the exact mix of paint every time you pick up the brush.
@@ -25,14 +25,14 @@
 //   Static colors (named swatches, alpha layers) go into the palette once during init().
 //   Animated colors (HSL rainbow, lerp gradient, pulse) are recalculated every tick
 //   inside update() and written back into their reserved palette slots.
-//   render() only ever uses palette index numbers - no Color32 objects there.
+//   render() only ever uses palette index numbers – no Color32 objects there.
 //
 //   The numbered section headers are drawn with the shared UI kit (src/shared/ui.js),
-//   which parks its own twelve colors in high slots 240-251 - far away from every slot
+//   which parks its own twelve colors in high slots 240-251 – far away from every slot
 //   this lesson uses. The swatches and their little labels stay hand-drawn on purpose:
 //   they ARE the lesson.
 //
-// IMPORTANT - update() ticks vs render() frames:
+// IMPORTANT – update() ticks vs render() frames:
 //   update() runs at a fixed rate (here, 60 times per second when the tab is active).
 //   Each call to update() is one "tick". Our animTime adds 1/60 on every tick, so after
 //   60 ticks (about one second), animTime is about 1.0. That is time measured in ticks,
@@ -54,39 +54,39 @@ import { applyTheme, ui } from './shared/ui.js';
 
 //
 // These numbers are the palette "addresses". We name them so the code is readable.
-// Index 0 is always transparent and reserved - never assign to it.
+// Index 0 is always transparent and reserved – never assign to it.
 
 // Basic colors (set once in init, never change).
-const C_WHITE = 1; // Pure white - the WHT swatch and labels on dark swatches.
+const C_WHITE = 1; // Pure white – the WHT swatch and labels on dark swatches.
 const C_BG = 2; // Dark gray-blue background.
-const C_BLACK = 3; // Pure black - labels on light-colored swatches.
-const C_RED = 4; // Color32.red - (255, 0, 0).
-const C_GREEN_N = 5; // Color32.green - (0, 255, 0).
-const C_BLUE_N = 6; // Color32.blue - (0, 0, 255).
-const C_YELLOW_N = 7; // Color32.yellow - (255, 255, 0).
-const C_CYAN_N = 8; // Color32.cyan - (0, 255, 255).
-const C_MAGENTA_N = 9; // Color32.magenta - (255, 0, 255).
+const C_BLACK = 3; // Pure black – labels on light-colored swatches.
+const C_RED = 4; // Color32.red – (255, 0, 0).
+const C_GREEN_N = 5; // Color32.green – (0, 255, 0).
+const C_BLUE_N = 6; // Color32.blue – (0, 0, 255).
+const C_YELLOW_N = 7; // Color32.yellow – (255, 255, 0).
+const C_CYAN_N = 8; // Color32.cyan – (0, 255, 255).
+const C_MAGENTA_N = 9; // Color32.magenta – (255, 0, 255).
 
 // Semi-transparent versions for the RGB mix section.
-const C_MIX_RED_A = 10; // (255, 0, 0, 140) - translucent red.
-const C_MIX_GREEN_A = 11; // (0, 255, 0, 140) - translucent green.
-const C_MIX_BLUE_A = 12; // (0, 0, 255, 140) - translucent blue.
+const C_MIX_RED_A = 10; // (255, 0, 0, 140) – translucent red.
+const C_MIX_GREEN_A = 11; // (0, 255, 0, 140) – translucent green.
+const C_MIX_BLUE_A = 12; // (0, 0, 255, 140) – translucent blue.
 
 // Alpha-layered colors for the alpha demo section.
-const C_ALPHA_BASE = 13; // (255, 140, 40, 255) - opaque orange base.
-const C_ALPHA_1 = 14; // (80, 120, 255, 180) - semi-transparent blue.
-const C_ALPHA_2 = 15; // (200, 80, 200, 140) - semi-transparent purple.
-const C_ALPHA_3 = 16; // (120, 255, 120, 100) - semi-transparent green.
+const C_ALPHA_BASE = 13; // (255, 140, 40, 255) – opaque orange base.
+const C_ALPHA_1 = 14; // (80, 120, 255, 180) – semi-transparent blue.
+const C_ALPHA_2 = 15; // (200, 80, 200, 140) – semi-transparent purple.
+const C_ALPHA_3 = 16; // (120, 255, 120, 100) – semi-transparent green.
 const C_ALPHA_4 = 17; // (255, 255, 255, 70)  - almost-invisible white.
 
 // Lerp endpoints (the two colors being blended).
-const C_LERP_A = 18; // (180, 40, 220) - purple.
-const C_LERP_B = 19; // (40, 220, 160) - teal.
+const C_LERP_A = 18; // (180, 40, 220) – purple.
+const C_LERP_B = 19; // (40, 220, 160) – teal.
 
-// Static overlay bar color - never animated (configure() needs a fixed slot).
+// Static overlay bar color – never animated (configure() needs a fixed slot).
 const C_OVERLAY_BAR = 20; // Soft blue-gray for the engine overlay background strip.
 
-// Dynamic slots - recalculated every tick in update().
+// Dynamic slots – recalculated every tick in update().
 
 // HSL rainbow strip: 64 hue slots covering the full 0..360 degree color wheel.
 // Slot C_HSL_BASE+i represents the color for column group i.
@@ -103,7 +103,7 @@ const C_PULSE = 126;
 /**
  * Shows how Color32 works: RGB names, mixing, HSL rainbow, alpha, and lerp.
  * All animated colors are computed in update() and stored in palette slots.
- * render() uses only palette index numbers - no Color32 objects there.
+ * render() uses only palette index numbers – no Color32 objects there.
  *
  * @implements {IBTDemo}
  */
@@ -140,7 +140,7 @@ class Demo {
             overlayPaletteRowsVisible: 4,
 
             overlayStyle: {
-                // Dedicated static slot - not C_LERP_BASE, which update() rewrites every tick.
+                // Dedicated static slot – not C_LERP_BASE, which update() rewrites every tick.
                 barPaletteIndex: C_OVERLAY_BAR,
                 textPaletteIndex: C_ALPHA_2,
                 gapPaletteIndex: C_BLACK,
@@ -187,7 +187,7 @@ class Demo {
         this.palette.set(C_ALPHA_3, new Color32(120, 255, 120, 100));
         this.palette.set(C_ALPHA_4, new Color32(255, 255, 255, 70));
 
-        // Lerp endpoints - the two colors the gradient blends between.
+        // Lerp endpoints – the two colors the gradient blends between.
         this.lerpColorA = new Color32(180, 40, 220); // Purple.
         this.lerpColorB = new Color32(40, 220, 160); // Teal.
         this.palette.set(C_LERP_A, this.lerpColorA);
@@ -365,7 +365,7 @@ class Demo {
      * Draws one horizontal strip where each column group uses a palette slot from C_HSL_BASE.
      *
      * The HSL slots are updated in update() so the rainbow scrolls over time.
-     * This function only maps each x column to the right slot - no Color32 objects needed.
+     * This function only maps each x column to the right slot – no Color32 objects needed.
      *
      * Hue is an angle 0..360 on a color wheel. 64 slots cover the whole wheel in steps.
      */
@@ -398,7 +398,7 @@ class Demo {
 
         const box = new Rect2i(20, 138, 200, 40);
 
-        // Bottom layer: fully opaque orange - you always see this one.
+        // Bottom layer: fully opaque orange – you always see this one.
         BT.drawRectFill(box, C_ALPHA_BASE);
 
         // Each new layer is more transparent so you still see the orange through them.

--- a/packages/demos/src/crt-pipboy.js
+++ b/packages/demos/src/crt-pipboy.js
@@ -1,4 +1,4 @@
-// @pageTitle BLIT386 Demo - PipBoy CRT
+// @pageTitle BLIT386 Demo – PipBoy CRT
 //
 // PipBoy CRT: a faux Fallout terminal with scanlines, glitches, and bloom.
 //
@@ -36,13 +36,13 @@
 // writes a new one, and the last effect in the display chain writes to the swap chain.
 //
 // Pixel-tier effects (e.g. PixelGlitch) operate on the logical framebuffer, which stores
-// palette slot indices (GPU format r8uint) at 320x240 - not full RGBA yet. They stay
+// palette slot indices (GPU format r8uint) at 320x240 – not full RGBA yet. They stay
 // palette-native: integer texture reads, no averaging into fake in-between colors.
 //
 // Next the engine runs palette LUT resolve plus upscale: each index becomes a real RGBA
 // color and the image grows to the canvas size (here 1280x960). Display-tier effects
 // (e.g. BarrelDistortion, Scanlines) run on that RGBA output. Crucially, BarrelDistortion
-// does NOT bend the curve on the 320x240 index grid - lines stay smooth instead of
+// does NOT bend the curve on the 320x240 index grid – lines stay smooth instead of
 // breaking into stair-steps.
 //
 // HOW THE GLITCH STATE MACHINE WORKS
@@ -132,7 +132,7 @@ const BOOT_LINE_SPACER_TICKS = 6;
 const BOOT_TICKS_PER_CHAR = 2;
 
 // The boot sequence. Each entry is one line that appears letter-by-letter.
-// Keep this short - with too many lines the demo never finishes booting.
+// Keep this short – with too many lines the demo never finishes booting.
 // Tip: read this top-to-bottom to imagine how a real PipBoy might wake up.
 const BOOT_LINES = [
     'ROBCO INDUSTRIES (TM) PIP-BOY 3000',
@@ -186,7 +186,7 @@ const FLICKER_BASE = 1.0;
 const FLICKER_DIP = 0.6;
 
 // Resting values the glitch state machine returns to between bursts.
-// ABERRATION_BASE is 0 so the screen is clean between bursts - chromasplit
+// ABERRATION_BASE is 0 so the screen is clean between bursts – chromasplit
 // glitches then clearly pop the channel split on from nothing rather than
 // boosting an already-visible split. NOISE_BASE is the constant faint grain.
 const ABERRATION_BASE = 0;
@@ -238,7 +238,7 @@ class Demo {
     /** Tick count captured when the boot sequence started. */
     bootStartTick = 0;
 
-    /** Ticks elapsed since bootStartTick - refreshed every update(). */
+    /** Ticks elapsed since bootStartTick – refreshed every update(). */
     ticksSinceBoot = 0;
 
     /** True after the first frame where the boot sequence is fully visible. */
@@ -335,7 +335,7 @@ class Demo {
         BT.paletteSet(palette);
 
         // Step 2: load the bitmap font
-        // PragmataPro is a monospaced programming font - a perfect fit for a fictional
+        // PragmataPro is a monospaced programming font – a perfect fit for a fictional
         // terminal. The .btfont is a BLIT386 bitmap font: a PNG glyph atlas plus a
         // small JSON describing each character's bounds.
         this.font = await BitmapFont.load('/fonts/PragmataPro14.btfont');
@@ -422,7 +422,7 @@ class Demo {
         this.flicker = new Flicker();
         this.flicker.amount = FLICKER_BASE;
 
-        // Bloom: a soft glow on bright pixels - the warm phosphor halo of an old monitor.
+        // Bloom: a soft glow on bright pixels – the warm phosphor halo of an old monitor.
         // Stacked LAST so the bloom sees the final post-CRT image.
         this.bloom = new Bloom();
         this.bloom.spread = 3.0; // size of the bloom kernel
@@ -471,7 +471,7 @@ class Demo {
         }
 
         // 1. Drive the boot animation timer
-        // We don't draw here - render() reads `this.ticksSinceBoot` and computes how many
+        // We don't draw here – render() reads `this.ticksSinceBoot` and computes how many
         // characters to show. update() just provides time.
         this.ticksSinceBoot = BT.ticks - this.bootStartTick;
 
@@ -506,7 +506,7 @@ class Demo {
             this.renderBlinkingCursor();
         }
 
-        // In software mode the CRT stack is skipped - say so with a kit label. Omitting
+        // In software mode the CRT stack is skipped – say so with a kit label. Omitting
         // ui.panel() keeps the group borderless, so it reads as a single caption line.
         if (!this.effectsAvailable) {
             ui.begin('bottomLeft');
@@ -517,10 +517,10 @@ class Demo {
 
     /**
      * Layers the chosen glitch personality onto the resting effect uniforms.
-     * Different burst types drive different effect uniforms - that is what gives each
+     * Different burst types drive different effect uniforms – that is what gives each
      * burst its own visual feel.
      *
-     * @param {number} envelope - 0 -> 1 -> 0 over the lifetime of the burst.
+     * @param {number} envelope – 0 -> 1 -> 0 over the lifetime of the burst.
      */
     applyGlitchUniforms(envelope) {
         const peak = this.glitchPeak * envelope;
@@ -574,7 +574,7 @@ class Demo {
     stepGlitchMachine() {
         if (this.glitchTicksLeft > 0) {
             // We are inside a glitch burst. Build an "envelope": ramps up to glitchPeak,
-            // holds, then ramps down. Sounds fancy - in practice it just makes a sin curve
+            // holds, then ramps down. Sounds fancy – in practice it just makes a sin curve
             // over the lifetime of the burst (sin from 0 to PI is a nice 0 -> 1 -> 0 hump).
             const t = 1 - this.glitchTicksLeft / this.glitchDuration; // 0 at start, 1 at end
             const envelope = Math.sin(t * Math.PI); // 0 -> 1 -> 0
@@ -588,7 +588,7 @@ class Demo {
                 this.glitchCooldown = BT.random.int(GLITCH_COOLDOWN_MIN, GLITCH_COOLDOWN_MAX);
             }
         } else {
-            // No active glitch - count down to the next one.
+            // No active glitch – count down to the next one.
             this.glitchCooldown--;
             if (this.glitchCooldown <= 0) {
                 // Roll a new burst. pick() draws one item out of a list, like taking a
@@ -612,7 +612,7 @@ class Demo {
      *
      * @param {Vector2i} pos
      * @param {string} text
-     * @param {number} slot - target palette slot index (e.g. C_GREEN)
+     * @param {number} slot – target palette slot index (e.g. C_GREEN)
      */
     print(pos, text, slot) {
         BT.printFont(this.font, pos, text, slot - C_WHITE);
@@ -640,7 +640,7 @@ class Demo {
             // BOOT_TICKS_PER_CHAR ticks. Clamp to [0, length].
             const charsToShow = Math.max(0, Math.min(fullLine.length, Math.floor(ticksLeft / BOOT_TICKS_PER_CHAR)));
             if (charsToShow === 0) {
-                // Future line, not yet started. Stop - everything below is also invisible.
+                // Future line, not yet started. Stop – everything below is also invisible.
                 return;
             }
 
@@ -684,7 +684,7 @@ class Demo {
             const y = y0 + (i + 2) * LINE_HEIGHT;
             this.print(new Vector2i(x, y), label, C_GREEN_DIM);
             // Right-align the value. Label sits at column 0; value sits at column 70px.
-            // Hand-tuned for this font size - fine because both label and value are short.
+            // Hand-tuned for this font size – fine because both label and value are short.
             this.print(new Vector2i(x + 70, y), value, colorSlot(colorName));
         }
     }

--- a/packages/demos/src/crt-pipboy.js
+++ b/packages/demos/src/crt-pipboy.js
@@ -9,7 +9,7 @@
 //
 // Live version: https://demos.blit386.dev/crt-pipboy
 //
-// Live article: https://vancura.dev/articles/blit386-pipboy-crt
+// Guide: https://blit386.dev/docs/guides/post-process-effects
 //
 // WHAT YOU WILL SEE
 // A green-on-black terminal that looks like an old curved CRT screen. Scanlines, a soft

--- a/packages/demos/src/crt-toggle.js
+++ b/packages/demos/src/crt-toggle.js
@@ -9,7 +9,7 @@
 //
 // Live version: https://demos.blit386.dev/crt-toggle
 //
-// Live article: https://vancura.dev/articles/blit386-crt-toggle
+// Guide: https://blit386.dev/docs/guides/post-process-effects
 //
 // WHAT YOU WILL SEE
 // A colorful, simple scene – bouncing squares and a few horizontal bars. Every two seconds

--- a/packages/demos/src/crt-toggle.js
+++ b/packages/demos/src/crt-toggle.js
@@ -1,4 +1,4 @@
-// @pageTitle BLIT386 Demo - CRT Toggle
+// @pageTitle BLIT386 Demo – CRT Toggle
 //
 // CRT Toggle: turn the post-process effects on and off in flight.
 //
@@ -12,7 +12,7 @@
 // Live article: https://vancura.dev/articles/blit386-crt-toggle
 //
 // WHAT YOU WILL SEE
-// A colorful, simple scene - bouncing squares and a few horizontal bars. Every two seconds
+// A colorful, simple scene – bouncing squares and a few horizontal bars. Every two seconds
 // the CRT preset flips on and off automatically. Status text sits in a small panel drawn
 // with the shared UI kit. While it is on
 // you see scanlines, the RGB shadow mask, smooth barrel curvature, and a soft phosphor
@@ -20,8 +20,8 @@
 // The bouncing keeps going either way, so you can compare the two looks side by side.
 //
 // Notice that the lines stay STRAIGHT through the toggle: barrel distortion is display-tier,
-// so it runs on RGBA after palette resolve + upscale to the canvas size - not on the
-// 320x240 index buffer - which avoids stair-step artifacts on diagonals.
+// so it runs on RGBA after palette resolve + upscale to the canvas size – not on the
+// 320x240 index buffer – which avoids stair-step artifacts on diagonals.
 //
 // WHAT YOU WILL LEARN
 //   - How to add and remove a STACK of post-process effects at runtime.
@@ -30,7 +30,7 @@
 //     screen texture; the last BT.effectRemove or BT.effectClear frees it again.
 //   - That you keep the SAME effect instances across toggles. Demos that destroy and
 //     recreate them on every toggle would also work, but they would re-create the GPU
-//     pipeline on every toggle - wasteful when the look is the same.
+//     pipeline on every toggle – wasteful when the look is the same.
 //   - The convenience of `BT.preset.crtPipBoy()`: returns a fresh array of pre-configured
 //     display-tier effects so you do not have to wire them up by hand.
 //
@@ -87,7 +87,7 @@ const SQUARE_SIZE = 24;
 const SQUARE_COUNT = 5;
 
 // How fast each square moves (pixels per tick). One value per square so the
-// motion looks irregular - if all five moved at the same speed, they would
+// motion looks irregular – if all five moved at the same speed, they would
 // line up vertically and the demo would look duller.
 const SQUARE_SPEEDS = [
     new Vector2i(2, 1),
@@ -147,7 +147,7 @@ class Demo {
             maxCanvasSize: new Vector2i(OUTPUT_W, OUTPUT_H),
 
             // 'nearest' keeps each source pixel as a crisp 4x4 block. 'linear' would
-            // soften them into bilinear-blended squishes - a different look, also valid.
+            // soften them into bilinear-blended squishes – a different look, also valid.
             outputUpscaleFilter: 'nearest',
 
             targetFPS: TARGET_FPS,
@@ -174,7 +174,7 @@ class Demo {
     async init() {
         // Step 1: build the palette
         // A small, colorful set of scene colors in the low slots. Bright primaries make
-        // the CRT effect visually obvious - soft pastels would look the same with or
+        // the CRT effect visually obvious – soft pastels would look the same with or
         // without. The palette is 256 entries long so the shared UI theme can live in
         // the high slots (240-251), far away from the scene colors.
         const palette = BT.paletteCreate(256);
@@ -203,7 +203,7 @@ class Demo {
             //
             // We hold onto the array so we can re-add the SAME instances on each toggle.
             // Re-creating them every toggle would also work, but it would re-allocate the
-            // GPU pipelines and uniform buffers each time - wasteful when the look is the
+            // GPU pipelines and uniform buffers each time – wasteful when the look is the
             // same.
             this.stack = BT.preset.crtPipBoy();
 
@@ -226,7 +226,7 @@ class Demo {
         // Step 5: place the bouncing squares
         // Place them evenly across the bottom half so they don't all start in the same
         // spot. Each square keeps its own position (pos) and velocity (vel) as Vector2i
-        // instances - the engine convention for all pixel-level coordinates.
+        // instances – the engine convention for all pixel-level coordinates.
         this.squares = [];
         for (let i = 0; i < SQUARE_COUNT; i++) {
             const startPos = new Vector2i(20 + i * 50, 150 + (i % 2) * 30);
@@ -236,7 +236,7 @@ class Demo {
                 // prevPos remembers where the square was at the START of the most recent
                 // update() tick. render() blends between prevPos and pos using
                 // BT.renderAlpha so each square glides smoothly between physics ticks
-                // instead of jumping - see "Interpolating render state with renderAlpha"
+                // instead of jumping – see "Interpolating render state with renderAlpha"
                 // in the engine's docs/api-game-loop.md.
                 prevPos: startPos,
                 vel: new Vector2i(SQUARE_SPEEDS[i].x, SQUARE_SPEEDS[i].y),
@@ -247,7 +247,7 @@ class Demo {
     }
 
     update() {
-        // 1. Time-based toggle (WebGPU only - effectAdd throws in software mode)
+        // 1. Time-based toggle (WebGPU only – effectAdd throws in software mode)
         // Every TOGGLE_PERIOD_TICKS we flip the boolean and either add or remove the
         // entire preset stack. The engine handles the GPU pipeline lifecycle for us.
         if (this.effectsAvailable && BT.ticks - this.lastToggleTick >= TOGGLE_PERIOD_TICKS) {
@@ -274,7 +274,7 @@ class Demo {
 
         if (this.effectsAvailable) {
             // The CRT shaders use `time` for their rolling line and noise. Feed it seconds.
-            // Safe to set even when the effects are not in the chain - the field is just a
+            // Safe to set even when the effects are not in the chain – the field is just a
             // number on the JS instance until the next encode pass reads it.
             const seconds = BT.ticks / TARGET_FPS;
             for (const fx of this.timedEffects) {
@@ -292,7 +292,7 @@ class Demo {
 
             sq.pos = new Vector2i(sq.pos.x + sq.vel.x, sq.pos.y + sq.vel.y);
 
-            // Bounce against the left/right walls. We compare against [0, DISPLAY_W - SQUARE_SIZE]
+            // Bounce against the left/right walls. We compare against [0, DISPLAY_W – SQUARE_SIZE]
             // because the square's anchor is its top-left corner.
             if (sq.pos.x <= 0 || sq.pos.x >= DISPLAY_W - SQUARE_SIZE) {
                 sq.vel = new Vector2i(-sq.vel.x, sq.vel.y);
@@ -320,7 +320,7 @@ class Demo {
 
         // Draw the bouncing squares on top of the bars. Vector2i.lerp() blends prevPos
         // toward pos by BT.renderAlpha, so a square's drawn position matches this exact
-        // render moment instead of only its last-tick position - smoother motion when
+        // render moment instead of only its last-tick position – smoother motion when
         // render() runs at a different rate than update() (see docs/api-game-loop.md
         // in the engine repo for the full explanation).
         for (const sq of this.squares) {
@@ -330,7 +330,7 @@ class Demo {
 
         // Status readout: a small panel from the shared UI kit, drawn last so it sits on
         // top of the moving squares. Like everything the demo draws, it lives on the
-        // logical buffer, so the CRT effects warp and glow the panel too - a nice way to
+        // logical buffer, so the CRT effects warp and glow the panel too – a nice way to
         // read the toggle even when you cannot see the scanlines up close.
         ui.begin('topLeft');
         ui.panel();

--- a/packages/demos/src/flurry.js
+++ b/packages/demos/src/flurry.js
@@ -5,22 +5,22 @@
 //
 // WHAT IS FLURRY?
 // Flurry was a free screensaver for macOS that showed a cloud of glowing particles
-// swirling around invisible "sparks" - points in space that pull particles toward them
+// swirling around invisible "sparks" – points in space that pull particles toward them
 // like tiny gravity wells. Twelve sparks trace beautiful figure-eight-like paths
 // (called Lissajous orbits), and hundreds of particles spiral around them.
 //
 // HOW DOES THIS VERSION DIFFER FROM THE ORIGINAL?
-// The original Flurry used "additive blending" - overlapping particles added their light
+// The original Flurry used "additive blending" – overlapping particles added their light
 // together to create soft glowing halos. BLIT386 does not support that technique.
 // Instead, we use palette animation: every frame, we rewrite the palette so that young
 // particles appear bright and large, while old particles appear dim and small.
 // The mesmerizing orbital motion and rainbow color cycling are fully preserved.
 //
 // KEY PHYSICS CONCEPTS:
-//   Inverse-square gravity - each particle is pulled toward every spark.
+//   Inverse-square gravity – each particle is pulled toward every spark.
 //     The closer the particle, the stronger the pull. Same law as real planets.
-//   Drag - a tiny friction force applied each tick, slowing particles gradually.
-//   Lissajous orbit - a path traced by two sine waves with different frequencies.
+//   Drag – a tiny friction force applied each tick, slowing particles gradually.
+//   Lissajous orbit – a path traced by two sine waves with different frequencies.
 //     The spark's x position follows one sine wave; its y position follows another.
 //     When the frequencies are slightly different, the path never exactly repeats.
 //
@@ -66,7 +66,7 @@ const GRAVITY_CONST = 1500000;
 // How much velocity the particle keeps each tick (a fraction between 0 and 1).
 // The ** operator is JavaScript's "exponent" symbol: base ** exponent.
 // 0.9965^(85/60) is the original Flurry formula; the result is about 0.9950.
-// That means each tick a particle keeps 99.5% of its speed - very gentle drag.
+// That means each tick a particle keeps 99.5% of its speed – very gentle drag.
 const DRAG_FACTOR = 0.9965 ** (85 / 60);
 
 // How fast newly spawned particles shoot outward from their spark, in world units per tick.
@@ -89,7 +89,7 @@ const SPEED_CAP = 600;
 // At 60 FPS: 0.4 degrees/tick × 60 ticks/sec = 24 degrees/sec.
 // One full rotation (360 degrees) takes 360 / 24 = 15 seconds.
 // During those 15 seconds every particle cycles through red, orange, yellow, green,
-// cyan, blue, violet, and back to red - a complete rainbow.
+// cyan, blue, violet, and back to red – a complete rainbow.
 const HUE_ADVANCE = 0.4;
 
 // Lightness values (brightness) for the 5 particle age tiers.
@@ -123,12 +123,12 @@ const PALETTE_STRIP_SPARK_H = 3; // 3 px tall.
 const PALETTE_STRIP_PART_Y = DISPLAY_H - 4; // Particle color row top edge (y = 236).
 const PALETTE_STRIP_PART_H = 4; // 4 px tall.
 
-// Palette slot numbers - "addresses" in the 256-slot color table.
+// Palette slot numbers – "addresses" in the 256-slot color table.
 // Slot 0 is always transparent; the engine reserves it. Never write to slot 0.
 //
 // Think of each slot as a numbered paint pot.
 // update() refills the pots every tick with fresh Color32 objects.
-// render() only reads the pot numbers - it never touches Color32 directly.
+// render() only reads the pot numbers – it never touches Color32 directly.
 // This separation is the essence of palette animation.
 const C_WHITE = 1; // Pure white.
 const C_BG = 2; // Near-black deep-space background color.
@@ -181,7 +181,7 @@ const SPARK_TABLE = [
  * Converts one axis of a world position into a screen pixel coordinate.
  *
  * Two steps happen here:
- *   1. Blend: prev + (cur - prev) * alpha slides the position from where it was at
+ *   1. Blend: prev + (cur – prev) * alpha slides the position from where it was at
  *      the start of the last physics tick (prev) toward where it is now (cur), by
  *      the fraction alpha (BT.renderAlpha, 0 = tick just finished, almost 1 = next
  *      tick about to happen). This gives the true position at this exact render
@@ -193,10 +193,10 @@ const SPARK_TABLE = [
  *
  * Call it once with HALF_W for the x axis and once with HALF_H for the y axis.
  *
- * @param {number} prev - World coordinate at the start of the last tick.
- * @param {number} cur - World coordinate now, after the last tick.
- * @param {number} alpha - BT.renderAlpha blend fraction (0..1).
- * @param {number} halfExtent - HALF_W for x, HALF_H for y.
+ * @param {number} prev – World coordinate at the start of the last tick.
+ * @param {number} cur – World coordinate now, after the last tick.
+ * @param {number} alpha – BT.renderAlpha blend fraction (0..1).
+ * @param {number} halfExtent – HALF_W for x, HALF_H for y.
  * @returns {number} Whole-pixel screen coordinate.
  */
 function worldToScreen(prev, cur, alpha, halfExtent) {
@@ -218,7 +218,7 @@ class Demo {
 
     // Total elapsed animation time, measured in seconds.
     // Grows by exactly 1 / TARGET_FPS each tick (e.g. 1/60 when TARGET_FPS is 60).
-    // The spark position formula uses this as its clock - every tick the sparks move forward.
+    // The spark position formula uses this as its clock – every tick the sparks move forward.
     animTime = 0;
 
     // Current hue rotation offset in degrees (0..359).
@@ -233,11 +233,11 @@ class Demo {
     //   prevX, prevY  - world position as of the START of the most recent update() tick,
     //     before this tick's orbit math moved it. render() blends between prevX/prevY and
     //     x/y using BT.renderAlpha so sparks glide smoothly between physics ticks instead
-    //     of jumping - see "Interpolating render state with renderAlpha" in the engine's
+    //     of jumping – see "Interpolating render state with renderAlpha" in the engine's
     //     docs/api-game-loop.md.
     //   vx, vy      - instantaneous velocity (used as a hint when spawning particles)
     //   freqX, freqY  - oscillation frequencies for the Lissajous orbit
-    //   phaseX, phaseY - starting angles on the orbit path
+    //   phaseX, phaseY – starting angles on the orbit path
     //   hueOffset   - this spark's personal color angle on the rainbow (0..330 degrees)
     sparks = [];
 
@@ -365,7 +365,7 @@ class Demo {
     }
 
     /**
-     * Draws the current frame. Only palette slot numbers appear here - no Color32 objects.
+     * Draws the current frame. Only palette slot numbers appear here – no Color32 objects.
      * All color decisions were already made in update() and stored in the palette.
      */
     render() {
@@ -459,12 +459,12 @@ class Demo {
     /**
      * Moves one particle forward one tick: gravity, drag, speed cap, position.
      *
-     * @param {object} p - The particle to update.
+     * @param {object} p – The particle to update.
      */
     updateParticle(p) {
         // Advance the particle's age by its personal ageRate (about 0.002 per tick).
         // age counts from 0.0 (just born) toward 1.0 (end of life).
-        // Think of it like a candle burning down - each tick uses a little more.
+        // Think of it like a candle burning down – each tick uses a little more.
         p.age += p.ageRate;
 
         if (p.age >= 1.0) {
@@ -560,7 +560,7 @@ class Demo {
     /**
      * Resets a dead particle: places it near a random spark and gives it a fresh start.
      *
-     * @param {object} p - The particle object to reinitialize.
+     * @param {object} p – The particle object to reinitialize.
      */
     spawnParticle(p) {
         // Pick a random spark to be born near.
@@ -584,7 +584,7 @@ class Demo {
 
         // Give the particle a random initial velocity in a random direction.
         // angle() picks any direction on the compass, measured in radians. (Radians are another way to measure angles:
-        // 2*PI radians, about 6.28, is a full 360-degree turn - and that is exactly the range angle() draws from.)
+        // 2*PI radians, about 6.28, is a full 360-degree turn – and that is exactly the range angle() draws from.)
         const angle = BT.random.angle();
 
         // Random speed between 50% and 150% of STREAM_SPEED.
@@ -631,7 +631,7 @@ class Demo {
             // Lissajous orbit: x follows a sine wave, y follows a cosine wave.
             // Slightly different frequencies (freqX vs freqY) mean the path slowly
             // drifts and fills in, never quite repeating itself.
-            // FIELD_RANGE * 0.8: sparks orbit within 80% of the field - they stay on screen.
+            // FIELD_RANGE * 0.8: sparks orbit within 80% of the field – they stay on screen.
             spark.x = Math.sin(this.animTime * spark.freqX + spark.phaseX) * FIELD_RANGE * 0.8;
             spark.y = Math.cos(this.animTime * spark.freqY + spark.phaseY) * FIELD_RANGE * 0.8;
 
@@ -704,8 +704,8 @@ class Demo {
      * simply paint over it, which is the correct layering order.
      * This avoids sorting the particle array (which would be much slower).
      *
-     * Pass 1 - old particles (tier 3 and 4): drawn as 1×1 single pixels.
-     * Pass 2 - young particles (tier 0, 1, 2): drawn as 2×2 filled rectangles.
+     * Pass 1 – old particles (tier 3 and 4): drawn as 1×1 single pixels.
+     * Pass 2 – young particles (tier 0, 1, 2): drawn as 2×2 filled rectangles.
      */
     renderParticles() {
         // How far we are, right now, between the last completed physics tick and the
@@ -721,7 +721,7 @@ class Demo {
             // "continue" means: stop processing this particle and jump straight
             // to the next one. It is like saying "skip this one".
             if (!p.alive) {
-                continue; // Skip dead particles - they have no position to draw.
+                continue; // Skip dead particles – they have no position to draw.
             }
 
             // Convert age (0..1) to a tier index (0..4).
@@ -732,7 +732,7 @@ class Demo {
 
             // Pass 1 only draws particles that are in their last two tiers (3 or 4).
             // Tier 3 is "aging" (lightness 36) and tier 4 is "near-dead" (lightness 20).
-            // Tiers 0, 1, 2 are handled in pass 2 - skip them here.
+            // Tiers 0, 1, 2 are handled in pass 2 – skip them here.
             if (tier < 3) {
                 continue;
             }
@@ -767,7 +767,7 @@ class Demo {
 
             // Recompute the tier for this pass. Each particle is only handled in one pass,
             // so checking the tier again here costs very little and keeps both passes
-            // independent - no shared state needed between the two loops.
+            // independent – no shared state needed between the two loops.
             const tier = Math.min(4, Math.floor(p.age * 5));
 
             // This pass only draws young particles (tiers 0, 1, and 2).
@@ -782,7 +782,7 @@ class Demo {
 
             // A 2×2 rect occupies pixels at (sx, sy), (sx+1, sy), (sx, sy+1), (sx+1, sy+1).
             // We therefore need both sx and sx+1 to be inside the screen, so sx <= DISPLAY_W-2.
-            // DISPLAY_W - 1 = 319, so "sx >= 319" means "sx+1 would be 320" which is off-screen.
+            // DISPLAY_W – 1 = 319, so "sx >= 319" means "sx+1 would be 320" which is off-screen.
             if (sx < 0 || sx >= DISPLAY_W - 1 || sy < 0 || sy >= DISPLAY_H - 1) {
                 continue;
             }
@@ -800,7 +800,7 @@ class Demo {
      *
      * Three layers are stacked from largest (drawn first / underneath) to smallest (on top):
      *   Layer 1: 5×5 pixels, dim halo color   - the outer glow ring.
-     *   Layer 2: 3×3 pixels, bright body color - the vivid colored core.
+     *   Layer 2: 3×3 pixels, bright body color – the vivid colored core.
      *   Layer 3: 1×1 pixel,  white             - the white-hot center point.
      *
      * Drawing larger shapes first and smaller shapes on top is how layered "glow" effects
@@ -823,7 +823,7 @@ class Demo {
 
             // The outermost layer is a 5×5 rect extending 2 pixels in each direction.
             // We therefore need sx >= 2 (so sx-2 >= 0) and sx <= DISPLAY_W-3 (so sx+2 <= DISPLAY_W-1).
-            // The check "sx >= DISPLAY_W - 2" catches the right-edge case in one comparison.
+            // The check "sx >= DISPLAY_W – 2" catches the right-edge case in one comparison.
             if (sx < 2 || sx >= DISPLAY_W - 2 || sy < 2 || sy >= DISPLAY_H - 2) {
                 continue; // Skip sparks that are too close to the edge to draw safely.
             }
@@ -844,12 +844,12 @@ class Demo {
     /**
      * Draws two thin rows of colored squares along the very bottom of the screen.
      *
-     * Top row - 12 spark-bright slots:
+     * Top row – 12 spark-bright slots:
      *   Each of the 12 sparks gets one rectangle ~26 px wide.
      *   All 12 span different hues (the sparks are 30 degrees apart on the color wheel),
      *   so this row always looks like a full rainbow no matter where huePhase is.
      *
-     * Bottom row - 40 particle slots (8 hues x 5 brightness tiers):
+     * Bottom row – 40 particle slots (8 hues x 5 brightness tiers):
      *   The 40 particle palette entries are displayed left to right.
      *   Each group of 5 squares (40 px wide) is one hue band, going from bright to dim.
      *   As the global hue rotates, this entire row slides through the rainbow in real time.
@@ -868,9 +868,9 @@ class Demo {
 
             // Width of this rectangle.
             // The ternary operator "condition ? valueIfTrue : valueIfFalse" is a compact if/else.
-            // For the last spark (i === SPARK_COUNT - 1), we stretch to the right edge
-            // of the screen by using DISPLAY_W - x instead of sparkW. This fills the
-            // 8 leftover pixels (320 - 12*26 = 8) so the strip reaches all the way to
+            // For the last spark (i === SPARK_COUNT – 1), we stretch to the right edge
+            // of the screen by using DISPLAY_W – x instead of sparkW. This fills the
+            // 8 leftover pixels (320 – 12*26 = 8) so the strip reaches all the way to
             // the edge with no gap. For every other spark we use the standard sparkW.
             const w = i === SPARK_COUNT - 1 ? DISPLAY_W - x : sparkW;
 
@@ -878,7 +878,7 @@ class Demo {
         }
 
         // Bottom row: 40 particle color slots, each 8 px wide
-        // 8 hues × 5 tiers = 40 slots. 40 × 8 px = 320 px - a perfect fit.
+        // 8 hues × 5 tiers = 40 slots. 40 × 8 px = 320 px – a perfect fit.
         // The slots are arranged in the same order as the palette layout:
         //   index 0..4   = hue 0, tiers 0..4 (brightest to darkest)
         //   index 5..9   = hue 1, tiers 0..4

--- a/packages/demos/src/flurry.js
+++ b/packages/demos/src/flurry.js
@@ -27,7 +27,7 @@
 // Prerequisites:
 //   Basics            https://demos.blit386.dev/basics
 //   Palette Animation https://demos.blit386.dev/palette-animation
-//     (walkthrough: https://vancura.dev/articles/blit386-palette-animation)
+//     (guide: https://blit386.dev/docs/guides/palette#runtime-palette-effects)
 //
 // Live version: https://demos.blit386.dev/flurry
 

--- a/packages/demos/src/game-scene.js
+++ b/packages/demos/src/game-scene.js
@@ -39,7 +39,7 @@
 //
 // `Color32.multiply()` is a built-in engine method: it scales each channel of `base` by
 // the matching channel of `ambient` and returns a new Color32. Think of it as shining a
-// colored flashlight on a surface - a blue light on a red wall gives you a darker,
+// colored flashlight on a surface – a blue light on a red wall gives you a darker,
 // purple-ish result.
 //
 // Example: the grass fill has a base color (50, 140, 70) and a reserved slot C_GRASS.
@@ -179,8 +179,8 @@ class Demo {
     heroSprite = null;
 
     // Hero sprite size in world pixels, read from the loaded sheet in init()
-    // (test.png is 44x44). Deriving it from the real image - instead of guessing a
-    // number here - keeps movement bounds, camera centering, and particle spawns
+    // (test.png is 44x44). Deriving it from the real image – instead of guessing a
+    // number here – keeps movement bounds, camera centering, and particle spawns
     // matching what is actually drawn on screen.
     /** @type {Vector2i} */
     heroSize = new Vector2i(0, 0);
@@ -199,7 +199,7 @@ class Demo {
     // Rock position at the START of the most recent update() tick, before this tick's
     // walk step moved it. render() blends between heroPrevPos and heroPos using
     // BT.renderAlpha so the rock glides smoothly between physics ticks instead of
-    // jumping - see "Interpolating render state with renderAlpha" in the engine's
+    // jumping – see "Interpolating render state with renderAlpha" in the engine's
     // docs/api-game-loop.md. init() snaps this to match heroPos so the very first
     // frame does not blend in from a stale position.
     heroPrevPos = new Vector2i(120, 0);
@@ -207,7 +207,7 @@ class Demo {
     // +1 = moving right, -1 = moving left.
     heroFacing = 1;
 
-    // Walk "step" counter (not a frame index - just bobs the rock position slightly).
+    // Walk "step" counter (not a frame index – just bobs the rock position slightly).
     walkStep = 0;
     walkFrameTimer = new Timer(WALK_FRAME_TICKS);
 
@@ -376,8 +376,8 @@ class Demo {
         console.log(`[GameSceneDemo] Loaded sprite: ${this.heroSprite.width}x${this.heroSprite.height}px`);
 
         // Read the hero's real size from the loaded sheet (44x44 for test.png), the
-        // same way basics-enhanced and logo-lowres do. Every bit of math below - movement bounds,
-        // camera centering, particle spawns - uses this size, so the logic always
+        // same way basics-enhanced and logo-lowres do. Every bit of math below – movement bounds,
+        // camera centering, particle spawns – uses this size, so the logic always
         // matches the picture on screen.
         this.heroSize.set(this.heroSheet.size.x, this.heroSheet.size.y);
 
@@ -416,7 +416,7 @@ class Demo {
         // "remembered" and starts for real the instant the player clicks or presses a key.
         //
         // Wrap load + play like snake-game: a missing or undecodable file must not
-        // abort the whole scene - the capstone still renders with SFX only.
+        // abort the whole scene – the capstone still renders with SFX only.
         try {
             this.musicClip = await AudioClip.load('/audio/music-intro-loop.wav');
             BT.musicPlay(this.musicClip, {
@@ -481,10 +481,10 @@ class Demo {
     /**
      * Plays a short chime the instant the day/night phase label changes (Day -> Toward dusk
      * -> Night -> Toward dawn -> Day...). Comparing this tick's label against last tick's
-     * label is the same "edge detection" idea Keyboard Input uses for key presses - we
+     * label is the same "edge detection" idea Keyboard Input uses for key presses – we
      * only care about the moment something changes, not every tick it stays the same.
      *
-     * @param {number} tick - Current engine tick (BT.ticks).
+     * @param {number} tick – Current engine tick (BT.ticks).
      */
     updateDayPhaseSound(tick) {
         const currentPhase = this.getDayPhaseLabel(tick);
@@ -498,12 +498,12 @@ class Demo {
 
     /**
      * Draws world layers back-to-front. HUD text is handled by the engine overlay.
-     * Every draw call uses only palette index numbers - no Color32 objects.
+     * Every draw call uses only palette index numbers – no Color32 objects.
      */
     render() {
         BT.clear(C_BLACK);
 
-        // Blend cameraPrevPos toward cameraPos by BT.renderAlpha - a fraction from 0
+        // Blend cameraPrevPos toward cameraPos by BT.renderAlpha – a fraction from 0
         // (a tick just finished) to just under 1 (the next tick is about to happen) -
         // so the camera's on-screen position matches this exact render moment instead
         // of only its last-tick position. Both the sky parallax below and the full
@@ -801,7 +801,7 @@ class Demo {
      * Advances a step counter every WALK_FRAME_TICKS ticks.
      * Used to add a subtle bob to the rock as it moves.
      *
-     * @param {number} tick - Current tick.
+     * @param {number} tick – Current tick.
      */
     updateWalkStep(tick) {
         if (this.walkFrameTimer.fireIfElapsed(tick)) {
@@ -857,7 +857,7 @@ class Demo {
     }
 
     /**
-     * Keeps cameraPos.x between 0 and WORLD_W - DISPLAY_W.
+     * Keeps cameraPos.x between 0 and WORLD_W – DISPLAY_W.
      */
     clampCamera() {
         const clamped = BT.cameraClamp(this.cameraPos, this.worldSize, BT.displaySize);
@@ -869,7 +869,7 @@ class Demo {
     /**
      * +1 score every SCORE_INTERVAL_TICKS.
      *
-     * @param {number} tick - Current tick.
+     * @param {number} tick – Current tick.
      */
     updateScore(tick) {
         if (this.scoreTimer.fireIfElapsed(tick)) {
@@ -880,7 +880,7 @@ class Demo {
     /**
      * Spawns a handful of sparkles near the rock on a fixed schedule.
      *
-     * @param {number} tick - Current tick.
+     * @param {number} tick – Current tick.
      */
     updateParticlesSpawn(tick) {
         if (this.particleSpawnTimer.fireIfElapsed(tick)) {
@@ -890,7 +890,7 @@ class Demo {
 
                 // Scatter each sparkle around the rock.
                 // BT.random is the engine's shared random number generator, and int() returns a whole number starting
-                // at the first value and stopping just before the second - so int(-10, 10) gives anything from -10 to
+                // at the first value and stopping just before the second – so int(-10, 10) gives anything from -10 to
                 // 9, and 10 itself never comes up.
                 // Left and right come up about equally often. The y range is lopsided on purpose: most of those
                 // offsets are negative, which on screen means upward, so the sparkles gather above the rock.
@@ -915,7 +915,7 @@ class Demo {
     /**
      * Removes particles older than 72 ticks (~1.2 seconds).
      *
-     * @param {number} tick - Current tick.
+     * @param {number} tick – Current tick.
      */
     cleanupParticles(tick) {
         this.particles = this.particles.filter((p) => tick - p.spawnTick < 72);
@@ -926,7 +926,7 @@ class Demo {
      * Hue comes from spawnTick; alpha fades out as the particle ages.
      * The ambient tint is also applied so sparkles dim at night.
      *
-     * @param {number} tick - Current tick.
+     * @param {number} tick – Current tick.
      */
     updateParticleColors(tick) {
         const ambient = this.getAmbientTint();
@@ -946,7 +946,7 @@ class Demo {
 
     /**
      * Draws active particles as 3x3 colored squares.
-     * Colors were already computed in update() - render() just reads the slot.
+     * Colors were already computed in update() – render() just reads the slot.
      */
     renderParticles() {
         for (const p of this.particles) {
@@ -993,8 +993,8 @@ class Demo {
     }
 
     /**
-     * Starts one PNG download (Image Output demo). BT.downloadFrame() is asynchronous - it hands
-     * the browser a file and resolves later - so we flip `capturing` on now and set the
+     * Starts one PNG download (Image Output demo). BT.downloadFrame() is asynchronous – it hands
+     * the browser a file and resolves later – so we flip `capturing` on now and set the
      * result message (shown for ~3 seconds via messageTimer) when the promise settles.
      */
     startCapture() {

--- a/packages/demos/src/game-scene.js
+++ b/packages/demos/src/game-scene.js
@@ -17,7 +17,7 @@
 //   Tilemap      https://demos.blit386.dev/tilemap
 //   Image Output https://demos.blit386.dev/image-output
 //
-// Live article: https://vancura.dev/articles/blit386-game-scene
+// Guide: https://blit386.dev/docs
 //
 // WHAT YOU SEE (how the pieces connect):
 //   - Sky gradient and slow-moving clouds = colors + parallax idea from starfield.

--- a/packages/demos/src/image-output.js
+++ b/packages/demos/src/image-output.js
@@ -7,7 +7,7 @@
 // saved PNG as well. That is fine for this demo – see the comment in render().
 //
 // Prerequisites: Basics (https://demos.blit386.dev/basics).
-// Live article: https://vancura.dev/articles/blit386-image-output
+// Guide: https://blit386.dev/docs/api/rendering#frame-capture
 
 import { bootstrap, BT, Color32, Rect2i, Vector2i } from 'blit386';
 

--- a/packages/demos/src/image-output.js
+++ b/packages/demos/src/image-output.js
@@ -2,9 +2,9 @@
 //
 // BT.downloadFrame() takes a screenshot of whatever is currently on screen and saves
 // it as a PNG image file to your computer. Click or tap the "Save PNG" button from the
-// shared UI kit (or press Space) to download the current frame - so the demo works on
+// shared UI kit (or press Space) to download the current frame – so the demo works on
 // touch screens too. Note: the kit panel is drawn on screen, so it appears in the
-// saved PNG as well. That is fine for this demo - see the comment in render().
+// saved PNG as well. That is fine for this demo – see the comment in render().
 //
 // Prerequisites: Basics (https://demos.blit386.dev/basics).
 // Live article: https://vancura.dev/articles/blit386-image-output
@@ -21,7 +21,7 @@ import { applyTheme, ui } from './shared/ui.js';
 // Every color used for drawing is stored in a numbered "palette" slot.
 // Think of each slot like a labeled paint jar on an artist's shelf.
 // Index 0 is always transparent (invisible). Our custom colors start at 1.
-// These are the SCENE colors - the test pattern itself. All the UI text and the
+// These are the SCENE colors – the test pattern itself. All the UI text and the
 // Save button draw with the shared UI theme instead (installed by applyTheme() in init()).
 const C_WHITE = 1; // White: grid dots, border, and crosshairs
 const C_BG = 2; // Very dark blue-gray: the background color
@@ -29,7 +29,7 @@ const C_BG = 2; // Very dark blue-gray: the background color
 // Dynamic slots: these six colors change every frame to create the animated rainbow stripes.
 // We pre-allocate (reserve) index slots 10 through 15, one for each horizontal stripe.
 // In update() we calculate the new color and store it here; render() just uses the index.
-// This is called "palette animation" - the retro trick that made old consoles look alive!
+// This is called "palette animation" – the retro trick that made old consoles look alive!
 const C_STRIPE_0 = 10; // Animated color for the top stripe (stripe 0)
 // Stripes 1-5 follow at C_STRIPE_0 + 1 through C_STRIPE_0 + 5
 
@@ -76,7 +76,7 @@ class Demo {
             // overlay. This demo's whole point is saving a picture with
             // BT.downloadFrame(), and the overlay is drawn on top of everything, so
             // that hint would end up baked into the saved PNG. We hide the hint to keep
-            // captures tidy. (The kit's Save panel DOES appear in the capture - a
+            // captures tidy. (The kit's Save panel DOES appear in the capture – a
             // deliberate trade-off so touch users can save at all; see render().)
             // The overlay still works on demand: press ` to show it and ` again to
             // hide it before you capture. The bottom-left 17x13 corner also stays
@@ -110,7 +110,7 @@ class Demo {
         // Step 2: install the shared UI theme. applyTheme() writes the twelve UI kit
         // colors into high palette slots (240-251 by default), far above our scene
         // slots 1-15. Every kit widget (the panel, button, labels) draws with these
-        // colors automatically - this demo never needs the slot numbers itself, so
+        // colors automatically – this demo never needs the slot numbers itself, so
         // we call applyTheme() only for that side effect and ignore its return value.
         applyTheme(this.palette);
 
@@ -142,7 +142,7 @@ class Demo {
         // Palette animation for the six horizontal stripes
         // Instead of computing colors inside render(), we compute them here in update()
         // and store the results in reserved palette slots. render() then just uses the index numbers.
-        // This is the classic "palette animation" technique - retro hardware did the same thing!
+        // This is the classic "palette animation" technique – retro hardware did the same thing!
         for (let i = 0; i < 6; i++) {
             // phase is an angle-like value 0-359 that moves as tick increases.
             // Each stripe adds i * 20 so neighboring stripes do not look identical.
@@ -163,7 +163,7 @@ class Demo {
             const b = Math.floor(127 + 127 * Math.sin(((phase + 240) * Math.PI) / 180));
 
             // Store the computed color in the palette slot for this stripe.
-            // render() will read C_STRIPE_0 + i to draw each stripe - no Color32 needed there!
+            // render() will read C_STRIPE_0 + i to draw each stripe – no Color32 needed there!
             this.palette.set(C_STRIPE_0 + i, new Color32(r, g, b));
         }
     }
@@ -181,7 +181,7 @@ class Demo {
         BT.clear(C_BG);
 
         // Draw six horizontal stripes using the animated palette slots we updated in update().
-        // Each stripe's color was already computed and stored - we just reference the index.
+        // Each stripe's color was already computed and stored – we just reference the index.
         const stripeHeight = 40;
 
         for (let i = 0; i < 6; i++) {
@@ -215,13 +215,13 @@ class Demo {
         // because the engine keeps the bottom-left 17x13 corner tappable for toggling
         // the stats overlay, and we do not want the two to fight over taps.
         // Note: this panel is drawn onto the frame, so it WILL be part of the saved
-        // PNG. That is acceptable here - it even doubles as a caption telling you
+        // PNG. That is acceptable here – it even doubles as a caption telling you
         // which demo produced the screenshot.
         ui.begin('topRight');
         ui.panel('Image Output');
 
         // The Save button. ui.button() returns true only on the single frame it was
-        // clicked, tapped, or its bound key (Space) was pressed - so holding Space
+        // clicked, tapped, or its bound key (Space) was pressed – so holding Space
         // does not spam downloads. We also ignore it while a save is already running.
         if (ui.button('Save PNG (Space)', { key: 'Space' }) && !this.capturing) {
             this.saveFrame();
@@ -230,13 +230,13 @@ class Demo {
         // One status row below the button. We always draw a row (even when idle) so
         // the panel does not jump in size when a message appears or disappears.
         if (this.capturing) {
-            // A save is in flight - the browser is busy reading the canvas.
+            // A save is in flight – the browser is busy reading the canvas.
             ui.label('Capturing...', { color: 'info' });
         } else if (this.messageTimer > 0) {
-            // A save just finished - show the result in green (success) or orange (error).
+            // A save just finished – show the result in green (success) or orange (error).
             ui.label(this.lastCaptureMessage, { color: this.lastCaptureColor });
         } else {
-            // Nothing happening - a quiet hint in dim gray.
+            // Nothing happening – a quiet hint in dim gray.
             ui.label('Saves the current frame', { color: 'dim' });
         }
 
@@ -257,7 +257,7 @@ class Demo {
         // BT.downloadFrame() reads the canvas and asks the browser to save a file.
         // Most browsers open a "Save as" dialog or drop the file straight into your
         // Downloads folder (depends on your browser settings). The demo cannot pick
-        // the folder for you - that is normal browser security.
+        // the folder for you – that is normal browser security.
         BT.downloadFrame('blit386-capture.png')
             .then(() => {
                 // Success: remember a friendly message and show it in green.

--- a/packages/demos/src/palette-animation.js
+++ b/packages/demos/src/palette-animation.js
@@ -7,10 +7,10 @@
 //   Primitives      https://demos.blit386.dev/primitives
 //   Colors          https://demos.blit386.dev/colors
 //   Palette Presets https://demos.blit386.dev/palette-presets
-//     (walkthrough: https://vancura.dev/articles/blit386-palette-presets)
+//     (guide: https://blit386.dev/docs/guides/palette-presets)
 //
 // Live version: https://demos.blit386.dev/palette-animation
-// Live article: https://vancura.dev/articles/blit386-palette-animation
+// Guide: https://blit386.dev/docs/guides/palette#runtime-palette-effects
 //
 // WHAT IS PALETTE ANIMATION?
 //

--- a/packages/demos/src/palette-animation.js
+++ b/packages/demos/src/palette-animation.js
@@ -15,18 +15,18 @@
 // WHAT IS PALETTE ANIMATION?
 //
 // Old game hardware (Super Nintendo, Sega Genesis, Commodore 64) had strict rules:
-// each pixel only stored a small number - a "palette index" pointing to one color slot.
+// each pixel only stored a small number – a "palette index" pointing to one color slot.
 // To animate colors, programmers changed what color was IN the slot, not what was on screen.
 //
 // Imagine 16 buckets of paint, each numbered. A painting only records the bucket number
 // for every spot, not the actual color. To change the sky from blue to red, you just
-// repaint bucket 5. Every sky-colored spot changes instantly - without touching the painting!
+// repaint bucket 5. Every sky-colored spot changes instantly – without touching the painting!
 //
 // That trick is called "palette animation". Modern engines don't need it, but it's a
 // beautiful technique to understand, and BLIT386 lets you do it the same way.
 //
 // THE KEY RULE:
-//   render() writes palette indices (numbers) - never Color32 objects.
+//   render() writes palette indices (numbers) – never Color32 objects.
 //   update() computes new Color32 values and stores them in palette slots.
 //
 // The section headings and panels are drawn with the shared UI kit (src/shared/ui.js);
@@ -84,15 +84,15 @@ const HEALTH_MAX = 100;
 // How many ticks for one full health drain cycle.
 const HEALTH_DRAIN_TICKS = 360; // ~6 seconds to drain completely.
 
-// Palette slot constants - we group our palette like compartments in a paint box.
+// Palette slot constants – we group our palette like compartments in a paint box.
 // Each animated section owns a range of slots that it fills in update() every tick.
 // The shared UI kit adds its own 12 theme colors in slots 240..251 (see init()),
 // safely above everything listed here.
 
-// Slot 0:   always transparent - reserved by the engine.
+// Slot 0:   always transparent – reserved by the engine.
 
 // Engine overlay style slots. configure() runs BEFORE init() installs the shared UI
-// theme, so the overlay style cannot use theme slots - instead it points at these four
+// theme, so the overlay style cannot use theme slots – instead it points at these four
 // low slots, which init() fills by hand with fixed colors.
 const C_OVERLAY_BAR = 2; // Overlay bar background (very dark navy).
 const C_OVERLAY_ERR = 3; // Timing chart error bars (dark blue).
@@ -210,7 +210,7 @@ class Demo {
         }
 
         // Install the shared UI kit colors (panel fills, borders, headings, dim text).
-        // applyTheme() writes 12 colors into slots 240..251 - far above every range this
+        // applyTheme() writes 12 colors into slots 240..251 – far above every range this
         // demo animates (gradient 10..41, fire 50..69, health 80, water 90..92), so the
         // palette animation can never overwrite the UI theme. The returned map remembers
         // where each color landed (this.theme.bg, this.theme.header, ...).
@@ -221,7 +221,7 @@ class Demo {
         BT.paletteSet(this.palette);
 
         // Run one update cycle so all dynamic slots have real colors before the first render.
-        // update() takes no arguments - this priming call still advances animTime by one tick,
+        // update() takes no arguments – this priming call still advances animTime by one tick,
         // same as every regular call from the engine's game loop.
         this.update();
 
@@ -231,7 +231,7 @@ class Demo {
 
     /**
      * Called 60 times per second. Computes new Color32 values for every dynamic slot.
-     * render() will never see Color32 - it only reads slot indices we set here.
+     * render() will never see Color32 – it only reads slot indices we set here.
      */
     update() {
         // Advance the clock. animTime grows by 1/60 each frame.
@@ -263,7 +263,7 @@ class Demo {
     }
 
     /**
-     * Draws all four panels. Only palette indices appear here - no Color32 objects.
+     * Draws all four panels. Only palette indices appear here – no Color32 objects.
      */
     render() {
         // Clear the screen with the UI theme's dark background.
@@ -327,7 +327,7 @@ class Demo {
      *   0.6 = bright orange (active flame)
      *   1.0 = pale yellow  (hottest, near the tip)
      *
-     * @param {number} ft - Position along the flame, 0 at the bottom, 1 at the top.
+     * @param {number} ft – Position along the flame, 0 at the bottom, 1 at the top.
      * @returns {Color32} The blended color for that position.
      */
     fireColor(ft) {
@@ -352,7 +352,7 @@ class Demo {
      * Health bar: toggles one slot between red and near-white every FLASH_PERIOD ticks.
      * Only flashes when health is critically low.
      *
-     * @param {number} tick - Current tick count from BT.ticks.
+     * @param {number} tick – Current tick count from BT.ticks.
      */
     updateHealthBar(tick) {
         if (this.health <= HEALTH_LOW) {
@@ -371,7 +371,7 @@ class Demo {
      * Each slot cycles: bright -> medium -> dim -> bright -> ...
      * The phases are offset by one slot so the bright spot appears to travel.
      *
-     * @param {number} tick - Current tick count from BT.ticks.
+     * @param {number} tick – Current tick count from BT.ticks.
      */
     updateWater(tick) {
         // Advance the ripple every 8 ticks (about 7 ripples per second).
@@ -389,13 +389,13 @@ class Demo {
             let color;
 
             if (dist === 0) {
-                // Bright highlight - the "wave crest".
+                // Bright highlight – the "wave crest".
                 color = new Color32(80, 200, 255);
             } else if (dist === 1) {
-                // Medium shade - just before or after the crest.
+                // Medium shade – just before or after the crest.
                 color = new Color32(30, 100, 200);
             } else {
-                // Dark trough - between ripples.
+                // Dark trough – between ripples.
                 color = new Color32(10, 40, 120);
             }
 
@@ -459,7 +459,7 @@ class Demo {
         // Explanatory notes beside the column, lined up with the parts they describe:
         // the brightest band is at the top of the column, the darkest at the bottom.
         // "Band" here means the position in the fire stack (0..19), not the palette
-        // slot number - the actual slots are C_FIRE_BASE + band, i.e. 50..69.
+        // slot number – the actual slots are C_FIRE_BASE + band, i.e. 50..69.
         const noteX = colX + FIRE_COL_W + 6;
         BT.systemPrint(new Vector2i(noteX, bandY + 44), this.theme.dim, 'band 19 = white');
         BT.systemPrint(new Vector2i(noteX, bandY + 74), this.theme.dim, '...     = red');
@@ -494,7 +494,7 @@ class Demo {
         BT.drawRectFill(new Rect2i(6, bandY + 22, barMaxW, 12), this.theme.bg);
         BT.drawRect(new Rect2i(6, bandY + 22, barMaxW, 12), this.theme.border);
 
-        // Filled bar - uses C_HEALTH_BAR, which flashes in update() when health is low.
+        // Filled bar – uses C_HEALTH_BAR, which flashes in update() when health is low.
         BT.drawRectFill(new Rect2i(6, bandY + 22, barW, 12), C_HEALTH_BAR);
 
         // Health value as text, in the theme's amber heading color.

--- a/packages/demos/src/palette-cycling.js
+++ b/packages/demos/src/palette-cycling.js
@@ -7,11 +7,11 @@
 //   Primitives        https://demos.blit386.dev/primitives
 //   Palette Presets   https://demos.blit386.dev/palette-presets
 //   Palette Animation https://demos.blit386.dev/palette-animation
-//     (walkthroughs: https://vancura.dev/articles/blit386-palette-presets,
-//      https://vancura.dev/articles/blit386-palette-animation)
+//     (guides: https://blit386.dev/docs/guides/palette-presets,
+//      https://blit386.dev/docs/guides/palette#runtime-palette-effects)
 //
 // Live version: https://demos.blit386.dev/palette-cycling
-// Live article: https://vancura.dev/articles/blit386-palette-cycling
+// Guide: https://blit386.dev/docs/guides/palette#runtime-palette-effects
 //
 // WHAT IS PALETTE CYCLING?
 //

--- a/packages/demos/src/palette-cycling.js
+++ b/packages/demos/src/palette-cycling.js
@@ -17,13 +17,13 @@
 //
 // On old hardware, colors were stored in numbered "slots" called a palette.
 // Every pixel on screen was just a number pointing to a slot.
-// If you ROTATE the colors - move each color one slot forward, wrap the last
-// one to the beginning - everything on screen that uses those slots appears
+// If you ROTATE the colors – move each color one slot forward, wrap the last
+// one to the beginning – everything on screen that uses those slots appears
 // to ripple or flow. The picture data never changes; only the paint-bucket
 // labels shift around.
 //
 // This trick powered water, lava, plasma, and aurora effects in classic games
-// like Sonic, Secret of Mana, and Chrono Trigger - all without redrawing a
+// like Sonic, Secret of Mana, and Chrono Trigger – all without redrawing a
 // single pixel.
 //
 // BLIT386 gives you BT.paletteCycle(start, end, speed) to do exactly that.
@@ -31,7 +31,7 @@
 // each frame. Positive speed = forward, negative = backward.
 //
 // UPDATE VS RENDER (palette work split):
-//   init() registers gradient colors and starts BT.paletteCycle() - the engine
+//   init() registers gradient colors and starts BT.paletteCycle() – the engine
 //   rotates those slot ranges automatically every frame.
 //   update() only runs the periodic BT.paletteSwap() demo and hides its label.
 //   render() draws fixed rectangles using palette index numbers; the bands
@@ -43,8 +43,8 @@
 //
 // WHAT YOU WILL SEE (three horizontal bands):
 //   1. Sky   (top)    - purple-pink slots cycling very slowly = twilight drift
-//   2. Fire  (middle) - orange-yellow slots cycling backward = rising flames
-//   3. Water (bottom) - blue gradient slots cycling forward = flowing water
+//   2. Fire  (middle) – orange-yellow slots cycling backward = rising flames
+//   3. Water (bottom) – blue gradient slots cycling forward = flowing water
 //
 // Plus a palette swap demonstration every few seconds.
 
@@ -79,7 +79,7 @@ const SWAP_INTERVAL = 180; // ~3 seconds at 60 FPS
 // Slot 0: always transparent (reserved by the engine).
 
 // Engine overlay style slots. configure() runs BEFORE init() installs the shared UI
-// theme, so the overlay style cannot use theme slots - instead it points at these six
+// theme, so the overlay style cannot use theme slots – instead it points at these six
 // low slots, which init() fills by hand with fixed colors.
 const C_OVERLAY_TAG = 1; // Chart milestone tags (white).
 const C_OVERLAY_BAR = 2; // Overlay bar background (very dark navy).
@@ -100,17 +100,17 @@ const C_WATER_BASE = 50;
 /**
  * Fills a run of palette slots with a smooth gradient.
  *
- * For each slot we compute t = i / (count - 1). Think of t as "how far along the
- * gradient are we?" - the first slot gets t = 0 (the start), the last slot gets
+ * For each slot we compute t = i / (count – 1). Think of t as "how far along the
+ * gradient are we?" – the first slot gets t = 0 (the start), the last slot gets
  * t = 1 (the end), and the slots between get evenly spaced fractions like 0.25
  * or 0.5 (exactly halfway). The colorAt callback turns that fraction into the
  * actual Color32 for the slot, so each gradient only has to describe its own
  * start and end colors.
  *
- * @param {Palette} palette - The palette to write into.
- * @param {number} baseSlot - The first slot of the gradient run.
- * @param {number} count - How many slots to fill.
- * @param {(t: number) => Color32} colorAt - Returns the color for progress t (0..1).
+ * @param {Palette} palette – The palette to write into.
+ * @param {number} baseSlot – The first slot of the gradient run.
+ * @param {number} count – How many slots to fill.
+ * @param {(t: number) => Color32} colorAt – Returns the color for progress t (0..1).
  */
 function fillGradient(palette, baseSlot, count, colorAt) {
     for (let i = 0; i < count; i++) {
@@ -212,7 +212,7 @@ class Demo {
         );
 
         // Install the shared UI kit colors (panel fills, borders, headings, dim text).
-        // applyTheme() writes 12 colors into slots 240..251 - far above every range the
+        // applyTheme() writes 12 colors into slots 240..251 – far above every range the
         // engine cycles here (sky 10..19, fire 30..35, water 50..57), so the rotation
         // can never touch the UI theme.
         this.theme = applyTheme(this.palette);
@@ -237,7 +237,7 @@ class Demo {
         const tick = BT.ticks;
 
         // Every SWAP_INTERVAL ticks, swap two fire slots to demonstrate BT.paletteSwap().
-        // The pair is not random - it is computed from the tick counter, so each swap
+        // The pair is not random – it is computed from the tick counter, so each swap
         // picks a predictable pair: tick % FIRE_SLOTS and (tick + 3) % FIRE_SLOTS.
         if (tick - this.lastSwapTick >= SWAP_INTERVAL) {
             // Pick two different slots within the fire range.
@@ -260,7 +260,7 @@ class Demo {
 
     /**
      * Draws the three animated bands and their kit-panel headings.
-     * No Color32 objects here - only palette indices.
+     * No Color32 objects here – only palette indices.
      */
     render() {
         BT.clear(this.theme.bg);

--- a/packages/demos/src/palette-exposure-fade.js
+++ b/packages/demos/src/palette-exposure-fade.js
@@ -53,7 +53,7 @@
 // fade drives them:
 //
 //   Left  - BT.paletteFadeRange(), the plain "mix the numbers" fade
-//   Right - BT.paletteFadeExposure(), the camera-style fade
+//   Right – BT.paletteFadeExposure(), the camera-style fade
 //
 // So anything you see differing between the halves comes from the curve alone.
 //
@@ -65,7 +65,7 @@
 //
 //   Slots 1..12   - the right half's picture (the exposure fade)
 //   Slots 16..27  - the left half's picture (the plain fade)
-//   Slots 240..251 - the shared UI panel colors (neither fade touches these)
+//   Slots 240..251 – the shared UI panel colors (neither fade touches these)
 //
 // BT.paletteFadeRange(start, end, ...) already takes a slot range, so the left
 // half is easy. For the right half we use a trick the engine supports on
@@ -80,16 +80,16 @@
 // small square is one of the 256 slots. The first row holds the exposure fade's
 // slots 1..12 and the second row holds the plain fade's 16..27, so during a fade
 // you can see the first group's bright slots run ahead of the second group while
-// its dark slots lag behind - the whole point of the effect, as raw numbers.
+// its dark slots lag behind – the whole point of the effect, as raw numbers.
 //
 // Press ~ (or tap the symbol in the bottom-left corner) to close the overlay and
 // watch just the pictures.
 //
 // WHAT YOU WILL SEE:
 //   A lamp-lit room, drawn twice. The cycle repeats forever:
-//   1. Fade up from black - 2 seconds
+//   1. Fade up from black – 2 seconds
 //   2. Hold, fully lit    - 1.5 seconds
-//   3. Fade down to black - 2 seconds
+//   3. Fade down to black – 2 seconds
 //   4. Hold, dark         - 1 second
 //   On the way up, the right lamp lights before the left one and the right
 //   shadows stay black longer. On the way down, the right lamp is still glowing
@@ -129,7 +129,7 @@ const PHASE_TRANSITIONS = {
 // The right half's slots. Slot 0 is always transparent, so scene colors start at 1.
 const EXP_FIRST_SLOT = 1;
 
-// The left half's slots. Just above the exposure target's 16 slots - the exposure
+// The left half's slots. Just above the exposure target's 16 slots – the exposure
 // fade's own reach stops at slot 15, so this is out of its way.
 const PLAIN_FIRST_SLOT = 16;
 
@@ -141,7 +141,7 @@ const EXPOSURE_TARGET_SIZE = 16;
 // The twelve colors of the lamp-lit room, brightest first. Both halves use this
 // exact list, so any difference on screen comes from the fade, not the art.
 const SCENE_COLORS = [
-    new Color32(255, 250, 225), // 0 lamp bulb - the brightest thing in the room
+    new Color32(255, 250, 225), // 0 lamp bulb – the brightest thing in the room
     new Color32(255, 226, 150), // 1 lamp glow
     new Color32(214, 178, 116), // 2 lit patch of wall right under the lamp
     new Color32(168, 138, 96), // 3 wall, still well lit
@@ -234,8 +234,8 @@ const STEM_Y = 37;
 /**
  * Writes the room colors into a palette, starting at `firstSlot`.
  *
- * @param {Palette} palette - Palette to fill.
- * @param {number} firstSlot - Slot that receives the first color of SCENE_COLORS.
+ * @param {Palette} palette – Palette to fill.
+ * @param {number} firstSlot – Slot that receives the first color of SCENE_COLORS.
  */
 function fillScene(palette, firstSlot) {
     for (let i = 0; i < SCENE_COLORS.length; i++) {
@@ -246,8 +246,8 @@ function fillScene(palette, firstSlot) {
 /**
  * Writes plain black into the same run of slots, for the "faded out" target.
  *
- * @param {Palette} palette - Palette to fill.
- * @param {number} firstSlot - First slot of the run.
+ * @param {Palette} palette – Palette to fill.
+ * @param {number} firstSlot – First slot of the run.
  */
 function fillBlack(palette, firstSlot) {
     for (let i = 0; i < SCENE_COLORS.length; i++) {
@@ -324,7 +324,7 @@ class Demo {
             overlayPaletteRowsVisible: 2,
             overlayPaletteColumns: 15,
 
-            // The overlay defaults to drawing itself with slots 1 and 2 - which in
+            // The overlay defaults to drawing itself with slots 1 and 2 – which in
             // this demo are the lamp bulb and its glow, and fade to black along with
             // everything else. So point it at the shared UI theme colors instead,
             // which neither fade can reach. configure() runs before init(), so the
@@ -351,7 +351,7 @@ class Demo {
         // the whole way through.
         this.theme = applyTheme(this.palette);
 
-        // The exposure fade's targets are small on purpose - see the header comment.
+        // The exposure fade's targets are small on purpose – see the header comment.
         this.expLit = BT.paletteCreate(EXPOSURE_TARGET_SIZE);
         fillScene(this.expLit, EXP_FIRST_SLOT);
 
@@ -394,7 +394,7 @@ class Demo {
         BT.clear(this.theme.shadow);
 
         // Left half: the plain fade. Right half: the exposure fade. Same drawing
-        // code both times - only the first palette slot differs.
+        // code both times – only the first palette slot differs.
         this.renderRoom(0, PLAIN_FIRST_SLOT);
         this.renderRoom(HALF_WIDTH, EXP_FIRST_SLOT);
 
@@ -407,7 +407,7 @@ class Demo {
         ui.begin('topLeft', { y: PANEL_Y });
         ui.panel('Exposure Fade');
 
-        // Dragging this changes the next fade, not the one already running - a fade
+        // Dragging this changes the next fade, not the one already running – a fade
         // captures its settings the moment it starts.
         this.highlightLead = ui.slider('Highlight lead', this.highlightLead, { min: 0, max: 0.95, width: 456 });
 
@@ -458,8 +458,8 @@ class Demo {
     /**
      * Starts both fades on the same frame with the same duration and easing.
      *
-     * @param {Palette} plainTarget - Where the left half's colors should end up.
-     * @param {Palette} exposureTarget - Where the right half's colors should end up.
+     * @param {Palette} plainTarget – Where the left half's colors should end up.
+     * @param {Palette} exposureTarget – Where the right half's colors should end up.
      */
     startFades(plainTarget, exposureTarget) {
         // Left half: the plain fade, limited to the slots the left picture uses.
@@ -475,8 +475,8 @@ class Demo {
     /**
      * Moves to the next step of the cycle once the current one has run long enough.
      *
-     * @param {number} elapsed - Ticks since this step started.
-     * @param {number} tick - The current tick.
+     * @param {number} elapsed – Ticks since this step started.
+     * @param {number} tick – The current tick.
      */
     advancePhaseIfExpired(elapsed, tick) {
         const current = PHASE_TRANSITIONS[this.phase];
@@ -513,8 +513,8 @@ class Demo {
      * Draws one lamp-lit room. Every draw call names a palette slot, never a
      * color, which is why changing the palette changes the picture.
      *
-     * @param {number} originX - Left edge of this half of the screen.
-     * @param {number} firstSlot - Slot holding the first color of SCENE_COLORS.
+     * @param {number} originX – Left edge of this half of the screen.
+     * @param {number} firstSlot – Slot holding the first color of SCENE_COLORS.
      */
     renderRoom(originX, firstSlot) {
         // Back wall, in three bands that get brighter closer to the lamp.
@@ -567,8 +567,8 @@ class Demo {
     /**
      * Draws the strip of brightness steps under a room.
      *
-     * @param {number} originX - Left edge of this half of the screen.
-     * @param {number} firstSlot - Slot holding the first color of SCENE_COLORS.
+     * @param {number} originX – Left edge of this half of the screen.
+     * @param {number} firstSlot – Slot holding the first color of SCENE_COLORS.
      */
     renderRamp(originX, firstSlot) {
         // Share the width evenly between the steps, darkest on the left.

--- a/packages/demos/src/palette-exposure-fade.js
+++ b/packages/demos/src/palette-exposure-fade.js
@@ -6,8 +6,8 @@
 //   Basics             https://demos.blit386.dev/basics
 //   Palette Presets    https://demos.blit386.dev/palette-presets
 //   Palette Fade       https://demos.blit386.dev/palette-fade
-//     (walkthroughs: https://vancura.dev/articles/blit386-palette-presets,
-//      https://vancura.dev/articles/blit386-palette-fade)
+//     (guides: https://blit386.dev/docs/guides/palette-presets,
+//      https://blit386.dev/docs/guides/palette#runtime-palette-effects)
 //
 // Live version: https://demos.blit386.dev/palette-exposure-fade
 //

--- a/packages/demos/src/palette-fade.js
+++ b/packages/demos/src/palette-fade.js
@@ -20,7 +20,7 @@
 // Imagine you have two sets of paint buckets: one for a sunny day, one for a
 // dark night. A "palette fade" gradually mixes the day paints with the night
 // paints over several seconds, so the whole picture smoothly transitions from
-// bright to dark - like watching a sunset.
+// bright to dark – like watching a sunset.
 //
 // BLIT386 does this with BT.paletteFade(targetPalette, durationMs, easing).
 // You give it the destination paint set, how long the transition should take,
@@ -36,13 +36,13 @@
 // UPDATE VS RENDER (palette work split):
 //   init() builds separate day and night Palette objects and activates the day set.
 //   update() runs the day/night state machine and calls BT.paletteFade() or
-//   BT.paletteFlash() once per phase - the engine blends active palette slots over time.
+//   BT.paletteFlash() once per phase – the engine blends active palette slots over time.
 //   render() draws the same landscape geometry every frame using palette indices only;
 //   sky, trees, and ground change color because the engine updated the palette, not
 //   because render() passes new Color32 values to draw calls.
 //
 // The phase caption panel is drawn with the shared UI kit (src/shared/ui.js). Its theme
-// colors live in slots 240..251 - and because BT.paletteFade() blends EVERY slot toward
+// colors live in slots 240..251 – and because BT.paletteFade() blends EVERY slot toward
 // the target palette, init() writes the same theme colors into the day and night target
 // palettes too. That makes the UI slots "fade" from a color to the identical color, so
 // the panel stays readable while the whole scene transitions around it.
@@ -52,7 +52,7 @@
 //   1. Day (bright)   - hold 3 seconds
 //   2. Fade to night  - 2 seconds, ease-in-out
 //   3. Night (dark)   - hold 3 seconds
-//   4. Lightning flash - 200 ms white flash
+//   4. Lightning flash – 200 ms white flash
 //   5. Night hold     - 2 seconds
 //   6. Fade to day    - 2 seconds, ease-out (dawn)
 //   Repeat forever.
@@ -108,9 +108,9 @@ const C_MOUNTAIN = 22;
 const C_MOUNTAIN_LIGHT = 23;
 
 /**
- * Builds the "day" palette - bright, saturated outdoor colors.
+ * Builds the "day" palette – bright, saturated outdoor colors.
  *
- * @param {Palette} p - Palette to fill.
+ * @param {Palette} p – Palette to fill.
  */
 function fillDay(p) {
     p.set(C_LABEL, new Color32(255, 210, 80));
@@ -134,9 +134,9 @@ function fillDay(p) {
 }
 
 /**
- * Builds the "night" palette - dark, desaturated blues and purples.
+ * Builds the "night" palette – dark, desaturated blues and purples.
  *
- * @param {Palette} p - Palette to fill.
+ * @param {Palette} p – Palette to fill.
  */
 function fillNight(p) {
     p.set(C_LABEL, new Color32(180, 160, 100));
@@ -234,12 +234,12 @@ class Demo {
 
         // Install the shared UI kit colors (slots 240..251) into ALL THREE palettes.
         // This matters because BT.paletteFade() blends every slot toward the target
-        // palette - if the day and night targets left those slots at their default
+        // palette – if the day and night targets left those slots at their default
         // black, the first fade would fade the UI colors away for good. Writing the
         // identical theme colors into the targets turns the UI slots into fixed
         // points: they "fade" from a color to the very same color, so nothing moves.
         // (BT.paletteFlash() still whites them out for 200 ms, but it snapshots and
-        // restores every slot afterwards, so the flash heals itself - just like it
+        // restores every slot afterwards, so the flash heals itself – just like it
         // always did for the scene colors.)
         applyTheme(this.day);
         applyTheme(this.night);
@@ -317,8 +317,8 @@ class Demo {
     /**
      * Transitions to a new phase of the day/night cycle.
      *
-     * @param {string} newPhase - Name of the phase to enter.
-     * @param {number} tick - Current tick when the phase starts.
+     * @param {string} newPhase – Name of the phase to enter.
+     * @param {number} tick – Current tick when the phase starts.
      */
     startPhase(newPhase, tick) {
         this.phase = newPhase;
@@ -355,8 +355,8 @@ class Demo {
     /**
      * Checks whether the current phase has run long enough and advances to the next.
      *
-     * @param {number} elapsed - Ticks since the current phase started.
-     * @param {number} tick - Current tick count.
+     * @param {number} elapsed – Ticks since the current phase started.
+     * @param {number} tick – Current tick count.
      */
     advancePhaseIfExpired(elapsed, tick) {
         const current = PHASE_TRANSITIONS[this.phase];
@@ -406,8 +406,8 @@ class Demo {
     /**
      * Draws a simple cloud shape at the given position.
      *
-     * @param {number} x - Left position.
-     * @param {number} y - Top position.
+     * @param {number} x – Left position.
+     * @param {number} y – Top position.
      */
     drawCloud(x, y) {
         BT.drawRectFill(new Rect2i(x, y, 30, 8), C_CLOUD);
@@ -417,10 +417,10 @@ class Demo {
     /**
      * Draws a triangular mountain shape using stacked rectangles.
      *
-     * @param {number} x - Center x.
-     * @param {number} baseY - Bottom of the mountain.
-     * @param {number} width - Base width.
-     * @param {number} height - Mountain height.
+     * @param {number} x – Center x.
+     * @param {number} baseY – Bottom of the mountain.
+     * @param {number} width – Base width.
+     * @param {number} height – Mountain height.
      */
     drawMountain(x, baseY, width, height) {
         // Draw the mountain as a series of horizontal slices getting narrower toward the top.
@@ -440,8 +440,8 @@ class Demo {
     /**
      * Draws a simple tree (trunk + leaf canopy).
      *
-     * @param {number} x - Trunk center x.
-     * @param {number} groundY - Y position of the ground line.
+     * @param {number} x – Trunk center x.
+     * @param {number} groundY – Y position of the ground line.
      */
     drawTree(x, groundY) {
         // Trunk.

--- a/packages/demos/src/palette-fade.js
+++ b/packages/demos/src/palette-fade.js
@@ -8,12 +8,11 @@
 //   Palette Presets   https://demos.blit386.dev/palette-presets
 //   Palette Animation https://demos.blit386.dev/palette-animation
 //   Palette Cycling   https://demos.blit386.dev/palette-cycling
-//     (walkthroughs: https://vancura.dev/articles/blit386-palette-presets,
-//      https://vancura.dev/articles/blit386-palette-animation,
-//      https://vancura.dev/articles/blit386-palette-cycling)
+//     (guides: https://blit386.dev/docs/guides/palette-presets,
+//      https://blit386.dev/docs/guides/palette#runtime-palette-effects)
 //
 // Live version: https://demos.blit386.dev/palette-fade
-// Live article: https://vancura.dev/articles/blit386-palette-fade
+// Guide: https://blit386.dev/docs/guides/palette#runtime-palette-effects
 //
 // WHAT ARE PALETTE FADES?
 //

--- a/packages/demos/src/palette-presets.js
+++ b/packages/demos/src/palette-presets.js
@@ -7,10 +7,10 @@
 //   Primitives https://demos.blit386.dev/primitives
 //   Colors     https://demos.blit386.dev/colors
 //   Fonts      https://demos.blit386.dev/fonts
-//     (text drawing basics with BT.systemPrint; walkthrough: https://vancura.dev/articles/blit386-fonts)
+//     (text drawing basics with BT.systemPrint; guide: https://blit386.dev/docs/guides/bitmap-fonts)
 //
 // Live version: https://demos.blit386.dev/palette-presets
-// Live article: https://vancura.dev/articles/blit386-palette-presets
+// Guide: https://blit386.dev/docs/guides/palette-presets
 //
 // WHAT IS A PALETTE PRESET?
 //

--- a/packages/demos/src/palette-presets.js
+++ b/packages/demos/src/palette-presets.js
@@ -18,19 +18,19 @@
 //   palette.set(1, new Color32(255, 0, 0)); // My red.
 //   palette.set(2, new Color32(0, 255, 0)); // My green.
 //
-// BLIT386 ships with six "preset" palettes - ready-made color sets based on
+// BLIT386 ships with six "preset" palettes – ready-made color sets based on
 // real hardware from the history of video games:
 //
-//   Game Boy    4 colors   (1989 Nintendo handheld - shades of green)
-//   CGA        16 colors   (1981 IBM PC graphics card - loud, iconic)
-//   C64        16 colors   (1982 Commodore 64 - earthy, distinctive)
-//   PICO-8     16 colors   (2015 fantasy console - soft, retro feel)
-//   NES        56 colors   (1983 Nintendo console - wide but limited)
-//   VGA       256 colors   (1987 IBM PC graphics standard - rich range)
+//   Game Boy    4 colors   (1989 Nintendo handheld – shades of green)
+//   CGA        16 colors   (1981 IBM PC graphics card – loud, iconic)
+//   C64        16 colors   (1982 Commodore 64 – earthy, distinctive)
+//   PICO-8     16 colors   (2015 fantasy console – soft, retro feel)
+//   NES        56 colors   (1983 Nintendo console – wide but limited)
+//   VGA       256 colors   (1987 IBM PC graphics standard – rich range)
 //
 // A preset palette gives you instant authentic retro style.
 //
-// You can also NAME slots using setNamed() / getNamed() - like labeling paint cans
+// You can also NAME slots using setNamed() / getNamed() – like labeling paint cans
 // instead of just numbering them. "live-swatch-0" is easier to remember than slot 200.
 //
 // The title strip, row captions, and the live-view panel are drawn with the shared demo
@@ -72,7 +72,7 @@ const LIVE_PANEL_Y = 152;
 // Shared UI theme slots used by configure().
 //
 // applyTheme() (see init()) writes the twelve shared UI colors into palette slots
-// 240..251 - its default start slot, safely above this demo's swatch slots (10..181)
+// 240..251 – its default start slot, safely above this demo's swatch slots (10..181)
 // and live-view slots (200..215). configure() runs BEFORE init(), so the overlay
 // styles below have to name those slots as plain numbers instead of reading this.theme.
 const THEME_BG = 240; // Deep navy screen background.
@@ -208,7 +208,7 @@ class Demo {
         // setNamed() lets you refer to a slot by a descriptive word instead of a number.
         // This is like writing "live-swatch-0" on a label instead of "slot 200".
         // (applyTheme() above did the same trick for its UI colors: try
-        // palette.getNamed('ui_bg') - it answers 240.)
+        // palette.getNamed('ui_bg') – it answers 240.)
         this.palette.setNamed('live-swatch-0', LIVE_SWATCH_SLOT);
 
         // Activate palette
@@ -240,11 +240,11 @@ class Demo {
 
     /**
      * Draws the title strip, the static swatch rows with captions, and the live
-     * cycling preview panel. NO Color32 objects appear in draw calls here - only
+     * cycling preview panel. NO Color32 objects appear in draw calls here – only
      * palette index numbers (and the kit, which uses its own theme slots).
      */
     render() {
-        // Background - the shared theme's deep navy, so every demo looks alike.
+        // Background – the shared theme's deep navy, so every demo looks alike.
         BT.clear(this.theme.bg);
 
         // Full-width title strip across the top, drawn by the shared UI kit.
@@ -337,13 +337,13 @@ class Demo {
     renderLivePreview() {
         // The kit panel: a pinned group with a fixed width so the swatches fit.
         // ui.spacer(28) reserves an empty band inside the panel where the 24px-tall
-        // swatches will be drawn AFTER ui.end() - the kit paints its panel fill on
+        // swatches will be drawn AFTER ui.end() – the kit paints its panel fill on
         // end(), so anything drawn later lands on top of it.
         ui.begin('topLeft', { x: LIVE_PANEL_X, y: LIVE_PANEL_Y, width: 298 });
         ui.panel('Live view (cycles every 2s)');
         ui.spacer(28);
 
-        // Explain named slots - this is real code from init() above.
+        // Explain named slots – this is real code from init() above.
         ui.label("palette.setNamed('live-swatch-0', 200)", { color: 'dim' });
         ui.label("palette.getNamed('live-swatch-0') => 200", { color: 'dim' });
         ui.end();

--- a/packages/demos/src/palette-swap.js
+++ b/packages/demos/src/palette-swap.js
@@ -7,12 +7,12 @@
 //   Sprites           https://demos.blit386.dev/sprites
 //   Palette Presets   https://demos.blit386.dev/palette-presets
 //   Palette Animation https://demos.blit386.dev/palette-animation
-//     (walkthroughs: https://vancura.dev/articles/blit386-sprites,
-//      https://vancura.dev/articles/blit386-palette-presets,
-//      https://vancura.dev/articles/blit386-palette-animation)
+//     (guides: https://blit386.dev/docs/api/rendering#sprites,
+//      https://blit386.dev/docs/guides/palette-presets,
+//      https://blit386.dev/docs/guides/palette#runtime-palette-effects)
 //
 // Live version: https://demos.blit386.dev/palette-swap
-// Live article: https://vancura.dev/articles/blit386-palette-swap
+// Guide: https://blit386.dev/docs/guides/palette#layout-swap-vs-value-swap
 //
 // WHAT IS PALETTE SWAP?
 //

--- a/packages/demos/src/palette-swap.js
+++ b/packages/demos/src/palette-swap.js
@@ -45,7 +45,7 @@
 //
 // All captions and the code column are drawn with the shared UI kit (src/shared/ui.js).
 // Because this demo swaps the WHOLE palette every 2 seconds, every theme palette must
-// carry the same UI kit colors in the same slots - see buildTheme() for the details.
+// carry the same UI kit colors in the same slots – see buildTheme() for the details.
 
 import { bootstrap, BT, Color32, Rect2i, SpriteSheet, Timer, Vector2i } from 'blit386';
 
@@ -150,8 +150,8 @@ class Demo {
      *   1. Extract unique colors from the sprite PNG.
      *   2. Build the stone (base) palette with those colors.
      *   3. Build fire, ice, void palettes by tinting the base colors.
-     *   4. BT.paletteSet(stonePalette) - activate the starting palette.
-     *   5. SpriteSheet.load() + indexize() - link pixels to slot numbers.
+     *   4. BT.paletteSet(stonePalette) – activate the starting palette.
+     *   5. SpriteSheet.load() + indexize() – link pixels to slot numbers.
      *
      * @returns {Promise<boolean>} True when everything is ready.
      */
@@ -238,7 +238,7 @@ class Demo {
 
     /**
      * Draws the theme legend, cycling sprite, and code column.
-     * NO Color32 objects appear in draw calls - only palette indices and offsets.
+     * NO Color32 objects appear in draw calls – only palette indices and offsets.
      */
     render() {
         // Clear to the shared UI theme background (same slot in all theme palettes).
@@ -256,7 +256,7 @@ class Demo {
      * A highlight box shows which theme is currently active.
      *
      * The swatch squares use this demo's own scene slots (30..33), which the UI kit
-     * cannot draw, so the legend rows stay hand-rolled - but their text and outline
+     * cannot draw, so the legend rows stay hand-rolled – but their text and outline
      * use the shared theme slots so the colors match the rest of the UI.
      */
     renderThemeLegend() {
@@ -294,7 +294,7 @@ class Demo {
 
     /**
      * Draws the large cycling sprite in the center of the screen.
-     * The sprite uses offset 0 - it draws from COLOR_BASE..COLOR_BASE+N-1,
+     * The sprite uses offset 0 – it draws from COLOR_BASE..COLOR_BASE+N-1,
      * which contains the current theme's colors in whichever palette is active.
      */
     renderCyclingSprite() {
@@ -343,7 +343,7 @@ class Demo {
         ui.spacer();
 
         // spritesRefresh() only matters when the new palette moves colors to
-        // DIFFERENT slot numbers - see the header comment at the top of this file.
+        // DIFFERENT slot numbers – see the header comment at the top of this file.
         ui.label('// Sync sprites', { color: 'dim' });
         ui.label('BT.spritesRefresh()', { color: 'info' });
         ui.spacer();
@@ -365,10 +365,10 @@ class Demo {
      *
      * Because the sprite slot NUMBERS (10..N) are the same in every palette,
      * the sprite sheet does not need re-indexization when we swap themes.
-     * The sprite's stored indices already point to the right slots - just the colors
+     * The sprite's stored indices already point to the right slots – just the colors
      * in those slots differ.
      *
-     * @param {'stone'|'fire'|'ice'|'void'} themeName - Which tint to apply.
+     * @param {'stone'|'fire'|'ice'|'void'} themeName – Which tint to apply.
      * @returns {import('blit386').Palette} Ready-to-use Palette object.
      */
     buildTheme(themeName) {
@@ -415,13 +415,13 @@ class Demo {
      * A "tint" is a simple recipe: nudge the red, green, and blue channels up or
      * down, clamped to the valid 0..255 range so the math never overflows.
      *
-     * @param {Color32} base - The original stone color from the sprite.
-     * @param {'stone'|'fire'|'ice'|'void'} themeName - Which tint recipe to apply.
+     * @param {Color32} base – The original stone color from the sprite.
+     * @param {'stone'|'fire'|'ice'|'void'} themeName – Which tint recipe to apply.
      * @returns {Color32} The tinted color for this theme.
      */
     tintColor(base, themeName) {
         if (themeName === 'stone') {
-            // Original colors - no tint.
+            // Original colors – no tint.
             return base;
         }
 

--- a/packages/demos/src/patterns.js
+++ b/packages/demos/src/patterns.js
@@ -21,17 +21,17 @@
 //   Radial    - lines radiating from a center point like sun rays
 //   Wave      - overlapping wave curves that interfere with each other
 //   Circle    - a circle drawn from many tiny line segments
-//   Lissajous - a smooth looping curve used in physics and electronics
+//   Lissajous – a smooth looping curve used in physics and electronics
 //   Tunnel    - concentric rectangles that spin to look like a tunnel
 //
 // HOW COLORS WORK IN THIS DEMO:
 //
 // Every color must be registered in a "palette" before drawing. Think of it
-// like choosing all your paint colors before starting a painting - you pick
+// like choosing all your paint colors before starting a painting – you pick
 // them out first, then use them by number ("color 5", "color 12", etc.).
 //
-// Some colors never change (white, background, wave colors) - those are set
-// once during setup. Other colors animate (spiral, Lissajous, tunnel) - those
+// Some colors never change (white, background, wave colors) – those are set
+// once during setup. Other colors animate (spiral, Lissajous, tunnel) – those
 // are recalculated every tick in update() and stored back in the palette.
 // The render() function only ever uses color numbers (indices), never Color32 objects.
 //
@@ -49,16 +49,16 @@ import { applyTheme, ui } from './shared/ui.js';
 /** @typedef {import('blit386').Palette} Palette */
 //
 // These numbers are the "addresses" in the palette table.
-// Index 0 is always reserved for transparent - we never use it.
+// Index 0 is always reserved for transparent – we never use it.
 // We give each color a readable name so the code is easier to follow.
 
 // Static colors (set once in init, never change).
-const C_WHITE = 1; // Pure white - overlay bar style color (see configure()).
+const C_WHITE = 1; // Pure white – overlay bar style color (see configure()).
 const C_BG = 2; // Very dark blue-black background.
-const C_TAG = 3; // Dim white - only feeds the overlay timing-chart tag color (see configure()).
-const C_WAVE_1 = 5; // Blue - primary sine wave.
-const C_WAVE_2 = 6; // Orange - secondary cosine wave.
-const C_WAVE_3 = 7; // Green - interference (both waves combined).
+const C_TAG = 3; // Dim white – only feeds the overlay timing-chart tag color (see configure()).
+const C_WAVE_1 = 5; // Blue – primary sine wave.
+const C_WAVE_2 = 6; // Orange – secondary cosine wave.
+const C_WAVE_3 = 7; // Green – interference (both waves combined).
 
 // Circle segments: 32 entries at indices 8..39.
 // Each segment gets a different hue. Hue never changes so this is static.
@@ -273,7 +273,7 @@ class Demo {
         this.drawTunnel(new Vector2i(200, 130));
 
         // Label each grid cell so viewers know which pattern they are looking at.
-        // ui.caption() is the shared UI kit's pinned one-line caption - the same widget
+        // ui.caption() is the shared UI kit's pinned one-line caption – the same widget
         // every demo in the series uses, so all captions look identical everywhere.
         // Text draws left-aligned, so we nudge x until short names sit under each center.
         ui.caption(22, 92, 'Spiral');
@@ -288,10 +288,10 @@ class Demo {
      * Draws an Archimedean spiral: a coil of colored dots that expands outward
      * while rotating. The inner dots are near the center, the outer ones are far.
      *
-     * Colors are animated - they scroll along the spiral over time. The actual
+     * Colors are animated – they scroll along the spiral over time. The actual
      * color values are computed in update() and stored in palette slots C_SPIRAL_BASE+i.
      *
-     * @param {Vector2i} center - The center point to spiral around.
+     * @param {Vector2i} center – The center point to spiral around.
      */
     drawSpiral(center) {
         const maxRadius = 35;
@@ -314,7 +314,7 @@ class Demo {
             const x = center.x + Math.cos(t) * radius;
             const y = center.y + Math.sin(t) * radius;
 
-            // Use the animated color for dot i - already updated in update().
+            // Use the animated color for dot i – already updated in update().
             this.tempVec1.set(Math.floor(x), Math.floor(y));
             BT.drawPixel(this.tempVec1, C_SPIRAL_BASE + i);
         }
@@ -324,7 +324,7 @@ class Demo {
      * Draws lines radiating from a center point like sun rays.
      * Each ray has a different color (set once in init) and its length pulses.
      *
-     * @param {Vector2i} center - The center point to draw rays from.
+     * @param {Vector2i} center – The center point to draw rays from.
      */
     drawRadialLines(center) {
         const radius = 35; // Maximum length of each ray.
@@ -353,9 +353,9 @@ class Demo {
      * Two separate waves plus a combined "interference" pattern that shows
      * what happens when the two waves add together.
      *
-     * All three wave colors are static - they never change.
+     * All three wave colors are static – they never change.
      *
-     * @param {Vector2i} center - The center point to draw the waves around.
+     * @param {Vector2i} center – The center point to draw the waves around.
      */
     drawWavePattern(center) {
         const width = 60; // The wave spans 60 pixels wide.
@@ -391,7 +391,7 @@ class Demo {
      *
      * Segment colors are static (set once in init based on hue position).
      *
-     * @param {Vector2i} center - The center of the circle.
+     * @param {Vector2i} center – The center of the circle.
      */
     drawCircleApproximation(center) {
         // The radius pulses between 2 and 30 pixels (16 ± 14) using Math.sin.
@@ -418,17 +418,17 @@ class Demo {
     }
 
     /**
-     * Draws a Lissajous curve - a parametric figure where the x and y axes
+     * Draws a Lissajous curve – a parametric figure where the x and y axes
      * oscillate at different frequencies. The ratio 3:4 here creates an interlocking
      * looping curve (not a simple figure-eight; a classic figure-eight shape often
      * comes from a 1:2 frequency ratio instead).
      *
      * Lissajous figures are used in physics and electronics to visualize frequency ratios.
      *
-     * Colors are animated - 200 curve points are mapped to 32 color bands,
+     * Colors are animated – 200 curve points are mapped to 32 color bands,
      * and those bands rotate through the rainbow over time.
      *
-     * @param {Vector2i} center - The center of the curve.
+     * @param {Vector2i} center – The center of the curve.
      */
     drawLissajous(center) {
         const points = 200; // More points = smoother curve.
@@ -471,14 +471,14 @@ class Demo {
      * Draws a tunnel effect by stacking concentric rectangles of decreasing size.
      * The rectangles slowly rotate and wobble, creating an illusion of depth.
      *
-     * Colors are animated - each rectangle's hue and brightness are updated in update().
+     * Colors are animated – each rectangle's hue and brightness are updated in update().
      *
-     * @param {Vector2i} center - The vanishing point (center) of the tunnel.
+     * @param {Vector2i} center – The vanishing point (center) of the tunnel.
      */
     drawTunnel(center) {
         for (let i = 0; i < TUNNEL_RECTS; i++) {
             // t = i / TUNNEL_RECTS: i = 0 is the outer/near largest rectangle;
-            // the final i is the inner/far smallest (size uses 1 - t below).
+            // the final i is the inner/far smallest (size uses 1 – t below).
             const t = i / TUNNEL_RECTS;
 
             // Outer rectangles are large, inner ones are small.

--- a/packages/demos/src/patterns.js
+++ b/packages/demos/src/patterns.js
@@ -10,7 +10,7 @@
 // palettes later, in palette-presets demo and beyond.
 //
 // Live version: https://demos.blit386.dev/patterns
-// Walkthrough article: https://vancura.dev/articles/blit386-patterns
+// Guide: https://blit386.dev/docs/api/rendering#primitives
 //
 // All six patterns here are drawn using just pixels, lines, and rectangles
 // no images needed. Each pattern is based on simple math (angles, waves, circles)

--- a/packages/demos/src/sprite-effects.js
+++ b/packages/demos/src/sprite-effects.js
@@ -2,7 +2,7 @@
 //
 // Prerequisites: Basics (https://demos.blit386.dev/basics),
 // Sprites (https://demos.blit386.dev/sprites).
-// Live article: https://vancura.dev/articles/blit386-sprite-effects
+// Guide: https://blit386.dev/docs/guides/palette#per-draw-palette-offsets-zero-cost-color-variants
 //
 // In the palette-based rendering system, each sprite pixel stores a palette index.
 // By drawing the same sprite with a different palette offset (the fourth argument

--- a/packages/demos/src/sprite-effects.js
+++ b/packages/demos/src/sprite-effects.js
@@ -86,25 +86,25 @@ const COLOR_BASE = 12;
 
 // Palette slots of the shared UI theme. applyTheme() in init() writes the twelve UI kit
 // colors into slots 240-251 (its default start slot). configure() runs BEFORE init(), so
-// the overlay styles below cannot read this.theme yet - these constants spell out where
+// the overlay styles below cannot read this.theme yet – these constants spell out where
 // each theme color will land once init() runs.
-const UI_BG = 240; // 'ui_bg' - deep navy screen background.
-const UI_TEXT = 244; // 'ui_text' - off-white primary text.
-const UI_DIM = 245; // 'ui_text_dim' - secondary gray text.
-const UI_HEADER = 246; // 'ui_header' - warm amber (render bars, chart warnings).
-const UI_ACCENT = 247; // 'ui_accent' - phosphor green (update bars).
-const UI_WARM = 248; // 'ui_accent_warm' - orange (chart error frames).
-const UI_INFO = 249; // 'ui_info' - light blue (chart tags).
+const UI_BG = 240; // 'ui_bg' – deep navy screen background.
+const UI_TEXT = 244; // 'ui_text' – off-white primary text.
+const UI_DIM = 245; // 'ui_text_dim' – secondary gray text.
+const UI_HEADER = 246; // 'ui_header' – warm amber (render bars, chart warnings).
+const UI_ACCENT = 247; // 'ui_accent' – phosphor green (update bars).
+const UI_WARM = 248; // 'ui_accent_warm' – orange (chart error frames).
+const UI_INFO = 249; // 'ui_info' – light blue (chart tags).
 
 // Theme block indices (as palette offsets from COLOR_BASE).
-// Each block contains one entry per unique sprite color - that count lives in
+// Each block contains one entry per unique sprite color – that count lives in
 // this.colorCount, extracted in init(). Offset = blockIndex * colorCount.
 // Blocks 0..7 are static; blocks 8..12 are dynamic (updated in update()).
 //
 // Block 0 (offset 0):                 Original stone colors.
-// Block 1 (offset colorCount):        Silhouette - all colors near-black.
-// Block 2 (offset 2 * colorCount):    Damage white - all colors bright white.
-// Block 3 (offset 3 * colorCount):    Damage red - all colors shifted red.
+// Block 1 (offset colorCount):        Silhouette – all colors near-black.
+// Block 2 (offset 2 * colorCount):    Damage white – all colors bright white.
+// Block 3 (offset 3 * colorCount):    Damage red – all colors shifted red.
 // Block 4 (offset 4 * colorCount):    Team red.
 // Block 5 (offset 5 * colorCount):    Team blue.
 // Block 6 (offset 6 * colorCount):    Team green.
@@ -185,7 +185,7 @@ const BAND_WOBBLE_INTENSITY = 0.11;
  * The timing chart maps bar height from real update()/render() time; this demo adds
  * a gentle pulse so the scrolling bars are easy to see while you watch the effects.
  *
- * @param {number} ms - Target delay in milliseconds.
+ * @param {number} ms – Target delay in milliseconds.
  */
 function burnCpuMs(ms) {
     if (ms <= 0) {
@@ -219,7 +219,7 @@ class Demo {
     /** @type {Rect2i | null} */
     charRect = null;
 
-    // How many unique colors the sprite has - every theme block is this many
+    // How many unique colors the sprite has – every theme block is this many
     // palette slots wide. Computed in init() after the colors are extracted.
     colorCount = 0;
 
@@ -362,7 +362,7 @@ class Demo {
             return false;
         }
 
-        // Glitch state is shared by both backends - initialize once before the CRT check.
+        // Glitch state is shared by both backends – initialize once before the CRT check.
         // BT.random is the engine's shared random number generator.
         // Its int() method returns a whole number from the first value up to (but not including) the second,
         // so this waits a random number of ticks before the first burst.
@@ -431,7 +431,7 @@ class Demo {
 
     /**
      * Runs once per screen refresh to draw all the sprite effect demonstrations.
-     * Notice: NO Color32 objects appear in draw calls - only palette indices and offsets.
+     * Notice: NO Color32 objects appear in draw calls – only palette indices and offsets.
      */
     render() {
         // Clear the whole screen with the shared UI theme's background color.
@@ -492,7 +492,7 @@ class Demo {
         this.pixelGlitch.intensity = 0;
         BT.effectAdd(this.pixelGlitch);
 
-        // Display tier: Tesla Orava B/W tube - curved glass, faint grille, soft halation.
+        // Display tier: Tesla Orava B/W tube – curved glass, faint grille, soft halation.
         this.barrel = new BarrelDistortion();
         this.barrel.curvature = 0.07;
 
@@ -635,11 +635,11 @@ class Demo {
 
     /**
      * Builds the 8 static theme blocks by transforming the base colors.
-     * Called once in init() - these never change after setup.
+     * Called once in init() – these never change after setup.
      */
     buildStaticThemeBlocks() {
         // Block 0 (original) is already filled by SpriteSheet.loadColorsIntoPalette above.
-        // n is how many unique colors the sprite has - every block is n slots wide.
+        // n is how many unique colors the sprite has – every block is n slots wide.
         const n = this.colorCount;
 
         for (let i = 0; i < n; i++) {
@@ -648,27 +648,27 @@ class Demo {
             // The average brightness of this pixel (0..255 range).
             const lum = Math.floor(base.luminance);
 
-            // Block 1: Silhouette - near-black with slight variation to preserve depth cues.
+            // Block 1: Silhouette – near-black with slight variation to preserve depth cues.
             // Floor channels like blocks 4-7 so every recipe hands Color32 whole bytes.
             this.palette.set(
                 COLOR_BASE + BLOCK_SILHOUETTE * n + i,
                 new Color32(Math.floor(lum * 0.08), Math.floor(lum * 0.08), Math.floor(lum * 0.1), base.a),
             );
 
-            // Block 2: Damage white - everything shifted toward bright white.
+            // Block 2: Damage white – everything shifted toward bright white.
             const whitened = Math.floor(128 + lum * 0.5);
             this.palette.set(
                 COLOR_BASE + BLOCK_DAMAGE_WHITE * n + i,
                 new Color32(whitened, whitened, whitened, base.a),
             );
 
-            // Block 3: Damage red - everything shifted toward red.
+            // Block 3: Damage red – everything shifted toward red.
             this.palette.set(
                 COLOR_BASE + BLOCK_DAMAGE_RED * n + i,
                 new Color32(Math.min(255, lum + 80), Math.floor(lum * 0.3), Math.floor(lum * 0.3), base.a),
             );
 
-            // Block 4: Team red - multiply base colors with a red tint.
+            // Block 4: Team red – multiply base colors with a red tint.
             this.palette.set(
                 COLOR_BASE + BLOCK_TEAM_RED * n + i,
                 new Color32(
@@ -679,7 +679,7 @@ class Demo {
                 ),
             );
 
-            // Block 5: Team blue - multiply with a blue tint.
+            // Block 5: Team blue – multiply with a blue tint.
             this.palette.set(
                 COLOR_BASE + BLOCK_TEAM_BLUE * n + i,
                 new Color32(
@@ -690,7 +690,7 @@ class Demo {
                 ),
             );
 
-            // Block 6: Team green - multiply with a green tint.
+            // Block 6: Team green – multiply with a green tint.
             this.palette.set(
                 COLOR_BASE + BLOCK_TEAM_GREEN * n + i,
                 new Color32(
@@ -701,7 +701,7 @@ class Demo {
                 ),
             );
 
-            // Block 7: Frozen - push toward cold blue-white.
+            // Block 7: Frozen – push toward cold blue-white.
             this.palette.set(
                 COLOR_BASE + BLOCK_FROZEN * n + i,
                 new Color32(Math.floor(lum * 0.7 + 40), Math.floor(lum * 0.8 + 40), Math.min(255, lum + 80), base.a),

--- a/packages/demos/src/sprites.js
+++ b/packages/demos/src/sprites.js
@@ -3,7 +3,7 @@
 // Prerequisites: Basics (https://demos.blit386.dev/basics),
 // Primitives (https://demos.blit386.dev/primitives),
 // Colors (https://demos.blit386.dev/colors).
-// Live article: https://vancura.dev/articles/blit386-sprites
+// Guide: https://blit386.dev/docs/api/rendering#sprites
 //
 // A "sprite" is a 2D image used in a game – like a character, a coin, or an enemy.
 // In BLIT386, sprites are stored in a "sprite sheet": one big image that

--- a/packages/demos/src/sprites.js
+++ b/packages/demos/src/sprites.js
@@ -5,15 +5,15 @@
 // Colors (https://demos.blit386.dev/colors).
 // Live article: https://vancura.dev/articles/blit386-sprites
 //
-// A "sprite" is a 2D image used in a game - like a character, a coin, or an enemy.
+// A "sprite" is a 2D image used in a game – like a character, a coin, or an enemy.
 // In BLIT386, sprites are stored in a "sprite sheet": one big image that
 // contains many small sprites arranged in a grid. You draw individual sprites by
 // telling the engine which rectangular region (a Rect2i "source rect") to copy.
 //
 // This demo builds a six-shape sheet on an offscreen canvas, then shows:
 //   1. BT.drawSprite() with different source regions (one shape per cell).
-//   2. Palette offsets - shifting every pixel index to a different color block.
-//   3. Opacity pulsing - rewriting palette alpha slots in update().
+//   2. Palette offsets – shifting every pixel index to a different color block.
+//   3. Opacity pulsing – rewriting palette alpha slots in update().
 //
 // Captions and the code panel are drawn with the shared UI kit (src/shared/ui.js), which
 // installs its own twelve UI colors high in the palette (slots 240-251) via applyTheme().
@@ -67,16 +67,16 @@ const SHAPE_NAMES = ['Square', 'Circle', 'Tri', 'Star', 'Heart', 'Gem'];
 
 // Palette slots of the shared UI theme. applyTheme() in init() writes the twelve UI kit
 // colors into slots 240-251 (its default start slot). configure() runs BEFORE init(), so
-// the overlay styles below cannot read this.theme yet - these constants spell out where
+// the overlay styles below cannot read this.theme yet – these constants spell out where
 // each theme color will land once init() runs.
-const UI_BG = 240; // 'ui_bg' - deep navy screen background
-const UI_TEXT = 244; // 'ui_text' - off-white primary text
-const UI_DIM = 245; // 'ui_text_dim' - secondary gray text
-const UI_INFO = 249; // 'ui_info' - code blue
+const UI_BG = 240; // 'ui_bg' – deep navy screen background
+const UI_TEXT = 244; // 'ui_text' – off-white primary text
+const UI_DIM = 245; // 'ui_text_dim' – secondary gray text
+const UI_INFO = 249; // 'ui_info' – code blue
 
 // The exact two colors drawShapeInCell() paints with (see fill/stroke below).
 // The canvas smooths shape edges automatically (anti-aliasing), which blends these two
-// colors - and the transparent background - together one pixel at a time. Read back from
+// colors – and the transparent background – together one pixel at a time. Read back from
 // the canvas, that blending produces dozens of barely-different colors along every curve,
 // which would each want their own palette slot. Since our palette can only hold 256 colors
 // total, and this demo needs room for several recolored copies of the same shape, we snap
@@ -89,7 +89,7 @@ const STROKE_COLOR = new Color32(0xff, 0xff, 0xff);
 
 /**
  * Finds whichever of FILL_COLOR/STROKE_COLOR is closer to a given pixel color.
- * "Closer" here means smaller distance in RGB space - treating red, green, and blue like
+ * "Closer" here means smaller distance in RGB space – treating red, green, and blue like
  * three coordinates and measuring the straight-line distance between two colors, the same
  * way you would measure distance between two points on a map.
  *
@@ -105,7 +105,7 @@ function nearestShapeColor(r, g, b) {
     return distanceToFill <= distanceToStroke ? FILL_COLOR : STROKE_COLOR;
 }
 
-// Below this alpha, an anti-aliased edge pixel is mostly background - treat it as fully
+// Below this alpha, an anti-aliased edge pixel is mostly background – treat it as fully
 // transparent instead of a faint smudge of shape color.
 const ALPHA_OPAQUE_THRESHOLD = 128;
 
@@ -113,7 +113,7 @@ const ALPHA_OPAQUE_THRESHOLD = 128;
  * Rewrites every pixel of the canvas so it is either fully transparent or one of the exact
  * design colors (see FILL_COLOR/STROKE_COLOR above). sheet.indexize() later requires each
  * pixel to match a palette entry exactly, so the smooth, blended edges anti-aliasing draws
- * must be snapped to flat colors here - otherwise indexize() would reject every blended
+ * must be snapped to flat colors here – otherwise indexize() would reject every blended
  * edge pixel as "not in the palette".
  *
  * @param {OffscreenCanvasRenderingContext2D} ctx
@@ -147,9 +147,9 @@ function quantizeCanvasToShapeColors(ctx, w, h) {
  * Draws one filled shape centered inside a square cell.
  *
  * @param {OffscreenCanvasRenderingContext2D} ctx
- * @param {number} cellX - Left edge of the cell in sheet pixels.
- * @param {number} cellY - Top edge of the cell in sheet pixels.
- * @param {number} kind - 0 square, 1 circle, 2 triangle, 3 star, 4 heart, 5 diamond.
+ * @param {number} cellX – Left edge of the cell in sheet pixels.
+ * @param {number} cellY – Top edge of the cell in sheet pixels.
+ * @param {number} kind – 0 square, 1 circle, 2 triangle, 3 star, 4 heart, 5 diamond.
  */
 function drawShapeInCell(ctx, cellX, cellY, kind) {
     const cx = cellX + SHAPE_CELL / 2;
@@ -278,7 +278,7 @@ class Demo {
     // One Rect2i per shape cell in the programmatic sheet.
     shapeRects = [];
 
-    // Star cell - reused for the palette-offset row below the shape grid.
+    // Star cell – reused for the palette-offset row below the shape grid.
     /** @type {Rect2i | null} */
     themeRect = null;
 
@@ -326,7 +326,7 @@ class Demo {
         try {
             const { canvas, ctx, rects } = buildShapeSheet();
             this.shapeRects = rects;
-            this.themeRect = rects[3]; // Star - used for palette-offset demos.
+            this.themeRect = rects[3]; // Star – used for palette-offset demos.
 
             this.baseColors = registerCanvasColors(this.palette, ctx, canvas.width, canvas.height, COLOR_BASE);
             this.colorCount = this.baseColors.length;
@@ -389,7 +389,7 @@ class Demo {
         // Clear the whole screen with the shared UI theme's background color.
         BT.clear(this.theme.bg);
 
-        // Row 1: six shapes - each draw call uses a different source Rect2i.
+        // Row 1: six shapes – each draw call uses a different source Rect2i.
         const shapeY = 14;
         const shapeSpacing = 50;
 

--- a/packages/demos/src/starfield.js
+++ b/packages/demos/src/starfield.js
@@ -28,7 +28,7 @@
 // Every star has a unique brightness (how bright its gray color is). Instead of
 // making a new Color32 every frame, we register each star's gray color in the
 // palette once at startup and store the palette slot number on the star.
-// render() just reads that slot number - no Color32 objects needed per frame.
+// render() just reads that slot number – no Color32 objects needed per frame.
 //
 // The three explainer lines in the corner are drawn with the shared UI kit
 // (src/shared/ui.js), so their colors and spacing match every other demo.
@@ -90,12 +90,12 @@ class Demo {
     mediumLayer = [];
     nearLayer = [];
 
-    // Shooting star: not an array - only one at a time, or none.
+    // Shooting star: not an array – only one at a time, or none.
     // When active is false, we ignore the numbers until we spawn again.
     // prevHeadX/prevHeadY remember the head position at the START of the most recent
     // update() tick, before this tick's movement. render() blends between them and
     // headX/headY using BT.renderAlpha so the streak glides smoothly between physics
-    // ticks instead of hopping in 14px jumps - see "Interpolating render state with
+    // ticks instead of hopping in 14px jumps – see "Interpolating render state with
     // renderAlpha" in the engine's docs/api-game-loop.md.
     streak = {
         active: false,
@@ -141,7 +141,7 @@ class Demo {
      *   1. Create palette and register static colors.
      *   2. Build the star layers (this decides each star's brightness).
      *   3. Register each star's gray color in the palette, store the slot on the star.
-     *   4. BT.paletteSet() - tell the engine to use this palette.
+     *   4. BT.paletteSet() – tell the engine to use this palette.
      *
      * @returns {Promise<boolean>}
      */
@@ -270,7 +270,7 @@ class Demo {
             const brightness = BT.random.intInclusive(brightMin, brightMax);
 
             // paletteIndex starts at 0; init() will fill it in after palette setup.
-            // prevX/prevY start equal to x/y - see moveLayer() for how they update.
+            // prevX/prevY start equal to x/y – see moveLayer() for how they update.
             layer.push({ x, y, prevX: x, prevY: y, speed, brightness, paletteIndex: 0 });
         }
 
@@ -319,7 +319,7 @@ class Demo {
             this.streak.prevHeadX = this.streak.headX;
             this.streak.prevHeadY = this.streak.headY;
 
-            // Very fast compared to normal stars - several pixels per tick.
+            // Very fast compared to normal stars – several pixels per tick.
             this.streak.headX -= 14;
 
             // A gentle downward drift sells the "falling" look.
@@ -371,9 +371,9 @@ class Demo {
             return;
         }
 
-        // Blend the head's previous and current tick position by BT.renderAlpha - a
+        // Blend the head's previous and current tick position by BT.renderAlpha – a
         // fraction from 0 (a tick just finished) to just under 1 (the next tick is
-        // about to happen) - so the streak's drawn position matches this exact render
+        // about to happen) – so the streak's drawn position matches this exact render
         // moment instead of only its last-tick position.
         const alpha = BT.renderAlpha;
         const hx = Math.floor(this.streak.prevHeadX + (this.streak.headX - this.streak.prevHeadX) * alpha);
@@ -393,13 +393,13 @@ class Demo {
      * Each star's paletteIndex was set in init() to point at its unique gray shade.
      *
      * @param {Array<{x: number, y: number, prevX: number, prevY: number, paletteIndex: number}>} layer
-     * @param {number} size - Star width and height in pixels: 1 draws a single pixel,
+     * @param {number} size – Star width and height in pixels: 1 draws a single pixel,
      *   anything bigger draws a filled square (near stars use NEAR_STAR_SIZE).
      */
     drawLayer(layer, size) {
-        // Blend each star's previous and current tick position by BT.renderAlpha - a
+        // Blend each star's previous and current tick position by BT.renderAlpha – a
         // fraction from 0 (a tick just finished) to just under 1 (the next tick is
-        // about to happen) - so the star's drawn position matches this exact render
+        // about to happen) – so the star's drawn position matches this exact render
         // moment instead of only its last-tick position.
         const alpha = BT.renderAlpha;
 

--- a/packages/demos/src/starfield.js
+++ b/packages/demos/src/starfield.js
@@ -7,7 +7,7 @@
 //   Primitives https://demos.blit386.dev/primitives
 //   Colors     https://demos.blit386.dev/colors
 //
-// Live article: https://vancura.dev/articles/blit386-starfield
+// Guide: https://blit386.dev/docs/api/rendering#primitives
 //
 // WHAT YOU WILL SEE
 // Three layers of stars scroll to the left at different speeds. Stars that are

--- a/packages/demos/src/tilemap.js
+++ b/packages/demos/src/tilemap.js
@@ -10,7 +10,7 @@
 //
 // A "tilemap" is like a floor made of same-sized square tiles. Each cell in a 2D array
 // (a list of rows, each row a list of columns) stores a small number that means "which
-// kind of tile goes here" - like a Lego instruction sheet that says which brick color
+// kind of tile goes here" – like a Lego instruction sheet that says which brick color
 // fits each stud. The computer walks the grid with nested loops (one loop for rows,
 // one loop for columns) and draws only the tiles the camera can see, which is faster
 // than drawing thousands of off-screen tiles nobody would see.
@@ -35,7 +35,7 @@ import { applyTheme, ui } from './shared/ui.js';
 
 // These numbers are the "tile IDs" stored inside the 2D array.
 // Using named constants helps you remember what each number means when you read the map.
-const TILE_SKY = 0; // Empty air - we skip drawing and let the sky clear color show through.
+const TILE_SKY = 0; // Empty air – we skip drawing and let the sky clear color show through.
 const TILE_GRASS = 1; // Green ground.
 const TILE_DIRT = 2; // Brown earth below or beside grass.
 const TILE_STONE = 3; // Gray rocks.
@@ -55,7 +55,7 @@ const WORLD_HEIGHT_PX = MAP_HEIGHT_TILES * TILE_SIZE;
 
 // Each color in this demo has a reserved palette slot (a number from 1 upward).
 // Index 0 is always transparent. Giving each slot a name makes the drawing code
-// easier to read - "draw in C_GRASS" is clearer than "draw in index 5."
+// easier to read – "draw in C_GRASS" is clearer than "draw in index 5."
 // The caption panel and the mini-map frame use the shared UI kit theme instead,
 // which applyTheme() installs into high palette slots (240 and up).
 const C_SKY = 2; // Soft sky blue: fills the screen background
@@ -91,7 +91,7 @@ class Demo {
     // Where the camera was at the START of the most recent update() tick, before this
     // tick's sine math moved it. render() blends between cameraPrevPos and cameraPos
     // using BT.renderAlpha so the camera pans smoothly between physics ticks instead
-    // of jumping - see "Interpolating render state with renderAlpha" in the engine's
+    // of jumping – see "Interpolating render state with renderAlpha" in the engine's
     // docs/api-game-loop.md.
     cameraPrevPos = new Vector2i(0, 0);
 
@@ -144,7 +144,7 @@ class Demo {
      */
     async init() {
         // Set up the color palette
-        // A palette is like an artist's paint tray - we choose all our colors BEFORE
+        // A palette is like an artist's paint tray – we choose all our colors BEFORE
         // drawing anything. Each color gets a number (an "index") that we use in draw calls.
         this.palette = BT.paletteCreate(256);
 
@@ -210,12 +210,12 @@ class Demo {
         this.cameraPos = BT.cameraClamp(this.cameraPos, new Vector2i(WORLD_WIDTH_PX, WORLD_HEIGHT_PX), viewSize);
 
         // BT.cameraSet() now happens in render(), using a position blended between
-        // cameraPrevPos and cameraPos - see render() below.
+        // cameraPrevPos and cameraPos – see render() below.
 
         // Update the animated water color in the palette
         // Instead of computing a new Color32 inside render() every frame, we compute it
         // here in update() and store it in the reserved C_WATER palette slot.
-        // render() can then just write C_WATER as a plain number - no Color32 needed there.
+        // render() can then just write C_WATER as a plain number – no Color32 needed there.
         // This "palette animation" technique is how retro hardware made water shimmer!
         const waterPulse = Math.sin(BT.ticks * 0.12); // a slow gentle wave between -1 and +1
         const waterBlue = Math.floor(210 + waterPulse * 28); // shifts the blue channel 28 units up and down
@@ -231,7 +231,7 @@ class Demo {
         // color shows through in "empty" cells.
         BT.clear(C_SKY);
 
-        // Blend cameraPrevPos toward cameraPos by BT.renderAlpha - a fraction from 0
+        // Blend cameraPrevPos toward cameraPos by BT.renderAlpha – a fraction from 0
         // (a tick just finished) to just under 1 (the next tick is about to happen) -
         // so the camera's on-screen position matches this exact render moment instead
         // of only its last-tick position. Both the camera offset and the visible-tile
@@ -379,7 +379,7 @@ class Demo {
                 this.tileRect.set(worldX, worldY, TILE_SIZE, TILE_SIZE);
 
                 // Pick the palette index for this tile ID. if / else if is like a menu: first match wins.
-                // We pass just a number (C_GRASS, C_DIRT, etc.) - the palette knows the actual color.
+                // We pass just a number (C_GRASS, C_DIRT, etc.) – the palette knows the actual color.
                 if (id === TILE_GRASS) {
                     BT.drawRectFill(this.tileRect, C_GRASS);
                 } else if (id === TILE_DIRT) {
@@ -387,7 +387,7 @@ class Demo {
                 } else if (id === TILE_STONE) {
                     BT.drawRectFill(this.tileRect, C_STONE);
                 } else if (id === TILE_WATER) {
-                    // C_WATER is the animated water slot - update() already set its color this frame.
+                    // C_WATER is the animated water slot – update() already set its color this frame.
                     BT.drawRectFill(this.tileRect, C_WATER);
                 } else if (id === TILE_TREE_TOP) {
                     BT.drawRectFill(this.tileRect, C_TREE_TOP);
@@ -404,7 +404,7 @@ class Demo {
         // ui.begin() and ui.end() stack into one anchored group; the kit measures the
         // rows, draws the panel background, and places the group for us.
         // The kit draws in whatever camera space is active, so this must run AFTER
-        // BT.cameraReset() - otherwise the panel would scroll away with the world.
+        // BT.cameraReset() – otherwise the panel would scroll away with the world.
         ui.begin('topLeft');
         ui.panel('Tilemap');
         ui.label('30x20 tiles, 16px each', { color: 'dim' });
@@ -442,7 +442,7 @@ class Demo {
 
                 // Pick a palette index for each tile type.
                 // Using C_SKY for sky tiles shows the background color as the map background.
-                // We use C_MINIMAP_WATER for water on the mini-map - this is a static shade,
+                // We use C_MINIMAP_WATER for water on the mini-map – this is a static shade,
                 // not the animated C_WATER, so the mini-map stays calm even as the tiles shimmer.
                 let c = C_SKY;
                 if (id === TILE_GRASS) {
@@ -464,7 +464,7 @@ class Demo {
 
         // Viewport indicator: where is the 320x240 window inside the 480x320 world?
         // Use this.cameraPos, not BT.camera: render() already called BT.cameraReset(),
-        // which zeroes BT.camera - our own field still remembers the real position.
+        // which zeroes BT.camera – our own field still remembers the real position.
         const cam = this.cameraPos;
         const disp = BT.displaySize;
         const vx = mapX + Math.floor((cam.x / WORLD_WIDTH_PX) * mapPixelW);

--- a/packages/demos/src/tilemap.js
+++ b/packages/demos/src/tilemap.js
@@ -6,7 +6,7 @@
 // Optional background: Sprites (https://demos.blit386.dev/sprites) also
 // places art on a grid, but this demo uses colored rectangles instead of a PNG sheet.
 //
-// Live walkthrough: https://vancura.dev/articles/blit386-tilemap
+// Guide: https://blit386.dev/docs/api/camera
 //
 // A "tilemap" is like a floor made of same-sized square tiles. Each cell in a 2D array
 // (a list of rows, each row a list of columns) stores a small number that means "which


### PR DESCRIPTION
## Summary

- Twenty `packages/demos/src/*.js` files carried header comments linking to `vancura.dev/articles/...` walkthrough articles. All 18 distinct URLs 404 (checked 2026-08-08). The demo source is published and rendered in the source panel on every demo at demos.blit386.dev, so these were reader-visible dead links, not just internal notes.
- Repointed each link to the equivalent guide or API reference page on `blit386.dev/docs/...`, mapped by what each demo actually covers (e.g. `blit386-camera` -> `api/camera`, `blit386-palette-animation`/`palette-cycling`/`palette-fade` -> `guides/palette#runtime-palette-effects`). For the four topics with no one-to-one doc equivalent (`patterns`, `starfield`, `tilemap`, the `game-scene` capstone), pointed at the closest general page (`api/rendering#primitives`, `api/camera`, the docs index) rather than dropping the line.
- Verified every mapped anchor resolves live in a browser (no 404s) before committing.
- A separate first commit normalizes pre-existing dash-typography debt (plain hyphens used as parenthetical breaks) in these same 20 files, since the pre-commit hook scans whole staged files and that debt predates this change — kept isolated from the link-fix commit so the diff stays reviewable.

Fixes BT-448

## Follow-up

Filed [BT-459](https://linear.app/vancura/issue/BT-459) (milestone 1.6.0) to add a preflight-gated check that catches this class of dead/placeholder link in `packages/demos/src/**` header comments going forward, since neither `linkValidationPlugin` nor `docs:links` cover that tree today.

## Test plan

- [x] `pnpm run preflight` in `packages/demos` (format, lint, spellcheck, knip, demo-registry check, production build) — passes
- [x] `node scripts/check-dash-typography.mjs` on all 20 files — passes
- [x] Every new `blit386.dev/docs/...` link opened live in a browser and confirmed to resolve (not 404)
- [x] `git push` pre-push hook (per-package preflight + root-level format/docs-links/agent-config checks) — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)