### PR TITLE
fix(content): drop maintainer plural and link awesome-blit386 from showcase

### DIFF
--- a/.github/markdown-link-check.json
+++ b/.github/markdown-link-check.json
@@ -72,6 +72,9 @@
       "pattern": "^/community(/|$)"
     },
     {
+      "pattern": "^/showcase(/|$)"
+    },
+    {
       "pattern": "^https://blit386\\.dev/sitemap\\.xml$"
     }
   ],

--- a/packages/website/content/community.mdx
+++ b/packages/website/content/community.mdx
@@ -24,6 +24,12 @@ Found something broken? Open an issue on the main engine repository:
 Please include a minimal reproduction and the browser and GPU you are using. WebGPU behavior can vary across drivers, so
 details matter.
 
+## See what others are building
+
+Beyond the official [showcase](/showcase), the community-curated
+[awesome-blit386](https://github.com/blit386/awesome-blit386) list tracks games, tools, and resources from the wider
+ecosystem.
+
 ## Follow updates
 
 Releases, new demos, and project news are posted through these channels:

--- a/packages/website/content/showcase.mdx
+++ b/packages/website/content/showcase.mdx
@@ -22,6 +22,9 @@ presets, post-process CRT effects, bitmap fonts, pointer and gamepad input, audi
 procedural synth), the overlay HUD, and more. Each demo is a single self-contained JavaScript file under
 [`packages/demos`](https://github.com/blit386/blit386/tree/main/packages/demos) in the monorepo.
 
+For more games, tools, and resources from the wider ecosystem, see the community-curated
+[awesome-blit386](https://github.com/blit386/awesome-blit386) list.
+
 ## How to submit
 
 To add your project to this page:
@@ -33,4 +36,4 @@ To add your project to this page:
 3. Projects must use a published version of BLIT386 (`>= 1.0.0`) and must not contain content that violates the
    [code of conduct](https://github.com/blit386/blit386/blob/main/CODE_OF_CONDUCT.md).
 
-There is no formal review SLA for small projects, but a maintainer will respond within a few days.
+There is no formal review SLA for small projects, but I read every submission and reply when I can.


### PR DESCRIPTION
## Summary

- Fixes BT-452: the showcase page's closing line said "a maintainer will respond within a few days" - the only first-person-plural phrasing on the hand-authored site, and a response-time promise nobody validated. Switched to first person, matching the Authors page voice, and dropped the specific timeframe.
- Links the community-curated [awesome-blit386](https://github.com/blit386/awesome-blit386) list from both `showcase.mdx` and `community.mdx`, since the showcase page currently only features the maintainer's own Catcher starter and demo suite.
- Adds `/showcase` to the markdown-link-check ignore patterns, alongside the existing `/docs` and `/community` entries, so the new cross-link resolves as a site route instead of a filesystem path.

Deliberately did not add the three known third-party projects (blit386-compass, blit386-pinballpin, killer-math) to the showcase - per the issue, that's a decision for their owners to make, not a unilateral content change.

## Test plan

- [x] `pnpm run preflight` (website): format, typecheck, 161/161 tests, knip, build - all pass
- [x] `pnpm run docs:links`, root `format:check`, `agents:check` - all pass
- [x] Spellcheck run manually with `--no-gitignore` (BT-460 - cspell silently finds 0 files under a git worktree) - clean, 0 issues
- [x] Built the site and verified `/showcase` and `/community` render correctly in-browser, with both new links (`/showcase`, `awesome-blit386`) resolving to the right hrefs
- [x] Pushed with `--no-verify`: the pre-push hook's preflight step is currently blocked by BT-460 (cspell) in every worktree checkout; ran every other gate by hand per the documented recovery steps for PR #498

Refs BT-452

🤖 Generated with [Claude Code](https://claude.com/claude-code)