### PR TITLE
fix(repo): clear the 3,274 pre-existing dash-typography violations

### DIFF
--- a/.claude/skills/preflight/SKILL.md
+++ b/.claude/skills/preflight/SKILL.md
@@ -117,18 +117,19 @@ No combined `preflight` script exists at root; run what does:
 - `pnpm run format:check` – Biome + Prettier across the whole tree
 - `pnpm run docs:links` – Markdown link checker
 - `pnpm run agents:check` – skills symlinks, AGENTS.md <-> CLAUDE.md pointers, Copilot instructions, Zed settings
+- `pnpm run check-dash-typography` – en-dash-only rule (root CLAUDE.md, "Shared conventions") over every tracked
+  `.ts`/`.tsx`/`.js`/`.cjs`/`.mjs`/`.md`/`.mdx` file
 
 `.husky/pre-push` dispatches each changed package's own `preflight` script
-(`pnpm --filter "...[ref]" --if-present run preflight`), then – only if that succeeds – runs these three root-level
+(`pnpm --filter "...[ref]" --if-present run preflight`), then – only if that succeeds – runs these four root-level
 checks unconditionally on every push, since pnpm's per-package `--filter` dispatch only looks at files under
-`packages/*` and would otherwise miss a root-only change entirely.
+`packages/*` and would otherwise miss a root-only change entirely. `check-dash-typography` also runs in `quality-root`
+in `.github/workflows/ci.yml` (BT-461), so a repo-wide dash-typography regression fails both the push and CI, on top of
+the existing per-commit gates below.
 
 The following are not part of that pre-push gate – run them directly when auditing:
 
 - `pnpm run test:agent-config` – unit tests for the `agents:check` script itself
-- `pnpm run check-dash-typography` – en-dash-only rule (root CLAUDE.md, "Shared conventions") over every tracked
-  `.ts`/`.tsx`/`.js`/`.cjs`/`.mjs`/`.md`/`.mdx` file; already gated per-commit via lint-staged (staged files) and
-  commitlint (the commit message), so this manual run is for auditing pre-existing drift, not a step a clean push needs
 - `pnpm run test:dash-typography` – unit tests for `check-dash-typography.mjs`
 - `pnpm run test:bump-lockstep` – unit tests for `scripts/bump-lockstep.mjs`, the lockstep version-bump script covering
   `blit386`, `@blit386/kit`, and `create-blit386` (see `/release`)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,10 @@ jobs:
         run: pnpm run agents:check
         background: true
 
+      - name: Check dash typography
+        run: pnpm run check-dash-typography
+        background: true
+
       - name: Run shell-safety hook tests
         run: pnpm run test:shell-safety
         background: true

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -97,8 +97,8 @@ fi
 # changes nothing there (root CLAUDE.md, .claude/, .husky/, root scripts/, root
 # configs) would otherwise run zero checks. Always run the root-level gate too.
 if [ "$PREFLIGHT_STATUS" -eq 0 ]; then
-    echo "Running root-level checks (format:check, docs:links, agents:check)..."
-    pnpm run format:check && pnpm run docs:links && pnpm run agents:check || PREFLIGHT_STATUS=$?
+    echo "Running root-level checks (format:check, docs:links, agents:check, check-dash-typography)..."
+    pnpm run format:check && pnpm run docs:links && pnpm run agents:check && pnpm run check-dash-typography || PREFLIGHT_STATUS=$?
 fi
 
 if [ "$PREFLIGHT_STATUS" -ne 0 ]; then

--- a/packages/blit386/.claude/rules/bt-api-getters.md
+++ b/packages/blit386/.claude/rules/bt-api-getters.md
@@ -19,7 +19,7 @@ Zero-argument read-only values on `BT`:
   `?backend=software`); `null` before `BT.init()`
 - Loop: `deltaSeconds`, `timeSeconds`, `ticks`, `renderAlpha`
 - Runtime: `activeBackend`, `camera`, `palette`, `random`, `isAudioUnlocked`, `isMusicPlaying`, `screenOrientation`,
-  `loadingAssetsCount` — `activeBackend` is `null` before init or on failure; `isAudioUnlocked` is `false` until the
+  `loadingAssetsCount` – `activeBackend` is `null` before init or on failure; `isAudioUnlocked` is `false` until the
   first user gesture resumes the audio context; `isMusicPlaying` is `true` while the music player has a live current
   track; `screenOrientation` is the current `screen.orientation.type` string, or `null` when the API is unavailable;
   `loadingAssetsCount` is the combined count of in-flight `AssetLoader` + `AudioClip` loads (poll for a loading screen);
@@ -51,7 +51,7 @@ frame; calling methods on `BT.random` advances the shared stream.
 - Any parameter: `pointerPos(0)`, `isDown(BT.BTN_A)`, `cameraClamp(...)`
 - Boolean queries with parameters (Tier A; always methods on `BT`): `isPointerActive(0)`, `isDown(...)`,
   `isPressed(...)`, `isReleased(...)`, `isKeyDown(...)`, `isKeyPressed(...)`, `isKeyReleased(...)`
-- Side-effect booleans (Tier C): `Timer.fireIfElapsed()` — not `is*` because the call advances state
+- Side-effect booleans (Tier C): `Timer.fireIfElapsed()` – not `is*` because the call advances state
 - Async: `captureFrame`, `downloadFrame`
 
 Deprecated aliases still on `BT` (do not use in new code): see `docs/reference-deprecations.md` (`pointerPosValid`,
@@ -68,7 +68,7 @@ Deprecated aliases still on `BT` (do not use in new code): see `docs/reference-d
 - Use `-ing` for configure flags that enable ongoing behavior (`isDetectingDroppedFrames`).
 - Hold vs edge on `BT`: `isDown` / `isKeyDown`; `isPressed` / `isReleased`; `isKeyPressed` / `isKeyReleased`. Public
   `BT` uses `isDown`; internal input classes use `isButtonDown` / `isKeyDown` and related names. No embedded second `Is`
-  — audit with `\bis[A-Za-z]+Is[A-Z]`.
+  – audit with `\bis[A-Za-z]+Is[A-Z]`.
 - Identifier acronyms: `canvasID`, `containerID` (not `canvasId`).
 
 ## Naming when adding getters

--- a/packages/blit386/.claude/rules/docs-authoring.md
+++ b/packages/blit386/.claude/rules/docs-authoring.md
@@ -75,5 +75,5 @@ Renaming or splitting a published doc:
    table padding).
 
 After any doc change: add new proper nouns / coined words to the root `cspell.json`; re-sync the mirror
-(`pnpm run sync:docs` in `packages/website`) - required after every edit to a published doc's content, not just when a
+(`pnpm run sync:docs` in `packages/website`) – required after every edit to a published doc's content, not just when a
 sitemap entry changes.

--- a/packages/blit386/.claude/rules/internal-scoped-naming.md
+++ b/packages/blit386/.claude/rules/internal-scoped-naming.md
@@ -19,7 +19,7 @@ class or file name.** Context already supplies that scope.
 | `#privateField`, `private method()` | yes |
 | `protected readonly fragmentShader` | yes |
 | Module `const`, file-local `type` / `interface` | yes |
-| `BT.*`, barrel exports, public class methods | **no** — public API stays stable |
+| `BT.*`, barrel exports, public class methods | **no** – public API stays stable |
 | JSDoc `@link` to another module's public symbol | use the **full public name** |
 
 ## Good vs bad (same file provides context)

--- a/packages/blit386/.claude/rules/ts-file-structure.md
+++ b/packages/blit386/.claude/rules/ts-file-structure.md
@@ -14,24 +14,24 @@ When adding or moving code in library TypeScript (`src/`). **Class member order 
 
 ## File layout (top to bottom)
 
-1. **Module JSDoc** — `/** … */` describing the file's purpose.
-2. **Imports** — `import type` for type-only imports; inline `type` in mixed imports. Order is auto-fixed by
+1. **Module JSDoc** – `/** … */` describing the file's purpose.
+2. **Imports** – `import type` for type-only imports; inline `type` in mixed imports. Order is auto-fixed by
    `pnpm run lint:fix` (`simple-import-sort`).
-3. **Leading module members** — config/input constants (`MAX_VERTICES`, `INV_255`), validators/lookup tables, and type
+3. **Leading module members** – config/input constants (`MAX_VERTICES`, `INV_255`), validators/lookup tables, and type
    aliases (`type EffectTier`, `type Resolve`). Module-level init loops live here too.
-4. **Primary export** — the class / interface / function the file is named for.
-5. **Trailing module members** — large WGSL/template-literal constants (`const FRAGMENT_WGSL`) and pure helper functions
+4. **Primary export** – the class / interface / function the file is named for.
+5. **Trailing module members** – large WGSL/template-literal constants (`const FRAGMENT_WGSL`) and pure helper functions
    **after** the class. Exported helpers before private ones.
 
 ## Class member order
 
-1. **Static fields** — cached singletons (`_zero`, `_white`), registries (`namedColors`).
-2. **Instance fields** — public → protected → private (`#field` / `private`). Group `readonly` together. One JSDoc and a
+1. **Static fields** – cached singletons (`_zero`, `_white`), registries (`namedColors`).
+2. **Instance fields** – public → protected → private (`#field` / `private`). Group `readonly` together. One JSDoc and a
    blank line per field (no packed field blocks).
-3. **Constructor** — parameter-properties carry inline `/** … */` JSDoc.
-4. **Accessors** — static getters first, then instance getters/setters.
-5. **Static methods** — public before private.
-6. **Instance methods** — public → protected → private. Private helpers (`cleanup`, `getOrCreateBindGroup`) last.
+3. **Constructor** – parameter-properties carry inline `/** … */` JSDoc.
+4. **Accessors** – static getters first, then instance getters/setters.
+5. **Static methods** – public before private.
+6. **Instance methods** – public → protected → private. Private helpers (`cleanup`, `getOrCreateBindGroup`) last.
 
 ## Cross-cutting
 

--- a/packages/blit386/docs/_api-history.json
+++ b/packages/blit386/docs/_api-history.json
@@ -1451,7 +1451,7 @@
       "changes": [
         {
           "version": "1.4.0",
-          "note": "Calling `bootstrap()` again while already initialized now routes to a hot\nswap (via {@link registerHotReload}) when a Vite HMR context is registered, or logs a\ndouble-bootstrap guard and returns `false` otherwise - previously it silently started a\nsecond, unstoppable `GameLoop`."
+          "note": "Calling `bootstrap()` again while already initialized now routes to a hot\nswap (via {@link registerHotReload}) when a Vite HMR context is registered, or logs a\ndouble-bootstrap guard and returns `false` otherwise – previously it silently started a\nsecond, unstoppable `GameLoop`."
         }
       ],
       "deprecated": null,

--- a/packages/blit386/docs/api-audio.md
+++ b/packages/blit386/docs/api-audio.md
@@ -109,7 +109,7 @@ gesture, and why no configure flag can skip this requirement.
 <Since symbol="AudioClip" />
 
 `AudioClip` decodes an audio file into a reusable `AudioBuffer`, exposing the winning source URL, duration, and sample
-rate. Loading and decoding work even while the audio context is locked (suspended, pre-gesture) - only real-time
+rate. Loading and decoding work even while the audio context is locked (suspended, pre-gesture) – only real-time
 playback needs an unlocked context. See [Preloading audio clips](guide-audio.md#preloading-audio-clips).
 
 ```ts twoslash
@@ -165,12 +165,12 @@ theme.unload(); // releases the decoded buffer; safe to call more than once
 - `AudioClip.load()` and `loadAll()` throw a beginner-friendly error covering network/CORS failures, HTTP status errors,
   unsupported container/codec decode failures, and loading before the engine has started.
 - Prefer a fallback list (for example `['theme.ogg', 'theme.mp3']`) for any clip whose primary format might not decode
-  in every browser - see [Audio formats](api-browser-support.md#audio-formats).
+  in every browser – see [Audio formats](api-browser-support.md#audio-formats).
 - Playing a loaded clip back as SFX is covered in [Playback (SFX)](#playback-sfx) below; as looping, crossfading music
   in [Playback (Music)](#playback-music).
 
 Under a Vite dev server with the `blit386/vite` plugin installed, editing an audio file under a watched asset directory
-(`public/` by default) swaps the decoded buffer inside the same `AudioClip` instance - demo-held references stay valid.
+(`public/` by default) swaps the decoded buffer inside the same `AudioClip` instance – demo-held references stay valid.
 Any SFX voice still playing the old buffer is stopped; if the replaced clip is the currently playing music track,
 playback restarts immediately (`fadeMs: 0`, no crossfade). `duration`/`sampleRate` reflect the buffer decoded at initial
 load and are not updated by a hot reload. See [Hot Reload](guide-hot-reload.md#asset-hot-replace-matrix) for the full
@@ -180,10 +180,10 @@ asset type matrix.
 
 <Since symbol="SynthParams" />
 
-`AudioClip.synth` renders a clip procedurally from a `SynthParams` descriptor - no source file, no network request, and
+`AudioClip.synth` renders a clip procedurally from a `SynthParams` descriptor – no source file, no network request, and
 no `OfflineAudioContext`. Rendering runs entirely on the CPU and is deterministic: identical params (including `seed`)
 always produce identical sample data, so a `SynthParams` object can be stored and replayed as a preset. Unlike
-[Loading](#loading), there is nothing to fetch or decode from the network - a synthesized clip is ready the instant
+[Loading](#loading), there is nothing to fetch or decode from the network – a synthesized clip is ready the instant
 `synth()` resolves, even before `BT.isAudioUnlocked` is `true` (see [Unlock state](#unlock-state) above).
 
 ```ts twoslash
@@ -225,7 +225,7 @@ const laser = await AudioClip.synth({
   }} />
 
 The release phase always finishes exactly at `duration`, even on a very short clip where the attack, decay, and release
-phases overlap - a percussive hit is never cut off mid-fade.
+phases overlap – a percussive hit is never cut off mid-fade.
 
 <Since symbol="SynthPitchSweep" />
 
@@ -263,7 +263,7 @@ BT.soundPlay(boom, { volume: 0.7 });
 <Callout title="Not cached, not deduplicated">
 
 Unlike `AudioClip.load()`, `AudioClip.synth()` never populates the URL-keyed resolved cache and never deduplicates
-concurrent calls - every call renders a fresh, independent `AudioBuffer`, even for byte-identical `params`. `unload()`
+concurrent calls – every call renders a fresh, independent `AudioBuffer`, even for byte-identical `params`. `unload()`
 still works the same way (releases the buffer, stops any voice playing it), it just has no cache entry to clear.
 
 </Callout>
@@ -274,7 +274,7 @@ still works the same way (releases the buffer, stops any voice playing it), it j
 
 `BT.synthPreset` bundles six ready-made `SynthParams` factories for common sound effects: `jump`, `pickup`, `explosion`,
 `laser`, `hit`, `blip`. Each takes an optional `seed` and applies small, bounded, deterministic jitter to a couple of
-hand-picked fields (frequency, duration, or noise mix) - the same seed always renders the exact same variant, so a
+hand-picked fields (frequency, duration, or noise mix) – the same seed always renders the exact same variant, so a
 preset stays reproducible even though it varies from call to call.
 
 ```ts twoslash
@@ -293,7 +293,7 @@ BT.soundPlay(menuBlip);
 BT.soundPlay(coin, { volume: 0.8 });
 ```
 
-Omitting `seed` (or passing `0`) always renders the same baseline variant - useful when you want a preset's default
+Omitting `seed` (or passing `0`) always renders the same baseline variant – useful when you want a preset's default
 character rather than per-play variation. See [Playback (SFX)](#playback-sfx) below for playing the resulting clip
 through the SFX voice pool, and [Design a sound](guide-audio.md#design-a-sound) in the Audio Guide for a walkthrough of
 tuning `SynthParams` by hand and storing presets as data.
@@ -308,7 +308,7 @@ tuning `SynthParams` by hand and storing presets as data.
 <Since symbol="BT.isSoundPlaying" />
 
 `BT.soundPlay` plays a loaded `AudioClip` through a fixed-size pool of SFX voices. Each call returns an opaque
-`SoundRef` handle - pass it to `BT.soundStop` and the per-sound volume, pitch, and pan controls.
+`SoundRef` handle – pass it to `BT.soundStop` and the per-sound volume, pitch, and pan controls.
 
 ```ts twoslash
 import { AudioClip, BT } from 'blit386';
@@ -338,17 +338,17 @@ BT.soundStop(ref, { fadeOutMs: 200 }); // fades out over 200 ms
 
 <Callout title="Voice cap and stealing">
 
-`HardwareSettings.audioVoices` (default `16`) sizes a fixed pool of voices - it never grows. When every voice is in use,
+`HardwareSettings.audioVoices` (default `16`) sizes a fixed pool of voices – it never grows. When every voice is in use,
 a new `BT.soundPlay` call steals the lowest-priority active voice at or below the incoming priority (ties broken by
 whichever voice started first). If every active voice outranks the incoming priority, the new sound is dropped silently:
 no throw, and the returned `SoundRef` is inert (`BT.isSoundPlaying` reports `false` for it immediately).
 
 Set `isOverlayAudioMetersEnabled: true` to see active/total voices, steal count, and drop count live in the overlay
-instead of reasoning about the pool from code - see [Audio meters](api-overlay.md#audio-meters-optional).
+instead of reasoning about the pool from code – see [Audio meters](api-overlay.md#audio-meters-optional).
 
 </Callout>
 
-A common pattern - vary pitch slightly per play so a repeated sound (footsteps, hits) doesn't sound robotic:
+A common pattern – vary pitch slightly per play so a repeated sound (footsteps, hits) doesn't sound robotic:
 
 ```ts twoslash
 import { AudioClip, BT } from 'blit386';
@@ -369,7 +369,7 @@ function playFootstep() {
 <Since symbol="BT.soundPanSet" />
 <Since symbol="BT.soundPanGet" />
 
-Per-sound controls, all silent no-ops on a stale or invalid `SoundRef` (already stopped, stolen, or completed - never
+Per-sound controls, all silent no-ops on a stale or invalid `SoundRef` (already stopped, stolen, or completed – never
 throws):
 
 ```ts twoslash
@@ -448,7 +448,7 @@ BT.musicPlay(battle, { fadeMs: 800, overlap: 0 }); // battle starts fading in ex
 BT.musicPlay(battle, { fadeMs: 800, overlap: -1 }); // an 800 ms silence gap between the two
 ```
 
-Calling `BT.musicPlay` again before a crossfade finishes immediately cuts the track that was already fading out - only
+Calling `BT.musicPlay` again before a crossfade finishes immediately cuts the track that was already fading out – only
 one crossfade is ever in flight, so rapid calls (menu navigation, quick scene changes) never pile up.
 
 ### Loop points
@@ -488,7 +488,7 @@ BT.musicVolumeGet(); // 0.4
 
 <Callout title="Remembered while locked, not dropped">
 
-Unlike `BT.soundPlay`, a `BT.musicPlay` call made before `BT.isAudioUnlocked` is `true` is not dropped - the engine
+Unlike `BT.soundPlay`, a `BT.musicPlay` call made before `BT.isAudioUnlocked` is `true` is not dropped – the engine
 remembers the most recent pending request and starts it automatically the instant the context unlocks. Calling
 `BT.musicPlay` again while still locked replaces the remembered request; only the latest survives to unlock.
 
@@ -504,7 +504,7 @@ intro-then-loop recipe.
 
 ## Hardware settings
 
-`audioVoices` (default `16`) caps the number of simultaneous SFX voices - see [Playback (SFX)](#playback-sfx) for the
+`audioVoices` (default `16`) caps the number of simultaneous SFX voices – see [Playback (SFX)](#playback-sfx) for the
 allocation and stealing policy. Documented in [Hardware settings](api-core.md#hardware-settings).
 
 <PageChangelog page="api/audio" />

--- a/packages/blit386/docs/api-browser-support.md
+++ b/packages/blit386/docs/api-browser-support.md
@@ -48,8 +48,8 @@ codec support follows the browser, not BLIT386.
 <Callout title="Point-in-time snapshot">
 
 Codec support shifts with browser updates. Treat this matrix as a snapshot and re-check the vendor release notes
-periodically. This is why `AudioClip.load()` accepts an ordered fallback list (for example
-`['theme.ogg', 'theme.mp3']`) - the engine tries each candidate in order until one decodes.
+periodically. This is why `AudioClip.load()` accepts an ordered fallback list (for example `['theme.ogg', 'theme.mp3']`)
+– the engine tries each candidate in order until one decodes.
 
 </Callout>
 
@@ -90,7 +90,7 @@ attempt `screen.orientation.lock()` after init; the default `'any'` skips the lo
 
 <Callout title="Silent no-op fallback">
 
-Lock support is uneven - Chrome on Android and Samsung Internet typically allow it; iOS Safari does not. When locking is
+Lock support is uneven – Chrome on Android and Samsung Internet typically allow it; iOS Safari does not. When locking is
 unsupported or rejected, the engine continues without unlocking or failing `init()`. Detection and `onOrientationChange`
 still work wherever `screen.orientation` exists.
 

--- a/packages/blit386/docs/api-game-loop.md
+++ b/packages/blit386/docs/api-game-loop.md
@@ -85,9 +85,9 @@ sizeable fraction of render frames have zero preceding `update()` calls that fra
 
 `render()` frequently runs at a different cadence than `update()` (see the two sections above), so game state read
 during `render()` can be up to one fixed step stale. The accumulator introduced above always holds less than one
-`updateInterval` of leftover time once its whole-step chunks are removed for the frame - that remainder is exactly what
+`updateInterval` of leftover time once its whole-step chunks are removed for the frame – that remainder is exactly what
 the whole-step loop couldn't consume. Dividing that leftover by `updateInterval` gives, from first principles, how far
-the simulation has already progressed toward its next step - a fraction in `[0, 1)`. `BT.renderAlpha` exposes that
+the simulation has already progressed toward its next step – a fraction in `[0, 1)`. `BT.renderAlpha` exposes that
 fraction: `0` means a fixed update just completed, values approaching `1` mean the next update is imminent.
 
 ```ts twoslash

--- a/packages/blit386/docs/api-random.md
+++ b/packages/blit386/docs/api-random.md
@@ -113,7 +113,7 @@ rng.direction8(); // cardinals plus diagonals
 
 ## Coordinate hashing
 
-Stateless spatial lookups for chunked and procedural worlds. Same coordinates and seed always return the same value - no
+Stateless spatial lookups for chunked and procedural worlds. Same coordinates and seed always return the same value – no
 stored RNG state, so you do not need an instance per chunk. Complements `Random` (a sequence generator).
 
 <Since symbol="hash1i" />
@@ -166,7 +166,7 @@ classes are distinct from the post-process `Noise` display effect (GPU grain).
 | `PerlinNoise` | Same surface as `ValueNoise` (gradient Perlin) |
 | `SimplexNoise` | `noise2D` / `noise3D`, `fbm2D` / `fbm3D` (no 1D) |
 
-Omit the constructor seed (or pass `0`) for a fixed default world seed - same convention as `hash2i`. Call `seed(n)` to
+Omit the constructor seed (or pass `0`) for a fixed default world seed – same convention as `hash2i`. Call `seed(n)` to
 switch fields. fBm defaults: `octaves = 4`, `persistence = 0.5`, `lacunarity = 2`. Octave amplitudes are normalized so
 fBm stays in approximately `[-1, 1]`.
 

--- a/packages/blit386/docs/changelog.md
+++ b/packages/blit386/docs/changelog.md
@@ -59,18 +59,18 @@ notes, including dependency bumps and CI changes omitted here for brevity.
 - The BLIT386 splash: a logo bitmap fading in on its own 16-step gray ramp, holding, and fading out before the game's
   first frame. Shown in release builds by default and disabled in development by default, with
   `HardwareSettings.isSplashEnabled` and the `?splash` / `?nosplash` URL flags to override either default. It doubles as
-  a loading screen - the game's `init()` runs concurrently and the hold extends until it settles - and hands off into
+  a loading screen – the game's `init()` runs concurrently and the hold extends until it settles – and hands off into
   the game's palette with a single continuous `BT.paletteFadeExposure`, so there is no cut. Any key, click, or tap
   skips, and that press is swallowed. New getters `BT.splashState` and `BT.isSplashVisible`, plus `splashColorDark` /
   `splashColorLight` for the ramp endpoints. The pixelated dissolve is WebGPU-only; the software backend gets the plain
   fade. See [the splash guide](guide-splash.md) and [Core](api-core.md#splash-state).
 
-## 1.4.0 - 2026-07-23
+## 1.4.0 – 2026-07-23
 
 ### Added
 
 - Engine-side hot-reload runtime: `registerHotReload` (wired automatically by the `blit386/vite` plugin), an optional
-  `IBTDemo.onHotReload(context)` hook, and a tiered hot-swap - a method-only prototype swap when only method bodies
+  `IBTDemo.onHotReload(context)` hook, and a tiered hot-swap – a method-only prototype swap when only method bodies
   changed, a full re-init when `init()` or the constructor changed, and a full page reload when hardware settings
   changed. Demo/game state persists across method and re-init swaps: ticks, camera, palette, and palette effects are
   never reset. This lands the engine half of BLIT386's HMR support; adoption in `blit386-demos`/`create-blit386` ships
@@ -82,9 +82,9 @@ notes, including dependency bumps and CI changes omitted here for brevity.
   runtime dependency on `vite` itself.
 - Engine-side asset hot-replace: `AssetLoader.evict`, plus internal routing in `HotRuntime.handleAssetChanged` for
   `blit386:asset-changed` events. A changed image, audio, or `.btfont` file under `public/` updates the running demo in
-  place - sprite sheets swap their texture (calling `indexize()` against the active palette when needed), audio clips
+  place – sprite sheets swap their texture (calling `indexize()` against the active palette when needed), audio clips
   swap their decoded buffer (stopping SFX voices on the old buffer and restarting the music player if the replaced clip
-  is the current track), and bitmap fonts rebuild their glyph tables and texture - all without a page reload. Adoption
+  is the current track), and bitmap fonts rebuild their glyph tables and texture – all without a page reload. Adoption
   in `blit386-demos`/`create-blit386` ships in a follow-up release.
 - Asset loading progress: `BT.loadingAssetsCount` is polled once per frame as a combined image+audio signal (the sum of
   `AssetLoader.loadingCount` and `AudioClip.loadingCount`) to drive a loading spinner or progress bar until it returns
@@ -101,14 +101,14 @@ notes, including dependency bumps and CI changes omitted here for brevity.
   `configure()` change triggers a reload, matching the behavior already seen under the default `webgpu` backend.
 - The `blit386/vite` plugin now syntax-checks a plain `.js`/`.mjs` entry module before injecting the hot-reload snippet.
   Vite's own default transform pipeline excludes those extensions from server-side parsing, so a broken entry module
-  previously surfaced only as a silently caught client-side error - Vite's error overlay never appeared. `.ts`/`.mts`
+  previously surfaced only as a silently caught client-side error – Vite's error overlay never appeared. `.ts`/`.mts`
   entries are unaffected; they already get real syntax validation from Vite's own transform.
 - `canvas.style.touch-action` was hardcoded to `none` on attach, blocking touch tap-hold-scroll past the canvas even
   when `HardwareSettings.isCapturingPointerScroll` was left at its default `false`. It is now gated by the same flag:
   `none` while pointer scroll capture is active (configure-time opt-in or the overlay's palette-band force), `pan-y`
   otherwise, updated live as either source of capture changes.
 
-## 1.3.1 - 2026-07-19
+## 1.3.1 – 2026-07-19
 
 ### Added
 
@@ -135,7 +135,7 @@ notes, including dependency bumps and CI changes omitted here for brevity.
 - The overlay's bottom-left toggle hit region shrinks from `48×48` to `17×13` pixels, matching the visible toggle icon
   more closely.
 
-## 1.3.0 - 2026-07-13
+## 1.3.0 – 2026-07-13
 
 The audio release: the engine gains a full sound subsystem, from bus mixing to procedural synthesis, plus render-time
 interpolation for smoother motion between fixed update steps.
@@ -152,12 +152,12 @@ interpolation for smoother motion between fixed update steps.
   getters), and generational `SoundRef` handles. `HardwareSettings.audioVoices` (default `16`, range `1`-`64`) sizes the
   pool.
 - Deterministic procedural synthesis via `AudioClip.synth(params)` - waveforms, an ADSR envelope, a linear pitch sweep,
-  vibrato, and noise mixing, rendered on the CPU with no source file - plus a preset library `BT.synthPreset` (`jump`,
+  vibrato, and noise mixing, rendered on the CPU with no source file – plus a preset library `BT.synthPreset` (`jump`,
   `pickup`, `explosion`, `laser`, `hit`, `blip`).
 - Crossfading music playback with configurable fade, overlap, and loop points: `BT.musicPlay`, `BT.musicStop`,
   `BT.musicVolumeSet` / `BT.musicVolumeGet`, and the `BT.isMusicPlaying` getter.
 - Overlay audio meters: a per-bus level band with a voices used/total, steal, and drop readout, gated by
-  `HardwareSettings.isOverlayAudioMetersEnabled` with lazy opt-in metering - no metering cost is paid unless the flag is
+  `HardwareSettings.isOverlayAudioMetersEnabled` with lazy opt-in metering – no metering cost is paid unless the flag is
   set.
 - `BT.renderAlpha` getter: the fractional interpolation factor in `[0, 1)` between fixed `update()` steps, for smoothing
   render state on high-refresh displays. See the new game-loop smoothing guide.
@@ -179,7 +179,7 @@ interpolation for smoother motion between fixed update steps.
 - The engine overlay's toggle key press is now sampled during the fixed-update tick instead of the render phase, fixing
   intermittently dropped toggle presses under rapid input on high-refresh displays.
 
-## 1.2.1 - 2026-06-20
+## 1.2.1 – 2026-06-20
 
 ### Fixed
 
@@ -193,7 +193,7 @@ interpolation for smoother motion between fixed update steps.
 - "See also" cross-reference sections added or expanded across 16 documentation files; `README.md` rewritten with a
   beginner-first voice.
 
-## 1.2.0 - 2026-06-19
+## 1.2.0 – 2026-06-19
 
 Package and API rename – the engine is now published as `blit386` (previously `blit-tech`).
 
@@ -210,7 +210,7 @@ Package and API rename – the engine is now published as `blit386` (previously 
   browsers (including Firefox on Linux) before the Canvas 2D fallback could activate. Access is now inlined at call
   sites.
 
-## 1.1.1 - 2026-06-07
+## 1.1.1 – 2026-06-07
 
 ### Fixed
 
@@ -221,13 +221,13 @@ Package and API rename – the engine is now published as `blit386` (previously 
 
 - Boolean queries and predicate methods normalized to `is*`/`has*` conventions: `isDown`, `isPressed`,
   `isPointerActive`, `isEqual`, `isContaining`, `isIntersecting`. `HardwareSettings` config flags renamed to
-  `isOverlayEnabled`, `isDetectingDroppedFrames`, and so on. Deprecated aliases keep the previous names working - see
+  `isOverlayEnabled`, `isDetectingDroppedFrames`, and so on. Deprecated aliases keep the previous names working – see
   the [Deprecation Timeline](reference-deprecations.md).
 - Asset system structural refactor across `BitmapFont`, `SpriteSheet`, `Palette`, `PaletteEffect`, and `SystemFont` -
   internal only, no public API change.
 - Documentation corrected and expanded across 45+ files; a new overlay guide added.
 
-## 1.1.0 - 2026-05-30
+## 1.1.0 – 2026-05-30
 
 The overlay release: the old software-mode ticker is replaced by a full engine HUD subsystem.
 
@@ -246,7 +246,7 @@ The overlay release: the old software-mode ticker is replaced by a full engine H
 - Breaking: every `statsOverlay*` setting, the `statsOverlayRows()` hook, and the `StatsOverlay*` exported types drop
   the `stats`/`StatsOverlay` prefix (for example `overlayEnabled`, `overlayRows()`, `OverlayRow`).
 
-## 1.0.5 - 2026-05-21
+## 1.0.5 – 2026-05-21
 
 ### Added
 
@@ -254,7 +254,7 @@ The overlay release: the old software-mode ticker is replaced by a full engine H
 
 ### Changed
 
-- `configure()` now accepts a partial `HardwareSettings` object - demos can override just `targetFPS` without spelling
+- `configure()` now accepts a partial `HardwareSettings` object – demos can override just `targetFPS` without spelling
   out every field. The engine merges the result with `defaultConfig()` via the new exported `mergeHardwareSettings()`.
 
 ### Security
@@ -262,7 +262,7 @@ The overlay release: the old software-mode ticker is replaced by a full engine H
 - `.btfont` embedded textures must now use `data:image/png;base64` with a 512 KiB payload cap; glyph metrics are
   validated before atlas decode begins. A new `AssetLimits` module centralizes these constants.
 
-## 1.0.4 - 2026-05-17
+## 1.0.4 – 2026-05-17
 
 `BT` namespace read-only properties changed from methods to ES getters.
 
@@ -284,7 +284,7 @@ The overlay release: the old software-mode ticker is replaced by a full engine H
   supply-chain hardening enabled (`minimum-release-age`, `block-exotic-subdeps`, `strict-dep-builds`). CI action tags
   pinned to commit SHAs.
 
-## 1.0.3 - 2026-05-16
+## 1.0.3 – 2026-05-16
 
 First stable release, closing out the 0.2.x prototype arc. The rendering stack is palette-first end to end, the input
 system is complete across pointer, keyboard, and gamepad, and the `BT` namespace reaches its stable shape.
@@ -315,7 +315,7 @@ system is complete across pointer, keyboard, and gamepad, and the `BT` namespace
 - Breaking: `IBlitTechDemo.queryHardware()` renamed to `configure()` and made optional; omitting it falls back to
   `defaultConfig()` (320×240 display, 640×480 canvas, 60 FPS, nearest-neighbor upscale).
 - Breaking: `Color32.white()`, `black()`, `transparent()`, and the other color-primary statics converted from
-  zero-argument methods to static getters returning frozen singletons - drop the call parentheses.
+  zero-argument methods to static getters returning frozen singletons – drop the call parentheses.
 - `BTAPI` split into three focused modules: `GameLoop` (fixed-timestep accumulator), `WebGPUContext`
   (adapter/device/context setup), delegated to by `BTAPI` itself.
 
@@ -325,7 +325,7 @@ system is complete across pointer, keyboard, and gamepad, and the `BT` namespace
   `buildErrorPreviewEntries`, `previewWebGPUErrors` - superseded by the `SoftwareRenderer` auto-fallback and a shared
   `errorMessages.ts` module.
 
-## 0.2.0 - 2025-12-22
+## 0.2.0 – 2025-12-22
 
 Pre-release published under the original `blit-tech` package name.
 
@@ -334,7 +334,7 @@ Pre-release published under the original `blit-tech` package name.
 - Bootstrap utilities for streamlined game initialization.
 - CI checks: commit message linting, bundle size monitoring, documentation link validation, spell checking with cspell.
 
-## 0.1.0 - 2025-12-13
+## 0.1.0 – 2025-12-13
 
 Initial pre-release published under the original `blit-tech` package name.
 

--- a/packages/blit386/docs/documentation-and-versioning-guide.md
+++ b/packages/blit386/docs/documentation-and-versioning-guide.md
@@ -2,11 +2,11 @@
 
 How to keep public API changes documented to the same standard as the rest of the engine: every public symbol carries an
 accurate `@since`/`@changed`/`@deprecated` history, and every published doc page that discusses a symbol shows its
-version badge, availability table, and per-page changelog. This is not optional polish - it is part of shipping the
+version badge, availability table, and per-page changelog. This is not optional polish – it is part of shipping the
 feature, the same way updating `docs/api-*.md` prose already is (see
 [Docs sync required](../../../.claude/rules/docs-sync-required.md) and the root `CLAUDE.md`, "Working with Claude").
 
-Contributor-only - not published to blit386.dev. See the
+Contributor-only – not published to blit386.dev. See the
 [Documentation index](developer-experience-guide.md#documentation-index) for the published guides this one is about
 maintaining.
 
@@ -70,7 +70,7 @@ Tag syntax:
 
 - `@since <version>` - bare semver, no `v` prefix. The release the symbol first shipped in. If you are adding the symbol
   on `main` ahead of the next tagged release, use the actual target version (check `package.json`'s current `version`
-  field and the project's release cadence - ask if unsure, do not guess).
+  field and the project's release cadence – ask if unsure, do not guess).
 - `@changed <version> <note>` - repeatable, one per behavioral or signature change. The note is a short human-readable
   summary in the same voice as a Keep a Changelog "Changed" entry.
   ```
@@ -78,13 +78,13 @@ Tag syntax:
   @changed 1.2.0 Added the optional paletteOffset parameter.
   @changed 1.3.0 Now throws when the sheet is not indexized.
   ```
-  A malformed `@changed` tag (missing the note, or empty) is not silently dropped - the generator warns to stderr with
+  A malformed `@changed` tag (missing the note, or empty) is not silently dropped – the generator warns to stderr with
   the file and line so it is visible during manifest generation. Fix the tag rather than ignoring the warning.
 - `@deprecated` - extend the tag to carry a version while keeping the removal-checklist date:
   ```
   @deprecated Deprecated since 1.3.0 (2026-08-01). Use {@link newMethodName} instead.
   ```
-  `docs/reference-deprecations.md` greps for the literal `Deprecated since` string for its removal checklist - keep that
+  `docs/reference-deprecations.md` greps for the literal `Deprecated since` string for its removal checklist – keep that
   phrasing.
 
 ## Step 2: regenerate and verify locally
@@ -96,11 +96,11 @@ pnpm run api:history:check    # fails if the committed JSON has drifted from sou
 ```
 
 All three are already wired into `pnpm run preflight`, so a normal preflight run catches a missing or malformed tag
-before you get to docs work. Commit the regenerated `docs/_api-history.json` alongside your source change - it is a
+before you get to docs work. Commit the regenerated `docs/_api-history.json` alongside your source change – it is a
 deterministic, sorted-key, timestamp-free file, so an unrelated regeneration should produce a byte-identical diff
 (empty) if nothing you changed affects the manifest.
 
-## Step 3: decide the symbol's documentation home - one home per symbol
+## Step 3: decide the symbol's documentation home – one home per symbol
 
 Before adding any `<Since>` tag to a doc page, check whether the symbol already has one:
 
@@ -117,13 +117,13 @@ badge in two places that could drift.
 
 Two consequences worth knowing before you guess:
 
-- A symbol can lack a dedicated `api-*.md` page entirely - the input subsystem (`BTN_*`, `AXIS_*`, `BT.isPressed`, and
+- A symbol can lack a dedicated `api-*.md` page entirely – the input subsystem (`BTN_*`, `AXIS_*`, `BT.isPressed`, and
   so on) has no `api-input.md`; its only home is `guide-input.md`. Check `docs/_sitemap.json` for the full page list
   before assuming an `api-*` page exists.
 - A symbol can be genuinely under-documented on the page that first seems obvious (for example an effect class only
   table-listed on `api-rendering.md`) while a **guide** page gives it real per-symbol prose (
   `guide-post-process-effects.md`'s dedicated `### ClassName` sections). When that happens, the guide page is the home,
-  not the api page - substance decides, not the page's category.
+  not the api page – substance decides, not the page's category.
 
 If you cannot confidently identify a page that substantively documents the symbol, it is correct to leave it untagged
 for now rather than force a badge onto a page that only mentions it in passing. `<ApiAvailability>` still surfaces every
@@ -131,7 +131,7 @@ symbol that page does claim; an occasional untagged symbol is a smaller problem 
 
 ## Step 4: add the components
 
-Three MDX components, registered on the `packages/website` side and passed through verbatim by the sync script - write
+Three MDX components, registered on the `packages/website` side and passed through verbatim by the sync script – write
 them directly into the engine `.md` source:
 
 ```
@@ -146,22 +146,22 @@ page: name, since, last changed, status. The `page` prop is the page's `path` fr
 <Since symbol="Vector2i" />
 ```
 
-One per symbol, placed near the content that documents it - directly after the heading when the heading is the symbol's
+One per symbol, placed near the content that documents it – directly after the heading when the heading is the symbol's
 name (`## Vector2i`), or immediately before the code block that demonstrates it when there is no natural per-symbol
 heading. When several symbols are introduced together as a cohesive unit under one heading (for example a family of
 related constants, or several getters described in the same paragraph), stack their `<Since>` tags together rather than
-spreading them across the section - matches the precedent set across every page in this rollout.
+spreading them across the section – matches the precedent set across every page in this rollout.
 
 ```
 <PageChangelog page="api/core-types" />
 ```
 
-One per page (optional - skip it if the page has zero homed symbols), placed near the bottom, before `## See also`.
+One per page (optional – skip it if the page has zero homed symbols), placed near the bottom, before `## See also`.
 Renders a Keep-a-Changelog-style grouped view of every `@since`/`@changed`/`@deprecated` event across the page's
 symbols.
 
 All three are block form: a blank line before and after the tag, never inline in a sentence. Props are always bare
-string literals (`symbol="Vector2i"`, `page="api/core-types"`) - never a `{` expression or a lowercase-initial tag
+string literals (`symbol="Vector2i"`, `page="api/core-types"`) – never a `{` expression or a lowercase-initial tag
 inside a prop, or the sync script's MDX-aware prose escaper will corrupt the output.
 
 ## Step 5: verify end-to-end
@@ -196,7 +196,7 @@ A build success is not sufficient proof by itself. Actually inspect the built ou
 grep -o "Since [0-9.]*\|Unreleased\|Deprecated [0-9.]*" dist/public/docs/<section>/<page>/index.html
 ```
 
-If nothing matches, the tag did not render - most likely a symbol name that does not exactly match a key in
+If nothing matches, the tag did not render – most likely a symbol name that does not exactly match a key in
 `docs/_api-history.json`'s `symbols` object (a typo silently renders nothing; the `<Since>` component design prefers a
 missing badge over a build failure). Cross-check every symbol name against the JSON before trusting a green build.
 
@@ -206,21 +206,21 @@ This is the checklist a second pair of eyes (human or agent) should actually run
 
 1. For every `<Since symbol="X">` added, confirm `X` is an exact key in `docs/_api-history.json`'s `symbols` object -
    grep it, do not eyeball it.
-2. For every symbol tagged, read the actual surrounding prose and confirm it substantively documents that symbol - a
+2. For every symbol tagged, read the actual surrounding prose and confirm it substantively documents that symbol – a
    badge next to a heading that does not really explain the symbol is a misattribution, not a win.
 3. For every symbol _not_ tagged that you would have expected to see, check whether it is legitimately homed on a
    different page (search `docs/_api-history.json`'s `pages` object) before treating the omission as a gap.
-4. Confirm no symbol is double-homed - the same symbol name should not appear in two different pages' entries in the
+4. Confirm no symbol is double-homed – the same symbol name should not appear in two different pages' entries in the
    `pages` object.
-5. Run the actual build and grep the rendered HTML for the expected badge text (see Step 5) - do not accept "the
+5. Run the actual build and grep the rendered HTML for the expected badge text (see Step 5) – do not accept "the
    generator ran without errors" as proof of correct rendering.
-6. Run the full verification suite in both packages (Step 5) - a change that only touches `packages/blit386`'s docs is
+6. Run the full verification suite in both packages (Step 5) – a change that only touches `packages/blit386`'s docs is
    incomplete until `packages/website`'s sync and build are re-verified too.
 
 ## See also
 
-- [Docs sync required](../../../.claude/rules/docs-sync-required.md) - the broader rule this workflow is one instance
+- [Docs sync required](../../../.claude/rules/docs-sync-required.md) – the broader rule this workflow is one instance
   of.
-- [Deprecation Timeline](reference-deprecations.md) - the removal checklist `@deprecated` tags feed into.
-- [Developer Experience](developer-experience-guide.md) - general contributing workflow, code style, commit conventions.
-- `packages/website/CLAUDE.md`, Documentation mirror section - how the sync script consumes what this guide produces.
+- [Deprecation Timeline](reference-deprecations.md) – the removal checklist `@deprecated` tags feed into.
+- [Developer Experience](developer-experience-guide.md) – general contributing workflow, code style, commit conventions.
+- `packages/website/CLAUDE.md`, Documentation mirror section – how the sync script consumes what this guide produces.

--- a/packages/blit386/docs/guide-audio.md
+++ b/packages/blit386/docs/guide-audio.md
@@ -28,7 +28,7 @@ src/assets/
 ```
 
 `AudioManager` is owned by the internal `BTAPI` singleton (created and torn down alongside pointer, keyboard, and
-gamepad input) and is never exposed to demo code directly - only through the `BT.audio*`/`BT.sound*`/`BT.music*` methods
+gamepad input) and is never exposed to demo code directly – only through the `BT.audio*`/`BT.sound*`/`BT.music*` methods
 and the `BT.isAudioUnlocked`/`BT.isMusicPlaying` getters documented in [API: Audio](api-audio.md). On `attach()`,
 `AudioManager` registers its Web Audio context in `audioDecodeContext.ts`, a small bridge that `AudioClip` reads from to
 decode audio data without needing a direct reference to `AudioManager` itself.
@@ -74,7 +74,7 @@ class Demo implements IBTDemo {
 
 ## Preloading audio clips
 
-`AudioClip.load()` downloads and decodes audio even while the context is locked (suspended, pre-gesture) - decoding only
+`AudioClip.load()` downloads and decodes audio even while the context is locked (suspended, pre-gesture) – decoding only
 needs a registered context, not an unlocked one. That makes a title screen or a loading state a good place to preload
 every clip a level needs, so they're ready the instant the player's first gesture unlocks audio. Poll
 [`BT.loadingAssetsCount`](api-assets.md#loading-assets) to show progress while image and audio loads are still in
@@ -97,26 +97,26 @@ class Demo implements IBTDemo {
 ```
 
 Prefer a fallback list (for example `['theme.ogg', 'theme.mp3']`) for any clip whose primary format might not decode in
-every browser - see [Audio formats](api-browser-support.md#audio-formats) for the current per-browser matrix.
+every browser – see [Audio formats](api-browser-support.md#audio-formats) for the current per-browser matrix.
 
 ## Web audio constraints
 
 Every major browser enforces an autoplay policy: an `AudioContext` starts `'suspended'` and stays that way until a user
-gesture calls `resume()`. This is a platform rule, not something BLIT386 can configure around - there is no flag to
+gesture calls `resume()`. This is a platform rule, not something BLIT386 can configure around – there is no flag to
 start audio unlocked, and none is planned.
 
 - Volume and mute calls made before the gesture are not lost; they update the engine's internal bus state and take
   effect immediately once the context resumes.
 - The gesture requirement is independent of the render backend. Unlocking audio has nothing to do with
-  `BT.activeBackend` or the WebGPU/Canvas 2D fallback described in [Browser Support](api-browser-support.md) - a demo
+  `BT.activeBackend` or the WebGPU/Canvas 2D fallback described in [Browser Support](api-browser-support.md) – a demo
   can be fully unlocked on the software renderer, or fully locked on WebGPU.
 - Loading and decoding clips is implemented via `AudioClip` (see [Loading](api-audio.md#loading)) and works regardless
   of lock state. `BT.soundPlay` (see [Playback (SFX)](api-audio.md#playback-sfx)) behaves differently from a pre-unlock
   bus call: `playSound()` drops the request entirely before unlock (no voice allocated, no throw, counted as a dropped
   SFX request), where `AudioManager.volumeSet()` (`BT.audioVolumeSet`) still updates the engine's internal bus state and
-  applies once the context resumes - it is only inaudible while locked, not dropped.
+  applies once the context resumes – it is only inaudible while locked, not dropped.
 - `BT.musicPlay` (see [Playback (Music)](api-audio.md#playback-music)) sits between those two behaviors: a pre-unlock
-  call isn't dropped like `BT.soundPlay`, but it isn't merely inaudible-and-applied like a bus call either - it is
+  call isn't dropped like `BT.soundPlay`, but it isn't merely inaudible-and-applied like a bus call either – it is
   remembered and starts automatically the instant the context unlocks. Calling `BT.musicPlay` again while still locked
   replaces the remembered request, so only the last call before unlock actually plays.
 
@@ -129,7 +129,7 @@ of each sound's own per-voice volume from `BT.soundVolumeSet`.
 The pool itself (`src/audio/VoicePool.ts`) is a fixed-size array sized by `HardwareSettings.audioVoices` - it never
 grows at runtime. Each `BT.soundPlay` call either claims a free slot or steals the lowest-priority active voice at or
 below the incoming priority; see [Playback (SFX)](api-audio.md#playback-sfx) for the exact policy and a worked example.
-This cap exists because each slot is a real `AudioBufferSourceNode -> GainNode -> StereoPannerNode` chain - letting the
+This cap exists because each slot is a real `AudioBufferSourceNode -> GainNode -> StereoPannerNode` chain – letting the
 pool grow unbounded would let a busy scene (an explosion with dozens of debris impacts, for example) spend unbounded CPU
 on nodes the player can't meaningfully hear over each other anyway.
 
@@ -138,7 +138,7 @@ To see the pool cap and stealing policy in action instead of reasoning about it 
 voices used/total, steal, and drop readout. See [Audio meters](api-overlay.md#audio-meters-optional) in the Overlay API
 reference.
 
-A sound that plays often (footsteps, hits, bullet casings) reads as repetitive at a fixed pitch - vary it slightly per
+A sound that plays often (footsteps, hits, bullet casings) reads as repetitive at a fixed pitch – vary it slightly per
 play instead:
 
 ```ts twoslash
@@ -158,7 +158,7 @@ function playFootstep() {
 ## Playing music
 
 `BT.musicPlay` (see [Playback (Music)](api-audio.md#playback-music)) drives a single looping music player through the
-`'music'` bus - there is no per-track handle to manage like `SoundRef`, and a second call crossfades from whatever is
+`'music'` bus – there is no per-track handle to manage like `SoundRef`, and a second call crossfades from whatever is
 currently playing into the new track instead of layering the two. Two patterns cover most games: switching tracks by
 game state, and looping a region after a one-shot intro.
 
@@ -193,7 +193,7 @@ function setGameState(next: GameState) {
 
 Reach for `overlap: 0` instead of the default simultaneous crossfade when the outgoing track should finish cleanly
 before the new one starts (a menu jingle that shouldn't blend into gameplay music), or `overlap: -1` for a deliberate
-beat of silence between tracks (a boss intro sting) - see [Crossfading](api-audio.md#crossfading) for the exact timing
+beat of silence between tracks (a boss intro sting) – see [Crossfading](api-audio.md#crossfading) for the exact timing
 math.
 
 ### Intro then loop
@@ -217,7 +217,7 @@ BT.musicPlay(theme, { loopStart: 8, loopEnd: 32 });
 
 ## Design a sound
 
-Beyond loading audio files, `AudioClip.synth` generates a clip entirely on the CPU from a `SynthParams` descriptor - no
+Beyond loading audio files, `AudioClip.synth` generates a clip entirely on the CPU from a `SynthParams` descriptor – no
 source file, no network fetch, and no `OfflineAudioContext`. Rendering is deterministic and synchronous: the same params
 (including `seed`) always produce the same samples, so a `SynthParams` value behaves like ordinary game data rather than
 a recorded asset. See [Synth](api-audio.md#synth) for the full field reference.
@@ -240,7 +240,7 @@ BT.soundPlay(zap);
 ```
 
 `BT.synthPreset` bundles ready-made starting points for common effects (`jump`, `pickup`, `explosion`, `laser`, `hit`,
-`blip`) - see [Presets](api-audio.md#presets) for the full list. Passing a different `seed` to a preset applies small,
+`blip`) – see [Presets](api-audio.md#presets) for the full list. Passing a different `seed` to a preset applies small,
 bounded jitter to a couple of its fields, so a repeated sound (footsteps, hits, pickups) doesn't sound identical every
 time, while staying reproducible for any given seed:
 
@@ -255,7 +255,7 @@ async function playFootstep(stepIndex: number) {
 }
 ```
 
-Because `SynthParams` is plain data (numbers, strings, and nested objects - no functions or class instances), a tuned
+Because `SynthParams` is plain data (numbers, strings, and nested objects – no functions or class instances), a tuned
 sound can be stored, checked into a level file, or embedded in a save alongside the rest of your game's JSON, then
 handed to `AudioClip.synth` whenever it's needed:
 

--- a/packages/blit386/docs/guide-game-loop.md
+++ b/packages/blit386/docs/guide-game-loop.md
@@ -53,7 +53,7 @@ class Player {
 ```
 
 `Vector2i.lerp` truncates its result to integer pixels (see [API: Core Types](api-core-types.md#vector2i)), so this only
-smooths motion that covers more than a pixel or two per tick - it doesn't add subpixel precision to a pixel-perfect
+smooths motion that covers more than a pixel or two per tick – it doesn't add subpixel precision to a pixel-perfect
 renderer. For a sprite moving `2` px/tick at `targetFPS: 60` on a `144` Hz display, it turns a visible 1-then-2-then-0
 px stutter into a steadier progression across render frames.
 

--- a/packages/blit386/docs/guide-hot-reload.md
+++ b/packages/blit386/docs/guide-hot-reload.md
@@ -19,14 +19,14 @@ tiers with worked examples, the asset hot-replace matrix, and the `blit386/vite`
 ## What hot reload replaces
 
 Without it, every saved change to a demo or game source file triggers a full page reload: the whole module graph
-re-evaluates, `bootstrap()` runs cold again, and every piece of runtime state is lost - the player's position, score,
+re-evaluates, `bootstrap()` runs cold again, and every piece of runtime state is lost – the player's position, score,
 current level, whatever was on screen. Editing an asset under `public/` (a sprite, a sound, a font) does nothing at all;
 the running instance keeps using whatever it already loaded.
 
 With the `blit386/vite` plugin installed, both of those become live updates instead. A code change injects new behavior
 into the already-running demo, preserving as much state as the change allows. An asset change replaces the
 already-loaded resource in place. A page reload still happens, but only for the handful of changes that are genuinely
-incompatible with swapping in place - see [What always forces a full reload](#what-always-forces-a-full-reload) below.
+incompatible with swapping in place – see [What always forces a full reload](#what-always-forces-a-full-reload) below.
 
 This is engine-side infrastructure. Nothing about it requires demo code to change - `onHotReload` is optional, and a
 demo that never implements it still gets prototype swaps and re-inits for free. It only affects local development;
@@ -35,7 +35,7 @@ demo that never implements it still gets prototype swaps and re-inits for free. 
 ## The three tiers
 
 `bootstrap()` decides which tier applies by comparing the newly re-evaluated demo class against the one currently
-running, every time Vite's HMR boundary re-evaluates the entry module. The decision is entirely mechanical - it is not
+running, every time Vite's HMR boundary re-evaluates the entry module. The decision is entirely mechanical – it is not
 configurable, and there is no way to force a different tier from demo code.
 
 ### Tier 1: method-only change
@@ -72,23 +72,23 @@ jump back to the origin.
 
 The `SPEED` case is the detail worth understanding: a Tier 1 swap does not touch `this.pos`, but it does replace
 `update` with a brand new function, freshly defined in the newly re-evaluated module. That new function closes over the
-new module's top-level scope - so the new value of `SPEED` takes effect on the very next tick, even though no field on
+new module's top-level scope – so the new value of `SPEED` takes effect on the very next tick, even though no field on
 the instance changed. Module-level constants referenced from methods are effectively live-editable.
 
 <Callout type="warn" title="A constant baked into an instance field by init() is not live-editable">
   The live-editable behavior above only holds while every reader of the constant is a method that runs fresh each
-  tick. If `init()` also reads the same constant to build data cached in an instance field - filling a scene buffer,
-  precomputing a lookup table, seeding a starting position - editing the constant is still a methods-only change as
+  tick. If `init()` also reads the same constant to build data cached in an instance field – filling a scene buffer,
+  precomputing a lookup table, seeding a starting position – editing the constant is still a methods-only change as
   far as the fingerprint in [Tier 2](#tier-2-initconstructor-change) is concerned: `init()`'s own source text did not
   change, only the value an unrelated top-level `const` resolves to. So the swap stays Tier 1, `init()` does not
-  re-run, and the instance field keeps whatever it was built from before the edit - while methods swapped in by the
+  re-run, and the instance field keeps whatever it was built from before the edit – while methods swapped in by the
   same save read the new value immediately. The two go out of sync until you force a Tier 2 path yourself (touch
   `init()`, the constructor, or a class field initializer) or fall back to a full page reload / dev server restart.
 </Callout>
 
 ### Tier 2: init/constructor change
 
-If `init()`, the constructor, or a class field initializer changed, a Tier 1 swap is not safe - the running instance was
+If `init()`, the constructor, or a class field initializer changed, a Tier 1 swap is not safe – the running instance was
 built by code that no longer exists. Instead, a fresh instance is constructed and its `init()` runs while the previous
 instance keeps driving the loop. Only once that succeeds does the engine swap the new instance in; a failed `init()`
 (returns `false`, or throws) leaves the previous instance running untouched, so a broken save never crashes your game.
@@ -134,13 +134,13 @@ class Demo implements IBTDemo {
 }
 ```
 
-Without the `onHotReload` hook, a Tier 2 swap still works - it just means every field resets to whatever `init()` sets
+Without the `onHotReload` hook, a Tier 2 swap still works – it just means every field resets to whatever `init()` sets
 it to, same as a cold boot. Implementing `onHotReload` is how you opt into carrying state across a re-init.
 
 ### Tier 3: hardware settings change
 
-If `configure()`'s return value differs from what is currently running - a different `displaySize`, backend, target
-frame rate, or any other field listed in [Hardware settings](api-core.md#hardware-settings) - neither swap is safe. Some
+If `configure()`'s return value differs from what is currently running – a different `displaySize`, backend, target
+frame rate, or any other field listed in [Hardware settings](api-core.md#hardware-settings) – neither swap is safe. Some
 of those changes mean recreating the canvas, the WebGPU device, or the audio graph, and there is no in-place path for
 that. The engine requests a full page reload instead, through Vite's `import.meta.hot.invalidate()`.
 
@@ -164,10 +164,10 @@ class Demo implements IBTDemo {
 }
 ```
 
-`onHotReload` never fires for a Tier 3 reload - the page is gone before there is anything left to notify.
+`onHotReload` never fires for a Tier 3 reload – the page is gone before there is anything left to notify.
 
 Running under `?backend=software` does not itself force a Tier 3 reload on every edit. The comparison accounts for the
-URL override on both sides, so only a genuine `configure()` change - not the override alone - triggers a full page
+URL override on both sides, so only a genuine `configure()` change – not the override alone – triggers a full page
 reload.
 
 ## The `blit386:hot-reload` DOM event
@@ -187,7 +187,7 @@ canvas.addEventListener('blit386:hot-reload', (event) => {
 ```
 
 This is a DOM event rather than a second `BT` callback API on purpose: `onHotReload` is for the demo class itself to
-react to its own state; the DOM event is for anything outside the demo class that wants to know a reload happened - a
+react to its own state; the DOM event is for anything outside the demo class that wants to know a reload happened – a
 browser extension, an in-page dev overlay, a Playwright test waiting for the swap to settle, or any other tooling that
 has no reason to import `blit386` at all. It fires whether or not the demo implements `onHotReload`.
 
@@ -199,14 +199,14 @@ event for anything it recognizes. The engine routes that event by file type:
 | Asset type | What happens |
 | --- | --- |
 | Image (`.png`, `.gif`, `.webp`, `.jpg`, `.jpeg`) | Every registered `SpriteSheet` built from that URL swaps its texture in place, re-running `indexize()` against the active palette when the sheet was already indexized. See the dimension-change caveat below. |
-| Audio (`.wav`, `.mp3`, `.ogg`, `.flac`) | The same `AudioClip` instance swaps its decoded buffer in place - demo-held references stay valid. Any SFX voice still playing the old buffer is stopped; if the replaced clip is the currently playing music track, playback restarts immediately (`fadeMs: 0`, no crossfade). `duration`/`sampleRate` reflect the buffer decoded at initial load and are not updated. |
-| Bitmap font (`.btfont`) | The same `BitmapFont` instance rebuilds its glyph tables and texture in place. `name`/`size`/`lineHeight`/`baseline` are frozen at their original values - only glyph data and the texture update. |
+| Audio (`.wav`, `.mp3`, `.ogg`, `.flac`) | The same `AudioClip` instance swaps its decoded buffer in place – demo-held references stay valid. Any SFX voice still playing the old buffer is stopped; if the replaced clip is the currently playing music track, playback restarts immediately (`fadeMs: 0`, no crossfade). `duration`/`sampleRate` reflect the buffer decoded at initial load and are not updated. |
+| Bitmap font (`.btfont`) | The same `BitmapFont` instance rebuilds its glyph tables and texture in place. `name`/`size`/`lineHeight`/`baseline` are frozen at their original values – only glyph data and the texture update. |
 | Palette | Nothing hot-reload-specific needed - `BT.palette` is already a live reference, so mutating a slot with `palette.set()` takes effect on the very next frame regardless of how the change was triggered. |
 | Anything else | Falls back to a full page reload (`fullReloadOnUnknownAssets`, default `true` - see [Plugin options](#plugin-options)). |
 
 <Callout title="Demo-held srcRects and dimension changes">
   If a hot-replaced image has different dimensions than the one it replaced, the sprite sheet's `size` updates to
-  match and its internal buffers rebuild accordingly - but any `Rect2i` a demo is holding onto as a `srcRect` into
+  match and its internal buffers rebuild accordingly – but any `Rect2i` a demo is holding onto as a `srcRect` into
   that sheet does not update itself. Reconciling a stale `srcRect` after a dimension change is the demo's own
   responsibility; keep sprite sheet dimensions stable during a hot-reload session, or recompute `srcRect`s from the
   sheet's current `width`/`height` in `onHotReload`.
@@ -223,7 +223,7 @@ Beyond the Tier 3 hardware-settings case above, three other situations always me
 swap:
 
 - Editing the engine's own source (a `blit386` dist rebuild). The hot-reload boundary lives in the demo/game's entry
-  module, not inside the engine bundle itself - a changed `blit386` dist is a different module identity as far as Vite's
+  module, not inside the engine bundle itself – a changed `blit386` dist is a different module identity as far as Vite's
   module graph is concerned, so there is nothing to swap into.
 - An asset change with an unrecognized extension, when `fullReloadOnUnknownAssets` is left at its default `true`.
 - Calling `bootstrap()` a second time with no Vite HMR context registered at all (for example, calling it twice by
@@ -231,7 +231,7 @@ swap:
   unstoppable game loop. Before 1.4.0, the same mistake silently started a second GameLoop.
 
 This is a deliberate design choice, not a current limitation: a hard reload is always a full page reload, so there is
-never a point in the engine's lifetime where a renderer needs to tear itself down and rebuild in place - the whole page,
+never a point in the engine's lifetime where a renderer needs to tear itself down and rebuild in place – the whole page,
 canvas, and WebGPU device go away and come back fresh instead. That is why `IRenderer` has no `dispose` method. Adding
 one would mean maintaining a teardown path that a real page reload already gives you for free.
 
@@ -268,14 +268,14 @@ runtime cost or behavior change to ship):
   `registerHotReload` is imported under a plugin-specific alias so the snippet cannot collide with an entry module that
   already binds `registerHotReload` itself (which would be a duplicate-declaration `SyntaxError`).
 
-  The literal `import.meta.hot.accept()` call has to appear in the emitted source - Vite marks a module self-accepting
+  The literal `import.meta.hot.accept()` call has to appear in the emitted source – Vite marks a module self-accepting
   by static analysis, so an indirect call would not register self-acceptance and every edit would fall back to a full
   reload regardless of which tier should have applied. You never write or call `registerHotReload` yourself; the plugin
   injects it, and the engine handles everything from there.
 
   For a plain `.js`/`.mjs` entry, the plugin also syntax-checks the module before injecting. Vite's own default
   transform pipeline excludes those extensions from server-side parsing, so without this a broken entry module would
-  surface only as a silently caught client-side error - Vite's error overlay would never appear. A `.ts`/`.mts` entry is
+  surface only as a silently caught client-side error – Vite's error overlay would never appear. A `.ts`/`.mts` entry is
   unaffected; it already gets real syntax validation from Vite's own transform.
 
 - Marks the build as dev for [`BT.isDevMode`](api-core.md#dev-vs-release-mode) via the snippet's
@@ -337,13 +337,13 @@ export default defineConfig({
 
 ## Future ideas
 
-Not implemented yet - notes for where this could go next:
+Not implemented yet – notes for where this could go next:
 
 - An overlay badge showing the current reload count and the last file that triggered it.
 - A `?hardreload` query parameter or a keyboard chord that forces a clean Tier 2 re-init on demand, without waiting for
   a source edit.
 - Live `.btfont` glyph-metric editing (today only the texture and glyph tables hot-reload; metrics come from the
-  descriptor JSON, which does already reload - this is about interactively nudging metrics from a tool, not a gap in
+  descriptor JSON, which does already reload – this is about interactively nudging metrics from a tool, not a gap in
   what already reloads).
 - Hot-editing a palette file directly, rather than only palette slot mutations already being live.
 - Resuming music at its previous playback position across a hot-reload restart, instead of restarting from the top.

--- a/packages/blit386/docs/guide-input.md
+++ b/packages/blit386/docs/guide-input.md
@@ -355,7 +355,7 @@ long as a pointer is over the band, independent of the configure flag.
 <Callout type="warn" title="Upgrading from 1.3.0 or earlier">
 
 Pointer wheel capture is opt-in as of 1.4.0. If your game relied on `BT.pointerScrollDelta` without setting
-`isCapturingPointerScroll: true` in `configure()`, add the flag - otherwise the delta stays zero and the host page
+`isCapturingPointerScroll: true` in `configure()`, add the flag – otherwise the delta stays zero and the host page
 scrolls normally.
 
 </Callout>

--- a/packages/blit386/docs/guide-splash.md
+++ b/packages/blit386/docs/guide-splash.md
@@ -12,7 +12,7 @@
 
 Every published BLIT386 game shows a short BLIT386 splash before it starts: a logo bitmap fading in on its own 16-step
 gray ramp, holding, then fading out into the game's palette. Release builds play it by default and development builds
-skip it by default - both are defaults you can override.
+skip it by default – both are defaults you can override.
 
 This guide covers when it plays and how to turn it off, the loading-screen behavior, the palette handoff, and the skip.
 The getters themselves – `BT.splashState` and `BT.isSplashVisible` – are in [API: Core](api-core.md#splash-state), and

--- a/packages/blit386/eslint.config.js
+++ b/packages/blit386/eslint.config.js
@@ -209,7 +209,7 @@ export default [
         },
     },
 
-    // Config files - relaxed rules
+    // Config files – relaxed rules
     {
         files: ['*.config.js', '*.config.ts', '*.config.mjs', '**/*.config.js', '**/*.config.ts', '**/*.config.mjs'],
         languageOptions: {
@@ -223,7 +223,7 @@ export default [
         },
     },
 
-    // Test files - relaxed rules
+    // Test files – relaxed rules
     {
         files: ['**/*.test.ts', 'src/__test__/**/*.ts', 'tests/visual/**/*.ts'],
         languageOptions: {

--- a/packages/blit386/scripts/__fixtures__/gen-api-history/entry.ts
+++ b/packages/blit386/scripts/__fixtures__/gen-api-history/entry.ts
@@ -28,11 +28,11 @@ export const FixtureBT = {
     /**
      * Fixture method member with no version tag yet.
      *
-     * @param amount - Amount to add.
+     * @param amount – Amount to add.
      * @returns The amount, unchanged.
      */
     add: (amount: number): number => amount,
 
-    /** Fixture single-line JSDoc member, no version tag yet - matches the real `BT` namespace style. */
+    /** Fixture single-line JSDoc member, no version tag yet – matches the real `BT` namespace style. */
     flag: 1,
 };

--- a/packages/blit386/scripts/check-declaration-tooling.mjs
+++ b/packages/blit386/scripts/check-declaration-tooling.mjs
@@ -191,8 +191,8 @@ export function findViteDeclarationSizeFailure(fileSizeBytes) {
 
 /**
  * Verifies rolled-up `dist/vite.d.ts` exports required top-level members. Unlike the `BT`
- * facade, `dist/vite.d.ts` has no wrapping namespace/object block - it is flat top-level
- * `export declare` statements - so this checks for a matching function declaration directly.
+ * facade, `dist/vite.d.ts` has no wrapping namespace/object block – it is flat top-level
+ * `export declare` statements – so this checks for a matching function declaration directly.
  *
  * @param {string} dtsText Contents of `dist/vite.d.ts`.
  * @param {readonly string[]} [requiredMembers] Export names that must be present.

--- a/packages/blit386/scripts/convert-bmfont.mjs
+++ b/packages/blit386/scripts/convert-bmfont.mjs
@@ -12,8 +12,8 @@ import { dirname, join, relative, resolve, sep } from 'node:path';
 /**
  * Extracts the value of a specified attribute from an XML tag.
  *
- * @param {string} tag - The XML tag string from which to extract the attribute value.
- * @param {string} attr - The name of the attribute to extract.
+ * @param {string} tag – The XML tag string from which to extract the attribute value.
+ * @param {string} attr – The name of the attribute to extract.
  * @returns {string|null} The value of the specified attribute, or null if the attribute is not found.
  */
 function parseXmlAttribute(tag, attr) {
@@ -26,7 +26,7 @@ function parseXmlAttribute(tag, attr) {
 /**
  * Parses the `<info>` XML tag from the provided font file data and extracts the font name and size.
  *
- * @param {string} xmlData - The XML data containing the font information, including the `<info>` tag.
+ * @param {string} xmlData – The XML data containing the font information, including the `<info>` tag.
  * @returns {{fontName: string, fontSize: number}} An object containing the `fontName` and `fontSize` extracted from the `<info>` tag. Defaults to 'Unknown' for font name and 12 for font size if attributes are missing.
  */
 function parseInfoTag(xmlData) {
@@ -54,8 +54,8 @@ function parseInfoTag(xmlData) {
 /**
  * Parses the `<common>` tag from the provided XML data and extracts font-related attributes.
  *
- * @param {string} xmlData - The XML data containing the `<common>` tag.
- * @param {number} fontSize - The font size to be used as a fallback value if attributes are missing.
+ * @param {string} xmlData – The XML data containing the `<common>` tag.
+ * @param {number} fontSize – The font size to be used as a fallback value if attributes are missing.
  * @returns {{lineHeight: number, baseline: number}} An object containing the parsed `lineHeight` and `baseline` values from the `<common>` tag.
  */
 function parseCommonTag(xmlData, fontSize) {
@@ -128,10 +128,10 @@ function parsePageTag(xmlData) {
  * Generates and returns the appropriate texture value based on the specified options.
  * This can either be an embedded base64 representation of the texture or a path to the texture file.
  *
- * @param {boolean} embedTexture - Indicates whether the texture should be embedded in base64 format.
- * @param {string} textureFilename - The filename of the texture file to be used.
- * @param {string} fntDir - The directory where the texture file is located.
- * @param {string} outputPath - The output path used for computing relative paths if embedding is off.
+ * @param {boolean} embedTexture – Indicates whether the texture should be embedded in base64 format.
+ * @param {string} textureFilename – The filename of the texture file to be used.
+ * @param {string} fntDir – The directory where the texture file is located.
+ * @param {string} outputPath – The output path used for computing relative paths if embedding is off.
  * @returns {string} The texture value, either as a base64-encoded string or a relative path.
  */
 function getTextureValue(embedTexture, textureFilename, fntDir, outputPath) {
@@ -198,10 +198,10 @@ function getTextureValue(embedTexture, textureFilename, fntDir, outputPath) {
 /**
  * Parses glyph data from a given XML tag and updates the glyph object with the corresponding character's properties.
  *
- * @param {Object} glyphs - The object representing all glyph data, which will be updated with the parsed character information.
- * @param {string} char - The character corresponding to the glyph data being parsed.
- * @param {string} tag - The XML tag containing the attributes for the glyph's properties.
- * @param {number} charCode - The character code for error reporting.
+ * @param {Object} glyphs – The object representing all glyph data, which will be updated with the parsed character information.
+ * @param {string} char – The character corresponding to the glyph data being parsed.
+ * @param {string} tag – The XML tag containing the attributes for the glyph's properties.
+ * @param {number} charCode – The character code for error reporting.
  * @returns {void} Does not return a value; updates the glyph object directly with parsed data.
  */
 function parseGlyphData(glyphs, char, tag, charCode) {
@@ -256,7 +256,7 @@ function parseGlyphData(glyphs, char, tag, charCode) {
 /**
  * Parses glyph data from an XML string containing font information and extracts individual character properties.
  *
- * @param {string} xmlData - The XML string containing font glyph definitions.
+ * @param {string} xmlData – The XML string containing font glyph definitions.
  * @returns {{glyphs: Object, glyphCount: number}} An object containing the parsed glyphs as key-value pairs and the total count of glyphs found.
  */
 function parseGlyphs(xmlData) {
@@ -301,13 +301,13 @@ function parseGlyphs(xmlData) {
 /**
  * Writes the given font data to a file and logs the conversion details.
  *
- * @param {string} outputPath - The path where the font data will be written.
- * @param {object} btfont - The font data to be serialized and written to the file.
- * @param {string} fontName - The name of the font being processed.
- * @param {number} fontSize - The size of the font, in points.
- * @param {number} lineHeight - The line height of the font, in pixels.
- * @param {number} baseline - The baseline offset of the font, in pixels.
- * @param {number} glyphCount - The total number of glyphs in the font.
+ * @param {string} outputPath – The path where the font data will be written.
+ * @param {object} btfont – The font data to be serialized and written to the file.
+ * @param {string} fontName – The name of the font being processed.
+ * @param {number} fontSize – The size of the font, in points.
+ * @param {number} lineHeight – The line height of the font, in pixels.
+ * @param {number} baseline – The baseline offset of the font, in pixels.
+ * @param {number} glyphCount – The total number of glyphs in the font.
  * @returns {void} This function doesn't return a value.
  */
 function writeOutput(outputPath, btfont, fontName, fontSize, lineHeight, baseline, glyphCount) {
@@ -324,8 +324,8 @@ function writeOutput(outputPath, btfont, fontName, fontSize, lineHeight, baselin
 /**
  * Converts a BMFont `.fnt` file to a `.btfont` format file.
  *
- * @param {string} fntPath - The path to the input `.fnt` file. This should be a valid BMFont XML file.
- * @param {string} outputPath - The path where the converted `.btfont` file will be saved.
+ * @param {string} fntPath – The path to the input `.fnt` file. This should be a valid BMFont XML file.
+ * @param {string} outputPath – The path where the converted `.btfont` file will be saved.
  * @param {boolean} [embedTexture=false] - Whether to embed the texture file as a base64-encoded string within the output `.btfont` file. Defaults to `false`.
  * @returns {void} Does not return a value. The converted file is saved to the specified output path.
  */

--- a/packages/blit386/scripts/convert-splash-logo.mjs
+++ b/packages/blit386/scripts/convert-splash-logo.mjs
@@ -51,7 +51,7 @@ const CHANNELS = 4;
 /**
  * Reads the PNG and quantizes every pixel onto the splash ramp.
  *
- * @param {string} inputPath - Path to the source PNG.
+ * @param {string} inputPath – Path to the source PNG.
  * @returns {{ width: number, height: number, indices: number[] }} Dimensions and flat index array.
  */
 function extractIndices(inputPath) {
@@ -81,7 +81,7 @@ function extractIndices(inputPath) {
 /**
  * Renders the generated TypeScript module.
  *
- * @param {{ width: number, height: number, indices: number[] }} data - Extracted logo data.
+ * @param {{ width: number, height: number, indices: number[] }} data – Extracted logo data.
  * @returns {string} File contents.
  */
 function renderModule(data) {

--- a/packages/blit386/scripts/convert-system-font.mjs
+++ b/packages/blit386/scripts/convert-system-font.mjs
@@ -42,7 +42,7 @@ const ON_THRESHOLD = 128; // Red channel >= this means "on".
 /**
  * Reads the PNG and extracts bit patterns for all 95 glyphs.
  *
- * @param {string} inputPath - Path to the 96x84 PNG atlas.
+ * @param {string} inputPath – Path to the 96x84 PNG atlas.
  * @returns {number[]} Flat array of 1330 bytes (95 glyphs x 14 rows).
  */
 function extractBitmaps(inputPath) {
@@ -88,7 +88,7 @@ function extractBitmaps(inputPath) {
 /**
  * Returns the printable label for a character code.
  *
- * @param {number} charCode - ASCII character code.
+ * @param {number} charCode – ASCII character code.
  * @returns {string} Human-readable label (e.g., "A (65)" or "Space (32)").
  */
 function charLabel(charCode) {
@@ -102,7 +102,7 @@ function charLabel(charCode) {
 /**
  * Formats a byte as a two-digit hex string with 0x prefix.
  *
- * @param {number} value - Byte value (0-255).
+ * @param {number} value – Byte value (0-255).
  * @returns {string} Formatted hex string.
  */
 function hex(value) {
@@ -112,7 +112,7 @@ function hex(value) {
 /**
  * Generates the TypeScript source for systemFontData.ts.
  *
- * @param {number[]} bitmaps - Flat array of 1330 bytes.
+ * @param {number[]} bitmaps – Flat array of 1330 bytes.
  * @returns {string} Complete TypeScript source file content.
  */
 function generateTypeScript(bitmaps) {

--- a/packages/blit386/scripts/export-system-font.mjs
+++ b/packages/blit386/scripts/export-system-font.mjs
@@ -62,7 +62,7 @@ function parseBitmapData() {
 
     const arrayContent = source.slice(startIndex + 1, endIndex);
 
-    // Extract all hex values (0x00 - 0xff).
+    // Extract all hex values (0x00 – 0xff).
     const hexPattern = /0x[\da-fA-F]{2}/g;
     const matches = arrayContent.match(hexPattern);
 
@@ -80,7 +80,7 @@ function parseBitmapData() {
  * Builds a 96x84 RGBA PNG from the bit-pattern data.
  * Set bits become white (255,255,255,255), clear bits become black (0,0,0,255).
  *
- * @param {number[]} bitmaps - The flat array of glyph bytes.
+ * @param {number[]} bitmaps – The flat array of glyph bytes.
  * @returns {Buffer} The PNG file data.
  */
 function buildPNG(bitmaps) {

--- a/packages/blit386/scripts/gen-api-history.mjs
+++ b/packages/blit386/scripts/gen-api-history.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Builds `docs/_api-history.json` - the versioned public API surface - from JSDoc
+ * Builds `docs/_api-history.json` - the versioned public API surface – from JSDoc
  * `@since` / `@changed` / `@deprecated` tags in `src/`.
  *
  * The engine's public entrypoint (`src/BLIT386.ts`) is the single source of truth: every
@@ -63,7 +63,7 @@ export const DEFAULT_TEST_COMPILER_OPTIONS = {
  * text and `{@link}` nodes) into plain text, preserving `{@link Name}` markup so downstream
  * consumers (docs prose) keep the link.
  *
- * @param {string | ts.NodeArray<ts.JSDocComment> | undefined} comment - Raw tag comment.
+ * @param {string | ts.NodeArray<ts.JSDocComment> | undefined} comment – Raw tag comment.
  * @returns {string} Flattened comment text.
  */
 export function commentToText(comment) {
@@ -91,7 +91,7 @@ export function commentToText(comment) {
 /**
  * Renders a JSDoc link target (`EntityName` or `JSDocMemberName`) back to dotted text.
  *
- * @param {ts.EntityName | ts.JSDocMemberName} node - Link target node.
+ * @param {ts.EntityName | ts.JSDocMemberName} node – Link target node.
  * @returns {string} Dotted/hashed text representation.
  */
 function entityNameToText(node) {
@@ -116,7 +116,7 @@ const DEPRECATED_PATTERN =
  * Parses an `@deprecated` tag's comment text into a structured record. Backward compatible
  * with the 52 pre-existing date-only tags (`version` resolves to `null`).
  *
- * @param {string} text - Flattened `@deprecated` comment text.
+ * @param {string} text – Flattened `@deprecated` comment text.
  * @returns {{ version: string | null, date: string | null, note: string }} Parsed fields.
  */
 export function parseDeprecatedTag(text) {
@@ -137,12 +137,12 @@ export function parseDeprecatedTag(text) {
 
 /**
  * Warns (to stderr) about an `@changed` tag whose text doesn't match `<version> <note>` - a
- * missing version token, or a version with no note - so a malformed tag is visibly dropped
+ * missing version token, or a version with no note – so a malformed tag is visibly dropped
  * during manifest generation rather than silently discarded, matching how `--since-check`
  * surfaces missing `@since` tags instead of guessing at them.
  *
- * @param {ts.Node} declaration - Declaration the malformed tag was found on.
- * @param {string} text - Raw `@changed` comment text that failed to parse.
+ * @param {ts.Node} declaration – Declaration the malformed tag was found on.
+ * @param {string} text – Raw `@changed` comment text that failed to parse.
  */
 function warnMalformedChangedTag(declaration, text) {
     const sourceFile = declaration.getSourceFile();
@@ -157,7 +157,7 @@ function warnMalformedChangedTag(declaration, text) {
 /**
  * Reads `@since` / `@changed` / `@deprecated` off a declaration node via the compiler API.
  *
- * @param {ts.Node} declaration - Declaration node to inspect.
+ * @param {ts.Node} declaration – Declaration node to inspect.
  * @returns {{
  *   since: string | null,
  *   changes: Array<{ version: string, note: string }>,
@@ -195,10 +195,10 @@ export function extractTags(declaration) {
 
 /**
  * Compares two bare `major.minor.patch` version strings numerically (no pre-release/build
- * metadata support - this project's tags are plain semver).
+ * metadata support – this project's tags are plain semver).
  *
- * @param {string} a - First version.
- * @param {string} b - Second version.
+ * @param {string} a – First version.
+ * @param {string} b – Second version.
  * @returns {number} Negative if `a < b`, positive if `a > b`, zero if equal.
  */
 export function compareVersions(a, b) {
@@ -223,7 +223,7 @@ export function compareVersions(a, b) {
  * release state), then `unreleased` for the configured unreleased version or missing/untagged
  * future versions, otherwise `stable`.
  *
- * @param {{ since: string | null, deprecated: unknown }} entry - Symbol's parsed tags.
+ * @param {{ since: string | null, deprecated: unknown }} entry – Symbol's parsed tags.
  * @param {{ packageVersion: string, unreleasedVersion: string, hasTag: (version: string) => boolean }} context
  *   - Release context.
  * @returns {'stable' | 'unreleased' | 'deprecated'} Derived status.
@@ -252,7 +252,7 @@ export function deriveStatus(entry, context) {
  * Builds a `ts.Program` from an explicit file list, for fixture-driven unit tests that do not
  * want the real `tsconfig.json`.
  *
- * @param {string[]} rootNames - Entry file paths.
+ * @param {string[]} rootNames – Entry file paths.
  * @param {ts.CompilerOptions} [options] - Compiler options; defaults to a minimal ES2022/bundler set.
  * @returns {ts.Program} Compiled program.
  */
@@ -262,7 +262,7 @@ export function createProgramFromFiles(rootNames, options = DEFAULT_TEST_COMPILE
 
 /**
  * Resolves the real `tsconfig.json`'s fully-parsed compiler options (correct `lib` mapping,
- * `moduleResolution`, etc.) without pulling in its whole `include` file list - the program only
+ * `moduleResolution`, etc.) without pulling in its whole `include` file list – the program only
  * needs the public entrypoint as a root; the compiler follows imports from there.
  *
  * @returns {ts.CompilerOptions} Parsed compiler options.
@@ -295,8 +295,8 @@ function createRepoProgram() {
  * Resolves an export symbol through its alias (an `export { X }` / `export type { X }` name)
  * to the symbol backing its real declaration.
  *
- * @param {ts.TypeChecker} checker - Type checker for the program.
- * @param {ts.Symbol} symbol - Export symbol, possibly an alias.
+ * @param {ts.TypeChecker} checker – Type checker for the program.
+ * @param {ts.Symbol} symbol – Export symbol, possibly an alias.
  * @returns {ts.Symbol} Resolved (non-alias) symbol.
  */
 function resolveAliasedSymbol(checker, symbol) {
@@ -310,7 +310,7 @@ function resolveAliasedSymbol(checker, symbol) {
 /**
  * Classifies a top-level declaration's kind for the JSON `kind` field.
  *
- * @param {ts.Node} declaration - Resolved declaration node.
+ * @param {ts.Node} declaration – Resolved declaration node.
  * @returns {'class' | 'interface' | 'type' | 'function' | 'const' | 'unknown'} Symbol kind.
  */
 function classifyDeclarationKind(declaration) {
@@ -347,7 +347,7 @@ function classifyDeclarationKind(declaration) {
  * Classifies a `BT` namespace member's kind (getter vs method vs plain constant), matching the
  * getters-vs-methods convention documented in `CLAUDE.md`.
  *
- * @param {ts.Node} declaration - Member declaration node (property of the `BT` object literal).
+ * @param {ts.Node} declaration – Member declaration node (property of the `BT` object literal).
  * @returns {'getter' | 'setter' | 'method' | 'const' | 'unknown'} Member kind.
  */
 function classifyBtMemberKind(declaration) {
@@ -384,9 +384,9 @@ function classifyBtMemberKind(declaration) {
  * Walks the type of the resolved `BT` (or fixture equivalent) export and yields one record per
  * member property, keyed `BT.<member>`.
  *
- * @param {ts.TypeChecker} checker - Type checker for the program.
- * @param {ts.Symbol} btSymbol - Resolved symbol for the namespace object export.
- * @param {string} exportName - Public name of the namespace export (`'BT'` in production).
+ * @param {ts.TypeChecker} checker – Type checker for the program.
+ * @param {ts.Symbol} btSymbol – Resolved symbol for the namespace object export.
+ * @param {string} exportName – Public name of the namespace export (`'BT'` in production).
  * @returns {Array<{ name: string, kind: string, node: ts.Node, sourceFile: ts.SourceFile, tags: object }>}
  *   One record per member.
  */
@@ -424,8 +424,8 @@ function collectNamespaceMemberRecords(checker, btSymbol, exportName) {
  * of the configured namespace object export (`BT` in production), each carrying its parsed
  * version tags and the AST node/file needed for the `--backfill` codemod.
  *
- * @param {ts.Program} program - Compiled program.
- * @param {string} entryFilePath - Absolute path to the public entrypoint module.
+ * @param {ts.Program} program – Compiled program.
+ * @param {string} entryFilePath – Absolute path to the public entrypoint module.
  * @param {{ namespaceExportName?: string }} [options] - `namespaceExportName` defaults to `'BT'`;
  *   override for fixtures that use a different namespace object name.
  * @returns {Array<{ name: string, kind: string, node: ts.Node, sourceFile: ts.SourceFile, tags: object }>}
@@ -479,8 +479,8 @@ export function collectSymbolRecords(program, entryFilePath, options = {}) {
  * Thin wrapper over {@link collectSymbolRecords} returning just the `{ kind, since, changes,
  * deprecated }` data needed for the JSON manifest, keyed by symbol name.
  *
- * @param {ts.Program} program - Compiled program.
- * @param {string} entryFilePath - Absolute path to the public entrypoint module.
+ * @param {ts.Program} program – Compiled program.
+ * @param {string} entryFilePath – Absolute path to the public entrypoint module.
  * @param {{ namespaceExportName?: string }} [options] - See {@link collectSymbolRecords}.
  * @returns {Record<string, { kind: string, since: string | null, changes: Array<object>, deprecated: object | null }>}
  *   Parsed tags keyed by symbol name.
@@ -499,7 +499,7 @@ export function enumerateSymbols(program, entryFilePath, options = {}) {
  * Resolves a tag's commit date via `git log -1 --format=%aI <tag>`. Returns `null` when the tag
  * does not exist locally (shallow clones, or a version that has not shipped yet).
  *
- * @param {string} tag - Tag name (bare semver, no `v` prefix).
+ * @param {string} tag – Tag name (bare semver, no `v` prefix).
  * @param {{ cwd?: string }} [runOptions] - `cwd` to run git in; defaults to the repo root.
  * @returns {string | null} ISO 8601 tag date, or `null` if unresolved.
  */
@@ -525,8 +525,8 @@ export function resolveTagDate(tag, runOptions = {}) {
  *
  * @param {Record<string, { since: string | null, changes: Array<{ version: string }>, deprecated: { version: string | null } | null }>} symbols
  *   Parsed symbol tags.
- * @param {string} packageVersion - Current `package.json` version.
- * @param {string} unreleasedVersion - Configured next-release version.
+ * @param {string} packageVersion – Current `package.json` version.
+ * @param {string} unreleasedVersion – Configured next-release version.
  * @param {(version: string) => string | null} [resolveDate] - Injectable for tests.
  * @returns {Record<string, string | null>} Version -> ISO date (or `null`), sorted by version.
  */
@@ -561,7 +561,7 @@ export function buildVersionsMap(symbols, packageVersion, unreleasedVersion, res
  * Maps a doc filename to its sitemap-style page key (`api-core-types.md` -> `api/core-types`,
  * `guide-audio.md` -> `guides/audio`).
  *
- * @param {string} filename - Doc filename.
+ * @param {string} filename – Doc filename.
  * @returns {string} Page key.
  */
 function pageKeyFromFilename(filename) {

--- a/packages/blit386/scripts/gen-api-history.test.mjs
+++ b/packages/blit386/scripts/gen-api-history.test.mjs
@@ -402,7 +402,7 @@ describe('JSDoc backfill codemod', () => {
         // outside any comment (the exact regression this fix addresses).
         assert.match(
             updatedSource,
-            /\/\*\*\n\s+\* Fixture single-line JSDoc member, no version tag yet - matches the real `BT` namespace style\.\n\s+\* @since 1\.2\.0\n\s+\*\/\n\s+flag: 1,/u,
+            /\/\*\*\n\s+\* Fixture single-line JSDoc member, no version tag yet – matches the real `BT` namespace style\.\n\s+\* @since 1\.2\.0\n\s+\*\/\n\s+flag: 1,/u,
         );
 
         // Re-parsing the updated text (in memory – never touching the fixture file on disk) must

--- a/packages/blit386/scripts/sync-doc-banners.mjs
+++ b/packages/blit386/scripts/sync-doc-banners.mjs
@@ -7,7 +7,7 @@
  * GitHub readers at the typeset copy on blit386.dev. The banner is wrapped in
  * sentinel HTML comments so the public mirror generator
  * (`packages/website/scripts/sync-docs-from-engine.mjs`) can strip it back
- * out - the live site should never tell its own readers to go to the site.
+ * out – the live site should never tell its own readers to go to the site.
  *
  * This script is the single owner of that banner. It derives every URL from the
  * sitemap, so the link can never drift: run it and each doc gets a banner with

--- a/packages/blit386/src/BLIT386.ts
+++ b/packages/blit386/src/BLIT386.ts
@@ -116,8 +116,8 @@ resetKeyboardFaceButtonMaps();
 /**
  * Shows a beginner-friendly runtime error in the canvas container and console.
  *
- * @param message - Human-readable guidance to display.
- * @param title - Short heading for the error panel.
+ * @param message – Human-readable guidance to display.
+ * @param title – Short heading for the error panel.
  */
 function showBeginnerRuntimeError(message: string, title: string = 'Demo Error'): void {
     displayError(title, message);
@@ -136,7 +136,7 @@ function isRendererReady(): boolean {
 /**
  * Shows a friendly error when a draw call is made before bootstrap finishes.
  *
- * @param methodName - BT method name that was called too early.
+ * @param methodName – BT method name that was called too early.
  */
 function reportEngineNotReady(methodName: string): void {
     showBeginnerRuntimeError(
@@ -149,7 +149,7 @@ function reportEngineNotReady(methodName: string): void {
 /**
  * Converts an unknown runtime value into a concise display type label.
  *
- * @param value - Runtime value to inspect.
+ * @param value – Runtime value to inspect.
  * @returns A short readable type description.
  */
 function describeRuntimeType(value: unknown): string {
@@ -188,7 +188,7 @@ function describeRuntimeType(value: unknown): string {
 /**
  * Shows a friendly hint when a Promise was passed instead of an awaited asset.
  *
- * @param loadCall - Asset loader call name to reference in the message.
+ * @param loadCall – Asset loader call name to reference in the message.
  */
 function reportMissingAwait(loadCall: string): void {
     showBeginnerRuntimeError(`Did you forget to use 'await' before ${loadCall}?`, 'Missing await');
@@ -197,8 +197,8 @@ function reportMissingAwait(loadCall: string): void {
 /**
  * Runs a draw call with readiness checks and beginner-friendly error handling.
  *
- * @param methodName - BT method name for contextual error text.
- * @param callback - Draw-call body to execute.
+ * @param methodName – BT method name for contextual error text.
+ * @param callback – Draw-call body to execute.
  */
 function executeDrawCall(methodName: string, callback: () => void): void {
     if (!isRendererReady()) {
@@ -221,8 +221,8 @@ function executeDrawCall(methodName: string, callback: () => void): void {
  * Returns runtime keyboard `KeyboardEvent.code` list for a face button and player,
  * or `null` when there is no keyboard fallback (e.g. players 2-3 for face buttons).
  *
- * @param button - Face button constant (`BT.BTN_UP` … `BT.BTN_SELECT`).
- * @param player - Zero-based player index.
+ * @param button – Face button constant (`BT.BTN_UP` … `BT.BTN_SELECT`).
+ * @param player – Zero-based player index.
  * @returns Key codes for that mapping, or `null` if unsupported.
  */
 function faceButtonKeys(button: number, player: number): readonly string[] | null {
@@ -244,7 +244,7 @@ function faceButtonKeys(button: number, player: number): readonly string[] | nul
 /**
  * Maps a single pointer button bit flag to the pointer subsystem button code.
  *
- * @param pointerFlag - One pointer button bit from `BTN_POINTER_A..D`.
+ * @param pointerFlag – One pointer button bit from `BTN_POINTER_A..D`.
  * @returns Pointer subsystem button code (`20..23`) or `null` if not a pointer button.
  */
 function pointerFlagToPointerCode(pointerFlag: number): number | null {
@@ -539,8 +539,8 @@ export const BT = {
      * `canvas.focus()` so keyboard events reach the canvas.
      *
      * @since 0.1.0
-     * @param demo - Demo implementation that provides lifecycle hooks.
-     * @param canvas - Canvas used as the engine render target.
+     * @param demo – Demo implementation that provides lifecycle hooks.
+     * @param canvas – Canvas used as the engine render target.
      * @returns `true` when initialization succeeds; otherwise `false`.
      */
     init: async (demo: IBTDemo, canvas: HTMLCanvasElement): Promise<boolean> => {
@@ -692,7 +692,7 @@ export const BT = {
      * `"Untitled"`. Chart width resets add an automatic `"Start"` tag.
      *
      * @since 1.1.0
-     * @param label - Short event name (for example `'Round start'`).
+     * @param label – Short event name (for example `'Round start'`).
      */
     assignTag: (label?: string): void => {
         BTAPI.instance.assignTag(label);
@@ -703,7 +703,7 @@ export const BT = {
      *
      * `'webgpu'` or `'software'` after successful init; `null` before init or on failure.
      * May differ from {@link BT.requestedBackend} when WebGPU was requested but unavailable
-     * (automatic software fallback). Use this getter for runtime behavior - for example,
+     * (automatic software fallback). Use this getter for runtime behavior – for example,
      * skipping post-process effects that only work under WebGPU:
      *
      * ```ts
@@ -740,7 +740,7 @@ export const BT = {
      * Current BLIT386 splash lifecycle state.
      *
      * `'disabled'` when the splash was gated off, `'done'` once it has finished.
-     * Both mean "not on screen, never will be again" - prefer
+     * Both mean "not on screen, never will be again" – prefer
      * {@link BT.isSplashVisible} in game code, and reach for this only when the
      * distinction genuinely matters (debugging, the engine overlay).
      *
@@ -819,11 +819,11 @@ export const BT = {
      * Sets the logical volume for an audio bus, optionally fading to it.
      *
      * @since 1.3.0
-     * @param bus - Audio bus to update (`'main'`, `'music'`, or `'sfx'`).
-     * @param value - Target volume, clamped to `[0, 1]`.
-     * @param options - Optional fade behavior.
-     * @param options.fadeMs - Fade duration in milliseconds. Omit for an immediate change.
-     * @param options.easing - Easing curve for the fade. Defaults to `'linear'`; ignored when `fadeMs` is omitted.
+     * @param bus – Audio bus to update (`'main'`, `'music'`, or `'sfx'`).
+     * @param value – Target volume, clamped to `[0, 1]`.
+     * @param options – Optional fade behavior.
+     * @param options.fadeMs – Fade duration in milliseconds. Omit for an immediate change.
+     * @param options.easing – Easing curve for the fade. Defaults to `'linear'`; ignored when `fadeMs` is omitted.
      */
     audioVolumeSet: (bus: AudioBus, value: number, options?: { fadeMs?: number; easing?: EasingFunction }): void => {
         BTAPI.instance.audioVolumeSet(bus, value, options?.fadeMs, options?.easing);
@@ -835,7 +835,7 @@ export const BT = {
      * Unaffected by {@link BT.audioMuteSet} - muting never overwrites the configured level.
      *
      * @since 1.3.0
-     * @param bus - Audio bus to query.
+     * @param bus – Audio bus to query.
      * @returns Volume in `[0, 1]`, or `0` before initialization.
      */
     audioVolumeGet: (bus: AudioBus): number => {
@@ -846,7 +846,7 @@ export const BT = {
      * Mutes or unmutes an audio bus.
      *
      * @since 1.3.0
-     * @param bus - Audio bus to mute or unmute.
+     * @param bus – Audio bus to mute or unmute.
      * @param muted - `true` to mute, `false` to unmute.
      */
     audioMuteSet: (bus: AudioBus, muted: boolean): void => {
@@ -857,7 +857,7 @@ export const BT = {
      * Reports whether an audio bus is currently muted.
      *
      * @since 1.3.0
-     * @param bus - Audio bus to query.
+     * @param bus – Audio bus to query.
      * @returns `true` when muted; `false` when unmuted or before initialization.
      */
     isAudioMuted: (bus: AudioBus): boolean => {
@@ -872,10 +872,10 @@ export const BT = {
      * priority, or before the engine has unlocked audio playback.
      *
      * @since 1.3.0
-     * @param clip - Loaded audio clip to play.
-     * @param options - Playback options.
+     * @param clip – Loaded audio clip to play.
+     * @param options – Playback options.
      * @returns A handle identifying the new voice; pass it to {@link BT.soundStop} and the other
-     *   per-sound controls. Safe to use even when playback was silently dropped - every accessor
+     *   per-sound controls. Safe to use even when playback was silently dropped – every accessor
      *   on an inert handle is a no-op.
      */
     soundPlay: (clip: AudioClip, options?: SoundPlayOptions): SoundRef => {
@@ -886,9 +886,9 @@ export const BT = {
      * Stops a playing sound, optionally fading it out.
      *
      * @since 1.3.0
-     * @param ref - Sound to stop, from {@link BT.soundPlay}.
-     * @param options - Optional fade behavior.
-     * @param options.fadeOutMs - Fade-out duration in milliseconds. Omit to stop immediately.
+     * @param ref – Sound to stop, from {@link BT.soundPlay}.
+     * @param options – Optional fade behavior.
+     * @param options.fadeOutMs – Fade-out duration in milliseconds. Omit to stop immediately.
      */
     soundStop: (ref: SoundRef, options?: SoundStopOptions): void => {
         BTAPI.instance.soundStop(ref, options?.fadeOutMs);
@@ -898,7 +898,7 @@ export const BT = {
      * Reports whether a sound is still playing.
      *
      * @since 1.3.0
-     * @param ref - Sound to query.
+     * @param ref – Sound to query.
      * @returns `true` when still playing; `false` once it has stopped, been stolen, or completed.
      */
     isSoundPlaying: (ref: SoundRef): boolean => {
@@ -909,10 +909,10 @@ export const BT = {
      * Sets a sound's gain, optionally fading to it.
      *
      * @since 1.3.0
-     * @param ref - Sound to update.
-     * @param value - Target gain.
-     * @param options - Optional fade behavior.
-     * @param options.fadeMs - Fade duration in milliseconds. Omit for an immediate change.
+     * @param ref – Sound to update.
+     * @param value – Target gain.
+     * @param options – Optional fade behavior.
+     * @param options.fadeMs – Fade duration in milliseconds. Omit for an immediate change.
      */
     soundVolumeSet: (ref: SoundRef, value: number, options?: SoundParamSetOptions): void => {
         BTAPI.instance.soundVolumeSet(ref, value, options?.fadeMs);
@@ -922,7 +922,7 @@ export const BT = {
      * Gets a sound's current gain.
      *
      * @since 1.3.0
-     * @param ref - Sound to query.
+     * @param ref – Sound to query.
      * @returns Current gain, or `1` once the sound has stopped.
      */
     soundVolumeGet: (ref: SoundRef): number => {
@@ -933,10 +933,10 @@ export const BT = {
      * Sets a sound's playback rate, optionally fading to it.
      *
      * @since 1.3.0
-     * @param ref - Sound to update.
-     * @param value - Target playback rate.
-     * @param options - Optional fade behavior.
-     * @param options.fadeMs - Fade duration in milliseconds. Omit for an immediate change.
+     * @param ref – Sound to update.
+     * @param value – Target playback rate.
+     * @param options – Optional fade behavior.
+     * @param options.fadeMs – Fade duration in milliseconds. Omit for an immediate change.
      */
     soundPitchSet: (ref: SoundRef, value: number, options?: SoundParamSetOptions): void => {
         BTAPI.instance.soundPitchSet(ref, value, options?.fadeMs);
@@ -946,7 +946,7 @@ export const BT = {
      * Gets a sound's current playback rate.
      *
      * @since 1.3.0
-     * @param ref - Sound to query.
+     * @param ref – Sound to query.
      * @returns Current playback rate, or `1` once the sound has stopped.
      */
     soundPitchGet: (ref: SoundRef): number => {
@@ -957,10 +957,10 @@ export const BT = {
      * Sets a sound's stereo pan, optionally fading to it.
      *
      * @since 1.3.0
-     * @param ref - Sound to update.
-     * @param value - Target pan.
-     * @param options - Optional fade behavior.
-     * @param options.fadeMs - Fade duration in milliseconds. Omit for an immediate change.
+     * @param ref – Sound to update.
+     * @param value – Target pan.
+     * @param options – Optional fade behavior.
+     * @param options.fadeMs – Fade duration in milliseconds. Omit for an immediate change.
      */
     soundPanSet: (ref: SoundRef, value: number, options?: SoundParamSetOptions): void => {
         BTAPI.instance.soundPanSet(ref, value, options?.fadeMs);
@@ -970,7 +970,7 @@ export const BT = {
      * Gets a sound's current stereo pan.
      *
      * @since 1.3.0
-     * @param ref - Sound to query.
+     * @param ref – Sound to query.
      * @returns Current pan, or `0` once the sound has stopped.
      */
     soundPanGet: (ref: SoundRef): number => {
@@ -984,11 +984,11 @@ export const BT = {
      * Silently does nothing when the clip hasn't finished loading yet (or was already unloaded
      * with `clip.unload()`), or before the engine has initialized. While the audio context is
      * still locked (before the first unlock gesture), the request is remembered instead of
-     * dropped - it starts automatically the instant the context unlocks, unlike {@link BT.soundPlay}.
+     * dropped – it starts automatically the instant the context unlocks, unlike {@link BT.soundPlay}.
      *
      * @since 1.3.0
-     * @param clip - Loaded audio clip to play.
-     * @param options - Crossfade, volume, and loop options; see {@link MusicPlayOptions}.
+     * @param clip – Loaded audio clip to play.
+     * @param options – Crossfade, volume, and loop options; see {@link MusicPlayOptions}.
      */
     musicPlay: (clip: AudioClip, options?: MusicPlayOptions): void => {
         BTAPI.instance.musicPlay(clip, options);
@@ -998,8 +998,8 @@ export const BT = {
      * Stops the music player, optionally fading out first.
      *
      * @since 1.3.0
-     * @param options - Optional fade behavior.
-     * @param options.fadeMs - Fade-out duration in milliseconds. Omit to stop immediately.
+     * @param options – Optional fade behavior.
+     * @param options.fadeMs – Fade-out duration in milliseconds. Omit to stop immediately.
      */
     musicStop: (options?: { fadeMs?: number }): void => {
         BTAPI.instance.musicStop(options?.fadeMs);
@@ -1020,9 +1020,9 @@ export const BT = {
      * Sets the music player's volume, optionally fading to it.
      *
      * @since 1.3.0
-     * @param value - Target gain.
-     * @param options - Optional fade behavior.
-     * @param options.fadeMs - Fade duration in milliseconds. Omit for an immediate change.
+     * @param value – Target gain.
+     * @param options – Optional fade behavior.
+     * @param options.fadeMs – Fade duration in milliseconds. Omit for an immediate change.
      */
     musicVolumeSet: (value: number, options?: { fadeMs?: number }): void => {
         BTAPI.instance.musicVolumeSet(value, options?.fadeMs);
@@ -1059,7 +1059,7 @@ export const BT = {
      * Creates a standalone palette instance.
      *
      * @since 1.0.3
-     * @param size - Palette size. Defaults to 256 colors.
+     * @param size – Palette size. Defaults to 256 colors.
      * @returns New mutable palette.
      */
     paletteCreate: (size: number = 256): Palette => {
@@ -1084,7 +1084,7 @@ export const BT = {
      * pixels against the new slot layout.
      *
      * @since 1.0.3
-     * @param palette - Palette to make active.
+     * @param palette – Palette to make active.
      */
     paletteSet: (palette: Palette): void => {
         if (!(palette instanceof Palette)) {
@@ -1099,7 +1099,7 @@ export const BT = {
     },
 
     /**
-     * Active engine palette (live reference - not a copy).
+     * Active engine palette (live reference – not a copy).
      *
      * Mutating slots updates colors on the next frame without {@link BT.paletteSet}.
      *
@@ -1118,7 +1118,7 @@ export const BT = {
     },
 
     /**
-     * Default engine PRNG (live reference - not a copy).
+     * Default engine PRNG (live reference – not a copy).
      *
      * Time-seeded when the engine singleton is created. Call {@link BT.randomSeed}
      * for a reproducible run. Mutating the instance (for example `BT.random.int(10)`)
@@ -1139,7 +1139,7 @@ export const BT = {
      * Reseeds the default engine PRNG so subsequent draws are reproducible.
      *
      * @since 1.5.0
-     * @param seed - Any finite number; only its lower 32 bits are used.
+     * @param seed – Any finite number; only its lower 32 bits are used.
      * @example
      * BT.randomSeed(1234);
      * const a = BT.random.next();
@@ -1158,9 +1158,9 @@ export const BT = {
      * for sub-frame precision.
      *
      * @since 1.0.3
-     * @param start - First palette index in the cycling range (inclusive).
-     * @param end - Last palette index in the cycling range (inclusive).
-     * @param speed - Steps per second. Positive = forward, negative = backward.
+     * @param start – First palette index in the cycling range (inclusive).
+     * @param end – Last palette index in the cycling range (inclusive).
+     * @param speed – Steps per second. Positive = forward, negative = backward.
      */
     paletteCycle: (start: number, end: number, speed: number): void => {
         BTAPI.instance.paletteCycle(start, end, speed);
@@ -1179,9 +1179,9 @@ export const BT = {
      * - Cross-fade: `BT.paletteFade(nightPalette, 2000, 'ease-in-out')`
      *
      * @since 1.0.3
-     * @param target - Target palette to fade toward.
-     * @param durationMs - Fade duration in milliseconds.
-     * @param easing - Easing curve. Defaults to `'linear'`.
+     * @param target – Target palette to fade toward.
+     * @param durationMs – Fade duration in milliseconds.
+     * @param easing – Easing curve. Defaults to `'linear'`.
      */
     paletteFade: (target: Palette, durationMs: number, easing?: EasingFunction): void => {
         BTAPI.instance.paletteFade(target, durationMs, easing);
@@ -1205,7 +1205,7 @@ export const BT = {
      * entry on one schedule, higher values push the highlights further ahead.
      * Defaults to `0.5`.
      *
-     * This is a per-index effect, not a per-pixel one - a dark object in a bright
+     * This is a per-index effect, not a per-pixel one – a dark object in a bright
      * scene fades on the dark schedule regardless of what surrounds it, because
      * the engine only knows its palette slot.
      *
@@ -1218,9 +1218,9 @@ export const BT = {
      * - Fade out: `BT.paletteFadeExposure(blackPalette, 1000)`
      *
      * @since 1.5.0
-     * @param target - Target palette to fade toward.
-     * @param durationMs - Fade duration in milliseconds.
-     * @param options - Highlight lead and easing curve.
+     * @param target – Target palette to fade toward.
+     * @param durationMs – Fade duration in milliseconds.
+     * @param options – Highlight lead and easing curve.
      */
     paletteFadeExposure: (target: Palette, durationMs: number, options?: ExposureFadeOptions): void => {
         BTAPI.instance.paletteFadeExposure(target, durationMs, options);
@@ -1233,11 +1233,11 @@ export const BT = {
      * Indices outside the range are left untouched.
      *
      * @since 1.0.3
-     * @param start - First palette index to fade (inclusive).
-     * @param end - Last palette index to fade (inclusive).
-     * @param target - Target palette to fade toward.
-     * @param durationMs - Fade duration in milliseconds.
-     * @param easing - Easing curve. Defaults to `'linear'`.
+     * @param start – First palette index to fade (inclusive).
+     * @param end – Last palette index to fade (inclusive).
+     * @param target – Target palette to fade toward.
+     * @param durationMs – Fade duration in milliseconds.
+     * @param easing – Easing curve. Defaults to `'linear'`.
      */
     paletteFadeRange: (
         start: number,
@@ -1256,8 +1256,8 @@ export const BT = {
      * and restored after the duration elapses. Auto-removes when complete.
      *
      * @since 1.0.3
-     * @param color - Flash color applied to all non-zero entries.
-     * @param durationMs - How long the flash lasts in milliseconds.
+     * @param color – Flash color applied to all non-zero entries.
+     * @param durationMs – How long the flash lasts in milliseconds.
      */
     paletteFlash: (color: Color32, durationMs: number): void => {
         BTAPI.instance.paletteFlash(color, durationMs);
@@ -1270,8 +1270,8 @@ export const BT = {
      * takes effect on the next frame.
      *
      * @since 1.0.3
-     * @param indexA - First palette index.
-     * @param indexB - Second palette index.
+     * @param indexA – First palette index.
+     * @param indexB – Second palette index.
      */
     paletteSwap: (indexA: number, indexB: number): void => {
         BTAPI.instance.paletteSwap(indexA, indexB);
@@ -1303,7 +1303,7 @@ export const BT = {
      * each frame from demo code.
      *
      * @since 1.0.3
-     * @param effect - Effect instance to append.
+     * @param effect – Effect instance to append.
      * When the engine is not ready, shows a canvas error instead of throwing.
      */
     effectAdd: (effect: Effect): void => {
@@ -1319,7 +1319,7 @@ export const BT = {
      * it. Removing an effect that was never added is a no-op.
      *
      * @since 1.0.3
-     * @param effect - Effect instance to remove.
+     * @param effect – Effect instance to remove.
      * When the engine is not ready, shows a canvas error instead of throwing.
      */
     effectRemove: (effect: Effect): void => {
@@ -1362,7 +1362,7 @@ export const BT = {
      * of the next frame.
      *
      * @since 0.1.0
-     * @param paletteIndex - Palette index for the full-screen clear pass.
+     * @param paletteIndex – Palette index for the full-screen clear pass.
      */
     clear: (paletteIndex: number): void => {
         executeDrawCall('clear', () => {
@@ -1374,8 +1374,8 @@ export const BT = {
      * Fills a rectangular display region with a palette-indexed color.
      *
      * @since 0.1.0
-     * @param rect - Rectangle in display pixel coordinates.
-     * @param paletteIndex - Palette color index.
+     * @param rect – Rectangle in display pixel coordinates.
+     * @param paletteIndex – Palette color index.
      */
     clearRect: (rect: Rect2i, paletteIndex: number): void => {
         executeDrawCall('clearRect', () => {
@@ -1391,9 +1391,9 @@ export const BT = {
      * - `(posOrX: number, yOrColor: number, maybeColor: number)` for `(x, y, paletteIndex)`.
      *
      * @since 0.1.0
-     * @param posOrX - Pixel position as `Vector2i`, or x coordinate when using numeric overload.
-     * @param yOrColor - Palette index for vector overload, or y coordinate for numeric overload.
-     * @param maybeColor - Palette index when using numeric overload.
+     * @param posOrX – Pixel position as `Vector2i`, or x coordinate when using numeric overload.
+     * @param yOrColor – Palette index for vector overload, or y coordinate for numeric overload.
+     * @param maybeColor – Palette index when using numeric overload.
      */
     drawPixel: (posOrX: Vector2i | number, yOrColor: number, maybeColor?: number): void => {
         executeDrawCall('drawPixel', () => {
@@ -1427,9 +1427,9 @@ export const BT = {
      * Uses rasterized line drawing without antialiasing.
      *
      * @since 0.1.0
-     * @param p0 - Start position in display coordinates.
-     * @param p1 - End position in display coordinates.
-     * @param paletteIndex - Palette color index.
+     * @param p0 – Start position in display coordinates.
+     * @param p1 – End position in display coordinates.
+     * @param paletteIndex – Palette color index.
      */
     drawLine: (p0: Vector2i, p1: Vector2i, paletteIndex: number): void => {
         executeDrawCall('drawLine', () => {
@@ -1441,8 +1441,8 @@ export const BT = {
      * Draws an unfilled rectangle outline.
      *
      * @since 0.1.0
-     * @param rect - Rectangle bounds in display coordinates.
-     * @param paletteIndex - Palette color index.
+     * @param rect – Rectangle bounds in display coordinates.
+     * @param paletteIndex – Palette color index.
      */
     drawRect: (rect: Rect2i, paletteIndex: number): void => {
         executeDrawCall('drawRect', () => {
@@ -1454,8 +1454,8 @@ export const BT = {
      * Draws a filled rectangle.
      *
      * @since 0.1.0
-     * @param rect - Rectangle bounds in display coordinates.
-     * @param paletteIndex - Palette color index.
+     * @param rect – Rectangle bounds in display coordinates.
+     * @param paletteIndex – Palette color index.
      */
     drawRectFill: (rect: Rect2i, paletteIndex: number): void => {
         executeDrawCall('drawRectFill', () => {
@@ -1467,7 +1467,7 @@ export const BT = {
      * Sets the global camera offset applied to subsequent draw calls.
      *
      * @since 0.1.0
-     * @param offset - Camera translation in display pixels.
+     * @param offset – Camera translation in display pixels.
      */
     cameraSet: (offset: Vector2i): void => {
         BTAPI.instance.setCameraOffset(offset);
@@ -1490,9 +1490,9 @@ export const BT = {
      * If `viewSize` is omitted, the active {@link BT.displaySize} is used.
      *
      * @since 1.0.3
-     * @param camera - Desired camera origin in world coordinates.
-     * @param worldSize - Full world size in pixels.
-     * @param viewSize - Viewport size in pixels (defaults to {@link BT.displaySize}).
+     * @param camera – Desired camera origin in world coordinates.
+     * @param worldSize – Full world size in pixels.
+     * @param viewSize – Viewport size in pixels (defaults to {@link BT.displaySize}).
      * @returns Clamped camera origin.
      */
     cameraClamp: (camera: Vector2i, worldSize: Vector2i, viewSize?: Vector2i): Vector2i => {
@@ -1517,7 +1517,7 @@ export const BT = {
      * pointer.
      *
      * @since 1.0.3
-     * @param pointerIndex - Pointer slot (defaults to 0 = mouse).
+     * @param pointerIndex – Pointer slot (defaults to 0 = mouse).
      * @returns Pointer position in display coordinates.
      */
     pointerPos: (pointerIndex: number = 0): Vector2i => {
@@ -1533,7 +1533,7 @@ export const BT = {
      * not initialized or `pointerIndex` is out of range.
      *
      * @since 1.0.3
-     * @param pointerIndex - Pointer slot (defaults to 0 = mouse).
+     * @param pointerIndex – Pointer slot (defaults to 0 = mouse).
      * @returns Per-frame movement in display coordinates.
      */
     pointerDelta: (pointerIndex: number = 0): Vector2i => {
@@ -1548,7 +1548,7 @@ export const BT = {
      * true while the contact is down.
      *
      * @since 1.1.1
-     * @param pointerIndex - Pointer slot (defaults to 0 = mouse).
+     * @param pointerIndex – Pointer slot (defaults to 0 = mouse).
      * @returns `true` while the slot has live position data.
      */
     isPointerActive: (pointerIndex: number = 0): boolean => {
@@ -1560,7 +1560,7 @@ export const BT = {
      *
      * @since 1.0.3
      * @deprecated Deprecated since 1.0.3 (2026-05-31). Use {@link isPointerActive} instead.
-     * @param pointerIndex - Pointer slot (defaults to 0 = mouse).
+     * @param pointerIndex – Pointer slot (defaults to 0 = mouse).
      * @returns `true` while the slot has live position data.
      */
     pointerPosValid: (pointerIndex: number = 0): boolean => {
@@ -1629,8 +1629,8 @@ export const BT = {
      * Pointer flags (`BTN_POINTER_*`) use the `player` argument as pointer slot.
      *
      * @since 1.1.1
-     * @param button - Button constant from the `BTN_*` set.
-     * @param player - Zero-based player index for gamepads / keyboard, or pointer slot
+     * @param button – Button constant from the `BTN_*` set.
+     * @param player – Zero-based player index for gamepads / keyboard, or pointer slot
      *                 (0-3) for `BTN_POINTER_*`.
      * @returns `true` while the button remains pressed.
      */
@@ -1680,8 +1680,8 @@ export const BT = {
      *
      * @since 0.1.0
      * @deprecated Deprecated since 0.1.0 (2026-05-31). Use {@link isDown} instead.
-     * @param button - Button constant from the `BTN_*` set.
-     * @param player - Zero-based player index for gamepads / keyboard, or pointer slot.
+     * @param button – Button constant from the `BTN_*` set.
+     * @param player – Zero-based player index for gamepads / keyboard, or pointer slot.
      * @returns `true` while the button remains pressed.
      */
     buttonDown: (button: number, player: number = 0): boolean => {
@@ -1699,10 +1699,10 @@ export const BT = {
      * which always runs before that frame's `render()`.
      *
      * @since 1.1.1
-     * @param button - Button constant from the `BTN_*` set.
-     * @param player - Zero-based player index for gamepads, or pointer slot
+     * @param button – Button constant from the `BTN_*` set.
+     * @param player – Zero-based player index for gamepads, or pointer slot
      *                 (0-3) for `BTN_POINTER_*`.
-     * @param repeatRate - Optional repeat interval in fixed ticks (`0`/omitted = edge only).
+     * @param repeatRate – Optional repeat interval in fixed ticks (`0`/omitted = edge only).
      * @returns `true` on the transition frame.
      */
     // eslint-disable-next-line complexity -- explicit per-flag routing keeps input semantics easy to audit.
@@ -1764,9 +1764,9 @@ export const BT = {
      *
      * @since 0.1.0
      * @deprecated Deprecated since 0.1.0 (2026-05-31). Use {@link isPressed} instead.
-     * @param button - Button constant from the `BTN_*` set.
-     * @param player - Zero-based player index for gamepads, or pointer slot.
-     * @param repeatRate - Optional repeat interval in fixed ticks (`0`/omitted = edge only).
+     * @param button – Button constant from the `BTN_*` set.
+     * @param player – Zero-based player index for gamepads, or pointer slot.
+     * @param repeatRate – Optional repeat interval in fixed ticks (`0`/omitted = edge only).
      * @returns `true` on the transition frame.
      */
     buttonPressed: (button: number, player: number = 0, repeatRate?: number): boolean => {
@@ -1784,8 +1784,8 @@ export const BT = {
      * which always runs before that frame's `render()`.
      *
      * @since 1.1.1
-     * @param button - Button constant from the `BTN_*` set.
-     * @param player - Zero-based player index for gamepads, or pointer slot
+     * @param button – Button constant from the `BTN_*` set.
+     * @param player – Zero-based player index for gamepads, or pointer slot
      *                 (0-3) for `BTN_POINTER_*`.
      * @returns `true` on the release frame.
      */
@@ -1845,8 +1845,8 @@ export const BT = {
      *
      * @since 0.1.0
      * @deprecated Deprecated since 0.1.0 (2026-05-31). Use {@link isReleased} instead.
-     * @param button - Button constant from the `BTN_*` set.
-     * @param player - Zero-based player index for gamepads, or pointer slot.
+     * @param button – Button constant from the `BTN_*` set.
+     * @param player – Zero-based player index for gamepads, or pointer slot.
      * @returns `true` on the release frame.
      */
     buttonReleased: (button: number, player: number = 0): boolean => {
@@ -1862,9 +1862,9 @@ export const BT = {
      * to clear keyboard bindings for that button until remapped again.
      *
      * @since 1.0.3
-     * @param player - Zero-based player index (`0` or `1`).
-     * @param button - Face button constant.
-     * @param keys - DOM key codes (for example `'Space'`, `'KeyW'`).
+     * @param player – Zero-based player index (`0` or `1`).
+     * @param button – Face button constant.
+     * @param keys – DOM key codes (for example `'Space'`, `'KeyW'`).
      */
     inputMap: (player: number, button: number, ...keys: string[]): void => {
         if (player !== 0 && player !== 1) {
@@ -1902,8 +1902,8 @@ export const BT = {
      * Trigger axes return values in `[0.0, 1.0]`.
      *
      * @since 1.0.3
-     * @param axis - Axis constant (`AXIS_LEFT_X` .. `AXIS_TRIGGER_R`).
-     * @param player - Zero-based player index (`0`..`3`).
+     * @param axis – Axis constant (`AXIS_LEFT_X` .. `AXIS_TRIGGER_R`).
+     * @param player – Zero-based player index (`0`..`3`).
      * @returns Axis value, or `0` when unavailable.
      */
     getAxis: (axis: number, player: number = 0): number => {
@@ -1914,7 +1914,7 @@ export const BT = {
      * Reports whether a player's gamepad is connected.
      *
      * @since 1.1.1
-     * @param player - Zero-based player index (`0`..`3`).
+     * @param player – Zero-based player index (`0`..`3`).
      * @returns `true` when a gamepad is available for that slot.
      */
     isGamepadConnected: (player: number = 0): boolean => {
@@ -1926,7 +1926,7 @@ export const BT = {
      *
      * @since 1.0.3
      * @deprecated Deprecated since 1.0.3 (2026-05-31). Use {@link isGamepadConnected} instead.
-     * @param player - Zero-based player index (`0`..`3`).
+     * @param player – Zero-based player index (`0`..`3`).
      * @returns `true` when a gamepad is available for that slot.
      */
     gamepadConnected: (player: number = 0): boolean => {
@@ -1949,7 +1949,7 @@ export const BT = {
      * Uses `KeyboardEvent.code` (for example `"KeyW"`, `"Space"`, `"ArrowUp"`).
      *
      * @since 1.1.1
-     * @param key - DOM keyboard code string.
+     * @param key – DOM keyboard code string.
      * @returns `true` while the key remains pressed.
      */
     isKeyDown: (key: string): boolean => {
@@ -1961,7 +1961,7 @@ export const BT = {
      *
      * @since 0.1.0
      * @deprecated Deprecated since 0.1.0 (2026-05-31). Use {@link isKeyDown} instead.
-     * @param key - DOM keyboard code string.
+     * @param key – DOM keyboard code string.
      * @returns `true` while the key remains pressed.
      */
     keyDown: (key: string): boolean => {
@@ -1980,8 +1980,8 @@ export const BT = {
      * `render()` can be intermittently missed under rapid input.
      *
      * @since 1.1.1
-     * @param key - DOM keyboard code string.
-     * @param repeatRate - Ticks between repeat triggers; omit or `0` for no repeat.
+     * @param key – DOM keyboard code string.
+     * @param repeatRate – Ticks between repeat triggers; omit or `0` for no repeat.
      * @returns `true` on the press edge (and on repeat ticks when configured).
      */
     isKeyPressed: (key: string, repeatRate?: number): boolean => {
@@ -1995,8 +1995,8 @@ export const BT = {
      *
      * @since 0.1.0
      * @deprecated Deprecated since 0.1.0 (2026-05-31). Use {@link isKeyPressed} instead.
-     * @param key - DOM keyboard code string.
-     * @param repeatRate - Ticks between repeat triggers; omit or `0` for no repeat.
+     * @param key – DOM keyboard code string.
+     * @param repeatRate – Ticks between repeat triggers; omit or `0` for no repeat.
      * @returns `true` on the press edge (and on repeat ticks when configured).
      */
     keyPressed: (key: string, repeatRate?: number): boolean => {
@@ -2011,7 +2011,7 @@ export const BT = {
      * `render()` can be intermittently missed under rapid input.
      *
      * @since 1.1.1
-     * @param key - DOM keyboard code string.
+     * @param key – DOM keyboard code string.
      * @returns `true` on the release edge.
      */
     isKeyReleased: (key: string): boolean => {
@@ -2023,7 +2023,7 @@ export const BT = {
      *
      * @since 0.1.0
      * @deprecated Deprecated since 0.1.0 (2026-05-31). Use {@link isKeyReleased} instead.
-     * @param key - DOM keyboard code string.
+     * @param key – DOM keyboard code string.
      * @returns `true` on the release edge.
      */
     keyReleased: (key: string): boolean => {
@@ -2049,9 +2049,9 @@ export const BT = {
      * bitmap fonts with proportional glyphs, use {@link BT.printFont} instead.
      *
      * @since 1.0.3
-     * @param pos - Text origin in display coordinates.
-     * @param paletteIndex - Palette color index for the text.
-     * @param text - String to render.
+     * @param pos – Text origin in display coordinates.
+     * @param paletteIndex – Palette color index for the text.
+     * @param text – String to render.
      */
     systemPrint: (pos: Vector2i, paletteIndex: number, text: string): void => {
         executeDrawCall('systemPrint', () => {
@@ -2064,7 +2064,7 @@ export const BT = {
      * system font.
      *
      * @since 1.0.3
-     * @param text - Text string to measure.
+     * @param text – Text string to measure.
      * @returns Width and height in pixels, or `Vector2i.zero()` before engine initialization.
      */
     systemPrintMeasure: (text: string): Vector2i => {
@@ -2090,10 +2090,10 @@ export const BT = {
      * {@link BT.drawSprite}.
      *
      * @since 0.1.0
-     * @param font - Font asset used for rendering.
-     * @param pos - Text origin in display coordinates.
-     * @param text - String to render.
-     * @param paletteOffset - Shift added to every stored glyph index before palette lookup (default 0).
+     * @param font – Font asset used for rendering.
+     * @param pos – Text origin in display coordinates.
+     * @param text – String to render.
+     * @param paletteOffset – Shift added to every stored glyph index before palette lookup (default 0).
      */
     printFont: (font: BitmapFont, pos: Vector2i, text: string, paletteOffset?: number): void => {
         executeDrawCall('printFont', () => {
@@ -2130,7 +2130,7 @@ export const BT = {
      * object URL and clicks a synthetic anchor element.
      *
      * @since 1.0.3
-     * @param filename - Target download filename.
+     * @param filename – Target download filename.
      *
      * @example
      * await BT.downloadFrame();
@@ -2171,15 +2171,15 @@ export const BT = {
      * **Out-of-range behavior:** No CPU-side validation is performed. `paletteOffset` is passed to
      * the GPU as a `u32`. If `storedIndex + paletteOffset` exceeds the last palette index, WebGPU's
      * robust buffer access returns 0 for every component; because the fragment shader forces alpha
-     * to 1.0, the affected pixels render as opaque black. Negative values are forbidden - a negative
+     * to 1.0, the affected pixels render as opaque black. Negative values are forbidden – a negative
      * JS number written into a `u32` vertex attribute wraps to a large unsigned integer, which also
      * produces out-of-bounds black pixels.
      *
      * @since 0.1.0
-     * @param spriteSheet - Indexed sprite sheet.
-     * @param srcRect - Source rectangle within the sprite sheet, in pixels.
-     * @param destPos - Destination top-left position in display coordinates.
-     * @param paletteOffset - Shift added to every stored pixel index before palette lookup (default 0).
+     * @param spriteSheet – Indexed sprite sheet.
+     * @param srcRect – Source rectangle within the sprite sheet, in pixels.
+     * @param destPos – Destination top-left position in display coordinates.
+     * @param paletteOffset – Shift added to every stored pixel index before palette lookup (default 0).
      *
      * @example
      * BT.drawSprite(sheet, new Rect2i(0, 0, 16, 16), new Vector2i(10, 10));
@@ -2209,7 +2209,7 @@ export const BT = {
      *
      * **Do not call this after a palette-value swap.** If you changed what color a
      * slot holds (e.g. palette animation, theme tinting), the stored indices are
-     * still correct - the fragment shader picks up the new color automatically.
+     * still correct – the fragment shader picks up the new color automatically.
      * Calling `spritesRefresh()` in that case is wasteful at best; at worst, if the
      * original RGBA values are gone from the palette, sheets with missing colors
      * will fail reindexing and be removed from the registry.

--- a/packages/blit386/src/__test__/webaudio-mock.ts
+++ b/packages/blit386/src/__test__/webaudio-mock.ts
@@ -102,7 +102,7 @@ export interface MockAudioContext {
  * Creates a mock `AudioParam` that applies every scheduling call immediately
  * (no real audio clock in tests) while recording call arguments.
  *
- * @param initialValue - Starting parameter value. Defaults to {@link DEFAULT_GAIN_VALUE}.
+ * @param initialValue – Starting parameter value. Defaults to {@link DEFAULT_GAIN_VALUE}.
  * @returns Mock `AudioParam` stub, cast from a plain tracking object.
  */
 export function createMockAudioParam(initialValue: number = DEFAULT_GAIN_VALUE): AudioParam {
@@ -283,9 +283,9 @@ export function createMockAnalyserNode(): AnalyserNode {
  * used both for {@link createMockAudioContext}'s default `decodeAudioData` resolution and its
  * `createBuffer()` implementation.
  *
- * @param numberOfChannels - Channel count. Defaults to `1`.
- * @param length - Per-channel sample count. Defaults to `0`.
- * @param sampleRate - Sample rate in Hz. Defaults to {@link MOCK_SAMPLE_RATE}.
+ * @param numberOfChannels – Channel count. Defaults to `1`.
+ * @param length – Per-channel sample count. Defaults to `0`.
+ * @param sampleRate – Sample rate in Hz. Defaults to {@link MOCK_SAMPLE_RATE}.
  * @returns Stub `AudioBuffer`, cast from a plain tracking object with live channel data.
  */
 export function createMockAudioBuffer(
@@ -418,9 +418,9 @@ export function createMockAudioContext(): AudioContext {
  * progression for tests exercising `atTime` scheduling or fade-timing assertions anchored to a
  * non-zero clock.
  *
- * @param context - Mock context created by {@link createMockAudioContext} (or the instance
+ * @param context – Mock context created by {@link createMockAudioContext} (or the instance
  *   returned by {@link installMockAudioContext}'s `getLastInstance()`).
- * @param currentTime - New `currentTime` value in seconds.
+ * @param currentTime – New `currentTime` value in seconds.
  */
 export function setMockCurrentTime(context: AudioContext, currentTime: number): void {
     (context as unknown as { currentTime: number }).currentTime = currentTime;

--- a/packages/blit386/src/__test__/webgpu-mock.ts
+++ b/packages/blit386/src/__test__/webgpu-mock.ts
@@ -78,9 +78,9 @@ function resolveMockTextureSize(size: GPUTextureDescriptor['size']): { width: nu
 /**
  * Creates a mock GPUTexture.
  *
- * @param width - Texture width in pixels.
- * @param height - Texture height in pixels.
- * @param label - Texture label.
+ * @param width – Texture width in pixels.
+ * @param height – Texture height in pixels.
+ * @param label – Texture label.
  * @returns Mock GPUTexture stub.
  */
 export function createMockGPUTexture(
@@ -237,7 +237,7 @@ export function createMockGPUCanvasContext(): GPUCanvasContext {
 
 /**
  * Creates a mock GPUBuffer matching the real 4096-byte palette uniform layout.
- * Returns a plain object - does not call device.createBuffer.
+ * Returns a plain object – does not call device.createBuffer.
  *
  * @returns Mock GPUBuffer stub.
  */

--- a/packages/blit386/src/assets/AssetLoader.test.ts
+++ b/packages/blit386/src/assets/AssetLoader.test.ts
@@ -444,7 +444,7 @@ describe('AssetLoader', () => {
             instances[0]?.onload?.();
             const first = await firstPromise;
 
-            // The superseded request still resolves its own caller with its own image - only
+            // The superseded request still resolves its own caller with its own image – only
             // the shared cache skips it.
             expect(first).toBe(instances[0]);
             expect(AssetLoader.getImage('race.png')).toBe(second);

--- a/packages/blit386/src/assets/AssetLoader.ts
+++ b/packages/blit386/src/assets/AssetLoader.ts
@@ -26,7 +26,7 @@ const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bm
 /**
  * Returns whether a URL is absolute or uses a special browser scheme.
  *
- * @param url - Path or URL to inspect.
+ * @param url – Path or URL to inspect.
  * @returns True when the URL already has an explicit scheme.
  */
 function isExplicitUrl(url: string): boolean {
@@ -45,7 +45,7 @@ function isExplicitUrl(url: string): boolean {
  * a special browser scheme, or a rooted/relative (`/`, `./`) path. When this is
  * false, the caller suggests an `images/` location.
  *
- * @param url - Path or URL to inspect.
+ * @param url – Path or URL to inspect.
  * @returns True when the URL needs no `images/` prefix hint.
  */
 function hasExplicitLocation(url: string): boolean {
@@ -61,7 +61,7 @@ function hasExplicitLocation(url: string): boolean {
  * Extracts the lowercase file extension (including the dot) from a URL,
  * ignoring any query string or fragment.
  *
- * @param url - Path or URL to inspect.
+ * @param url – Path or URL to inspect.
  * @returns Extension like `.png`, or an empty string when none is present.
  */
 function extractExtension(url: string): string {
@@ -75,7 +75,7 @@ function extractExtension(url: string): string {
 /**
  * Builds the extension-specific hint for a failing image URL.
  *
- * @param extension - Lowercase extension including the dot (or empty string).
+ * @param extension – Lowercase extension including the dot (or empty string).
  * @returns Hint text, or null when the extension warrants no hint.
  */
 function buildExtensionHint(extension: string): string | null {
@@ -93,7 +93,7 @@ function buildExtensionHint(extension: string): string | null {
 /**
  * Appends beginner-friendly path and extension hints for image URLs.
  *
- * @param url - Failing image path.
+ * @param url – Failing image path.
  * @returns Extra hint text (or empty string when no hint applies).
  */
 function buildImageHints(url: string): string {
@@ -106,7 +106,7 @@ function buildImageHints(url: string): string {
 /**
  * Builds the rejection error for a failed browser image load.
  *
- * @param url - Path or URL that failed to load.
+ * @param url – Path or URL that failed to load.
  * @returns Error with path, extension, and location hints.
  */
 function buildImageNotFoundError(url: string): Error {
@@ -120,7 +120,7 @@ function buildImageNotFoundError(url: string): Error {
 /**
  * Removes an in-flight entry so a later request can retry the same URL.
  *
- * @param url - Path or URL whose pending load should be cleared.
+ * @param url – Path or URL whose pending load should be cleared.
  */
 function clearInFlight(url: string): void {
     loadingPromises.delete(url);
@@ -132,7 +132,7 @@ function clearInFlight(url: string): void {
  * Bumped whenever a fresh load starts for a key ({@link startLoading}) or the key is
  * explicitly evicted ({@link AssetLoader.evict}), so a superseded in-flight request's
  * `onload`/`onerror` handler can tell it is no longer the current request for that key and
- * skip mutating the shared caches - otherwise a stale request that finishes after a newer one
+ * skip mutating the shared caches – otherwise a stale request that finishes after a newer one
  * (or after an eviction) could silently overwrite the correct result with old data.
  */
 const loadGenerations = new Map<string, number>();
@@ -140,7 +140,7 @@ const loadGenerations = new Map<string, number>();
 /**
  * Advances and returns the generation for `cacheKey`.
  *
- * @param cacheKey - Cache key whose generation should advance.
+ * @param cacheKey – Cache key whose generation should advance.
  * @returns The new, current generation number for `cacheKey`.
  */
 function bumpGeneration(cacheKey: string): number {
@@ -154,8 +154,8 @@ function bumpGeneration(cacheKey: string): number {
 /**
  * Reports whether `generation` is still the current one for `cacheKey`.
  *
- * @param cacheKey - Cache key to check.
- * @param generation - Generation captured when the request being checked started.
+ * @param cacheKey – Cache key to check.
+ * @param generation – Generation captured when the request being checked started.
  * @returns `true` if no newer load or eviction has superseded `generation`.
  */
 function isCurrentGeneration(cacheKey: string, generation: number): boolean {
@@ -166,12 +166,12 @@ function isCurrentGeneration(cacheKey: string, generation: number): boolean {
  * Starts a browser image load and registers the in-flight promise.
  *
  * The returned promise always settles with this specific request's own outcome, even once
- * superseded - only the shared `loadedImages`/`loadingPromises` caches are skipped for a
+ * superseded – only the shared `loadedImages`/`loadingPromises` caches are skipped for a
  * superseded request, via the {@link loadGenerations} guard, so a stale completion can never
  * clobber a newer load's result.
  *
- * @param fetchUrl - Path or URL to actually request (may carry a hot-reload cache-bust query).
- * @param cacheKey - Key to cache the result and track the in-flight load under. Defaults to
+ * @param fetchUrl – Path or URL to actually request (may carry a hot-reload cache-bust query).
+ * @param cacheKey – Key to cache the result and track the in-flight load under. Defaults to
  *   `fetchUrl` for a normal load; a hot reload passes the original, un-busted URL here so the
  *   result re-caches under the same key callers already hold.
  * @returns Promise that resolves to the loaded image element.
@@ -247,7 +247,7 @@ export class AssetLoader {
      * Reuses an already-cached image immediately and shares a single in-flight
      * promise when multiple callers request the same URL concurrently.
      *
-     * @param url - Path or URL to the image file.
+     * @param url – Path or URL to the image file.
      * @returns Loaded image element for the requested URL.
      * @throws Error if the image cannot be loaded.
      */
@@ -258,7 +258,7 @@ export class AssetLoader {
     /**
      * Loads multiple images concurrently.
      *
-     * @param urls - Array of image paths or URLs.
+     * @param urls – Array of image paths or URLs.
      * @returns Loaded image elements in the same order as `urls`.
      * @throws Error if any requested image fails to load.
      */
@@ -269,7 +269,7 @@ export class AssetLoader {
     /**
      * Checks if an image is already loaded and cached.
      *
-     * @param url - Path or URL to check.
+     * @param url – Path or URL to check.
      * @returns `true` if the image is already cached and ready to use.
      */
     static isLoaded(url: string): boolean {
@@ -279,7 +279,7 @@ export class AssetLoader {
     /**
      * Returns a previously loaded image from the cache without starting a new request.
      *
-     * @param url - Path or URL of the cached image.
+     * @param url – Path or URL of the cached image.
      * @returns The cached image, or null if not loaded.
      */
     static getImage(url: string): HTMLImageElement | null {
@@ -291,10 +291,10 @@ export class AssetLoader {
      * {@link AssetLoader.loadImage} starts fresh.
      *
      * Also bumps the URL's load generation, so an in-flight request that was already under way
-     * before this call can no longer repopulate the cache once it completes - see
+     * before this call can no longer repopulate the cache once it completes – see
      * {@link isCurrentGeneration}.
      *
-     * @param url - Path or URL whose cache entry (and in-flight load, if any) should be evicted.
+     * @param url – Path or URL whose cache entry (and in-flight load, if any) should be evicted.
      * @returns `true` if a cached image was removed; `false` if nothing was cached under `url`.
      * @since 1.4.0
      */
@@ -316,7 +316,7 @@ export class AssetLoader {
      * Internal – routed from `HotRuntime.handleAssetChanged` when the dev asset
      * watcher reports a changed image file.
      *
-     * @param url - Cache key (and fetch URL) of the image to hot-reload.
+     * @param url – Cache key (and fetch URL) of the image to hot-reload.
      * @returns The freshly loaded image element, cached under `url`.
      * @throws Error if the cache-busted image fails to load.
      */

--- a/packages/blit386/src/assets/AudioClip.test.ts
+++ b/packages/blit386/src/assets/AudioClip.test.ts
@@ -43,7 +43,7 @@ import type { SynthParams } from './synth/SynthParams';
  * @param opts.status        - HTTP status code. Defaults to `200`.
  * @param opts.contentLength - `Content-Length` header value; omit to simulate a missing header.
  * @param opts.chunks        - Body chunks streamed via a fake `ReadableStream` reader.
- * @param opts.arrayBufferBytes - Byte length returned by the `arrayBuffer()` fallback path.
+ * @param opts.arrayBufferBytes – Byte length returned by the `arrayBuffer()` fallback path.
  * @returns Response stub accepted by the `fetch` mock.
  */
 function mockAudioFetchResponse({
@@ -449,7 +449,7 @@ describe('AudioClip', () => {
         /**
          * Builds a valid baseline `SynthParams`, overridden per test.
          *
-         * @param overrides - Fields to override on top of the baseline.
+         * @param overrides – Fields to override on top of the baseline.
          * @returns A valid `SynthParams` value merged with `overrides`.
          */
         function buildSynthParams(overrides: Partial<SynthParams> = {}): SynthParams {

--- a/packages/blit386/src/assets/AudioClip.ts
+++ b/packages/blit386/src/assets/AudioClip.ts
@@ -57,7 +57,7 @@ export interface AudioClipLoadOptions {
      * Called with download and decode progress snapshots.
      *
      * When a URL is already cached or shares an in-flight load with another
-     * caller, no further progress events fire for this call - only the
+     * caller, no further progress events fire for this call – only the
      * caller that started the load receives its events.
      */
     onProgress?: AudioClipProgressCallback;
@@ -81,7 +81,7 @@ const inFlightLoads = new Map<string, Promise<AudioClip>>();
  * @since 1.3.0
  */
 export class AudioClip {
-    /** Source URL this clip was decoded from - the winning entry when loaded from a fallback list. */
+    /** Source URL this clip was decoded from – the winning entry when loaded from a fallback list. */
     public readonly url: string;
 
     /** Duration in seconds, read from the decoded buffer at load time. */
@@ -97,8 +97,8 @@ export class AudioClip {
      * Creates an `AudioClip` from an already-decoded buffer.
      * Use {@link AudioClip.load} or {@link AudioClip.loadAll} to construct instances.
      *
-     * @param url - Winning source URL the buffer was decoded from.
-     * @param buffer - Decoded audio buffer.
+     * @param url – Winning source URL the buffer was decoded from.
+     * @param buffer – Decoded audio buffer.
      */
     private constructor(url: string, buffer: AudioBuffer) {
         this.url = url;
@@ -134,13 +134,13 @@ export class AudioClip {
      * A single URL runs the download+decode pipeline directly, sharing the
      * per-URL cache and in-flight dedup described on {@link AudioClip}. A URL
      * array tries each candidate in order and resolves with the first one
-     * that downloads and decodes successfully - useful for offering a
+     * that downloads and decodes successfully – useful for offering a
      * browser-friendly fallback (for example `['music.ogg', 'music.mp3']`)
      * when a container or codec isn't universally supported. If every
      * candidate fails, the error from the last candidate is thrown.
      *
-     * @param url - Single audio URL, or an ordered list of fallback URLs.
-     * @param options - Optional load options (progress reporting).
+     * @param url – Single audio URL, or an ordered list of fallback URLs.
+     * @param options – Optional load options (progress reporting).
      * @returns Loaded clip, cached under its winning source URL.
      * @throws Error if the URL (or every URL in the list) fails to load or decode.
      */
@@ -155,8 +155,8 @@ export class AudioClip {
      * every entry starts loading immediately rather than one at a time. Each
      * entry is resolved the same way as {@link AudioClip.load}.
      *
-     * @param urls - Array of clip requests; each entry is a single URL or a fallback list.
-     * @param options - Optional load options applied to every entry.
+     * @param urls – Array of clip requests; each entry is a single URL or a fallback list.
+     * @param options – Optional load options applied to every entry.
      * @returns Loaded clips in the same order as `urls`.
      * @throws Error if any requested clip fails to load.
      */
@@ -165,18 +165,18 @@ export class AudioClip {
     }
 
     /**
-     * Synthesizes a clip from deterministic procedural parameters - no source file, no
+     * Synthesizes a clip from deterministic procedural parameters – no source file, no
      * `OfflineAudioContext`, and no audio graph involved.
      *
      * Rendering happens entirely on the CPU via the pure {@link renderSynthSamples} function
      * against an `AudioBuffer` allocated from the registered decode context. The returned clip
      * flows through the same {@link buffer} getter and playback path as a loaded clip, but uses
-     * a synthetic, non-cached identifier (`synth:<waveform>`) - it is never added to the
+     * a synthetic, non-cached identifier (`synth:<waveform>`) – it is never added to the
      * URL-keyed resolved cache and never deduplicated, so identical `params` still render a
      * fresh, independent `AudioBuffer` on every call. See {@link SynthParams} for the full
      * parameter set.
      *
-     * @param params - Deterministic synthesis parameters.
+     * @param params – Deterministic synthesis parameters.
      * @returns A new clip wrapping the synthesized buffer.
      * @throws Error if `params` fails validation, or the engine has not registered a decode
      *   context yet (see {@link audioClipNotReadyError}).
@@ -201,7 +201,7 @@ export class AudioClip {
     /**
      * Checks if a clip is already loaded and cached under `url`.
      *
-     * @param url - Winning source URL to check.
+     * @param url – Winning source URL to check.
      * @returns `true` if a clip is already cached and ready to use.
      */
     static isLoaded(url: string): boolean {
@@ -211,7 +211,7 @@ export class AudioClip {
     /**
      * Returns a previously loaded clip from the cache without starting a new request.
      *
-     * @param url - Winning source URL of the cached clip.
+     * @param url – Winning source URL of the cached clip.
      * @returns The cached clip, or `null` if not loaded.
      */
     static getClip(url: string): AudioClip | null {
@@ -223,7 +223,7 @@ export class AudioClip {
      * may repopulate the cache once complete.
      *
      * Primarily intended for tests or explicit asset-lifecycle resets. Does
-     * not call {@link unload} on cached clips - their buffers stay decoded
+     * not call {@link unload} on cached clips – their buffers stay decoded
      * until each clip is unloaded explicitly.
      */
     static clear(): void {
@@ -243,7 +243,7 @@ export class AudioClip {
      * reflect the buffer decoded at initial load time and are not updated by a
      * hot reload.
      *
-     * @param url - Cache key (and fetch URL) of the clip to hot-reload.
+     * @param url – Cache key (and fetch URL) of the clip to hot-reload.
      * @returns `true` if a cached clip was found and reloaded; `false` if no clip is
      *   cached under `url` (never loaded, or already unloaded).
      * @throws Error if the cache-busted fetch or decode fails.
@@ -269,8 +269,8 @@ export class AudioClip {
     /**
      * Loads a single URL with cache reuse and in-flight dedup.
      *
-     * @param url - Audio URL to load.
-     * @param options - Optional load options (progress reporting).
+     * @param url – Audio URL to load.
+     * @param options – Optional load options (progress reporting).
      * @returns Loaded clip, cached under `url`.
      */
     private static async loadSingle(url: string, options?: AudioClipLoadOptions): Promise<AudioClip> {
@@ -307,8 +307,8 @@ export class AudioClip {
      * Tries each URL in `urls` in order, resolving with the first clip that
      * downloads and decodes successfully.
      *
-     * @param urls - Ordered list of candidate URLs.
-     * @param options - Optional load options (progress reporting).
+     * @param urls – Ordered list of candidate URLs.
+     * @param options – Optional load options (progress reporting).
      * @returns Loaded clip for the first candidate that succeeded.
      * @throws Error from the last candidate when every candidate fails, or when `urls` is empty.
      */
@@ -335,10 +335,10 @@ export class AudioClip {
      * the caller's perspective - `decodeAudioData` reports no intermediate
      * progress, so exactly one `'decoding'` snapshot fires before it starts.
      * It runs correctly whether the decode context is suspended (locked,
-     * pre-unlock) or running - only real-time playback needs an unlocked context.
+     * pre-unlock) or running – only real-time playback needs an unlocked context.
      *
-     * @param url - Audio URL to download and decode.
-     * @param onProgress - Optional progress callback.
+     * @param url – Audio URL to download and decode.
+     * @param onProgress – Optional progress callback.
      * @returns Decoded audio buffer.
      * @throws Error if no decode context is registered, the download fails, or decoding fails.
      */
@@ -369,8 +369,8 @@ export class AudioClip {
      * surfaces the same network error as any other rejected fetch. The
      * timeout is always cleared once the request settles, however it settles.
      *
-     * @param url - Audio URL to download.
-     * @param onProgress - Optional progress callback.
+     * @param url – Audio URL to download.
+     * @param onProgress – Optional progress callback.
      * @returns Downloaded bytes, ready for `decodeAudioData`.
      * @throws Error if the fetch rejects or times out, the stream fails, or the response status is not ok.
      */
@@ -409,8 +409,8 @@ export class AudioClip {
      * progress report when the length is missing, non-numeric, or the
      * response has no body reader to stream from.
      *
-     * @param response - Successful fetch response.
-     * @param onProgress - Optional progress callback.
+     * @param response – Successful fetch response.
+     * @param onProgress – Optional progress callback.
      * @returns Downloaded bytes.
      */
     private static async readResponseBody(
@@ -450,8 +450,8 @@ export class AudioClip {
     /**
      * Concatenates streamed body chunks into a single `ArrayBuffer`.
      *
-     * @param chunks - Chunks read from the response body stream, in order.
-     * @param totalBytes - Combined byte length of `chunks`.
+     * @param chunks – Chunks read from the response body stream, in order.
+     * @param totalBytes – Combined byte length of `chunks`.
      * @returns Backing buffer of a `Uint8Array` holding all chunks in order.
      */
     private static concatChunks(chunks: Uint8Array[], totalBytes: number): ArrayBuffer {
@@ -471,7 +471,7 @@ export class AudioClip {
      * and stops and invalidates any voice still playing this buffer via the
      * registered `AudioClip` unload hook (see `audioDecodeContext.ts`).
      *
-     * Safe to call more than once - the second and later calls are a no-op.
+     * Safe to call more than once – the second and later calls are a no-op.
      */
     unload(): void {
         if (this.decodedBuffer === null) {

--- a/packages/blit386/src/assets/BitmapFont.bench.ts
+++ b/packages/blit386/src/assets/BitmapFont.bench.ts
@@ -41,9 +41,9 @@ type BitmapFontCacheView = {
 /**
  * Creates synthetic glyph metadata for benchmark-only font construction.
  *
- * @param advance - Horizontal advance for the glyph.
- * @param x - Glyph x position inside the synthetic atlas.
- * @param y - Glyph y position inside the synthetic atlas.
+ * @param advance – Horizontal advance for the glyph.
+ * @param x – Glyph x position inside the synthetic atlas.
+ * @param y – Glyph y position inside the synthetic atlas.
  * @returns Glyph metadata matching the runtime shape used by `BitmapFont`.
  */
 function createGlyph(advance: number, x: number, y: number): Glyph {
@@ -101,8 +101,8 @@ function createBenchmarkFont(): BitmapFont {
 /**
  * Pre-populates the measurement cache to simulate different occupancy levels.
  *
- * @param font - Font whose cache should be filled.
- * @param count - Number of synthetic entries to insert.
+ * @param font – Font whose cache should be filled.
+ * @param count – Number of synthetic entries to insert.
  */
 function fillMeasureCache(font: BitmapFont, count: number): void {
     const cache = (font as unknown as BitmapFontCacheView).measureCache;
@@ -117,8 +117,8 @@ function fillMeasureCache(font: BitmapFont, count: number): void {
 /**
  * Generates a string of exactly `length` characters by repeating a seed.
  *
- * @param seed - Source substring to repeat.
- * @param length - Final string length.
+ * @param seed – Source substring to repeat.
+ * @param length – Final string length.
  * @returns Repeated string truncated to the requested length.
  */
 function createRepeatedText(seed: string, length: number): string {
@@ -128,8 +128,8 @@ function createRepeatedText(seed: string, length: number): string {
 /**
  * Produces unique ASCII strings used to force `measureText` cache misses.
  *
- * @param length - Length of each generated string.
- * @param count - Number of unique strings to create.
+ * @param length – Length of each generated string.
+ * @param count – Number of unique strings to create.
  * @returns Array of unique strings for cold-path benchmarking.
  */
 function createUniqueTexts(length: number, count: number): string[] {
@@ -147,8 +147,8 @@ function createUniqueTexts(length: number, count: number): string[] {
 /**
  * Registers a benchmark for cache-miss text measurement at a fixed text length.
  *
- * @param name - Benchmark label shown in Vitest output.
- * @param length - Text length to generate for the cold-path workload.
+ * @param name – Benchmark label shown in Vitest output.
+ * @param length – Text length to generate for the cold-path workload.
  */
 function benchColdMeasureText(name: string, length: number): void {
     const font = createBenchmarkFont();
@@ -168,8 +168,8 @@ function benchColdMeasureText(name: string, length: number): void {
 /**
  * Registers a benchmark for repeated cache-hit width measurement of one string.
  *
- * @param name - Benchmark label shown in Vitest output.
- * @param text - Precomputed string that should remain hot in the cache.
+ * @param name – Benchmark label shown in Vitest output.
+ * @param text – Precomputed string that should remain hot in the cache.
  */
 function benchWarmMeasureText(name: string, text: string): void {
     const font = createBenchmarkFont();
@@ -188,8 +188,8 @@ function benchWarmMeasureText(name: string, text: string): void {
 /**
  * Registers a benchmark for cached `measureTextSize` calls over one string.
  *
- * @param name - Benchmark label shown in Vitest output.
- * @param text - Precomputed string to measure.
+ * @param name – Benchmark label shown in Vitest output.
+ * @param text – Precomputed string to measure.
  */
 function benchMeasureTextSize(name: string, text: string): void {
     const font = createBenchmarkFont();

--- a/packages/blit386/src/assets/BitmapFont.test.ts
+++ b/packages/blit386/src/assets/BitmapFont.test.ts
@@ -28,8 +28,8 @@ import { SpriteSheet } from './SpriteSheet';
 
 // registerFontForHotReload() normalizes the source url against `document.baseURI`
 // whenever hot reload is active (see BitmapFont.ts). Real browsers always have
-// `document`; this file's default Node test environment does not, so - like the
-// GPU/AudioContext stubs in src/__test__/setup.ts - install it once, only if
+// `document`; this file's default Node test environment does not, so – like the
+// GPU/AudioContext stubs in src/__test__/setup.ts – install it once, only if
 // missing, so it survives every describe block's `vi.unstubAllGlobals()` call.
 if (typeof globalThis.document === 'undefined') {
     (globalThis as unknown as { document?: { baseURI: string } }).document = { baseURI: 'http://localhost/' };
@@ -49,7 +49,7 @@ type FontData = {
  * Creates a stub Image class for use with `vi.stubGlobal('Image', ...)`.
  *
  * @param opts           - Configuration options.
- * @param opts.fireError - When true, fires `onerror` instead of `onload` on src assignment.
+ * @param opts.fireError – When true, fires `onerror` instead of `onload` on src assignment.
  * @param opts.onSrcSet  - Optional callback invoked with the assigned src value before the load/error event.
  * @param opts.width     - Reported image width (default 64).
  * @param opts.height    - Reported image height (default 16).
@@ -99,7 +99,7 @@ function createStubImage({
 /**
  * Builds a mocked fetch response that returns JSON text like {@link BitmapFont.load} expects.
  *
- * @param data - Font descriptor object to serialize.
+ * @param data – Font descriptor object to serialize.
  * @returns Resolved fetch response stub.
  */
 function mockFontFetchResponse(data: unknown) {

--- a/packages/blit386/src/assets/BitmapFont.ts
+++ b/packages/blit386/src/assets/BitmapFont.ts
@@ -106,7 +106,7 @@ const ASCII_CACHE_SIZE = 128;
  * Returns whether a value is a non-null plain object (not an array).
  * Used to validate `FileData.glyphs` and individual glyph entries before reading their fields.
  *
- * @param value - The value to check.
+ * @param value – The value to check.
  * @returns `true` if the value is a non-null plain object, `false` otherwise.
  */
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
@@ -125,9 +125,9 @@ function createAsciiGlyphTable(): (Glyph | null)[] {
 /**
  * Writes a single-byte glyph into the ASCII fast-path table when the key is in range.
  *
- * @param asciiGlyphs - Pre-sized lookup table for codes `0-127`.
- * @param char - Glyph map key from the `.btfont` file.
- * @param glyph - Runtime glyph metadata to store.
+ * @param asciiGlyphs – Pre-sized lookup table for codes `0-127`.
+ * @param char – Glyph map key from the `.btfont` file.
+ * @param glyph – Runtime glyph metadata to store.
  */
 function populateAsciiGlyph(asciiGlyphs: (Glyph | null)[], char: string, glyph: Glyph): void {
     if (char.length === 1) {
@@ -154,8 +154,8 @@ const hotReloadRegistry = new Map<string, Set<BitmapFont>>();
  * Registers `font` under its normalized source URL for hot-reload routing, when a
  * Vite HMR context is active. Called by {@link BitmapFont.load}.
  *
- * @param url - Source URL the font was loaded from.
- * @param font - Font to register.
+ * @param url – Source URL the font was loaded from.
+ * @param font – Font to register.
  */
 function registerFontForHotReload(url: string, font: BitmapFont): void {
     if (!isHotActive()) {
@@ -175,7 +175,7 @@ function registerFontForHotReload(url: string, font: BitmapFont): void {
  * Internal – used by `HotRuntime.handleAssetChanged` to route a `'font'`
  * asset-changed event to the fonts that need reloading.
  *
- * @param url - Changed asset URL to look up.
+ * @param url – Changed asset URL to look up.
  * @returns Matching fonts, or `undefined` when none are registered.
  */
 export function getHotReloadFonts(url: string): ReadonlySet<BitmapFont> | undefined {
@@ -222,13 +222,13 @@ export class BitmapFont {
      * Creates a BitmapFont instance.
      * Use {@link BitmapFont.load} or {@link BitmapFont.createFromGlyphs} to construct instances.
      *
-     * @param spriteSheet - Texture atlas containing all font glyphs.
-     * @param glyphs - Map of character strings to glyph metadata.
-     * @param asciiGlyphs - Pre-populated ASCII lookup array.
-     * @param name - Font display name.
-     * @param size - Original font size in points.
-     * @param lineHeight - Vertical spacing between lines.
-     * @param baseline - Distance from top to text baseline.
+     * @param spriteSheet – Texture atlas containing all font glyphs.
+     * @param glyphs – Map of character strings to glyph metadata.
+     * @param asciiGlyphs – Pre-populated ASCII lookup array.
+     * @param name – Font display name.
+     * @param size – Original font size in points.
+     * @param lineHeight – Vertical spacing between lines.
+     * @param baseline – Distance from top to text baseline.
      */
     private constructor(
         spriteSheet: SpriteSheet,
@@ -265,12 +265,12 @@ export class BitmapFont {
      * should already contain indexed pixel data via
      * {@link SpriteSheet.fromIndexedPixels}.
      *
-     * @param spriteSheet - Texture atlas containing all font glyphs.
-     * @param glyphs - Map of character strings to glyph metadata.
-     * @param name - Font display name.
-     * @param size - Font size in points.
-     * @param lineHeight - Vertical spacing between lines in pixels.
-     * @param baseline - Distance from top to text baseline in pixels.
+     * @param spriteSheet – Texture atlas containing all font glyphs.
+     * @param glyphs – Map of character strings to glyph metadata.
+     * @param name – Font display name.
+     * @param size – Font size in points.
+     * @param lineHeight – Vertical spacing between lines in pixels.
+     * @param baseline – Distance from top to text baseline in pixels.
      * @returns Fully constructed BitmapFont ready for rendering.
      */
     static createFromGlyphs(
@@ -296,7 +296,7 @@ export class BitmapFont {
      * The font descriptor can reference either an embedded PNG data URI
      * (`data:image/png;base64,...`) or a texture file path relative to the font JSON file.
      *
-     * @param url - Path to the .btfont file.
+     * @param url – Path to the .btfont file.
      * @returns Loaded bitmap font instance.
      * @throws Error if the font descriptor or texture cannot be loaded.
      */
@@ -311,7 +311,7 @@ export class BitmapFont {
 
         BitmapFont.validateGlyphEntriesPreAtlas(glyphEntries);
 
-        // Load texture - embedded PNG data URIs and relative PNG paths are both allowed.
+        // Load texture – embedded PNG data URIs and relative PNG paths are both allowed.
         const image = await BitmapFont.loadTexture(data.texture, url);
         const spriteSheet = new SpriteSheet(image);
         const atlasWidth = spriteSheet.width;
@@ -345,7 +345,7 @@ export class BitmapFont {
     /**
      * Coerces a `.btfont` display `name` field to a non-empty string.
      *
-     * @param value - Raw JSON value for `name`.
+     * @param value – Raw JSON value for `name`.
      * @returns Trimmed name when `value` is a non-empty string; otherwise `'Unknown'`.
      */
     private static resolveDisplayName(value: unknown): string {
@@ -361,8 +361,8 @@ export class BitmapFont {
     /**
      * Coerces a `.btfont` metadata field to a positive finite number.
      *
-     * @param value - Raw JSON value for `size`, `lineHeight`, or `baseline`.
-     * @param fallback - Value used when `value` is missing or invalid.
+     * @param value – Raw JSON value for `size`, `lineHeight`, or `baseline`.
+     * @param fallback – Value used when `value` is missing or invalid.
      * @returns Safe positive metric for {@link BitmapFont} construction.
      */
     private static resolvePositiveMetric(value: unknown, fallback: number): number {
@@ -379,7 +379,7 @@ export class BitmapFont {
     /**
      * Coerces a raw `.btfont` metric field to a number.
      *
-     * @param value - Raw JSON value for `size`, `lineHeight`, or `baseline`.
+     * @param value – Raw JSON value for `size`, `lineHeight`, or `baseline`.
      * @returns Parsed number, or `NaN` when the value cannot be coerced.
      */
     private static parseMetricValue(value: unknown): number {
@@ -397,8 +397,8 @@ export class BitmapFont {
     /**
      * Parses and validates a `.btfont` JSON payload after byte-size checks.
      *
-     * @param url - Path to the `.btfont` file (used in error messages).
-     * @param jsonText - Raw JSON text from the font file.
+     * @param url – Path to the `.btfont` file (used in error messages).
+     * @param jsonText – Raw JSON text from the font file.
      * @returns Parsed font descriptor and glyph map entries.
      */
     private static parseBtfontFile(
@@ -447,7 +447,7 @@ export class BitmapFont {
      * Used by both the JSON parse failure and the structural validation failure paths in
      * {@link parseBtfontFile} to ensure identical messaging.
      *
-     * @param url - Path to the `.btfont` file (used in the error message and hint).
+     * @param url – Path to the `.btfont` file (used in the error message and hint).
      * @returns Error ready to throw.
      */
     private static buildBrokenFileError(url: string): Error {
@@ -460,7 +460,7 @@ export class BitmapFont {
     /**
      * Returns whether parsed `.btfont` JSON has the required top-level fields.
      *
-     * @param data - Parsed font descriptor.
+     * @param data – Parsed font descriptor.
      * @returns Whether the data is valid.
      */
     private static isValidFileData(data: unknown): data is FileData {
@@ -481,7 +481,7 @@ export class BitmapFont {
     /**
      * Returns whether a glyph entry is a plain object suitable for validation.
      *
-     * @param glyphData - Raw glyph entry from the parsed font file.
+     * @param glyphData – Raw glyph entry from the parsed font file.
      * @returns Whether the glyph data is a valid object.
      */
     private static isGlyphEntryObject(glyphData: unknown): glyphData is GlyphData {
@@ -491,7 +491,7 @@ export class BitmapFont {
     /**
      * Validates glyph entries before the font atlas image is decoded.
      *
-     * @param glyphEntries - Glyph map entries from the parsed font file.
+     * @param glyphEntries – Glyph map entries from the parsed font file.
      */
     private static validateGlyphEntriesPreAtlas(glyphEntries: Array<[string, GlyphData]>): void {
         for (const [char, glyphData] of glyphEntries) {
@@ -510,9 +510,9 @@ export class BitmapFont {
     /**
      * Converts validated `.btfont` glyph entries into runtime glyph maps.
      *
-     * @param glyphEntries - Glyph map entries from the parsed font file.
-     * @param atlasWidth - Font texture atlas width in pixels.
-     * @param atlasHeight - Font texture atlas height in pixels.
+     * @param glyphEntries – Glyph map entries from the parsed font file.
+     * @param atlasWidth – Font texture atlas width in pixels.
+     * @param atlasHeight – Font texture atlas height in pixels.
      * @returns Glyph lookup tables for Unicode and ASCII fast paths.
      */
     private static buildGlyphsFromEntries(
@@ -553,8 +553,8 @@ export class BitmapFont {
     /**
      * Loads a texture from either a base64 data URI or a relative path.
      *
-     * @param texture - Data URI (starts with "data:") or relative path.
-     * @param url - URL of the .btfont file (used to resolve relative paths).
+     * @param texture – Data URI (starts with "data:") or relative path.
+     * @param url – URL of the .btfont file (used to resolve relative paths).
      * @returns Loaded texture image for the font atlas.
      */
     private static loadTexture(texture: string, url: string): Promise<HTMLImageElement> {
@@ -571,7 +571,7 @@ export class BitmapFont {
      * Cache-busts a `.btfont` texture reference for a hot reload, unless it is an
      * embedded data URI (always fresh from the just-re-fetched JSON, nothing to bust).
      *
-     * @param texture - Raw `texture` field from the re-fetched `.btfont` JSON.
+     * @param texture – Raw `texture` field from the re-fetched `.btfont` JSON.
      * @returns `texture` unchanged for a data URI; otherwise with a cache-bust query appended.
      */
     private static bustTextureUrl(texture: string): string {
@@ -583,8 +583,8 @@ export class BitmapFont {
     /**
      * Returns a user-friendly load error for a font request.
      *
-     * @param url - Font file path that failed to load.
-     * @param status - HTTP status code from fetch.
+     * @param url – Font file path that failed to load.
+     * @param status – HTTP status code from fetch.
      * @returns Beginner-friendly message with useful hints.
      */
     private static buildLoadErrorMessage(url: string, status: number): string {
@@ -611,8 +611,8 @@ export class BitmapFont {
     /**
      * Suggests a corrected extension when the URL uses a different file type.
      *
-     * @param url - Original URL string.
-     * @param expectedExtension - Extension that should be used.
+     * @param url – Original URL string.
+     * @param expectedExtension – Extension that should be used.
      * @returns Hint text or an empty string.
      */
     private static buildExtensionHint(url: string, expectedExtension: string): string {
@@ -629,7 +629,7 @@ export class BitmapFont {
     /**
      * Formats a glyph character label for user-facing validation errors.
      *
-     * @param char - Glyph map key from the `.btfont` file.
+     * @param char – Glyph map key from the `.btfont` file.
      * @returns Printable label or a Unicode code point for control characters.
      */
     private static formatGlyphCharLabel(char: string): string {
@@ -655,7 +655,7 @@ export class BitmapFont {
     /**
      * Loads an image from a URL or data URI.
      *
-     * @param src - Image source (URL or data URI).
+     * @param src – Image source (URL or data URI).
      * @returns Loaded image element for the font texture.
      */
     private static loadImage(src: string): Promise<HTMLImageElement> {
@@ -699,7 +699,7 @@ export class BitmapFont {
      * Uses the ASCII lookup table for single-byte characters and falls back to
      * the Unicode glyph map for everything else.
      *
-     * @param char - Single character to look up (supports Unicode).
+     * @param char – Single character to look up (supports Unicode).
      * @returns Glyph metadata, or `null` when the font does not contain the character.
      */
     getGlyph(char: string): Glyph | null {
@@ -728,7 +728,7 @@ export class BitmapFont {
      * Uses the ASCII lookup table for codes below `128` and falls back to the
      * Unicode glyph map for all other values.
      *
-     * @param charCode - Character code to look up.
+     * @param charCode – Character code to look up.
      * @returns Glyph metadata, or `null` when no glyph exists for the code.
      */
     getGlyphByCode(charCode: number): Glyph | null {
@@ -759,7 +759,7 @@ export class BitmapFont {
      * Results are cached for repeated measurements and use an optimized ASCII
      * fast path during width calculation.
      *
-     * @param text - String to measure.
+     * @param text – String to measure.
      * @returns Total width in pixels.
      */
     measureText(text: string): number {
@@ -778,7 +778,7 @@ export class BitmapFont {
                     // eslint-disable-next-line security/detect-object-injection -- Index is bounds-checked above
                     glyph = this.asciiGlyphs[code] ?? null;
                 } else {
-                    // Unicode fallback - index is guaranteed valid within loop bounds.
+                    // Unicode fallback – index is guaranteed valid within loop bounds.
                     // eslint-disable-next-line security/detect-object-injection -- Index is within loop bounds
                     const char = text[i];
 
@@ -820,7 +820,7 @@ export class BitmapFont {
      * results from separate calls never alias each other. For hot loops where
      * per-call allocation matters, use `measureTextSizeInto()` instead.
      *
-     * @param text - String to measure.
+     * @param text – String to measure.
      * @returns A new width/height pair for the measured text.
      */
     measureTextSize(text: string): TextSize {
@@ -837,8 +837,8 @@ export class BitmapFont {
      * performance-sensitive call sites: writes into `result` instead of
      * allocating a new object.
      *
-     * @param text - String to measure.
-     * @param result - Object that receives the measured width and height.
+     * @param text – String to measure.
+     * @param result – Object that receives the measured width and height.
      * @returns The same `result` object after being populated.
      */
     measureTextSizeInto(text: string, result: TextSize): TextSize {
@@ -853,7 +853,7 @@ export class BitmapFont {
      *
      * Uses the same ASCII fast path as `getGlyph()` for single-byte characters.
      *
-     * @param char - Character to check.
+     * @param char – Character to check.
      * @returns `true` if the font can render the character.
      */
     hasGlyph(char: string): boolean {
@@ -898,7 +898,7 @@ export class BitmapFont {
      * hot reload – only glyph data and the texture.
      *
      * @param url - `.btfont` URL this font was originally loaded from.
-     * @param palette - Active palette, forwarded to {@link SpriteSheet.hotReplaceImage}.
+     * @param palette – Active palette, forwarded to {@link SpriteSheet.hotReplaceImage}.
      * @throws Error if the re-fetched `.btfont` file is missing or malformed (mirrors {@link BitmapFont.load}).
      */
     async hotReload(url: string, palette: Palette | null): Promise<void> {

--- a/packages/blit386/src/assets/Palette.ts
+++ b/packages/blit386/src/assets/Palette.ts
@@ -46,7 +46,7 @@ type Serialized = {
 /**
  * Checks whether a palette size is one of the supported indexed formats.
  *
- * @param size - Candidate palette size.
+ * @param size – Candidate palette size.
  * @returns `true` when the size is supported.
  */
 function isValidSize(size: number): boolean {
@@ -59,7 +59,7 @@ function isValidSize(size: number): boolean {
 /**
  * Validates a palette size and throws for unsupported values.
  *
- * @param size - Palette size to validate.
+ * @param size – Palette size to validate.
  * @throws Error if the size is not one of the supported indexed formats.
  */
 function validateSize(size: number): void {
@@ -71,9 +71,9 @@ function validateSize(size: number): void {
 /**
  * Reads a preset or serialized hex color string at a known index.
  *
- * @param hexColors - Source hex color collection.
- * @param index - Entry index to read.
- * @param context - Human-readable context for thrown errors.
+ * @param hexColors – Source hex color collection.
+ * @param index – Entry index to read.
+ * @param context – Human-readable context for thrown errors.
  * @returns Hex color string.
  * @throws Error if the requested entry is missing.
  */
@@ -91,8 +91,8 @@ function readHexColor(hexColors: readonly string[], index: number, context: stri
 /**
  * Reads a byte from a typed array and throws if it is unexpectedly missing.
  *
- * @param data - Source byte array.
- * @param index - Byte index to read.
+ * @param data – Source byte array.
+ * @param index – Byte index to read.
  * @returns Byte value.
  * @throws Error if the requested byte is missing.
  */
@@ -113,8 +113,8 @@ function readByte(data: Uint8Array, index: number): number {
  * Index `0` remains the reserved transparent entry. Preset data therefore
  * begins at index `1`.
  *
- * @param hexColors - Preset color data in `RRGGBB` format.
- * @param size - Palette size to construct.
+ * @param hexColors – Preset color data in `RRGGBB` format.
+ * @param size – Palette size to construct.
  * @returns New palette populated with the preset colors.
  */
 function createPreset(hexColors: readonly string[], size: number): Palette {
@@ -161,14 +161,14 @@ export class Palette {
      *
      * Set by {@link set} and {@link copyFrom}. Cleared by {@link clearDirty} after
      * the renderer has uploaded the updated palette uniform buffer. Not set by the
-     * constructor - initial upload is always triggered by {@link IRenderer.setPalette}.
+     * constructor – initial upload is always triggered by {@link IRenderer.setPalette}.
      */
     private _isDirty: boolean = false;
 
     /**
      * Creates a new palette with the requested indexed size.
      *
-     * @param size - Palette size. Must be one of `2, 4, 16, 32, 64, 128, 256`.
+     * @param size – Palette size. Must be one of `2, 4, 16, 32, 64, 128, 256`.
      */
     constructor(size: number = GPU_SIZE) {
         validateSize(size);
@@ -182,7 +182,7 @@ export class Palette {
      *
      * The renderer checks this flag each frame and re-uploads the palette uniform
      * buffer when it is set, then calls {@link clearDirty} to reset it. Palette
-     * animation works automatically - no per-frame {@link BT.paletteSet} required.
+     * animation works automatically – no per-frame {@link BT.paletteSet} required.
      *
      * @returns `true` if any color has been written via {@link set} or {@link copyFrom}
      *   since the last call to {@link clearDirty}.
@@ -194,7 +194,7 @@ export class Palette {
     /**
      * Reconstructs a palette from JSON data produced by {@link Palette.toJSON}.
      *
-     * @param data - Serialized palette payload.
+     * @param data – Serialized palette payload.
      * @returns Reconstructed palette.
      * @throws Error if the payload shape or size is invalid.
      */
@@ -237,8 +237,8 @@ export class Palette {
     /**
      * Creates a palette from packed RGB bytes.
      *
-     * @param data - Byte array containing RGB triplets.
-     * @param size - Optional explicit palette size. When omitted, it is
+     * @param data – Byte array containing RGB triplets.
+     * @param size – Optional explicit palette size. When omitted, it is
      * inferred from `data.length / 3`.
      * @returns Reconstructed palette.
      * @throws Error if the byte length or palette size is invalid.
@@ -350,7 +350,7 @@ export class Palette {
      * - `hud_dim`    - `#646464` dim gray (FPS, secondary info)
      * - `hud_code`   - `#6496c8` slate blue code snippets
      *
-     * @param startSlot - First palette index to write. Must be a positive integer >= 1
+     * @param startSlot – First palette index to write. Must be a positive integer >= 1
      *   and leave room for all six entries within the palette size. Defaults to `1`.
      * @throws Error if `startSlot` is not an integer, is NaN, or is less than 1.
      * @throws Error if the six entries would exceed the palette size.
@@ -375,8 +375,8 @@ export class Palette {
     /**
      * Writes a color into a palette slot.
      *
-     * @param index - Palette index to overwrite.
-     * @param color - Color to store.
+     * @param index – Palette index to overwrite.
+     * @param color – Color to store.
      * @throws Error if the index is invalid or if index `0` is set opaque.
      */
     public set(index: number, color: Color32): void {
@@ -401,7 +401,7 @@ export class Palette {
      * Returns a clone so callers cannot mutate internal state without going
      * through {@link set}, which keeps the dirty flag accurate.
      *
-     * @param index - Palette index to read.
+     * @param index – Palette index to read.
      * @returns Clone of the stored color entry.
      * @throws Error if the index is invalid.
      */
@@ -423,7 +423,7 @@ export class Palette {
      * per-frame cloning is unacceptable. Normal application code should prefer
      * {@link get} and {@link set} to keep the dirty flag accurate automatically.
      *
-     * @param index - Palette index to access.
+     * @param index – Palette index to access.
      * @returns Direct reference to the internal color entry.
      * @throws Error if the index is invalid.
      */
@@ -436,8 +436,8 @@ export class Palette {
     /**
      * Associates a human-readable name with a palette index.
      *
-     * @param name - Name to register.
-     * @param index - Palette index referenced by the name.
+     * @param name – Name to register.
+     * @param index – Palette index referenced by the name.
      * @throws Error if the index is invalid.
      */
     public setNamed(name: string, index: number): void {
@@ -449,7 +449,7 @@ export class Palette {
     /**
      * Looks up a previously named palette index.
      *
-     * @param name - Registered color name.
+     * @param name – Registered color name.
      * @returns Palette index bound to the name.
      * @throws Error if the name is unknown.
      */
@@ -468,7 +468,7 @@ export class Palette {
     /**
      * Resolves a named color directly to its stored {@link Color32}.
      *
-     * @param name - Registered color name.
+     * @param name – Registered color name.
      * @returns Color stored at the named index.
      * @throws Error if the name is unknown.
      */
@@ -502,7 +502,7 @@ export class Palette {
      * transparent in the destination. Named indices that do not fit inside the
      * destination size are ignored.
      *
-     * @param other - Source palette to copy from.
+     * @param other – Source palette to copy from.
      */
     public copyFrom(other: Palette): void {
         const copyCount = Math.min(this.size, other.size);
@@ -588,7 +588,7 @@ export class Palette {
      * palette size are left unchanged in the target buffer. {@link toFloat32Array}
      * zero-initializes a fresh 256-slot buffer before calling this method.
      *
-     * @param target - Pre-allocated float buffer to write normalized RGBA values into.
+     * @param target – Pre-allocated float buffer to write normalized RGBA values into.
      */
     public toFloat32ArrayInto(target: Float32Array): void {
         for (let i = 0; i < this.size; i++) {
@@ -599,7 +599,7 @@ export class Palette {
     /**
      * Searches the palette for an exact color match.
      *
-     * @param color - Color to search for.
+     * @param color – Color to search for.
      * @returns Matching palette index, or `-1` when no exact match exists.
      */
     public findColor(color: Color32): number {
@@ -621,7 +621,7 @@ export class Palette {
      * Aliases that reference an index outside this palette's size are ignored.
      * Clears the current named index map before copying.
      *
-     * @param from - Source palette to copy named indices from.
+     * @param from – Source palette to copy named indices from.
      */
     private copyNamedIndices(from: Palette): void {
         this.namedIndices.clear();
@@ -636,7 +636,7 @@ export class Palette {
     /**
      * Validates that a palette index is within the active palette size.
      *
-     * @param index - Palette index to validate.
+     * @param index – Palette index to validate.
      * @throws Error if the index is outside the active palette size.
      */
     private assertIndexInRange(index: number): void {
@@ -652,7 +652,7 @@ export class Palette {
     /**
      * Returns a palette color after initialization checks.
      *
-     * @param index - Palette index to resolve.
+     * @param index – Palette index to resolve.
      * @returns Stored color instance.
      * @throws Error if the entry is unexpectedly uninitialized.
      */

--- a/packages/blit386/src/assets/PaletteEffect.test.ts
+++ b/packages/blit386/src/assets/PaletteEffect.test.ts
@@ -541,10 +541,10 @@ const BRIGHT_SLOT = 1;
 /** Palette index used for the dark entry in exposure-ordering tests. */
 const DARK_SLOT = 2;
 
-/** Bright test color - near the top of the range, so it has the most headroom to emulate. */
+/** Bright test color – near the top of the range, so it has the most headroom to emulate. */
 const BRIGHT_COLOR = new Color32(240, 240, 240);
 
-/** Dark test color - low enough to sit deep in the sRGB toe. */
+/** Dark test color – low enough to sit deep in the sRGB toe. */
 const DARK_COLOR = new Color32(40, 40, 40);
 
 /**
@@ -576,8 +576,8 @@ function makeBlackPalette(): Palette {
  * Linear light is the space the exposure curve actually works in, so this is the
  * quantity the per-entry timing offset is supposed to reorder.
  *
- * @param current - Current palette entry.
- * @param reference - Fully lit color the entry is measured against.
+ * @param current – Current palette entry.
+ * @param reference – Fully lit color the entry is measured against.
  * @returns Fraction in range 0-1.
  */
 function linearFraction(current: Color32, reference: Color32): number {
@@ -668,7 +668,7 @@ describe('ExposureFadeEffect', () => {
 
         effect.update(palette, 700);
 
-        // Every entry still lands on black together at t = 1 - the shoulder is about
+        // Every entry still lands on black together at t = 1 – the shoulder is about
         // how much light each one is still carrying on the way there.
         expect(palette.getRef(BRIGHT_SLOT).r).toBeGreaterThan(BRIGHT_COLOR.r * 0.8);
         expect(palette.getRef(DARK_SLOT).r).toBeLessThan(DARK_COLOR.r * 0.6);

--- a/packages/blit386/src/assets/PaletteEffect.ts
+++ b/packages/blit386/src/assets/PaletteEffect.ts
@@ -25,8 +25,8 @@ export interface PaletteEffect {
     /**
      * Advances the effect by one frame.
      *
-     * @param palette - Active palette to modify.
-     * @param deltaMs - Wall-clock milliseconds since the last frame.
+     * @param palette – Active palette to modify.
+     * @param deltaMs – Wall-clock milliseconds since the last frame.
      * @returns `true` to keep running, `false` to remove from the manager.
      */
     update(palette: Palette, deltaMs: number): boolean;
@@ -51,7 +51,7 @@ export class PaletteEffectManager {
     /**
      * Creates a new effect manager.
      *
-     * @param timeProvider - Clock function returning milliseconds. Defaults to
+     * @param timeProvider – Clock function returning milliseconds. Defaults to
      *   `performance.now()`. Pass a custom function for deterministic unit tests.
      */
     constructor(timeProvider: () => number = () => performance.now()) {
@@ -70,7 +70,7 @@ export class PaletteEffectManager {
     /**
      * Adds an effect to the active list.
      *
-     * @param effect - Effect instance to run each frame.
+     * @param effect – Effect instance to run each frame.
      */
     add(effect: PaletteEffect): void {
         // Reset the clock when waking from idle so the first update after a gap
@@ -88,7 +88,7 @@ export class PaletteEffectManager {
      * Call this once per frame. Completed effects (returning `false`) are pruned
      * in place without allocating a new array.
      *
-     * @param palette - Active palette to pass to each effect.
+     * @param palette – Active palette to pass to each effect.
      */
     update(palette: Palette): void {
         const now = this.timeProvider();
@@ -141,9 +141,9 @@ export class CycleEffect implements PaletteEffect {
     /**
      * Creates a palette cycling effect.
      *
-     * @param start - First palette index in the cycling range (inclusive).
-     * @param end - Last palette index in the cycling range (inclusive).
-     * @param speed - Steps per second. Positive = forward, negative = backward.
+     * @param start – First palette index in the cycling range (inclusive).
+     * @param end – Last palette index in the cycling range (inclusive).
+     * @param speed – Steps per second. Positive = forward, negative = backward.
      */
     constructor(
         /** First palette index in the cycling range (inclusive). */
@@ -159,8 +159,8 @@ export class CycleEffect implements PaletteEffect {
     /**
      * Advances the effect by one frame.
      *
-     * @param palette - Active palette to modify.
-     * @param deltaMs - Wall-clock milliseconds since the last frame.
+     * @param palette – Active palette to modify.
+     * @param deltaMs – Wall-clock milliseconds since the last frame.
      * @returns `true` to keep running, `false` to remove from the manager.
      */
     update(palette: Palette, deltaMs: number): boolean {
@@ -179,7 +179,7 @@ export class CycleEffect implements PaletteEffect {
     /**
      * Drains the forward accumulator, rotating entries toward lower indices one step at a time.
      *
-     * @param palette - Palette whose entries are rotated.
+     * @param palette – Palette whose entries are rotated.
      */
     private applyForwardSteps(palette: Palette): void {
         while (this.accumulator >= 1) {
@@ -191,7 +191,7 @@ export class CycleEffect implements PaletteEffect {
     /**
      * Drains the backward accumulator, rotating entries toward higher indices one step at a time.
      *
-     * @param palette - Palette whose entries are rotated.
+     * @param palette – Palette whose entries are rotated.
      */
     private applyBackwardSteps(palette: Palette): void {
         while (this.accumulator <= -1) {
@@ -203,7 +203,7 @@ export class CycleEffect implements PaletteEffect {
     /**
      * Shifts entries toward lower indices, wrapping the first entry to the end.
      *
-     * @param palette - Palette whose entries are rotated.
+     * @param palette – Palette whose entries are rotated.
      */
     private rotateForward(palette: Palette): void {
         this.temp.copyFrom(palette.getRef(this.start));
@@ -218,7 +218,7 @@ export class CycleEffect implements PaletteEffect {
     /**
      * Shifts entries toward higher indices, wrapping the last entry to the start.
      *
-     * @param palette - Palette whose entries are rotated.
+     * @param palette – Palette whose entries are rotated.
      */
     private rotateBackward(palette: Palette): void {
         this.temp.copyFrom(palette.getRef(this.end));
@@ -234,9 +234,9 @@ export class CycleEffect implements PaletteEffect {
 /**
  * Snapshots a contiguous palette index range into a new array.
  *
- * @param source - Palette to read from.
- * @param start - First index (inclusive).
- * @param end - Last index (inclusive).
+ * @param source – Palette to read from.
+ * @param start – First index (inclusive).
+ * @param end – Last index (inclusive).
  * @returns Cloned colors for each index in the range.
  */
 function snapshotPaletteRange(source: Palette, start: number, end: number): Color32[] {
@@ -246,9 +246,9 @@ function snapshotPaletteRange(source: Palette, start: number, end: number): Colo
 /**
  * Computes normalized and eased fade progress for the current elapsed time.
  *
- * @param elapsed - Elapsed fade time in milliseconds.
- * @param durationMs - Total fade duration in milliseconds.
- * @param easing - Easing curve to apply.
+ * @param elapsed – Elapsed fade time in milliseconds.
+ * @param durationMs – Total fade duration in milliseconds.
+ * @param easing – Easing curve to apply.
  * @returns Normalized `t`, eased factor, and whether the fade is still running.
  */
 function computeFadeProgress(
@@ -266,12 +266,12 @@ function computeFadeProgress(
 /**
  * Applies one fade step to a single palette entry.
  *
- * @param palette - Active palette to modify.
- * @param index - Palette index to update.
- * @param snap - Snapshot color at fade start.
- * @param tgt - Target color at fade end.
- * @param t - Normalized progress in [0, 1].
- * @param easedT - Eased progress factor.
+ * @param palette – Active palette to modify.
+ * @param index – Palette index to update.
+ * @param snap – Snapshot color at fade start.
+ * @param tgt – Target color at fade end.
+ * @param t – Normalized progress in [0, 1].
+ * @param easedT – Eased progress factor.
  */
 function applyFadeEntry(palette: Palette, index: number, snap: Color32, tgt: Color32, t: number, easedT: number): void {
     if (t >= 1) {
@@ -288,14 +288,14 @@ function applyFadeEntry(palette: Palette, index: number, snap: Color32, tgt: Col
  * Snapshot arrays use zero-based local indices; `offset` maps them to palette
  * indices: `snapshot[i - offset]` corresponds to palette entry `i`.
  *
- * @param palette - Active palette to modify.
- * @param snapshot - Snapshot colors indexed from `0`.
- * @param targets - Target colors indexed from `0`.
- * @param from - First palette index to update (inclusive).
- * @param to - Last palette index to update (inclusive).
- * @param offset - Value subtracted from a palette index to get the snapshot array index.
- * @param t - Normalized progress in [0, 1].
- * @param easedT - Eased progress factor.
+ * @param palette – Active palette to modify.
+ * @param snapshot – Snapshot colors indexed from `0`.
+ * @param targets – Target colors indexed from `0`.
+ * @param from – First palette index to update (inclusive).
+ * @param to – Last palette index to update (inclusive).
+ * @param offset – Value subtracted from a palette index to get the snapshot array index.
+ * @param t – Normalized progress in [0, 1].
+ * @param easedT – Eased progress factor.
  */
 function applyFadeToRange(
     palette: Palette,
@@ -348,10 +348,10 @@ export class FadeEffect implements PaletteEffect {
     /**
      * Creates a full-palette fade effect.
      *
-     * @param source - Snapshot of the starting palette (cloned internally).
-     * @param target - Target palette to fade toward.
-     * @param durationMs - Fade duration in milliseconds.
-     * @param easing - Easing curve to apply. Defaults to `'linear'`.
+     * @param source – Snapshot of the starting palette (cloned internally).
+     * @param target – Target palette to fade toward.
+     * @param durationMs – Fade duration in milliseconds.
+     * @param easing – Easing curve to apply. Defaults to `'linear'`.
      */
     constructor(
         source: Palette,
@@ -368,8 +368,8 @@ export class FadeEffect implements PaletteEffect {
     /**
      * Advances the effect by one frame.
      *
-     * @param palette - Active palette to modify.
-     * @param deltaMs - Wall-clock milliseconds since the last frame.
+     * @param palette – Active palette to modify.
+     * @param deltaMs – Wall-clock milliseconds since the last frame.
      * @returns `true` to keep running, `false` to remove from the manager.
      */
     update(palette: Palette, deltaMs: number): boolean {
@@ -403,12 +403,12 @@ export class FadeRangeEffect implements PaletteEffect {
     /**
      * Creates a range-limited fade effect.
      *
-     * @param start - First palette index to fade (inclusive).
-     * @param end - Last palette index to fade (inclusive).
-     * @param source - Snapshot of the starting palette (cloned internally).
-     * @param target - Target palette to fade toward.
-     * @param durationMs - Fade duration in milliseconds.
-     * @param easing - Easing curve to apply. Defaults to `'linear'`.
+     * @param start – First palette index to fade (inclusive).
+     * @param end – Last palette index to fade (inclusive).
+     * @param source – Snapshot of the starting palette (cloned internally).
+     * @param target – Target palette to fade toward.
+     * @param durationMs – Fade duration in milliseconds.
+     * @param easing – Easing curve to apply. Defaults to `'linear'`.
      */
     constructor(
         private readonly start: number,
@@ -425,8 +425,8 @@ export class FadeRangeEffect implements PaletteEffect {
     /**
      * Advances the effect by one frame.
      *
-     * @param palette - Active palette to modify.
-     * @param deltaMs - Wall-clock milliseconds since the last frame.
+     * @param palette – Active palette to modify.
+     * @param deltaMs – Wall-clock milliseconds since the last frame.
      * @returns `true` to keep running, `false` to remove from the manager.
      */
     update(palette: Palette, deltaMs: number): boolean {
@@ -449,7 +449,7 @@ export interface ExposureFadeOptions {
     /**
      * How far ahead of the schedule a fully lit entry runs, in range 0-1.
      *
-     * `0` is a plain linear-light fade - every entry on the same schedule. Higher
+     * `0` is a plain linear-light fade – every entry on the same schedule. Higher
      * values push bright entries further ahead on the way up and further behind on
      * the way down. Defaults to `0.5`. Values outside the range are clamped;
      * anything at or above the cap is held just below `1` so the schedule stays
@@ -481,7 +481,7 @@ const MAX_HIGHLIGHT_LEAD = 0.95;
 /**
  * Clamps a caller-supplied highlight lead into the usable range.
  *
- * @param value - Raw option value, possibly missing or out of range.
+ * @param value – Raw option value, possibly missing or out of range.
  * @returns Offset in range [0, {@link MAX_HIGHLIGHT_LEAD}].
  */
 function resolveHighlightLead(value: number | undefined): number {
@@ -498,16 +498,16 @@ function resolveHighlightLead(value: number | undefined): number {
  * The offset stands in for exposure headroom, which a palette engine does not
  * have: 255 is the ceiling, so a bright entry cannot sit above diffuse white and
  * clip through the first stops of an iris pull. Shifting its schedule instead
- * produces the same read - bright entries rise first and fall last, dark entries
+ * produces the same read – bright entries rise first and fall last, dark entries
  * come in late and crush early.
  *
  * The entry's own lit brightness drives the offset, and the direction of travel
  * decides which way it points, so a fade-out mirrors a fade-in rather than
  * inverting it.
  *
- * @param snap - Entry color at fade start.
- * @param target - Entry color at fade end.
- * @param highlightLead - Resolved offset scale in range [0, 1).
+ * @param snap – Entry color at fade start.
+ * @param target – Entry color at fade end.
+ * @param highlightLead – Resolved offset scale in range [0, 1).
  * @returns Offset subtracted from the global schedule for this entry.
  */
 function entryLead(snap: Color32, target: Color32, highlightLead: number): number {
@@ -515,7 +515,7 @@ function entryLead(snap: Color32, target: Color32, highlightLead: number): numbe
     const targetLuminance = target.luminance * INV_255;
 
     // Rising entries are timed off where they end up, falling entries off where
-    // they started - either way it is the lit end that gets the headroom.
+    // they started – either way it is the lit end that gets the headroom.
     const isRising = targetLuminance >= sourceLuminance;
     const litLuminance = isRising ? targetLuminance : sourceLuminance;
 
@@ -525,9 +525,9 @@ function entryLead(snap: Color32, target: Color32, highlightLead: number): numbe
 /**
  * Interpolates one channel through linear light and re-encodes the result.
  *
- * @param from - Encoded channel byte at fade start.
- * @param to - Encoded channel byte at fade end.
- * @param tc - Per-entry progress in range [0, 1].
+ * @param from – Encoded channel byte at fade start.
+ * @param to – Encoded channel byte at fade end.
+ * @param tc – Per-entry progress in range [0, 1].
  * @returns Encoded channel byte for the current frame.
  */
 function exposeChannel(from: number, to: number, tc: number): number {
@@ -541,13 +541,13 @@ function exposeChannel(from: number, to: number, tc: number): number {
 /**
  * Applies one exposure-fade step to a single palette entry.
  *
- * @param palette - Active palette to modify.
- * @param index - Palette index to update.
- * @param snap - Snapshot color at fade start.
- * @param tgt - Target color at fade end.
- * @param t - Normalized progress in [0, 1].
- * @param easedT - Eased global progress factor.
- * @param highlightLead - Resolved offset scale in range [0, 1).
+ * @param palette – Active palette to modify.
+ * @param index – Palette index to update.
+ * @param snap – Snapshot color at fade start.
+ * @param tgt – Target color at fade end.
+ * @param t – Normalized progress in [0, 1].
+ * @param easedT – Eased global progress factor.
+ * @param highlightLead – Resolved offset scale in range [0, 1).
  */
 function applyExposureEntry(
     palette: Palette,
@@ -629,10 +629,10 @@ export class ExposureFadeEffect implements PaletteEffect {
     /**
      * Creates a full-palette exposure fade.
      *
-     * @param source - Snapshot of the starting palette (cloned internally).
-     * @param target - Target palette to fade toward.
-     * @param durationMs - Fade duration in milliseconds.
-     * @param options - Highlight lead and easing curve.
+     * @param source – Snapshot of the starting palette (cloned internally).
+     * @param target – Target palette to fade toward.
+     * @param durationMs – Fade duration in milliseconds.
+     * @param options – Highlight lead and easing curve.
      */
     constructor(
         source: Palette,
@@ -651,8 +651,8 @@ export class ExposureFadeEffect implements PaletteEffect {
     /**
      * Advances the effect by one frame.
      *
-     * @param palette - Active palette to modify.
-     * @param deltaMs - Wall-clock milliseconds since the last frame.
+     * @param palette – Active palette to modify.
+     * @param deltaMs – Wall-clock milliseconds since the last frame.
      * @returns `true` to keep running, `false` to remove from the manager.
      */
     update(palette: Palette, deltaMs: number): boolean {
@@ -679,8 +679,8 @@ export class ExposureFadeEffect implements PaletteEffect {
 /**
  * Copies `color` into every palette slot except the transparent sentinel at index 0.
  *
- * @param palette - Active palette to modify.
- * @param color - Flash color applied to all palette slots except index 0 (transparent sentinel).
+ * @param palette – Active palette to modify.
+ * @param color – Flash color applied to all palette slots except index 0 (transparent sentinel).
  */
 function copyColorToNonZeroSlots(palette: Palette, color: Color32): void {
     for (let i = 1; i < palette.size; i++) {
@@ -691,8 +691,8 @@ function copyColorToNonZeroSlots(palette: Palette, color: Color32): void {
 /**
  * Restores palette slots 1..size-1 from a full-range snapshot array.
  *
- * @param palette - Active palette to modify.
- * @param snapshot - Colors captured before the flash (index-aligned).
+ * @param palette – Active palette to modify.
+ * @param snapshot – Colors captured before the flash (index-aligned).
  */
 function restoreNonZeroSlots(palette: Palette, snapshot: Color32[]): void {
     for (let i = 1; i < palette.size; i++) {
@@ -722,8 +722,8 @@ export class FlashEffect implements PaletteEffect {
     /**
      * Creates a palette flash effect.
      *
-     * @param color - Flash color applied to all palette slots except index 0 (transparent sentinel).
-     * @param durationMs - How long the flash lasts in milliseconds.
+     * @param color – Flash color applied to all palette slots except index 0 (transparent sentinel).
+     * @param durationMs – How long the flash lasts in milliseconds.
      */
     constructor(
         private readonly color: Color32,
@@ -733,8 +733,8 @@ export class FlashEffect implements PaletteEffect {
     /**
      * Advances the effect by one frame.
      *
-     * @param palette - Active palette to modify.
-     * @param deltaMs - Wall-clock milliseconds since the last frame.
+     * @param palette – Active palette to modify.
+     * @param deltaMs – Wall-clock milliseconds since the last frame.
      * @returns `true` to keep running, `false` to remove from the manager.
      */
     update(palette: Palette, deltaMs: number): boolean {
@@ -763,9 +763,9 @@ export class FlashEffect implements PaletteEffect {
  * This is an immediate operation, not an animated effect. It modifies the
  * palette directly and marks it dirty for the renderer.
  *
- * @param palette - Palette to modify.
- * @param indexA - First palette index.
- * @param indexB - Second palette index.
+ * @param palette – Palette to modify.
+ * @param indexA – First palette index.
+ * @param indexB – Second palette index.
  */
 export function paletteSwap(palette: Palette, indexA: number, indexB: number): void {
     if (indexA !== indexB) {

--- a/packages/blit386/src/assets/SpriteSheet.bench.ts
+++ b/packages/blit386/src/assets/SpriteSheet.bench.ts
@@ -20,8 +20,8 @@ const SPRITE_RECT = new Rect2i(0, 0, 64, 64);
 /**
  * Builds an indexized sheet filled with cycling non-zero palette indices.
  *
- * @param width - Sheet width in pixels.
- * @param height - Sheet height in pixels.
+ * @param width – Sheet width in pixels.
+ * @param height – Sheet height in pixels.
  * @returns Sprite sheet for benchmark fixtures.
  */
 function makeBenchSheet(width: number, height: number): SpriteSheet {

--- a/packages/blit386/src/assets/SpriteSheet.test.ts
+++ b/packages/blit386/src/assets/SpriteSheet.test.ts
@@ -29,8 +29,8 @@ import { getHotReloadSheets, SpriteSheet } from './SpriteSheet';
 // SpriteSheet.destroy() unconditionally normalizes `sourceUrl` against `document.baseURI`
 // (see unregisterFromHotReload in SpriteSheet.ts) whenever a sheet was loaded via
 // SpriteSheet.load(), regardless of whether hot reload was ever active. Real browsers
-// always have `document`; this file's default Node test environment does not, so - like
-// the GPU/AudioContext stubs in src/__test__/setup.ts - install it once, only if missing,
+// always have `document`; this file's default Node test environment does not, so – like
+// the GPU/AudioContext stubs in src/__test__/setup.ts – install it once, only if missing,
 // so it survives every describe block's `vi.unstubAllGlobals()` call.
 if (typeof globalThis.document === 'undefined') {
     (globalThis as unknown as { document?: { baseURI: string } }).document = { baseURI: 'http://localhost/' };
@@ -218,7 +218,7 @@ describe('SpriteSheet', () => {
         });
 
         it('maps transparent pixels (alpha=0) to palette index 0', () => {
-            // All pixels fully transparent - expect no throws and all indices to be 0.
+            // All pixels fully transparent – expect no throws and all indices to be 0.
             const palette = new Palette(16);
             const sheet = new SpriteSheet({ width: 2, height: 2 } as HTMLImageElement);
 
@@ -246,7 +246,7 @@ describe('SpriteSheet', () => {
         it('throws when an opaque pixel color is not in the palette', () => {
             const w = 1;
             const h = 1;
-            // Solid red pixel - not in an empty palette.
+            // Solid red pixel – not in an empty palette.
             const pixels = new Uint8ClampedArray([200, 100, 50, 255]);
 
             vi.stubGlobal('OffscreenCanvas', makeOffscreenCanvasMock(pixels, w, h));
@@ -280,7 +280,7 @@ describe('SpriteSheet', () => {
             sheet.indexize(palette);
             const first = sheet.getTexture(device);
 
-            // Call indexize again - should destroy the existing texture.
+            // Call indexize again – should destroy the existing texture.
             sheet.indexize(palette);
             const second = sheet.getTexture(device);
 
@@ -560,7 +560,7 @@ describe('SpriteSheet', () => {
         });
 
         it('forces alpha to 255 even when source alpha is partial', async () => {
-            // Source has alpha=128 - should be stored as 255 to match indexize() lookup.
+            // Source has alpha=128 – should be stored as 255 to match indexize() lookup.
             const pixels = new Uint8ClampedArray([200, 100, 50, 128]);
             stubLoad(pixels, 1, 1);
 

--- a/packages/blit386/src/assets/SpriteSheet.ts
+++ b/packages/blit386/src/assets/SpriteSheet.ts
@@ -25,7 +25,7 @@ const TEXTURE_LAYER_COUNT = 1;
  * Lifecycle status of a sprite sheet's backing image data.
  *
  * A sheet only ever reports `'loading'` or `'failed'` while a hot-reload
- * replacement image is in flight - normal construction always resolves an
+ * replacement image is in flight – normal construction always resolves an
  * image beforehand, so a sheet starts (and, once reloaded, settles back to)
  * `'ready'`.
  */
@@ -45,7 +45,7 @@ const hotReloadRegistry = new Map<string, Set<SpriteSheet>>();
  * Internal – used by `HotRuntime.handleAssetChanged` to route an `'image'`
  * asset-changed event to the sheets that need their texture replaced.
  *
- * @param url - Changed asset URL to look up.
+ * @param url – Changed asset URL to look up.
  * @returns Matching sheets, or `undefined` when none are registered.
  */
 export function getHotReloadSheets(url: string): ReadonlySet<SpriteSheet> | undefined {
@@ -55,11 +55,11 @@ export function getHotReloadSheets(url: string): ReadonlySet<SpriteSheet> | unde
 /**
  * Maps retained RGBA bytes to palette indices for one sprite sheet.
  *
- * @param w - Image width in pixels.
- * @param h - Image height in pixels.
- * @param rgba - RGBA byte buffer (`w * h * 4` bytes).
- * @param palette - Active palette used for color lookup.
- * @param imageSrc - Source label for error messages.
+ * @param w – Image width in pixels.
+ * @param h – Image height in pixels.
+ * @param rgba – RGBA byte buffer (`w * h * 4` bytes).
+ * @param palette – Active palette used for color lookup.
+ * @param imageSrc – Source label for error messages.
  * @returns Palette index per pixel (`w * h` bytes).
  */
 function mapRgbaPixelsToIndexed(
@@ -77,7 +77,7 @@ function mapRgbaPixelsToIndexed(
         const a = rgba[base + 3];
 
         if (a === 0) {
-            // Index 0 is the transparent sentinel - the shader discards any pixel with rawIndex == 0.
+            // Index 0 is the transparent sentinel – the shader discards any pixel with rawIndex == 0.
             // eslint-disable-next-line security/detect-object-injection
             indexed[i] = 0;
             continue;
@@ -111,7 +111,7 @@ function mapRgbaPixelsToIndexed(
 /**
  * Collects unique opaque RGB colors from a flat RGBA byte buffer.
  *
- * @param data - RGBA bytes in row-major order.
+ * @param data – RGBA bytes in row-major order.
  * @returns Deduped opaque colors with alpha forced to 255.
  */
 function collectUniqueOpaqueColors(data: Uint8Array): Color32[] {
@@ -147,9 +147,9 @@ function collectUniqueOpaqueColors(data: Uint8Array): Color32[] {
 /**
  * Validates that opaque colors can be written into consecutive palette slots.
  *
- * @param collected - Colors to register.
- * @param palette - Target palette.
- * @param startSlot - First destination slot.
+ * @param collected – Colors to register.
+ * @param palette – Target palette.
+ * @param startSlot – First destination slot.
  * @throws RangeError when `startSlot` is invalid or the colors do not fit.
  */
 function assertOpaqueColorsFitInPalette(collected: Color32[], palette: Palette, startSlot: number): void {
@@ -173,9 +173,9 @@ function assertOpaqueColorsFitInPalette(collected: Color32[], palette: Palette, 
 /**
  * Writes collected colors into consecutive palette slots.
  *
- * @param collected - Colors in write order.
- * @param palette - Target palette.
- * @param startSlot - First destination slot.
+ * @param collected – Colors in write order.
+ * @param palette – Target palette.
+ * @param startSlot – First destination slot.
  */
 function writeCollectedColors(collected: Color32[], palette: Palette, startSlot: number): void {
     collected.forEach((color, index) => {
@@ -186,15 +186,15 @@ function writeCollectedColors(collected: Color32[], palette: Palette, startSlot:
 /**
  * Marks palette indices referenced by non-zero pixels inside a bounded scan rect.
  *
- * @param pixels - Indexed pixel buffer for the full sheet.
- * @param sheetWidth - Sheet width in pixels.
- * @param startX - Inclusive left bound in sheet coordinates.
- * @param startY - Inclusive top bound in sheet coordinates.
- * @param endX - Exclusive right bound in sheet coordinates.
- * @param endY - Exclusive bottom bound in sheet coordinates.
- * @param paletteOffset - Palette offset applied at draw time.
- * @param usedMask - Mutable usage mask indexed by resolved palette slot.
- * @param seenSheetIndices - Per-call scratch mask for deduplicating sheet indices.
+ * @param pixels – Indexed pixel buffer for the full sheet.
+ * @param sheetWidth – Sheet width in pixels.
+ * @param startX – Inclusive left bound in sheet coordinates.
+ * @param startY – Inclusive top bound in sheet coordinates.
+ * @param endX – Exclusive right bound in sheet coordinates.
+ * @param endY – Exclusive bottom bound in sheet coordinates.
+ * @param paletteOffset – Palette offset applied at draw time.
+ * @param usedMask – Mutable usage mask indexed by resolved palette slot.
+ * @param seenSheetIndices – Per-call scratch mask for deduplicating sheet indices.
  */
 function markUniqueIndicesInBounds(
     pixels: Uint8Array,
@@ -294,8 +294,8 @@ export class SpriteSheet {
      * Creates a sprite sheet from a loaded image.
      * Use the static load() method for easier loading from URL.
      *
-     * @param image - Pre-loaded HTMLImageElement, or null for raw indexed data sheets.
-     * @param size - Explicit dimensions (required when image is null).
+     * @param image – Pre-loaded HTMLImageElement, or null for raw indexed data sheets.
+     * @param size – Explicit dimensions (required when image is null).
      */
     constructor(image: HTMLImageElement | null, size?: Vector2i) {
         this.image = image;
@@ -380,7 +380,7 @@ export class SpriteSheet {
      * settings for more predictable GPU uploads. If bitmap creation fails, the
      * instance still works and falls back to uploading the `HTMLImageElement`.
      *
-     * @param url - Path or URL to the image file.
+     * @param url – Path or URL to the image file.
      * @returns Promise resolving to the loaded SpriteSheet.
      */
     static async load(url: string): Promise<SpriteSheet> {
@@ -421,11 +421,11 @@ export class SpriteSheet {
      * colors that were written into the palette. Callers still control when to
      * activate the palette via `BT.paletteSet(palette)`.
      *
-     * @param url - Path or URL to the PNG file.
-     * @param palette - Target palette used for both registration and indexization.
-     * @param startSlot - First palette slot to write discovered colors into.
-     * @param options - Optional color-sort behavior for registration.
-     * @param options.sort - Color ordering for palette registration.
+     * @param url – Path or URL to the PNG file.
+     * @param palette – Target palette used for both registration and indexization.
+     * @param startSlot – First palette slot to write discovered colors into.
+     * @param options – Optional color-sort behavior for registration.
+     * @param options.sort – Color ordering for palette registration.
      * @returns Object with `sheet`, `srcRect`, and registered `colors`.
      */
     static async loadIndexed(
@@ -450,7 +450,7 @@ export class SpriteSheet {
      * Walks a PNG's pixels and registers every unique opaque color into the
      * supplied palette starting at `startSlot`.
      *
-     * Pixels with alpha 0 are skipped - they map to the engine's transparent
+     * Pixels with alpha 0 are skipped – they map to the engine's transparent
      * sentinel slot 0 at draw time. Opaque pixels are deduplicated on RGB and
      * stored with alpha forced to 255, matching the lookup performed by
      * `indexize()` so a subsequent `sheet.indexize(palette)` call resolves
@@ -468,11 +468,11 @@ export class SpriteSheet {
      * (`startSlot < 1` or `startSlot + count > palette.size`), the method
      * throws without touching any slot.
      *
-     * @param url - Path or URL to the PNG file.
-     * @param palette - Target palette to populate.
-     * @param startSlot - First palette slot to write into.
-     * @param options - Optional configuration.
-     * @param options.sort - Color ordering. Defaults to `'luminance'`.
+     * @param url – Path or URL to the PNG file.
+     * @param palette – Target palette to populate.
+     * @param startSlot – First palette slot to write into.
+     * @param options – Optional configuration.
+     * @param options.sort – Color ordering. Defaults to `'luminance'`.
      * @returns Registered colors in palette-write order.
      * @throws Error if the image cannot be loaded.
      * @throws RangeError if the discovered colors do not fit in the palette starting at `startSlot`.
@@ -511,7 +511,7 @@ export class SpriteSheet {
     /**
      * Creates a sprite sheet from pre-computed palette-indexed pixel data.
      *
-     * The resulting sheet is immediately indexized - its `getTexture()` call
+     * The resulting sheet is immediately indexized – its `getTexture()` call
      * will produce an `r8uint` GPU texture without needing `indexize()`. This
      * is used for embedded assets like the built-in system font where the pixel
      * data is already expressed as palette indices.
@@ -519,9 +519,9 @@ export class SpriteSheet {
      * Sheets created this way do not support `indexize()` or `reindexize()`
      * because there is no source RGBA data to re-map.
      *
-     * @param width - Texture width in pixels.
-     * @param height - Texture height in pixels.
-     * @param indexedPixels - Flat array of palette indices, one byte per pixel (row-major).
+     * @param width – Texture width in pixels.
+     * @param height – Texture height in pixels.
+     * @param indexedPixels – Flat array of palette indices, one byte per pixel (row-major).
      * @returns Sprite sheet ready for rendering.
      */
     static fromIndexedPixels(width: number, height: number, indexedPixels: Uint8Array<ArrayBuffer>): SpriteSheet {
@@ -538,9 +538,9 @@ export class SpriteSheet {
      * Decodes an image's pixels via an off-screen canvas and returns a flat
      * RGBA byte buffer. Shared by `indexize` and `loadColorsIntoPalette`.
      *
-     * @param image - Source HTML image element.
-     * @param w - Image width in pixels.
-     * @param h - Image height in pixels.
+     * @param image – Source HTML image element.
+     * @param w – Image width in pixels.
+     * @param h – Image height in pixels.
      * @returns Flat RGBA byte array (`w * h * RGBA_BYTES_PER_PIXEL` bytes).
      */
     private static readRgbaPixels(image: HTMLImageElement, w: number, h: number): Uint8Array<ArrayBuffer> {
@@ -564,7 +564,7 @@ export class SpriteSheet {
      * The original RGBA data is retained so `reindexize()` can re-convert after a
      * palette swap without reloading the image.
      *
-     * @param palette - Active palette used for color-to-index mapping.
+     * @param palette – Active palette used for color-to-index mapping.
      * @throws If any opaque pixel's color is not present in the palette.
      */
     indexize(palette: Palette): void {
@@ -586,14 +586,14 @@ export class SpriteSheet {
     /**
      * Re-converts retained RGBA pixels to palette indices using a new palette.
      *
-     * Use this only when the **slot layout** of the palette has changed - that is,
+     * Use this only when the **slot layout** of the palette has changed – that is,
      * when the same colors now live at different index positions. It works by
      * replaying the original RGBA data through `palette.findColor()` and assigning
      * each opaque pixel the index of its matching color in the new palette.
      *
      * **Do not call this to change what color a slot displays.** If you only want
      * to swap the visible color at a slot (e.g. animate a fire effect), mutate the
-     * palette entry directly - the stored indices remain valid and the fragment
+     * palette entry directly – the stored indices remain valid and the fragment
      * shader picks up the new color automatically on the next frame:
      *
      * ```ts
@@ -620,7 +620,7 @@ export class SpriteSheet {
      * Must be preceded by a call to `indexize()`. The GPU texture is invalidated and
      * re-created on the next `getTexture()` call.
      *
-     * @param palette - New palette used for color-to-index mapping.
+     * @param palette – New palette used for color-to-index mapping.
      * @throws If `indexize()` has not been called yet.
      * @throws If any opaque pixel's color is not found in the new palette.
      */
@@ -683,8 +683,8 @@ export class SpriteSheet {
      * dev-only-path risk, not a production code path. {@link status} is set to
      * `'failed'` and the error is rethrown.
      *
-     * @param image - Newly loaded replacement image.
-     * @param palette - Active palette, used to re-run `indexize` when the sheet was
+     * @param image – Newly loaded replacement image.
+     * @param palette – Active palette, used to re-run `indexize` when the sheet was
      *   already indexized.
      * @throws If the replacement image exceeds engine size limits, or `indexize()` throws.
      */
@@ -771,9 +771,9 @@ export class SpriteSheet {
      * calls. Does not allocate; writes into the supplied usage mask. Each unique
      * sheet index in the rect is resolved once.
      *
-     * @param srcRect - Region to scan in sheet coordinates.
-     * @param paletteOffset - Palette offset applied at draw time.
-     * @param usedMask - Mutable usage mask indexed by resolved palette slot.
+     * @param srcRect – Region to scan in sheet coordinates.
+     * @param paletteOffset – Palette offset applied at draw time.
+     * @param usedMask – Mutable usage mask indexed by resolved palette slot.
      */
     markPaletteIndicesInRect(srcRect: Rect2i, paletteOffset: number, usedMask: Uint8Array): void {
         const pixels = this.indexedPixels;
@@ -831,7 +831,7 @@ export class SpriteSheet {
      * palette index data. Otherwise creates an `rgba8unorm` texture from the
      * original image. The result is cached until `destroy()` is called.
      *
-     * @param device - WebGPU device for texture creation.
+     * @param device – WebGPU device for texture creation.
      * @returns GPU texture ready for rendering.
      */
     getTexture(device: GPUDevice): GPUTexture {
@@ -851,7 +851,7 @@ export class SpriteSheet {
      * Calculates normalized UV coordinates for a sprite region.
      * Converts pixel coordinates to 0.0-1.0 texture coordinate range.
      *
-     * @param rect - Source rectangle in pixel coordinates.
+     * @param rect – Source rectangle in pixel coordinates.
      * @returns Object with u0, v0 (top-left) and u1, v1 (bottom-right) UV coordinates.
      */
     getUVs(rect: Rect2i): { u0: number; v0: number; u1: number; v1: number } {
@@ -890,7 +890,7 @@ export class SpriteSheet {
      * Uses `ImageBitmap` when available, then releases it immediately after the
      * upload to avoid holding duplicate image resources in memory.
      *
-     * @param device - WebGPU device for texture creation.
+     * @param device – WebGPU device for texture creation.
      */
     private createTexture(device: GPUDevice): void {
         if (!this.image) {
@@ -924,7 +924,7 @@ export class SpriteSheet {
      * Called lazily by `getTexture()` after `indexize()` has been invoked.
      * Uses `writeTexture` because `r8uint` does not support `copyExternalImageToTexture`.
      *
-     * @param device - WebGPU device for texture creation.
+     * @param device – WebGPU device for texture creation.
      */
     private createIndexedTexture(device: GPUDevice): void {
         assertDimensions('sprite sheet texture', this.size.x, this.size.y);

--- a/packages/blit386/src/assets/SystemFont.ts
+++ b/packages/blit386/src/assets/SystemFont.ts
@@ -3,7 +3,7 @@
  *
  * Expands the embedded glyph bitmaps from system font data into a
  * palette-indexed texture atlas and wraps the result in a {@link BitmapFont}.
- * The font is fully synchronous to create - no `fetch()`, no image decode.
+ * The font is fully synchronous to create – no `fetch()`, no image decode.
  *
  * The glyph data lives in `src/assets/fonts/systemFontData.ts`. To edit it
  * visually, export the current bitmaps to a PNG, redraw in a pixel editor,
@@ -46,10 +46,10 @@ const ATLAS_HEIGHT = ATLAS_ROWS * SYSTEM_FONT_GLYPH_HEIGHT;
  * Bit 7 of each bitmap byte is the leftmost pixel.
  * A set bit maps to palette index 1 (foreground); a clear bit maps to 0 (transparent).
  *
- * @param bitmapOffset - Offset into the glyph bitmap data.
- * @param baseX - X-coordinate of the glyph's top-left corner in the atlas.
- * @param baseY - Y-coordinate of the glyph's top-left corner in the atlas.
- * @param pixels - Output pixel buffer to write into.
+ * @param bitmapOffset – Offset into the glyph bitmap data.
+ * @param baseX – X-coordinate of the glyph's top-left corner in the atlas.
+ * @param baseY – Y-coordinate of the glyph's top-left corner in the atlas.
+ * @param pixels – Output pixel buffer to write into.
  */
 function writeGlyphPixels(bitmapOffset: number, baseX: number, baseY: number, pixels: Uint8Array<ArrayBuffer>): void {
     const pixelCount = SYSTEM_FONT_GLYPH_HEIGHT * SYSTEM_FONT_GLYPH_WIDTH;

--- a/packages/blit386/src/assets/palettes/presetData.ts
+++ b/packages/blit386/src/assets/palettes/presetData.ts
@@ -12,9 +12,9 @@ const BYTE_MASK = 0xff;
 /**
  * Formats three RGB bytes into a compact `RRGGBB` hex string.
  *
- * @param r - Red channel.
- * @param g - Green channel.
- * @param b - Blue channel.
+ * @param r – Red channel.
+ * @param g – Green channel.
+ * @param b – Blue channel.
  * @returns RGB color string without a leading `#`.
  */
 function rgbToHex(r: number, g: number, b: number): string {

--- a/packages/blit386/src/assets/synth/SynthParams.ts
+++ b/packages/blit386/src/assets/synth/SynthParams.ts
@@ -2,7 +2,7 @@
  * Parameter definitions for {@link AudioClip.synth}'s deterministic synthesis engine.
  *
  * Every field is a plain number, string, or nested object of the same, so a `SynthParams`
- * value round-trips through `JSON.stringify`/`JSON.parse` without loss - useful for storing
+ * value round-trips through `JSON.stringify`/`JSON.parse` without loss – useful for storing
  * synth presets as data (level files, preset libraries) rather than code.
  */
 
@@ -79,7 +79,7 @@ export interface SynthVibrato {
     rate?: number;
 
     /**
-     * Vibrato depth in Hz - the peak frequency deviation applied above and below the carrier.
+     * Vibrato depth in Hz – the peak frequency deviation applied above and below the carrier.
      * Defaults to {@link DEFAULT_VIBRATO_DEPTH}.
      */
     depth?: number;
@@ -132,7 +132,7 @@ export interface SynthParams {
      */
     dutyCycle?: number;
 
-    /** Seed for the deterministic PRNG driving noise generation - identical seeds render identical output. */
+    /** Seed for the deterministic PRNG driving noise generation – identical seeds render identical output. */
     seed: number;
 }
 

--- a/packages/blit386/src/assets/synth/synthEnvelope.test.ts
+++ b/packages/blit386/src/assets/synth/synthEnvelope.test.ts
@@ -63,7 +63,7 @@ describe('envelopeValueAt', () => {
     });
 
     it('should fall from sustain to 0 across the release phase', () => {
-        // releaseStart = duration - release = 0.7
+        // releaseStart = duration – release = 0.7
         expect(envelopeValueAt(0.7, duration, envelope)).toBeCloseTo(0.5, 5);
         expect(envelopeValueAt(0.85, duration, envelope)).toBeCloseTo(0.25, 5);
     });
@@ -86,7 +86,7 @@ describe('envelopeValueAt', () => {
 
     it('should reach exactly 0 at t=duration even when release alone is longer than duration', () => {
         // release (2s) is longer than duration (1s) and the clip has no attack/decay, so
-        // releaseStart clamps to 0 and startGain is the (non-zero) sustain level - the release
+        // releaseStart clamps to 0 and startGain is the (non-zero) sustain level – the release
         // ramp must still finish exactly at duration rather than only covering `release` seconds.
         const longRelease = { attack: 0, decay: 0, sustain: 0.8, release: 2 };
 
@@ -98,8 +98,8 @@ describe('envelopeValueAt', () => {
         const shortEnvelope = { attack: 0.5, decay: 0.5, sustain: 0.5, release: 0.5 };
         const shortDuration = 0.2;
 
-        // releaseStart = max(0.2 - 0.5, 0) = 0, so the entire clip is release, starting from
-        // whatever gain the attack phase had reached at t=0 (which is 0) - exact, both endpoints.
+        // releaseStart = max(0.2 – 0.5, 0) = 0, so the entire clip is release, starting from
+        // whatever gain the attack phase had reached at t=0 (which is 0) – exact, both endpoints.
         expect(envelopeValueAt(0, shortDuration, shortEnvelope)).toBe(0);
         expect(envelopeValueAt(shortDuration, shortDuration, shortEnvelope)).toBe(0);
     });

--- a/packages/blit386/src/assets/synth/synthEnvelope.ts
+++ b/packages/blit386/src/assets/synth/synthEnvelope.ts
@@ -24,7 +24,7 @@ export interface ResolvedEnvelope {
 /**
  * Fills in every omitted {@link SynthEnvelope} field with its default.
  *
- * @param envelope - Envelope descriptor, or `undefined` for an envelope built entirely from
+ * @param envelope – Envelope descriptor, or `undefined` for an envelope built entirely from
  *   defaults.
  * @returns Envelope with every field resolved to a concrete number.
  */
@@ -40,8 +40,8 @@ export function resolveEnvelope(envelope: SynthEnvelope | undefined): ResolvedEn
 /**
  * Computes the ADSR gain multiplier for the attack and decay phases only, ignoring release.
  *
- * @param t - Time in seconds since the start of the clip.
- * @param envelope - Resolved envelope.
+ * @param t – Time in seconds since the start of the clip.
+ * @param envelope – Resolved envelope.
  * @returns Gain in [0, 1] following the attack ramp, then the decay ramp, then holding at
  *   `sustain`.
  */
@@ -71,9 +71,9 @@ function attackDecayGain(t: number, envelope: ResolvedEnvelope): number {
  * attack/decay curve had reached at that point, rather than from `sustain` - this keeps very
  * short percussive clips free of a discontinuous jump.
  *
- * @param t - Time in seconds since the start of the clip.
- * @param duration - Total clip duration in seconds.
- * @param envelope - Resolved envelope.
+ * @param t – Time in seconds since the start of the clip.
+ * @param duration – Total clip duration in seconds.
+ * @param envelope – Resolved envelope.
  * @returns Gain multiplier in [0, 1].
  */
 export function envelopeValueAt(t: number, duration: number, envelope: ResolvedEnvelope): number {
@@ -90,7 +90,7 @@ export function envelopeValueAt(t: number, duration: number, envelope: ResolvedE
 
     // Ramp across whatever span is actually available before `duration` (`release` itself when
     // `release <= duration`, but only `duration` when a longer release got clamped to
-    // `releaseStart = 0`) - otherwise the ramp would still be mid-fade at the last sample.
+    // `releaseStart = 0`) – otherwise the ramp would still be mid-fade at the last sample.
     const releaseSpan = duration - releaseStart;
     const startGain = attackDecayGain(releaseStart, envelope);
     const releaseT = releaseSpan > 0 ? Math.min((t - releaseStart) / releaseSpan, 1) : 1;

--- a/packages/blit386/src/assets/synth/synthPitch.ts
+++ b/packages/blit386/src/assets/synth/synthPitch.ts
@@ -1,5 +1,5 @@
 /**
- * Per-sample pitch modulation - linear frequency sweep and sine vibrato - for the
+ * Per-sample pitch modulation – linear frequency sweep and sine vibrato – for the
  * deterministic synthesis engine.
  */
 
@@ -10,10 +10,10 @@ import { DEFAULT_VIBRATO_DEPTH, DEFAULT_VIBRATO_RATE } from './SynthParams';
  * Linearly interpolates from `baseFrequency` to `pitchSweep.toFrequency` across `duration`
  * seconds.
  *
- * @param t - Time in seconds since the start of the clip.
- * @param duration - Total clip duration in seconds.
- * @param baseFrequency - Frequency at `t = 0`.
- * @param pitchSweep - Sweep target, or `undefined` for no sweep.
+ * @param t – Time in seconds since the start of the clip.
+ * @param duration – Total clip duration in seconds.
+ * @param baseFrequency – Frequency at `t = 0`.
+ * @param pitchSweep – Sweep target, or `undefined` for no sweep.
  * @returns Swept frequency in Hz at time `t`. Returns `baseFrequency` unchanged when
  *   `pitchSweep` is `undefined` or `duration` is 0.
  */
@@ -35,8 +35,8 @@ export function sweepFrequencyAt(
 /**
  * Computes the sine-wave vibrato frequency offset at time `t`.
  *
- * @param t - Time in seconds since the start of the clip.
- * @param vibrato - Vibrato descriptor, or `undefined` for no vibrato.
+ * @param t – Time in seconds since the start of the clip.
+ * @param vibrato – Vibrato descriptor, or `undefined` for no vibrato.
  * @returns Frequency deviation in Hz to add to the carrier frequency. Returns `0` when
  *   `vibrato` is `undefined`.
  */
@@ -55,11 +55,11 @@ export function vibratoOffsetAt(t: number, vibrato: SynthVibrato | undefined): n
  * Computes the instantaneous carrier frequency at time `t`, combining the base frequency,
  * linear pitch sweep, and sine vibrato.
  *
- * @param t - Time in seconds since the start of the clip.
- * @param duration - Total clip duration in seconds.
- * @param baseFrequency - Frequency at `t = 0` with no sweep or vibrato applied.
- * @param pitchSweep - Optional linear sweep target.
- * @param vibrato - Optional vibrato descriptor.
+ * @param t – Time in seconds since the start of the clip.
+ * @param duration – Total clip duration in seconds.
+ * @param baseFrequency – Frequency at `t = 0` with no sweep or vibrato applied.
+ * @param pitchSweep – Optional linear sweep target.
+ * @param vibrato – Optional vibrato descriptor.
  * @returns Instantaneous frequency in Hz, floored at 0 to avoid a negative frequency reversing
  *   the oscillator's direction.
  */

--- a/packages/blit386/src/assets/synth/synthPresets.ts
+++ b/packages/blit386/src/assets/synth/synthPresets.ts
@@ -10,7 +10,7 @@
  * {@link DEFAULT_PRESET_SEED} - still fully deterministic, just a fixed baseline variant.
  *
  * This is a single module rather than one file per preset (unlike
- * `render/effects/presets/`) - each factory is a few lines of parameter tuning, not a
+ * `render/effects/presets/`) – each factory is a few lines of parameter tuning, not a
  * multi-effect pipeline, so splitting further would not add clarity.
  */
 
@@ -32,8 +32,8 @@ const MIX_JITTER = 0.1;
 /**
  * Computes a deterministic multiplicative jitter factor in `[1 - amount, 1 + amount]`.
  *
- * @param rng - Seeded PRNG driving this preset's variation.
- * @param amount - Maximum fractional deviation from `1`.
+ * @param rng – Seeded PRNG driving this preset's variation.
+ * @param amount – Maximum fractional deviation from `1`.
  * @returns Multiplier to apply to a base value.
  */
 function jitterMultiplier(rng: Rng, amount: number): number {
@@ -44,7 +44,7 @@ function jitterMultiplier(rng: Rng, amount: number): number {
  * Clamps a value into `[0, 1]`, used after jittering a `noiseMix`/`dutyCycle` field so a preset
  * can never render an out-of-range value that {@link validateSynthParams} would reject.
  *
- * @param value - Value to clamp.
+ * @param value – Value to clamp.
  * @returns `value` clamped to `[0, 1]`.
  */
 function clampUnit(value: number): number {
@@ -59,7 +59,7 @@ function clampUnit(value: number): number {
  * doesn't sound identical every time. Omit `seed` (or pass {@link DEFAULT_PRESET_SEED}) for a
  * fixed baseline variant.
  *
- * @param seed - Seed for deterministic jitter. Defaults to {@link DEFAULT_PRESET_SEED}.
+ * @param seed – Seed for deterministic jitter. Defaults to {@link DEFAULT_PRESET_SEED}.
  * @returns A fresh `SynthParams` for a jump sound effect.
  */
 export function jump(seed: number = DEFAULT_PRESET_SEED): SynthParams {
@@ -83,7 +83,7 @@ export function jump(seed: number = DEFAULT_PRESET_SEED): SynthParams {
  * `seed` jitters the base frequency (+/-8%) and duration (+/-12%). Omit `seed` for a fixed
  * baseline variant.
  *
- * @param seed - Seed for deterministic jitter. Defaults to {@link DEFAULT_PRESET_SEED}.
+ * @param seed – Seed for deterministic jitter. Defaults to {@link DEFAULT_PRESET_SEED}.
  * @returns A fresh `SynthParams` for a pickup sound effect.
  */
 export function pickup(seed: number = DEFAULT_PRESET_SEED): SynthParams {
@@ -105,10 +105,10 @@ export function pickup(seed: number = DEFAULT_PRESET_SEED): SynthParams {
  * a boom that lingers.
  *
  * `seed` jitters the base frequency (+/-8%), duration (+/-12%), and `noiseMix` (+/-10%,
- * clamped to `[0, 1]`) - the mix jitter alone gives every explosion a distinct noisy texture.
+ * clamped to `[0, 1]`) – the mix jitter alone gives every explosion a distinct noisy texture.
  * Omit `seed` for a fixed baseline variant.
  *
- * @param seed - Seed for deterministic jitter. Defaults to {@link DEFAULT_PRESET_SEED}.
+ * @param seed – Seed for deterministic jitter. Defaults to {@link DEFAULT_PRESET_SEED}.
  * @returns A fresh `SynthParams` for an explosion sound effect.
  */
 export function explosion(seed: number = DEFAULT_PRESET_SEED): SynthParams {
@@ -130,7 +130,7 @@ export function explosion(seed: number = DEFAULT_PRESET_SEED): SynthParams {
  * `seed` jitters the base frequency (+/-8%) and duration (+/-12%). Omit `seed` for a fixed
  * baseline variant.
  *
- * @param seed - Seed for deterministic jitter. Defaults to {@link DEFAULT_PRESET_SEED}.
+ * @param seed – Seed for deterministic jitter. Defaults to {@link DEFAULT_PRESET_SEED}.
  * @returns A fresh `SynthParams` for a laser sound effect.
  */
 export function laser(seed: number = DEFAULT_PRESET_SEED): SynthParams {
@@ -153,7 +153,7 @@ export function laser(seed: number = DEFAULT_PRESET_SEED): SynthParams {
  * `seed` jitters the base frequency (+/-8%) and `noiseMix` (+/-10%, clamped to `[0, 1]`). Omit
  * `seed` for a fixed baseline variant.
  *
- * @param seed - Seed for deterministic jitter. Defaults to {@link DEFAULT_PRESET_SEED}.
+ * @param seed – Seed for deterministic jitter. Defaults to {@link DEFAULT_PRESET_SEED}.
  * @returns A fresh `SynthParams` for a hit sound effect.
  */
 export function hit(seed: number = DEFAULT_PRESET_SEED): SynthParams {
@@ -172,11 +172,11 @@ export function hit(seed: number = DEFAULT_PRESET_SEED): SynthParams {
 /**
  * UI blip / menu select: a very short, clean sine tone.
  *
- * `seed` jitters only the base frequency, and only slightly (+/-3%) - UI feedback should stay
+ * `seed` jitters only the base frequency, and only slightly (+/-3%) – UI feedback should stay
  * recognizably consistent rather than vary as much as a gameplay sound effect. Omit `seed` for
  * a fixed baseline variant.
  *
- * @param seed - Seed for deterministic jitter. Defaults to {@link DEFAULT_PRESET_SEED}.
+ * @param seed – Seed for deterministic jitter. Defaults to {@link DEFAULT_PRESET_SEED}.
  * @returns A fresh `SynthParams` for a UI blip sound effect.
  */
 export function blip(seed: number = DEFAULT_PRESET_SEED): SynthParams {

--- a/packages/blit386/src/assets/synth/synthRender.test.ts
+++ b/packages/blit386/src/assets/synth/synthRender.test.ts
@@ -10,7 +10,7 @@ import { renderSynthSamples } from './synthRender';
 /**
  * Builds a valid baseline `SynthParams`, overridden per test.
  *
- * @param overrides - Fields to override on top of the baseline.
+ * @param overrides – Fields to override on top of the baseline.
  * @returns A valid `SynthParams` value merged with `overrides`.
  */
 function buildParams(overrides: Partial<SynthParams> = {}): SynthParams {

--- a/packages/blit386/src/assets/synth/synthRender.ts
+++ b/packages/blit386/src/assets/synth/synthRender.ts
@@ -29,9 +29,9 @@ const CLIP_MAX = 1;
  * continuous instead of producing phase discontinuities. Output is clamped to `[-1, 1]`
  * regardless of envelope, volume, or noise mix.
  *
- * @param params - Synthesis parameters. Assumed already validated by
+ * @param params – Synthesis parameters. Assumed already validated by
  *   {@link validateSynthParams}.
- * @param sampleRate - Output sample rate in Hz.
+ * @param sampleRate – Output sample rate in Hz.
  * @returns Rendered mono samples, `Math.round(params.duration * sampleRate)` long.
  */
 export function renderSynthSamples(params: SynthParams, sampleRate: number): Float32Array<ArrayBuffer> {
@@ -70,11 +70,11 @@ export function renderSynthSamples(params: SynthParams, sampleRate: number): Flo
 /**
  * Computes one waveform sample, blending in white noise when `noiseMix` is positive.
  *
- * @param waveform - Oscillator shape for this clip.
- * @param phase - Carrier phase in [0, 1) at this sample.
- * @param dutyCycle - Resolved duty cycle, used only by `'square'`.
- * @param noiseMix - Resolved noise mix in [0, 1]; ignored when `waveform` is already `'noise'`.
- * @param rng - Seeded PRNG shared across the whole render, advanced by this call whenever noise
+ * @param waveform – Oscillator shape for this clip.
+ * @param phase – Carrier phase in [0, 1) at this sample.
+ * @param dutyCycle – Resolved duty cycle, used only by `'square'`.
+ * @param noiseMix – Resolved noise mix in [0, 1]; ignored when `waveform` is already `'noise'`.
+ * @param rng – Seeded PRNG shared across the whole render, advanced by this call whenever noise
  *   is drawn.
  * @returns Sample in [-1, 1] before envelope/volume are applied.
  */
@@ -97,9 +97,9 @@ function renderTone(
 /**
  * Clamps `value` to `[min, max]`.
  *
- * @param value - Value to clamp.
- * @param min - Lower bound.
- * @param max - Upper bound.
+ * @param value – Value to clamp.
+ * @param min – Lower bound.
+ * @param max – Upper bound.
  * @returns Clamped value.
  */
 function clamp(value: number, min: number, max: number): number {

--- a/packages/blit386/src/assets/synth/synthValidation.test.ts
+++ b/packages/blit386/src/assets/synth/synthValidation.test.ts
@@ -11,7 +11,7 @@ import { validateSynthParams } from './synthValidation';
 /**
  * Builds a valid baseline `SynthParams`, overridden per test.
  *
- * @param overrides - Fields to override on top of the baseline.
+ * @param overrides – Fields to override on top of the baseline.
  * @returns A valid `SynthParams` value merged with `overrides`.
  */
 function buildParams(overrides: Partial<SynthParams> = {}): SynthParams {

--- a/packages/blit386/src/assets/synth/synthValidation.ts
+++ b/packages/blit386/src/assets/synth/synthValidation.ts
@@ -22,8 +22,8 @@ const VALID_WAVEFORMS = new Set<string>(SYNTH_WAVEFORMS);
 /**
  * Validates `params` and the target `sampleRate` before {@link renderSynthSamples} runs.
  *
- * @param params - Synthesis parameters supplied to {@link AudioClip.synth}.
- * @param sampleRate - Target sample rate, read from the live decode context.
+ * @param params – Synthesis parameters supplied to {@link AudioClip.synth}.
+ * @param sampleRate – Target sample rate, read from the live decode context.
  * @throws Error describing the first invalid field found.
  */
 export function validateSynthParams(params: SynthParams, sampleRate: number): void {
@@ -69,7 +69,7 @@ export function validateSynthParams(params: SynthParams, sampleRate: number): vo
 /**
  * Validates the optional envelope timing and sustain fields.
  *
- * @param envelope - Envelope descriptor to validate, or `undefined` to skip.
+ * @param envelope – Envelope descriptor to validate, or `undefined` to skip.
  * @throws Error describing the first invalid field found.
  */
 function validateEnvelope(envelope: SynthEnvelope | undefined): void {
@@ -97,7 +97,7 @@ function validateEnvelope(envelope: SynthEnvelope | undefined): void {
 /**
  * Validates the optional vibrato rate and depth fields.
  *
- * @param vibrato - Vibrato descriptor to validate.
+ * @param vibrato – Vibrato descriptor to validate.
  * @throws Error describing the first invalid field found.
  */
 function validateVibrato(vibrato: SynthVibrato): void {

--- a/packages/blit386/src/assets/synth/synthWaveforms.ts
+++ b/packages/blit386/src/assets/synth/synthWaveforms.ts
@@ -8,10 +8,10 @@ import type { SynthWaveform } from './SynthParams';
 /**
  * Computes an oscillator sample for a tonal waveform at a normalized phase.
  *
- * @param waveform - Oscillator shape. `'noise'` is generated separately by {@link noiseSample}
+ * @param waveform – Oscillator shape. `'noise'` is generated separately by {@link noiseSample}
  *   and must never reach this function.
- * @param phase - Phase in [0, 1), already wrapped by the caller.
- * @param dutyCycle - Fraction of the cycle spent high. Only affects `'square'`.
+ * @param phase – Phase in [0, 1), already wrapped by the caller.
+ * @param dutyCycle – Fraction of the cycle spent high. Only affects `'square'`.
  * @returns Sample in [-1, 1].
  * @throws If `waveform` is not one of the supported tonal shapes (defensive guard; `'noise'`
  *   and unknown values must never reach this function).
@@ -34,7 +34,7 @@ export function oscillatorSample(waveform: Exclude<SynthWaveform, 'noise'>, phas
 /**
  * Draws a single white-noise sample from a seeded PRNG.
  *
- * @param rng - Deterministic PRNG to draw from; advances its state by one call.
+ * @param rng – Deterministic PRNG to draw from; advances its state by one call.
  * @returns Sample in [-1, 1).
  */
 export function noiseSample(rng: Rng): number {

--- a/packages/blit386/src/audio/AudioManager.test.ts
+++ b/packages/blit386/src/audio/AudioManager.test.ts
@@ -730,7 +730,7 @@ describe('AudioManager', () => {
             expect(audio.getSfxBus()).toBeNull();
 
             // Re-attaching and asking the (new, empty) pool about the old ref must not throw and
-            // must report it as not playing - the old pool instance was discarded on detach.
+            // must report it as not playing – the old pool instance was discarded on detach.
             audio.attach(canvas);
             expect(() => audio.playSound(createMockAudioBuffer())).not.toThrow();
             expect(ref).not.toEqual(INVALID_SOUND_REF);
@@ -747,7 +747,7 @@ describe('AudioManager', () => {
             expect(audio.isMusicPlaying()).toBe(false);
             expect(audio.hasRememberedMusicRequest()).toBe(true);
 
-            // No voice was actually started - the request is only remembered, never dropped
+            // No voice was actually started – the request is only remembered, never dropped
             // silently like a pre-unlock playSound() call, but also not started early.
             const context = getMockContext();
 
@@ -767,7 +767,7 @@ describe('AudioManager', () => {
 
             const context = getMockContext();
 
-            // Still locked - neither call started a voice yet, only the second overwrote the
+            // Still locked – neither call started a voice yet, only the second overwrote the
             // first as the remembered pending request.
             expect((context as unknown as { createBufferSourceCalls: unknown[] }).createBufferSourceCalls).toHaveLength(
                 0,
@@ -839,7 +839,7 @@ describe('AudioManager', () => {
 
             const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-            // Invalid loopStart/loopEnd pair - MusicPlayer.play() validates and throws
+            // Invalid loopStart/loopEnd pair – MusicPlayer.play() validates and throws
             // synchronously, which must not be mistaken for a context.resume() failure.
             audio.musicPlay(createMockAudioBuffer(), { loopStart: 5, loopEnd: 1 });
 
@@ -866,7 +866,7 @@ describe('AudioManager', () => {
         it('does not replay a stale remembered request on a later unlock attempt', async () => {
             audio.attach(canvas);
 
-            // Queue a request while locked, then unlock - this replays it exactly once.
+            // Queue a request while locked, then unlock – this replays it exactly once.
             audio.musicPlay(createMockAudioBuffer());
 
             canvas.dispatchEvent(new Event('pointerdown', { bubbles: true }));
@@ -881,7 +881,7 @@ describe('AudioManager', () => {
                 1,
             );
 
-            // A later gesture must not find a stale remembered request to replay - the source
+            // A later gesture must not find a stale remembered request to replay – the source
             // count stays at 1, not 2.
             canvas.dispatchEvent(new Event('pointerdown', { bubbles: true }));
 

--- a/packages/blit386/src/audio/AudioManager.ts
+++ b/packages/blit386/src/audio/AudioManager.ts
@@ -129,7 +129,7 @@ export class AudioManager {
      * `BTAPI.init()`. Registers the new context with `audioDecodeContext` on
      * success, so `AudioClip.load()` can later decode against the live context.
      *
-     * @param target - Canvas that receives the one-shot unlock gesture listeners.
+     * @param target – Canvas that receives the one-shot unlock gesture listeners.
      */
     public attach(target: HTMLCanvasElement): void {
         this.detach();
@@ -249,7 +249,7 @@ export class AudioManager {
      *
      * Unaffected by {@link muteSet} - muting never overwrites the configured level.
      *
-     * @param bus - Audio bus to query.
+     * @param bus – Audio bus to query.
      * @returns Volume in `[0, 1]`.
      */
     public volumeGet(bus: AudioBus): number {
@@ -262,10 +262,10 @@ export class AudioManager {
      * unless the bus is currently muted (in which case only the logical value
      * updates; the audible gain stays at 0 until {@link muteSet} unmutes it).
      *
-     * @param bus - Audio bus to update.
-     * @param volume - Target volume, clamped to `[0, 1]`.
-     * @param fadeMs - Optional fade duration in milliseconds; omit for an immediate change.
-     * @param easing - Easing curve for the fade. Defaults to `'linear'`; ignored when `fadeMs` is omitted.
+     * @param bus – Audio bus to update.
+     * @param volume – Target volume, clamped to `[0, 1]`.
+     * @param fadeMs – Optional fade duration in milliseconds; omit for an immediate change.
+     * @param easing – Easing curve for the fade. Defaults to `'linear'`; ignored when `fadeMs` is omitted.
      */
     public volumeSet(bus: AudioBus, volume: number, fadeMs?: number, easing: EasingFunction = 'linear'): void {
         const clamped = clampVolume(volume);
@@ -291,7 +291,7 @@ export class AudioManager {
     /**
      * Reports whether `bus` is currently muted.
      *
-     * @param bus - Audio bus to query.
+     * @param bus – Audio bus to query.
      * @returns `true` when the bus gain is held at 0 by {@link muteSet}.
      */
     public isMuted(bus: AudioBus): boolean {
@@ -308,7 +308,7 @@ export class AudioManager {
      * immediately (no fade). Unmuting restores the exact snapshotted value, so
      * a mute/unmute pair never destroys the level configured by {@link volumeSet}.
      *
-     * @param bus - Audio bus to mute or unmute.
+     * @param bus – Audio bus to mute or unmute.
      * @param muted - `true` to mute, `false` to unmute.
      */
     public muteSet(bus: AudioBus, muted: boolean): void {
@@ -358,7 +358,7 @@ export class AudioManager {
      * Remembers that a music play request arrived while the audio context was
      * locked, so {@link resumeAndUnlock} can resume it once unlocked.
      *
-     * Called by {@link musicPlay}; carries no payload itself - see {@link pendingMusicRequest}
+     * Called by {@link musicPlay}; carries no payload itself – see {@link pendingMusicRequest}
      * for the actual buffer and options.
      */
     public rememberMusicRequest(): void {
@@ -394,8 +394,8 @@ export class AudioManager {
      * free or stealable slot) are tracked separately by the pool's own `getDropCount()`, surfaced
      * through {@link getVoiceDropCount}.
      *
-     * @param buffer - Decoded audio buffer to play.
-     * @param options - Playback options; see {@link VoicePlayOptions}.
+     * @param buffer – Decoded audio buffer to play.
+     * @param options – Playback options; see {@link VoicePlayOptions}.
      * @returns A {@link SoundRef} identifying the new voice, or {@link INVALID_SOUND_REF}.
      */
     public playSound(buffer: AudioBuffer, options?: VoicePlayOptions): SoundRef {
@@ -411,8 +411,8 @@ export class AudioManager {
     /**
      * Stops a playing sound, optionally fading it out.
      *
-     * @param ref - Sound to stop.
-     * @param fadeOutMs - Optional linear fade-out duration in milliseconds.
+     * @param ref – Sound to stop.
+     * @param fadeOutMs – Optional linear fade-out duration in milliseconds.
      */
     public soundStop(ref: SoundRef, fadeOutMs?: number): void {
         this.voicePool?.stop(ref, fadeOutMs);
@@ -421,7 +421,7 @@ export class AudioManager {
     /**
      * Reports whether a sound is still playing.
      *
-     * @param ref - Sound to query.
+     * @param ref – Sound to query.
      * @returns `true` when `ref` still identifies a live voice; `false` on a stale ref or before {@link attach}.
      */
     public isSoundPlaying(ref: SoundRef): boolean {
@@ -431,9 +431,9 @@ export class AudioManager {
     /**
      * Sets a sound's gain, optionally fading to it.
      *
-     * @param ref - Sound to update.
-     * @param value - Target gain.
-     * @param fadeMs - Optional fade duration in milliseconds; omit for an immediate change.
+     * @param ref – Sound to update.
+     * @param value – Target gain.
+     * @param fadeMs – Optional fade duration in milliseconds; omit for an immediate change.
      */
     public soundVolumeSet(ref: SoundRef, value: number, fadeMs?: number): void {
         this.voicePool?.volumeSet(ref, value, fadeMs);
@@ -442,7 +442,7 @@ export class AudioManager {
     /**
      * Gets a sound's current gain.
      *
-     * @param ref - Sound to query.
+     * @param ref – Sound to query.
      * @returns Current gain, or {@link DEFAULT_VOLUME} on a stale ref or before {@link attach}.
      */
     public soundVolumeGet(ref: SoundRef): number {
@@ -452,9 +452,9 @@ export class AudioManager {
     /**
      * Sets a sound's playback rate, optionally fading to it.
      *
-     * @param ref - Sound to update.
-     * @param value - Target playback rate.
-     * @param fadeMs - Optional fade duration in milliseconds; omit for an immediate change.
+     * @param ref – Sound to update.
+     * @param value – Target playback rate.
+     * @param fadeMs – Optional fade duration in milliseconds; omit for an immediate change.
      */
     public soundPitchSet(ref: SoundRef, value: number, fadeMs?: number): void {
         this.voicePool?.pitchSet(ref, value, fadeMs);
@@ -463,7 +463,7 @@ export class AudioManager {
     /**
      * Gets a sound's current playback rate.
      *
-     * @param ref - Sound to query.
+     * @param ref – Sound to query.
      * @returns Current playback rate, or {@link DEFAULT_PITCH} on a stale ref or before {@link attach}.
      */
     public soundPitchGet(ref: SoundRef): number {
@@ -473,9 +473,9 @@ export class AudioManager {
     /**
      * Sets a sound's stereo pan, optionally fading to it.
      *
-     * @param ref - Sound to update.
-     * @param value - Target pan.
-     * @param fadeMs - Optional fade duration in milliseconds; omit for an immediate change.
+     * @param ref – Sound to update.
+     * @param value – Target pan.
+     * @param fadeMs – Optional fade duration in milliseconds; omit for an immediate change.
      */
     public soundPanSet(ref: SoundRef, value: number, fadeMs?: number): void {
         this.voicePool?.panSet(ref, value, fadeMs);
@@ -484,7 +484,7 @@ export class AudioManager {
     /**
      * Gets a sound's current stereo pan.
      *
-     * @param ref - Sound to query.
+     * @param ref – Sound to query.
      * @returns Current pan, or {@link DEFAULT_PAN} on a stale ref or before {@link attach}.
      */
     public soundPanGet(ref: SoundRef): number {
@@ -499,8 +499,8 @@ export class AudioManager {
      * so {@link resumeAndUnlock} can start it the moment the context unlocks. A newer call while
      * still locked overwrites the previously stored request; only the latest survives to unlock.
      *
-     * @param buffer - Decoded audio buffer to play.
-     * @param options - Playback options; see {@link MusicPlayOptions}.
+     * @param buffer – Decoded audio buffer to play.
+     * @param options – Playback options; see {@link MusicPlayOptions}.
      */
     public musicPlay(buffer: AudioBuffer, options?: MusicPlayOptions): void {
         if (!this.unlocked) {
@@ -516,7 +516,7 @@ export class AudioManager {
     /**
      * Stops the music player, optionally fading out first.
      *
-     * @param fadeMs - Optional linear fade-out duration in milliseconds; omit to stop immediately.
+     * @param fadeMs – Optional linear fade-out duration in milliseconds; omit to stop immediately.
      */
     public musicStop(fadeMs?: number): void {
         this.musicPlayer?.stop(fadeMs);
@@ -525,8 +525,8 @@ export class AudioManager {
     /**
      * Sets the music player's volume, optionally fading to it.
      *
-     * @param value - Target gain.
-     * @param fadeMs - Optional fade duration in milliseconds; omit for an immediate change.
+     * @param value – Target gain.
+     * @param fadeMs – Optional fade duration in milliseconds; omit for an immediate change.
      */
     public musicVolumeSet(value: number, fadeMs?: number): void {
         this.musicPlayer?.volumeSet(value, fadeMs);
@@ -642,7 +642,7 @@ export class AudioManager {
      * Creates the `sfx` / `music` / `main` gain nodes and wires `sfx` and
      * `music` into `main`, which connects to `destination`.
      *
-     * @param context - Audio context to build the graph on.
+     * @param context – Audio context to build the graph on.
      * @returns The newly created bus gain nodes.
      */
     private buildBusGraph(context: AudioContext): PerBus<GainNode> {
@@ -683,7 +683,7 @@ export class AudioManager {
      * On success, starts any music request remembered from before unlock (see
      * {@link musicPlay}) via {@link startRememberedMusicRequest}.
      *
-     * @param context - Audio context to resume.
+     * @param context – Audio context to resume.
      */
     private async resumeAndUnlock(context: AudioContext): Promise<void> {
         try {
@@ -705,7 +705,7 @@ export class AudioManager {
      * Starts the music request remembered from before unlock (see {@link musicPlay}), if any.
      *
      * Clears {@link isMusicRequestRemembered} and {@link pendingMusicRequest} before calling
-     * {@link MusicPlayer.play} (rather than after), so a `play()` failure - for example invalid
+     * {@link MusicPlayer.play} (rather than after), so a `play()` failure – for example invalid
      * `loopStart`/`loopEnd` - can never leave a stale request dangling forever. `unlock()` never
      * calls {@link resumeAndUnlock} again once {@link unlocked} is `true`, so a request left
      * uncleared here would never get another chance to be replayed or discarded. A `play()`
@@ -747,7 +747,7 @@ export class AudioManager {
 /**
  * Clamps a bus volume to `[0, 1]`.
  *
- * @param volume - Raw volume value.
+ * @param volume – Raw volume value.
  * @returns Volume clamped to `[MIN_BUS_VOLUME, MAX_BUS_VOLUME]`.
  */
 function clampVolume(volume: number): number {
@@ -757,8 +757,8 @@ function clampVolume(volume: number): number {
 /**
  * Computes a normalized RMS level from `analyzer`'s current time-domain samples.
  *
- * @param analyzer - Bus analyzer to sample.
- * @param samples - Reusable scratch buffer sized to `analyzer.fftSize`; overwritten in place.
+ * @param analyzer – Bus analyzer to sample.
+ * @param samples – Reusable scratch buffer sized to `analyzer.fftSize`; overwritten in place.
  * @returns RMS level in `[0, 1]` for a full-scale signal.
  */
 function computeBusLevel(analyzer: AnalyserNode, samples: Float32Array<ArrayBuffer>): number {

--- a/packages/blit386/src/audio/MusicPlayer.test.ts
+++ b/packages/blit386/src/audio/MusicPlayer.test.ts
@@ -216,7 +216,7 @@ describe('MusicPlayer', () => {
             expect(() => player.play(invalidBuffer, { loopStart: 5, loopEnd: 1 })).toThrow();
 
             // Validation runs before any promotion/teardown, so the already-playing track from
-            // the first play() call is still the current voice - never demoted to previous, never
+            // the first play() call is still the current voice – never demoted to previous, never
             // stopped.
             expect(player.isPlaying()).toBe(true);
 
@@ -410,7 +410,7 @@ describe('MusicPlayer', () => {
             const secondGain = asMockGain(context2.createGainCalls.at(-1) as GainNode);
             const secondSource = context2.createBufferSourceCalls.at(-1) as AudioBufferSourceNode;
 
-            // fadeSeconds*(1 - overlap) = 1 * 0.5 = 0.5s offset, halfway between simultaneous and sequential.
+            // fadeSeconds*(1 – overlap) = 1 * 0.5 = 0.5s offset, halfway between simultaneous and sequential.
             expect(firstGain.gain.setValueAtTimeCalls).toEqual([{ value: 1, startTime: 0 }]);
             expect(firstGain.gain.linearRampToValueAtTimeCalls).toEqual([{ value: 0, endTime: 1 }]);
             expect(asMockSource(firstSource).stopCalls).toEqual([1]);
@@ -832,7 +832,7 @@ describe('MusicPlayer', () => {
         it('restarts successfully when the old loop region no longer fits the new, shorter buffer', () => {
             const { player } = createPlayer();
             const oldBuffer = createMockAudioBuffer(1, 10, 10); // duration 1s at sampleRate 10
-            const newBuffer = createMockAudioBuffer(1, 5, 10); // duration 0.5s - shorter than the old loopEnd
+            const newBuffer = createMockAudioBuffer(1, 5, 10); // duration 0.5s – shorter than the old loopEnd
             player.play(oldBuffer, { loopStart: 0.2, loopEnd: 0.8 });
 
             const restarted = player.hotReplaceCurrentBuffer(oldBuffer, newBuffer);
@@ -862,7 +862,7 @@ describe('MusicPlayer', () => {
             const { player, context } = createPlayer();
             const context2 = context as unknown as { createBufferSourceCalls: AudioBufferSourceNode[] };
             const oldBuffer = createMockAudioBuffer(1, 10, 10);
-            const newBuffer = createMockAudioBuffer(1, 10, 10); // same duration - loop region still valid
+            const newBuffer = createMockAudioBuffer(1, 10, 10); // same duration – loop region still valid
             player.play(oldBuffer, { loopStart: 0.2, loopEnd: 0.8 });
 
             player.hotReplaceCurrentBuffer(oldBuffer, newBuffer);

--- a/packages/blit386/src/audio/MusicPlayer.ts
+++ b/packages/blit386/src/audio/MusicPlayer.ts
@@ -105,7 +105,7 @@ export class MusicPlayer {
     /**
      * Creates a player with no live voices.
      *
-     * @param context - Live audio context to schedule against.
+     * @param context – Live audio context to schedule against.
      * @param musicBus - `music` bus gain node every voice connects to.
      */
     constructor(
@@ -129,8 +129,8 @@ export class MusicPlayer {
      * `overlap = 0` starts the fade-in exactly as the fade-out ends, and `overlap = -1` leaves a
      * silence gap of `fadeMs` between them.
      *
-     * @param buffer - Decoded audio buffer to play.
-     * @param options - Playback options; see {@link MusicPlayOptions}.
+     * @param buffer – Decoded audio buffer to play.
+     * @param options – Playback options; see {@link MusicPlayOptions}.
      * @throws Error if `loopStart`/`loopEnd` are given without each other, or describe an invalid
      *   region for `buffer`'s duration.
      */
@@ -143,7 +143,7 @@ export class MusicPlayer {
         const fadeSeconds = Math.max(0, options.fadeMs ?? DEFAULT_FADE_MS) / 1000;
         const overlap = clampOverlap(options.overlap ?? DEFAULT_OVERLAP);
 
-        // overlap only describes the offset between an outgoing and incoming fade - with no
+        // overlap only describes the offset between an outgoing and incoming fade – with no
         // current voice to crossfade against, there is nothing to offset from, so the new track
         // always starts at now regardless of overlap.
         const fadeInStart = this.current !== null ? now + fadeSeconds * (1 - overlap) : now;
@@ -175,13 +175,13 @@ export class MusicPlayer {
      *
      * Immediately stops and releases any voice still crossfading out from a prior {@link play}
      * call, then demotes the current voice to "previous" and schedules its fade-out and stop the
-     * same way {@link play} does for a replaced track - it stays tracked (not discarded) until
+     * same way {@link play} does for a replaced track – it stays tracked (not discarded) until
      * the fade actually completes, so a subsequent {@link play} or {@link stop} call can still
      * find and immediately silence it instead of leaving it to fade out on its own unmanaged.
      * {@link current} is cleared synchronously, so {@link isPlaying} reports `false` right away
      * even while the fade-out is still audible. No-op when nothing is playing.
      *
-     * @param fadeMs - Optional linear fade-out duration in milliseconds; omit to stop immediately.
+     * @param fadeMs – Optional linear fade-out duration in milliseconds; omit to stop immediately.
      */
     public stop(fadeMs?: number): void {
         const now = this.context.currentTime;
@@ -203,8 +203,8 @@ export class MusicPlayer {
      * Sets the current track's gain, optionally ramping to it, and remembers the value for
      * future {@link volumeGet} calls even before the next {@link play}.
      *
-     * @param value - Target gain.
-     * @param fadeMs - Optional fade duration in milliseconds; omit for an immediate change.
+     * @param value – Target gain.
+     * @param fadeMs – Optional fade duration in milliseconds; omit for an immediate change.
      */
     public volumeSet(value: number, fadeMs?: number): void {
         this.volume = value;
@@ -239,10 +239,10 @@ export class MusicPlayer {
      * Hot-reload seam: if `oldBuffer` is the buffer of the currently playing track,
      * restarts playback with `newBuffer` using the last {@link play} options but no
      * crossfade (`fadeMs: 0`) so a hot-reloaded track picks up immediately. Same-
-     * position resume is out of scope - playback restarts from the beginning.
+     * position resume is out of scope – playback restarts from the beginning.
      *
-     * @param oldBuffer - Buffer identity to match against the current track.
-     * @param newBuffer - Replacement buffer to play when `oldBuffer` matches.
+     * @param oldBuffer – Buffer identity to match against the current track.
+     * @param newBuffer – Replacement buffer to play when `oldBuffer` matches.
      * @returns `true` if the current track was restarted; `false` if it didn't
      *   match, or nothing is currently playing.
      */
@@ -262,12 +262,12 @@ export class MusicPlayer {
      * Builds a fresh `source -> gain -> music bus` chain and starts playback with a scheduled
      * fade-in.
      *
-     * @param buffer - Decoded audio buffer to play.
-     * @param options - Playback options; see {@link MusicPlayOptions}.
-     * @param targetVolume - Resolved target gain (already defaulted by the caller).
-     * @param fadeInStart - Audio-clock time the fade-in (and playback) starts at.
-     * @param fadeSeconds - Fade-in duration in seconds; `0` starts at `targetVolume` immediately.
-     * @param easeIn - Easing curve for the fade-in ramp.
+     * @param buffer – Decoded audio buffer to play.
+     * @param options – Playback options; see {@link MusicPlayOptions}.
+     * @param targetVolume – Resolved target gain (already defaulted by the caller).
+     * @param fadeInStart – Audio-clock time the fade-in (and playback) starts at.
+     * @param fadeSeconds – Fade-in duration in seconds; `0` starts at `targetVolume` immediately.
+     * @param easeIn – Easing curve for the fade-in ramp.
      * @returns The newly started voice.
      */
     private startVoice(
@@ -312,14 +312,14 @@ export class MusicPlayer {
     /**
      * Schedules `voice`'s gain to fade to `0` and its source(s) to stop once the fade completes.
      *
-     * Does not disconnect anything synchronously - the node chain keeps playing until the
+     * Does not disconnect anything synchronously – the node chain keeps playing until the
      * scheduled stop time, and each source's `onended` handler (installed in {@link startVoice})
      * disconnects it when that actually fires.
      *
-     * @param voice - Voice to fade out and stop.
-     * @param startTime - Audio-clock time the fade-out starts at.
-     * @param fadeSeconds - Fade-out duration in seconds; `0` stops immediately.
-     * @param easeOut - Easing curve for the fade-out ramp.
+     * @param voice – Voice to fade out and stop.
+     * @param startTime – Audio-clock time the fade-out starts at.
+     * @param fadeSeconds – Fade-out duration in seconds; `0` stops immediately.
+     * @param easeOut – Easing curve for the fade-out ramp.
      */
     private scheduleFadeOutAndStop(
         voice: Voice,
@@ -344,7 +344,7 @@ export class MusicPlayer {
      * Used to release a stale previous voice when {@link play} or {@link stop} is called again
      * before its crossfade finished, so only one crossfade pair is ever live.
      *
-     * @param voice - Voice to force-stop.
+     * @param voice – Voice to force-stop.
      */
     private forceStopVoice(voice: Voice): void {
         for (const source of voice.sources) {
@@ -364,7 +364,7 @@ export class MusicPlayer {
      * {@link startVoice} call allocates a fresh one), so identity alone disambiguates without
      * needing a generation counter.
      *
-     * @param voice - Voice one of whose sources just ended.
+     * @param voice – Voice one of whose sources just ended.
      */
     private handleVoiceSourceEnded(voice: Voice): void {
         voice.pendingSources -= 1;
@@ -397,7 +397,7 @@ export class MusicPlayer {
 /**
  * Clamps a crossfade overlap value to `[-1, 1]`.
  *
- * @param overlap - Raw overlap value.
+ * @param overlap – Raw overlap value.
  * @returns Overlap clamped to `[MIN_OVERLAP, MAX_OVERLAP]`.
  */
 function clampOverlap(overlap: number): number {
@@ -408,8 +408,8 @@ function clampOverlap(overlap: number): number {
  * Applies `options.loop` / `options.loopStart` / `options.loopEnd` to a freshly created source
  * node. Assumes {@link validateLoopRegion} already passed.
  *
- * @param source - Source node to configure.
- * @param options - Playback options; see {@link MusicPlayOptions}.
+ * @param source – Source node to configure.
+ * @param options – Playback options; see {@link MusicPlayOptions}.
  */
 function applyLoopOptions(source: AudioBufferSourceNode, options: MusicPlayOptions): void {
     const { loopStart, loopEnd } = options;
@@ -434,8 +434,8 @@ function applyLoopOptions(source: AudioBufferSourceNode, options: MusicPlayOptio
  * points may no longer fit. Falls back to whole-buffer looping via `options.loop` in that case,
  * so a valid buffer replacement always restarts successfully instead of throwing.
  *
- * @param options - Options to sanitize.
- * @param duration - Duration in seconds of the buffer these options are about to be replayed against.
+ * @param options – Options to sanitize.
+ * @param duration – Duration in seconds of the buffer these options are about to be replayed against.
  * @returns `options` unchanged when its loop region already fits `duration`; otherwise `options`
  *   with `loopStart`/`loopEnd` removed.
  */
@@ -457,12 +457,12 @@ function sanitizeLoopRegion(options: MusicPlayOptions, duration: number): MusicP
  * playback state changes, so an invalid call to {@link MusicPlayer.play} never leaves the
  * player mid-mutated.
  *
- * This is the one deliberate throw in the music playback path - clearly-invalid programmer
+ * This is the one deliberate throw in the music playback path – clearly-invalid programmer
  * input, the same way {@link AudioClip.synth} and {@link VoicePool} validate their own
  * boundary values.
  *
- * @param options - Playback options; see {@link MusicPlayOptions}.
- * @param duration - Duration in seconds of the buffer about to be played.
+ * @param options – Playback options; see {@link MusicPlayOptions}.
+ * @param duration – Duration in seconds of the buffer about to be played.
  * @throws Error if only one of `loopStart`/`loopEnd` is given, or the pair does not satisfy
  *   `0 <= loopStart < loopEnd <= duration`.
  */

--- a/packages/blit386/src/audio/VoicePool.test.ts
+++ b/packages/blit386/src/audio/VoicePool.test.ts
@@ -55,7 +55,7 @@ const getLiveContext = (installed: ReturnType<typeof installMockAudioContext>): 
 };
 
 /**
- * Returns the most recently created gain node - the current voice's gain. Bus gains
+ * Returns the most recently created gain node – the current voice's gain. Bus gains
  * (main/music/sfx) are all created once during `attach()`, before any voice plays, so the last
  * entry is always the voice gain regardless of how many bus gains exist.
  */
@@ -533,7 +533,7 @@ describe('VoicePool', () => {
 
             const pool = new VoicePool(audio);
 
-            // A fresh pool's last slot has generation 0 - the same value `Array.at(-1)` would
+            // A fresh pool's last slot has generation 0 – the same value `Array.at(-1)` would
             // wrap to if the explicit bounds check in getActiveSlot were ever removed. This ref
             // must still be rejected because voiceIndex -1 is out of range.
             const wouldWrapToLastSlot = { voiceIndex: -1, generation: 0 };

--- a/packages/blit386/src/audio/VoicePool.ts
+++ b/packages/blit386/src/audio/VoicePool.ts
@@ -5,7 +5,7 @@
  * chain, built fresh on every {@link VoicePool.play} call (source nodes are one-shot and cannot
  * be replayed). The pool is sized from `HardwareSettings.audioVoices` and never grows; when
  * every slot is in use, a new `play()` call steals the lowest-priority active voice at or below
- * the incoming priority (oldest start order breaks ties - see {@link VoiceSlot.startOrder}), or
+ * the incoming priority (oldest start order breaks ties – see {@link VoiceSlot.startOrder}), or
  * drops the request when no slot qualifies. Callers identify a playing voice by an opaque,
  * generational {@link SoundRef} - every accessor validates the ref's generation against the
  * live slot and silently no-ops with inert defaults on a stale ref.
@@ -130,7 +130,7 @@ interface VoiceSlot {
     /** Panner node for the current voice, or `null` when inactive. */
     panner: StereoPannerNode | null;
 
-    /** Buffer the current voice was started with, or `null` when inactive - used by {@link VoicePool.stopVoicesUsingBuffer}. */
+    /** Buffer the current voice was started with, or `null` when inactive – used by {@link VoicePool.stopVoicesUsingBuffer}. */
     buffer: AudioBuffer | null;
 
     /** `true` while this slot holds a live voice. */
@@ -168,7 +168,7 @@ export class VoicePool {
     /**
      * Creates a pool with a fixed number of voice slots.
      *
-     * @param audioManager - Owning audio manager; used to reach the live context and `sfx` bus.
+     * @param audioManager – Owning audio manager; used to reach the live context and `sfx` bus.
      */
     constructor(audioManager: AudioManager) {
         this.audioManager = audioManager;
@@ -184,8 +184,8 @@ export class VoicePool {
      * or `sfx` bus (not attached, or already detached), and increments {@link getDropCount} when
      * every active slot outranks the incoming priority.
      *
-     * @param buffer - Decoded audio buffer to play.
-     * @param options - Playback options; see {@link VoicePlayOptions}.
+     * @param buffer – Decoded audio buffer to play.
+     * @param options – Playback options; see {@link VoicePlayOptions}.
      * @returns A {@link SoundRef} identifying the new voice, or {@link INVALID_SOUND_REF}.
      */
     public play(buffer: AudioBuffer, options: VoicePlayOptions = {}): SoundRef {
@@ -225,14 +225,14 @@ export class VoicePool {
      * Stops a playing voice, immediately freeing its slot for reuse.
      *
      * When `fadeOutMs` is given, ramps gain to `0` over that duration and schedules the
-     * underlying source to stop only once the ramp completes - the fade is still audible even
+     * underlying source to stop only once the ramp completes – the fade is still audible even
      * though the slot itself is already free and may be reused by the very next `play()` call
      * (the reused slot gets fresh nodes; the fading-out nodes keep playing independently until
      * their own scheduled stop fires and their `onended` closure disconnects them). Silently
      * no-ops when `ref` is stale, out of range, or already stopped.
      *
-     * @param ref - Voice to stop.
-     * @param fadeOutMs - Optional linear fade-out duration in milliseconds.
+     * @param ref – Voice to stop.
+     * @param fadeOutMs – Optional linear fade-out duration in milliseconds.
      */
     public stop(ref: SoundRef, fadeOutMs?: number): void {
         const slot = this.getActiveSlot(ref);
@@ -256,7 +256,7 @@ export class VoicePool {
     /**
      * Reports whether `ref` still identifies a live voice.
      *
-     * @param ref - Voice to query.
+     * @param ref – Voice to query.
      * @returns `true` when `ref`'s generation matches its slot's current generation.
      */
     public isPlaying(ref: SoundRef): boolean {
@@ -266,7 +266,7 @@ export class VoicePool {
     /**
      * Returns a voice's current gain.
      *
-     * @param ref - Voice to query.
+     * @param ref – Voice to query.
      * @returns Current gain, or {@link DEFAULT_VOLUME} on a stale/invalid ref.
      */
     public volumeGet(ref: SoundRef): number {
@@ -276,9 +276,9 @@ export class VoicePool {
     /**
      * Sets a voice's gain, optionally ramping to it.
      *
-     * @param ref - Voice to update.
-     * @param value - Target gain.
-     * @param fadeMs - Optional fade duration in milliseconds; omit for an immediate change.
+     * @param ref – Voice to update.
+     * @param value – Target gain.
+     * @param fadeMs – Optional fade duration in milliseconds; omit for an immediate change.
      */
     public volumeSet(ref: SoundRef, value: number, fadeMs?: number): void {
         const slot = this.getActiveSlot(ref);
@@ -293,7 +293,7 @@ export class VoicePool {
     /**
      * Returns a voice's current playback rate.
      *
-     * @param ref - Voice to query.
+     * @param ref – Voice to query.
      * @returns Current playback rate, or {@link DEFAULT_PITCH} on a stale/invalid ref.
      */
     public pitchGet(ref: SoundRef): number {
@@ -303,9 +303,9 @@ export class VoicePool {
     /**
      * Sets a voice's playback rate, optionally ramping to it.
      *
-     * @param ref - Voice to update.
-     * @param value - Target playback rate.
-     * @param fadeMs - Optional fade duration in milliseconds; omit for an immediate change.
+     * @param ref – Voice to update.
+     * @param value – Target playback rate.
+     * @param fadeMs – Optional fade duration in milliseconds; omit for an immediate change.
      */
     public pitchSet(ref: SoundRef, value: number, fadeMs?: number): void {
         const slot = this.getActiveSlot(ref);
@@ -320,7 +320,7 @@ export class VoicePool {
     /**
      * Returns a voice's current stereo pan.
      *
-     * @param ref - Voice to query.
+     * @param ref – Voice to query.
      * @returns Current pan, or {@link DEFAULT_PAN} on a stale/invalid ref.
      */
     public panGet(ref: SoundRef): number {
@@ -330,9 +330,9 @@ export class VoicePool {
     /**
      * Sets a voice's stereo pan, optionally ramping to it.
      *
-     * @param ref - Voice to update.
-     * @param value - Target pan.
-     * @param fadeMs - Optional fade duration in milliseconds; omit for an immediate change.
+     * @param ref – Voice to update.
+     * @param value – Target pan.
+     * @param fadeMs – Optional fade duration in milliseconds; omit for an immediate change.
      */
     public panSet(ref: SoundRef, value: number, fadeMs?: number): void {
         const slot = this.getActiveSlot(ref);
@@ -369,7 +369,7 @@ export class VoicePool {
      * using this buffer. That is safe: Web Audio keeps the decoded buffer alive as long as a
      * source node is still using it, independent of {@link AudioClip}'s own JS-side reference.
      *
-     * @param buffer - Buffer being released.
+     * @param buffer – Buffer being released.
      */
     public stopVoicesUsingBuffer(buffer: AudioBuffer): void {
         for (const slot of this.slots) {
@@ -418,7 +418,7 @@ export class VoicePool {
     /**
      * Picks a slot for a new voice: the first free slot, or the best steal candidate.
      *
-     * @param priority - Allocation priority of the incoming voice.
+     * @param priority – Allocation priority of the incoming voice.
      * @returns Slot index to use, or `null` when no free or stealable slot exists.
      */
     private allocateSlot(priority: number): number | null {
@@ -435,7 +435,7 @@ export class VoicePool {
      * Finds the best active slot to steal for an incoming voice: the lowest-priority active
      * slot at or below `incomingPriority`, breaking ties by oldest {@link VoiceSlot.startOrder}.
      *
-     * @param incomingPriority - Allocation priority of the incoming voice.
+     * @param incomingPriority – Allocation priority of the incoming voice.
      * @returns Slot index to steal, or `null` when every active slot outranks `incomingPriority`.
      */
     private findStealCandidate(incomingPriority: number): number | null {
@@ -469,13 +469,13 @@ export class VoicePool {
      * Bumps `slot.generation` so the returned {@link SoundRef} (built by the caller from the
      * post-call `slot.generation`) is unique even when reusing a stolen slot.
      *
-     * @param slot - Slot to populate (already disconnected from any prior voice by the caller).
-     * @param slotIndex - Index of `slot`, captured for the `onended` recycle callback.
-     * @param buffer - Decoded audio buffer to play.
-     * @param options - Playback options; see {@link VoicePlayOptions}.
-     * @param priority - Resolved allocation priority (already defaulted by the caller).
-     * @param context - Live audio context (already validated non-null by the caller).
-     * @param sfxBus - Live `sfx` bus gain node (already validated non-null by the caller).
+     * @param slot – Slot to populate (already disconnected from any prior voice by the caller).
+     * @param slotIndex – Index of `slot`, captured for the `onended` recycle callback.
+     * @param buffer – Decoded audio buffer to play.
+     * @param options – Playback options; see {@link VoicePlayOptions}.
+     * @param priority – Resolved allocation priority (already defaulted by the caller).
+     * @param context – Live audio context (already validated non-null by the caller).
+     * @param sfxBus – Live `sfx` bus gain node (already validated non-null by the caller).
      */
     private startVoice(
         slot: VoiceSlot,
@@ -541,7 +541,7 @@ export class VoicePool {
      * single-threaded execution guarantees no interleaving between this synchronous teardown
      * and the slot's next synchronous mutation).
      *
-     * @param slot - Slot whose current node chain should be torn down.
+     * @param slot – Slot whose current node chain should be torn down.
      */
     private disconnectVoice(slot: VoiceSlot): void {
         if (slot.source !== null) {
@@ -555,10 +555,10 @@ export class VoicePool {
 
     /**
      * Immediately stops, disconnects, and recycles `slot` if it is active. Unlike
-     * {@link stop}, this always tears the node chain down synchronously - used for teardown
+     * {@link stop}, this always tears the node chain down synchronously – used for teardown
      * paths ({@link stopAll}, {@link stopVoicesUsingBuffer}) where lingering audio is not wanted.
      *
-     * @param slot - Slot to force-stop.
+     * @param slot – Slot to force-stop.
      */
     private forceStopSlot(slot: VoiceSlot): void {
         this.disconnectVoice(slot);
@@ -569,7 +569,7 @@ export class VoicePool {
      * Returns `ref`'s slot when `ref` still identifies a live voice, or `null` when the index is
      * out of range or the generation no longer matches (stale ref).
      *
-     * @param ref - Voice reference to validate.
+     * @param ref – Voice reference to validate.
      * @returns The live slot, or `null` on a stale/invalid ref.
      */
     private getActiveSlot(ref: SoundRef): VoiceSlot | null {
@@ -599,7 +599,7 @@ export class VoicePool {
      * Clears a slot's node references and marks it inactive, bumping its generation so any
      * outstanding {@link SoundRef} pointing at it becomes stale.
      *
-     * @param slot - Slot to reset.
+     * @param slot – Slot to reset.
      */
     private resetSlot(slot: VoiceSlot): void {
         slot.source = null;
@@ -612,10 +612,10 @@ export class VoicePool {
 
     /**
      * Recycles `slotIndex` when its generation still matches `expectedGeneration` (a no-op when
-     * the slot has already been reused - see {@link disconnectVoice}).
+     * the slot has already been reused – see {@link disconnectVoice}).
      *
-     * @param slotIndex - Index of the slot whose voice just ended.
-     * @param expectedGeneration - Generation captured when the ended voice was started.
+     * @param slotIndex – Index of the slot whose voice just ended.
+     * @param expectedGeneration – Generation captured when the ended voice was started.
      */
     private handleVoiceEnded(slotIndex: number, expectedGeneration: number): void {
         const slot = this.slots.at(slotIndex);

--- a/packages/blit386/src/audio/audioDecodeContext.ts
+++ b/packages/blit386/src/audio/audioDecodeContext.ts
@@ -17,7 +17,7 @@ let decodeContext: AudioContext | null = null;
  * Called by {@link AudioManager.attach} / {@link AudioManager.detach} so this
  * registry stays in sync with the live context lifecycle.
  *
- * @param context - Context to register, or `null` to clear it.
+ * @param context – Context to register, or `null` to clear it.
  */
 export function setAudioDecodeContext(context: AudioContext | null): void {
     decodeContext = context;
@@ -44,7 +44,7 @@ let audioClipUnloadHandler: (buffer: AudioBuffer) => void = () => {};
 /**
  * Registers the handler invoked by `AudioClip.unload()` with the released buffer.
  *
- * @param handler - Handler to invoke on unload.
+ * @param handler – Handler to invoke on unload.
  */
 export function setAudioClipUnloadHandler(handler: (buffer: AudioBuffer) => void): void {
     audioClipUnloadHandler = handler;
@@ -56,7 +56,7 @@ export function setAudioClipUnloadHandler(handler: (buffer: AudioBuffer) => void
  * Called by `AudioClip.unload()`; a no-op until a voice pool registers a
  * handler via {@link setAudioClipUnloadHandler}.
  *
- * @param buffer - Buffer being released.
+ * @param buffer – Buffer being released.
  */
 export function notifyAudioClipUnload(buffer: AudioBuffer): void {
     audioClipUnloadHandler(buffer);
@@ -79,7 +79,7 @@ let musicHotReplaceHandler: (oldBuffer: AudioBuffer, newBuffer: AudioBuffer) => 
  * Registers the handler invoked by `AudioClip.hotReload()` to restart the current
  * music track when its buffer was just hot-replaced.
  *
- * @param handler - Handler to invoke; returns whether it restarted playback.
+ * @param handler – Handler to invoke; returns whether it restarted playback.
  */
 export function setMusicHotReplaceHandler(handler: (oldBuffer: AudioBuffer, newBuffer: AudioBuffer) => boolean): void {
     musicHotReplaceHandler = handler;
@@ -91,8 +91,8 @@ export function setMusicHotReplaceHandler(handler: (oldBuffer: AudioBuffer, newB
  * Called by `AudioClip.hotReload()`; a no-op (returns `false`) until a music player
  * registers a handler via {@link setMusicHotReplaceHandler}.
  *
- * @param oldBuffer - Buffer being replaced.
- * @param newBuffer - Replacement buffer.
+ * @param oldBuffer – Buffer being replaced.
+ * @param newBuffer – Replacement buffer.
  * @returns Whether the music player restarted playback with `newBuffer`.
  */
 export function notifyMusicHotReplace(oldBuffer: AudioBuffer, newBuffer: AudioBuffer): boolean {

--- a/packages/blit386/src/core/BTAPI.test.ts
+++ b/packages/blit386/src/core/BTAPI.test.ts
@@ -57,7 +57,7 @@ import type { HardwareSettings, IBTDemo, OverlayRow } from './IBTDemo';
 import { collectUsedIndices } from './RenderPaletteUsage';
 
 function resetSingleton(): void {
-    // BTAPI._instance is private; the cast is intentional - there is no public
+    // BTAPI._instance is private; the cast is intentional – there is no public
     // reset API, and this is the least-invasive way to isolate singleton state
     // between tests without modifying production code.
     (BTAPI as unknown as { _instance: BTAPI | null })._instance = null;
@@ -279,7 +279,7 @@ describe('music playback passthroughs', () => {
     });
 
     function setAudio(audio: AudioManager | null): void {
-        // Same test-isolation technique as the "sound playback passthroughs" block above - see
+        // Same test-isolation technique as the "sound playback passthroughs" block above – see
         // its comment for why this cast is safe here.
         (BTAPI.instance as unknown as { audio: AudioManager | null }).audio = audio;
     }
@@ -1336,7 +1336,7 @@ describe('BTAPI', () => {
                     isSplashEnabled: false,
                     displaySize: new Vector2i(320, 240),
                     targetFPS: 60,
-                    // No backend field - defaults to 'webgpu', should auto-fallback
+                    // No backend field – defaults to 'webgpu', should auto-fallback
                 }),
                 init: vi.fn().mockResolvedValue(true),
                 update: vi.fn(),
@@ -1718,8 +1718,8 @@ describe('BTAPI', () => {
         /**
          * Runs game-loop ticks using a stubbed rAF queue seeded before init.
          *
-         * @param demo - Demo passed to {@link BTAPI.init}.
-         * @param stopWhen - Stop draining once this returns true.
+         * @param demo – Demo passed to {@link BTAPI.init}.
+         * @param stopWhen – Stop draining once this returns true.
          * @returns Overlay spy from the initialized instance.
          */
         async function initAndDrainUntil(
@@ -1924,8 +1924,8 @@ describe('BTAPI', () => {
         /**
          * Runs game-loop ticks using a stubbed rAF queue seeded before init.
          *
-         * @param demo - Demo passed to {@link BTAPI.init}.
-         * @param stopWhen - Stop draining once this returns true.
+         * @param demo – Demo passed to {@link BTAPI.init}.
+         * @param stopWhen – Stop draining once this returns true.
          * @returns Overlay spy from the initialized instance.
          */
         async function initAndDrainUntil(
@@ -2042,7 +2042,7 @@ describe('BTAPI', () => {
         /**
          * Drains the stubbed rAF queue until `stopWhen` returns true, spying on real renderer bar fills.
          *
-         * @param demo - Demo passed to {@link BTAPI.init}.
+         * @param demo – Demo passed to {@link BTAPI.init}.
          * @returns Collected bar fills in draw order.
          */
         async function drainAndCollectBarFills(demo: IBTDemo): Promise<{ index: number; rect: Rect2i }[]> {
@@ -2109,10 +2109,10 @@ describe('BTAPI', () => {
 
         /**
          * Matches a bar fill against the audio meter's known bar geometry (width and left-edge X),
-         * not width alone - width-only matching risks false positives from unrelated same-width bars.
+         * not width alone – width-only matching risks false positives from unrelated same-width bars.
          *
-         * @param fill - Collected bar fill from {@link drainAndCollectBarFills}.
-         * @param fill.rect - Filled rectangle in display coordinates.
+         * @param fill – Collected bar fill from {@link drainAndCollectBarFills}.
+         * @param fill.rect – Filled rectangle in display coordinates.
          * @returns `true` when the fill's rect matches one of the three bus bar positions.
          */
         function isAudioMeterBar(fill: { rect: Rect2i }): boolean {
@@ -2891,7 +2891,7 @@ describe('BTAPI splash palette capture', () => {
      * Replaces the private effect manager with one on a fake clock, and installs
      * a palette as if the splash owned it.
      *
-     * @param splashPalette - Palette standing in for the splash's own ramp.
+     * @param splashPalette – Palette standing in for the splash's own ramp.
      */
     function armWithSplashPalette(splashPalette: Palette): void {
         now = 0;
@@ -2927,7 +2927,7 @@ describe('BTAPI splash palette capture', () => {
      * The manager reports a zero delta on its first update after an idle gap, so
      * this primes it before stepping.
      *
-     * @param ms - Milliseconds to advance.
+     * @param ms – Milliseconds to advance.
      */
     function advanceEffects(ms: number): void {
         const manager = (BTAPI.instance as unknown as { paletteEffects: PaletteEffectManager }).paletteEffects;
@@ -3072,9 +3072,9 @@ describe('BTAPI splash lifecycle in init', () => {
      * Builds a demo whose `configure()` returns `settings` and whose `init()` runs
      * `initBody` before resolving.
      *
-     * @param settings - Extra hardware settings merged over the display defaults.
-     * @param initBody - Optional body run inside `init()`.
-     * @param initResult - Value `init()` resolves to.
+     * @param settings – Extra hardware settings merged over the display defaults.
+     * @param initBody – Optional body run inside `init()`.
+     * @param initResult – Value `init()` resolves to.
      * @returns A demo suitable for `BTAPI.init`.
      */
     function makeSplashDemo(
@@ -3103,7 +3103,7 @@ describe('BTAPI splash lifecycle in init', () => {
      * Stubs `requestAnimationFrame` and `performance.now` with a fake frame clock,
      * so the splash's own driver runs to completion without sleeping in real time.
      *
-     * @param stepMs - Milliseconds each frame advances the clock.
+     * @param stepMs – Milliseconds each frame advances the clock.
      */
     function driveAnimationFrames(stepMs = 16): void {
         let clock = 0;
@@ -3347,7 +3347,7 @@ describe('BTAPI splash lifecycle in init', () => {
         const endUpdate = vi.spyOn(KeyboardInput.prototype, 'endUpdate');
 
         // The skip listeners themselves are covered in Splash.dom.test.ts; this asserts
-        // the other half of the swallow - that BTAPI consumes the pending edges before
+        // the other half of the swallow – that BTAPI consumes the pending edges before
         // the game's first update() can observe them.
         await BTAPI.instance.init(makeSplashDemo({ isSplashEnabled: true }), makeMockCanvas());
 

--- a/packages/blit386/src/core/BTAPI.ts
+++ b/packages/blit386/src/core/BTAPI.ts
@@ -112,7 +112,7 @@ export class BTAPI {
      * fixed-update steps (common once the render rate approaches or exceeds the fixed update
      * rate, for example at 120 Hz) would draw the world with whatever the *previous* frame's
      * `render()` left the live offset at after its own {@link resetCamera} call for
-     * screen-space UI - which is always `(0, 0)` - producing a visible snap-to-origin flash
+     * screen-space UI – which is always `(0, 0)` - producing a visible snap-to-origin flash
      * instead of holding the last correct scroll position.
      */
     private lastCameraOffset: Vector2i = Vector2i.zero();
@@ -327,8 +327,8 @@ export class BTAPI {
      * silently reporting `false` would hide a renderer fault. `bootstrap()` catches
      * it and routes it to `onError`.
      *
-     * @param demo - Demo implementing the IBTDemo interface.
-     * @param canvas - Render target canvas (WebGPU or software backend).
+     * @param demo – Demo implementing the IBTDemo interface.
+     * @param canvas – Render target canvas (WebGPU or software backend).
      * @returns `true` when initialization succeeds; otherwise `false`.
      * @throws Error when a splash frame throws while the splash is on screen.
      */
@@ -567,7 +567,7 @@ export class BTAPI {
      * closes over the *previous* demo's bound `onOrientationChange`, so without this,
      * orientation events would keep reaching stale code after the swap.
      *
-     * @param newDemo - Freshly constructed candidate demo instance.
+     * @param newDemo – Freshly constructed candidate demo instance.
      * @returns `true` when `newDemo.init()` succeeds and {@link demo} was swapped to it.
      */
     public async hotReplaceDemo(newDemo: IBTDemo): Promise<boolean> {
@@ -634,7 +634,7 @@ export class BTAPI {
      *
      * No-op when the overlay or timing chart is disabled.
      *
-     * @param label - Tag text; empty becomes `"Untitled"`.
+     * @param label – Tag text; empty becomes `"Untitled"`.
      */
     public assignTag(label?: string): void {
         this.overlay?.assignTag(label, this.getTicks());
@@ -760,10 +760,10 @@ export class BTAPI {
      *
      * No-op when the audio subsystem is not initialized.
      *
-     * @param bus - Audio bus to update.
-     * @param volume - Target volume, clamped to `[0, 1]`.
-     * @param fadeMs - Optional fade duration in milliseconds; omit for an immediate change.
-     * @param easing - Easing curve for the fade. Defaults to `'linear'`; ignored when `fadeMs` is omitted.
+     * @param bus – Audio bus to update.
+     * @param volume – Target volume, clamped to `[0, 1]`.
+     * @param fadeMs – Optional fade duration in milliseconds; omit for an immediate change.
+     * @param easing – Easing curve for the fade. Defaults to `'linear'`; ignored when `fadeMs` is omitted.
      */
     public audioVolumeSet(bus: AudioBus, volume: number, fadeMs?: number, easing?: EasingFunction): void {
         this.audio?.volumeSet(bus, volume, fadeMs, easing);
@@ -772,7 +772,7 @@ export class BTAPI {
     /**
      * Gets the logical (pre-mute) volume for an audio bus.
      *
-     * @param bus - Audio bus to query.
+     * @param bus – Audio bus to query.
      * @returns Volume in `[0, 1]`, or `0` when the audio subsystem is not initialized.
      */
     public audioVolumeGet(bus: AudioBus): number {
@@ -784,7 +784,7 @@ export class BTAPI {
      *
      * No-op when the audio subsystem is not initialized.
      *
-     * @param bus - Audio bus to mute or unmute.
+     * @param bus – Audio bus to mute or unmute.
      * @param muted - `true` to mute, `false` to unmute.
      */
     public audioMuteSet(bus: AudioBus, muted: boolean): void {
@@ -794,7 +794,7 @@ export class BTAPI {
     /**
      * Reports whether an audio bus is currently muted.
      *
-     * @param bus - Audio bus to query.
+     * @param bus – Audio bus to query.
      * @returns `true` when muted; `false` when unmuted or not initialized.
      */
     public isAudioMuted(bus: AudioBus): boolean {
@@ -808,8 +808,8 @@ export class BTAPI {
      * available (not finished loading yet, or already unloaded) or when the audio subsystem is
      * not initialized.
      *
-     * @param clip - Loaded audio clip to play.
-     * @param options - Playback options; see {@link SoundPlayOptions}.
+     * @param clip – Loaded audio clip to play.
+     * @param options – Playback options; see {@link SoundPlayOptions}.
      * @returns A {@link SoundRef} identifying the new voice, or {@link INVALID_SOUND_REF}.
      */
     public soundPlay(clip: AudioClip, options?: SoundPlayOptions): SoundRef {
@@ -823,8 +823,8 @@ export class BTAPI {
     /**
      * Stops a playing sound, optionally fading it out.
      *
-     * @param ref - Sound to stop.
-     * @param fadeOutMs - Optional linear fade-out duration in milliseconds.
+     * @param ref – Sound to stop.
+     * @param fadeOutMs – Optional linear fade-out duration in milliseconds.
      */
     public soundStop(ref: SoundRef, fadeOutMs?: number): void {
         this.audio?.soundStop(ref, fadeOutMs);
@@ -833,7 +833,7 @@ export class BTAPI {
     /**
      * Reports whether a sound is still playing.
      *
-     * @param ref - Sound to query.
+     * @param ref – Sound to query.
      * @returns `true` when still playing; `false` on a stale ref or when the audio subsystem is not initialized.
      */
     public isSoundPlaying(ref: SoundRef): boolean {
@@ -843,9 +843,9 @@ export class BTAPI {
     /**
      * Sets a sound's gain, optionally fading to it.
      *
-     * @param ref - Sound to update.
-     * @param value - Target gain.
-     * @param fadeMs - Optional fade duration in milliseconds; omit for an immediate change.
+     * @param ref – Sound to update.
+     * @param value – Target gain.
+     * @param fadeMs – Optional fade duration in milliseconds; omit for an immediate change.
      */
     public soundVolumeSet(ref: SoundRef, value: number, fadeMs?: number): void {
         this.audio?.soundVolumeSet(ref, value, fadeMs);
@@ -854,7 +854,7 @@ export class BTAPI {
     /**
      * Gets a sound's current gain.
      *
-     * @param ref - Sound to query.
+     * @param ref – Sound to query.
      * @returns Current gain in `[0, 1]`, or `1` on a stale ref or when the audio subsystem is not initialized.
      */
     public soundVolumeGet(ref: SoundRef): number {
@@ -864,9 +864,9 @@ export class BTAPI {
     /**
      * Sets a sound's playback rate, optionally fading to it.
      *
-     * @param ref - Sound to update.
-     * @param value - Target playback rate.
-     * @param fadeMs - Optional fade duration in milliseconds; omit for an immediate change.
+     * @param ref – Sound to update.
+     * @param value – Target playback rate.
+     * @param fadeMs – Optional fade duration in milliseconds; omit for an immediate change.
      */
     public soundPitchSet(ref: SoundRef, value: number, fadeMs?: number): void {
         this.audio?.soundPitchSet(ref, value, fadeMs);
@@ -875,7 +875,7 @@ export class BTAPI {
     /**
      * Gets a sound's current playback rate.
      *
-     * @param ref - Sound to query.
+     * @param ref – Sound to query.
      * @returns Current playback rate, or `1` on a stale ref or when the audio subsystem is not initialized.
      */
     public soundPitchGet(ref: SoundRef): number {
@@ -885,9 +885,9 @@ export class BTAPI {
     /**
      * Sets a sound's stereo pan, optionally fading to it.
      *
-     * @param ref - Sound to update.
-     * @param value - Target pan.
-     * @param fadeMs - Optional fade duration in milliseconds; omit for an immediate change.
+     * @param ref – Sound to update.
+     * @param value – Target pan.
+     * @param fadeMs – Optional fade duration in milliseconds; omit for an immediate change.
      */
     public soundPanSet(ref: SoundRef, value: number, fadeMs?: number): void {
         this.audio?.soundPanSet(ref, value, fadeMs);
@@ -896,7 +896,7 @@ export class BTAPI {
     /**
      * Gets a sound's current stereo pan.
      *
-     * @param ref - Sound to query.
+     * @param ref – Sound to query.
      * @returns Current pan, or `0` on a stale ref or when the audio subsystem is not initialized.
      */
     public soundPanGet(ref: SoundRef): number {
@@ -910,8 +910,8 @@ export class BTAPI {
      * No-ops when the clip's buffer isn't available (not finished loading yet, or already
      * unloaded), mirroring {@link soundPlay}, or when the audio subsystem is not initialized.
      *
-     * @param clip - Loaded audio clip to play.
-     * @param options - Playback options; see {@link MusicPlayOptions}.
+     * @param clip – Loaded audio clip to play.
+     * @param options – Playback options; see {@link MusicPlayOptions}.
      */
     public musicPlay(clip: AudioClip, options?: MusicPlayOptions): void {
         if (clip.buffer === null) {
@@ -924,7 +924,7 @@ export class BTAPI {
     /**
      * Stops the music player, optionally fading out first.
      *
-     * @param fadeMs - Optional linear fade-out duration in milliseconds; omit to stop immediately.
+     * @param fadeMs – Optional linear fade-out duration in milliseconds; omit to stop immediately.
      */
     public musicStop(fadeMs?: number): void {
         this.audio?.musicStop(fadeMs);
@@ -943,8 +943,8 @@ export class BTAPI {
     /**
      * Sets the music player's volume, optionally fading to it.
      *
-     * @param value - Target gain.
-     * @param fadeMs - Optional fade duration in milliseconds; omit for an immediate change.
+     * @param value – Target gain.
+     * @param fadeMs – Optional fade duration in milliseconds; omit for an immediate change.
      */
     public musicVolumeSet(value: number, fadeMs?: number): void {
         this.audio?.musicVolumeSet(value, fadeMs);
@@ -997,7 +997,7 @@ export class BTAPI {
     /**
      * Returns the current `screen.orientation.type` string when available.
      *
-     * Does not require a successful init - reads the platform API directly.
+     * Does not require a successful init – reads the platform API directly.
      * Examples: `'landscape-primary'`, `'portrait-secondary'`.
      *
      * @returns Orientation type string, or `null` when the Screen Orientation API
@@ -1044,7 +1044,7 @@ export class BTAPI {
      */
     public getPalette(): Palette | null {
         // While the splash owns the palette, the game must see its own palette,
-        // not the splash's ramp - otherwise in-place slot edits and
+        // not the splash's ramp – otherwise in-place slot edits and
         // spritesRefresh() would both target the wrong object. Null until the
         // game sets one, which matches the pre-paletteSet behavior it already
         // expects.
@@ -1066,7 +1066,7 @@ export class BTAPI {
     /**
      * Reseeds the default engine PRNG.
      *
-     * @param seed - Any finite number; only its lower 32 bits are used.
+     * @param seed – Any finite number; only its lower 32 bits are used.
      */
     public randomSeed(seed: number): void {
         this.random.seed(seed);
@@ -1080,7 +1080,7 @@ export class BTAPI {
      * {@link BTAPI.spritesRefresh}). In-place slot value changes on the active
      * palette do not go through this method and need no refresh.
      *
-     * @param palette - Palette to store as the active engine palette.
+     * @param palette – Palette to store as the active engine palette.
      */
     public setPalette(palette: Palette): void {
         if (this.spriteSheets.size > 0) {
@@ -1153,7 +1153,7 @@ export class BTAPI {
     /**
      * Sets the background clear color for each frame using a palette index.
      *
-     * @param paletteIndex - Palette index for the clear color.
+     * @param paletteIndex – Palette index for the clear color.
      */
     public setClearColor(paletteIndex: number): void {
         this.assertPaletteIndex(paletteIndex);
@@ -1165,8 +1165,8 @@ export class BTAPI {
     /**
      * Fills a rectangular region with a palette-indexed color.
      *
-     * @param rect - Region to fill in pixel coordinates.
-     * @param paletteIndex - Palette color index.
+     * @param rect – Region to fill in pixel coordinates.
+     * @param paletteIndex – Palette color index.
      */
     public clearRect(rect: Rect2i, paletteIndex: number): void {
         this.assertPaletteIndex(paletteIndex);
@@ -1180,8 +1180,8 @@ export class BTAPI {
     /**
      * Draws a single pixel at the specified position.
      *
-     * @param pos - Pixel coordinates.
-     * @param paletteIndex - Palette color index.
+     * @param pos – Pixel coordinates.
+     * @param paletteIndex – Palette color index.
      */
     public drawPixel(pos: Vector2i, paletteIndex: number): void {
         this.assertPaletteIndex(paletteIndex);
@@ -1196,9 +1196,9 @@ export class BTAPI {
      * Draws a line between two points using Bresenham's algorithm.
      * Produces pixel-perfect lines without antialiasing.
      *
-     * @param p0 - Start point.
-     * @param p1 - End point.
-     * @param paletteIndex - Palette color index.
+     * @param p0 – Start point.
+     * @param p1 – End point.
+     * @param paletteIndex – Palette color index.
      */
     public drawLine(p0: Vector2i, p1: Vector2i, paletteIndex: number): void {
         this.assertPaletteIndex(paletteIndex);
@@ -1212,8 +1212,8 @@ export class BTAPI {
     /**
      * Draws a rectangle outline (unfilled).
      *
-     * @param rect - Rectangle bounds.
-     * @param paletteIndex - Palette color index.
+     * @param rect – Rectangle bounds.
+     * @param paletteIndex – Palette color index.
      */
     public drawRect(rect: Rect2i, paletteIndex: number): void {
         this.assertPaletteIndex(paletteIndex);
@@ -1227,8 +1227,8 @@ export class BTAPI {
     /**
      * Draws a filled rectangle.
      *
-     * @param rect - Rectangle bounds.
-     * @param paletteIndex - Palette color index.
+     * @param rect – Rectangle bounds.
+     * @param paletteIndex – Palette color index.
      */
     public drawRectFill(rect: Rect2i, paletteIndex: number): void {
         this.assertPaletteIndex(paletteIndex);
@@ -1246,14 +1246,14 @@ export class BTAPI {
      * `paletteIndex` parameter is converted to a sprite pipeline palette
      * offset so that each foreground pixel maps to `palette[paletteIndex]`.
      *
-     * @param pos - Text position (top-left corner).
-     * @param paletteIndex - Palette color index for the text.
-     * @param text - String to display.
+     * @param pos – Text position (top-left corner).
+     * @param paletteIndex – Palette color index for the text.
+     * @param text – String to display.
      */
     public drawSystemText(pos: Vector2i, paletteIndex: number, text: string): void {
         this.assertPaletteIndex(paletteIndex);
 
-        // Palette index 0 is transparent - nothing to draw.
+        // Palette index 0 is transparent – nothing to draw.
         if (paletteIndex === 0) {
             return;
         }
@@ -1263,7 +1263,7 @@ export class BTAPI {
             this.markDrawCall();
 
             // Offset math: font stores foreground as index 1.
-            // Shader computes 1 + (paletteIndex - 1) = paletteIndex.
+            // Shader computes 1 + (paletteIndex – 1) = paletteIndex.
             this.renderer?.drawBitmapText(this.systemFont, pos, text, paletteIndex - 1);
         }
     }
@@ -1281,10 +1281,10 @@ export class BTAPI {
      * Draws a sprite region from an indexed sprite sheet.
      * The renderer batches compatible sprite draws internally.
      *
-     * @param spriteSheet - Source sprite sheet (must have been indexized via spriteSheet.indexize()).
-     * @param srcRect - Region to copy from the sprite sheet.
-     * @param destPos - Screen position to draw in (the top-left corner).
-     * @param paletteOffset - Palette index offset applied at draw time (default 0).
+     * @param spriteSheet – Source sprite sheet (must have been indexized via spriteSheet.indexize()).
+     * @param srcRect – Region to copy from the sprite sheet.
+     * @param destPos – Screen position to draw in (the top-left corner).
+     * @param paletteOffset – Palette index offset applied at draw time (default 0).
      * @throws If the sprite sheet has not been indexized.
      */
     public drawSprite(spriteSheet: SpriteSheet, srcRect: Rect2i, destPos: Vector2i, paletteOffset: number = 0): void {
@@ -1304,10 +1304,10 @@ export class BTAPI {
      * Draws text using a bitmap font with variable-width glyphs.
      * Supports Unicode characters and per-glyph render offsets.
      *
-     * @param font - Bitmap font containing character glyphs (underlying sheet must be indexized).
-     * @param pos - Text position (top-left corner).
-     * @param text - String to render.
-     * @param paletteOffset - Palette index offset applied to all glyphs (default 0).
+     * @param font – Bitmap font containing character glyphs (underlying sheet must be indexized).
+     * @param pos – Text position (top-left corner).
+     * @param text – String to render.
+     * @param paletteOffset – Palette index offset applied to all glyphs (default 0).
      * @throws If the font's sprite sheet has not been indexized.
      */
     public drawBitmapText(font: BitmapFont, pos: Vector2i, text: string, paletteOffset: number = 0): void {
@@ -1381,7 +1381,7 @@ export class BTAPI {
      * Sets the camera offset for scrolling effects.
      * The offset is applied to subsequent renderer draw calls.
      *
-     * @param offset - Camera position offset in pixels.
+     * @param offset – Camera position offset in pixels.
      */
     public setCameraOffset(offset: Vector2i): void {
         this.lastCameraOffset = offset.clone();
@@ -1410,9 +1410,9 @@ export class BTAPI {
      * Classic water/fire/plasma animation. Runs indefinitely until canceled
      * via {@link paletteClearEffects}.
      *
-     * @param start - First palette index in the cycling range (inclusive).
-     * @param end - Last palette index in the cycling range (inclusive).
-     * @param speed - Steps per second. Positive = forward, negative = backward.
+     * @param start – First palette index in the cycling range (inclusive).
+     * @param end – Last palette index in the cycling range (inclusive).
+     * @param speed – Steps per second. Positive = forward, negative = backward.
      */
     public paletteCycle(start: number, end: number, speed: number): void {
         if (!Number.isFinite(speed)) {
@@ -1431,9 +1431,9 @@ export class BTAPI {
      *
      * Snapshots the current palette at start. Auto-removes when complete.
      *
-     * @param target - Target palette to fade toward.
-     * @param durationMs - Fade duration in milliseconds.
-     * @param easing - Easing curve. Defaults to `'linear'`.
+     * @param target – Target palette to fade toward.
+     * @param durationMs – Fade duration in milliseconds.
+     * @param easing – Easing curve. Defaults to `'linear'`.
      */
     public paletteFade(target: Palette, durationMs: number, easing?: EasingFunction): void {
         const palette = this.getPalette();
@@ -1453,9 +1453,9 @@ export class BTAPI {
      * values, and offsets each entry's schedule by its luminance. With black at
      * one end that is a straight scaling of light. Auto-removes when complete.
      *
-     * @param target - Target palette to fade toward.
-     * @param durationMs - Fade duration in milliseconds.
-     * @param options - Highlight lead and easing curve.
+     * @param target – Target palette to fade toward.
+     * @param durationMs – Fade duration in milliseconds.
+     * @param options – Highlight lead and easing curve.
      */
     public paletteFadeExposure(target: Palette, durationMs: number, options?: ExposureFadeOptions): void {
         const palette = this.getPalette();
@@ -1471,11 +1471,11 @@ export class BTAPI {
     /**
      * Fades only a subset of palette indices toward a target over time.
      *
-     * @param start - First palette index to fade (inclusive).
-     * @param end - Last palette index to fade (inclusive).
-     * @param target - Target palette to fade toward.
-     * @param durationMs - Fade duration in milliseconds.
-     * @param easing - Easing curve. Defaults to `'linear'`.
+     * @param start – First palette index to fade (inclusive).
+     * @param end – Last palette index to fade (inclusive).
+     * @param target – Target palette to fade toward.
+     * @param durationMs – Fade duration in milliseconds.
+     * @param easing – Easing curve. Defaults to `'linear'`.
      */
     public paletteFadeRange(
         start: number,
@@ -1499,8 +1499,8 @@ export class BTAPI {
      *
      * Index 0 (transparent) is preserved. Auto-removes after duration.
      *
-     * @param color - Flash color applied to all non-zero entries.
-     * @param durationMs - How long the flash lasts in milliseconds.
+     * @param color – Flash color applied to all non-zero entries.
+     * @param durationMs – How long the flash lasts in milliseconds.
      */
     public paletteFlash(color: Color32, durationMs: number): void {
         if (!this.getPalette()) {
@@ -1516,8 +1516,8 @@ export class BTAPI {
      *
      * This is an immediate operation, not an animated effect.
      *
-     * @param indexA - First palette index.
-     * @param indexB - Second palette index.
+     * @param indexA – First palette index.
+     * @param indexB – Second palette index.
      */
     public paletteSwap(indexA: number, indexB: number): void {
         // getPalette(), so a swap during the splash edits the game's captured palette
@@ -1548,7 +1548,7 @@ export class BTAPI {
      * require `drawingBufferSize` in hardware settings. Effects run in
      * registration order within each tier.
      *
-     * @param effect - Effect instance to append.
+     * @param effect – Effect instance to append.
      * @throws Error if the renderer has not been initialized.
      */
     public effectAdd(effect: Effect): void {
@@ -1566,7 +1566,7 @@ export class BTAPI {
      * never added is a no-op. When the last effect is removed the renderer
      * reverts to drawing directly to the swap chain on the next frame.
      *
-     * @param effect - Effect instance to remove.
+     * @param effect – Effect instance to remove.
      * @throws Error if the renderer has not been initialized.
      */
     public effectRemove(effect: Effect): void {
@@ -1593,7 +1593,7 @@ export class BTAPI {
     /**
      * Reads and validates demo `configure()` output into resolved hardware settings.
      *
-     * @param demo - Demo implementing {@link IBTDemo}.
+     * @param demo – Demo implementing {@link IBTDemo}.
      * @returns `false` when hardware settings are invalid (bad dimensions, targetFPS, or audioVoices).
      */
     private loadHardwareSettings(demo: IBTDemo): boolean {
@@ -1681,7 +1681,7 @@ export class BTAPI {
     /**
      * Attaches pointer, keyboard, and gamepad input to the canvas.
      *
-     * @param canvas - Render target canvas.
+     * @param canvas – Render target canvas.
      */
     private attachInputSubsystems(canvas: HTMLCanvasElement): void {
         const hw = this.hwSettings;
@@ -1710,7 +1710,7 @@ export class BTAPI {
     /**
      * Attaches the audio context, bus graph, and unlock listeners to the canvas.
      *
-     * @param canvas - Render target canvas.
+     * @param canvas – Render target canvas.
      */
     private attachAudioSubsystem(canvas: HTMLCanvasElement): void {
         const hw = this.hwSettings;
@@ -1734,8 +1734,8 @@ export class BTAPI {
      * Logs the selected backend name, constructs the matching {@link IRenderer},
      * calls {@link IRenderer.init}, and reports success or failure.
      *
-     * @param canvas - Render target canvas.
-     * @param hw - Active hardware settings.
+     * @param canvas – Render target canvas.
+     * @param hw – Active hardware settings.
      * @returns `true` when the renderer is ready; `false` on failure.
      */
     private async initRenderer(canvas: HTMLCanvasElement, hw: HardwareSettings): Promise<boolean> {
@@ -1865,7 +1865,7 @@ export class BTAPI {
      * `false`, clears input and audio subsystems that were attached earlier in
      * the init sequence.
      *
-     * @param demo - Active demo instance.
+     * @param demo – Active demo instance.
      * @returns `true` when the demo reports success.
      */
     private async runDemoInit(demo: IBTDemo): Promise<boolean> {
@@ -1896,8 +1896,8 @@ export class BTAPI {
      * The {@link GameLoop} auto-calibrates its baseline to the actual rAF cadence,
      * so sustained slowness re-baselines instead of generating sustained log spam.
      *
-     * @param event - Dropped-frame event from {@link GameLoop}.
-     * @param logToConsole - When true, emits a one-line console warning.
+     * @param event – Dropped-frame event from {@link GameLoop}.
+     * @param logToConsole – When true, emits a one-line console warning.
      */
     private handleFrameDrop(event: FrameDropEvent, logToConsole: boolean): void {
         this.overlayTiming.droppedFrames = event.droppedFrames;
@@ -1913,7 +1913,7 @@ export class BTAPI {
     /**
      * Validates that a sprite sheet has been indexized and registers it for refresh tracking.
      *
-     * @param sheet - Sprite sheet to validate.
+     * @param sheet – Sprite sheet to validate.
      * @throws If the sprite sheet has not been indexized.
      */
     private requireIndexizedSheet(sheet: SpriteSheet): void {
@@ -1927,8 +1927,8 @@ export class BTAPI {
     /**
      * Validates that a duration is a finite, non-negative number.
      *
-     * @param method - Calling method name for the error message.
-     * @param durationMs - Duration to validate.
+     * @param method – Calling method name for the error message.
+     * @param durationMs – Duration to validate.
      * @throws Error if the duration is not finite or is negative.
      */
     private assertFiniteDuration(method: string, durationMs: number): void {
@@ -2025,7 +2025,7 @@ export class BTAPI {
     /**
      * Marks a palette index as used for the current frame.
      *
-     * @param index - Palette index to track.
+     * @param index – Palette index to track.
      */
     private trackPaletteIndexUsed(index: number): void {
         if (!this.isTrackingFramePaletteUsage() || !this.renderer) {
@@ -2038,9 +2038,9 @@ export class BTAPI {
     /**
      * Marks palette indices referenced by bitmap text glyphs in a string.
      *
-     * @param font - Bitmap font whose glyph atlas is scanned.
-     * @param text - Text about to be drawn.
-     * @param paletteOffset - Palette offset applied at draw time.
+     * @param font – Bitmap font whose glyph atlas is scanned.
+     * @param text – Text about to be drawn.
+     * @param paletteOffset – Palette offset applied at draw time.
      */
     private markBitmapTextPaletteUsage(font: BitmapFont, text: string, paletteOffset: number): void {
         if (!this.isTrackingFramePaletteUsage()) {
@@ -2065,7 +2065,7 @@ export class BTAPI {
      * The non-integer/negative check always runs regardless of palette state.
      * The range check only runs when a palette has been set.
      *
-     * @param index - Palette index to validate.
+     * @param index – Palette index to validate.
      * @throws Error if the index is not a non-negative integer.
      * @throws Error if a palette is active and the index is out of its range.
      */
@@ -2095,7 +2095,7 @@ export class BTAPI {
      * splash's ramp, and keeping it out is also what keeps the overlay free of
      * splash-state branching.
      *
-     * @param displaySize - Logical display size the splash centers its logo in.
+     * @param displaySize – Logical display size the splash centers its logo in.
      * @returns Promise resolving once the splash is done.
      */
     private async runSplash(displaySize: Vector2i): Promise<void> {
@@ -2154,8 +2154,8 @@ export class BTAPI {
     /**
      * Runs the game's `init()`, behind the splash when one is playing.
      *
-     * @param demo - Demo whose `init()` runs.
-     * @param hwSettings - Resolved hardware settings for this run.
+     * @param demo – Demo whose `init()` runs.
+     * @param hwSettings – Resolved hardware settings for this run.
      * @returns Whatever the demo's `init()` resolved to.
      */
     private async runDemoInitWithSplash(demo: IBTDemo, hwSettings: HardwareSettings): Promise<boolean> {
@@ -2174,9 +2174,9 @@ export class BTAPI {
      * The two run concurrently, so the splash doubles as a loading screen and
      * costs close to zero perceived time.
      *
-     * @param demo - Demo whose `init()` runs behind the splash.
-     * @param splash - The splash covering the screen.
-     * @param displaySize - Logical display size passed through to the splash.
+     * @param demo – Demo whose `init()` runs behind the splash.
+     * @param splash – The splash covering the screen.
+     * @param displaySize – Logical display size passed through to the splash.
      * @returns Whatever the demo's `init()` resolved to.
      */
     private async runDemoInitBehindSplash(demo: IBTDemo, splash: Splash, displaySize: Vector2i): Promise<boolean> {
@@ -2244,7 +2244,7 @@ export class BTAPI {
      * already-warned-about palette, and warning twice for one `BT.paletteSet()`
      * call would be noise.
      *
-     * @param palette - Palette to store as the active engine palette.
+     * @param palette – Palette to store as the active engine palette.
      */
     private installPalette(palette: Palette): void {
         // In-flight effects hold snapshots of the old palette. Drop them so they
@@ -2262,7 +2262,7 @@ export class BTAPI {
  * A module-level helper rather than a method so `init()` stays within its
  * complexity budget; it needs no instance state.
  *
- * @param hwSettings - Resolved hardware settings for this run.
+ * @param hwSettings – Resolved hardware settings for this run.
  * @returns A fresh splash, or `null` when gating turned it off.
  */
 function createSplashIfEnabled(hwSettings: HardwareSettings): Splash | null {

--- a/packages/blit386/src/core/GameLoop.test.ts
+++ b/packages/blit386/src/core/GameLoop.test.ts
@@ -160,7 +160,7 @@ describe('GameLoop', () => {
 
             p.isRunning = true;
             p.lastUpdateTime = 0;
-            p.tick(10000); // huge pause - MAX_STEPS clamp leaves 0 leftover
+            p.tick(10000); // huge pause – MAX_STEPS clamp leaves 0 leftover
 
             const alpha = loop.getRenderAlpha();
 
@@ -244,7 +244,7 @@ describe('GameLoop', () => {
             // Execute outer RAF callback.
             rafCallbacks[0]?.();
 
-            // Execute inner RAF callback - sets lastUpdateTime and schedules first tick.
+            // Execute inner RAF callback – sets lastUpdateTime and schedules first tick.
             rafCallbacks[1]?.();
 
             expect(p.lastUpdateTime).toBeGreaterThan(0);
@@ -300,7 +300,7 @@ describe('GameLoop', () => {
 
             p.isRunning = true;
             p.lastUpdateTime = 0;
-            p.tick(10000); // huge pause - MAX_STEPS = 8 caps at 8 updates
+            p.tick(10000); // huge pause – MAX_STEPS = 8 caps at 8 updates
 
             expect(onUpdate).toHaveBeenCalledTimes(8);
         });
@@ -420,7 +420,7 @@ describe('GameLoop', () => {
 
             const event = onFrameDrop.mock.calls[0]?.[0] as FrameDropEvent;
 
-            expect(event.droppedFrames).toBe(2); // round(50 / 16.67) - 1 = 2
+            expect(event.droppedFrames).toBe(2); // round(50 / 16.67) – 1 = 2
             expect(event.deltaTime).toBe(50);
             expect(event.expectedInterval).toBeCloseTo(16.67);
         });
@@ -434,7 +434,7 @@ describe('GameLoop', () => {
 
             p.isRunning = true;
             p.lastUpdateTime = 0;
-            p.tick(16); // 1.6x baseline - between 1 and 2 in raw frame terms
+            p.tick(16); // 1.6x baseline – between 1 and 2 in raw frame terms
 
             expect(onFrameDrop).toHaveBeenCalledOnce();
 

--- a/packages/blit386/src/core/GameLoop.ts
+++ b/packages/blit386/src/core/GameLoop.ts
@@ -32,7 +32,7 @@ export interface FrameDropEvent {
  * Called from inside the rAF handler on the same frame the drop is detected.
  * Keep the callback cheap; coalescing/rate-limiting is the caller's responsibility.
  *
- * @param event - Details of the detected drop.
+ * @param event – Details of the detected drop.
  */
 export type FrameDropCallback = (event: FrameDropEvent) => void;
 
@@ -84,7 +84,7 @@ export class GameLoop {
      * clean 16.667 ms. Left uncorrected, that rounding noise walks the accumulator's
      * phase back and forth across a step boundary, producing a deterministic
      * "extra step, then a stalled frame" beat (for example 2, 0, 1, 2, 0, 1, ...)
-     * instead of a steady one-step-per-frame cadence - visible as camera/scroll
+     * instead of a steady one-step-per-frame cadence – visible as camera/scroll
      * jitter even though the true average frame rate matches the target exactly.
      * 2 ms comfortably covers that rounding noise while staying far below
      * {@link DROP_THRESHOLD_MULTIPLIER}'s much larger gap, so a genuine dropped frame
@@ -143,10 +143,10 @@ export class GameLoop {
     /**
      * Creates a new GameLoop.
      *
-     * @param updateInterval - Milliseconds between fixed update steps (1000 / targetFPS).
-     * @param onUpdate - Called once per fixed update step at the target rate.
-     * @param onRender - Called once per rendered frame at the browser's refresh rate.
-     * @param onFrameDrop - Optional callback invoked when a dropped frame is detected.
+     * @param updateInterval – Milliseconds between fixed update steps (1000 / targetFPS).
+     * @param onUpdate – Called once per fixed update step at the target rate.
+     * @param onRender – Called once per rendered frame at the browser's refresh rate.
+     * @param onFrameDrop – Optional callback invoked when a dropped frame is detected.
      * @throws {Error} If updateInterval is not a finite positive number.
      */
     constructor(updateInterval: number, onUpdate: () => void, onRender: () => void, onFrameDrop?: FrameDropCallback) {
@@ -223,7 +223,7 @@ export class GameLoop {
      * Advances the accumulator, runs zero or more fixed updates, renders once,
      * and schedules the next frame while the loop remains active.
      *
-     * @param currentTime - High-resolution timestamp provided by rAF, in milliseconds.
+     * @param currentTime – High-resolution timestamp provided by rAF, in milliseconds.
      */
     private tick(currentTime: number): void {
         if (!this.isRunning) {
@@ -267,7 +267,7 @@ export class GameLoop {
      * Corrects rAF timer coarsening by snapping a delta that already lands close to an
      * exact multiple of {@link updateInterval} onto that multiple.
      *
-     * @param deltaTime - Raw milliseconds between the current and previous rAF callback.
+     * @param deltaTime – Raw milliseconds between the current and previous rAF callback.
      * @returns `deltaTime`, or the nearest update-interval multiple when within {@link SNAP_EPSILON_MS} of it.
      */
     private snapDeltaTime(deltaTime: number): number {
@@ -293,7 +293,7 @@ export class GameLoop {
      * Background-pause gaps are also excluded from the rolling sample set so
      * they cannot pollute the baseline.
      *
-     * @param deltaTime - Milliseconds elapsed since the previous tick.
+     * @param deltaTime – Milliseconds elapsed since the previous tick.
      */
     private detectFrameDrop(deltaTime: number): void {
         if (!this.onFrameDrop) {

--- a/packages/blit386/src/core/IBTDemo.ts
+++ b/packages/blit386/src/core/IBTDemo.ts
@@ -146,8 +146,8 @@ export interface HardwareSettings {
      * stutters during development. Defaults to `false`.
      *
      * Detection runs in `GameLoop.detectFrameDrop()` and uses an
-     * auto-calibrated baseline - the shortest `requestAnimationFrame` delta
-     * observed in a rolling window of recent frames - rather than a fixed
+     * auto-calibrated baseline – the shortest `requestAnimationFrame` delta
+     * observed in a rolling window of recent frames – rather than a fixed
      * `1.5 / targetFPS` threshold. A frame is reported as dropped when its
      * rAF delta exceeds 1.5x that baseline, which makes detection work on
      * any display refresh rate (60 / 120 / 144 Hz, etc.) and on browsers
@@ -409,7 +409,7 @@ export interface HardwareSettings {
      * When `true`, the engine draws a per-bus level meter band (main/music/sfx bars plus a
      * voices used/total, steal, and drop text readout) in the overlay. Defaults to `false` in
      * {@link defaultConfig}. Enabling this also lazily creates the `AnalyserNode`s backing the
-     * bus level readings ({@link AudioManager.enableBusMetering}) - no metering cost is paid
+     * bus level readings ({@link AudioManager.enableBusMetering}) – no metering cost is paid
      * unless this flag is `true`.
      *
      * @since 1.3.0
@@ -540,11 +540,11 @@ export interface OverlayRow {
  * Demo contract implemented by BLIT386 applications.
  *
  * Engine lifecycle order:
- * 1. configure() - Optional; called first to set display size, output buffer, FPS, overlay
- * 2. init() - Called after renderer setup, load assets here
- * 3. update() - Fixed timestep via accumulator (may run 0..N times per frame)
- * 4. render() - Called once per requestAnimationFrame (browser refresh rate)
- * 5. (engine) overlay - When {@link HardwareSettings.isOverlayEnabled} is true, drawn after `render()` on top
+ * 1. configure() – Optional; called first to set display size, output buffer, FPS, overlay
+ * 2. init() – Called after renderer setup, load assets here
+ * 3. update() – Fixed timestep via accumulator (may run 0..N times per frame)
+ * 4. render() – Called once per requestAnimationFrame (browser refresh rate)
+ * 5. (engine) overlay – When {@link HardwareSettings.isOverlayEnabled} is true, drawn after `render()` on top
  *
  * @since 0.1.0
  * @changed 1.3.1 Added optional {@link IBTDemo.onOrientationChange} hook.
@@ -634,7 +634,7 @@ export interface IBTDemo {
      * {@link BT.screenOrientation}.
      *
      * @since 1.3.1
-     * @param type - Current `screen.orientation.type` (for example
+     * @param type – Current `screen.orientation.type` (for example
      *   `'landscape-primary'` or `'portrait-secondary'`).
      */
     onOrientationChange?(type: string): void;
@@ -652,7 +652,7 @@ export interface IBTDemo {
      * this hook is only ever called during local development.
      *
      * @since 1.4.0
-     * @param context - Which tier ran, the new generation number, and (for
+     * @param context – Which tier ran, the new generation number, and (for
      *   `'reinit'`) a field snapshot of the previous instance.
      */
     onHotReload?(context: HotReloadContext): void;
@@ -695,7 +695,7 @@ export function defaultConfig(): HardwareSettings {
 /**
  * Clones a {@link Vector2i} so merged settings do not share mutable references.
  *
- * @param size - Source vector.
+ * @param size – Source vector.
  * @returns Fresh vector with the same components.
  */
 function cloneVector2i(size: Vector2i): Vector2i {
@@ -710,7 +710,7 @@ const INVALID_CONFIGURE_VECTOR_SIZE = new Vector2i(0, 0);
  *
  * Explicit `null` is detected from the original `partial` field during merge, not from `picked`.
  *
- * @param value - Field from demo `configure()`.
+ * @param value – Field from demo `configure()`.
  * @returns Cloned vector when valid, otherwise `undefined`.
  */
 function pickConfigureVector(value: Vector2i | undefined | null): Vector2i | undefined {
@@ -725,7 +725,7 @@ function pickConfigureVector(value: Vector2i | undefined | null): Vector2i | und
  * Clones a caller-supplied configure color so merged settings do not share a
  * mutable reference with the demo's `configure()` return value.
  *
- * @param value - Raw color from `configure()`, possibly undefined.
+ * @param value – Raw color from `configure()`, possibly undefined.
  * @returns Cloned color, or undefined when none was supplied.
  */
 function pickConfigureColor(value: Color32 | undefined): Color32 | undefined {
@@ -738,9 +738,9 @@ function pickConfigureColor(value: Color32 | undefined): Color32 | undefined {
  * Uses defaults only when the field was omitted (`undefined`). Explicit `null` maps to
  * {@link INVALID_CONFIGURE_VECTOR_SIZE} so {@link validateDimensions} can reject it.
  *
- * @param partialDisplaySize - Raw `configure()` value.
- * @param pickedDisplaySize - Cloned value from {@link pickDefinedHardwareSettings}, if any.
- * @param fallback - Baseline display size from {@link defaultConfig}.
+ * @param partialDisplaySize – Raw `configure()` value.
+ * @param pickedDisplaySize – Cloned value from {@link pickDefinedHardwareSettings}, if any.
+ * @param fallback – Baseline display size from {@link defaultConfig}.
  * @returns Resolved display size (never `null`).
  */
 function resolveExplicitDisplaySize(
@@ -762,8 +762,8 @@ function resolveExplicitDisplaySize(
 /**
  * Resolves an optional vector for the explicit display profile.
  *
- * @param partialValue - Raw `configure()` value.
- * @param picked - Cloned value from {@link pickDefinedHardwareSettings}, if any.
+ * @param partialValue – Raw `configure()` value.
+ * @param picked – Cloned value from {@link pickDefinedHardwareSettings}, if any.
  * @returns Cloned vector, {@link INVALID_CONFIGURE_VECTOR_SIZE} when `partialValue` is `null`, or `undefined` when omitted.
  */
 function resolveExplicitOptionalVector(
@@ -780,9 +780,9 @@ function resolveExplicitOptionalVector(
 /**
  * Copies a defined scalar or object field from `partial` into `picked`.
  *
- * @param picked - Output partial settings.
- * @param partial - Values returned by the demo's `configure()` hook.
- * @param key - Hardware settings field to copy when defined.
+ * @param picked – Output partial settings.
+ * @param partial – Values returned by the demo's `configure()` hook.
+ * @param key – Hardware settings field to copy when defined.
  */
 function pickIfDefinedPartial<K extends keyof HardwareSettings>(
     picked: Partial<HardwareSettings>,
@@ -799,8 +799,8 @@ function pickIfDefinedPartial<K extends keyof HardwareSettings>(
 /**
  * Copies defined overlay fields from `partial` into `picked`.
  *
- * @param picked - Output partial settings.
- * @param partial - Values returned by the demo's `configure()` hook.
+ * @param picked – Output partial settings.
+ * @param partial – Values returned by the demo's `configure()` hook.
  */
 function pickDefinedOverlaySettings(picked: Partial<HardwareSettings>, partial: Partial<HardwareSettings>): void {
     pickIfDefinedPartial(picked, partial, 'isOverlayEnabled');
@@ -834,7 +834,7 @@ function pickDefinedOverlaySettings(picked: Partial<HardwareSettings>, partial: 
 /**
  * Copies only defined fields from a partial configure() return value.
  *
- * @param partial - Values returned by the demo's `configure()` hook.
+ * @param partial – Values returned by the demo's `configure()` hook.
  * @returns Partial settings containing only defined entries, with vectors cloned.
  */
 function pickDefinedHardwareSettings(partial: Partial<HardwareSettings>): Partial<HardwareSettings> {
@@ -898,7 +898,7 @@ const DEPRECATED_BOOLEAN_ALIASES = [
  *
  * New names always win when both are provided in the same object.
  *
- * @param partial - Raw values returned by configure().
+ * @param partial – Raw values returned by configure().
  * @returns Partial settings with legacy keys mapped to current keys.
  */
 function normalizeDeprecatedHardwareSettings(partial: Partial<HardwareSettings>): Partial<HardwareSettings> {
@@ -920,9 +920,9 @@ function normalizeDeprecatedHardwareSettings(partial: Partial<HardwareSettings>)
 /**
  * Resolves an optional vector from picked configure values or defaults.
  *
- * @param partialValue - Raw value from `configure()` for this optional vector field.
- * @param picked - Value from `configure()`, if any.
- * @param fallback - Default vector when picked is omitted.
+ * @param partialValue – Raw value from `configure()` for this optional vector field.
+ * @param picked – Value from `configure()`, if any.
+ * @param fallback – Default vector when picked is omitted.
  * @returns Cloned vector or `undefined` when neither side provides a size.
  */
 function resolveMergedOptionalVector(
@@ -944,9 +944,9 @@ function resolveMergedOptionalVector(
 /**
  * Sets `target[key]` when `value` is defined.
  *
- * @param target - Partial settings object being built.
- * @param key - Hardware settings field to assign.
- * @param value - Resolved value, or `undefined` to skip.
+ * @param target – Partial settings object being built.
+ * @param key – Hardware settings field to assign.
+ * @param value – Resolved value, or `undefined` to skip.
  */
 function assignIfDefined<K extends keyof HardwareSettings>(
     target: Partial<HardwareSettings>,
@@ -962,7 +962,7 @@ function assignIfDefined<K extends keyof HardwareSettings>(
 /**
  * Shallow-clones an object-shaped optional before assignment.
  *
- * @param value - Optional record from configure or defaults.
+ * @param value – Optional record from configure or defaults.
  * @returns Cloned record, or `undefined` when input is omitted.
  */
 function shallowCloneOptional<T extends object>(value: T | undefined): T | undefined {
@@ -972,11 +972,11 @@ function shallowCloneOptional<T extends object>(value: T | undefined): T | undef
 /**
  * Merged optional vectors for the full-default configure path.
  *
- * @param optionals - Partial {@link HardwareSettings} object being built; optional
+ * @param optionals – Partial {@link HardwareSettings} object being built; optional
  *   vector fields are written here via {@link assignIfDefined} when resolved.
- * @param partial - Raw `configure()` return value being merged.
- * @param picked - Defined fields from `configure()`.
- * @param defaults - Baseline hardware settings.
+ * @param partial – Raw `configure()` return value being merged.
+ * @param picked – Defined fields from `configure()`.
+ * @param defaults – Baseline hardware settings.
  */
 function assignFullDefaultMergeVectors(
     optionals: Partial<HardwareSettings>,
@@ -1000,9 +1000,9 @@ function assignFullDefaultMergeVectors(
 /**
  * Merged optional scalars and overlay records for the full-default configure path.
  *
- * @param optionals - Partial settings object being built.
- * @param picked - Defined fields from `configure()`.
- * @param defaults - Baseline hardware settings.
+ * @param optionals – Partial settings object being built.
+ * @param picked – Defined fields from `configure()`.
+ * @param defaults – Baseline hardware settings.
  */
 // eslint-disable-next-line complexity -- flat fan-out of one assignIfDefined per field, not branching
 function assignFullDefaultMergeScalars(
@@ -1102,9 +1102,9 @@ function assignFullDefaultMergeScalars(
 /**
  * Merged optional audio meter fields for the full-default configure path.
  *
- * @param optionals - Partial settings object being built.
- * @param picked - Defined fields from `configure()`.
- * @param defaults - Baseline hardware settings.
+ * @param optionals – Partial settings object being built.
+ * @param picked – Defined fields from `configure()`.
+ * @param defaults – Baseline hardware settings.
  */
 function assignFullDefaultMergeAudioMeterScalars(
     optionals: Partial<HardwareSettings>,
@@ -1133,9 +1133,9 @@ function assignFullDefaultMergeAudioMeterScalars(
 /**
  * Collects optional hardware fields for the full-default merge path.
  *
- * @param partial - Raw `configure()` return value being merged.
- * @param picked - Defined fields from `configure()`.
- * @param defaults - Baseline hardware settings.
+ * @param partial – Raw `configure()` return value being merged.
+ * @param picked – Defined fields from `configure()`.
+ * @param defaults – Baseline hardware settings.
  * @returns Partial settings to spread into the resolved profile.
  */
 function buildFullDefaultMergeOptionals(
@@ -1152,8 +1152,8 @@ function buildFullDefaultMergeOptionals(
 /**
  * Optional fields explicitly set in `configure()` when the demo provided `displaySize`.
  *
- * @param partial - Raw `configure()` return value with explicit `displaySize`.
- * @param picked - Defined fields with vectors cloned.
+ * @param partial – Raw `configure()` return value with explicit `displaySize`.
+ * @param picked – Defined fields with vectors cloned.
  * @returns Partial settings to spread into the resolved profile.
  */
 function buildExplicitDisplayOptionals(
@@ -1200,9 +1200,9 @@ function buildExplicitDisplayOptionals(
  * Merges partial settings with {@link defaultConfig} when the demo did not set
  * `displaySize` (for example only `{ targetFPS: 30 }`).
  *
- * @param partial - Raw `configure()` return value being merged.
- * @param picked - Defined fields from `configure()`.
- * @param defaults - Baseline hardware settings.
+ * @param partial – Raw `configure()` return value being merged.
+ * @param picked – Defined fields from `configure()`.
+ * @param defaults – Baseline hardware settings.
  * @returns Resolved settings with full default resolution and output buffer.
  */
 function mergePartialWithFullDefaults(
@@ -1225,9 +1225,9 @@ function mergePartialWithFullDefaults(
 /**
  * Applies only fields present in `configure()` when the demo set `displaySize`.
  *
- * @param partial - Raw `configure()` return value with explicit `displaySize`.
- * @param picked - Defined fields with vectors cloned.
- * @param defaults - Baseline hardware settings for required fallbacks.
+ * @param partial – Raw `configure()` return value with explicit `displaySize`.
+ * @param picked – Defined fields with vectors cloned.
+ * @param defaults – Baseline hardware settings for required fallbacks.
  * @returns Resolved settings; omitted optionals such as `drawingBufferSize` stay unset.
  * `backend` always inherits from {@link defaultConfig} when omitted from `configure()`.
  */
@@ -1259,7 +1259,7 @@ function mergeExplicitDisplayProfile(
  * can match logical resolution. `isOverlayEnabled` defaults to `true` when omitted.
  *
  * @since 1.0.5
- * @param partial - Optional partial settings from `configure()`.
+ * @param partial – Optional partial settings from `configure()`.
  * @returns Resolved hardware settings for initialization.
  */
 export function mergeHardwareSettings(partial?: Partial<HardwareSettings>): HardwareSettings {
@@ -1287,7 +1287,7 @@ export type OverlayTimingChartDiagnosticsMode = false | 'minimal' | 'rich';
  *
  * Defaults to `'minimal'` when the timing chart is enabled and the field is omitted; `false` otherwise.
  *
- * @param settings - Resolved hardware settings.
+ * @param settings – Resolved hardware settings.
  * @returns Chart diagnostic visualization mode.
  */
 export function resolveOverlayTimingChartDiagnostics(settings: HardwareSettings): OverlayTimingChartDiagnosticsMode {
@@ -1301,7 +1301,7 @@ export function resolveOverlayTimingChartDiagnostics(settings: HardwareSettings)
 /**
  * Whether BTAPI should collect WebGPU renderer diagnostic counters this frame.
  *
- * @param settings - Resolved hardware settings.
+ * @param settings – Resolved hardware settings.
  * @returns `true` when chart diagnostics or the renderer diagnostics bar needs data.
  */
 export function needsOverlayRendererDiagnostics(settings: HardwareSettings): boolean {

--- a/packages/blit386/src/core/Orientation.ts
+++ b/packages/blit386/src/core/Orientation.ts
@@ -107,7 +107,7 @@ export class Orientation {
     /**
      * Calls `orientation.unlock()` and ignores failures.
      *
-     * @param orientation - Platform orientation object to unlock.
+     * @param orientation – Platform orientation object to unlock.
      */
     private static unlockQuietly(orientation: ScreenOrientation): void {
         try {
@@ -121,11 +121,11 @@ export class Orientation {
      * Installs the orientation `change` listener and optionally requests a lock.
      *
      * No-ops when the Screen Orientation API is unavailable. The lock request is
-     * fire-and-forget - a rejection is swallowed and never throws, so callers
+     * fire-and-forget – a rejection is swallowed and never throws, so callers
      * never need to await or catch this.
      *
-     * @param preferred - Preferred lock target; `'any'` skips the lock attempt.
-     * @param onChange - Optional demo callback for subsequent orientation changes.
+     * @param preferred – Preferred lock target; `'any'` skips the lock attempt.
+     * @param onChange – Optional demo callback for subsequent orientation changes.
      */
     public attach(preferred: PreferredOrientation, onChange: ChangeHandler | null): void {
         if (!Orientation.isSupported()) {
@@ -155,7 +155,7 @@ export class Orientation {
      * without this, orientation events would keep reaching the *previous* demo's bound
      * handler after the swap.
      *
-     * @param onChange - Replacement demo callback, or `null` to stop forwarding events.
+     * @param onChange – Replacement demo callback, or `null` to stop forwarding events.
      */
     public setOnChange(onChange: ChangeHandler | null): void {
         this.onChange = onChange;
@@ -197,7 +197,7 @@ export class Orientation {
      * lock, and never recorded as {@link held} for the new attachment.
      *
      * @param preferred - `'landscape'` or `'portrait'` lock target.
-     * @param generation - Attach generation captured when this request started.
+     * @param generation – Attach generation captured when this request started.
      */
     private async lock(preferred: Exclude<PreferredOrientation, 'any'>, generation: number): Promise<void> {
         const orientation = globalThis.screen.orientation as LockableOrientation;
@@ -212,7 +212,7 @@ export class Orientation {
 
             if (generation !== this.generation || !this.attached) {
                 // Stale relative to the current attach/detach cycle. Unlock only when
-                // a newer attach has not already recorded a held lock - unlocking
+                // a newer attach has not already recorded a held lock – unlocking
                 // while held would release that newer lock (unlock is process-wide).
                 if (!this.held) {
                     Orientation.unlockQuietly(orientation);

--- a/packages/blit386/src/core/RenderPaletteUsage.ts
+++ b/packages/blit386/src/core/RenderPaletteUsage.ts
@@ -11,7 +11,7 @@ export const USAGE_CAPACITY = 256;
 /**
  * Clears a palette usage bitmask.
  *
- * @param usedMask - Mutable usage mask cleared in place.
+ * @param usedMask – Mutable usage mask cleared in place.
  */
 export function resetUsage(usedMask: Uint8Array): void {
     usedMask.fill(0);
@@ -22,8 +22,8 @@ export function resetUsage(usedMask: Uint8Array): void {
  *
  * Index `0` (transparent) is ignored.
  *
- * @param usedMask - Mutable usage mask.
- * @param index - Palette index referenced by a draw call.
+ * @param usedMask – Mutable usage mask.
+ * @param index – Palette index referenced by a draw call.
  */
 export function markIndexUsed(usedMask: Uint8Array, index: number): void {
     if (!Number.isInteger(index) || index <= 0 || index >= usedMask.length) {
@@ -37,9 +37,9 @@ export function markIndexUsed(usedMask: Uint8Array, index: number): void {
 /**
  * Collects sorted used palette indices into a reusable scratch array.
  *
- * @param usedMask - Usage mask populated during the current frame.
- * @param paletteSize - Active palette size upper bound.
- * @param scratch - Reusable output buffer mutated in place.
+ * @param usedMask – Usage mask populated during the current frame.
+ * @param paletteSize – Active palette size upper bound.
+ * @param scratch – Reusable output buffer mutated in place.
  * @returns The same scratch array containing sorted used indices.
  */
 export function collectUsedIndices(usedMask: Uint8Array, paletteSize: number, scratch: number[]): readonly number[] {

--- a/packages/blit386/src/core/WakeLock.ts
+++ b/packages/blit386/src/core/WakeLock.ts
@@ -2,7 +2,7 @@
  * Screen Wake Lock subsystem.
  *
  * Requests a `navigator.wakeLock` screen lock after {@link WakeLock.attach} and keeps
- * it alive across page visibility changes - the platform releases the sentinel
+ * it alive across page visibility changes – the platform releases the sentinel
  * automatically while the page is hidden, so a `visibilitychange` listener
  * re-requests it once the page is visible again. Silently no-ops on browsers that
  * do not expose the Wake Lock API.
@@ -46,7 +46,7 @@ export class WakeLock {
      * Installs the `visibilitychange` listener and requests the initial lock.
      *
      * No-ops when the Wake Lock API is unavailable. The request itself is
-     * fire-and-forget - a failed acquire logs a warning but never throws, so
+     * fire-and-forget – a failed acquire logs a warning but never throws, so
      * callers never need to await or catch this.
      */
     public attach(): void {
@@ -108,7 +108,7 @@ export class WakeLock {
      * Guarded by {@link isRequesting} so overlapping calls (for example a rapid
      * hide/show toggle while a previous request is still pending) never race.
      * Logs a warning and leaves {@link sentinel} null on failure (for example a
-     * low-battery OS override) - never throws, so a failed acquire never fails
+     * low-battery OS override) – never throws, so a failed acquire never fails
      * `BTAPI.init()`. If {@link detach} runs before this request resolves, the
      * newly-acquired sentinel is released immediately instead of being stored,
      * so no lock is left orphaned with no owner able to release it.

--- a/packages/blit386/src/core/WebGPUContext.test.ts
+++ b/packages/blit386/src/core/WebGPUContext.test.ts
@@ -41,7 +41,7 @@ describe('initWebGPU', () => {
     });
 
     it('should return null when navigator.gpu is absent', async () => {
-        // Use Object.defineProperty to install a navigator without .gpu - direct
+        // Use Object.defineProperty to install a navigator without .gpu – direct
         // property deletion throws in Node.js when navigator is null/non-writable.
         Object.defineProperty(globalThis, 'navigator', {
             value: { userAgent: 'test' },

--- a/packages/blit386/src/core/WebGPUContext.ts
+++ b/packages/blit386/src/core/WebGPUContext.ts
@@ -28,9 +28,9 @@ export interface Result {
  * When `configuredDrawingBufferSize` is omitted, the drawing buffer matches
  * `displaySize` (no upscaling, no display-tier effects).
  *
- * @param canvas - HTML canvas element to configure for WebGPU rendering.
- * @param displaySize - Internal render resolution in pixels (`HardwareSettings.displaySize`).
- * @param configuredDrawingBufferSize - Optional drawing-buffer size from `configure()`
+ * @param canvas – HTML canvas element to configure for WebGPU rendering.
+ * @param displaySize – Internal render resolution in pixels (`HardwareSettings.displaySize`).
+ * @param configuredDrawingBufferSize – Optional drawing-buffer size from `configure()`
  *        (`HardwareSettings.drawingBufferSize`); when set, may exceed `displaySize` for
  *        display-tier post-processing (CRT scanlines, barrel distortion, etc.).
  * @returns Initialized device, context, and drawing-buffer size, or null when WebGPU

--- a/packages/blit386/src/hot/HotRuntime.test.ts
+++ b/packages/blit386/src/hot/HotRuntime.test.ts
@@ -35,11 +35,11 @@ function registerAndCaptureAssetHandler(
 }
 
 describe('HotRuntime', () => {
-    // Fresh module state per test - hot/generation/wired are module-scoped singletons
+    // Fresh module state per test – hot/generation/wired are module-scoped singletons
     // that mirror real page-load semantics (a fresh page load is a fresh module instance).
     // BTAPI is re-imported through the SAME vi.resetModules() epoch as HotRuntime so
     // `BTAPI.instance` in the test is the identical singleton HotRuntime's internal
-    // `import { BTAPI } from '../core/BTAPI'` resolves to - spying on the test's copy
+    // `import { BTAPI } from '../core/BTAPI'` resolves to – spying on the test's copy
     // then actually intercepts the call HotRuntime.announce() makes.
     // eslint-disable-next-line @typescript-eslint/consistent-type-imports
     let HotRuntime: typeof import('./HotRuntime');
@@ -252,7 +252,7 @@ describe('HotRuntime', () => {
             const handler = registerAndCaptureAssetHandler(HotRuntime);
             handler({ url: 'hero.png', type: 'image', timestamp: 1 });
 
-            // The fetch is still pending here - beginHotReplace already ran, hotReplaceImage/failHotReplace have not.
+            // The fetch is still pending here – beginHotReplace already ran, hotReplaceImage/failHotReplace have not.
             expect(fakeSheet.beginHotReplace).toHaveBeenCalledOnce();
             expect(fakeSheet.hotReplaceImage).not.toHaveBeenCalled();
             expect(fakeSheet.failHotReplace).not.toHaveBeenCalled();
@@ -284,7 +284,7 @@ describe('HotRuntime', () => {
             const handler = registerAndCaptureAssetHandler(HotRuntime);
             handler({ url: 'hero.png', type: 'image', timestamp: 1 });
 
-            // The fetch is still pending here - beginHotReplace already ran, failHotReplace has not (yet).
+            // The fetch is still pending here – beginHotReplace already ran, failHotReplace has not (yet).
             expect(fakeSheet.beginHotReplace).toHaveBeenCalledOnce();
             expect(fakeSheet.failHotReplace).not.toHaveBeenCalled();
             expect(fakeSheet.hotReplaceImage).not.toHaveBeenCalled();
@@ -328,7 +328,7 @@ describe('HotRuntime', () => {
         });
 
         it('requests a hard reload for an unrecognized asset type', () => {
-            // Capture the handler first, before anything has wired the listener - registerHotContext
+            // Capture the handler first, before anything has wired the listener – registerHotContext
             // only calls context.on(...) once per module instance (guarded by the internal `wired`
             // flag), so a second registerHotContext call updates which context requestHardReload
             // targets without re-registering the listener.

--- a/packages/blit386/src/hot/HotRuntime.ts
+++ b/packages/blit386/src/hot/HotRuntime.ts
@@ -54,7 +54,7 @@ const KNOWN_ASSET_TYPES = new Set(['image', 'audio', 'font', 'other']);
 /**
  * Narrows an unknown HMR event payload to {@link AssetChangedPayload}.
  *
- * @param payload - Raw payload received from the Vite plugin's custom HMR event.
+ * @param payload – Raw payload received from the Vite plugin's custom HMR event.
  * @returns `true` when the payload has the expected shape.
  */
 function isAssetChangedPayload(payload: unknown): payload is AssetChangedPayload {
@@ -81,7 +81,7 @@ function isAssetChangedPayload(payload: unknown): payload is AssetChangedPayload
  * failed (the fetch itself threw) or handed to `hotReplaceImage` (the fetch
  * resolved), so `SpriteSheet.status`/`progress` track the replacement in flight.
  *
- * @param url - Changed image URL, matching whatever the engine cached it under.
+ * @param url – Changed image URL, matching whatever the engine cached it under.
  */
 async function hotReloadImageAsset(url: string): Promise<void> {
     const sheets = getHotReloadSheets(url);
@@ -123,7 +123,7 @@ async function hotReloadImageAsset(url: string): Promise<void> {
  *
  * No-ops when no font is registered under `url` - a benign miss, not an error.
  *
- * @param url - Changed `.btfont` URL, matching whatever the font was loaded from.
+ * @param url – Changed `.btfont` URL, matching whatever the font was loaded from.
  */
 async function hotReloadFontAsset(url: string): Promise<void> {
     const fonts = getHotReloadFonts(url);
@@ -143,10 +143,10 @@ async function hotReloadFontAsset(url: string): Promise<void> {
  *
  * Routes by `payload.type`: `AssetLoader`/`SpriteSheet` for `'image'`, `AudioClip`
  * for `'audio'`, the `BitmapFont` registry for `'font'`, and {@link requestHardReload}
- * for anything else (belt-and-suspenders - the plugin already full-reloads
+ * for anything else (belt-and-suspenders – the plugin already full-reloads
  * unrecognized asset extensions itself).
  *
- * @param payload - Asset-changed event payload from the Vite plugin.
+ * @param payload – Asset-changed event payload from the Vite plugin.
  */
 async function routeAssetChanged(payload: unknown): Promise<void> {
     if (!isAssetChangedPayload(payload)) {
@@ -181,10 +181,10 @@ async function routeAssetChanged(payload: unknown): Promise<void> {
 /**
  * Routes a `blit386:asset-changed` payload to the right hot-replace handler by
  * asset kind. Wrapped entirely in try/catch (inside {@link routeAssetChanged}) so a
- * broken or unexpected asset event can never crash the game loop - on failure this
+ * broken or unexpected asset event can never crash the game loop – on failure this
  * logs and leaves the currently running state intact.
  *
- * @param payload - Asset-changed event payload from the Vite plugin.
+ * @param payload – Asset-changed event payload from the Vite plugin.
  */
 function handleAssetChanged(payload: unknown): void {
     void routeAssetChanged(payload);
@@ -199,7 +199,7 @@ function handleAssetChanged(payload: unknown): void {
  * injects), so a throw here (for example from an incompatible or broken `hot`
  * object) must not abort loading the game.
  *
- * @param context - Vite's `import.meta.hot` context.
+ * @param context – Vite's `import.meta.hot` context.
  */
 export function registerHotContext(context: HotContext): void {
     try {
@@ -230,11 +230,11 @@ export function registerHotContext(context: HotContext): void {
  * }
  * ```
  *
- * Never called by hand - it does nothing useful without the plugin's matching
+ * Never called by hand – it does nothing useful without the plugin's matching
  * asset watcher and snippet injection.
  *
  * @since 1.4.0
- * @param hot - Vite's `import.meta.hot` context (or a structurally compatible object).
+ * @param hot – Vite's `import.meta.hot` context (or a structurally compatible object).
  */
 export function registerHotReload(hot: HotContext): void {
     registerHotContext(hot);
@@ -268,7 +268,7 @@ export function nextGeneration(): number {
  * Requests a full page reload through Vite's invalidation API, falling back to
  * a direct reload when no HMR context is registered.
  *
- * @param reason - Human-readable reason surfaced in Vite's overlay/log.
+ * @param reason – Human-readable reason surfaced in Vite's overlay/log.
  */
 export function requestHardReload(reason: string): void {
     if (hot) {
@@ -286,9 +286,9 @@ export function requestHardReload(reason: string): void {
  * Dispatches on the engine canvas so games can add a listener scoped to their
  * own canvas element; falls back to `window` before the canvas exists.
  *
- * @param reason - Which swap tier ran (`'methods'` mutated the prototype in place; `'reinit'` re-ran `init()`).
- * @param generationValue - Generation number after this swap.
- * @param elapsedMs - Wall-clock duration of the swap, for the console line.
+ * @param reason – Which swap tier ran (`'methods'` mutated the prototype in place; `'reinit'` re-ran `init()`).
+ * @param generationValue – Generation number after this swap.
+ * @param elapsedMs – Wall-clock duration of the swap, for the console line.
  */
 export function announce(reason: 'methods' | 'reinit', generationValue: number, elapsedMs: number): void {
     console.log(`[BT] Hot reload #${generationValue} (${reason}) in ${elapsedMs.toFixed(1)}ms`);

--- a/packages/blit386/src/hot/HotSwap.test.ts
+++ b/packages/blit386/src/hot/HotSwap.test.ts
@@ -97,7 +97,7 @@ describe('initFingerprint', () => {
     // exercised here, though: Vitest's esbuild-based TS transform re-serializes the parsed AST
     // rather than preserving literal source text, and this repo's Biome formatter would also
     // collapse any such whitespace-only edit on the next `pnpm run format` pass regardless.
-    // Verified empirically (blank lines, extra inter-token spacing) - both are normalized away
+    // Verified empirically (blank lines, extra inter-token spacing) – both are normalized away
     // before Function.prototype.toString() ever sees them in this environment. This test
     // documents that behavior directly instead of asserting the untestable production claim.
     it('is unaffected by a whitespace-only edit inside init() under this test transform', () => {
@@ -284,7 +284,7 @@ describe('hotSwapDemo', () => {
         // no palette is set, and a real tick would throw after this test already returned.
         vi.stubGlobal('requestAnimationFrame', vi.fn());
 
-        // configure() never mentions backend - mergeHardwareSettings() alone would default it to
+        // configure() never mentions backend – mergeHardwareSettings() alone would default it to
         // 'webgpu'; only the URL override (applied during init, see applyBackendQueryOverride())
         // makes the running settings 'software'.
         class OriginalClass {
@@ -309,7 +309,7 @@ describe('hotSwapDemo', () => {
             }
             update() {}
             render() {
-                // A pure render()-body edit - the exact BT-318 repro (changing a BT.clear
+                // A pure render()-body edit – the exact BT-318 repro (changing a BT.clear
                 // argument). Must swap in place, not force a full reload.
                 return 'edited';
             }
@@ -435,7 +435,7 @@ describe('hotSwapDemo', () => {
 
         // score stays 7, matching Original: initFingerprint treats a class-field initializer
         // change as a Tier 2 signal (see the initFingerprint describe block above), so this
-        // test - which isolates a methods-only change - must not vary it. Its value would be
+        // test – which isolates a methods-only change – must not vary it. Its value would be
         // moot at runtime either way, since Tier 1 never re-runs a constructor.
         class NewClass {
             score = 7;

--- a/packages/blit386/src/hot/HotSwap.ts
+++ b/packages/blit386/src/hot/HotSwap.ts
@@ -47,7 +47,7 @@ const HARD_RELOAD_STYLE_FIELDS = ['overlayStyle', 'overlayTimingChartStyle', 'ov
  * {@link Function.prototype.toString} dump of a class declaration, so {@link initFingerprint}
  * can normalize it away. Vite HMR always re-evaluates the same class declaration under the
  * same name across a hot reload, so the identifier itself carries no signal about whether a
- * reinit is needed - keeping it would only make two structurally identical classes fingerprint
+ * reinit is needed – keeping it would only make two structurally identical classes fingerprint
  * differently because a test double (or a renamed export) happens to use a different name.
  */
 const CLASS_NAME_HEADER_PATTERN = /^class\s+[$A-Za-z_][$\w]*/;
@@ -55,8 +55,8 @@ const CLASS_NAME_HEADER_PATTERN = /^class\s+[$A-Za-z_][$\w]*/;
 /**
  * Compares two optional {@link Vector2i} hardware-settings fields.
  *
- * @param previous - Value from the currently running settings.
- * @param next - Value from the candidate demo's resolved `configure()`.
+ * @param previous – Value from the currently running settings.
+ * @param next – Value from the candidate demo's resolved `configure()`.
  * @returns `true` when both are undefined or equal; `false` otherwise.
  */
 function isVectorFieldEqual(previous: Vector2i | undefined, next: Vector2i | undefined): boolean {
@@ -71,8 +71,8 @@ function isVectorFieldEqual(previous: Vector2i | undefined, next: Vector2i | und
  * Reports whether any init-only hardware-settings field differs between the running
  * settings and a hot-swap candidate's resolved `configure()` output.
  *
- * @param previous - Currently active hardware settings.
- * @param next - Candidate demo's resolved hardware settings.
+ * @param previous – Currently active hardware settings.
+ * @param next – Candidate demo's resolved hardware settings.
  * @returns `true` when a hard reload is required.
  */
 export function hasHardReloadDiff(previous: HardwareSettings, next: HardwareSettings): boolean {
@@ -101,7 +101,7 @@ export function hasHardReloadDiff(previous: HardwareSettings, next: HardwareSett
 
 /**
  * Builds a fingerprint that changes only when a class's constructor, class-field
- * initializers, or `init()` change - not when an unrelated method body is edited or
+ * initializers, or `init()` change – not when an unrelated method body is edited or
  * the class itself is declared under a different name.
  *
  * Concatenates `init()`'s own source with the class's full source (its declared name
@@ -109,7 +109,7 @@ export function hasHardReloadDiff(previous: HardwareSettings, next: HardwareSett
  * method's source (other than `constructor`) stripped out. What remains covers the
  * constructor and class-field initializers.
  *
- * @param cls - Demo class to fingerprint.
+ * @param cls – Demo class to fingerprint.
  * @returns Fingerprint string; equal fingerprints mean a Tier 1 (methods-only) swap is safe.
  */
 export function initFingerprint(cls: DemoConstructor): string {
@@ -136,7 +136,7 @@ export function initFingerprint(cls: DemoConstructor): string {
 /**
  * Constructs a candidate instance from `NewClass` in try/catch.
  *
- * @param NewClass - Newly evaluated demo class.
+ * @param NewClass – Newly evaluated demo class.
  * @returns The constructed instance, or `null` on throw (logged).
  */
 function constructCandidate(NewClass: DemoConstructor): IBTDemo | null {
@@ -162,7 +162,7 @@ const HARD_RELOAD_OUTCOME_RELOAD = 'reload';
  * Outcome of the Tier 3 hardware-settings check. {@link HARD_RELOAD_OUTCOME_RELOAD} and
  * {@link HARD_RELOAD_OUTCOME_NO_DIFF} mean the check itself ran to completion (settings
  * differed, or they didn't); {@link HARD_RELOAD_OUTCOME_ABORTED} means the check could not
- * run at all, so {@link hotSwapDemo} must stop without attempting any swap - a hard-reload
+ * run at all, so {@link hotSwapDemo} must stop without attempting any swap – a hard-reload
  * result and an aborted check are not interchangeable "no swap happened" outcomes.
  */
 type HardReloadOutcome =
@@ -173,7 +173,7 @@ type HardReloadOutcome =
 /**
  * Runs the Tier 3 check: a hardware-settings change forces a full page reload.
  *
- * @param newDemo - Constructed candidate instance.
+ * @param newDemo – Constructed candidate instance.
  * @returns The check's outcome; see {@link HardReloadOutcome}.
  */
 function tryHardReload(newDemo: IBTDemo): HardReloadOutcome {
@@ -190,7 +190,7 @@ function tryHardReload(newDemo: IBTDemo): HardReloadOutcome {
     // The running settings already have any `?backend=software` URL override baked in (applied
     // once at init by BTAPI.applyBackendQueryOverride). The candidate's configure() output never
     // sees that override, so without reapplying it here `backend` would mismatch on every single
-    // check under an override - forcing a hard reload on every edit, not just a real configure()
+    // check under an override – forcing a hard reload on every edit, not just a real configure()
     // change.
     const backendOverride = BTAPI.getBackendQueryOverride();
 
@@ -213,8 +213,8 @@ function tryHardReload(newDemo: IBTDemo): HardReloadOutcome {
  * Runs the Tier 2 check: re-creates the instance and re-runs `init()` while the previous
  * instance keeps driving the loop, swapping in the new instance only on success.
  *
- * @param oldDemo - Currently running instance.
- * @param newDemo - Constructed candidate instance.
+ * @param oldDemo – Currently running instance.
+ * @param newDemo – Constructed candidate instance.
  * @param startedAt - `performance.now()` when this swap attempt began, for the announce timing.
  * @returns `true` once the swap completed; `false` when `hotReplaceDemo` reported failure (already logged there).
  */
@@ -244,8 +244,8 @@ async function tryReinit(oldDemo: IBTDemo, newDemo: IBTDemo, startedAt: number):
  * Runs the Tier 1 (default) swap: rebinds the running instance's prototype to the new
  * class in place, keeping every field untouched.
  *
- * @param oldDemo - Currently running instance, mutated in place.
- * @param NewClass - Newly evaluated demo class.
+ * @param oldDemo – Currently running instance, mutated in place.
+ * @param NewClass – Newly evaluated demo class.
  * @param startedAt - `performance.now()` when this swap attempt began, for the announce timing.
  */
 function applyMethodSwap(oldDemo: IBTDemo, NewClass: DemoConstructor, startedAt: number): void {
@@ -266,7 +266,7 @@ function applyMethodSwap(oldDemo: IBTDemo, NewClass: DemoConstructor, startedAt:
  * Hot-swaps the running demo in place with a newly evaluated demo class, using the
  * cheapest tier that is safe for what changed.
  *
- * @param NewClass - Newly evaluated demo class from the re-run entry module.
+ * @param NewClass – Newly evaluated demo class from the re-run entry module.
  * @returns `true` when a swap tier ran (including a requested hard reload); `false` only
  *   when construction or the Tier 2 re-init failed and the previous demo instance is
  *   still running unmodified.

--- a/packages/blit386/src/input/GamepadInput.ts
+++ b/packages/blit386/src/input/GamepadInput.ts
@@ -77,8 +77,8 @@ const VALID_AXIS_INDICES = [
 /**
  * Reads and clamps a raw stick axis to `[-1, 1]`.
  *
- * @param pad - Gamepad object.
- * @param index - Raw axis index.
+ * @param pad – Gamepad object.
+ * @param index – Raw axis index.
  * @returns Clamped axis value.
  */
 function getAxis(pad: Gamepad, index: number): number {
@@ -94,8 +94,8 @@ function getAxis(pad: Gamepad, index: number): number {
 /**
  * Reads a trigger/button analog value and clamps to `[0, 1]`.
  *
- * @param pad - Gamepad object.
- * @param index - Raw button index.
+ * @param pad – Gamepad object.
+ * @param index – Raw button index.
  * @returns Clamped analog value.
  */
 function getButtonValue(pad: Gamepad, index: number): number {
@@ -113,8 +113,8 @@ function getButtonValue(pad: Gamepad, index: number): number {
 /**
  * Checks digital down-state for a gamepad button.
  *
- * @param pad - Gamepad object.
- * @param index - Raw button index.
+ * @param pad – Gamepad object.
+ * @param index – Raw button index.
  * @returns `true` when considered pressed.
  */
 function isButtonDown(pad: Gamepad, index: number): boolean {
@@ -169,7 +169,7 @@ export class GamepadInput {
     /**
      * Creates a gamepad input tracker.
      *
-     * @param deadZone - Stick dead-zone threshold in `[0, 0.99]`.
+     * @param deadZone – Stick dead-zone threshold in `[0, 0.99]`.
      */
     constructor(deadZone: number = DEFAULT_GAMEPAD_DEAD_ZONE) {
         this.current = [
@@ -220,7 +220,7 @@ export class GamepadInput {
     /**
      * Sets the analog stick dead zone used by {@link GamepadInput.getAxis} for stick axes.
      *
-     * @param deadZone - New dead-zone threshold.
+     * @param deadZone – New dead-zone threshold.
      */
     public setDeadZone(deadZone: number): void {
         this.deadZone = this.sanitizeDeadZone(deadZone);
@@ -239,7 +239,7 @@ export class GamepadInput {
      * Polls gamepads, then snapshots current state into previous-state storage
      * for next frame's edge detection.
      *
-     * @param _currentTick - Current engine tick (unused; kept for BTAPI parity).
+     * @param _currentTick – Current engine tick (unused; kept for BTAPI parity).
      */
     public endFrame(_currentTick: number): void {
         this.poll();
@@ -265,8 +265,8 @@ export class GamepadInput {
     /**
      * Reports whether any button in `buttonMask` is currently held for `player`.
      *
-     * @param buttonMask - One or more `BTN_*` bit flags.
-     * @param player - Zero-based player index.
+     * @param buttonMask – One or more `BTN_*` bit flags.
+     * @param player – Zero-based player index.
      * @returns `true` when any requested button is currently down.
      */
     public isButtonDown(buttonMask: number, player: number): boolean {
@@ -292,10 +292,10 @@ export class GamepadInput {
      *
      * Matching uses ANY semantics across `buttonMask` bits.
      *
-     * @param buttonMask - One or more `BTN_*` bit flags.
-     * @param player - Zero-based player index.
-     * @param repeatRate - Tick interval for repeat (`<= 0` or omitted = edge only).
-     * @param currentTick - Current fixed-update tick.
+     * @param buttonMask – One or more `BTN_*` bit flags.
+     * @param player – Zero-based player index.
+     * @param repeatRate – Tick interval for repeat (`<= 0` or omitted = edge only).
+     * @param currentTick – Current fixed-update tick.
      * @returns `true` on press edge or repeat tick.
      */
     public isButtonPressed(
@@ -351,8 +351,8 @@ export class GamepadInput {
      * Reports whether any button in `buttonMask` was released this frame, including
      * when the gamepad disconnects while buttons were held.
      *
-     * @param buttonMask - One or more `BTN_*` bit flags.
-     * @param player - Zero-based player index.
+     * @param buttonMask – One or more `BTN_*` bit flags.
+     * @param player – Zero-based player index.
      * @returns `true` when any requested button transitions from down to up.
      */
     public isButtonReleased(buttonMask: number, player: number): boolean {
@@ -387,8 +387,8 @@ export class GamepadInput {
      *
      * Stick axes apply dead-zone filtering. Trigger axes return raw `[0, 1]`.
      *
-     * @param axis - Axis constant (`AXIS_*`).
-     * @param player - Zero-based player index.
+     * @param axis – Axis constant (`AXIS_*`).
+     * @param player – Zero-based player index.
      * @returns Axis value, or `0` for invalid/disconnected inputs.
      */
     public getAxis(axis: number, player: number): number {
@@ -412,7 +412,7 @@ export class GamepadInput {
     /**
      * Reports whether a gamepad is connected for the given player slot.
      *
-     * @param player - Zero-based player index.
+     * @param player – Zero-based player index.
      * @returns `true` when connected.
      */
     public isConnected(player: number): boolean {
@@ -462,7 +462,7 @@ export class GamepadInput {
     /**
      * Normalizes and clamps dead-zone configuration.
      *
-     * @param deadZone - Requested dead-zone value.
+     * @param deadZone – Requested dead-zone value.
      * @returns Clamped dead-zone value.
      */
     private sanitizeDeadZone(deadZone: number): number {
@@ -518,7 +518,7 @@ export class GamepadInput {
     /**
      * Maps standard Gamepad API buttons to `BTN_*` bit flags.
      *
-     * @param pad - Gamepad object from browser API.
+     * @param pad – Gamepad object from browser API.
      * @returns Button-state bitmask.
      */
     private mapButtons(pad: Gamepad): number {
@@ -567,7 +567,7 @@ export class GamepadInput {
     /**
      * Maps gamepad axis/button values into `AXIS_*` order.
      *
-     * @param pad - Gamepad object from browser API.
+     * @param pad – Gamepad object from browser API.
      * @returns Axis tuple in engine API order.
      */
     private mapAxes(pad: Gamepad): PlayerSnapshot['axes'] {
@@ -584,7 +584,7 @@ export class GamepadInput {
     /**
      * Applies configured dead zone and re-normalizes stick range.
      *
-     * @param value - Raw stick axis value.
+     * @param value – Raw stick axis value.
      * @returns Dead-zone filtered value.
      */
     private applyStickDeadZone(value: number): number {
@@ -602,7 +602,7 @@ export class GamepadInput {
     /**
      * Validates player slot index.
      *
-     * @param player - Caller-supplied player index.
+     * @param player – Caller-supplied player index.
      * @returns Normalized index or `null` when invalid.
      */
     private normalizePlayer(player: number): number | null {
@@ -616,9 +616,9 @@ export class GamepadInput {
     /**
      * Stores first-press ticks for newly pressed buttons in this frame.
      *
-     * @param player - Player slot index.
-     * @param edgeMask - Newly pressed button bits.
-     * @param tick - Current engine tick.
+     * @param player – Player slot index.
+     * @param edgeMask – Newly pressed button bits.
+     * @param tick – Current engine tick.
      */
     private recordNewPressTicks(player: number, edgeMask: number, tick: number): void {
         const table = this.firstPressTick[player];
@@ -637,8 +637,8 @@ export class GamepadInput {
     /**
      * Finds the oldest held-button first-press tick within `heldMask`.
      *
-     * @param player - Player slot index.
-     * @param heldMask - Currently held button bits.
+     * @param player – Player slot index.
+     * @param heldMask – Currently held button bits.
      * @returns Earliest held-button tick anchor, if any.
      */
     private getMinFirstPressTick(player: number, heldMask: number): number | undefined {
@@ -668,8 +668,8 @@ export class GamepadInput {
     /**
      * Removes repeat anchors for buttons no longer held.
      *
-     * @param player - Player slot index.
-     * @param heldMask - Current held button mask.
+     * @param player – Player slot index.
+     * @param heldMask – Current held button mask.
      */
     private dropReleasedTickAnchors(player: number, heldMask: number): void {
         const table = this.firstPressTick[player];

--- a/packages/blit386/src/input/KeyboardInput.ts
+++ b/packages/blit386/src/input/KeyboardInput.ts
@@ -92,8 +92,8 @@ export class KeyboardInput {
      * Attaches listeners to the canvas and window. Also listens for `window`
      * `blur` to clear held keys and the text buffer when focus leaves the page.
      *
-     * @param canvas - Canvas that receives keyboard events when focused.
-     * @param options - Supplies {@link KeyboardAttachOptions.getTicks} for repeat timing.
+     * @param canvas – Canvas that receives keyboard events when focused.
+     * @param options – Supplies {@link KeyboardAttachOptions.getTicks} for repeat timing.
      */
     public attach(canvas: HTMLCanvasElement, options: KeyboardAttachOptions): void {
         this.detach();
@@ -139,7 +139,7 @@ export class KeyboardInput {
      * calls `preventDefault` so the host page does not scroll while the canvas is
      * focused. When disabled (the default), those keys keep their browser defaults.
      *
-     * @param enabled - Whether the demo opted into keyboard scroll capture.
+     * @param enabled – Whether the demo opted into keyboard scroll capture.
      */
     public setIsCapturingScroll(enabled: boolean): void {
         this.isCapturingScroll = enabled;
@@ -149,7 +149,7 @@ export class KeyboardInput {
      * Ends a fixed update step: snapshots `prevHeld`, clears pending edges and
      * {@link getInputString}. Call once per `demo.update()` (not once per render frame).
      *
-     * @param _currentTick - Reserved for future use; fixed-update tick when the demo read input.
+     * @param _currentTick – Reserved for future use; fixed-update tick when the demo read input.
      */
     public endUpdate(_currentTick: number): void {
         this.pendingPress.clear();
@@ -168,7 +168,7 @@ export class KeyboardInput {
      * Alias for {@link endUpdate}; kept for tests and callers that still use the old name.
      *
      * @deprecated Deprecated since 1.0.3 (2026-05-31). Call {@link endUpdate} once per fixed update instead.
-     * @param currentTick - Passed through to {@link endUpdate}.
+     * @param currentTick – Passed through to {@link endUpdate}.
      */
     public endFrame(currentTick: number): void {
         this.endUpdate(currentTick);
@@ -177,7 +177,7 @@ export class KeyboardInput {
     /**
      * Whether `code` is held this frame (`KeyboardEvent.code`).
      *
-     * @param code - DOM key code string (for example `"Space"`).
+     * @param code – DOM key code string (for example `"Space"`).
      * @returns `true` while the key is held.
      */
     public isKeyDown(code: string): boolean {
@@ -187,9 +187,9 @@ export class KeyboardInput {
     /**
      * Edge or optional repeat (fixed ticks). `repeatRate <= 0` means edge only.
      *
-     * @param code - DOM key code string.
-     * @param repeatRate - Ticks between repeats; omit or non-positive for edge only.
-     * @param currentTick - Current fixed-update tick (`BT.ticks`).
+     * @param code – DOM key code string.
+     * @param repeatRate – Ticks between repeats; omit or non-positive for edge only.
+     * @param currentTick – Current fixed-update tick (`BT.ticks`).
      * @returns `true` on the initial press edge or on repeat ticks when configured.
      */
     public isKeyPressed(code: string, repeatRate: number | undefined, currentTick: number): boolean {
@@ -221,7 +221,7 @@ export class KeyboardInput {
     /**
      * Released edge for `code`.
      *
-     * @param code - DOM key code string.
+     * @param code – DOM key code string.
      * @returns `true` on the frame the key transitions from down to up.
      */
     public isKeyReleased(code: string): boolean {
@@ -267,8 +267,8 @@ export class KeyboardInput {
      * held to at least one held, or on repeat ticks when configured.
      *
      * @param codes - `KeyboardEvent.code` values for one logical button.
-     * @param repeatRate - Optional tick repeat interval for held buttons.
-     * @param currentTick - Current fixed-update tick (`BT.ticks`).
+     * @param repeatRate – Optional tick repeat interval for held buttons.
+     * @param currentTick – Current fixed-update tick (`BT.ticks`).
      * @returns `true` on the initial edge or on repeat ticks when configured.
      */
     public isButtonPressed(codes: readonly string[], repeatRate: number | undefined, currentTick: number): boolean {
@@ -331,7 +331,7 @@ export class KeyboardInput {
     /**
      * Minimum `firstPressTick` among codes that are still held (OR-button repeat).
      *
-     * @param codes - Key codes that belong to one logical button.
+     * @param codes – Key codes that belong to one logical button.
      * @returns Smallest tick anchor among held keys, or `undefined`.
      */
     private getOrMinFirstPressTick(codes: readonly string[]): number | undefined {
@@ -365,7 +365,7 @@ export class KeyboardInput {
     /**
      * Applies first keydown for a code and queues Tab / Escape for {@link getInputString}.
      *
-     * @param event - DOM keydown event.
+     * @param event – DOM keydown event.
      */
     private handleKeyDown(event: KeyboardEvent): void {
         const code = event.code;
@@ -398,7 +398,7 @@ export class KeyboardInput {
     /**
      * Removes a code on keyup.
      *
-     * @param event - DOM keyup event.
+     * @param event – DOM keyup event.
      */
     private handleKeyUp(event: KeyboardEvent): void {
         const code = event.code;
@@ -414,7 +414,7 @@ export class KeyboardInput {
     /**
      * Filters `beforeinput` into {@link getInputString}.
      *
-     * @param event - DOM beforeinput event.
+     * @param event – DOM beforeinput event.
      */
     private handleBeforeInput(event: InputEvent): void {
         const inputType = event.inputType;

--- a/packages/blit386/src/input/PointerInput.test.ts
+++ b/packages/blit386/src/input/PointerInput.test.ts
@@ -687,11 +687,11 @@ describe('PointerInput', () => {
                 pointerEvent('pointermove', { pointerId: 1, pointerType: 'mouse', clientX: 186, clientY: 156 }),
             );
 
-            // Tick 2 update: delta = current pos - prev pos snapshotted at
+            // Tick 2 update: delta = current pos – prev pos snapshotted at
             // the end of tick 1.
             // rect = { left:10, top:20, width:640, height:480 }, display 320x240.
             // (170, 140) -> (80, 60).  (186, 156) -> (88, 68).
-            // Expected delta = (88 - 80, 68 - 60) = (8, 8).
+            // Expected delta = (88 – 80, 68 – 60) = (8, 8).
             const delta = input.getDelta(0);
             expect(delta.x).toBe(8);
             expect(delta.y).toBe(8);
@@ -772,7 +772,7 @@ describe('PointerInput', () => {
 
         it('preserves pos and delta on the touch-release frame', () => {
             // Simulates a tick lifecycle with a touch landing, dragging, then
-            // releasing - the demo's drag-and-flick pattern. The release-frame
+            // releasing – the demo's drag-and-flick pattern. The release-frame
             // delta must reflect the final movement so the demo can use it as
             // throw velocity.
 
@@ -876,7 +876,7 @@ describe('PointerInput', () => {
 
         it('reports zero delta on the first frame after touch activation', () => {
             // Without prevPos sync on activation, the very first frame's
-            // delta would be (touchPos - 0) which feeds a phantom velocity
+            // delta would be (touchPos – 0) which feeds a phantom velocity
             // into demos that read pointerDelta on the press frame.
             canvas.dispatchEvent(
                 pointerEvent('pointerdown', {

--- a/packages/blit386/src/input/PointerInput.ts
+++ b/packages/blit386/src/input/PointerInput.ts
@@ -171,8 +171,8 @@ export class PointerInput {
      * - `contextmenu.preventDefault()` so right-click feeds `BTN_B`
      *   instead of popping the OS context menu
      *
-     * @param canvas - Canvas element rendering the engine output.
-     * @param displaySize - Logical display size used to convert screen coordinates.
+     * @param canvas – Canvas element rendering the engine output.
+     * @param displaySize – Logical display size used to convert screen coordinates.
      */
     public attach(canvas: HTMLCanvasElement, displaySize: Vector2i): void {
         this.detach();
@@ -284,7 +284,7 @@ export class PointerInput {
      * Valid slots return a clone; invalid slots return the shared zero singleton
      * (do not mutate the return value when the slot is invalid).
      *
-     * @param slot - Pointer slot index (0 = mouse, 1-3 = touch / pen).
+     * @param slot – Pointer slot index (0 = mouse, 1-3 = touch / pen).
      * @returns Pointer position in display coordinates, or `Vector2i.zero()` for invalid slots.
      */
     public getPos(slot: number): Vector2i {
@@ -302,7 +302,7 @@ export class PointerInput {
      *
      * Returns `Vector2i.zero()` when the slot index is out of range.
      *
-     * @param slot - Pointer slot index.
+     * @param slot – Pointer slot index.
      * @returns Per-frame delta in display coordinates.
      */
     public getDelta(slot: number): Vector2i {
@@ -322,7 +322,7 @@ export class PointerInput {
      * the canvas and no subsequent `pointerleave` has cleared it. For touch /
      * pen slots this means the contact is still down.
      *
-     * @param slot - Pointer slot index.
+     * @param slot – Pointer slot index.
      * @returns `true` when the slot has live position data.
      */
     public isActive(slot: number): boolean {
@@ -333,8 +333,8 @@ export class PointerInput {
      * Reports whether the pointer in slot `slot` is positioned inside `rect`, without
      * allocating a `Vector2i` (unlike `getPos(slot)` followed by a containment check).
      *
-     * @param slot - Pointer slot index.
-     * @param rect - Rectangle to test against, in display coordinates.
+     * @param slot – Pointer slot index.
+     * @param rect – Rectangle to test against, in display coordinates.
      * @returns `true` when the slot is active and its position is inside `rect`.
      */
     public isSlotInRect(slot: number, rect: Rect2i): boolean {
@@ -375,7 +375,7 @@ export class PointerInput {
      * scroll while the pointer is over the canvas unless
      * {@link setIsScrollCaptureForced} is active.
      *
-     * @param enabled - Whether the demo opted into pointer scroll capture.
+     * @param enabled – Whether the demo opted into pointer scroll capture.
      */
     public setIsCapturingScroll(enabled: boolean): void {
         this.isCapturingScroll = enabled;
@@ -388,7 +388,7 @@ export class PointerInput {
      * Independent of {@link setIsCapturingScroll}. Cleared when the pointer
      * leaves the palette band or the overlay body is hidden.
      *
-     * @param forced - Whether overlay scroll capture is active this frame.
+     * @param forced – Whether overlay scroll capture is active this frame.
      */
     public setIsScrollCaptureForced(forced: boolean): void {
         this.isScrollCaptureForced = forced;
@@ -405,8 +405,8 @@ export class PointerInput {
      * For slots 1-3 (touch / pen): only `BTN_A` is ever true while the
      * contact is down; `B`, `C`, `D` always return `false`.
      *
-     * @param button - One of `BTN_A..D`.
-     * @param slot - Pointer slot index.
+     * @param button – One of `BTN_A..D`.
+     * @param slot – Pointer slot index.
      * @returns `true` while the button remains pressed and the slot is active.
      */
     public isButtonDown(button: number, slot: number): boolean {
@@ -435,8 +435,8 @@ export class PointerInput {
      * Unlike {@link isButtonDown}, does not require the slot to be active, so press
      * edges remain visible after deactivation.
      *
-     * @param button - One of `BTN_A..D`.
-     * @param slot - Pointer slot index.
+     * @param button – One of `BTN_A..D`.
+     * @param slot – Pointer slot index.
      * @returns `true` only on the frame the button transitions from up to down.
      */
     public isButtonPressed(button: number, slot: number): boolean {
@@ -464,8 +464,8 @@ export class PointerInput {
      * Reports whether the given pointer button transitioned to up on the current frame.
      * Unlike {@link isButtonDown}, does not require the slot to be active.
      *
-     * @param button - One of `BTN_A..D`.
-     * @param slot - Pointer slot index.
+     * @param button – One of `BTN_A..D`.
+     * @param slot – Pointer slot index.
      * @returns `true` only on the frame the button transitions from down to up.
      */
     public isButtonReleased(button: number, slot: number): boolean {
@@ -516,7 +516,7 @@ export class PointerInput {
      * already bound to this `pointerId` for touch / pen. Drops touch / pen
      * moves with no slot binding (allocation only happens on `pointerdown`).
      *
-     * @param event - DOM pointer event from the canvas.
+     * @param event – DOM pointer event from the canvas.
      */
     private handleMove(event: PointerEvent): void {
         if (event.pointerType === 'mouse') {
@@ -554,7 +554,7 @@ export class PointerInput {
      * 1..3 and set `BTN_A`; events that arrive while all touch
      * slots are full are dropped silently.
      *
-     * @param event - DOM pointer event from the canvas.
+     * @param event – DOM pointer event from the canvas.
      */
     private handleDown(event: PointerEvent): void {
         if (event.pointerType === 'mouse') {
@@ -578,7 +578,7 @@ export class PointerInput {
             return;
         }
 
-        // Touch or pen: route to the first free slot in 1..POINTER_SLOT_COUNT - 1.
+        // Touch or pen: route to the first free slot in 1..POINTER_SLOT_COUNT – 1.
         if (this.idToSlot.has(event.pointerId)) {
             return;
         }
@@ -620,7 +620,7 @@ export class PointerInput {
      * slot 0 but leave the slot valid. Touch / pen events free their slot
      * completely so a subsequent contact can reuse it.
      *
-     * @param event - DOM pointer event from the canvas.
+     * @param event – DOM pointer event from the canvas.
      */
     private handleUp(event: PointerEvent): void {
         if (event.pointerType === 'mouse') {
@@ -653,7 +653,7 @@ export class PointerInput {
      * same as `pointerleave`: deactivates slot 0 for mouse, frees the slot
      * for touch / pen.
      *
-     * @param event - DOM pointer event from the canvas.
+     * @param event – DOM pointer event from the canvas.
      */
     private handleCancel(event: PointerEvent): void {
         if (event.pointerType === 'mouse') {
@@ -676,7 +676,7 @@ export class PointerInput {
      * mouse: deactivates slot 0 and clears all buttons. For touch / pen:
      * frees the slot.
      *
-     * @param event - DOM pointer event from the canvas.
+     * @param event – DOM pointer event from the canvas.
      */
     private handlePointerLeave(event: PointerEvent): void {
         if (event.pointerType === 'mouse') {
@@ -704,7 +704,7 @@ export class PointerInput {
      * Capture is active when {@link setIsCapturingScroll} or
      * {@link setIsScrollCaptureForced} is enabled.
      *
-     * @param event - DOM wheel event from the canvas.
+     * @param event – DOM wheel event from the canvas.
      */
     private handleWheel(event: WheelEvent): void {
         if (!this.isCapturingScroll && !this.isScrollCaptureForced) {
@@ -771,7 +771,7 @@ export class PointerInput {
      * Returns a slot to the empty / inactive state without reallocating its
      * `Vector2i` storage.
      *
-     * @param slot - Slot to reset in place.
+     * @param slot – Slot to reset in place.
      */
     private resetSlot(slot: Slot): void {
         slot.pointerId = null;
@@ -815,7 +815,7 @@ export class PointerInput {
      * velocity via `getDelta`. The next pointerdown that reuses this slot
      * resyncs `prevPos` so the first frame's delta starts at zero.
      *
-     * @param slotIndex - Index of the slot to free.
+     * @param slotIndex – Index of the slot to free.
      */
     private freeSlot(slotIndex: number): void {
         // eslint-disable-next-line security/detect-object-injection -- slotIndex resolved from idToSlot, always in [0, POINTER_SLOT_COUNT)
@@ -873,8 +873,8 @@ export class PointerInput {
      * Buttons 3 and 4 (back / forward) both map to `D`. Other values are
      * silently ignored.
      *
-     * @param slot - Mouse slot to update (always slot 0).
-     * @param button - DOM `PointerEvent.button` value.
+     * @param slot – Mouse slot to update (always slot 0).
+     * @param button – DOM `PointerEvent.button` value.
      * @param isPressed - `true` to set the button down, `false` to release it.
      */
     private setMouseButton(slot: Slot, button: number, isPressed: boolean): void {
@@ -904,9 +904,9 @@ export class PointerInput {
      * Skips the update when the canvas has zero size (no layout yet) so the
      * division does not produce NaN coordinates.
      *
-     * @param slot - Slot whose position to update.
-     * @param clientX - DOM `clientX` from the source event.
-     * @param clientY - DOM `clientY` from the source event.
+     * @param slot – Slot whose position to update.
+     * @param clientX – DOM `clientX` from the source event.
+     * @param clientY – DOM `clientY` from the source event.
      */
     private updateSlotPosition(slot: Slot, clientX: number, clientY: number): void {
         const canvas = this.canvas;
@@ -942,7 +942,7 @@ export class PointerInput {
      * Used by all public read methods to bounds-check the caller-supplied slot
      * argument while keeping `noUncheckedIndexedAccess` happy.
      *
-     * @param index - Slot index to look up.
+     * @param index – Slot index to look up.
      * @returns Slot at the index, or `null` for out-of-range indices.
      */
     private getSlotOrNull(index: number): Slot | null {
@@ -960,7 +960,7 @@ export class PointerInput {
      * Resolves the `idToSlot` map and the indexed slot lookup in one
      * helper so event handlers can early-return without repeating the guards.
      *
-     * @param pointerId - Native `pointerId` from a DOM pointer event.
+     * @param pointerId – Native `pointerId` from a DOM pointer event.
      * @returns Slot bound to this `pointerId`, or `null` when no slot is bound.
      */
     private lookupSlotById(pointerId: number): Slot | null {

--- a/packages/blit386/src/input/defaultKeyboardMap.ts
+++ b/packages/blit386/src/input/defaultKeyboardMap.ts
@@ -67,7 +67,7 @@ export const DEFAULT_KEYBOARD_PLAYER2: Readonly<Record<FaceButtonCode, readonly 
  *
  * Used by {@link BT.inputMapReset} so exported defaults are never mutated.
  *
- * @param source - One player's default record (`DEFAULT_KEYBOARD_PLAYER1` or `DEFAULT_KEYBOARD_PLAYER2`).
+ * @param source – One player's default record (`DEFAULT_KEYBOARD_PLAYER1` or `DEFAULT_KEYBOARD_PLAYER2`).
  * @returns Map with face-button bit-flag keys and copied string arrays.
  */
 export function cloneDefaultKeyboardPlayerMap(

--- a/packages/blit386/src/overlay/Overlay.ts
+++ b/packages/blit386/src/overlay/Overlay.ts
@@ -53,7 +53,7 @@ const EMPTY_PALETTE_USAGE_MASK = new Uint8Array(0);
 /**
  * Resolves overlay bar/text/gap palette indices from optional {@link OverlayStyle}.
  *
- * @param style - Optional configure-time overlay style.
+ * @param style – Optional configure-time overlay style.
  * @returns Resolved palette indices for overlay chrome.
  */
 function resolveStyleIndices(style?: OverlayStyle): { bg: number; gap: number; text: number } {
@@ -66,10 +66,10 @@ function resolveStyleIndices(style?: OverlayStyle): { bg: number; gap: number; t
 /**
  * Creates a timing chart instance and resets its ring buffer when enabled.
  *
- * @param layout - Cached display layout.
- * @param isEnabled - Whether the timing chart band is active.
- * @param targetFps - Configured fixed-update rate.
- * @param diagnosticsMode - Renderer diagnostic visualization mode.
+ * @param layout – Cached display layout.
+ * @param isEnabled – Whether the timing chart band is active.
+ * @param targetFps – Configured fixed-update rate.
+ * @param diagnosticsMode – Renderer diagnostic visualization mode.
  * @returns Configured {@link TimingChart} for the overlay.
  */
 function createTimingChart(
@@ -90,7 +90,7 @@ function createTimingChart(
 /**
  * Creates an audio meter instance with the given feature flag.
  *
- * @param isEnabled - Whether the audio meter band is active.
+ * @param isEnabled – Whether the audio meter band is active.
  * @returns Configured {@link AudioMeter} for the overlay.
  */
 function createAudioMeter(isEnabled: boolean): AudioMeter {
@@ -100,7 +100,7 @@ function createAudioMeter(isEnabled: boolean): AudioMeter {
 /**
  * Formats a millisecond timing value to one decimal place, padded to the fixed overlay field width.
  *
- * @param valueMs - Timing value in milliseconds.
+ * @param valueMs – Timing value in milliseconds.
  * @returns Padded `X.X` text for the `Frame`/`update()`/`render()` metrics row.
  */
 function formatOverlayMsField(valueMs: number): string {
@@ -172,26 +172,26 @@ export class Overlay {
     /**
      * Creates an overlay with fixed layout and text strings.
      *
-     * @param layout - Cached display layout from {@link createOverlayLayout}.
-     * @param topLeftLabel - Short title shown on the top-left.
-     * @param targetFps - Configured fixed-update rate for the target FPS line.
-     * @param activeBackend - Backend started by BTAPI (`webgpu` or `software`).
-     * @param style - Optional palette indices from {@link HardwareSettings.overlayStyle}.
-     * @param isOverlayPaletteEnabled - When true, draws the live palette swatch grid.
-     * @param paletteColumns - Optional max swatches per row from {@link HardwareSettings.overlayPaletteColumns}.
-     * @param paletteRowsVisible - Optional max visible palette grid rows from {@link HardwareSettings.overlayPaletteRowsVisible}.
-     * @param isOverlayTimingChartEnabled - When true, draws the update/render timing chart band.
-     * @param timingChartStyle - Optional timing chart palette overrides.
-     * @param timingChartHeight - Chart band height in pixels (default 22).
-     * @param timingChartDiagnostics - Chart renderer diagnostic mode (`minimal`, `rich`, or `false`).
-     * @param isOverlayRendererDiagnosticsBarEnabled - When true, draws the GPU diagnostics text row.
-     * @param isOverlayVisibleAtStart - Initial overlay body visibility (default false).
-     * @param isOverlayToggleHintVisible - Draw toggle hint while body hidden (default true).
-     * @param isOverlayToggleEnabled - Enable Backquote and corner toggle input (default true).
-     * @param isOverlayToggleHitDebugVisible - Draw a 1 px outline of the toggle hit region (default false).
-     * @param isOverlayAudioMetersEnabled - When true, draws the per-bus level and voice/steal/drop band.
-     * @param audioMeterStyle - Optional audio meter palette overrides.
-     * @param audioMeterHeight - Audio meter band height in pixels (default 13).
+     * @param layout – Cached display layout from {@link createOverlayLayout}.
+     * @param topLeftLabel – Short title shown on the top-left.
+     * @param targetFps – Configured fixed-update rate for the target FPS line.
+     * @param activeBackend – Backend started by BTAPI (`webgpu` or `software`).
+     * @param style – Optional palette indices from {@link HardwareSettings.overlayStyle}.
+     * @param isOverlayPaletteEnabled – When true, draws the live palette swatch grid.
+     * @param paletteColumns – Optional max swatches per row from {@link HardwareSettings.overlayPaletteColumns}.
+     * @param paletteRowsVisible – Optional max visible palette grid rows from {@link HardwareSettings.overlayPaletteRowsVisible}.
+     * @param isOverlayTimingChartEnabled – When true, draws the update/render timing chart band.
+     * @param timingChartStyle – Optional timing chart palette overrides.
+     * @param timingChartHeight – Chart band height in pixels (default 22).
+     * @param timingChartDiagnostics – Chart renderer diagnostic mode (`minimal`, `rich`, or `false`).
+     * @param isOverlayRendererDiagnosticsBarEnabled – When true, draws the GPU diagnostics text row.
+     * @param isOverlayVisibleAtStart – Initial overlay body visibility (default false).
+     * @param isOverlayToggleHintVisible – Draw toggle hint while body hidden (default true).
+     * @param isOverlayToggleEnabled – Enable Backquote and corner toggle input (default true).
+     * @param isOverlayToggleHitDebugVisible – Draw a 1 px outline of the toggle hit region (default false).
+     * @param isOverlayAudioMetersEnabled – When true, draws the per-bus level and voice/steal/drop band.
+     * @param audioMeterStyle – Optional audio meter palette overrides.
+     * @param audioMeterHeight – Audio meter band height in pixels (default 13).
      */
     constructor(
         layout: OverlayLayout,
@@ -268,8 +268,8 @@ export class Overlay {
      *
      * No-op when the timing chart is disabled.
      *
-     * @param label - Tag text; empty becomes `"Untitled"`.
-     * @param currentTick - Current fixed-update tick (`BT.ticks`).
+     * @param label – Tag text; empty becomes `"Untitled"`.
+     * @param currentTick – Current fixed-update tick (`BT.ticks`).
      */
     assignTag(label: string | undefined, currentTick: number): void {
         if (!this.#timingChart.isEnabled) {
@@ -282,12 +282,12 @@ export class Overlay {
     /**
      * Handles overlay frame input: palette swatch copy first, then body toggle.
      *
-     * @param pointer - Pointer subsystem, or `null` when unavailable.
-     * @param isTogglePressed - Whether the Backquote toggle key edge fired this frame. The caller must
+     * @param pointer – Pointer subsystem, or `null` when unavailable.
+     * @param isTogglePressed – Whether the Backquote toggle key edge fired this frame. The caller must
      * sample this before the keyboard subsystem's end-of-tick edge reset runs; see {@link Toggle.handleInput}.
-     * @param currentTick - Current fixed-update tick for keyboard edge detection.
-     * @param getCustomRows - Optional supplier for demo rows (layout plan for palette hits).
-     * @param palette - Active demo palette for slot count, if any.
+     * @param currentTick – Current fixed-update tick for keyboard edge detection.
+     * @param getCustomRows – Optional supplier for demo rows (layout plan for palette hits).
+     * @param palette – Active demo palette for slot count, if any.
      */
     handleFrameInput(
         pointer: PointerInput | null,
@@ -338,9 +338,9 @@ export class Overlay {
      * `handleFrameInput`, this reads the keyboard directly at call time, so it remains susceptible to
      * missing a Backquote press that a fixed-update tick already consumed this frame.
      *
-     * @param pointer - Pointer subsystem, or `null` when unavailable.
-     * @param keyboard - Keyboard subsystem, or `null` when unavailable.
-     * @param currentTick - Current fixed-update tick for keyboard edge detection.
+     * @param pointer – Pointer subsystem, or `null` when unavailable.
+     * @param keyboard – Keyboard subsystem, or `null` when unavailable.
+     * @param currentTick – Current fixed-update tick for keyboard edge detection.
      */
     handleToggle(pointer: PointerInput | null, keyboard: KeyboardInput | null, currentTick: number): void {
         const isTogglePressed = keyboard?.isKeyPressed(OVERLAY_TOGGLE_KEY_CODE, undefined, currentTick) ?? false;
@@ -352,16 +352,16 @@ export class Overlay {
      * Draws the overlay. Toggle input is handled earlier in the frame by BTAPI
      * ({@link BTAPI.beginRenderFrame}) so palette usage tracking matches visibility.
      *
-     * @param renderer - Active {@link OverlayRenderer} instance.
-     * @param font - System bitmap font.
-     * @param pointer - Pointer subsystem for palette swatch hover tooltips.
-     * @param _keyboard - Reserved; toggle input is handled in BTAPI before render.
-     * @param currentTick - Current fixed-update tick for copy-status expiry.
-     * @param getCustomRows - Optional supplier for demo rows; not invoked while the overlay body is hidden.
-     * @param timing - Optional timing snapshot from the previous rendered frame.
-     * @param palette - Active demo palette for optional palette grid.
-     * @param usedPaletteMask - Per-frame palette usage mask populated during demo render.
-     * @param audioSnapshot - Optional audio snapshot (bus levels and voice counters) from the previous rendered frame.
+     * @param renderer – Active {@link OverlayRenderer} instance.
+     * @param font – System bitmap font.
+     * @param pointer – Pointer subsystem for palette swatch hover tooltips.
+     * @param _keyboard – Reserved; toggle input is handled in BTAPI before render.
+     * @param currentTick – Current fixed-update tick for copy-status expiry.
+     * @param getCustomRows – Optional supplier for demo rows; not invoked while the overlay body is hidden.
+     * @param timing – Optional timing snapshot from the previous rendered frame.
+     * @param palette – Active demo palette for optional palette grid.
+     * @param usedPaletteMask – Per-frame palette usage mask populated during demo render.
+     * @param audioSnapshot – Optional audio snapshot (bus levels and voice counters) from the previous rendered frame.
      */
     updateAndRender(
         renderer: OverlayRenderer,
@@ -415,8 +415,8 @@ export class Overlay {
      * user wheels over the palette grid, even when the demo did not opt into
      * `HardwareSettings.isCapturingPointerScroll`.
      *
-     * @param pointer - Pointer subsystem, or `null` when unavailable.
-     * @param paletteBand - Palette band rect from the layout plan.
+     * @param pointer – Pointer subsystem, or `null` when unavailable.
+     * @param paletteBand – Palette band rect from the layout plan.
      * @returns `true` when an active pointer is inside the band.
      */
     #isPointerOverPaletteBand(pointer: PointerInput | null, paletteBand: Rect2i): boolean {
@@ -436,7 +436,7 @@ export class Overlay {
     /**
      * Records timing samples when a snapshot is provided.
      *
-     * @param timing - Optional timing snapshot from the previous rendered frame.
+     * @param timing – Optional timing snapshot from the previous rendered frame.
      */
     #sampleTiming(timing?: OverlayTimingSnapshot): void {
         if (!timing) {
@@ -450,7 +450,7 @@ export class Overlay {
     /**
      * Records an audio sample when a snapshot is provided.
      *
-     * @param audioSnapshot - Optional audio snapshot from the previous rendered frame.
+     * @param audioSnapshot – Optional audio snapshot from the previous rendered frame.
      */
     #sampleAudio(audioSnapshot?: OverlayAudioSnapshot): void {
         if (!audioSnapshot) {
@@ -463,8 +463,8 @@ export class Overlay {
     /**
      * Builds per-frame layout config including optional palette grid dimensions.
      *
-     * @param customRowCount - Demo custom row count for this frame.
-     * @param palette - Active demo palette, if any.
+     * @param customRowCount – Demo custom row count for this frame.
+     * @param palette – Active demo palette, if any.
      * @returns Layout config for {@link buildOverlayLayoutPlan}.
      */
     #createLayoutConfig(customRowCount: number, palette: Palette | null | undefined): OverlayLayoutConfig {
@@ -502,8 +502,8 @@ export class Overlay {
     /**
      * Builds the per-frame layout plan shared by body and hint-only draws.
      *
-     * @param customRowCount - Demo custom row count for this frame.
-     * @param palette - Active demo palette, if any.
+     * @param customRowCount – Demo custom row count for this frame.
+     * @param palette – Active demo palette, if any.
      * @returns Layout config and computed plan.
      */
     #buildFramePlan(
@@ -525,8 +525,8 @@ export class Overlay {
     /**
      * Resets camera for screen-space overlay drawing.
      *
-     * @param renderer - Active renderer.
-     * @param draw - Callback that issues overlay draws.
+     * @param renderer – Active renderer.
+     * @param draw – Callback that issues overlay draws.
      */
     #withCamera(renderer: OverlayRenderer, draw: () => void): void {
         const savedCamera = renderer.getCameraOffset();
@@ -548,16 +548,16 @@ export class Overlay {
      * when the body is visible it renders inverted (cutout) against the hint bar,
      * otherwise as a solid glyph.
      *
-     * @param renderer - Active renderer.
-     * @param font - System bitmap font.
-     * @param plan - Computed layout plan for this frame.
-     * @param layoutConfig - Layout config used to build the plan.
-     * @param isBodyVisible - Whether metrics bars and palette grid should draw.
-     * @param customRows - Optional demo rows, if any.
-     * @param palette - Active demo palette.
-     * @param usedPaletteMask - Per-frame palette usage mask from BTAPI.
-     * @param pointer - Pointer subsystem for palette swatch hover, or `null` when unavailable.
-     * @param currentTick - Current fixed-update tick for copy-status expiry.
+     * @param renderer – Active renderer.
+     * @param font – System bitmap font.
+     * @param plan – Computed layout plan for this frame.
+     * @param layoutConfig – Layout config used to build the plan.
+     * @param isBodyVisible – Whether metrics bars and palette grid should draw.
+     * @param customRows – Optional demo rows, if any.
+     * @param palette – Active demo palette.
+     * @param usedPaletteMask – Per-frame palette usage mask from BTAPI.
+     * @param pointer – Pointer subsystem for palette swatch hover, or `null` when unavailable.
+     * @param currentTick – Current fixed-update tick for copy-status expiry.
      */
     #drawFrame(
         renderer: OverlayRenderer,
@@ -689,9 +689,9 @@ export class Overlay {
     /**
      * Draws the toggle hint icon and the optional hit-zone debug outline.
      *
-     * @param renderer - Active renderer.
-     * @param plan - Computed layout plan for this frame.
-     * @param isBodyVisible - Whether the overlay body is visible this frame.
+     * @param renderer – Active renderer.
+     * @param plan – Computed layout plan for this frame.
+     * @param isBodyVisible – Whether the overlay body is visible this frame.
      */
     #drawToggleAffordance(renderer: OverlayRenderer, plan: OverlayLayoutPlan, isBodyVisible: boolean): void {
         if (isBodyVisible || this.#isToggleHintVisible) {
@@ -706,7 +706,7 @@ export class Overlay {
     /**
      * Draws a 1 px outline of the bottom-left toggle hit region for hit-zone tuning.
      *
-     * @param target - Overlay draw target.
+     * @param target – Overlay draw target.
      */
     #drawToggleHitDebug(target: OverlayDrawTarget): void {
         const rect = this.#layout.toggleRect;

--- a/packages/blit386/src/overlay/OverlayDrawTarget.ts
+++ b/packages/blit386/src/overlay/OverlayDrawTarget.ts
@@ -15,8 +15,8 @@ export interface OverlayDrawTarget {
      *
      * On WebGPU, batched in `overlayPrimitives` after the demo sprite pass.
      *
-     * @param rect - Rectangle bounds in display coordinates.
-     * @param paletteIndex - Palette color index.
+     * @param rect – Rectangle bounds in display coordinates.
+     * @param paletteIndex – Palette color index.
      */
     drawBarFill(rect: Rect2i, paletteIndex: number): void;
 
@@ -25,8 +25,8 @@ export interface OverlayDrawTarget {
      *
      * On WebGPU, batched in `overlayTopPrimitives` after the overlay label pass.
      *
-     * @param rect - Rectangle bounds in display coordinates.
-     * @param paletteIndex - Palette color index.
+     * @param rect – Rectangle bounds in display coordinates.
+     * @param paletteIndex – Palette color index.
      */
     drawBarFillOnTop(rect: Rect2i, paletteIndex: number): void;
 
@@ -35,10 +35,10 @@ export interface OverlayDrawTarget {
      *
      * On WebGPU, batched in `overlaySprites` after overlay bar fills.
      *
-     * @param font - Bitmap font with character glyphs (underlying sheet must be indexed via {@link SpriteSheet.isIndexed}).
-     * @param pos - Text position (top-left corner).
-     * @param text - String to render.
-     * @param paletteOffset - Palette index offset applied to all glyphs (default 0).
+     * @param font – Bitmap font with character glyphs (underlying sheet must be indexed via {@link SpriteSheet.isIndexed}).
+     * @param pos – Text position (top-left corner).
+     * @param text – String to render.
+     * @param paletteOffset – Palette index offset applied to all glyphs (default 0).
      */
     drawLabel(font: BitmapFont, pos: Vector2i, text: string, paletteOffset?: number): void;
 
@@ -47,10 +47,10 @@ export interface OverlayDrawTarget {
      *
      * On WebGPU, batched in `overlayTopSprites` after `overlayTopPrimitives`.
      *
-     * @param font - Bitmap font with character glyphs (underlying sheet must be indexed via {@link SpriteSheet.isIndexed}).
-     * @param pos - Text position (top-left corner).
-     * @param text - String to render.
-     * @param paletteOffset - Palette index offset applied to all glyphs (default 0).
+     * @param font – Bitmap font with character glyphs (underlying sheet must be indexed via {@link SpriteSheet.isIndexed}).
+     * @param pos – Text position (top-left corner).
+     * @param text – String to render.
+     * @param paletteOffset – Palette index offset applied to all glyphs (default 0).
      */
     drawLabelOnTop(font: BitmapFont, pos: Vector2i, text: string, paletteOffset?: number): void;
 }

--- a/packages/blit386/src/overlay/OverlayToggleIcon.ts
+++ b/packages/blit386/src/overlay/OverlayToggleIcon.ts
@@ -18,7 +18,7 @@ const iconDrawScratch = {
 /**
  * Computes the icon top-left Y inside the hint bar without allocating.
  *
- * @param hintBarTopY - Top Y of the bottom hint bar from the layout plan.
+ * @param hintBarTopY – Top Y of the bottom hint bar from the layout plan.
  * @returns Icon top Y in display pixels.
  */
 export function hintIconY(hintBarTopY: number): number {
@@ -28,7 +28,7 @@ export function hintIconY(hintBarTopY: number): number {
 /**
  * Returns the top-left screen position for the toggle hint icon inside the hint bar.
  *
- * @param hintBarTopY - Top Y of the bottom hint bar from the layout plan.
+ * @param hintBarTopY – Top Y of the bottom hint bar from the layout plan.
  * @returns Icon anchor in display pixels.
  */
 export function hintIconPos(hintBarTopY: number): Vector2i {
@@ -38,7 +38,7 @@ export function hintIconPos(hintBarTopY: number): Vector2i {
 /**
  * Returns the screen-space rect reserved for the toggle hint icon (palette swatch exclusion).
  *
- * @param hintBarTopY - Top Y of the bottom hint bar from the layout plan.
+ * @param hintBarTopY – Top Y of the bottom hint bar from the layout plan.
  * @returns Icon bounding rect in display pixels.
  */
 export function hintIconExclusionRect(hintBarTopY: number): Rect2i {
@@ -51,10 +51,10 @@ export function hintIconExclusionRect(hintBarTopY: number): Rect2i {
  * Collapses each mask row into horizontal runs to minimize draw calls. Reuses scratch rects
  * so the path stays allocation-free after warmup.
  *
- * @param target - Overlay draw target.
- * @param hintBarTopY - Top Y of the bottom hint bar from the layout plan.
- * @param textPaletteIndex - Overlay text palette index (`OverlayStyle.textPaletteIndex`, default `2`).
- * @param isInverted - When `true`, draw the complement mask so the symbol reads against the hint bar fill.
+ * @param target – Overlay draw target.
+ * @param hintBarTopY – Top Y of the bottom hint bar from the layout plan.
+ * @param textPaletteIndex – Overlay text palette index (`OverlayStyle.textPaletteIndex`, default `2`).
+ * @param isInverted – When `true`, draw the complement mask so the symbol reads against the hint bar fill.
  */
 export function toggleIcon(
     target: OverlayDrawTarget,
@@ -96,8 +96,8 @@ export function toggleIcon(
 /**
  * Writes the toggle hint icon top-left origin into {@link target} without allocating.
  *
- * @param target - Reusable vector mutated in place.
- * @param hintBarTopY - Top Y of the bottom hint bar from the layout plan.
+ * @param target – Reusable vector mutated in place.
+ * @param hintBarTopY – Top Y of the bottom hint bar from the layout plan.
  */
 function writeHintIconOrigin(target: Vector2i, hintBarTopY: number): void {
     target.x = overlayToggleHintIconX();

--- a/packages/blit386/src/overlay/audio-meter/AudioMeter.ts
+++ b/packages/blit386/src/overlay/audio-meter/AudioMeter.ts
@@ -64,7 +64,7 @@ export class AudioMeter {
     /**
      * Creates an audio meter with the given feature flag.
      *
-     * @param isEnabled - When false, sample/draw are no-ops.
+     * @param isEnabled – When false, sample/draw are no-ops.
      */
     constructor(isEnabled = false) {
         this.#isEnabled = isEnabled;
@@ -82,7 +82,7 @@ export class AudioMeter {
     /**
      * Records the latest per-bus levels and voice counters.
      *
-     * @param snapshot - Per-frame audio snapshot from BTAPI.
+     * @param snapshot – Per-frame audio snapshot from BTAPI.
      */
     sample(snapshot: OverlayAudioSnapshot): void {
         if (!this.#isEnabled) {
@@ -104,10 +104,10 @@ export class AudioMeter {
      * {@link OverlayDrawTarget.drawLabel} for the text readout, mirroring
      * {@link TimingChart.draw}.
      *
-     * @param target - Overlay draw target.
-     * @param rect - Screen-space meter band from layout plan.
-     * @param style - Resolved meter palette indices.
-     * @param font - System bitmap font for the text readout.
+     * @param target – Overlay draw target.
+     * @param rect – Screen-space meter band from layout plan.
+     * @param style – Resolved meter palette indices.
+     * @param font – System bitmap font for the text readout.
      */
     draw(target: OverlayDrawTarget, rect: Rect2i, style: AudioMeterDrawStyle, font: BitmapFont): void {
         if (!this.#isEnabled || rect.width <= 0 || rect.height <= 0) {
@@ -122,9 +122,9 @@ export class AudioMeter {
      * Draws one track (full band height) and, when the bus level is non-zero, one
      * bottom-anchored fill rect per bus.
      *
-     * @param target - Overlay draw target.
-     * @param rect - Screen-space meter band.
-     * @param style - Resolved meter palette indices.
+     * @param target – Overlay draw target.
+     * @param rect – Screen-space meter band.
+     * @param style – Resolved meter palette indices.
      */
     #drawBars(target: OverlayDrawTarget, rect: Rect2i, style: AudioMeterDrawStyle): void {
         for (let busIndex = 0; busIndex < AUDIO_METER_BUSES.length; busIndex++) {
@@ -161,10 +161,10 @@ export class AudioMeter {
      * The `|` separators between the readout segments render as 1 px full-band-height
      * dividers in the gap palette index, matching the other engine-composed labels.
      *
-     * @param target - Overlay draw target.
-     * @param rect - Screen-space meter band.
-     * @param style - Resolved meter palette indices.
-     * @param font - System bitmap font.
+     * @param target – Overlay draw target.
+     * @param rect – Screen-space meter band.
+     * @param style – Resolved meter palette indices.
+     * @param font – System bitmap font.
      */
     #drawText(target: OverlayDrawTarget, rect: Rect2i, style: AudioMeterDrawStyle, font: BitmapFont): void {
         const barsBlockWidth = gridRowWidth(AUDIO_METER_BUS_COUNT, AUDIO_METER_BAR_WIDTH_PX, AUDIO_METER_BAR_GAP_PX);
@@ -189,8 +189,8 @@ export class AudioMeter {
     /**
      * Resolves a bus fill's palette index from its level against the warning/clip thresholds.
      *
-     * @param level - Normalized bus level.
-     * @param style - Resolved meter palette indices.
+     * @param level – Normalized bus level.
+     * @param style – Resolved meter palette indices.
      * @returns Clip, warning, or normal level bar palette index.
      */
     #levelPaletteIndex(level: number, style: AudioMeterDrawStyle): number {
@@ -210,8 +210,8 @@ export class AudioMeter {
  * Computes the left edge X of the `busIndex`-th bus bar, reusing {@link gridRowWidth}'s
  * fixed-count column arithmetic instead of an adaptive grid.
  *
- * @param rect - Screen-space meter band.
- * @param busIndex - Index into {@link AUDIO_METER_BUSES}.
+ * @param rect – Screen-space meter band.
+ * @param busIndex – Index into {@link AUDIO_METER_BUSES}.
  * @returns Bar left edge X in display pixels.
  */
 function busBarX(rect: Rect2i, busIndex: number): number {

--- a/packages/blit386/src/overlay/audio-meter/style.ts
+++ b/packages/blit386/src/overlay/audio-meter/style.ts
@@ -27,8 +27,8 @@ const pickOverlayBarTextGap = (
 /**
  * Resolves audio meter palette indices from overlay and meter-specific settings.
  *
- * @param overlayStyle - Global overlay bar/text/gap indices from hardware settings.
- * @param meterStyle - Optional audio meter palette overrides.
+ * @param overlayStyle – Global overlay bar/text/gap indices from hardware settings.
+ * @param meterStyle – Optional audio meter palette overrides.
  * @returns Resolved indices for meter draw and semantic level tints.
  */
 export function resolveAudioMeterStyle(
@@ -53,9 +53,9 @@ export function resolveAudioMeterStyle(
  * Scales linearly so `fullScale` fills the meter band height. Any non-zero level draws at
  * least one pixel so quiet buses stay visible.
  *
- * @param level - Normalized bus level (0..1 for a full-scale signal).
- * @param meterHeight - Meter band height in pixels.
- * @param fullScale - Level value that maps to full band height.
+ * @param level – Normalized bus level (0..1 for a full-scale signal).
+ * @param meterHeight – Meter band height in pixels.
+ * @param fullScale – Level value that maps to full band height.
  * @returns Clamped fill height in pixels (0 when the level is zero).
  */
 export function computeAudioMeterBarHeight(level: number, meterHeight: number, fullScale: number): number {

--- a/packages/blit386/src/overlay/bars/Bars.ts
+++ b/packages/blit386/src/overlay/bars/Bars.ts
@@ -24,9 +24,9 @@ export class OverlayBars {
     /**
      * Draws 1 px row gaps between stacked overlay bands.
      *
-     * @param target - Overlay draw target.
-     * @param plan - Computed layout plan.
-     * @param gapIndex - Palette index for gap fills.
+     * @param target – Overlay draw target.
+     * @param plan – Computed layout plan.
+     * @param gapIndex – Palette index for gap fills.
      */
     drawRowGaps(target: OverlayDrawTarget, plan: OverlayLayoutPlan, gapIndex: number): void {
         for (const gapRect of plan.rowGapRects) {
@@ -37,11 +37,11 @@ export class OverlayBars {
     /**
      * Draws boundary separators between overlay clusters and demo content.
      *
-     * @param target - Overlay draw target.
-     * @param plan - Computed layout plan.
-     * @param gapIndex - Palette index for separator fills.
-     * @param isDrawTop - When true, draws the separator below the top overlay cluster.
-     * @param isDrawBottom - When true, draws the separator above the bottom overlay cluster.
+     * @param target – Overlay draw target.
+     * @param plan – Computed layout plan.
+     * @param gapIndex – Palette index for separator fills.
+     * @param isDrawTop – When true, draws the separator below the top overlay cluster.
+     * @param isDrawBottom – When true, draws the separator above the bottom overlay cluster.
      */
     drawClusterSeparators(
         target: OverlayDrawTarget,
@@ -62,9 +62,9 @@ export class OverlayBars {
     /**
      * Draws title, timing chart, metrics, timing text, renderer diagnostics, and audio meter bar fills.
      *
-     * @param target - Overlay draw target.
-     * @param plan - Computed layout plan.
-     * @param barIndex - Palette index for bar fills.
+     * @param target – Overlay draw target.
+     * @param plan – Computed layout plan.
+     * @param barIndex – Palette index for bar fills.
      */
     drawTopBars(target: OverlayDrawTarget, plan: OverlayLayoutPlan, barIndex: number): void {
         target.drawBarFill(plan.titleBar, barIndex);
@@ -88,9 +88,9 @@ export class OverlayBars {
     /**
      * Draws the palette band background fill when the overlay body is visible.
      *
-     * @param target - Overlay draw target.
-     * @param plan - Computed layout plan.
-     * @param barIndex - Palette index for bar fills.
+     * @param target – Overlay draw target.
+     * @param plan – Computed layout plan.
+     * @param barIndex – Palette index for bar fills.
      */
     drawPaletteBandFill(target: OverlayDrawTarget, plan: OverlayLayoutPlan, barIndex: number): void {
         if (plan.paletteBand.height > 0) {
@@ -101,9 +101,9 @@ export class OverlayBars {
     /**
      * Draws the bottom hint bar background fill.
      *
-     * @param target - Overlay draw target.
-     * @param plan - Computed layout plan.
-     * @param barIndex - Palette index for bar fills.
+     * @param target – Overlay draw target.
+     * @param plan – Computed layout plan.
+     * @param barIndex – Palette index for bar fills.
      */
     drawHintBarFill(target: OverlayDrawTarget, plan: OverlayLayoutPlan, barIndex: number): void {
         target.drawBarFill(plan.hintBar, barIndex);
@@ -116,16 +116,16 @@ export class OverlayBars {
      * dividers in the gap palette index; the demo title is user content and keeps
      * literal pipes.
      *
-     * @param target - Overlay draw target.
-     * @param font - System bitmap font.
-     * @param plan - Computed layout plan.
-     * @param style - Default overlay palette indices.
-     * @param gapIndex - Palette index for in-row separator dividers (same as row gaps).
-     * @param topLeftLabel - Demo title (left).
-     * @param topRightLabel - Backend and resolution (right).
-     * @param topMetricsLabel - Present FPS / target / draw calls line.
-     * @param topTimingLabel - Frame / update / render ms line.
-     * @param rendererDiagnosticsLabel - Optional GPU diagnostics line; omitted when empty.
+     * @param target – Overlay draw target.
+     * @param font – System bitmap font.
+     * @param plan – Computed layout plan.
+     * @param style – Default overlay palette indices.
+     * @param gapIndex – Palette index for in-row separator dividers (same as row gaps).
+     * @param topLeftLabel – Demo title (left).
+     * @param topRightLabel – Backend and resolution (right).
+     * @param topMetricsLabel – Present FPS / target / draw calls line.
+     * @param topTimingLabel – Frame / update / render ms line.
+     * @param rendererDiagnosticsLabel – Optional GPU diagnostics line; omitted when empty.
      */
     drawTopLabels(
         target: OverlayDrawTarget,
@@ -189,10 +189,10 @@ export class OverlayBars {
     /**
      * Draws demo-supplied custom row bar fills from the layout plan.
      *
-     * @param target - Overlay draw target.
-     * @param plan - Computed layout plan with custom bar rects.
-     * @param rows - Custom overlay rows.
-     * @param style - Default overlay palette indices.
+     * @param target – Overlay draw target.
+     * @param plan – Computed layout plan with custom bar rects.
+     * @param rows – Custom overlay rows.
+     * @param style – Default overlay palette indices.
      */
     drawCustomRowFills(
         target: OverlayDrawTarget,
@@ -221,11 +221,11 @@ export class OverlayBars {
     /**
      * Draws demo-supplied custom row labels from the layout plan.
      *
-     * @param target - Overlay draw target.
-     * @param font - System bitmap font.
-     * @param plan - Computed layout plan with custom bar rects.
-     * @param rows - Custom overlay rows.
-     * @param style - Default overlay palette indices.
+     * @param target – Overlay draw target.
+     * @param font – System bitmap font.
+     * @param plan – Computed layout plan with custom bar rects.
+     * @param rows – Custom overlay rows.
+     * @param style – Default overlay palette indices.
      */
     drawCustomRowLabels(
         target: OverlayDrawTarget,
@@ -278,7 +278,7 @@ export class OverlayBars {
     /**
      * Ensures the custom-row scratch pool has at least `count` entries.
      *
-     * @param count - Number of demo rows to draw this frame.
+     * @param count – Number of demo rows to draw this frame.
      */
     #ensureCustomRowPool(count: number): void {
         while (this.#customLeftPos.length < count) {

--- a/packages/blit386/src/overlay/input/Toggle.ts
+++ b/packages/blit386/src/overlay/input/Toggle.ts
@@ -16,8 +16,8 @@ export class Toggle {
     /**
      * Creates toggle state from configure-time visibility and input flags.
      *
-     * @param isOverlayVisibleAtStart - Initial overlay body visibility from configure.
-     * @param isOverlayToggleEnabled - When false, toggle input is ignored.
+     * @param isOverlayVisibleAtStart – Initial overlay body visibility from configure.
+     * @param isOverlayToggleEnabled – When false, toggle input is ignored.
      */
     constructor(isOverlayVisibleAtStart = false, isOverlayToggleEnabled = true) {
         this.#isBodyVisible = isOverlayVisibleAtStart;
@@ -36,12 +36,12 @@ export class Toggle {
     /**
      * Handles toggle input (Backquote and bottom-left corner press).
      *
-     * @param pointer - Pointer subsystem, or `null` when unavailable.
-     * @param isTogglePressed - Whether the Backquote toggle key edge fired this frame. Callers must
+     * @param pointer – Pointer subsystem, or `null` when unavailable.
+     * @param isTogglePressed – Whether the Backquote toggle key edge fired this frame. Callers must
      * sample this before the keyboard subsystem's own end-of-tick edge reset runs, so a press landing
      * inside a fixed-update tick is not lost by the time this render-phase check runs.
-     * @param toggleRect - Bottom-left toggle hit region.
-     * @param isPointerPressConsumed - When true, skip pointer corner toggle (palette swatch handled the press).
+     * @param toggleRect – Bottom-left toggle hit region.
+     * @param isPointerPressConsumed – When true, skip pointer corner toggle (palette swatch handled the press).
      */
     handleInput(
         pointer: PointerInput | null,
@@ -82,11 +82,11 @@ export class Toggle {
      * Backward-compatible alias for {@link handleInput}.
      *
      * @deprecated Deprecated since 1.1.0 (2026-05-31). Use {@link handleInput} instead.
-     * @param pointer - Pointer subsystem, or `null` when unavailable.
-     * @param keyboard - Keyboard subsystem, or `null` when unavailable.
-     * @param currentTick - Current fixed-update tick for keyboard edge detection.
-     * @param toggleRect - Bottom-left toggle hit region.
-     * @param isPointerPressConsumed - When true, skip pointer corner toggle.
+     * @param pointer – Pointer subsystem, or `null` when unavailable.
+     * @param keyboard – Keyboard subsystem, or `null` when unavailable.
+     * @param currentTick – Current fixed-update tick for keyboard edge detection.
+     * @param toggleRect – Bottom-left toggle hit region.
+     * @param isPointerPressConsumed – When true, skip pointer corner toggle.
      */
     handleToggle(
         pointer: PointerInput | null,

--- a/packages/blit386/src/overlay/labels.ts
+++ b/packages/blit386/src/overlay/labels.ts
@@ -4,7 +4,7 @@ import { Vector2i } from '../utils/Vector2i';
 import { OVERLAY_DIVIDER_GAP_PX, SYSTEM_CHAR_ADVANCE } from './constants';
 import type { OverlayDrawTarget } from './OverlayDrawTarget';
 
-/** Matches demo registry titles: "BLIT386 Demo 006 - Patterns". */
+/** Matches demo registry titles: "BLIT386 Demo 006 – Patterns". */
 const REGISTRY_TITLE_PATTERN = /^BLIT386 Demo\s+.+?\s+-\s+(.+)$/;
 
 /** Trailing tracking column inside each 6 px glyph cell (glyphs ink 5 of the 6 px advance). */
@@ -33,8 +33,8 @@ const segmentScratch = new Vector2i(0, 0);
  * the row. Padding every such field to the same width up front keeps divider and segment
  * positions stable regardless of the underlying value.
  *
- * @param text - Already-formatted field text, e.g. `'8.3'`, `'60'`, or `'x3'` (may be empty).
- * @param width - Fixed column width in characters.
+ * @param text – Already-formatted field text, e.g. `'8.3'`, `'60'`, or `'x3'` (may be empty).
+ * @param width – Fixed column width in characters.
  * @returns `text` padded with leading spaces to at least `width` characters.
  */
 export function padOverlayField(text: string, width: number): string {
@@ -44,7 +44,7 @@ export function padOverlayField(text: string, width: number): string {
 /**
  * Turns the browser page title into a short top-left overlay label.
  *
- * @param pageTitle - Browser document title when available.
+ * @param pageTitle – Browser document title when available.
  * @returns Short label for the top-left bar (registry titles such as
  *   `BLIT386 Demo 002 - Primitives` become `Primitives Demo`).
  */
@@ -75,13 +75,13 @@ export function resolveOverlayTopLeftLabel(pageTitle: string | undefined): strin
  * literal pipes via plain {@link OverlayDrawTarget.drawLabel}. Measure the rendered
  * width with {@link overlayDividerLabelWidth}.
  *
- * @param target - Overlay draw target.
- * @param font - System bitmap font.
- * @param pos - Label draw position.
- * @param text - Engine-composed label; every `|` becomes a drawn divider.
- * @param rowRect - Row band rect the dividers span vertically.
- * @param textPaletteOffset - Palette offset for the label glyphs.
- * @param gapIndex - Palette index for divider fills (same as row gaps).
+ * @param target – Overlay draw target.
+ * @param font – System bitmap font.
+ * @param pos – Label draw position.
+ * @param text – Engine-composed label; every `|` becomes a drawn divider.
+ * @param rowRect – Row band rect the dividers span vertically.
+ * @param textPaletteOffset – Palette offset for the label glyphs.
+ * @param gapIndex – Palette index for divider fills (same as row gaps).
  */
 export function drawOverlayLabelWithDividers(
     target: OverlayDrawTarget,
@@ -130,7 +130,7 @@ export function drawOverlayLabelWithDividers(
  * {@link drawOverlayLabelWithDividers}: segment glyph advances plus
  * {@link SEGMENT_SEPARATOR_ADVANCE_PX} per divider.
  *
- * @param text - Engine-composed label with `|` separator markers.
+ * @param text – Engine-composed label with `|` separator markers.
  * @returns Rendered width in pixels (same convention as `length * SYSTEM_CHAR_ADVANCE`
  *   for plain text, including the last glyph's trailing tracking).
  */

--- a/packages/blit386/src/overlay/layout/layoutHelpers.ts
+++ b/packages/blit386/src/overlay/layout/layoutHelpers.ts
@@ -15,9 +15,9 @@ import type { OverlayLayout } from './types';
 /**
  * Builds cached layout from logical display size and system font line height.
  *
- * @param displayWidth - Logical display width in pixels.
- * @param displayHeight - Logical display height in pixels.
- * @param lineHeight - System font line height in pixels.
+ * @param displayWidth – Logical display width in pixels.
+ * @param displayHeight – Logical display height in pixels.
+ * @param lineHeight – System font line height in pixels.
  * @returns Frozen layout used for the lifetime of the overlay instance.
  */
 export function createOverlayLayout(displayWidth: number, displayHeight: number, lineHeight: number): OverlayLayout {
@@ -40,8 +40,8 @@ export function createOverlayLayout(displayWidth: number, displayHeight: number,
 /**
  * Returns whether a pointer position lies inside the toggle corner rect.
  *
- * @param pos - Pointer position in display coordinates.
- * @param toggleRect - Bottom-left toggle region.
+ * @param pos – Pointer position in display coordinates.
+ * @param toggleRect – Bottom-left toggle region.
  * @returns `true` when the point is inside the rect (`Rect2i.isContaining` half-open bounds).
  */
 export function isPointerInOverlayToggleCorner(pos: Vector2i, toggleRect: Rect2i): boolean {
@@ -51,8 +51,8 @@ export function isPointerInOverlayToggleCorner(pos: Vector2i, toggleRect: Rect2i
 /**
  * X position for right-aligned overlay text inside a bar.
  *
- * @param text - Text to place flush right with {@link OVERLAY_EDGE_MARGIN_PX} inset.
- * @param displayWidth - Logical display width in pixels.
+ * @param text – Text to place flush right with {@link OVERLAY_EDGE_MARGIN_PX} inset.
+ * @param displayWidth – Logical display width in pixels.
  * @returns Left edge X for {@link OverlayDrawTarget.drawLabel} (never less than the margin).
  */
 export function overlayRightAlignedTextX(text: string, displayWidth: number): number {
@@ -68,8 +68,8 @@ export function overlayRightAlignedTextX(text: string, displayWidth: number): nu
  * Same flush-right convention as {@link overlayRightAlignedTextX}, but measured with
  * {@link overlayDividerLabelWidth} so the divider spacing is accounted for.
  *
- * @param text - Engine-composed label with `|` separator markers.
- * @param displayWidth - Logical display width in pixels.
+ * @param text – Engine-composed label with `|` separator markers.
+ * @param displayWidth – Logical display width in pixels.
  * @returns Left edge X for {@link drawOverlayLabelWithDividers} (never less than the margin).
  */
 export function overlayRightAlignedDividerLabelX(text: string, displayWidth: number): number {
@@ -92,7 +92,7 @@ export function overlayToggleHintIconX(): number {
 /**
  * Palette offset for system-font overlay text (foreground glyphs stored as index 1).
  *
- * @param paletteIndex - Palette color index for overlay text.
+ * @param paletteIndex – Palette color index for overlay text.
  * @returns Offset passed to {@link OverlayDrawTarget.drawLabel}, or `0` when index 0 (transparent).
  */
 export function overlayBitmapTextPaletteOffset(paletteIndex: number): number {
@@ -102,7 +102,7 @@ export function overlayBitmapTextPaletteOffset(paletteIndex: number): number {
 /**
  * Y coordinate of the top edge of a custom row bar stacked above the footer.
  *
- * @param footerStackTopY - Top Y of the footer stack (palette band or hint bar).
+ * @param footerStackTopY – Top Y of the footer stack (palette band or hint bar).
  * @param rowIndex - `0` is directly above the footer stack.
  * @returns Bar top Y in display pixels.
  */

--- a/packages/blit386/src/overlay/layout/layoutPlan.ts
+++ b/packages/blit386/src/overlay/layout/layoutPlan.ts
@@ -69,7 +69,7 @@ export function createOverlayLayoutPlanScratch(): OverlayLayoutPlanScratch {
 /**
  * Top Y of the bottom hint bar (13 px strip at the display bottom edge).
  *
- * @param displayHeight - Logical display height in pixels.
+ * @param displayHeight – Logical display height in pixels.
  * @returns Hint bar top Y.
  */
 export function hintBarY(displayHeight: number): number {
@@ -79,8 +79,8 @@ export function hintBarY(displayHeight: number): number {
 /**
  * Top Y of the palette swatch grid band stacked above the hint bar row gap.
  *
- * @param displayHeight - Logical display height in pixels.
- * @param paletteGridHeight - Total palette grid height from {@link computeGrid}.
+ * @param displayHeight – Logical display height in pixels.
+ * @param paletteGridHeight – Total palette grid height from {@link computeGrid}.
  * @returns Palette band top Y.
  */
 export function paletteBandY(displayHeight: number, paletteGridHeight: number): number {
@@ -90,8 +90,8 @@ export function paletteBandY(displayHeight: number, paletteGridHeight: number): 
 /**
  * Resolves footer rects: optional palette band above a row gap, then the hint bar at the display bottom.
  *
- * @param config - Layout configuration.
- * @param displayHeight - Logical display height in pixels.
+ * @param config – Layout configuration.
+ * @param displayHeight – Logical display height in pixels.
  * @returns Palette band height, footer stack anchor Y, and hint bar top Y.
  */
 function resolveFooterLayout(
@@ -121,7 +121,7 @@ function resolveFooterLayout(
 /**
  * Total reserved footer height (palette grid + row gap + hint bar, or hint bar alone).
  *
- * @param config - Layout configuration.
+ * @param config – Layout configuration.
  * @returns Footer band height in pixels.
  */
 export function resolveOverlayFooterHeight(config: OverlayLayoutConfig): number {
@@ -135,9 +135,9 @@ export function resolveOverlayFooterHeight(config: OverlayLayoutConfig): number 
 /**
  * Ensures the custom bar scratch pool has at least `count` entries.
  *
- * @param scratch - Layout scratch object.
- * @param count - Number of custom rows.
- * @param displayWidth - Logical display width.
+ * @param scratch – Layout scratch object.
+ * @param count – Number of custom rows.
+ * @param displayWidth – Logical display width.
  */
 function ensureCustomBarPool(scratch: OverlayLayoutPlanScratch, count: number, displayWidth: number): void {
     while (scratch.customBars.length < count) {
@@ -148,10 +148,10 @@ function ensureCustomBarPool(scratch: OverlayLayoutPlanScratch, count: number, d
 /**
  * Writes a 1 px row gap rect immediately below a bar band.
  *
- * @param scratch - Layout scratch object.
- * @param bar - Bar whose bottom edge precedes the gap.
- * @param displayWidth - Logical display width.
- * @param gapIndex - Index into {@link OverlayLayoutPlanScratch.rowGapRects}.
+ * @param scratch – Layout scratch object.
+ * @param bar – Bar whose bottom edge precedes the gap.
+ * @param displayWidth – Logical display width.
+ * @param gapIndex – Index into {@link OverlayLayoutPlanScratch.rowGapRects}.
  * @returns Next gap index.
  */
 function writeRowGapBelow(
@@ -181,8 +181,8 @@ function writeRowGapBelow(
 /**
  * Resolves the top Y of the footer overlay cluster (custom rows, palette band, or hint bar).
  *
- * @param scratch - Layout scratch with footer rects populated.
- * @param customRowCount - Demo custom row count for this frame.
+ * @param scratch – Layout scratch with footer rects populated.
+ * @param customRowCount – Demo custom row count for this frame.
  * @returns Top Y of the uppermost footer band.
  */
 function resolveFooterClusterTopY(scratch: OverlayLayoutPlanScratch, customRowCount: number): number {
@@ -204,9 +204,9 @@ function resolveFooterClusterTopY(scratch: OverlayLayoutPlanScratch, customRowCo
 /**
  * Populates row gap rects and cluster boundary separators from bar geometry.
  *
- * @param scratch - Layout scratch with bar rects already assigned.
- * @param config - Layout configuration.
- * @param displayWidth - Logical display width.
+ * @param scratch – Layout scratch with bar rects already assigned.
+ * @param config – Layout configuration.
+ * @param displayWidth – Logical display width.
  */
 function populateGapLayout(scratch: OverlayLayoutPlanScratch, config: OverlayLayoutConfig, displayWidth: number): void {
     let gapIndex = 0;
@@ -268,10 +268,10 @@ function populateGapLayout(scratch: OverlayLayoutPlanScratch, config: OverlayLay
 /**
  * Builds or updates a layout plan from configuration (top-down stack).
  *
- * @param config - Feature flags and display dimensions.
- * @param scratch - Reusable scratch object mutated in place.
- * @param topRightLabel - Text for top-right backend/resolution label.
- * @param toggleRect - Bottom-left toggle hit region from init layout.
+ * @param config – Feature flags and display dimensions.
+ * @param scratch – Reusable scratch object mutated in place.
+ * @param topRightLabel – Text for top-right backend/resolution label.
+ * @param toggleRect – Bottom-left toggle hit region from init layout.
  * @returns The same scratch object as {@link OverlayLayoutPlan}.
  */
 export function buildOverlayLayoutPlan(
@@ -415,10 +415,10 @@ export function buildOverlayLayoutPlan(
 /**
  * Default layout config with chart and palette features disabled.
  *
- * @param displayWidth - Logical display width.
- * @param displayHeight - Logical display height.
- * @param lineHeight - System font line height.
- * @param customRowCount - Demo custom row count for this frame.
+ * @param displayWidth – Logical display width.
+ * @param displayHeight – Logical display height.
+ * @param lineHeight – System font line height.
+ * @param customRowCount – Demo custom row count for this frame.
  * @returns Config suitable for {@link buildOverlayLayoutPlan}.
  */
 export function createDefaultLayoutConfig(

--- a/packages/blit386/src/overlay/palette/PaletteInteraction.ts
+++ b/packages/blit386/src/overlay/palette/PaletteInteraction.ts
@@ -52,10 +52,10 @@ const tooltipScratch = {
 /**
  * Returns whether a palette slot at the given swatch origin overlaps the hint exclusion rect.
  *
- * @param swatchX - Swatch left edge in display pixels.
- * @param swatchY - Swatch top edge in display pixels.
- * @param swatchSize - Side length of the swatch.
- * @param hintExclusion - Region reserved for the toggle hint icon.
+ * @param swatchX – Swatch left edge in display pixels.
+ * @param swatchY – Swatch top edge in display pixels.
+ * @param swatchSize – Side length of the swatch.
+ * @param hintExclusion – Region reserved for the toggle hint icon.
  * @returns `true` when the swatch should not receive hits or draws.
  */
 function isSwatchOverlappingWithHintExclusion(
@@ -77,10 +77,10 @@ function isSwatchOverlappingWithHintExclusion(
 /**
  * Tests whether a pointer lies outside the palette band, including the scrollbar track.
  *
- * @param pointerX - Pointer X in display coordinates.
- * @param pointerY - Pointer Y in display coordinates.
- * @param paletteBand - Palette band rect from the layout plan.
- * @param bandRight - Right edge of the hittable band (excludes scrollbar track).
+ * @param pointerX – Pointer X in display coordinates.
+ * @param pointerY – Pointer Y in display coordinates.
+ * @param paletteBand – Palette band rect from the layout plan.
+ * @param bandRight – Right edge of the hittable band (excludes scrollbar track).
  * @returns `true` when the pointer is outside the swatch hit region (including over the scrollbar track).
  */
 function isPointerOutsideBand(pointerX: number, pointerY: number, paletteBand: Rect2i, bandRight: number): boolean {
@@ -95,13 +95,13 @@ function isPointerOutsideBand(pointerX: number, pointerY: number, paletteBand: R
 /**
  * Maps band-local coordinates to a palette index, or `null` when not over a swatch cell.
  *
- * @param localX - X relative to the grid origin inside the palette band.
- * @param localY - Y relative to the grid origin inside the palette band.
- * @param cols - Grid column count.
- * @param swatchSize - Swatch side length in pixels.
- * @param gap - Gap between swatches.
- * @param scrollRowOffset - First visible grid row.
- * @param colorCount - Active palette slot count.
+ * @param localX – X relative to the grid origin inside the palette band.
+ * @param localY – Y relative to the grid origin inside the palette band.
+ * @param cols – Grid column count.
+ * @param swatchSize – Swatch side length in pixels.
+ * @param gap – Gap between swatches.
+ * @param scrollRowOffset – First visible grid row.
+ * @param colorCount – Active palette slot count.
  * @returns Palette index, or `null` when the point is in padding or out of range.
  */
 function resolveIndexAtBandLocal(
@@ -149,15 +149,15 @@ function resolveIndexAtBandLocal(
 /**
  * Maps a pointer position to a palette swatch index, or `null` when no swatch is under the point.
  *
- * @param pointerX - Pointer X in display coordinates.
- * @param pointerY - Pointer Y in display coordinates.
- * @param paletteBand - Palette band rect from the layout plan.
- * @param grid - Precomputed grid layout.
- * @param colorCount - Active palette slot count.
- * @param hintExclusion - Region to skip for the toggle hint icon.
- * @param displayWidth - Logical display width for scrollbar track exclusion.
- * @param scrollRowOffset - First visible grid row (default `0`).
- * @param scrollbarTrackWidth - Right-edge track width excluded from hits (default {@link PALETTE_SCROLLBAR_TRACK_WIDTH_PX}).
+ * @param pointerX – Pointer X in display coordinates.
+ * @param pointerY – Pointer Y in display coordinates.
+ * @param paletteBand – Palette band rect from the layout plan.
+ * @param grid – Precomputed grid layout.
+ * @param colorCount – Active palette slot count.
+ * @param hintExclusion – Region to skip for the toggle hint icon.
+ * @param displayWidth – Logical display width for scrollbar track exclusion.
+ * @param scrollRowOffset – First visible grid row (default `0`).
+ * @param scrollbarTrackWidth – Right-edge track width excluded from hits (default {@link PALETTE_SCROLLBAR_TRACK_WIDTH_PX}).
  * @returns Palette index, or `null` when the pointer is not over a hittable swatch.
  */
 export function hitTestSwatch(
@@ -208,7 +208,7 @@ export function hitTestSwatch(
 /**
  * Returns the maximum scroll row offset for a palette grid viewport.
  *
- * @param grid - Precomputed grid layout.
+ * @param grid – Precomputed grid layout.
  * @returns Last valid `scrollRowOffset` (0 when all rows are visible).
  */
 export function maxScrollRowOffset(grid: PaletteGridLayout): number {
@@ -218,8 +218,8 @@ export function maxScrollRowOffset(grid: PaletteGridLayout): number {
 /**
  * Clamps a scroll row offset into the valid range for a palette grid viewport.
  *
- * @param offset - Requested first visible row.
- * @param grid - Precomputed grid layout.
+ * @param offset – Requested first visible row.
+ * @param grid – Precomputed grid layout.
  * @returns Clamped offset in `[0, maxScrollRowOffset]`.
  */
 export function clampScrollRowOffset(offset: number, grid: PaletteGridLayout): number {
@@ -239,9 +239,9 @@ export function clampScrollRowOffset(offset: number, grid: PaletteGridLayout): n
 /**
  * Returns whether a pointer lies inside the palette footer scroll region.
  *
- * @param pointerX - Pointer X in display coordinates.
- * @param pointerY - Pointer Y in display coordinates.
- * @param paletteBand - Palette band rect from the layout plan.
+ * @param pointerX – Pointer X in display coordinates.
+ * @param pointerY – Pointer Y in display coordinates.
+ * @param paletteBand – Palette band rect from the layout plan.
  * @returns `true` when wheel or drag scrolling may apply.
  */
 function isPointerInScrollRegion(pointerX: number, pointerY: number, paletteBand: Rect2i): boolean {
@@ -256,12 +256,12 @@ function isPointerInScrollRegion(pointerX: number, pointerY: number, paletteBand
 /**
  * Returns whether a pointer lies inside the palette scrollbar track.
  *
- * @param pointerX - Pointer X in display coordinates.
- * @param pointerY - Pointer Y in display coordinates.
- * @param paletteBand - Palette band rect from the layout plan.
- * @param grid - Precomputed grid layout.
- * @param scrollRowOffset - First visible grid row.
- * @param trackWidth - Scrollbar track width in pixels.
+ * @param pointerX – Pointer X in display coordinates.
+ * @param pointerY – Pointer Y in display coordinates.
+ * @param paletteBand – Palette band rect from the layout plan.
+ * @param grid – Precomputed grid layout.
+ * @param scrollRowOffset – First visible grid row.
+ * @param trackWidth – Scrollbar track width in pixels.
  * @returns `true` when the pointer is over the track rect.
  */
 export function isPointerInScrollbarTrack(
@@ -290,10 +290,10 @@ export function isPointerInScrollbarTrack(
 /**
  * Maps a pointer Y position within the scrollbar track to a scroll row offset.
  *
- * @param pointerY - Pointer Y in display coordinates.
- * @param paletteBand - Palette band rect from the layout plan.
- * @param grid - Precomputed grid layout.
- * @param trackWidth - Scrollbar track width in pixels.
+ * @param pointerY – Pointer Y in display coordinates.
+ * @param paletteBand – Palette band rect from the layout plan.
+ * @param grid – Precomputed grid layout.
+ * @param trackWidth – Scrollbar track width in pixels.
  * @returns Clamped scroll row offset.
  */
 export function resolveScrollRowOffsetFromTrackPointerY(
@@ -336,11 +336,11 @@ export interface PaletteTooltipLayout {
 /**
  * Lays out a docked tooltip above a swatch with clamping inside the display.
  *
- * @param target - Reusable layout object written in place.
- * @param swatchRect - Swatch bounds in display coordinates.
- * @param label - Tooltip label text.
- * @param displayWidth - Logical display width.
- * @param displayHeight - Logical display height.
+ * @param target – Reusable layout object written in place.
+ * @param swatchRect – Swatch bounds in display coordinates.
+ * @param label – Tooltip label text.
+ * @param displayWidth – Logical display width.
+ * @param displayHeight – Logical display height.
  * @returns `target` for chaining.
  */
 export function layoutTooltip(
@@ -383,10 +383,10 @@ export function layoutTooltip(
 /**
  * Draws a docked palette swatch tooltip body and 1px border.
  *
- * @param target - Overlay draw target.
- * @param layout - Tooltip layout from {@link layoutTooltip}.
- * @param barIndex - Palette index for tooltip body fill (overlay background).
- * @param textIndex - Palette index for the border stroke.
+ * @param target – Overlay draw target.
+ * @param layout – Tooltip layout from {@link layoutTooltip}.
+ * @param barIndex – Palette index for tooltip body fill (overlay background).
+ * @param textIndex – Palette index for the border stroke.
  */
 export function drawTooltipChrome(
     target: OverlayDrawTarget,
@@ -414,11 +414,11 @@ export function drawTooltipChrome(
 /**
  * Draws a docked palette swatch tooltip label.
  *
- * @param target - Overlay draw target.
- * @param font - System bitmap font.
- * @param layout - Tooltip layout from {@link layoutTooltip}.
- * @param label - Tooltip label text.
- * @param textIndex - Palette index for label text.
+ * @param target – Overlay draw target.
+ * @param font – System bitmap font.
+ * @param layout – Tooltip layout from {@link layoutTooltip}.
+ * @param label – Tooltip label text.
+ * @param textIndex – Palette index for label text.
  */
 export function drawTooltipLabel(
     target: OverlayDrawTarget,
@@ -439,7 +439,7 @@ export function drawTooltipLabel(
 /**
  * Writes palette index text to the clipboard when the API is available.
  *
- * @param index - Palette slot to copy.
+ * @param index – Palette slot to copy.
  * @returns Resolves on success; rejects when clipboard is unavailable or denied.
  */
 export async function writeIndexToClipboard(index: number): Promise<void> {
@@ -486,7 +486,7 @@ export class PaletteInteraction {
     /**
      * Creates palette interaction state.
      *
-     * @param targetFps - Configured fixed-update rate for copy-status timing.
+     * @param targetFps – Configured fixed-update rate for copy-status timing.
      */
     constructor(targetFps: number) {
         this.#targetFps = targetFps;
@@ -513,7 +513,7 @@ export class PaletteInteraction {
     /**
      * Clamps scroll offset when grid dimensions change between frames.
      *
-     * @param grid - Precomputed grid layout for this frame.
+     * @param grid – Precomputed grid layout for this frame.
      */
     syncScrollBounds(grid: PaletteGridLayout): void {
         this.#scrollRowOffset = clampScrollRowOffset(this.#scrollRowOffset, grid);
@@ -525,10 +525,10 @@ export class PaletteInteraction {
      * Wheel delta is consumed only while the pointer is over the palette band so
      * demo code reading {@link BT.pointerScrollDelta} elsewhere is unaffected.
      *
-     * @param pointer - Pointer subsystem, or `null` when unavailable.
-     * @param plan - Layout plan for this frame.
-     * @param grid - Palette grid layout.
-     * @param isSwatchPressConsumed - When true, drag scrolling is skipped this frame.
+     * @param pointer – Pointer subsystem, or `null` when unavailable.
+     * @param plan – Layout plan for this frame.
+     * @param grid – Palette grid layout.
+     * @param isSwatchPressConsumed – When true, drag scrolling is skipped this frame.
      * @returns `true` when a scrollbar-track press should block the toggle corner.
      */
     handleScroll(
@@ -591,7 +591,7 @@ export class PaletteInteraction {
     /**
      * Clears transient copy status when the expiry tick is reached.
      *
-     * @param currentTick - Current fixed-update tick.
+     * @param currentTick – Current fixed-update tick.
      */
     tickCopyStatus(currentTick: number): void {
         this.#lastKnownTick = currentTick;
@@ -607,12 +607,12 @@ export class PaletteInteraction {
     /**
      * Updates hovered swatch index from the current pointer position.
      *
-     * @param pointer - Pointer subsystem, or `null` when unavailable.
-     * @param plan - Layout plan for this frame.
-     * @param grid - Palette grid layout.
-     * @param colorCount - Active palette slot count.
-     * @param hintBarTopY - Top Y of the bottom hint bar for icon exclusion.
-     * @param displayWidth - Logical display width.
+     * @param pointer – Pointer subsystem, or `null` when unavailable.
+     * @param plan – Layout plan for this frame.
+     * @param grid – Palette grid layout.
+     * @param colorCount – Active palette slot count.
+     * @param hintBarTopY – Top Y of the bottom hint bar for icon exclusion.
+     * @param displayWidth – Logical display width.
      */
     updateHover(
         pointer: PointerInput | null,
@@ -668,13 +668,13 @@ export class PaletteInteraction {
     /**
      * Handles primary press over a swatch and attempts clipboard copy.
      *
-     * @param pointer - Pointer subsystem, or `null` when unavailable.
-     * @param currentTick - Current fixed-update tick.
-     * @param plan - Layout plan for this frame.
-     * @param grid - Palette grid layout.
-     * @param colorCount - Active palette slot count.
-     * @param hintBarTopY - Top Y of the bottom hint bar for icon exclusion.
-     * @param displayWidth - Logical display width.
+     * @param pointer – Pointer subsystem, or `null` when unavailable.
+     * @param currentTick – Current fixed-update tick.
+     * @param plan – Layout plan for this frame.
+     * @param grid – Palette grid layout.
+     * @param colorCount – Active palette slot count.
+     * @param hintBarTopY – Top Y of the bottom hint bar for icon exclusion.
+     * @param displayWidth – Logical display width.
      * @returns `true` when a swatch press was handled (toggle should be skipped).
      */
     handlePress(
@@ -734,13 +734,13 @@ export class PaletteInteraction {
     /**
      * Draws tooltip body and border during the overlay fill phase.
      *
-     * @param target - Overlay draw target.
-     * @param plan - Layout plan for this frame.
-     * @param grid - Palette grid layout.
-     * @param displayWidth - Logical display width.
-     * @param displayHeight - Logical display height.
-     * @param barIndex - Tooltip body fill palette index.
-     * @param textIndex - Tooltip border palette index.
+     * @param target – Overlay draw target.
+     * @param plan – Layout plan for this frame.
+     * @param grid – Palette grid layout.
+     * @param displayWidth – Logical display width.
+     * @param displayHeight – Logical display height.
+     * @param barIndex – Tooltip body fill palette index.
+     * @param textIndex – Tooltip border palette index.
      */
     drawTooltipChrome(
         target: OverlayDrawTarget,
@@ -763,13 +763,13 @@ export class PaletteInteraction {
     /**
      * Draws tooltip label text during the overlay label phase.
      *
-     * @param target - Overlay draw target.
-     * @param font - System bitmap font.
-     * @param plan - Layout plan for this frame.
-     * @param grid - Palette grid layout.
-     * @param displayWidth - Logical display width.
-     * @param displayHeight - Logical display height.
-     * @param textIndex - Tooltip label palette index.
+     * @param target – Overlay draw target.
+     * @param font – System bitmap font.
+     * @param plan – Layout plan for this frame.
+     * @param grid – Palette grid layout.
+     * @param displayWidth – Logical display width.
+     * @param displayHeight – Logical display height.
+     * @param textIndex – Tooltip label palette index.
      */
     drawTooltipLabel(
         target: OverlayDrawTarget,
@@ -792,9 +792,9 @@ export class PaletteInteraction {
     /**
      * Applies wheel scrolling when the pointer is over the palette footer region.
      *
-     * @param pointer - Pointer subsystem.
-     * @param plan - Layout plan for this frame.
-     * @param grid - Palette grid layout.
+     * @param pointer – Pointer subsystem.
+     * @param plan – Layout plan for this frame.
+     * @param grid – Palette grid layout.
      * @returns `true` when wheel delta was consumed.
      */
     #applyScrollWheel(pointer: PointerInput, plan: OverlayLayoutPlan, grid: PaletteGridLayout): boolean {
@@ -830,9 +830,9 @@ export class PaletteInteraction {
     /**
      * Applies primary-button drag scrolling over the palette grid or scrollbar track.
      *
-     * @param pointer - Pointer subsystem.
-     * @param plan - Layout plan for this frame.
-     * @param grid - Palette grid layout.
+     * @param pointer – Pointer subsystem.
+     * @param plan – Layout plan for this frame.
+     * @param grid – Palette grid layout.
      * @returns `true` when drag scrolling consumed a toggle-corner press.
      */
     #applyScrollDrag(pointer: PointerInput, plan: OverlayLayoutPlan, grid: PaletteGridLayout): boolean {
@@ -916,10 +916,10 @@ export class PaletteInteraction {
     /**
      * Lays out the active hover or copy-status tooltip, or returns `null` when none applies.
      *
-     * @param plan - Layout plan for this frame.
-     * @param grid - Palette grid layout.
-     * @param displayWidth - Logical display width.
-     * @param displayHeight - Logical display height.
+     * @param plan – Layout plan for this frame.
+     * @param grid – Palette grid layout.
+     * @param displayWidth – Logical display width.
+     * @param displayHeight – Logical display height.
      * @returns Tooltip layout and label, or `null`.
      */
     #layoutActiveTooltip(
@@ -950,9 +950,9 @@ export class PaletteInteraction {
     /**
      * Updates transient copy feedback after a clipboard write attempt.
      *
-     * @param status - New copy status.
-     * @param index - Palette index that was copied.
-     * @param completionTick - Fixed-update tick when the clipboard write finished.
+     * @param status – New copy status.
+     * @param index – Palette index that was copied.
+     * @param completionTick – Fixed-update tick when the clipboard write finished.
      */
     #setCopyStatus(status: Exclude<CopyStatus, 'idle'>, index: number, completionTick: number): void {
         this.#copyStatus = status;

--- a/packages/blit386/src/overlay/palette/PaletteView.ts
+++ b/packages/blit386/src/overlay/palette/PaletteView.ts
@@ -43,9 +43,9 @@ export const DEFAULT_PALETTE_GRID: PaletteGridLayout = {
 /**
  * Computes the horizontal span of one grid row.
  *
- * @param cols - Column count.
- * @param swatchSize - Side length of each swatch.
- * @param gap - Gap between swatches.
+ * @param cols – Column count.
+ * @param swatchSize – Side length of each swatch.
+ * @param gap – Gap between swatches.
  * @returns Row width in pixels.
  */
 export function gridRowWidth(cols: number, swatchSize: number, gap: number): number {
@@ -59,9 +59,9 @@ export function gridRowWidth(cols: number, swatchSize: number, gap: number): num
 /**
  * Computes the vertical span of the full grid.
  *
- * @param rows - Row count.
- * @param swatchSize - Side length of each swatch.
- * @param gap - Gap between swatches.
+ * @param rows – Row count.
+ * @param swatchSize – Side length of each swatch.
+ * @param gap – Gap between swatches.
  * @returns Grid height in pixels.
  */
 export function gridRowStackHeight(rows: number, swatchSize: number, gap: number): number {
@@ -75,11 +75,11 @@ export function gridRowStackHeight(rows: number, swatchSize: number, gap: number
 /**
  * Picks the widest column count that fits the display while halving from the palette size.
  *
- * @param displayWidth - Logical display width in pixels.
- * @param swatchSize - Side length of each swatch.
- * @param gap - Gap between swatches.
- * @param colorCount - Active palette slot count.
- * @param maxColumns - Optional cap from {@link HardwareSettings.overlayPaletteColumns}.
+ * @param displayWidth – Logical display width in pixels.
+ * @param swatchSize – Side length of each swatch.
+ * @param gap – Gap between swatches.
+ * @param colorCount – Active palette slot count.
+ * @param maxColumns – Optional cap from {@link HardwareSettings.overlayPaletteColumns}.
  * @returns Column count (at least 1).
  */
 export function pickGridColumnCount(
@@ -110,8 +110,8 @@ export function pickGridColumnCount(
 /**
  * Resolves the visible row count for a palette grid viewport.
  *
- * @param totalRows - Full palette row count.
- * @param maxVisibleRows - Optional cap from {@link HardwareSettings.overlayPaletteRowsVisible}.
+ * @param totalRows – Full palette row count.
+ * @param maxVisibleRows – Optional cap from {@link HardwareSettings.overlayPaletteRowsVisible}.
  * @returns Visible rows (0 when `totalRows` is 0; otherwise clamped to `[1, totalRows]`).
  */
 export function resolveGridVisibleRows(totalRows: number, maxVisibleRows?: number): number {
@@ -131,12 +131,12 @@ export function resolveGridVisibleRows(totalRows: number, maxVisibleRows?: numbe
 /**
  * Computes palette grid layout for the bottom band.
  *
- * @param displayWidth - Logical display width in pixels.
- * @param swatchSize - Side length of each swatch (default {@link DEFAULT_PALETTE_SWATCH_SIZE}).
- * @param colorCount - Number of palette slots to show (default 256).
- * @param gap - Gap between swatches (default 1).
- * @param maxColumns - Optional cap from {@link HardwareSettings.overlayPaletteColumns}.
- * @param maxVisibleRows - Optional cap from {@link HardwareSettings.overlayPaletteRowsVisible}.
+ * @param displayWidth – Logical display width in pixels.
+ * @param swatchSize – Side length of each swatch (default {@link DEFAULT_PALETTE_SWATCH_SIZE}).
+ * @param colorCount – Number of palette slots to show (default 256).
+ * @param gap – Gap between swatches (default 1).
+ * @param maxColumns – Optional cap from {@link HardwareSettings.overlayPaletteColumns}.
+ * @param maxVisibleRows – Optional cap from {@link HardwareSettings.overlayPaletteRowsVisible}.
  * @returns Grid dimensions and viewport band height.
  */
 export function computeGrid(
@@ -162,14 +162,14 @@ export function computeGrid(
 /**
  * Returns whether two axis-aligned rects overlap (zero allocation).
  *
- * @param ax - Left edge of rect A.
- * @param ay - Top edge of rect A.
- * @param aw - Width of rect A.
- * @param ah - Height of rect A.
- * @param bx - Left edge of rect B.
- * @param by - Top edge of rect B.
- * @param bw - Width of rect B.
- * @param bh - Height of rect B.
+ * @param ax – Left edge of rect A.
+ * @param ay – Top edge of rect A.
+ * @param aw – Width of rect A.
+ * @param ah – Height of rect A.
+ * @param bx – Left edge of rect B.
+ * @param by – Top edge of rect B.
+ * @param bw – Width of rect B.
+ * @param bh – Height of rect B.
  * @returns `true` when the rects overlap.
  */
 function doRectsOverlap(
@@ -188,10 +188,10 @@ function doRectsOverlap(
 /**
  * Returns whether a swatch rect intersects an exclusion region.
  *
- * @param x - Swatch left edge in display pixels.
- * @param y - Swatch top edge in display pixels.
- * @param swatchSize - Side length of the swatch.
- * @param exclusion - Region to avoid (for example the toggle hint icon).
+ * @param x – Swatch left edge in display pixels.
+ * @param y – Swatch top edge in display pixels.
+ * @param swatchSize – Side length of the swatch.
+ * @param exclusion – Region to avoid (for example the toggle hint icon).
  * @returns `true` when any part of the swatch overlaps the exclusion rect.
  */
 function doesSwatchIntersectExclusion(x: number, y: number, swatchSize: number, exclusion: Rect2i): boolean {
@@ -210,8 +210,8 @@ const hintExclusionCache = {
  *
  * Reuses {@link hintExclusionCache.rect} when `hintBarTopY` and `displayWidth` match the previous call.
  *
- * @param hintBarTopY - Top Y of the bottom hint bar from the layout plan.
- * @param displayWidth - Logical display width (cache key only; icon X is margin-based).
+ * @param hintBarTopY – Top Y of the bottom hint bar from the layout plan.
+ * @param displayWidth – Logical display width (cache key only; icon X is margin-based).
  * @returns Exclusion rect for swatch placement and hit testing.
  */
 export function resolveHintExclusionRect(hintBarTopY: number, displayWidth: number): Rect2i {
@@ -239,10 +239,10 @@ const gridDrawScratch = {
 /**
  * Writes the filled marker rect for an unused swatch into {@link target}.
  *
- * @param target - Reusable rect mutated in place.
- * @param x - Swatch left edge in display pixels.
- * @param y - Swatch top edge in display pixels.
- * @param swatchSize - Side length of the swatch.
+ * @param target – Reusable rect mutated in place.
+ * @param x – Swatch left edge in display pixels.
+ * @param y – Swatch top edge in display pixels.
+ * @param swatchSize – Side length of the swatch.
  */
 function writeUnusedSwatchMarkerRect(target: Rect2i, x: number, y: number, swatchSize: number): void {
     if (swatchSize <= 0) {
@@ -259,9 +259,9 @@ function writeUnusedSwatchMarkerRect(target: Rect2i, x: number, y: number, swatc
 /**
  * Computes the filled marker rect drawn inside an unused swatch.
  *
- * @param x - Swatch left edge in display pixels.
- * @param y - Swatch top edge in display pixels.
- * @param swatchSize - Side length of the swatch.
+ * @param x – Swatch left edge in display pixels.
+ * @param y – Swatch top edge in display pixels.
+ * @param swatchSize – Side length of the swatch.
  * @returns Marker rect clamped and centered within the swatch bounds, or a
  * zero-area rect at `(x, y)` when `swatchSize` is not positive.
  */
@@ -276,12 +276,12 @@ export function computeUnusedSwatchMarkerRect(x: number, y: number, swatchSize: 
 /**
  * Draws a centered filled marker inside an unused swatch.
  *
- * @param target - Overlay draw target.
- * @param markerScratch - Reusable marker rect mutated in place.
- * @param x - Swatch left edge in display pixels.
- * @param y - Swatch top edge in display pixels.
- * @param swatchSize - Side length of the swatch.
- * @param markIndex - Palette index for the marker fill.
+ * @param target – Overlay draw target.
+ * @param markerScratch – Reusable marker rect mutated in place.
+ * @param x – Swatch left edge in display pixels.
+ * @param y – Swatch top edge in display pixels.
+ * @param swatchSize – Side length of the swatch.
+ * @param markIndex – Palette index for the marker fill.
  */
 function drawUnusedSwatch(
     target: OverlayDrawTarget,
@@ -307,8 +307,8 @@ function drawUnusedSwatch(
 /**
  * Returns whether a palette slot was referenced by demo draw calls this frame.
  *
- * @param usedMask - Per-frame usage mask from BTAPI.
- * @param index - Palette slot to query.
+ * @param usedMask – Per-frame usage mask from BTAPI.
+ * @param index – Palette slot to query.
  * @returns `true` when the slot is marked used.
  */
 function isSlotUsed(usedMask: Uint8Array, index: number): boolean {
@@ -319,15 +319,15 @@ function isSlotUsed(usedMask: Uint8Array, index: number): boolean {
 /**
  * Draws one palette swatch or its unused marker.
  *
- * @param target - Overlay draw target.
- * @param swatchScratch - Reusable swatch rect mutated in place.
- * @param markerScratch - Reusable marker rect mutated in place.
- * @param x - Swatch left edge in display pixels.
- * @param y - Swatch top edge in display pixels.
- * @param swatchSize - Side length of the swatch.
- * @param index - Palette slot index for this swatch.
- * @param usedMask - Per-frame usage mask from BTAPI.
- * @param unusedMarkIndex - Palette index for unused swatch marker fills.
+ * @param target – Overlay draw target.
+ * @param swatchScratch – Reusable swatch rect mutated in place.
+ * @param markerScratch – Reusable marker rect mutated in place.
+ * @param x – Swatch left edge in display pixels.
+ * @param y – Swatch top edge in display pixels.
+ * @param swatchSize – Side length of the swatch.
+ * @param index – Palette slot index for this swatch.
+ * @param usedMask – Per-frame usage mask from BTAPI.
+ * @param unusedMarkIndex – Palette index for unused swatch marker fills.
  */
 function drawSwatch(
     target: OverlayDrawTarget,
@@ -351,11 +351,11 @@ function drawSwatch(
 /**
  * Writes the top-left corner of a palette swatch into {@link target}.
  *
- * @param target - Reusable rect mutated in place.
- * @param index - Palette slot index.
- * @param paletteBand - Palette band rect from layout plan.
- * @param grid - Precomputed grid layout.
- * @param scrollRowOffset - First visible grid row (default `0`).
+ * @param target – Reusable rect mutated in place.
+ * @param index – Palette slot index.
+ * @param paletteBand – Palette band rect from layout plan.
+ * @param grid – Precomputed grid layout.
+ * @param scrollRowOffset – First visible grid row (default `0`).
  */
 export function writeSwatchTopLeft(
     target: Rect2i,
@@ -384,14 +384,14 @@ export function writeSwatchTopLeft(
 /**
  * Draws the visible palette swatch window inside the bottom band.
  *
- * @param target - Overlay draw target.
- * @param paletteBand - Palette band rect from layout plan.
- * @param colorCount - Active palette slot count.
- * @param grid - Precomputed grid layout.
- * @param hintExclusion - Region to skip for the toggle hint icon.
- * @param usedMask - Per-frame usage mask from BTAPI.
- * @param unusedMarkIndex - Palette index for unused swatch marker fills.
- * @param scrollRowOffset - First visible grid row (default `0`).
+ * @param target – Overlay draw target.
+ * @param paletteBand – Palette band rect from layout plan.
+ * @param colorCount – Active palette slot count.
+ * @param grid – Precomputed grid layout.
+ * @param hintExclusion – Region to skip for the toggle hint icon.
+ * @param usedMask – Per-frame usage mask from BTAPI.
+ * @param unusedMarkIndex – Palette index for unused swatch marker fills.
+ * @param scrollRowOffset – First visible grid row (default `0`).
  */
 function drawSwatchGrid(
     target: OverlayDrawTarget,
@@ -427,8 +427,8 @@ function drawSwatchGrid(
 /**
  * Computes macOS-style thumb height: visible fraction of total rows, clamped to the track.
  *
- * @param trackHeight - Full palette band height in pixels.
- * @param grid - Precomputed grid layout.
+ * @param trackHeight – Full palette band height in pixels.
+ * @param grid – Precomputed grid layout.
  * @returns Thumb height in pixels, or `0` when inputs are invalid.
  */
 export function computeScrollbarThumbHeight(trackHeight: number, grid: PaletteGridLayout): number {
@@ -449,12 +449,12 @@ export function computeScrollbarThumbHeight(trackHeight: number, grid: PaletteGr
  * The track is inset 1 px from the palette band top, right, and bottom edges. Only the
  * thumb is drawn; the track rect is used for hit testing and thumb placement.
  *
- * @param trackTarget - Reusable track rect mutated in place.
- * @param thumbTarget - Reusable thumb rect mutated in place.
- * @param paletteBand - Palette band rect from layout plan.
- * @param grid - Precomputed grid layout.
- * @param scrollRowOffset - First visible grid row.
- * @param trackWidth - Scrollbar track width in pixels.
+ * @param trackTarget – Reusable track rect mutated in place.
+ * @param thumbTarget – Reusable thumb rect mutated in place.
+ * @param paletteBand – Palette band rect from layout plan.
+ * @param grid – Precomputed grid layout.
+ * @param scrollRowOffset – First visible grid row.
+ * @param trackWidth – Scrollbar track width in pixels.
  * @returns `true` when scrolling is possible and rects were written.
  */
 export function writeScrollbarRects(
@@ -500,12 +500,12 @@ export function writeScrollbarRects(
 /**
  * Draws the palette scrollbar thumb inside the bottom band (no track fill).
  *
- * @param target - Overlay draw target.
- * @param paletteBand - Palette band rect from layout plan.
- * @param grid - Precomputed grid layout.
- * @param scrollRowOffset - First visible grid row.
- * @param trackWidth - Scrollbar track width in pixels.
- * @param thumbIndex - Palette index for the thumb fill.
+ * @param target – Overlay draw target.
+ * @param paletteBand – Palette band rect from layout plan.
+ * @param grid – Precomputed grid layout.
+ * @param scrollRowOffset – First visible grid row.
+ * @param trackWidth – Scrollbar track width in pixels.
+ * @param thumbIndex – Palette index for the thumb fill.
  */
 function drawScrollbar(
     target: OverlayDrawTarget,
@@ -534,7 +534,7 @@ export class PaletteView {
     /**
      * Creates a palette view with the given feature flag.
      *
-     * @param isEnabled - When false, draw is a no-op (default matches public opt-in API).
+     * @param isEnabled – When false, draw is a no-op (default matches public opt-in API).
      */
     constructor(isEnabled = false) {
         this.#isEnabled = isEnabled;
@@ -552,17 +552,17 @@ export class PaletteView {
     /**
      * Draws palette swatches in the bottom band.
      *
-     * @param target - Overlay draw target.
-     * @param paletteBand - Palette band rect from layout plan.
-     * @param palette - Active demo palette.
-     * @param grid - Precomputed grid layout.
-     * @param hintBarTopY - Top Y of the bottom hint bar for icon exclusion.
-     * @param displayWidth - Logical display width for hint exclusion cache key.
-     * @param usedMask - Per-frame usage mask populated during demo render.
-     * @param unusedMarkIndex - Palette index for unused swatch marker fills.
-     * @param scrollRowOffset - First visible grid row (default `0`).
-     * @param scrollbarTrackWidth - Right-edge scrollbar track width (default `0`).
-     * @param scrollbarThumbIndex - Palette index for scrollbar thumb fill.
+     * @param target – Overlay draw target.
+     * @param paletteBand – Palette band rect from layout plan.
+     * @param palette – Active demo palette.
+     * @param grid – Precomputed grid layout.
+     * @param hintBarTopY – Top Y of the bottom hint bar for icon exclusion.
+     * @param displayWidth – Logical display width for hint exclusion cache key.
+     * @param usedMask – Per-frame usage mask populated during demo render.
+     * @param unusedMarkIndex – Palette index for unused swatch marker fills.
+     * @param scrollRowOffset – First visible grid row (default `0`).
+     * @param scrollbarTrackWidth – Right-edge scrollbar track width (default `0`).
+     * @param scrollbarThumbIndex – Palette index for scrollbar thumb fill.
      */
     draw(
         target: OverlayDrawTarget,

--- a/packages/blit386/src/overlay/sampling/FpsSampler.ts
+++ b/packages/blit386/src/overlay/sampling/FpsSampler.ts
@@ -14,7 +14,7 @@ export class FpsSampler {
     /**
      * Creates a sampler seeded with the configured target rate.
      *
-     * @param targetFps - Configured target FPS used until the first sample arrives.
+     * @param targetFps – Configured target FPS used until the first sample arrives.
      */
     constructor(targetFps: number) {
         this.#targetFps = targetFps;

--- a/packages/blit386/src/overlay/sampling/TimingSampler.ts
+++ b/packages/blit386/src/overlay/sampling/TimingSampler.ts
@@ -75,7 +75,7 @@ export class TimingSampler {
     /**
      * Ingests one frame-timing snapshot.
      *
-     * @param sample - Current-frame timing values from BTAPI.
+     * @param sample – Current-frame timing values from BTAPI.
      */
     sample(sample: OverlayTimingSnapshot): void {
         const frameMs = Math.max(0, sample.frameMs);
@@ -116,8 +116,8 @@ export class TimingSampler {
     /**
      * Pads one pipeline's vertex and overflow counts to their fixed field widths.
      *
-     * @param vertices - Submitted vertex count for the pipeline.
-     * @param overflow - Overflow (dropped-batch) count for the pipeline.
+     * @param vertices – Submitted vertex count for the pipeline.
+     * @param overflow – Overflow (dropped-batch) count for the pipeline.
      * @returns Formatted `Xv ov Y` segment with fixed-width padded fields.
      */
     #formatBatchStats(vertices: number, overflow: number): string {

--- a/packages/blit386/src/overlay/testFixtures.ts
+++ b/packages/blit386/src/overlay/testFixtures.ts
@@ -24,7 +24,7 @@ export type BitmapTextCall = {
  * Draw helpers reuse scratch `Rect2i`/`Vector2i` instances, so recording the raw call
  * arguments would capture their final mutated state instead of the value at call time.
  *
- * @param snapshot - Derives a defensive-copy snapshot from a call's arguments.
+ * @param snapshot – Derives a defensive-copy snapshot from a call's arguments.
  * @returns The mock function and the array its snapshots are pushed onto, in call order.
  */
 function createSnapshotMock<TArgs extends unknown[], TSnapshot>(
@@ -94,7 +94,7 @@ export function createMockRenderer(): OverlayRenderer & {
 /**
  * Collects {@link OverlayDrawTarget.drawLabel} calls from a mock renderer.
  *
- * @param renderer - Mock from {@link createMockRenderer}.
+ * @param renderer – Mock from {@link createMockRenderer}.
  * @returns Parsed draw calls in invocation order.
  */
 export function getBitmapTextCalls(renderer: ReturnType<typeof createMockRenderer>): BitmapTextCall[] {
@@ -108,7 +108,7 @@ export function getBitmapTextCalls(renderer: ReturnType<typeof createMockRendere
 /**
  * Collects {@link OverlayDrawTarget.drawLabelOnTop} calls from a mock renderer.
  *
- * @param renderer - Mock from {@link createMockRenderer}.
+ * @param renderer – Mock from {@link createMockRenderer}.
  * @returns Parsed draw calls in invocation order.
  */
 export function getLabelOnTopCalls(renderer: ReturnType<typeof createMockRenderer>): BitmapTextCall[] {
@@ -122,7 +122,7 @@ export function getLabelOnTopCalls(renderer: ReturnType<typeof createMockRendere
 /**
  * Collects {@link OverlayDrawTarget.drawBarFill} rects from a mock renderer.
  *
- * @param renderer - Mock from {@link createMockRenderer}.
+ * @param renderer – Mock from {@link createMockRenderer}.
  * @returns Filled rectangles in invocation order.
  */
 export function getRectFillCalls(renderer: ReturnType<typeof createMockRenderer>): Rect2i[] {
@@ -132,9 +132,9 @@ export function getRectFillCalls(renderer: ReturnType<typeof createMockRenderer>
 /**
  * Y of custom row bar top stacked above the footer.
  *
- * @param displayHeight - Logical display height.
- * @param rowIndex - Custom row index.
- * @param footerHeight - Reserved footer height from {@link resolveOverlayFooterHeight}.
+ * @param displayHeight – Logical display height.
+ * @param rowIndex – Custom row index.
+ * @param footerHeight – Reserved footer height from {@link resolveOverlayFooterHeight}.
  * @returns Bar top Y.
  */
 export function customRowBarY(displayHeight: number, rowIndex: number, footerHeight = OVERLAY_BAR_HEIGHT): number {

--- a/packages/blit386/src/overlay/timing-chart/TimingChart.test.ts
+++ b/packages/blit386/src/overlay/timing-chart/TimingChart.test.ts
@@ -26,10 +26,10 @@ const defaultStyle = {
 /**
  * Draws a chart band in tests with the required font and tick arguments.
  *
- * @param chart - Timing chart under test.
- * @param renderer - Mock overlay renderer.
- * @param chartRect - Chart band rectangle.
- * @param currentTick - Simulated fixed-update tick.
+ * @param chart – Timing chart under test.
+ * @param renderer – Mock overlay renderer.
+ * @param chartRect – Chart band rectangle.
+ * @param currentTick – Simulated fixed-update tick.
  */
 function drawChart(
     chart: TimingChart,

--- a/packages/blit386/src/overlay/timing-chart/TimingChart.ts
+++ b/packages/blit386/src/overlay/timing-chart/TimingChart.ts
@@ -87,9 +87,9 @@ export class TimingChart {
     /**
      * Creates a timing chart with the given feature flag.
      *
-     * @param isEnabled - When false, sample/draw are no-ops.
-     * @param targetFps - Configured fixed-step rate for frame-budget classification.
-     * @param diagnosticsMode - Renderer diagnostic visualization (`minimal`, `rich`, or `false`).
+     * @param isEnabled – When false, sample/draw are no-ops.
+     * @param targetFps – Configured fixed-step rate for frame-budget classification.
+     * @param diagnosticsMode – Renderer diagnostic visualization (`minimal`, `rich`, or `false`).
      */
     constructor(isEnabled = false, targetFps = 60, diagnosticsMode: OverlayTimingChartDiagnosticsMode = false) {
         this.#isEnabled = isEnabled;
@@ -111,8 +111,8 @@ export class TimingChart {
      *
      * No-op when the chart is disabled. Empty labels become `"Untitled"`.
      *
-     * @param label - Tag text shown above the chart band.
-     * @param currentTick - Current fixed-update tick (`BT.ticks`).
+     * @param label – Tag text shown above the chart band.
+     * @param currentTick – Current fixed-update tick (`BT.ticks`).
      */
     assignTag(label: string | undefined, currentTick: number): void {
         if (this.#bufferWidth <= 0) {
@@ -131,8 +131,8 @@ export class TimingChart {
      *
      * Resets tags and adds a {@link TIMING_CHART_TAG_START} marker (RetroBlit Reset parity).
      *
-     * @param width - New chart width in pixels.
-     * @param currentTick - Current fixed-update tick for tag epoch and start marker.
+     * @param width – New chart width in pixels.
+     * @param currentTick – Current fixed-update tick for tag epoch and start marker.
      */
     reset(width: number, currentTick = 0): void {
         if (width <= 0) {
@@ -168,7 +168,7 @@ export class TimingChart {
     /**
      * Records one frame timing sample into the ring buffer.
      *
-     * @param timing - Per-frame snapshot from BTAPI.
+     * @param timing – Per-frame snapshot from BTAPI.
      */
     sample(timing: OverlayTimingSnapshot): void {
         if (!this.#isEnabled || this.#bufferWidth <= 0) {
@@ -209,11 +209,11 @@ export class TimingChart {
      * Uses {@link OverlayDrawTarget.drawBarFill} with 1x1 rects so update and render samples stay
      * visible without alpha blending (palette-indexed engine).
      *
-     * @param target - Overlay draw target.
-     * @param chartRect - Screen-space chart band from layout plan.
-     * @param style - Resolved chart palette indices.
-     * @param font - System bitmap font for tag labels.
-     * @param currentTick - Current fixed-update tick for tag scroll and prune.
+     * @param target – Overlay draw target.
+     * @param chartRect – Screen-space chart band from layout plan.
+     * @param style – Resolved chart palette indices.
+     * @param font – System bitmap font for tag labels.
+     * @param currentTick – Current fixed-update tick for tag scroll and prune.
      */
     draw(
         target: OverlayDrawTarget,
@@ -244,9 +244,9 @@ export class TimingChart {
     /**
      * Draws one-pixel timing samples for each populated ring-buffer column.
      *
-     * @param target - Overlay draw target.
-     * @param chartRect - Screen-space chart band.
-     * @param style - Resolved chart palette indices.
+     * @param target – Overlay draw target.
+     * @param chartRect – Screen-space chart band.
+     * @param style – Resolved chart palette indices.
      */
     #drawSamples(target: OverlayDrawTarget, chartRect: Rect2i, style: TimingChartDrawStyle): void {
         const baselineY = timingChartBaselineY(chartRect);
@@ -314,10 +314,10 @@ export class TimingChart {
     /**
      * Draws a one-pixel vertical marker per tag, aligned with timing columns.
      *
-     * @param target - Overlay draw target.
-     * @param chartRect - Screen-space chart band.
-     * @param style - Resolved chart palette indices.
-     * @param tagGroups - Tags grouped by sample column.
+     * @param target – Overlay draw target.
+     * @param chartRect – Screen-space chart band.
+     * @param style – Resolved chart palette indices.
+     * @param tagGroups – Tags grouped by sample column.
      */
     #drawTagMarkers(
         target: OverlayDrawTarget,
@@ -340,11 +340,11 @@ export class TimingChart {
     /**
      * Draws event tag labels above the chart band.
      *
-     * @param target - Overlay draw target.
-     * @param chartRect - Screen-space chart band.
-     * @param style - Resolved chart palette indices.
-     * @param font - System bitmap font.
-     * @param tagGroups - Tags grouped by sample column.
+     * @param target – Overlay draw target.
+     * @param chartRect – Screen-space chart band.
+     * @param style – Resolved chart palette indices.
+     * @param font – System bitmap font.
+     * @param tagGroups – Tags grouped by sample column.
      */
     #drawTags(
         target: OverlayDrawTarget,
@@ -401,9 +401,9 @@ export class TimingChart {
     /**
      * Draws faint horizontal grid lines behind timing dots.
      *
-     * @param target - Overlay draw target.
-     * @param chartRect - Screen-space chart band from layout plan.
-     * @param style - Resolved chart palette indices.
+     * @param target – Overlay draw target.
+     * @param chartRect – Screen-space chart band from layout plan.
+     * @param style – Resolved chart palette indices.
      */
     #drawGridLines(target: OverlayDrawTarget, chartRect: Rect2i, style: TimingChartDrawStyle): void {
         const markerCount = writeTimingChartGridMarkers(this.#targetFps, this.#gridMarkerMs);
@@ -432,7 +432,7 @@ export class TimingChart {
      * Resolves semantic tint palette index for a severity level.
      *
      * @param severity - {@link TIMING_CHART_SEVERITY_NONE}, {@link TIMING_CHART_SEVERITY_WARNING}, or {@link TIMING_CHART_SEVERITY_ERROR}.
-     * @param style - Resolved chart palette indices.
+     * @param style – Resolved chart palette indices.
      * @returns Palette index, or `null` to use per-bar update/render colors.
      */
     #severityPaletteIndex(severity: number, style: TimingChartDrawStyle): number | null {
@@ -450,10 +450,10 @@ export class TimingChart {
     /**
      * Draws a one-pixel severity marker on the chart baseline.
      *
-     * @param target - Overlay draw target.
-     * @param x - Column X in screen space.
-     * @param baselineY - Bottom row of the chart band.
-     * @param paletteIndex - Palette index for the marker.
+     * @param target – Overlay draw target.
+     * @param x – Column X in screen space.
+     * @param baselineY – Bottom row of the chart band.
+     * @param paletteIndex – Palette index for the marker.
      */
     #drawBaselineMarker(target: OverlayDrawTarget, x: number, baselineY: number, paletteIndex: number): void {
         this.#dotScratch.set(x, baselineY, 1, 1);
@@ -463,11 +463,11 @@ export class TimingChart {
     /**
      * Draws one timing sample as a single pixel anchored from the chart bottom row.
      *
-     * @param target - Overlay draw target.
-     * @param x - Column X in screen space.
-     * @param ms - Timing sample in milliseconds.
-     * @param chartRect - Chart band bounds for clamping.
-     * @param paletteIndex - Palette index for the dot.
+     * @param target – Overlay draw target.
+     * @param x – Column X in screen space.
+     * @param ms – Timing sample in milliseconds.
+     * @param chartRect – Chart band bounds for clamping.
+     * @param paletteIndex – Palette index for the dot.
      */
     #drawDot(target: OverlayDrawTarget, x: number, ms: number, chartRect: Rect2i, paletteIndex: number): void {
         const y = computeTimingChartDotY(ms, chartRect, TIMING_CHART_FULL_SCALE_MS);
@@ -484,12 +484,12 @@ export class TimingChart {
     /**
      * Draws a vertex-pressure sample in the lower third of the chart band (rich diagnostics mode).
      *
-     * @param target - Overlay draw target.
-     * @param x - Column X in screen space.
-     * @param vertices - Submitted vertex count for the pipeline.
-     * @param chartRect - Chart band bounds for clamping.
-     * @param regionHeight - Height of the pressure sub-band in pixels.
-     * @param paletteIndex - Palette index for the dot.
+     * @param target – Overlay draw target.
+     * @param x – Column X in screen space.
+     * @param vertices – Submitted vertex count for the pipeline.
+     * @param chartRect – Chart band bounds for clamping.
+     * @param regionHeight – Height of the pressure sub-band in pixels.
+     * @param paletteIndex – Palette index for the dot.
      */
     #drawPressureDot(
         target: OverlayDrawTarget,

--- a/packages/blit386/src/overlay/timing-chart/constants.ts
+++ b/packages/blit386/src/overlay/timing-chart/constants.ts
@@ -1,4 +1,4 @@
-/** Default timing chart band height in pixels (RetroBlit uses bottom - 22). */
+/** Default timing chart band height in pixels (RetroBlit uses bottom – 22). */
 export const DEFAULT_TIMING_CHART_HEIGHT = 22;
 
 /** Milliseconds mapped to full chart band height (~one 60 FPS frame budget). */

--- a/packages/blit386/src/overlay/timing-chart/severity.ts
+++ b/packages/blit386/src/overlay/timing-chart/severity.ts
@@ -20,7 +20,7 @@ export const TIMING_CHART_BUDGET_ERROR_RATIO = 1.5;
 /**
  * Maps dropped-frame count from {@link GameLoop} to chart severity.
  *
- * @param droppedFrames - Estimated skipped refresh intervals (0 = none).
+ * @param droppedFrames – Estimated skipped refresh intervals (0 = none).
  * @returns Warning, error, or none.
  */
 export function severityFromDroppedFrames(droppedFrames: number): number {
@@ -38,8 +38,8 @@ export function severityFromDroppedFrames(droppedFrames: number): number {
 /**
  * Maps frame wall time against the configured fixed-step budget.
  *
- * @param frameMs - Total frame CPU time in milliseconds.
- * @param targetFps - Configured simulation rate from {@link HardwareSettings.targetFPS}.
+ * @param frameMs – Total frame CPU time in milliseconds.
+ * @param targetFps – Configured simulation rate from {@link HardwareSettings.targetFPS}.
  * @returns Warning, error, or none.
  */
 export function severityFromFrameBudget(frameMs: number, targetFps: number): number {
@@ -69,9 +69,9 @@ export function severityFromFrameBudget(frameMs: number, targetFps: number): num
 /**
  * Combines budget and dropped-frame signals; error wins over warning.
  *
- * @param frameMs - Total frame CPU time in milliseconds.
- * @param targetFps - Configured simulation rate.
- * @param droppedFrames - Dropped frames detected this present interval (0 when none).
+ * @param frameMs – Total frame CPU time in milliseconds.
+ * @param targetFps – Configured simulation rate.
+ * @param droppedFrames – Dropped frames detected this present interval (0 when none).
  * @returns Highest severity for the chart column.
  */
 export function classifyTimingChartSeverity(frameMs: number, targetFps: number, droppedFrames: number): number {

--- a/packages/blit386/src/overlay/timing-chart/style.ts
+++ b/packages/blit386/src/overlay/timing-chart/style.ts
@@ -35,8 +35,8 @@ const pickOverlayBarTextGap = (
 /**
  * Resolves timing chart palette indices from overlay and chart-specific settings.
  *
- * @param overlayStyle - Global overlay bar/text indices from hardware settings.
- * @param chartStyle - Optional timing-chart palette overrides.
+ * @param overlayStyle – Global overlay bar/text indices from hardware settings.
+ * @param chartStyle – Optional timing-chart palette overrides.
  * @returns Resolved indices for chart draw and semantic severity tints.
  */
 export function resolveTimingChartStyle(
@@ -65,9 +65,9 @@ export function resolveTimingChartStyle(
  * Scales linearly so `fullScaleMs` fills the chart band. Any non-zero sample draws at
  * least one pixel so lightweight demos (sub-millisecond `update()` / `render()`) stay visible.
  *
- * @param ms - Sample value in milliseconds.
- * @param chartHeight - Chart band height in pixels.
- * @param fullScaleMs - Milliseconds that map to full band height.
+ * @param ms – Sample value in milliseconds.
+ * @param chartHeight – Chart band height in pixels.
+ * @param fullScaleMs – Milliseconds that map to full band height.
  * @returns Clamped offset in pixels (0 when sample is zero).
  */
 export function computeTimingChartBarHeight(ms: number, chartHeight: number, fullScaleMs: number): number {
@@ -83,9 +83,9 @@ export function computeTimingChartBarHeight(ms: number, chartHeight: number, ful
 /**
  * Maps submitted vertex count to a vertical offset within a pressure sub-band (rich diagnostics mode).
  *
- * @param vertices - Submitted vertices for one pipeline this frame.
- * @param regionHeight - Height of the pressure sub-band in pixels.
- * @param maxVertices - Pipeline capacity (typically 50k).
+ * @param vertices – Submitted vertices for one pipeline this frame.
+ * @param regionHeight – Height of the pressure sub-band in pixels.
+ * @param maxVertices – Pipeline capacity (typically 50k).
  * @returns Clamped offset in pixels (0 when vertices is zero).
  */
 export function computeTimingChartPressureHeight(vertices: number, regionHeight: number, maxVertices: number): number {
@@ -103,9 +103,9 @@ export function computeTimingChartPressureHeight(vertices: number, regionHeight:
  *
  * Uses the same baseline and bar-height scale as timing chart dots.
  *
- * @param ms - Threshold in milliseconds.
- * @param chartRect - Chart band bounds.
- * @param fullScaleMs - Milliseconds mapped to full band height.
+ * @param ms – Threshold in milliseconds.
+ * @param chartRect – Chart band bounds.
+ * @param fullScaleMs – Milliseconds mapped to full band height.
  * @returns Screen Y for a 1 px row, or `null` when the line would not be visible.
  */
 export function computeTimingChartGridLineY(
@@ -132,9 +132,9 @@ export function computeTimingChartGridLineY(
  *
  * Dots anchor to the bottom band row for light samples (see {@link timingChartBaselineY}).
  *
- * @param ms - Sample value in milliseconds.
- * @param chartRect - Chart band bounds.
- * @param fullScaleMs - Milliseconds mapped to full band height.
+ * @param ms – Sample value in milliseconds.
+ * @param chartRect – Chart band bounds.
+ * @param fullScaleMs – Milliseconds mapped to full band height.
  * @returns Screen Y for the dot, or `null` when the sample is zero.
  */
 export function computeTimingChartDotY(
@@ -165,7 +165,7 @@ export function computeTimingChartDotY(
 /**
  * Bottom row of the timing chart band (zero / sub-ms samples sit here).
  *
- * @param chartRect - Chart band bounds from layout plan.
+ * @param chartRect – Chart band bounds from layout plan.
  * @returns Screen Y of the last inclusive row in the band.
  */
 export function timingChartBaselineY(chartRect: Rect2i): number {
@@ -175,8 +175,8 @@ export function timingChartBaselineY(chartRect: Rect2i): number {
 /**
  * Whether a mapped grid line should be drawn (skips top and bottom band edges).
  *
- * @param y - Screen Y from {@link computeTimingChartGridLineY}.
- * @param chartRect - Chart band bounds.
+ * @param y – Screen Y from {@link computeTimingChartGridLineY}.
+ * @param chartRect – Chart band bounds.
  * @returns `true` when the row is strictly inside the band and not the baseline.
  */
 export function isTimingChartGridLineAtY(y: number, chartRect: Rect2i): boolean {
@@ -187,8 +187,8 @@ export function isTimingChartGridLineAtY(y: number, chartRect: Rect2i): boolean 
  * Backward-compatible alias for {@link isTimingChartGridLineAtY}.
  *
  * @deprecated Deprecated since 1.1.0 (2026-05-31). Use {@link isTimingChartGridLineAtY} instead.
- * @param y - Screen Y from {@link computeTimingChartGridLineY}.
- * @param chartRect - Chart band bounds.
+ * @param y – Screen Y from {@link computeTimingChartGridLineY}.
+ * @param chartRect – Chart band bounds.
  * @returns `true` when the row is strictly inside the band and not the baseline.
  */
 export const shouldDrawTimingChartGridLineY = isTimingChartGridLineAtY;
@@ -196,7 +196,7 @@ export const shouldDrawTimingChartGridLineY = isTimingChartGridLineAtY;
 /**
  * Frame-budget grid marker in milliseconds from configured fixed-step rate.
  *
- * @param targetFps - Configured `targetFPS` (clamped to at least 1).
+ * @param targetFps – Configured `targetFPS` (clamped to at least 1).
  * @returns `1000 / targetFps`.
  */
 export function timingChartFrameBudgetMs(targetFps: number): number {
@@ -206,8 +206,8 @@ export function timingChartFrameBudgetMs(targetFps: number): number {
 /**
  * Writes timing-chart grid marker values (fixed thresholds plus frame budget) into `out`.
  *
- * @param targetFps - Configured fixed-step rate for the dynamic budget line.
- * @param out - Reusable buffer; must hold at least `TIMING_CHART_GRID_MARKER_MS.length + 1` elements.
+ * @param targetFps – Configured fixed-step rate for the dynamic budget line.
+ * @param out – Reusable buffer; must hold at least `TIMING_CHART_GRID_MARKER_MS.length + 1` elements.
  * @returns Number of marker values written.
  */
 export function writeTimingChartGridMarkers(targetFps: number, out: Float32Array): number {

--- a/packages/blit386/src/overlay/timing-chart/tags.ts
+++ b/packages/blit386/src/overlay/timing-chart/tags.ts
@@ -38,7 +38,7 @@ export type TimingChartTagColumnGroup = {
 /**
  * Normalizes a tag label; empty or missing labels become `"Untitled"`.
  *
- * @param label - Caller-provided label.
+ * @param label – Caller-provided label.
  * @returns Non-empty label string.
  */
 export function normalizeTimingChartTagLabel(label: string | undefined): string {
@@ -50,9 +50,9 @@ export function normalizeTimingChartTagLabel(label: string | undefined): string 
  *
  * Columns follow timing samples (one per overlay frame), not fixed-update ticks.
  *
- * @param sampleIndex - Sample ordinal when the tag was assigned.
- * @param totalSamples - Timing samples recorded since the last chart width reset.
- * @param chartWidth - Chart width in pixels (ring buffer width).
+ * @param sampleIndex – Sample ordinal when the tag was assigned.
+ * @param totalSamples – Timing samples recorded since the last chart width reset.
+ * @param chartWidth – Chart width in pixels (ring buffer width).
  * @returns Column index, or `null` when the tag is past the right edge.
  */
 export function computeTimingChartTagColumn(
@@ -77,9 +77,9 @@ export function computeTimingChartTagColumn(
 /**
  * Returns whether a tag should be removed from the active list.
  *
- * @param totalSamples - Timing samples recorded since the last chart width reset.
- * @param sampleIndex - Sample ordinal stored on the tag.
- * @param chartWidth - Chart width in pixels.
+ * @param totalSamples – Timing samples recorded since the last chart width reset.
+ * @param sampleIndex – Sample ordinal stored on the tag.
+ * @param chartWidth – Chart width in pixels.
  * @returns `true` when the tag should be dropped.
  */
 export function shouldPruneTimingChartTag(totalSamples: number, sampleIndex: number, chartWidth: number): boolean {
@@ -91,10 +91,10 @@ export function shouldPruneTimingChartTag(totalSamples: number, sampleIndex: num
 /**
  * Screen-space X for tick and label text above the chart band.
  *
- * @param chartX - Left edge of the chart band.
- * @param chartWidth - Chart width in pixels.
- * @param sampleIndex - Sample ordinal when the tag was assigned.
- * @param totalSamples - Timing samples recorded since the last chart width reset.
+ * @param chartX – Left edge of the chart band.
+ * @param chartWidth – Chart width in pixels.
+ * @param sampleIndex – Sample ordinal when the tag was assigned.
+ * @param totalSamples – Timing samples recorded since the last chart width reset.
  * @returns Pixel X for text left edge, or `null` when past the right edge.
  */
 export function computeTimingChartTagTextX(
@@ -115,10 +115,10 @@ export function computeTimingChartTagTextX(
 /**
  * Screen-space X for the one-pixel vertical marker (aligned with timing dots).
  *
- * @param chartX - Left edge of the chart band.
- * @param chartWidth - Chart width in pixels.
- * @param sampleIndex - Sample ordinal when the tag was assigned.
- * @param totalSamples - Timing samples recorded since the last chart width reset.
+ * @param chartX – Left edge of the chart band.
+ * @param chartWidth – Chart width in pixels.
+ * @param sampleIndex – Sample ordinal when the tag was assigned.
+ * @param totalSamples – Timing samples recorded since the last chart width reset.
  * @returns Pixel X for the marker column, or `null` when past the right edge.
  */
 export function computeTimingChartTagMarkerX(
@@ -139,7 +139,7 @@ export function computeTimingChartTagMarkerX(
 /**
  * Screen-space Y for the relative tick row above the chart band.
  *
- * @param chartTopY - Top edge of the chart band.
+ * @param chartTopY – Top edge of the chart band.
  * @returns Pixel Y for the tick text baseline.
  */
 export function computeTimingChartTagTickY(chartTopY: number): number {
@@ -149,8 +149,8 @@ export function computeTimingChartTagTickY(chartTopY: number): number {
 /**
  * Screen-space Y for a stacked tag label row below the tick row.
  *
- * @param chartTopY - Top edge of the chart band.
- * @param stackIndex - Zero-based row below the tick (0 = first label).
+ * @param chartTopY – Top edge of the chart band.
+ * @param stackIndex – Zero-based row below the tick (0 = first label).
  * @returns Pixel Y for the label text baseline.
  */
 export function computeTimingChartTagLabelY(chartTopY: number, stackIndex: number): number {
@@ -164,9 +164,9 @@ export function computeTimingChartTagLabelY(chartTopY: number, stackIndex: numbe
 /**
  * Groups on-screen tags by sample column for stacked drawing.
  *
- * @param tags - Active tags for the current frame.
- * @param totalSamples - Timing samples recorded since the last chart width reset.
- * @param chartWidth - Chart width in pixels.
+ * @param tags – Active tags for the current frame.
+ * @param totalSamples – Timing samples recorded since the last chart width reset.
+ * @param chartWidth – Chart width in pixels.
  * @returns Groups in first-seen column order.
  */
 export function groupTimingChartTagsByColumn(
@@ -209,8 +209,8 @@ export function groupTimingChartTagsByColumn(
 /**
  * Relative tick text for the tag tick row (ticks since chart reset).
  *
- * @param tagTick - Absolute tick when the tag was assigned.
- * @param startTick - Tick recorded when the chart last reset.
+ * @param tagTick – Absolute tick when the tag was assigned.
+ * @param startTick – Tick recorded when the chart last reset.
  * @returns Relative tick string capped at {@link TIMING_CHART_TAG_REL_TICK_MAX}.
  */
 export function formatTimingChartTagRelTick(tagTick: number, startTick: number): string {
@@ -222,9 +222,9 @@ export function formatTimingChartTagRelTick(tagTick: number, startTick: number):
 /**
  * Removes off-screen tags using an in-place compact (no allocation).
  *
- * @param tags - Mutable tag list.
- * @param totalSamples - Timing samples recorded since the last chart width reset.
- * @param chartWidth - Chart width in pixels.
+ * @param tags – Mutable tag list.
+ * @param totalSamples – Timing samples recorded since the last chart width reset.
+ * @param chartWidth – Chart width in pixels.
  */
 export function pruneTimingChartTagsInPlace(tags: TimingChartTag[], totalSamples: number, chartWidth: number): void {
     let write = 0;

--- a/packages/blit386/src/render/IRenderer.ts
+++ b/packages/blit386/src/render/IRenderer.ts
@@ -30,7 +30,7 @@ export interface IRenderer {
     /**
      * Sets the active palette used for all color lookups this frame and beyond.
      *
-     * @param palette - Palette to activate.
+     * @param palette – Palette to activate.
      */
     setPalette(palette: Palette): void;
 
@@ -51,7 +51,7 @@ export interface IRenderer {
     /**
      * Sets the background clear color for the current frame using a palette index.
      *
-     * @param paletteIndex - Palette index for the clear color.
+     * @param paletteIndex – Palette index for the clear color.
      */
     setClearColor(paletteIndex: number): void;
 
@@ -73,61 +73,61 @@ export interface IRenderer {
     /**
      * Draws a filled rectangle.
      *
-     * @param rect - Rectangle bounds.
-     * @param paletteIndex - Palette color index.
+     * @param rect – Rectangle bounds.
+     * @param paletteIndex – Palette color index.
      */
     drawRectFill(rect: Rect2i, paletteIndex: number): void;
 
     /**
      * Draws a single pixel.
      *
-     * @param pos - Pixel position.
-     * @param paletteIndex - Palette color index.
+     * @param pos – Pixel position.
+     * @param paletteIndex – Palette color index.
      */
     drawPixel(pos: Vector2i, paletteIndex: number): void;
 
     /**
      * Draws a line between two points.
      *
-     * @param p0 - Start point.
-     * @param p1 - End point.
-     * @param paletteIndex - Palette color index.
+     * @param p0 – Start point.
+     * @param p1 – End point.
+     * @param paletteIndex – Palette color index.
      */
     drawLine(p0: Vector2i, p1: Vector2i, paletteIndex: number): void;
 
     /**
      * Draws a rectangle outline.
      *
-     * @param rect - Rectangle bounds.
-     * @param paletteIndex - Palette color index.
+     * @param rect – Rectangle bounds.
+     * @param paletteIndex – Palette color index.
      */
     drawRect(rect: Rect2i, paletteIndex: number): void;
 
     /**
      * Fills a rectangular region with a palette-indexed color.
      *
-     * @param rect - Region to fill.
-     * @param paletteIndex - Palette color index.
+     * @param rect – Region to fill.
+     * @param paletteIndex – Palette color index.
      */
     clearRect(rect: Rect2i, paletteIndex: number): void;
 
     /**
      * Draws a sprite region from an indexed sprite sheet.
      *
-     * @param spriteSheet - Source sprite sheet (must be indexized).
-     * @param srcRect - Region to copy from the sprite sheet.
-     * @param destPos - Screen position to draw at.
-     * @param paletteOffset - Palette index offset applied at draw time (default 0).
+     * @param spriteSheet – Source sprite sheet (must be indexized).
+     * @param srcRect – Region to copy from the sprite sheet.
+     * @param destPos – Screen position to draw at.
+     * @param paletteOffset – Palette index offset applied at draw time (default 0).
      */
     drawSprite(spriteSheet: SpriteSheet, srcRect: Rect2i, destPos: Vector2i, paletteOffset?: number): void;
 
     /**
      * Draws text using a bitmap font.
      *
-     * @param font - Bitmap font with character glyphs (underlying sheet must be indexized).
-     * @param pos - Text position (top-left corner).
-     * @param text - String to render.
-     * @param paletteOffset - Palette index offset applied to all glyphs (default 0).
+     * @param font – Bitmap font with character glyphs (underlying sheet must be indexized).
+     * @param pos – Text position (top-left corner).
+     * @param text – String to render.
+     * @param paletteOffset – Palette index offset applied to all glyphs (default 0).
      */
     drawBitmapText(font: BitmapFont, pos: Vector2i, text: string, paletteOffset?: number): void;
 
@@ -142,7 +142,7 @@ export interface IRenderer {
     /**
      * Sets the camera offset for scrolling.
      *
-     * @param offset - Camera position in pixels.
+     * @param offset – Camera position in pixels.
      */
     setCameraOffset(offset: Vector2i): void;
 
@@ -163,14 +163,14 @@ export interface IRenderer {
      *
      * Backends that do not support shader effects must throw with a clear message.
      *
-     * @param effect - Effect instance to append.
+     * @param effect – Effect instance to append.
      */
     addEffect(effect: Effect): void;
 
     /**
      * Removes a previously registered post-processing effect.
      *
-     * @param effect - Effect instance to remove.
+     * @param effect – Effect instance to remove.
      */
     removeEffect(effect: Effect): void;
 

--- a/packages/blit386/src/render/PaletteResolveUpscalePass.ts
+++ b/packages/blit386/src/render/PaletteResolveUpscalePass.ts
@@ -28,10 +28,10 @@ export class PaletteResolveUpscalePass {
     /**
      * Initializes pipeline and uniform buffer. Call once per renderer init.
      *
-     * @param device - WebGPU device.
-     * @param destFormat - RGBA output format (swap chain format).
+     * @param device – WebGPU device.
+     * @param destFormat – RGBA output format (swap chain format).
      * @param filter - `'nearest'` or `'linear'` magnification (linear blends resolved RGBA neighbors).
-     * @param paletteBuffer - Shared 256-entry palette uniform buffer (same as scene pipelines).
+     * @param paletteBuffer – Shared 256-entry palette uniform buffer (same as scene pipelines).
      */
     init(device: GPUDevice, destFormat: GPUTextureFormat, filter: UpscaleFilter, paletteBuffer: GPUBuffer): void {
         this.uniformBuffer?.destroy();
@@ -68,10 +68,10 @@ export class PaletteResolveUpscalePass {
     /**
      * Encodes resolve + upscale into {@link destView}.
      *
-     * @param encoder - Command encoder.
-     * @param sourceUintView - Logical-resolution `r8uint` texture view.
-     * @param destView - Destination RGBA view (any size).
-     * @param logicalSize - Pixel dimensions of {@link sourceUintView}.
+     * @param encoder – Command encoder.
+     * @param sourceUintView – Logical-resolution `r8uint` texture view.
+     * @param destView – Destination RGBA view (any size).
+     * @param logicalSize – Pixel dimensions of {@link sourceUintView}.
      */
     encode(
         encoder: GPUCommandEncoder,
@@ -137,7 +137,7 @@ export class PaletteResolveUpscalePass {
     /**
      * Creates or returns a cached bind group wired to the supplied index texture view.
      *
-     * @param sourceView - Logical-resolution `r8uint` texture view.
+     * @param sourceView – Logical-resolution `r8uint` texture view.
      * @returns Bind group for resolve pass sampling the index texture view.
      */
     private getOrCreateBindGroup(sourceView: GPUTextureView): GPUBindGroup {

--- a/packages/blit386/src/render/PostProcessChain.test.ts
+++ b/packages/blit386/src/render/PostProcessChain.test.ts
@@ -188,7 +188,7 @@ describe('add()', () => {
         // texB stays allocated until the chain is fully cleared.
         chain.add(c);
 
-        // No new texture allocations - existing texA + texB are reused.
+        // No new texture allocations – existing texA + texB are reused.
         expect(createTexture).toHaveBeenCalledTimes(2);
     });
 

--- a/packages/blit386/src/render/PostProcessChain.ts
+++ b/packages/blit386/src/render/PostProcessChain.ts
@@ -61,11 +61,11 @@ export class PostProcessChain {
      *
      * No GPU resources are created until the first effect is registered.
      *
-     * @param device - WebGPU device used for resource creation.
-     * @param format - Attachment format for this chain's offscreen textures.
+     * @param device – WebGPU device used for resource creation.
+     * @param format – Attachment format for this chain's offscreen textures.
      *   Pixel tier typically uses `r8uint`; display tier uses an RGBA format.
-     * @param chainSize - Render target resolution in pixels for this tier.
-     * @param tier - Tier this chain serves. Effects added must match.
+     * @param chainSize – Render target resolution in pixels for this tier.
+     * @param tier – Tier this chain serves. Effects added must match.
      */
     constructor(device: GPUDevice, format: GPUTextureFormat, chainSize: Vector2i, tier: EffectTier) {
         this.device = device;
@@ -93,13 +93,13 @@ export class PostProcessChain {
      * the effect appended to the chain. GPU resources for the chain itself
      * are allocated lazily here: {@link texA} on the first add, {@link texB}
      * on the second. Existing offscreen textures are **reused** across
-     * remove/re-add cycles - we never reallocate a texture that is already
+     * remove/re-add cycles – we never reallocate a texture that is already
      * present.
      *
      * Adding the same effect instance twice throws. Construct a new instance
      * if you want a second copy of the same look.
      *
-     * @param effect - Effect to append to the chain.
+     * @param effect – Effect to append to the chain.
      * @throws If the effect's tier does not match this chain's tier.
      * @throws If the effect instance is already registered.
      */
@@ -137,7 +137,7 @@ export class PostProcessChain {
      *
      * Removing an effect that was never added is a no-op.
      *
-     * @param effect - Effect instance to remove.
+     * @param effect – Effect instance to remove.
      * @returns `true` if the effect was found and removed; otherwise `false`.
      */
     remove(effect: Effect): boolean {
@@ -212,9 +212,9 @@ export class PostProcessChain {
      *
      * No-op when no effects are registered.
      *
-     * @param encoder - Active command encoder.
-     * @param deltaMs - Wall-clock milliseconds since the previous frame.
-     * @param destinationView - View the final effect writes to (the next stage's
+     * @param encoder – Active command encoder.
+     * @param deltaMs – Wall-clock milliseconds since the previous frame.
+     * @param destinationView – View the final effect writes to (the next stage's
      *   input texture, or the swap chain).
      */
     encode(encoder: GPUCommandEncoder, deltaMs: number, destinationView: GPUTextureView): void {
@@ -278,7 +278,7 @@ export class PostProcessChain {
      * `texAView` partners with `texBView`; called only on multi-effect chains
      * where `texBView` is guaranteed to be allocated.
      *
-     * @param read - View currently being sampled by the effect.
+     * @param read – View currently being sampled by the effect.
      * @returns The opposite offscreen view to write into next.
      */
     private pickOffscreenView(read: GPUTextureView): GPUTextureView {

--- a/packages/blit386/src/render/PrimitivePipeline.ts
+++ b/packages/blit386/src/render/PrimitivePipeline.ts
@@ -90,10 +90,10 @@ export class PrimitivePipeline {
     /**
      * Initializes the GPU pipeline state and backing buffers.
      *
-     * @param device - WebGPU device for GPU operations.
-     * @param displaySize - Render target resolution in pixels.
-     * @param paletteBuffer - Shared palette uniform buffer (256 x vec4f = 4096 bytes).
-     * @param targetFormat - Color attachment format for primitive output.
+     * @param device – WebGPU device for GPU operations.
+     * @param displaySize – Render target resolution in pixels.
+     * @param paletteBuffer – Shared palette uniform buffer (256 x vec4f = 4096 bytes).
+     * @param targetFormat – Color attachment format for primitive output.
      */
     async init(
         device: GPUDevice,
@@ -108,7 +108,7 @@ export class PrimitivePipeline {
     /**
      * Sets the camera offset applied to all drawing operations.
      *
-     * @param offset - Camera position in pixels.
+     * @param offset – Camera position in pixels.
      */
     setCameraOffset(offset: Vector2i): void {
         this.cameraOffset = offset;
@@ -117,8 +117,8 @@ export class PrimitivePipeline {
     /**
      * Draws a filled rectangle using two triangles.
      *
-     * @param rect - Rectangle bounds in pixel coordinates.
-     * @param paletteIndex - Palette color index.
+     * @param rect – Rectangle bounds in pixel coordinates.
+     * @param paletteIndex – Palette color index.
      */
     drawRectFill(rect: Rect2i, paletteIndex: number): void {
         const x0 = rect.x;
@@ -138,8 +138,8 @@ export class PrimitivePipeline {
     /**
      * Draws a single pixel as a 1x1 filled rectangle.
      *
-     * @param pos - Pixel position.
-     * @param paletteIndex - Palette color index.
+     * @param pos – Pixel position.
+     * @param paletteIndex – Palette color index.
      */
     drawPixel(pos: Vector2i, paletteIndex: number): void {
         // Use pre-allocated rect to avoid allocation per pixel.
@@ -151,9 +151,9 @@ export class PrimitivePipeline {
      * Draws a single pixel at raw coordinates.
      * More efficient than `drawPixel()` when coordinates are already unpacked.
      *
-     * @param x - X position.
-     * @param y - Y position.
-     * @param paletteIndex - Palette color index.
+     * @param x – X position.
+     * @param y – Y position.
+     * @param paletteIndex – Palette color index.
      */
     drawPixelXY(x: number, y: number, paletteIndex: number): void {
         // Draw 1x1 rectangle (2 triangles = 6 vertices).
@@ -176,9 +176,9 @@ export class PrimitivePipeline {
      * Horizontal and vertical lines are emitted as a single quad. Diagonal
      * lines fall back to Bresenham-style pixel steps for pixel-art fidelity.
      *
-     * @param p0 - Start point.
-     * @param p1 - End point.
-     * @param paletteIndex - Palette color index.
+     * @param p0 – Start point.
+     * @param p1 – End point.
+     * @param paletteIndex – Palette color index.
      */
     drawLine(p0: Vector2i, p1: Vector2i, paletteIndex: number): void {
         // Vector2i already guarantees integers, but |0 ensures the 32-bit int for bitwise ops.
@@ -219,8 +219,8 @@ export class PrimitivePipeline {
      * Draws a rectangle outline using four 1-pixel quads.
      * Emits quads directly rather than delegating to `drawLine()`.
      *
-     * @param rect - Rectangle bounds.
-     * @param paletteIndex - Palette color index.
+     * @param rect – Rectangle bounds.
+     * @param paletteIndex – Palette color index.
      */
     drawRect(rect: Rect2i, paletteIndex: number): void {
         const x0 = rect.x;
@@ -258,8 +258,8 @@ export class PrimitivePipeline {
      * Fills a rectangular region with a palette-indexed color.
      * Alias for `drawRectFill()` kept for renderer API consistency.
      *
-     * @param rect - Region to fill.
-     * @param paletteIndex - Palette color index.
+     * @param rect – Region to fill.
+     * @param paletteIndex – Palette color index.
      */
     clearRect(rect: Rect2i, paletteIndex: number): void {
         this.drawRectFill(rect, paletteIndex);
@@ -269,7 +269,7 @@ export class PrimitivePipeline {
      * Uploads accumulated primitive vertices and encodes draw calls.
      * No-op when nothing has been queued for the current frame.
      *
-     * @param renderPass - Active render pass encoder.
+     * @param renderPass – Active render pass encoder.
      */
     encodePass(renderPass: GPURenderPassEncoder): void {
         // Flush any remaining vertices into the batch queue.
@@ -329,9 +329,9 @@ export class PrimitivePipeline {
     /**
      * Creates shader modules, pipeline state, and GPU buffers for primitive draws.
      *
-     * @param displaySize - Render target resolution in pixels.
-     * @param paletteBuffer - Shared palette uniform buffer.
-     * @param targetFormat - Color attachment format for primitive output.
+     * @param displaySize – Render target resolution in pixels.
+     * @param paletteBuffer – Shared palette uniform buffer.
+     * @param targetFormat – Color attachment format for primitive output.
      */
     private async createPipeline(
         displaySize: Vector2i,
@@ -453,11 +453,11 @@ export class PrimitivePipeline {
      * Produces pixel-perfect lines without antialiasing by emitting 1x1 quads
      * for each stepped pixel.
      *
-     * @param x0 - Start X coordinate.
-     * @param y0 - Start Y coordinate.
-     * @param x1 - End X coordinate.
-     * @param y1 - End Y coordinate.
-     * @param paletteIndex - Palette color index.
+     * @param x0 – Start X coordinate.
+     * @param y0 – Start Y coordinate.
+     * @param x1 – End X coordinate.
+     * @param y1 – End Y coordinate.
+     * @param paletteIndex – Palette color index.
      */
     private drawLineBresenham(x0: number, y0: number, x1: number, y1: number, paletteIndex: number): void {
         const dx = Math.abs(x1 - x0);
@@ -492,9 +492,9 @@ export class PrimitivePipeline {
      * Adds vertices for a single pixel (6 vertices for 2 triangles).
      * Internal helper used by the Bresenham path.
      *
-     * @param x - X position.
-     * @param y - Y position.
-     * @param paletteIndex - Palette color index.
+     * @param x – X position.
+     * @param y – Y position.
+     * @param paletteIndex – Palette color index.
      */
     private addPixelVertices(x: number, y: number, paletteIndex: number): void {
         // Ensure space for complete pixel (6 vertices) to prevent partial geometry.
@@ -506,7 +506,7 @@ export class PrimitivePipeline {
                 this.earlyFlush();
             }
 
-            // Check again after flush - if still no space, buffer is exhausted.
+            // Check again after flush – if still no space, buffer is exhausted.
             if ((this.totalVertices + this.vertexCount) * VALUES_PER_VERTEX + pixelValues > this.vertexFloats.length) {
                 console.warn('[PrimitivePipeline] Buffer exhausted, pixel dropped');
                 this.overflowCount++;
@@ -531,9 +531,9 @@ export class PrimitivePipeline {
      * Adds a single vertex to the primitive batch.
      * Flushes batching state first if the frame buffer has been filled.
      *
-     * @param x - X position in pixels.
-     * @param y - Y position in pixels.
-     * @param paletteIndex - Palette color index (written as uint32).
+     * @param x – X position in pixels.
+     * @param y – Y position in pixels.
+     * @param paletteIndex – Palette color index (written as uint32).
      */
     private addVertex(x: number, y: number, paletteIndex: number): void {
         const index = (this.totalVertices + this.vertexCount) * VALUES_PER_VERTEX;
@@ -541,7 +541,7 @@ export class PrimitivePipeline {
         if (index + VALUES_PER_VERTEX > this.vertexFloats.length) {
             this.earlyFlush();
 
-            // Re-check after flush - if still no space, buffer is exhausted for this frame.
+            // Re-check after flush – if still no space, buffer is exhausted for this frame.
             const newIndex = (this.totalVertices + this.vertexCount) * VALUES_PER_VERTEX;
 
             if (newIndex + VALUES_PER_VERTEX > this.vertexFloats.length) {
@@ -567,7 +567,7 @@ export class PrimitivePipeline {
     /**
      * Records the current vertex batch and resets the vertex count.
      * Used for early flush when the buffer is full mid-frame.
-     * Does not write to GPU - encodePass() uploads all batches at once.
+     * Does not write to GPU – encodePass() uploads all batches at once.
      */
     private earlyFlush(): void {
         if (this.vertexCount === 0) {

--- a/packages/blit386/src/render/SoftwareRenderer.ts
+++ b/packages/blit386/src/render/SoftwareRenderer.ts
@@ -112,9 +112,9 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
     /**
      * Creates a software renderer bound to the given canvas.
      *
-     * @param canvas - Target HTML canvas element to draw into.
-     * @param displaySize - Logical render resolution in pixels.
-     * @param outputSize - Output resolution in pixels. Defaults to `displaySize` (no upscaling).
+     * @param canvas – Target HTML canvas element to draw into.
+     * @param displaySize – Logical render resolution in pixels.
+     * @param outputSize – Output resolution in pixels. Defaults to `displaySize` (no upscaling).
      */
     constructor(canvas: HTMLCanvasElement, displaySize: Vector2i, outputSize?: Vector2i) {
         this.canvas = canvas;
@@ -126,10 +126,10 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
     /**
      * Estimates primitive vertices for a line using the same rules as {@link PrimitivePipeline.drawLine}.
      *
-     * @param x0 - Start X.
-     * @param y0 - Start Y.
-     * @param x1 - End X.
-     * @param y1 - End Y.
+     * @param x0 – Start X.
+     * @param y0 – Start Y.
+     * @param x1 – End X.
+     * @param y1 – End Y.
      * @returns Vertex count for the line draw.
      */
     private static estimateLineVertexCount(x0: number, y0: number, x1: number, y1: number): number {
@@ -148,7 +148,7 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
     /**
      * Estimates primitive vertices for a rectangle outline using {@link PrimitivePipeline.drawRect} rules.
      *
-     * @param rect - Outline bounds.
+     * @param rect – Outline bounds.
      * @returns Vertex count for the outline draw.
      */
     private static estimateRectOutlineVertexCount(rect: Rect2i): number {
@@ -166,8 +166,8 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
     /**
      * Estimates sprite vertices for bitmap text (one quad per resolved glyph).
      *
-     * @param font - Bitmap font containing glyph metrics.
-     * @param text - String to render.
+     * @param font – Bitmap font containing glyph metrics.
+     * @param text – String to render.
      * @returns Vertex count for the text draw.
      */
     private static estimateBitmapTextVertexCount(font: BitmapFont, text: string): number {
@@ -185,10 +185,10 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
     /**
      * Counts Bresenham steps between two integer endpoints (inclusive).
      *
-     * @param x0 - Start X.
-     * @param y0 - Start Y.
-     * @param x1 - End X.
-     * @param y1 - End Y.
+     * @param x0 – Start X.
+     * @param y0 – Start Y.
+     * @param x1 – End X.
+     * @param y1 – End Y.
      * @returns Number of pixels visited.
      */
     private static countBresenhamSteps(x0: number, y0: number, x1: number, y1: number): number {
@@ -260,7 +260,7 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
     /**
      * Sets the active palette used for all color lookups during rendering.
      *
-     * @param palette - Palette to activate.
+     * @param palette – Palette to activate.
      */
     setPalette(palette: Palette): void {
         this.palette = palette;
@@ -297,7 +297,7 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
     /**
      * Sets the palette index used to fill the background on each frame.
      *
-     * @param paletteIndex - Palette entry index for the clear color.
+     * @param paletteIndex – Palette entry index for the clear color.
      */
     setClearColor(paletteIndex: number): void {
         this.clearPaletteIndex = paletteIndex;
@@ -341,8 +341,8 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
     /**
      * Queues a filled rectangle draw command.
      *
-     * @param rect - Rectangle to fill in logical pixels.
-     * @param paletteIndex - Palette entry index for the fill color.
+     * @param rect – Rectangle to fill in logical pixels.
+     * @param paletteIndex – Palette entry index for the fill color.
      */
     drawRectFill(rect: Rect2i, paletteIndex: number): void {
         this.commands.push({
@@ -361,8 +361,8 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
     /**
      * Queues an overlay bar fill (same FIFO queue as {@link drawRectFill}).
      *
-     * @param rect - Rectangle to fill in logical pixels.
-     * @param paletteIndex - Palette entry index for the fill color.
+     * @param rect – Rectangle to fill in logical pixels.
+     * @param paletteIndex – Palette entry index for the fill color.
      */
     drawBarFill(rect: Rect2i, paletteIndex: number): void {
         this.drawRectFill(rect, paletteIndex);
@@ -373,8 +373,8 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
      * The software backend does not layer overlay draws above demo content;
      * `OnTop` variants are equivalent to their base methods.
      *
-     * @param rect - Rectangle to fill in logical pixels.
-     * @param paletteIndex - Palette entry index for the fill color.
+     * @param rect – Rectangle to fill in logical pixels.
+     * @param paletteIndex – Palette entry index for the fill color.
      */
     drawBarFillOnTop(rect: Rect2i, paletteIndex: number): void {
         this.drawBarFill(rect, paletteIndex);
@@ -383,8 +383,8 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
     /**
      * Queues a single pixel draw command at the given position.
      *
-     * @param pos - Pixel position in logical coordinates.
-     * @param paletteIndex - Palette entry index for the pixel color.
+     * @param pos – Pixel position in logical coordinates.
+     * @param paletteIndex – Palette entry index for the pixel color.
      */
     drawPixel(pos: Vector2i, paletteIndex: number): void {
         this.drawRectFill(new Rect2i(pos.x, pos.y, 1, 1), paletteIndex);
@@ -393,9 +393,9 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
     /**
      * Queues a Bresenham line draw command between two points.
      *
-     * @param p0 - Line start position in logical coordinates.
-     * @param p1 - Line end position in logical coordinates.
-     * @param paletteIndex - Palette entry index for the line color.
+     * @param p0 – Line start position in logical coordinates.
+     * @param p1 – Line end position in logical coordinates.
+     * @param paletteIndex – Palette entry index for the line color.
      */
     drawLine(p0: Vector2i, p1: Vector2i, paletteIndex: number): void {
         this.commands.push({
@@ -414,8 +414,8 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
     /**
      * Queues an outline rectangle draw command (four lines, no fill).
      *
-     * @param rect - Rectangle to outline in logical pixels.
-     * @param paletteIndex - Palette entry index for the border color.
+     * @param rect – Rectangle to outline in logical pixels.
+     * @param paletteIndex – Palette entry index for the border color.
      */
     drawRect(rect: Rect2i, paletteIndex: number): void {
         this.commands.push({
@@ -434,8 +434,8 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
     /**
      * Fills the given rectangle with a palette color (alias for `drawRectFill`).
      *
-     * @param rect - Rectangle to clear in logical pixels.
-     * @param paletteIndex - Palette entry index for the fill color.
+     * @param rect – Rectangle to clear in logical pixels.
+     * @param paletteIndex – Palette entry index for the fill color.
      */
     clearRect(rect: Rect2i, paletteIndex: number): void {
         this.drawRectFill(rect, paletteIndex);
@@ -444,10 +444,10 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
     /**
      * Queues a sprite blit from a source sheet rectangle to a destination position.
      *
-     * @param spriteSheet - Source sprite sheet containing the indexed pixels.
-     * @param srcRect - Source region within the sprite sheet in pixels.
-     * @param destPos - Destination position in logical coordinates.
-     * @param paletteOffset - Palette index offset applied to every non-transparent pixel.
+     * @param spriteSheet – Source sprite sheet containing the indexed pixels.
+     * @param srcRect – Source region within the sprite sheet in pixels.
+     * @param destPos – Destination position in logical coordinates.
+     * @param paletteOffset – Palette index offset applied to every non-transparent pixel.
      */
     drawSprite(spriteSheet: SpriteSheet, srcRect: Rect2i, destPos: Vector2i, paletteOffset: number = 0): void {
         this.commands.push({
@@ -465,10 +465,10 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
     /**
      * Queues a bitmap text draw command, expanding each character to a sprite blit on replay.
      *
-     * @param font - Bitmap font containing glyph sheet and metrics.
-     * @param pos - Top-left position of the text in logical coordinates.
-     * @param text - String to render.
-     * @param paletteOffset - Palette index offset applied to every glyph pixel.
+     * @param font – Bitmap font containing glyph sheet and metrics.
+     * @param pos – Top-left position of the text in logical coordinates.
+     * @param text – String to render.
+     * @param paletteOffset – Palette index offset applied to every glyph pixel.
      */
     drawBitmapText(font: BitmapFont, pos: Vector2i, text: string, paletteOffset: number = 0): void {
         this.commands.push({
@@ -486,10 +486,10 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
     /**
      * Queues an overlay label (same FIFO queue as {@link drawBitmapText}).
      *
-     * @param font - Bitmap font with character glyphs.
-     * @param pos - Text origin in logical pixels.
-     * @param text - String to render.
-     * @param paletteOffset - Palette index offset applied to all glyphs (default 0).
+     * @param font – Bitmap font with character glyphs.
+     * @param pos – Text origin in logical pixels.
+     * @param text – String to render.
+     * @param paletteOffset – Palette index offset applied to all glyphs (default 0).
      */
     drawLabel(font: BitmapFont, pos: Vector2i, text: string, paletteOffset: number = 0): void {
         this.drawBitmapText(font, pos, text, paletteOffset);
@@ -500,10 +500,10 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
      * The software backend does not layer overlay draws above demo content;
      * `OnTop` variants are equivalent to their base methods.
      *
-     * @param font - Bitmap font with character glyphs.
-     * @param pos - Text origin in logical pixels.
-     * @param text - String to render.
-     * @param paletteOffset - Palette index offset applied to all glyphs (default 0).
+     * @param font – Bitmap font with character glyphs.
+     * @param pos – Text origin in logical pixels.
+     * @param text – String to render.
+     * @param paletteOffset – Palette index offset applied to all glyphs (default 0).
      */
     drawLabelOnTop(font: BitmapFont, pos: Vector2i, text: string, paletteOffset: number = 0): void {
         this.drawLabel(font, pos, text, paletteOffset);
@@ -532,7 +532,7 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
     /**
      * Sets the camera scroll offset applied to all subsequent draw commands.
      *
-     * @param offset - New camera offset in logical pixels.
+     * @param offset – New camera offset in logical pixels.
      */
     setCameraOffset(offset: Vector2i): void {
         this.cameraOffset = offset.clone();
@@ -553,24 +553,24 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
     }
 
     /**
-     * Not supported - always throws.
+     * Not supported – always throws.
      *
-     * @param _effect - Ignored.
+     * @param _effect – Ignored.
      */
     addEffect(_effect: Effect): void {
         throw new Error(SoftwareRenderer.EFFECTS_UNSUPPORTED_MESSAGE);
     }
 
     /**
-     * Not supported - always throws.
+     * Not supported – always throws.
      *
-     * @param _effect - Ignored.
+     * @param _effect – Ignored.
      */
     removeEffect(_effect: Effect): void {
         throw new Error(SoftwareRenderer.EFFECTS_UNSUPPORTED_MESSAGE);
     }
 
-    /** Not supported - always throws. */
+    /** Not supported – always throws. */
     clearEffects(): void {
         throw new Error(SoftwareRenderer.EFFECTS_UNSUPPORTED_MESSAGE);
     }
@@ -596,10 +596,10 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
     /**
      * Fills the entire `framePixels` buffer with a solid RGBA color.
      *
-     * @param r - Red channel (0-255).
-     * @param g - Green channel (0-255).
-     * @param b - Blue channel (0-255).
-     * @param a - Alpha channel (0-255).
+     * @param r – Red channel (0-255).
+     * @param g – Green channel (0-255).
+     * @param b – Blue channel (0-255).
+     * @param a – Alpha channel (0-255).
      */
     private fillFrame(r: number, g: number, b: number, a: number): void {
         for (let i = 0; i < this.framePixels.length; i += 4) {
@@ -614,7 +614,7 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
     /**
      * Dispatches a single draw command to the appropriate rasterizer.
      *
-     * @param command - Command to replay into `framePixels`.
+     * @param command – Command to replay into `framePixels`.
      */
     private replayCommand(command: DrawCommand): void {
         switch (command.kind) {
@@ -667,13 +667,13 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
     /**
      * Rasterizes a filled rectangle into `framePixels`, clipped to display bounds.
      *
-     * @param x - Left edge in world coordinates.
-     * @param y - Top edge in world coordinates.
-     * @param width - Rectangle width in pixels.
-     * @param height - Rectangle height in pixels.
-     * @param paletteIndex - Palette entry index for the fill color.
-     * @param cameraX - Horizontal camera offset to subtract.
-     * @param cameraY - Vertical camera offset to subtract.
+     * @param x – Left edge in world coordinates.
+     * @param y – Top edge in world coordinates.
+     * @param width – Rectangle width in pixels.
+     * @param height – Rectangle height in pixels.
+     * @param paletteIndex – Palette entry index for the fill color.
+     * @param cameraX – Horizontal camera offset to subtract.
+     * @param cameraY – Vertical camera offset to subtract.
      */
     private rasterRectFill(
         x: number,
@@ -705,13 +705,13 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
     /**
      * Rasterizes a four-sided outline rectangle by drawing four lines.
      *
-     * @param x - Left edge in world coordinates.
-     * @param y - Top edge in world coordinates.
-     * @param width - Rectangle width in pixels.
-     * @param height - Rectangle height in pixels.
-     * @param paletteIndex - Palette entry index for the border color.
-     * @param cameraX - Horizontal camera offset to subtract.
-     * @param cameraY - Vertical camera offset to subtract.
+     * @param x – Left edge in world coordinates.
+     * @param y – Top edge in world coordinates.
+     * @param width – Rectangle width in pixels.
+     * @param height – Rectangle height in pixels.
+     * @param paletteIndex – Palette entry index for the border color.
+     * @param cameraX – Horizontal camera offset to subtract.
+     * @param cameraY – Vertical camera offset to subtract.
      */
     private rasterRect(
         x: number,
@@ -738,13 +738,13 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
     /**
      * Rasterizes a line using Bresenham's algorithm.
      *
-     * @param x0 - Start X in world coordinates.
-     * @param y0 - Start Y in world coordinates.
-     * @param x1 - End X in world coordinates.
-     * @param y1 - End Y in world coordinates.
-     * @param paletteIndex - Palette entry index for the line color.
-     * @param cameraX - Horizontal camera offset to subtract.
-     * @param cameraY - Vertical camera offset to subtract.
+     * @param x0 – Start X in world coordinates.
+     * @param y0 – Start Y in world coordinates.
+     * @param x1 – End X in world coordinates.
+     * @param y1 – End Y in world coordinates.
+     * @param paletteIndex – Palette entry index for the line color.
+     * @param cameraX – Horizontal camera offset to subtract.
+     * @param cameraY – Vertical camera offset to subtract.
      */
     private rasterLine(
         x0: number,
@@ -795,7 +795,7 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
      * Rasterizes a sprite by iterating its source rect and writing palette-resolved pixels.
      * Index 0 is treated as transparent and skipped.
      *
-     * @param command - Sprite draw command with sheet, source rect, destination, and camera state.
+     * @param command – Sprite draw command with sheet, source rect, destination, and camera state.
      */
     private rasterSprite(command: SpriteCommand): void {
         const indexedPixels = command.spriteSheet.getIndexedPixels();
@@ -835,7 +835,7 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
     /**
      * Rasterizes a bitmap text command by expanding each character to a sprite blit.
      *
-     * @param command - Bitmap text command with font, position, text string, and camera state.
+     * @param command – Bitmap text command with font, position, text string, and camera state.
      */
     private rasterBitmapText(command: BitmapTextCommand): void {
         let cursorX = command.pos.x;
@@ -864,12 +864,12 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
     /**
      * Writes one RGBA pixel into `framePixels`, bounds-checked against the display size.
      *
-     * @param x - Pixel X in logical coordinates.
-     * @param y - Pixel Y in logical coordinates.
-     * @param r - Red channel (0-255).
-     * @param g - Green channel (0-255).
-     * @param b - Blue channel (0-255).
-     * @param a - Alpha channel (0-255).
+     * @param x – Pixel X in logical coordinates.
+     * @param y – Pixel Y in logical coordinates.
+     * @param r – Red channel (0-255).
+     * @param g – Green channel (0-255).
+     * @param b – Blue channel (0-255).
+     * @param a – Alpha channel (0-255).
      */
     private writePixel(x: number, y: number, r: number, g: number, b: number, a: number): void {
         if (x < 0 || y < 0 || x >= this.displaySize.x || y >= this.displaySize.y) {
@@ -889,7 +889,7 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
      * Resolves a palette index to a `Color32` for primitive drawing.
      * Returns `null` for out-of-range indices and fully transparent colors.
      *
-     * @param paletteIndex - Palette entry index to look up.
+     * @param paletteIndex – Palette entry index to look up.
      * @returns Resolved color, or `null` when the pixel should not be drawn.
      */
     private resolvePrimitiveColor(paletteIndex: number): Color32 | null {
@@ -906,7 +906,7 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
      * Resolves a palette index to a `Color32` for sprite drawing.
      * Returns `Color32.black` for out-of-range indices instead of skipping.
      *
-     * @param paletteIndex - Palette entry index to look up.
+     * @param paletteIndex – Palette entry index to look up.
      * @returns Resolved color.
      */
     private resolveSpriteColor(paletteIndex: number): Color32 {

--- a/packages/blit386/src/render/SpritePipeline.test.ts
+++ b/packages/blit386/src/render/SpritePipeline.test.ts
@@ -460,7 +460,7 @@ describe('drawBitmapText', () => {
             sheet,
         );
 
-        // 'Z' has no glyph - should be silently skipped
+        // 'Z' has no glyph – should be silently skipped
         pipeline.drawBitmapText(font, new Vector2i(0, 0), 'AZA');
 
         let totalVertices = 0;

--- a/packages/blit386/src/render/SpritePipeline.ts
+++ b/packages/blit386/src/render/SpritePipeline.ts
@@ -52,10 +52,10 @@ export class SpritePipeline {
     /** Backing buffer for all vertex data. */
     private readonly vertexArrayBuffer: ArrayBuffer;
 
-    /** Float32 view over vertexArrayBuffer - for x, y, u, v (indices i*5+0..+3). */
+    /** Float32 view over vertexArrayBuffer – for x, y, u, v (indices i*5+0..+3). */
     private readonly vertexFloats: Float32Array;
 
-    /** Uint32 view over vertexArrayBuffer - for paletteOffset (index i*5+4). */
+    /** Uint32 view over vertexArrayBuffer – for paletteOffset (index i*5+4). */
     private readonly vertexUints: Uint32Array;
 
     /** Number of vertices in the current (unflushed) batch. */
@@ -101,10 +101,10 @@ export class SpritePipeline {
     /**
      * Initializes the GPU pipeline state and vertex buffer.
      *
-     * @param device - WebGPU device for GPU operations.
-     * @param displaySize - Render target resolution in pixels.
-     * @param paletteBuffer - Shared palette uniform buffer (256 x vec4f).
-     * @param targetFormat - Color attachment format for sprite output.
+     * @param device – WebGPU device for GPU operations.
+     * @param displaySize – Render target resolution in pixels.
+     * @param paletteBuffer – Shared palette uniform buffer (256 x vec4f).
+     * @param targetFormat – Color attachment format for sprite output.
      */
     async init(
         device: GPUDevice,
@@ -121,7 +121,7 @@ export class SpritePipeline {
     /**
      * Sets the camera offset applied to all drawing operations.
      *
-     * @param offset - Camera position in pixels.
+     * @param offset – Camera position in pixels.
      */
     setCameraOffset(offset: Vector2i): void {
         this.cameraOffset = offset;
@@ -130,10 +130,10 @@ export class SpritePipeline {
     /**
      * Draws a sprite region from an indexed sprite sheet.
      *
-     * @param spriteSheet - Source sprite sheet (must have been indexized).
-     * @param srcRect - Region to copy from the sprite sheet.
-     * @param destPos - Screen position to draw at.
-     * @param paletteOffset - Index offset added to every sprite pixel at draw time (default 0).
+     * @param spriteSheet – Source sprite sheet (must have been indexized).
+     * @param srcRect – Region to copy from the sprite sheet.
+     * @param destPos – Screen position to draw at.
+     * @param paletteOffset – Index offset added to every sprite pixel at draw time (default 0).
      */
     drawSprite(spriteSheet: SpriteSheet, srcRect: Rect2i, destPos: Vector2i, paletteOffset: number = 0): void {
         const texture = spriteSheet.getTexture(this.device as GPUDevice);
@@ -149,10 +149,10 @@ export class SpritePipeline {
      * Draws text using a bitmap font through the indexed sprite pipeline.
      * Renders each character as a textured sprite using glyph metadata from the font.
      *
-     * @param font - Bitmap font with character glyphs (underlying sheet must be indexized).
-     * @param pos - Text position (top-left corner).
-     * @param text - String to render.
-     * @param paletteOffset - Index offset applied to every glyph pixel (default 0).
+     * @param font – Bitmap font with character glyphs (underlying sheet must be indexized).
+     * @param pos – Text position (top-left corner).
+     * @param text – String to render.
+     * @param paletteOffset – Index offset applied to every glyph pixel (default 0).
      */
     drawBitmapText(font: BitmapFont, pos: Vector2i, text: string, paletteOffset: number = 0): void {
         const spriteSheet = font.getSpriteSheet();
@@ -178,7 +178,7 @@ export class SpritePipeline {
      * Uploads accumulated sprite data and encodes draw calls for each texture batch.
      * No-op when nothing has been queued for the current frame.
      *
-     * @param renderPass - Active render pass encoder.
+     * @param renderPass – Active render pass encoder.
      */
     encodePass(renderPass: GPURenderPassEncoder): void {
         // Flush any remaining vertices into the batch queue.
@@ -242,8 +242,8 @@ export class SpritePipeline {
     /**
      * Creates shader modules, pipeline state, and GPU buffers.
      *
-     * @param displaySize - Render target resolution in pixels.
-     * @param targetFormat - Color attachment format for sprite output.
+     * @param displaySize – Render target resolution in pixels.
+     * @param targetFormat – Color attachment format for sprite output.
      */
     private async createPipeline(displaySize: Vector2i, targetFormat: GPUTextureFormat): Promise<void> {
         const device = this.device as GPUDevice;
@@ -356,7 +356,7 @@ export class SpritePipeline {
             usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
         });
 
-        // Shared bind group (group 0): uniforms + palette - created once and reused for all textures.
+        // Shared bind group (group 0): uniforms + palette – created once and reused for all textures.
         this.sharedBindGroup = device.createBindGroup({
             label: 'Sprite Shared Bind Group',
             layout: (this.pipeline as GPURenderPipeline).getBindGroupLayout(0),
@@ -372,14 +372,14 @@ export class SpritePipeline {
      * Handles texture switching and keeps quad emission atomic so partial quads
      * are never left in the vertex buffer.
      *
-     * @param texture - GPU r8uint index texture.
-     * @param pos - Screen position (top-left corner).
-     * @param size - Quad dimensions in pixels.
-     * @param u0 - Left UV coordinate (0-1).
-     * @param v0 - Top UV coordinate (0-1).
-     * @param u1 - Right UV coordinate (0-1).
-     * @param v1 - Bottom UV coordinate (0-1).
-     * @param paletteOffset - Palette index offset for this quad.
+     * @param texture – GPU r8uint index texture.
+     * @param pos – Screen position (top-left corner).
+     * @param size – Quad dimensions in pixels.
+     * @param u0 – Left UV coordinate (0-1).
+     * @param v0 – Top UV coordinate (0-1).
+     * @param u1 – Right UV coordinate (0-1).
+     * @param v1 – Bottom UV coordinate (0-1).
+     * @param paletteOffset – Palette index offset for this quad.
      */
     private drawTexturedQuad(
         texture: GPUTexture,
@@ -408,7 +408,7 @@ export class SpritePipeline {
                 this.flushCurrentBatch();
             }
 
-            // Check again after flush - if still no space, the buffer is full for this frame.
+            // Check again after flush – if still no space, the buffer is full for this frame.
             if (!this.hasSpaceForQuad()) {
                 console.warn('[SpritePipeline] Sprite buffer capacity exceeded for this frame, quad dropped');
                 this.overflowCount++;
@@ -471,11 +471,11 @@ export class SpritePipeline {
      * Writes x, y, u, v as floats and paletteOffset as u32 into the shared
      * ArrayBuffer using dual typed-array views.
      *
-     * @param x - X position in pixels.
-     * @param y - Y position in pixels.
-     * @param u - U texture coordinate.
-     * @param v - V texture coordinate.
-     * @param paletteOffset - Palette index offset (u32).
+     * @param x – X position in pixels.
+     * @param y – Y position in pixels.
+     * @param u – U texture coordinate.
+     * @param v – V texture coordinate.
+     * @param paletteOffset – Palette index offset (u32).
      */
     private addVertex(x: number, y: number, u: number, v: number, paletteOffset: number): void {
         const base = (this.totalVertices + this.vertexCount) * VALUES_PER_VERTEX;
@@ -494,7 +494,7 @@ export class SpritePipeline {
      * Gets or creates a per-texture bind group (group 1) for the given texture.
      * Bind groups are cached per texture for reuse across frames.
      *
-     * @param texture - r8uint GPU texture to create the bind group for.
+     * @param texture – r8uint GPU texture to create the bind group for.
      * @returns Bind group containing the texture view.
      */
     private getOrCreateTextureBindGroup(texture: GPUTexture): GPUBindGroup {

--- a/packages/blit386/src/render/UpscalePass.ts
+++ b/packages/blit386/src/render/UpscalePass.ts
@@ -19,7 +19,7 @@ export type UpscaleFilter = 'nearest' | 'linear';
  * for unit tests and standalone upscale scenarios.
  *
  * The pass owns its render pipeline, sampler, and a per-source-view bind-group
- * cache. It does **not** own the source or destination textures - the caller
+ * cache. It does **not** own the source or destination textures – the caller
  * supplies views every frame.
  */
 export class UpscalePass {
@@ -54,10 +54,10 @@ export class UpscalePass {
      * canvas resizes; the pass itself only encodes the draw and is unaware of
      * lifecycle.
      *
-     * @param device - WebGPU device used for resource creation.
-     * @param size - Target texture dimensions in pixels.
-     * @param format - Color format (match the swap chain).
-     * @param label - Optional debug label.
+     * @param device – WebGPU device used for resource creation.
+     * @param size – Target texture dimensions in pixels.
+     * @param format – Color format (match the swap chain).
+     * @param label – Optional debug label.
      * @returns Newly created texture with usage flags suitable for upscale output.
      */
     static createOutputTexture(
@@ -80,9 +80,9 @@ export class UpscalePass {
      * Idempotent only on a freshly disposed instance: calling `init` twice
      * without `dispose` will leak the previous sampler and pipeline.
      *
-     * @param device - WebGPU device used for resource creation.
-     * @param format - Color attachment format (matches the swap chain).
-     * @param filter - Magnification filter mode.
+     * @param device – WebGPU device used for resource creation.
+     * @param format – Color attachment format (matches the swap chain).
+     * @param filter – Magnification filter mode.
      */
     init(device: GPUDevice, format: GPUTextureFormat, filter: UpscaleFilter): void {
         this.device = device;
@@ -116,9 +116,9 @@ export class UpscalePass {
      * Encodes a single full-screen pass that samples {@link sourceView} and
      * writes into {@link destView}.
      *
-     * @param encoder - Active command encoder.
-     * @param sourceView - View of the logical-resolution framebuffer.
-     * @param destView - View of the display-resolution destination texture
+     * @param encoder – Active command encoder.
+     * @param sourceView – View of the logical-resolution framebuffer.
+     * @param destView – View of the display-resolution destination texture
      *   (or the swap chain when no display effects are active).
      */
     encode(encoder: GPUCommandEncoder, sourceView: GPUTextureView, destView: GPUTextureView): void {
@@ -151,7 +151,7 @@ export class UpscalePass {
      * Safe to call multiple times.
      */
     dispose(): void {
-        // Bind groups don't have a destroy method - dropping the WeakMap entries is enough.
+        // Bind groups don't have a destroy method – dropping the WeakMap entries is enough.
         // Sampler / pipeline / layout are reference-counted by WebGPU; clearing the refs is enough.
         this.pipeline = null;
         this.bindGroupLayout = null;
@@ -163,7 +163,7 @@ export class UpscalePass {
      * Returns the bind group for the supplied source view, creating one on
      * first use and caching by view identity for subsequent frames.
      *
-     * @param sourceView - View of the source texture to sample.
+     * @param sourceView – View of the source texture to sample.
      * @returns Cached or newly created bind group.
      */
     private getOrCreateBindGroup(sourceView: GPUTextureView): GPUBindGroup {

--- a/packages/blit386/src/render/WebGPURenderer.test.ts
+++ b/packages/blit386/src/render/WebGPURenderer.test.ts
@@ -46,7 +46,7 @@ type PipelineAccess = {
 /**
  * Returns the six scene-pass pipeline batches for encode-order and routing tests.
  *
- * @param renderer - Initialized {@link WebGPURenderer}.
+ * @param renderer – Initialized {@link WebGPURenderer}.
  * @returns Primitive, sprite, overlay, and overlay-top pipeline instances.
  */
 function getRendererPipelines(renderer: WebGPURenderer): PipelineAccess {
@@ -407,7 +407,7 @@ describe('with initialized renderer', () => {
     it('drawBitmapText delegates without throwing', () => {
         renderer.beginFrame();
 
-        // Empty text - loop does not execute so glyph methods are never called.
+        // Empty text – loop does not execute so glyph methods are never called.
         const mockFont = {
             getSpriteSheet: () => ({}),
             getGlyphByCode: () => null,
@@ -570,7 +570,7 @@ describe('resolveClearColor fallbacks', () => {
 
         await r.init();
 
-        // No setPalette() call - endFrame() resolves clear color to black via fallback.
+        // No setPalette() call – endFrame() resolves clear color to black via fallback.
         expect(() => r.endFrame()).not.toThrow();
 
         uninstallMockNavigatorGPU();
@@ -867,7 +867,7 @@ describe('palette dirty-flag auto-propagation', () => {
 
         renderer.setPalette(palette);
 
-        // Mutate the original after setPalette - the renderer must see the change.
+        // Mutate the original after setPalette – the renderer must see the change.
         palette.set(1, new Color32(99, 99, 99, 255));
 
         // getPalette() returns a clone, so compare by value rather than reference.
@@ -930,7 +930,7 @@ describe('palette dirty-flag auto-propagation', () => {
 
         renderer.setPalette(palette);
 
-        // First frame - initial upload due to isPaletteDirty.
+        // First frame – initial upload due to isPaletteDirty.
         renderer.beginFrame();
         renderer.endFrame();
 
@@ -939,7 +939,7 @@ describe('palette dirty-flag auto-propagation', () => {
         // Mutate palette without calling BT.paletteSet() again.
         palette.set(1, new Color32(255, 0, 128, 255));
 
-        // Second frame - must re-upload because palette.isDirty is true.
+        // Second frame – must re-upload because palette.isDirty is true.
         renderer.beginFrame();
         renderer.endFrame();
 
@@ -964,13 +964,13 @@ describe('palette dirty-flag auto-propagation', () => {
 
         renderer.setPalette(palette);
 
-        // First frame - initial upload.
+        // First frame – initial upload.
         renderer.beginFrame();
         renderer.endFrame();
 
         const callsAfterFirstFrame = writeBufferSpy.mock.calls.length;
 
-        // No mutation - second frame should NOT upload.
+        // No mutation – second frame should NOT upload.
         renderer.beginFrame();
         renderer.endFrame();
 

--- a/packages/blit386/src/render/WebGPURenderer.ts
+++ b/packages/blit386/src/render/WebGPURenderer.ts
@@ -144,13 +144,13 @@ export class WebGPURenderer implements IRenderer, OverlayDrawTarget {
     /**
      * Creates a renderer bound to an initialized device and canvas context.
      *
-     * @param device - WebGPU device for GPU operations.
-     * @param context - WebGPU canvas context for presenting frames.
-     * @param displaySize - Logical render resolution in pixels.
-     * @param outputSize - Output drawing-buffer resolution in pixels (matches the
+     * @param device – WebGPU device for GPU operations.
+     * @param context – WebGPU canvas context for presenting frames.
+     * @param displaySize – Logical render resolution in pixels.
+     * @param outputSize – Output drawing-buffer resolution in pixels (matches the
      *   swap chain). When omitted, display-tier effects are disabled and the
      *   renderer operates at logical `displaySize` only.
-     * @param upscaleFilter - Magnification filter for the upscale pass. Defaults to
+     * @param upscaleFilter – Magnification filter for the upscale pass. Defaults to
      *   `'nearest'`.
      */
     constructor(
@@ -249,13 +249,13 @@ export class WebGPURenderer implements IRenderer, OverlayDrawTarget {
     /**
      * Sets the active palette used for rendering.
      *
-     * Stores a reference to the supplied palette - no clone is made. Subsequent
+     * Stores a reference to the supplied palette – no clone is made. Subsequent
      * calls to {@link Palette.set} or {@link Palette.copyFrom} on the same object
      * will be detected via {@link Palette.isDirty} and uploaded automatically at the
      * start of the next frame. The internal dirty flag guarantees the initial
      * upload even when the palette has never been mutated through {@link Palette.set}.
      *
-     * @param palette - Palette to use for color lookups and GPU upload.
+     * @param palette – Palette to use for color lookups and GPU upload.
      */
     setPalette(palette: Palette): void {
         this.palette = palette;
@@ -304,7 +304,7 @@ export class WebGPURenderer implements IRenderer, OverlayDrawTarget {
     /**
      * Sets the background clear color for this frame using a palette index.
      *
-     * @param paletteIndex - Palette index for the clear color.
+     * @param paletteIndex – Palette index for the clear color.
      */
     setClearColor(paletteIndex: number): void {
         this.clearPaletteIndex = paletteIndex;
@@ -382,8 +382,8 @@ export class WebGPURenderer implements IRenderer, OverlayDrawTarget {
     /**
      * Draws a filled rectangle using two triangles.
      *
-     * @param rect - Rectangle bounds in pixel coordinates.
-     * @param paletteIndex - Palette color index.
+     * @param rect – Rectangle bounds in pixel coordinates.
+     * @param paletteIndex – Palette color index.
      */
     drawRectFill(rect: Rect2i, paletteIndex: number): void {
         this.primitives.drawRectFill(rect, paletteIndex);
@@ -392,8 +392,8 @@ export class WebGPURenderer implements IRenderer, OverlayDrawTarget {
     /**
      * Draws a filled rectangle in the overlay primitive batch (above demo sprites).
      *
-     * @param rect - Rectangle bounds in pixel coordinates.
-     * @param paletteIndex - Palette color index.
+     * @param rect – Rectangle bounds in pixel coordinates.
+     * @param paletteIndex – Palette color index.
      */
     drawBarFill(rect: Rect2i, paletteIndex: number): void {
         this.overlayPrimitives.drawRectFill(rect, paletteIndex);
@@ -402,8 +402,8 @@ export class WebGPURenderer implements IRenderer, OverlayDrawTarget {
     /**
      * Draws a filled rectangle above overlay labels (tooltip chrome, etc.).
      *
-     * @param rect - Rectangle bounds in pixel coordinates.
-     * @param paletteIndex - Palette color index.
+     * @param rect – Rectangle bounds in pixel coordinates.
+     * @param paletteIndex – Palette color index.
      */
     drawBarFillOnTop(rect: Rect2i, paletteIndex: number): void {
         this.overlayTopPrimitives.drawRectFill(rect, paletteIndex);
@@ -412,8 +412,8 @@ export class WebGPURenderer implements IRenderer, OverlayDrawTarget {
     /**
      * Draws a single pixel as a 1x1 filled rectangle.
      *
-     * @param pos - Pixel position.
-     * @param paletteIndex - Palette color index.
+     * @param pos – Pixel position.
+     * @param paletteIndex – Palette color index.
      */
     drawPixel(pos: Vector2i, paletteIndex: number): void {
         this.drawPixelXYInternal(pos.x, pos.y, paletteIndex);
@@ -423,9 +423,9 @@ export class WebGPURenderer implements IRenderer, OverlayDrawTarget {
      * Draws a line using optimized quad rendering for axis-aligned lines,
      * falling back to Bresenham's algorithm for diagonal lines.
      *
-     * @param p0 - Start point.
-     * @param p1 - End point.
-     * @param paletteIndex - Palette color index.
+     * @param p0 – Start point.
+     * @param p1 – End point.
+     * @param paletteIndex – Palette color index.
      */
     drawLine(p0: Vector2i, p1: Vector2i, paletteIndex: number): void {
         this.primitives.drawLine(p0, p1, paletteIndex);
@@ -434,8 +434,8 @@ export class WebGPURenderer implements IRenderer, OverlayDrawTarget {
     /**
      * Draws a rectangle outline using four 1-pixel quads.
      *
-     * @param rect - Rectangle bounds.
-     * @param paletteIndex - Palette color index.
+     * @param rect – Rectangle bounds.
+     * @param paletteIndex – Palette color index.
      */
     drawRect(rect: Rect2i, paletteIndex: number): void {
         this.primitives.drawRect(rect, paletteIndex);
@@ -444,8 +444,8 @@ export class WebGPURenderer implements IRenderer, OverlayDrawTarget {
     /**
      * Fills a rectangular region with a palette-indexed color.
      *
-     * @param rect - Region to fill in pixel coordinates.
-     * @param paletteIndex - Palette color index.
+     * @param rect – Region to fill in pixel coordinates.
+     * @param paletteIndex – Palette color index.
      */
     clearRect(rect: Rect2i, paletteIndex: number): void {
         this.primitives.clearRect(rect, paletteIndex);
@@ -454,10 +454,10 @@ export class WebGPURenderer implements IRenderer, OverlayDrawTarget {
     /**
      * Draws a sprite region from an indexed sprite sheet.
      *
-     * @param spriteSheet - Source sprite sheet (must have been indexized).
-     * @param srcRect - Region to copy from the sprite sheet.
-     * @param destPos - Screen position to draw at.
-     * @param paletteOffset - Palette index offset applied at draw time (default 0).
+     * @param spriteSheet – Source sprite sheet (must have been indexized).
+     * @param srcRect – Region to copy from the sprite sheet.
+     * @param destPos – Screen position to draw at.
+     * @param paletteOffset – Palette index offset applied at draw time (default 0).
      */
     drawSprite(spriteSheet: SpriteSheet, srcRect: Rect2i, destPos: Vector2i, paletteOffset: number = 0): void {
         this.sprites.drawSprite(spriteSheet, srcRect, destPos, paletteOffset);
@@ -467,10 +467,10 @@ export class WebGPURenderer implements IRenderer, OverlayDrawTarget {
      * Draws text using a bitmap font through the indexed sprite pipeline.
      * Renders each character as a textured sprite.
      *
-     * @param font - Bitmap font with character glyphs (underlying sheet must be indexized).
-     * @param pos - Text position (top-left corner).
-     * @param text - String to render.
-     * @param paletteOffset - Palette index offset applied to all glyphs (default 0).
+     * @param font – Bitmap font with character glyphs (underlying sheet must be indexized).
+     * @param pos – Text position (top-left corner).
+     * @param text – String to render.
+     * @param paletteOffset – Palette index offset applied to all glyphs (default 0).
      */
     drawBitmapText(font: BitmapFont, pos: Vector2i, text: string, paletteOffset: number = 0): void {
         this.sprites.drawBitmapText(font, pos, text, paletteOffset);
@@ -479,10 +479,10 @@ export class WebGPURenderer implements IRenderer, OverlayDrawTarget {
     /**
      * Draws bitmap text in the overlay sprite batch (above overlay bar fills).
      *
-     * @param font - Bitmap font with character glyphs.
-     * @param pos - Text position (top-left corner).
-     * @param text - String to render.
-     * @param paletteOffset - Palette index offset applied to all glyphs (default 0).
+     * @param font – Bitmap font with character glyphs.
+     * @param pos – Text position (top-left corner).
+     * @param text – String to render.
+     * @param paletteOffset – Palette index offset applied to all glyphs (default 0).
      */
     drawLabel(font: BitmapFont, pos: Vector2i, text: string, paletteOffset: number = 0): void {
         this.overlaySprites.drawBitmapText(font, pos, text, paletteOffset);
@@ -491,10 +491,10 @@ export class WebGPURenderer implements IRenderer, OverlayDrawTarget {
     /**
      * Draws bitmap text above overlay top bar fills (tooltip labels, etc.).
      *
-     * @param font - Bitmap font with character glyphs.
-     * @param pos - Text position (top-left corner).
-     * @param text - String to render.
-     * @param paletteOffset - Palette index offset applied to all glyphs (default 0).
+     * @param font – Bitmap font with character glyphs.
+     * @param pos – Text position (top-left corner).
+     * @param text – String to render.
+     * @param paletteOffset – Palette index offset applied to all glyphs (default 0).
      */
     drawLabelOnTop(font: BitmapFont, pos: Vector2i, text: string, paletteOffset: number = 0): void {
         this.overlayTopSprites.drawBitmapText(font, pos, text, paletteOffset);
@@ -518,7 +518,7 @@ export class WebGPURenderer implements IRenderer, OverlayDrawTarget {
      * `overlayPrimitives`, `overlayTopPrimitives`, `sprites`, `overlaySprites`,
      * and `overlayTopSprites`.
      *
-     * @param offset - Camera position in pixels.
+     * @param offset – Camera position in pixels.
      */
     setCameraOffset(offset: Vector2i): void {
         this.cameraOffset = offset.clone();
@@ -560,7 +560,7 @@ export class WebGPURenderer implements IRenderer, OverlayDrawTarget {
      * - `tier='display'` -> display chain (output resolution); requires
      *   `drawingBufferSize` to be set in `configure()`.
      *
-     * @param effect - Effect instance to append.
+     * @param effect – Effect instance to append.
      * @throws If the renderer has not been initialized.
      * @throws If a `'display'` effect is added without `drawingBufferSize`
      *   set in `configure()`.
@@ -589,7 +589,7 @@ export class WebGPURenderer implements IRenderer, OverlayDrawTarget {
      * fallback tries the other chain. Removing an effect that was never added
      * is a no-op.
      *
-     * @param effect - Effect instance to remove.
+     * @param effect – Effect instance to remove.
      * @throws If the renderer has not been initialized.
      */
     removeEffect(effect: Effect): void {
@@ -680,8 +680,8 @@ export class WebGPURenderer implements IRenderer, OverlayDrawTarget {
      * `overlayTopPrimitives` ({@link drawBarFillOnTop}), then `overlayTopSprites`
      * ({@link drawLabelOnTop}).
      *
-     * @param encoder - Active command encoder.
-     * @param sceneView - Logical scene attachment view to render into.
+     * @param encoder – Active command encoder.
+     * @param sceneView – Logical scene attachment view to render into.
      */
     private encodeScenePass(encoder: GPUCommandEncoder, sceneView: GPUTextureView): void {
         const clearPaletteIndex = this.resolveClearPaletteIndex();
@@ -716,11 +716,11 @@ export class WebGPURenderer implements IRenderer, OverlayDrawTarget {
      * Encodes the optional pixel chain, upscale pass, and display chain in the
      * correct order based on which chains are active.
      *
-     * @param encoder - Active command encoder.
-     * @param swapChainView - Current swap-chain view (final destination).
-     * @param isPixelChainActive - Whether the pixel chain has any registered effects.
-     * @param isDisplayChainActive - Whether the display chain has any registered effects.
-     * @param deltaMs - Wall-clock milliseconds since the previous frame.
+     * @param encoder – Active command encoder.
+     * @param swapChainView – Current swap-chain view (final destination).
+     * @param isPixelChainActive – Whether the pixel chain has any registered effects.
+     * @param isDisplayChainActive – Whether the display chain has any registered effects.
+     * @param deltaMs – Wall-clock milliseconds since the previous frame.
      */
     private encodePostProcess(
         encoder: GPUCommandEncoder,
@@ -751,8 +751,8 @@ export class WebGPURenderer implements IRenderer, OverlayDrawTarget {
      * Adds the optional frame-capture readback, submits the command buffer,
      * and resets per-frame pipeline state.
      *
-     * @param encoder - Active command encoder.
-     * @param swapTexture - Current swap-chain texture (capture source).
+     * @param encoder – Active command encoder.
+     * @param swapTexture – Current swap-chain texture (capture source).
      */
     private submitFrame(encoder: GPUCommandEncoder, swapTexture: GPUTexture): void {
         const isCapturing = this.frameCapture.hasPending();
@@ -781,7 +781,7 @@ export class WebGPURenderer implements IRenderer, OverlayDrawTarget {
     /**
      * Picks the texture view the scene render pass should target this frame.
      *
-     * @param isPixelChainActive - Whether the pixel chain has any registered effects.
+     * @param isPixelChainActive – Whether the pixel chain has any registered effects.
      * @returns Stable view to render the scene into.
      */
     private resolveSceneView(isPixelChainActive: boolean): GPUTextureView {
@@ -844,9 +844,9 @@ export class WebGPURenderer implements IRenderer, OverlayDrawTarget {
      * Fast-path pixel draw using raw integer coordinates.
      * Avoids Vector2i unpacking overhead when coordinates are already available as numbers.
      *
-     * @param x - X position.
-     * @param y - Y position.
-     * @param paletteIndex - Palette color index.
+     * @param x – X position.
+     * @param y – Y position.
+     * @param paletteIndex – Palette color index.
      */
     private drawPixelXYInternal(x: number, y: number, paletteIndex: number): void {
         this.primitives.drawPixelXY(x, y, paletteIndex);

--- a/packages/blit386/src/render/effects/Effect.ts
+++ b/packages/blit386/src/render/effects/Effect.ts
@@ -55,11 +55,11 @@ export interface Effect {
      * Idempotent: calling twice on the same instance is undefined behavior; the
      * chain guarantees it is only invoked once per effect instance.
      *
-     * @param device - WebGPU device used for resource creation.
-     * @param format - Color attachment format for this chain (`r8uint` for the pixel
+     * @param device – WebGPU device used for resource creation.
+     * @param format – Color attachment format for this chain (`r8uint` for the pixel
      *   tier, swap-chain format for the display tier) so ping-pong textures match the
      *   effect pipelines.
-     * @param displaySize - Chain attachment dimensions in pixels for this pass
+     * @param displaySize – Chain attachment dimensions in pixels for this pass
      *   (logical size for the pixel tier, output size for the display tier).
      */
     init(device: GPUDevice, format: GPUTextureFormat, displaySize: Vector2i): void;
@@ -69,8 +69,8 @@ export interface Effect {
      *
      * Called by {@link PostProcessChain} immediately before {@link encodePass}.
      *
-     * @param deltaMs - Wall-clock milliseconds since the previous frame.
-     * @param sourceSize - Pixel dimensions of the source texture for this pass.
+     * @param deltaMs – Wall-clock milliseconds since the previous frame.
+     * @param sourceSize – Pixel dimensions of the source texture for this pass.
      */
     updateUniforms(deltaMs: number, sourceSize: Vector2i): void;
 
@@ -81,9 +81,9 @@ export interface Effect {
      * with `clear` (any clearColor; the shader overwrites the entire surface).
      * The pass binds the source texture view as its sampled input.
      *
-     * @param encoder - Active command encoder owned by the renderer.
-     * @param sourceView - View of the texture to sample from.
-     * @param destView - View of the texture to render into.
+     * @param encoder – Active command encoder owned by the renderer.
+     * @param sourceView – View of the texture to sample from.
+     * @param destView – View of the texture to render into.
      */
     encodePass(encoder: GPUCommandEncoder, sourceView: GPUTextureView, destView: GPUTextureView): void;
 

--- a/packages/blit386/src/render/effects/FullscreenEffect.ts
+++ b/packages/blit386/src/render/effects/FullscreenEffect.ts
@@ -36,7 +36,7 @@ export abstract class FullscreenEffect implements Effect {
     abstract readonly tier: EffectTier;
 
     /**
-     * Sampler filter mode. Defaults to `'linear'` (smooth - appropriate for
+     * Sampler filter mode. Defaults to `'linear'` (smooth – appropriate for
      * display-tier effects). Pixel-tier effects can override to `'nearest'` to
      * preserve palette colors during sampling.
      */
@@ -72,10 +72,10 @@ export abstract class FullscreenEffect implements Effect {
     /**
      * Creates the GPU pipeline, uniform buffer, sampler, and bind-group layout.
      *
-     * @param device - WebGPU device used for resource creation.
-     * @param format - Color attachment format. Pixel chain: `r8uint`; display
+     * @param device – WebGPU device used for resource creation.
+     * @param format – Color attachment format. Pixel chain: `r8uint`; display
      *   chain: swap-chain RGBA format.
-     * @param _displaySize - Source render target resolution. Most effects ignore
+     * @param _displaySize – Source render target resolution. Most effects ignore
      *   this and use the per-frame `sourceSize` from {@link updateUniforms}.
      */
     init(device: GPUDevice, format: GPUTextureFormat, _displaySize: Vector2i): void {
@@ -121,8 +121,8 @@ export abstract class FullscreenEffect implements Effect {
     /**
      * Calls {@link writeUniforms} then uploads the uniform block to the GPU.
      *
-     * @param deltaMs - Wall-clock milliseconds since the previous frame.
-     * @param sourceSize - Pixel dimensions of the source texture for this pass.
+     * @param deltaMs – Wall-clock milliseconds since the previous frame.
+     * @param sourceSize – Pixel dimensions of the source texture for this pass.
      */
     updateUniforms(deltaMs: number, sourceSize: Vector2i): void {
         if (!this.device || !this.uniformBuffer || !this.uniformData) {
@@ -137,9 +137,9 @@ export abstract class FullscreenEffect implements Effect {
      * Encodes the fullscreen pass that samples the source texture and writes
      * the result into the destination view.
      *
-     * @param encoder - Active command encoder owned by the renderer.
-     * @param sourceView - View of the texture to sample from.
-     * @param destView - View of the texture to render into.
+     * @param encoder – Active command encoder owned by the renderer.
+     * @param sourceView – View of the texture to sample from.
+     * @param destView – View of the texture to render into.
      */
     encodePass(encoder: GPUCommandEncoder, sourceView: GPUTextureView, destView: GPUTextureView): void {
         if (!this.pipeline) {
@@ -186,7 +186,7 @@ export abstract class FullscreenEffect implements Effect {
      * Returns the bind group for the supplied source view, creating one on
      * first use and caching by view identity.
      *
-     * @param sourceView - View of the source texture to sample.
+     * @param sourceView – View of the source texture to sample.
      * @returns Cached or newly created bind group.
      */
     private getOrCreateBindGroup(sourceView: GPUTextureView): GPUBindGroup {

--- a/packages/blit386/src/render/effects/FullscreenPixelEffect.ts
+++ b/packages/blit386/src/render/effects/FullscreenPixelEffect.ts
@@ -37,9 +37,9 @@ export abstract class FullscreenPixelEffect implements Effect {
     /**
      * Builds WGSL module and GPU pipeline for the supplied chain format.
      *
-     * @param device - WebGPU device.
-     * @param format - Pixel chain attachment format (`r8uint` or float swap format).
-     * @param _chainSize - Chain resolution (unused by base; subclasses may read via uniforms).
+     * @param device – WebGPU device.
+     * @param format – Pixel chain attachment format (`r8uint` or float swap format).
+     * @param _chainSize – Chain resolution (unused by base; subclasses may read via uniforms).
      */
     init(device: GPUDevice, format: GPUTextureFormat, _chainSize: Vector2i): void {
         if (this.uniformBytes <= 0 || this.uniformBytes % 16 !== 0) {
@@ -88,8 +88,8 @@ export abstract class FullscreenPixelEffect implements Effect {
     /**
      * Uploads uniform block after {@link writeUniforms}.
      *
-     * @param deltaMs - Milliseconds since previous frame.
-     * @param sourceSize - Source texture dimensions for this pass.
+     * @param deltaMs – Milliseconds since previous frame.
+     * @param sourceSize – Source texture dimensions for this pass.
      */
     updateUniforms(deltaMs: number, sourceSize: Vector2i): void {
         if (!this.device || !this.uniformBuffer || !this.uniformData) {
@@ -103,9 +103,9 @@ export abstract class FullscreenPixelEffect implements Effect {
     /**
      * Draws a fullscreen triangle sampling {@link sourceView} into {@link destView}.
      *
-     * @param encoder - Frame command encoder.
-     * @param sourceView - Input texture view.
-     * @param destView - Render target view.
+     * @param encoder – Frame command encoder.
+     * @param sourceView – Input texture view.
+     * @param destView – Render target view.
      */
     encodePass(encoder: GPUCommandEncoder, sourceView: GPUTextureView, destView: GPUTextureView): void {
         if (!this.pipeline) {
@@ -161,7 +161,7 @@ export abstract class FullscreenPixelEffect implements Effect {
     /**
      * Creates or returns a cached bind group for the active RGBA vs uint sampling layout.
      *
-     * @param sourceView - Texture view feeding this fullscreen pass.
+     * @param sourceView – Texture view feeding this fullscreen pass.
      * @returns Bind group bound to {@link sourceView}.
      */
     private getOrCreateBindGroup(sourceView: GPUTextureView): GPUBindGroup {

--- a/packages/blit386/src/render/effects/display/BarrelDistortion.ts
+++ b/packages/blit386/src/render/effects/display/BarrelDistortion.ts
@@ -36,8 +36,8 @@ export class BarrelDistortion extends FullscreenEffect {
 
     /**
      * Writes resolution and curvature into the uniform block.
-     * @param _deltaMs - Unused; effect reads public fields updated by demo code.
-     * @param sourceSize - Chain attachment dimensions in pixels for this pass.
+     * @param _deltaMs – Unused; effect reads public fields updated by demo code.
+     * @param sourceSize – Chain attachment dimensions in pixels for this pass.
      */
     protected writeUniforms(_deltaMs: number, sourceSize: Vector2i): void {
         const u = this.uniformData;

--- a/packages/blit386/src/render/effects/display/Bloom.ts
+++ b/packages/blit386/src/render/effects/display/Bloom.ts
@@ -38,8 +38,8 @@ export class Bloom extends FullscreenEffect {
 
     /**
      * Writes resolution, spread, and glow into the uniform block.
-     * @param _deltaMs - Unused; effect reads public fields updated by demo code.
-     * @param sourceSize - Chain attachment dimensions in pixels for this pass.
+     * @param _deltaMs – Unused; effect reads public fields updated by demo code.
+     * @param sourceSize – Chain attachment dimensions in pixels for this pass.
      */
     protected writeUniforms(_deltaMs: number, sourceSize: Vector2i): void {
         const u = this.uniformData;

--- a/packages/blit386/src/render/effects/display/ChromaticAberration.ts
+++ b/packages/blit386/src/render/effects/display/ChromaticAberration.ts
@@ -29,8 +29,8 @@ export class ChromaticAberration extends FullscreenEffect {
 
     /**
      * Writes resolution and aberration offset into the uniform block.
-     * @param _deltaMs - Unused; effect reads public fields updated by demo code.
-     * @param sourceSize - Chain attachment dimensions in pixels for this pass.
+     * @param _deltaMs – Unused; effect reads public fields updated by demo code.
+     * @param sourceSize – Chain attachment dimensions in pixels for this pass.
      */
     protected writeUniforms(_deltaMs: number, sourceSize: Vector2i): void {
         const u = this.uniformData;

--- a/packages/blit386/src/render/effects/display/Flicker.ts
+++ b/packages/blit386/src/render/effects/display/Flicker.ts
@@ -2,7 +2,7 @@ import type { Vector2i } from '../../../utils/Vector2i';
 import { FullscreenEffect } from '../FullscreenEffect';
 
 /**
- * Brightness multiplier - the simplest CRT animation knob.
+ * Brightness multiplier – the simplest CRT animation knob.
  *
  * Demos drive {@link amount} per frame to simulate flicker (e.g. with
  * `0.95 + sin(t) * 0.05`). The effect is intentionally trivial so the demo
@@ -32,8 +32,8 @@ export class Flicker extends FullscreenEffect {
 
     /**
      * Writes resolution and brightness amount into the uniform block.
-     * @param _deltaMs - Unused; effect reads public fields updated by demo code.
-     * @param sourceSize - Chain attachment dimensions in pixels for this pass.
+     * @param _deltaMs – Unused; effect reads public fields updated by demo code.
+     * @param sourceSize – Chain attachment dimensions in pixels for this pass.
      */
     protected writeUniforms(_deltaMs: number, sourceSize: Vector2i): void {
         const u = this.uniformData;

--- a/packages/blit386/src/render/effects/display/Interference.ts
+++ b/packages/blit386/src/render/effects/display/Interference.ts
@@ -34,8 +34,8 @@ export class Interference extends FullscreenEffect {
 
     /**
      * Writes resolution, amount, and time into the uniform block.
-     * @param _deltaMs - Unused; effect reads public fields updated by demo code.
-     * @param sourceSize - Chain attachment dimensions in pixels for this pass.
+     * @param _deltaMs – Unused; effect reads public fields updated by demo code.
+     * @param sourceSize – Chain attachment dimensions in pixels for this pass.
      */
     protected writeUniforms(_deltaMs: number, sourceSize: Vector2i): void {
         const u = this.uniformData;

--- a/packages/blit386/src/render/effects/display/Noise.ts
+++ b/packages/blit386/src/render/effects/display/Noise.ts
@@ -30,8 +30,8 @@ export class Noise extends FullscreenEffect {
 
     /**
      * Writes resolution, amount, and time into the uniform block.
-     * @param _deltaMs - Unused; effect reads public fields updated by demo code.
-     * @param sourceSize - Chain attachment dimensions in pixels for this pass.
+     * @param _deltaMs – Unused; effect reads public fields updated by demo code.
+     * @param sourceSize – Chain attachment dimensions in pixels for this pass.
      */
     protected writeUniforms(_deltaMs: number, sourceSize: Vector2i): void {
         const u = this.uniformData;

--- a/packages/blit386/src/render/effects/display/RGBMask.ts
+++ b/packages/blit386/src/render/effects/display/RGBMask.ts
@@ -34,8 +34,8 @@ export class RGBMask extends FullscreenEffect {
 
     /**
      * Writes resolution, intensity, size, and border into the uniform block.
-     * @param _deltaMs - Unused; effect reads public fields updated by demo code.
-     * @param sourceSize - Chain attachment dimensions in pixels for this pass.
+     * @param _deltaMs – Unused; effect reads public fields updated by demo code.
+     * @param sourceSize – Chain attachment dimensions in pixels for this pass.
      */
     protected writeUniforms(_deltaMs: number, sourceSize: Vector2i): void {
         const u = this.uniformData;

--- a/packages/blit386/src/render/effects/display/RollLine.ts
+++ b/packages/blit386/src/render/effects/display/RollLine.ts
@@ -31,8 +31,8 @@ export class RollLine extends FullscreenEffect {
 
     /**
      * Writes resolution, amount, speed, and time into the uniform block.
-     * @param _deltaMs - Unused; effect reads public fields updated by demo code.
-     * @param sourceSize - Chain attachment dimensions in pixels for this pass.
+     * @param _deltaMs – Unused; effect reads public fields updated by demo code.
+     * @param sourceSize – Chain attachment dimensions in pixels for this pass.
      */
     protected writeUniforms(_deltaMs: number, sourceSize: Vector2i): void {
         const u = this.uniformData;

--- a/packages/blit386/src/render/effects/display/Scanlines.ts
+++ b/packages/blit386/src/render/effects/display/Scanlines.ts
@@ -43,8 +43,8 @@ export class Scanlines extends FullscreenEffect {
 
     /**
      * Writes amount, strength, and density into the uniform block.
-     * @param _deltaMs - Unused; effect reads public fields updated by demo code.
-     * @param sourceSize - Chain attachment dimensions in pixels for this pass.
+     * @param _deltaMs – Unused; effect reads public fields updated by demo code.
+     * @param sourceSize – Chain attachment dimensions in pixels for this pass.
      */
     protected writeUniforms(_deltaMs: number, sourceSize: Vector2i): void {
         const u = this.uniformData;

--- a/packages/blit386/src/render/effects/display/Vignette.ts
+++ b/packages/blit386/src/render/effects/display/Vignette.ts
@@ -28,8 +28,8 @@ export class Vignette extends FullscreenEffect {
 
     /**
      * Writes resolution and amount into the uniform block.
-     * @param _deltaMs - Unused; effect reads public fields updated by demo code.
-     * @param sourceSize - Chain attachment dimensions in pixels for this pass.
+     * @param _deltaMs – Unused; effect reads public fields updated by demo code.
+     * @param sourceSize – Chain attachment dimensions in pixels for this pass.
      */
     protected writeUniforms(_deltaMs: number, sourceSize: Vector2i): void {
         const u = this.uniformData;

--- a/packages/blit386/src/render/effects/pixel/PixelGlitch.ts
+++ b/packages/blit386/src/render/effects/pixel/PixelGlitch.ts
@@ -42,8 +42,8 @@ export class PixelGlitch extends FullscreenPixelEffect {
     /**
      * Writes resolution, intensity, bandHeight, and seed into the uniform block.
      *
-     * @param _deltaMs - Unused.
-     * @param sourceSize - Logical texture dimensions for this pass.
+     * @param _deltaMs – Unused.
+     * @param sourceSize – Logical texture dimensions for this pass.
      */
     protected writeUniforms(_deltaMs: number, sourceSize: Vector2i): void {
         const u = this.uniformData;

--- a/packages/blit386/src/render/effects/pixel/PixelMosaic.ts
+++ b/packages/blit386/src/render/effects/pixel/PixelMosaic.ts
@@ -29,8 +29,8 @@ export class PixelMosaic extends FullscreenPixelEffect {
     /**
      * Writes resolution and blockSize into the uniform block.
      *
-     * @param _deltaMs - Unused.
-     * @param sourceSize - Logical texture dimensions for this pass.
+     * @param _deltaMs – Unused.
+     * @param sourceSize – Logical texture dimensions for this pass.
      */
     protected writeUniforms(_deltaMs: number, sourceSize: Vector2i): void {
         const u = this.uniformData;

--- a/packages/blit386/src/render/effects/presets/amber.ts
+++ b/packages/blit386/src/render/effects/presets/amber.ts
@@ -9,7 +9,7 @@ import type { Effect } from '../Effect';
 /**
  * Amber monochrome PC monitor look (think IBM 5151 / Hercules).
  *
- * Ships as a parameter-only set - the underlying colors stay full-RGB until
+ * Ships as a parameter-only set – the underlying colors stay full-RGB until
  * the planned MonochromeQuantize effect lands.
  * For now this preset gives you the *feel* (CRT curvature + scanlines +
  * vignette + warm-tinted bloom) without the actual amber re-quantization.

--- a/packages/blit386/src/render/effects/presets/green.ts
+++ b/packages/blit386/src/render/effects/presets/green.ts
@@ -9,7 +9,7 @@ import type { Effect } from '../Effect';
 /**
  * Green monochrome PC monitor look (think original IBM monochrome / VT100).
  *
- * Ships as a parameter-only set - see the {@link amber} preset for the
+ * Ships as a parameter-only set – see the {@link amber} preset for the
  * caveat about re-quantization. Same effect stack as `amber()`,
  * tuned slightly toward a cooler / more flickery aesthetic.
  *

--- a/packages/blit386/src/splash/Splash.test.ts
+++ b/packages/blit386/src/splash/Splash.test.ts
@@ -22,7 +22,7 @@ describe('Splash state machine', () => {
     /**
      * Advances the fake clock and steps the splash once.
      *
-     * @param ms - Milliseconds to advance.
+     * @param ms – Milliseconds to advance.
      */
     function step(ms: number): void {
         now += ms;

--- a/packages/blit386/src/splash/Splash.ts
+++ b/packages/blit386/src/splash/Splash.ts
@@ -88,8 +88,8 @@ export class Splash {
     /**
      * Creates a splash.
      *
-     * @param options - Ramp endpoints. Both default to black and white.
-     * @param timeProvider - Clock function returning milliseconds. Defaults to
+     * @param options – Ramp endpoints. Both default to black and white.
+     * @param timeProvider – Clock function returning milliseconds. Defaults to
      *   `performance.now()`. Pass a custom function for deterministic unit tests.
      */
     constructor(options: SplashOptions = {}, timeProvider: () => number = () => performance.now()) {
@@ -226,8 +226,8 @@ export class Splash {
      * `IRenderer` exposes no display size, so the caller passes it – `BTAPI` is
      * the one that knows it.
      *
-     * @param renderer - Active renderer; the caller has already begun the frame.
-     * @param displaySize - Logical display size in pixels.
+     * @param renderer – Active renderer; the caller has already begun the frame.
+     * @param displaySize – Logical display size in pixels.
      */
     public draw(renderer: IRenderer, displaySize: Vector2i): void {
         this.background.set(0, 0, displaySize.x, displaySize.y);
@@ -272,7 +272,7 @@ export class Splash {
      * Any key, click, or tap skips. The game loop is suspended for the splash's
      * whole duration, so the input is free to take.
      *
-     * @param target - Event target to listen on, normally `window`.
+     * @param target – Event target to listen on, normally `window`.
      */
     public attachSkipInput(target: EventTarget): void {
         this.detachSkipInput();
@@ -353,8 +353,8 @@ export class Splash {
      * The hold has a minimum but no maximum, so this refuses to move until the
      * game's `init()` has settled however long a skip has been waiting.
      *
-     * @param now - Current clock reading in milliseconds.
-     * @param elapsed - Milliseconds spent in `shown`.
+     * @param now – Current clock reading in milliseconds.
+     * @param elapsed – Milliseconds spent in `shown`.
      * @returns `true` when the state changed.
      */
     private leaveShown(now: number, elapsed: number): boolean {
@@ -384,7 +384,7 @@ export class Splash {
      * Peaks at the start of the fade-in and the end of the fade-out, and sits at
      * zero through the hold, so the logo is clean while it is being read.
      *
-     * @param elapsed - Milliseconds since the current state was entered.
+     * @param elapsed – Milliseconds since the current state was entered.
      */
     private updateDissolve(elapsed: number): void {
         const glitch = this.glitch;
@@ -418,8 +418,8 @@ export class Splash {
     /**
      * Transitions to a new state and stamps when it was entered.
      *
-     * @param next - State to enter.
-     * @param at - Effective entry time in milliseconds.
+     * @param next – State to enter.
+     * @param at – Effective entry time in milliseconds.
      */
     private enter(next: SplashState, at: number): void {
         this.currentState = next;

--- a/packages/blit386/src/splash/gating.test.ts
+++ b/packages/blit386/src/splash/gating.test.ts
@@ -92,8 +92,8 @@ describe('readUrlFlags', () => {
 /**
  * Runs `body` with `globalThis.location.search` stubbed to `search`.
  *
- * @param search - Query string including the leading '?'.
- * @param body - Assertions to run while the stub is installed.
+ * @param search – Query string including the leading '?'.
+ * @param body – Assertions to run while the stub is installed.
  */
 function withSearch(search: string, body: () => void): void {
     const original = Reflect.getOwnPropertyDescriptor(globalThis, 'location');

--- a/packages/blit386/src/splash/gating.ts
+++ b/packages/blit386/src/splash/gating.ts
@@ -50,7 +50,7 @@ export interface SplashUrlFlags {
  * An off switch should be unambiguous, so `?nosplash` beats `?splash` when both
  * are present.
  *
- * @param signals - See {@link SplashGatingSignals}.
+ * @param signals – See {@link SplashGatingSignals}.
  * @returns `true` when the splash should play.
  */
 export function resolveSplashEnabled(signals: SplashGatingSignals): boolean {
@@ -98,7 +98,7 @@ export function readUrlFlags(): SplashUrlFlags {
 /**
  * Gathers every gating signal and resolves them.
  *
- * @param configureFlag - Explicit `HardwareSettings.isSplashEnabled`, if the demo set one.
+ * @param configureFlag – Explicit `HardwareSettings.isSplashEnabled`, if the demo set one.
  * @returns `true` when the splash should play on this page load.
  */
 export function isSplashEnabled(configureFlag?: boolean): boolean {

--- a/packages/blit386/src/splash/ramp.ts
+++ b/packages/blit386/src/splash/ramp.ts
@@ -11,7 +11,7 @@
  * editor either jumped several steps brighter or crushed to black.
  *
  * This costs the fades nothing. `ExposureFadeEffect` converts to linear light
- * itself, per channel, on whatever colors the palette holds - so the in-camera
+ * itself, per channel, on whatever colors the palette holds – so the in-camera
  * behavior of the fade is independent of how the static steps are distributed.
  * The two concerns only looked coupled.
  */
@@ -28,8 +28,8 @@ import { RAMP_FIRST_SLOT, RAMP_PALETTE_SIZE, RAMP_STEPS } from './constants';
  * splash palette and the game's palette never coexist, the slot count costs the
  * game nothing.
  *
- * @param dark - Dark endpoint. Defaults to black.
- * @param light - Light endpoint. Defaults to white.
+ * @param dark – Dark endpoint. Defaults to black.
+ * @param light – Light endpoint. Defaults to white.
  * @returns A fresh palette holding the ramp.
  */
 export function createRamp(dark: Color32 = Color32.black, light: Color32 = Color32.white): Palette {
@@ -56,7 +56,7 @@ export function createRamp(dark: Color32 = Color32.black, light: Color32 = Color
  * the game's captured palette is installed in before its handoff fade brings it
  * up.
  *
- * @param source - Palette whose size is mirrored.
+ * @param source – Palette whose size is mirrored.
  * @returns A fresh same-sized palette, slot 0 transparent and every other slot opaque black.
  */
 export function createBlackened(source: Palette): Palette {
@@ -72,9 +72,9 @@ export function createBlackened(source: Palette): Palette {
 /**
  * Interpolates one encoded 8-bit channel between the two ramp endpoints.
  *
- * @param from - Dark endpoint channel in [0, 255].
- * @param to - Light endpoint channel in [0, 255].
- * @param t - Position along the ramp in [0, 1].
+ * @param from – Dark endpoint channel in [0, 255].
+ * @param to – Light endpoint channel in [0, 255].
+ * @param t – Position along the ramp in [0, 1].
  * @returns Encoded channel in [0, 255].
  */
 function mixChannel(from: number, to: number, t: number): number {

--- a/packages/blit386/src/utils/AssetLimits.ts
+++ b/packages/blit386/src/utils/AssetLimits.ts
@@ -52,7 +52,7 @@ export class AssetLimitError extends Error {
     /**
      * Creates an asset limit error.
      *
-     * @param message - User-facing validation message.
+     * @param message – User-facing validation message.
      */
     constructor(message: string) {
         super(message);
@@ -81,8 +81,8 @@ export interface BtfontGlyphData {
 /**
  * Formats width and height for error messages.
  *
- * @param width - Width in pixels.
- * @param height - Height in pixels.
+ * @param width – Width in pixels.
+ * @param height – Height in pixels.
  * @returns Size formatted as `WIDTHxHEIGHT`.
  */
 export function formatSize(width: number, height: number): string {
@@ -92,8 +92,8 @@ export function formatSize(width: number, height: number): string {
 /**
  * Computes a safe pixel count when width and height are valid asset dimensions.
  *
- * @param width - Width in pixels.
- * @param height - Height in pixels.
+ * @param width – Width in pixels.
+ * @param height – Height in pixels.
  * @returns Total pixels when valid, otherwise `null`.
  */
 export function computeSafePixelArea(width: number, height: number): number | null {
@@ -117,7 +117,7 @@ export function computeSafePixelArea(width: number, height: number): number | nu
 /**
  * Returns whether a value is a positive finite integer suitable for pixel sizing.
  *
- * @param value - Candidate dimension.
+ * @param value – Candidate dimension.
  * @returns True when the value is a positive whole number.
  */
 function isPositiveIntegerDimension(value: number): boolean {
@@ -127,7 +127,7 @@ function isPositiveIntegerDimension(value: number): boolean {
 /**
  * Returns whether a value is a finite integer suitable for glyph metrics.
  *
- * @param value - Candidate metric.
+ * @param value – Candidate metric.
  * @returns True when the value is a finite whole number.
  */
 function isIntegerMetric(value: number): boolean {
@@ -137,9 +137,9 @@ function isIntegerMetric(value: number): boolean {
 /**
  * Validates decoded image or indexed-buffer dimensions before allocation.
  *
- * @param context - Asset label used in error text (for example `'sprite sheet'`).
- * @param width - Width in pixels.
- * @param height - Height in pixels.
+ * @param context – Asset label used in error text (for example `'sprite sheet'`).
+ * @param width – Width in pixels.
+ * @param height – Height in pixels.
  * @returns A user-facing error message when invalid, otherwise `null`.
  */
 export function validateDimensions(context: string, width: number, height: number): string | null {
@@ -168,9 +168,9 @@ export function validateDimensions(context: string, width: number, height: numbe
 /**
  * Validates decoded image dimensions and throws when they exceed engine limits.
  *
- * @param context - Asset label used in error text.
- * @param width - Width in pixels.
- * @param height - Height in pixels.
+ * @param context – Asset label used in error text.
+ * @param width – Width in pixels.
+ * @param height – Height in pixels.
  * @throws {@link AssetLimitError} when the dimensions are invalid.
  */
 export function assertDimensions(context: string, width: number, height: number): void {
@@ -184,8 +184,8 @@ export function assertDimensions(context: string, width: number, height: number)
 /**
  * Validates an `HTMLImageElement` after decode and before canvas readback or texture upload.
  *
- * @param context - Asset label used in error text.
- * @param image - Loaded image element.
+ * @param context – Asset label used in error text.
+ * @param image – Loaded image element.
  * @throws {@link AssetLimitError} when the image dimensions are invalid.
  */
 export function assertImageElementWithinLimits(context: string, image: HTMLImageElement): void {
@@ -195,9 +195,9 @@ export function assertImageElementWithinLimits(context: string, image: HTMLImage
 /**
  * Validates raw indexed pixel dimensions and optional buffer length before retention.
  *
- * @param width - Texture width in pixels.
- * @param height - Texture height in pixels.
- * @param pixelLength - Optional indexed pixel array length to compare against `width * height`.
+ * @param width – Texture width in pixels.
+ * @param height – Texture height in pixels.
+ * @param pixelLength – Optional indexed pixel array length to compare against `width * height`.
  * @returns A user-facing error message when invalid, otherwise `null`.
  */
 export function validateIndexedPixelInput(width: number, height: number, pixelLength?: number): string | null {
@@ -223,9 +223,9 @@ export function validateIndexedPixelInput(width: number, height: number, pixelLe
 /**
  * Validates raw indexed pixel dimensions and throws before buffer allocation.
  *
- * @param width - Texture width in pixels.
- * @param height - Texture height in pixels.
- * @param pixelLength - Optional indexed pixel array length to compare against `width * height`.
+ * @param width – Texture width in pixels.
+ * @param height – Texture height in pixels.
+ * @param pixelLength – Optional indexed pixel array length to compare against `width * height`.
  * @throws {@link AssetLimitError} when the dimensions or length are invalid.
  */
 export function assertIndexedPixelInput(width: number, height: number, pixelLength?: number): void {
@@ -239,7 +239,7 @@ export function assertIndexedPixelInput(width: number, height: number, pixelLeng
 /**
  * Validates a `.btfont` JSON payload size before parsing.
  *
- * @param byteLength - UTF-8 byte length of the JSON text.
+ * @param byteLength – UTF-8 byte length of the JSON text.
  * @returns A user-facing error message when invalid, otherwise `null`.
  */
 export function validateBtfontJsonByteSize(byteLength: number): string | null {
@@ -257,7 +257,7 @@ export function validateBtfontJsonByteSize(byteLength: number): string | null {
 /**
  * Validates glyph map size before building lookup tables.
  *
- * @param count - Number of glyph entries.
+ * @param count – Number of glyph entries.
  * @returns A user-facing error message when invalid, otherwise `null`.
  */
 export function validateGlyphCount(count: number): string | null {
@@ -279,7 +279,7 @@ export function validateGlyphCount(count: number): string | null {
  * use {@link BTFONT_EMBEDDED_TEXTURE_PREFIX} and stay within
  * {@link MAX_BTFONT_EMBEDDED_TEXTURE_BYTES} base64 character count (after the prefix).
  *
- * @param texture - Texture field from a `.btfont` file.
+ * @param texture – Texture field from a `.btfont` file.
  * @returns A user-facing error message when invalid, otherwise `null`.
  */
 export function validateBtfontEmbeddedTextureUri(texture: string): string | null {
@@ -305,8 +305,8 @@ export function validateBtfontEmbeddedTextureUri(texture: string): string | null
 /**
  * Validates numeric glyph metrics before atlas bounds are checked.
  *
- * @param glyph - Glyph metrics from the `.btfont` file.
- * @param charLabel - Character label used in error text.
+ * @param glyph – Glyph metrics from the `.btfont` file.
+ * @param charLabel – Character label used in error text.
  * @returns A user-facing error message when invalid, otherwise `null`.
  */
 function validateBtfontGlyphMetrics(glyph: BtfontGlyphData, charLabel: string): string | null {
@@ -344,8 +344,8 @@ function validateBtfontGlyphMetrics(glyph: BtfontGlyphData, charLabel: string): 
 /**
  * Validates glyph metrics and per-glyph size limits before the font atlas image is decoded.
  *
- * @param glyph - Glyph metrics from the `.btfont` file.
- * @param charLabel - Character label used in error text.
+ * @param glyph – Glyph metrics from the `.btfont` file.
+ * @param charLabel – Character label used in error text.
  * @returns A user-facing error message when invalid, otherwise `null`.
  */
 export function validateBtfontGlyphDataPreAtlas(glyph: BtfontGlyphData, charLabel: string): string | null {
@@ -377,10 +377,10 @@ export function validateBtfontGlyphDataPreAtlas(glyph: BtfontGlyphData, charLabe
 /**
  * Validates that a glyph rectangle fits inside the decoded font atlas.
  *
- * @param glyph - Glyph metrics from the `.btfont` file.
- * @param atlasWidth - Font texture atlas width in pixels.
- * @param atlasHeight - Font texture atlas height in pixels.
- * @param charLabel - Character label used in error text.
+ * @param glyph – Glyph metrics from the `.btfont` file.
+ * @param atlasWidth – Font texture atlas width in pixels.
+ * @param atlasHeight – Font texture atlas height in pixels.
+ * @param charLabel – Character label used in error text.
  * @returns A user-facing error message when invalid, otherwise `null`.
  */
 export function validateBtfontGlyphAtlasBounds(
@@ -399,10 +399,10 @@ export function validateBtfontGlyphAtlasBounds(
 /**
  * Validates one serialized glyph entry against atlas bounds and metric rules.
  *
- * @param glyph - Glyph metrics from the `.btfont` file.
- * @param atlasWidth - Font texture atlas width in pixels.
- * @param atlasHeight - Font texture atlas height in pixels.
- * @param charLabel - Character label used in error text.
+ * @param glyph – Glyph metrics from the `.btfont` file.
+ * @param atlasWidth – Font texture atlas width in pixels.
+ * @param atlasHeight – Font texture atlas height in pixels.
+ * @param charLabel – Character label used in error text.
  * @returns A user-facing error message when invalid, otherwise `null`.
  */
 export function validateBtfontGlyphData(
@@ -426,9 +426,9 @@ export function validateBtfontGlyphData(
  * Returns `null` when the rectangle is empty, fully outside the sheet, or still
  * too large to iterate safely after clipping.
  *
- * @param srcRect - Requested source rectangle in sheet space.
- * @param sheetWidth - Sprite sheet width in pixels.
- * @param sheetHeight - Sprite sheet height in pixels.
+ * @param srcRect – Requested source rectangle in sheet space.
+ * @param sheetWidth – Sprite sheet width in pixels.
+ * @param sheetHeight – Sprite sheet height in pixels.
  * @returns Clipped source bounds, or `null` when the blit should be skipped.
  */
 export function clipSpriteSourceRect(

--- a/packages/blit386/src/utils/AudioParamRamp.ts
+++ b/packages/blit386/src/utils/AudioParamRamp.ts
@@ -17,10 +17,10 @@ const FADE_CURVE_SAMPLE_COUNT = 32;
  * easings sample {@link applyEasing} into a curve fed to `setValueCurveAtTime`.
  *
  * @param param - `AudioParam` to update (gain, `playbackRate`, or pan).
- * @param currentTime - Audio-clock time to anchor the ramp to (`AudioContext.currentTime`).
- * @param targetValue - Target parameter value.
- * @param fadeMs - Optional fade duration in milliseconds.
- * @param easing - Easing curve applied when `fadeMs` is a positive duration.
+ * @param currentTime – Audio-clock time to anchor the ramp to (`AudioContext.currentTime`).
+ * @param targetValue – Target parameter value.
+ * @param fadeMs – Optional fade duration in milliseconds.
+ * @param easing – Easing curve applied when `fadeMs` is a positive duration.
  */
 export function applyAudioParamRamp(
     param: AudioParam,
@@ -30,7 +30,7 @@ export function applyAudioParamRamp(
     easing: EasingFunction,
 ): void {
     if (fadeMs === undefined || fadeMs <= 0) {
-        // Cancel any pending ramp first - setting `.value` directly does not cancel scheduled
+        // Cancel any pending ramp first – setting `.value` directly does not cancel scheduled
         // automation events, so a fade started earlier could otherwise keep running and override
         // this "immediate" value once its scheduled end time arrives.
         param.cancelScheduledValues(currentTime);
@@ -57,9 +57,9 @@ export function applyAudioParamRamp(
 /**
  * Samples an eased curve from `startValue` to `targetValue` for `AudioParam.setValueCurveAtTime`.
  *
- * @param startValue - Parameter value at the start of the fade.
- * @param targetValue - Parameter value at the end of the fade.
- * @param easing - Easing curve to sample.
+ * @param startValue – Parameter value at the start of the fade.
+ * @param targetValue – Parameter value at the end of the fade.
+ * @param easing – Easing curve to sample.
  * @returns Sampled curve of {@link FADE_CURVE_SAMPLE_COUNT} values.
  */
 function sampleEasingCurve(startValue: number, targetValue: number, easing: EasingFunction): Float32Array {

--- a/packages/blit386/src/utils/Bootstrap.test.ts
+++ b/packages/blit386/src/utils/Bootstrap.test.ts
@@ -126,7 +126,7 @@ describe('bootstrap', () => {
 
     describe('canvas validation', () => {
         it('should return false and call onError when canvas is not found', async () => {
-            // No canvas in DOM - only the container.
+            // No canvas in DOM – only the container.
             const container = document.createElement('div');
 
             container.id = DEFAULT_CONTAINER_ID;

--- a/packages/blit386/src/utils/Bootstrap.ts
+++ b/packages/blit386/src/utils/Bootstrap.ts
@@ -89,11 +89,11 @@ async function waitForDOM(): Promise<void> {
 /**
  * Handles a bootstrap error by displaying it and invoking the callback.
  *
- * @param title - Error title for display.
- * @param message - Error message for display.
- * @param error - The Error object.
- * @param containerID - Container ID for error display.
- * @param onError - Optional error callback.
+ * @param title – Error title for display.
+ * @param message – Error message for display.
+ * @param error – The Error object.
+ * @param containerID – Container ID for error display.
+ * @param onError – Optional error callback.
  * @returns Result indicating failure.
  */
 function handleError(
@@ -111,9 +111,9 @@ function handleError(
 /**
  * Validates the canvas element and returns it.
  *
- * @param canvasID - Canvas element ID.
- * @param containerID - Container ID for error display.
- * @param onError - Optional error callback.
+ * @param canvasID – Canvas element ID.
+ * @param containerID – Container ID for error display.
+ * @param onError – Optional error callback.
  * @returns Canvas element or null with error handling.
  */
 function validateCanvas(
@@ -142,11 +142,11 @@ function validateCanvas(
 /**
  * Initializes the engine with the provided demo and canvas.
  *
- * @param DemoClass - Demo class constructor.
- * @param canvas - Canvas element.
- * @param containerID - Container ID for error display.
- * @param onSuccess - Optional success callback.
- * @param onError - Optional error callback.
+ * @param DemoClass – Demo class constructor.
+ * @param canvas – Canvas element.
+ * @param containerID – Container ID for error display.
+ * @param onSuccess – Optional success callback.
+ * @param onError – Optional error callback.
  * @returns Result with success status.
  */
 async function initDemo(
@@ -208,7 +208,7 @@ async function initDemo(
  * Routes an already-running engine's `bootstrap()` call to the hot-swap path, or logs a
  * double-bootstrap guard error when no hot-reload context is registered.
  *
- * @param DemoClass - Newly evaluated demo class constructor.
+ * @param DemoClass – Newly evaluated demo class constructor.
  * @returns The bootstrap result when the engine is already initialized (hot-swapped or
  *   guarded); `null` when a cold boot should proceed instead.
  */
@@ -240,14 +240,14 @@ async function routeIfAlreadyInitialized(DemoClass: DemoConstructor): Promise<bo
  * @since 0.2.0
  * @changed 1.4.0 Calling `bootstrap()` again while already initialized now routes to a hot
  *   swap (via {@link registerHotReload}) when a Vite HMR context is registered, or logs a
- *   double-bootstrap guard and returns `false` otherwise - previously it silently started a
+ *   double-bootstrap guard and returns `false` otherwise – previously it silently started a
  *   second, unstoppable `GameLoop`.
- * @param DemoClass - Demo class constructor implementing `IBTDemo` (optional `configure()` for hardware settings).
- * @param options - Optional configuration for IDs and callbacks.
+ * @param DemoClass – Demo class constructor implementing `IBTDemo` (optional `configure()` for hardware settings).
+ * @param options – Optional configuration for IDs and callbacks.
  * @returns `true` when the demo boots successfully; otherwise `false`.
  *
  * @example
- * // Simplest usage - uses default IDs.
+ * // Simplest usage – uses default IDs.
  * bootstrap(MyDemo);
  *
  * @example
@@ -269,8 +269,8 @@ async function routeIfAlreadyInitialized(DemoClass: DemoConstructor): Promise<bo
 export async function bootstrap(DemoClass: DemoConstructor, options: BootstrapOptions = {}): Promise<boolean> {
     // One microtask yield before anything else runs. Module top-level evaluation is
     // synchronous and this function is async, so the snippet's un-awaited
-    // `__blit386_registerHotReload(import.meta.hot)` call - which runs synchronously right after a
-    // demo's own un-awaited `bootstrap(Game);` call, at the same module top level - always
+    // `__blit386_registerHotReload(import.meta.hot)` call – which runs synchronously right after a
+    // demo's own un-awaited `bootstrap(Game);` call, at the same module top level – always
     // completes before this function proceeds past this line, regardless of
     // `isWaitingForDOMReady`.
     await Promise.resolve();

--- a/packages/blit386/src/utils/BootstrapHelpers.ts
+++ b/packages/blit386/src/utils/BootstrapHelpers.ts
@@ -25,8 +25,8 @@ export type ErrorContent =
  * Appends text to an element, converting newline characters to `<br>` elements.
  * Safe against XSS: all text is inserted via createTextNode, never innerHTML.
  *
- * @param element - Target element to append into.
- * @param text - Plain text, optionally containing newline characters.
+ * @param element – Target element to append into.
+ * @param text – Plain text, optionally containing newline characters.
  */
 function appendTextWithLineBreaks(element: HTMLElement, text: string): void {
     const lines = text.split('\n');
@@ -48,9 +48,9 @@ function appendTextWithLineBreaks(element: HTMLElement, text: string): void {
  * All text (including code) is treated as plain text, not interpreted as markup.
  *
  * @since 1.0.3
- * @param title - Error heading text displayed prominently.
- * @param content - Error message content (string or object with optional code formatting).
- * @param containerID - ID of the container element. Default: 'canvas-container'
+ * @param title – Error heading text displayed prominently.
+ * @param content – Error message content (string or object with optional code formatting).
+ * @param containerID – ID of the container element. Default: 'canvas-container'
  *
  * @example
  * displayError(
@@ -90,7 +90,7 @@ export function displayError(title: string, content: ErrorContent, containerID: 
 
         heading.textContent = title;
 
-        // Handle content - either plain string or object with code formatting.
+        // Handle content – either plain string or object with code formatting.
         // appendTextWithLineBreaks is used instead of textContent so that \n produces
         // visible line breaks, making numbered step lists readable in the error panel.
         if (typeof content === 'string') {
@@ -108,7 +108,7 @@ export function displayError(title: string, content: ErrorContent, containerID: 
                     'font-family: monospace; font-size: 12px; ' +
                     'text-align: left; overflow-x: auto; white-space: pre-wrap; word-break: break-all;';
 
-                codeBlock.textContent = content.code; // Safe - uses textContent
+                codeBlock.textContent = content.code; // Safe – uses textContent
 
                 msg.appendChild(codeBlock);
             }
@@ -136,7 +136,7 @@ export function displayError(title: string, content: ErrorContent, containerID: 
  * Validates that the element exists and is a canvas element.
  *
  * @since 1.0.3
- * @param canvasID - ID of the canvas element. Default: 'blit386-canvas'
+ * @param canvasID – ID of the canvas element. Default: 'blit386-canvas'
  * @returns The canvas element if found and valid, null otherwise.
  *
  * @example

--- a/packages/blit386/src/utils/CameraUtils.ts
+++ b/packages/blit386/src/utils/CameraUtils.ts
@@ -8,9 +8,9 @@ import { Vector2i } from './Vector2i';
  * world is smaller than the viewport on an axis, that axis clamps to `0`.
  *
  * @since 1.0.3
- * @param camera - Desired camera origin in world coordinates.
- * @param worldSize - Full world size in pixels.
- * @param viewSize - Viewport size in pixels.
+ * @param camera – Desired camera origin in world coordinates.
+ * @param worldSize – Full world size in pixels.
+ * @param viewSize – Viewport size in pixels.
  * @returns Clamped camera origin.
  */
 export function clampCameraToWorld(camera: Vector2i, worldSize: Vector2i, viewSize: Vector2i): Vector2i {

--- a/packages/blit386/src/utils/CanvasLayoutStyles.ts
+++ b/packages/blit386/src/utils/CanvasLayoutStyles.ts
@@ -17,7 +17,7 @@ export interface CanvasLayoutStyleOptions {
 /**
  * Resolves the layout root element for CSS custom property injection.
  *
- * @param canvas - The canvas element to check.
+ * @param canvas – The canvas element to check.
  * @returns The parent container when it carries the expected ID, otherwise the canvas itself.
  */
 function resolveLayoutRoot(canvas: HTMLCanvasElement): HTMLElement {
@@ -36,8 +36,8 @@ function resolveLayoutRoot(canvas: HTMLCanvasElement): HTMLElement {
  * The demos `layout.html` reads `--canvas-aspect-w/h` for aspect ratio and
  * `--canvas-max-w/h` for the largest allowed display size.
  *
- * @param canvas - Target canvas element.
- * @param options - Layout fields mirroring relevant {@link HardwareSettings} members.
+ * @param canvas – Target canvas element.
+ * @param options – Layout fields mirroring relevant {@link HardwareSettings} members.
  */
 export function applyCanvasLayoutStyles(canvas: HTMLCanvasElement, options: CanvasLayoutStyleOptions): void {
     const aspectSource = options.drawingBufferSize ?? options.displaySize;

--- a/packages/blit386/src/utils/Color32.bench.ts
+++ b/packages/blit386/src/utils/Color32.bench.ts
@@ -20,11 +20,11 @@ const BENCH_OPTIONS = {
 /**
  * Restores a mutable color to a known baseline before in-place benchmarks.
  *
- * @param color - Color to reset.
- * @param r - Red channel.
- * @param g - Green channel.
- * @param b - Blue channel.
- * @param a - Alpha channel.
+ * @param color – Color to reset.
+ * @param r – Red channel.
+ * @param g – Green channel.
+ * @param b – Blue channel.
+ * @param a – Alpha channel.
  */
 function resetColor(color: Color32, r: number, g: number, b: number, a: number): void {
     color.r = r;

--- a/packages/blit386/src/utils/Color32.test.ts
+++ b/packages/blit386/src/utils/Color32.test.ts
@@ -1118,7 +1118,7 @@ describe('srgbToLinear', () => {
     });
 
     it('uses the linear toe below the 0.04045 breakpoint', () => {
-        // 0.02 / 12.92 - a bare 2.2 power would give 0.000178 here, an order of magnitude darker.
+        // 0.02 / 12.92 – a bare 2.2 power would give 0.000178 here, an order of magnitude darker.
         expect(srgbToLinear(0.02)).toBeCloseTo(0.001548, 6);
     });
 
@@ -1141,7 +1141,7 @@ describe('linearToSrgb', () => {
     });
 
     it('lifts near-black linear values the way the sRGB toe does', () => {
-        // 1/255 in linear light encodes to ~0.0498 - a bare 2.2 power would give ~0.0806.
+        // 1/255 in linear light encodes to ~0.0498 – a bare 2.2 power would give ~0.0806.
         expect(linearToSrgb(1 / 255)).toBeCloseTo(0.0498, 3);
     });
 
@@ -1184,7 +1184,7 @@ describe('toLinear / toSrgb', () => {
         for (let v = 0; v <= 255; v++) {
             const back = new Color32(v, v, v, 255).toLinear().toSrgb().r;
 
-            // 8-bit linear storage crushes the darks - the toe is where the loss lands.
+            // 8-bit linear storage crushes the darks – the toe is where the loss lands.
             expect(Math.abs(back - v)).toBeLessThanOrEqual(10);
         }
     });

--- a/packages/blit386/src/utils/Color32.ts
+++ b/packages/blit386/src/utils/Color32.ts
@@ -88,10 +88,10 @@ export class Color32 {
     /**
      * Creates a clamped 8-bit RGBA color.
      *
-     * @param r - Red channel (0-255, defaults to 255).
-     * @param g - Green channel (0-255, defaults to 255).
-     * @param b - Blue channel (0-255, defaults to 255).
-     * @param a - Alpha channel (0-255, defaults to 255 = opaque).
+     * @param r – Red channel (0-255, defaults to 255).
+     * @param g – Green channel (0-255, defaults to 255).
+     * @param b – Blue channel (0-255, defaults to 255).
+     * @param a – Alpha channel (0-255, defaults to 255 = opaque).
      */
     constructor(r: number = 255, g: number = 255, b: number = 255, a: number = 255) {
         // Clamp and truncate to integer using optimized clampByte helper.
@@ -103,7 +103,7 @@ export class Color32 {
 
     /**
      * Pure white color (255, 255, 255, 255).
-     * Cached frozen singleton - do not modify.
+     * Cached frozen singleton – do not modify.
      * @returns The shared white Color32 instance.
      */
     static get white(): Color32 {
@@ -112,7 +112,7 @@ export class Color32 {
 
     /**
      * Pure black color (0, 0, 0, 255).
-     * Cached frozen singleton - do not modify.
+     * Cached frozen singleton – do not modify.
      * @returns The shared black Color32 instance.
      */
     static get black(): Color32 {
@@ -121,7 +121,7 @@ export class Color32 {
 
     /**
      * Fully transparent color (0, 0, 0, 0).
-     * Cached frozen singleton - do not modify.
+     * Cached frozen singleton – do not modify.
      * @returns The shared transparent Color32 instance.
      */
     static get transparent(): Color32 {
@@ -130,7 +130,7 @@ export class Color32 {
 
     /**
      * Pure red color (255, 0, 0, 255).
-     * Cached frozen singleton - do not modify.
+     * Cached frozen singleton – do not modify.
      * @returns The shared red Color32 instance.
      */
     static get red(): Color32 {
@@ -139,7 +139,7 @@ export class Color32 {
 
     /**
      * Pure green color (0, 255, 0, 255).
-     * Cached frozen singleton - do not modify.
+     * Cached frozen singleton – do not modify.
      * @returns The shared green Color32 instance.
      */
     static get green(): Color32 {
@@ -148,7 +148,7 @@ export class Color32 {
 
     /**
      * Pure blue color (0, 0, 255, 255).
-     * Cached frozen singleton - do not modify.
+     * Cached frozen singleton – do not modify.
      * @returns The shared blue Color32 instance.
      */
     static get blue(): Color32 {
@@ -157,7 +157,7 @@ export class Color32 {
 
     /**
      * Yellow color (255, 255, 0, 255).
-     * Cached frozen singleton - do not modify.
+     * Cached frozen singleton – do not modify.
      * @returns The shared yellow Color32 instance.
      */
     static get yellow(): Color32 {
@@ -166,7 +166,7 @@ export class Color32 {
 
     /**
      * Cyan color (0, 255, 255, 255).
-     * Cached frozen singleton - do not modify.
+     * Cached frozen singleton – do not modify.
      * @returns The shared cyan Color32 instance.
      */
     static get cyan(): Color32 {
@@ -175,7 +175,7 @@ export class Color32 {
 
     /**
      * Magenta color (255, 0, 255, 255).
-     * Cached frozen singleton - do not modify.
+     * Cached frozen singleton – do not modify.
      * @returns The shared magenta Color32 instance.
      */
     static get magenta(): Color32 {
@@ -194,7 +194,7 @@ export class Color32 {
     /**
      * Creates a grayscale color with equal RGB values.
      *
-     * @param value - Brightness level (0-255).
+     * @param value – Brightness level (0-255).
      * @returns Opaque gray color.
      */
     static gray(value: number): Color32 {
@@ -205,9 +205,9 @@ export class Color32 {
      * Linearly interpolates between two colors.
      * Each RGBA channel is interpolated independently. `t` is clamped to [0, 1].
      *
-     * @param a - Color at t = 0.
-     * @param b - Color at t = 1.
-     * @param t - Interpolation factor (0.0 = `a`, 1.0 = `b`).
+     * @param a – Color at t = 0.
+     * @param b – Color at t = 1.
+     * @param t – Interpolation factor (0.0 = `a`, 1.0 = `b`).
      * @returns New color blended between `a` and `b`.
      */
     static lerp(a: Color32, b: Color32, t: number): Color32 {
@@ -218,8 +218,8 @@ export class Color32 {
      * Registers a named color in the global color registry.
      * Name matching is case-insensitive and trims surrounding whitespace.
      *
-     * @param name - Named color key (for example `cornflowerblue`).
-     * @param color - Color value to store for that name.
+     * @param name – Named color key (for example `cornflowerblue`).
+     * @param color – Color value to store for that name.
      * @throws Error when name is empty after normalization or already exists.
      */
     static registerColor(name: string, color: Color32): void {
@@ -237,8 +237,8 @@ export class Color32 {
      * Name matching is case-insensitive and trims surrounding whitespace.
      * All alias keys that share the same object reference are updated in sync.
      *
-     * @param name - Existing named color key (or any alias).
-     * @param color - Replacement color value.
+     * @param name – Existing named color key (or any alias).
+     * @param color – Replacement color value.
      * @throws Error when name is empty after normalization or not registered.
      */
     static updateColor(name: string, color: Color32): void {
@@ -263,7 +263,7 @@ export class Color32 {
      * Name matching is case-insensitive and trims surrounding whitespace.
      * All alias keys that share the same object reference are removed in sync.
      *
-     * @param name - Existing named color key (or any alias).
+     * @param name – Existing named color key (or any alias).
      * @throws Error when name is empty after normalization or not registered.
      */
     static unregisterColor(name: string): void {
@@ -291,7 +291,7 @@ export class Color32 {
      * Looks up a named color from the global registry.
      * Name matching is case-insensitive and trims surrounding whitespace.
      *
-     * @param name - Named color key to resolve.
+     * @param name – Named color key to resolve.
      * @returns Frozen singleton color, or `undefined` when the name is unknown.
      */
     static resolveNamedColor(name: string): Color32 | undefined {
@@ -305,10 +305,10 @@ export class Color32 {
      * Intended for trusted hot paths where channel values are already known to
      * be valid byte-range numbers.
      *
-     * @param r - Red channel (must be integer 0-255).
-     * @param g - Green channel (must be integer 0-255).
-     * @param b - Blue channel (must be integer 0-255).
-     * @param a - Alpha channel (must be integer 0-255).
+     * @param r – Red channel (must be integer 0-255).
+     * @param g – Green channel (must be integer 0-255).
+     * @param b – Blue channel (must be integer 0-255).
+     * @param a – Alpha channel (must be integer 0-255).
      * @returns New Color32 with the specified values.
      */
     static fromRGBAUnchecked(r: number, g: number, b: number, a: number): Color32 {
@@ -326,7 +326,7 @@ export class Color32 {
      * Creates a color from a packed 32-bit unsigned integer (ABGR format).
      * Inverse of toUint32().
      *
-     * @param uint32 - Packed color value (A << 24 | B << 16 | G << 8 | R).
+     * @param uint32 – Packed color value (A << 24 | B << 16 | G << 8 | R).
      * @returns New color unpacked from the integer.
      */
     static fromUint32(uint32: number): Color32 {
@@ -342,7 +342,7 @@ export class Color32 {
      * Parses a CSS-style hex color string.
      * Supports `#RGB`, `#RGBA`, `#RRGGBB`, and `#RRGGBBAA`.
      *
-     * @param hex - Hex color string with or without leading #.
+     * @param hex – Hex color string with or without leading #.
      * @returns Parsed color.
      * @throws Error if the hex string format is invalid.
      */
@@ -392,10 +392,10 @@ export class Color32 {
     /**
      * Creates a color from normalized float components in the `0.0-1.0` range.
      *
-     * @param r - Red channel (0.0-1.0).
-     * @param g - Green channel (0.0-1.0).
-     * @param b - Blue channel (0.0-1.0).
-     * @param a - Alpha channel (0.0-1.0, defaults to 1.0).
+     * @param r – Red channel (0.0-1.0).
+     * @param g – Green channel (0.0-1.0).
+     * @param b – Blue channel (0.0-1.0).
+     * @param a – Alpha channel (0.0-1.0, defaults to 1.0).
      * @returns New color converted from float values.
      */
     static fromFloat(r: number, g: number, b: number, a: number = 1): Color32 {
@@ -405,10 +405,10 @@ export class Color32 {
     /**
      * Creates a color from HSL values.
      *
-     * @param h - Hue in degrees (0-360).
-     * @param s - Saturation as percentage (0-100).
-     * @param l - Lightness as percentage (0-100).
-     * @param a - Alpha channel (0-255, defaults to 255).
+     * @param h – Hue in degrees (0-360).
+     * @param s – Saturation as percentage (0-100).
+     * @param l – Lightness as percentage (0-100).
+     * @param a – Alpha channel (0-255, defaults to 255).
      * @returns New color converted from HSL values.
      */
     static fromHSL(h: number, s: number, l: number, a: number = 255): Color32 {
@@ -514,7 +514,7 @@ export class Color32 {
     /**
      * Normalizes a named-color key for case-insensitive lookups.
      *
-     * @param name - Input color name.
+     * @param name – Input color name.
      * @returns Trimmed lowercase name.
      * @throws Error when the normalized name is empty.
      */
@@ -530,7 +530,7 @@ export class Color32 {
     /**
      * Clones and freezes a color so registry entries are immutable singletons.
      *
-     * @param color - Source color to freeze.
+     * @param color – Source color to freeze.
      * @returns Frozen singleton copy.
      */
     private static freezeSingleton(color: Color32): Color32 {
@@ -557,8 +557,8 @@ export class Color32 {
      * Note: For maximum performance in tight loops, consider accessing
      * r/g/b/a directly and dividing by 255 inline to avoid method call overhead.
      *
-     * @param target - The Float32Array to write to.
-     * @param offset - Starting index in the array (default: 0).
+     * @param target – The Float32Array to write to.
+     * @param offset – Starting index in the array (default: 0).
      */
     writeToFloat32Array(target: Float32Array, offset: number = 0): void {
         // Using direct index assignment for the best performance.
@@ -630,7 +630,7 @@ export class Color32 {
     /**
      * Checks if this color equals another (all channels match).
      *
-     * @param other - Color to compare with.
+     * @param other – Color to compare with.
      * @returns True if all RGBA channels are identical.
      */
     isEqual(other: Color32): boolean {
@@ -650,7 +650,7 @@ export class Color32 {
      * Backward-compatible alias for {@link isEqual}.
      *
      * @deprecated Deprecated since 0.1.0 (2026-05-31). Use {@link isEqual} instead.
-     * @param other - Color to compare with.
+     * @param other – Color to compare with.
      * @returns True if all RGBA channels are identical.
      */
     equals(other: Color32): boolean {
@@ -670,7 +670,7 @@ export class Color32 {
     /**
      * Creates a new color with modified alpha, keeping RGB unchanged.
      *
-     * @param alpha - New alpha value (0-255).
+     * @param alpha – New alpha value (0-255).
      * @returns New color with updated alpha.
      */
     withAlpha(alpha: number): Color32 {
@@ -680,9 +680,9 @@ export class Color32 {
     /**
      * Creates a new color with modified RGB, keeping alpha unchanged.
      *
-     * @param r - New red value (0-255).
-     * @param g - New green value (0-255).
-     * @param b - New blue value (0-255).
+     * @param r – New red value (0-255).
+     * @param g – New green value (0-255).
+     * @param b – New blue value (0-255).
      * @returns New color with updated RGB.
      */
     withRGB(r: number, g: number, b: number): Color32 {
@@ -703,8 +703,8 @@ export class Color32 {
      * Linearly interpolates between this color and another.
      * Useful for color transitions and gradients.
      *
-     * @param other - Target color to blend toward.
-     * @param t - Interpolation factor (0.0 = this color, 1.0 = other color).
+     * @param other – Target color to blend toward.
+     * @param t – Interpolation factor (0.0 = this color, 1.0 = other color).
      * @returns New color blended between this and other.
      */
     lerp(other: Color32, t: number): Color32 {
@@ -725,8 +725,8 @@ export class Color32 {
      * Linearly interpolates this color toward another, modifying in place.
      * Use this in hot loops to avoid object allocation.
      *
-     * @param other - Target color to blend toward.
-     * @param t - Interpolation factor (0.0 = this color, 1.0 = other color).
+     * @param other – Target color to blend toward.
+     * @param t – Interpolation factor (0.0 = this color, 1.0 = other color).
      * @returns This color instance for chaining.
      */
     lerpInPlace(other: Color32, t: number): this {
@@ -746,7 +746,7 @@ export class Color32 {
      * Multiplies this color by another color component-wise.
      * Useful for tinting and color modulation.
      *
-     * @param other - Color to multiply with.
+     * @param other – Color to multiply with.
      * @returns New color with each channel multiplied and normalized.
      */
     multiply(other: Color32): Color32 {
@@ -762,7 +762,7 @@ export class Color32 {
      * Multiplies this color by another color component-wise, modifying in place.
      * Use this in hot loops to avoid object allocation.
      *
-     * @param other - Color to multiply with.
+     * @param other – Color to multiply with.
      * @returns This color instance for chaining.
      */
     multiplyInPlace(other: Color32): this {
@@ -778,7 +778,7 @@ export class Color32 {
      * Adds another color to this one, clamping to valid range.
      * Useful for additive blending effects.
      *
-     * @param other - Color to add.
+     * @param other – Color to add.
      * @returns New color with summed channels (clamped to 0-255).
      */
     add(other: Color32): Color32 {
@@ -789,7 +789,7 @@ export class Color32 {
      * Adds another color to this one in place, clamping to valid range.
      * Use this in hot loops to avoid object allocation.
      *
-     * @param other - Color to add.
+     * @param other – Color to add.
      * @returns This color instance for chaining.
      */
     addInPlace(other: Color32): this {
@@ -883,10 +883,10 @@ export class Color32 {
      * Sets all RGBA channels at once, with validation.
      * Use this to reuse a Color32 instance instead of creating a new one.
      *
-     * @param r - Red channel (0-255).
-     * @param g - Green channel (0-255).
-     * @param b - Blue channel (0-255).
-     * @param a - Alpha channel (0-255).
+     * @param r – Red channel (0-255).
+     * @param g – Green channel (0-255).
+     * @param b – Blue channel (0-255).
+     * @param a – Alpha channel (0-255).
      * @returns This color instance for chaining.
      */
     setRGBA(r: number, g: number, b: number, a: number): this {
@@ -904,10 +904,10 @@ export class Color32 {
      *
      * WARNING: Passing invalid values will result in undefined behavior.
      *
-     * @param r - Red channel (must be integer 0-255).
-     * @param g - Green channel (must be integer 0-255).
-     * @param b - Blue channel (must be integer 0-255).
-     * @param a - Alpha channel (must be integer 0-255).
+     * @param r – Red channel (must be integer 0-255).
+     * @param g – Green channel (must be integer 0-255).
+     * @param b – Blue channel (must be integer 0-255).
+     * @param a – Alpha channel (must be integer 0-255).
      * @returns This color instance for chaining.
      */
     setRGBAUnchecked(r: number, g: number, b: number, a: number): this {
@@ -923,7 +923,7 @@ export class Color32 {
      * Copies values from another Color32 instance.
      * Use this to reuse a Color32 instance instead of creating a new one.
      *
-     * @param other - Color to copy from.
+     * @param other – Color to copy from.
      * @returns This color instance for chaining.
      */
     copyFrom(other: Color32): this {
@@ -941,7 +941,7 @@ export class Color32 {
  * Optimized for the common case of color channel clamping.
  * Exported for use in other utilities that work with byte values.
  *
- * @param n - Value to clamp.
+ * @param n – Value to clamp.
  * @returns Integer in range 0-255.
  */
 export function clampByte(n: number): number {
@@ -953,7 +953,7 @@ export function clampByte(n: number): number {
 /**
  * Clamps a unit interpolation factor to the closed interval [0, 1].
  *
- * @param t - Raw interpolation factor.
+ * @param t – Raw interpolation factor.
  * @returns Clamped factor in range 0-1.
  */
 export function clampUnit(t: number): number {
@@ -971,7 +971,7 @@ export function clampUnit(t: number): number {
  * Exported for other utilities that need linear-light math; not part of the
  * public `blit386` surface.
  *
- * @param channel - Encoded channel value in range 0-1.
+ * @param channel – Encoded channel value in range 0-1.
  * @returns Linear-light value in range 0-1.
  */
 export function srgbToLinear(channel: number): number {
@@ -988,7 +988,7 @@ export function srgbToLinear(channel: number): number {
  * Exported for other utilities that need linear-light math; not part of the
  * public `blit386` surface.
  *
- * @param linear - Linear-light value in range 0-1.
+ * @param linear – Linear-light value in range 0-1.
  * @returns Encoded channel value in range 0-1.
  */
 export function linearToSrgb(linear: number): number {
@@ -1003,7 +1003,7 @@ export function linearToSrgb(linear: number): number {
  * Rounds to nearest so a {@link linearizeByte} / {@link encodeByte} round trip
  * does not drift downward one level at a time.
  *
- * @param value - Encoded channel byte in range 0-255.
+ * @param value – Encoded channel byte in range 0-255.
  * @returns Linear-light channel byte in range 0-255.
  */
 function linearizeByte(value: number): number {
@@ -1013,7 +1013,7 @@ function linearizeByte(value: number): number {
 /**
  * Converts one linear-light byte to an encoded sRGB byte.
  *
- * @param value - Linear-light channel byte in range 0-255.
+ * @param value – Linear-light channel byte in range 0-255.
  * @returns Encoded channel byte in range 0-255.
  */
 function encodeByte(value: number): number {
@@ -1023,7 +1023,7 @@ function encodeByte(value: number): number {
 /**
  * Throws a standardized beginner-friendly error for invalid hex colors.
  *
- * @param hex - Original input string.
+ * @param hex – Original input string.
  */
 function throwInvalidHex(hex: string): never {
     throw new Error(
@@ -1034,9 +1034,9 @@ function throwInvalidHex(hex: string): never {
 /**
  * Parses an exact-length hex substring and rejects partial/invalid tokens.
  *
- * @param hex - Original full hex string.
- * @param start - Token start index in the full string.
- * @param length - Expected token length.
+ * @param hex – Original full hex string.
+ * @param start – Token start index in the full string.
+ * @param length – Expected token length.
  * @returns Parsed base-16 number.
  */
 function parseHexToken(hex: string, start: number, length: number): number {

--- a/packages/blit386/src/utils/Easing.ts
+++ b/packages/blit386/src/utils/Easing.ts
@@ -61,7 +61,7 @@ type Curve = (t: number) => number;
 /**
  * Bounce-out curve shared by bounce-in / bounce-out / bounce-in-out.
  *
- * @param t - Normalized time in [0, 1].
+ * @param t – Normalized time in [0, 1].
  * @returns Eased value.
  */
 function bounceOut(t: number): number {
@@ -197,8 +197,8 @@ const CURVES: Record<EasingFunction, Curve> = {
  *
  * @since 1.0.3
  * @changed 1.5.0 Added sine, cubic, quartic, quintic, expo, circ, back, elastic, and bounce families.
- * @param t - Normalized time in [0, 1]. Values outside this range are not clamped.
- * @param easing - Easing curve to apply.
+ * @param t – Normalized time in [0, 1]. Values outside this range are not clamped.
+ * @param easing – Easing curve to apply.
  * @returns Eased value. Guaranteed to return 0 for `t = 0` and 1 for `t = 1`.
  */
 export function applyEasing(t: number, easing: EasingFunction): number {
@@ -220,10 +220,10 @@ export function applyEasing(t: number, easing: EasingFunction): number {
  * `Color32` channels are rounded and clamped to [0, 255].
  *
  * @since 1.5.0
- * @param easing - Easing curve to apply to `t` before interpolation.
- * @param start - Value at `t = 0`.
- * @param end - Value at `t = 1`.
- * @param t - Normalized time in [0, 1]. Values outside this range are not clamped.
+ * @param easing – Easing curve to apply to `t` before interpolation.
+ * @param start – Value at `t = 0`.
+ * @param end – Value at `t = 1`.
+ * @param t – Normalized time in [0, 1]. Values outside this range are not clamped.
  * @returns Interpolated value of the same type as `start` / `end`.
  */
 export function interpolate(easing: EasingFunction, start: number, end: number, t: number): number;
@@ -231,10 +231,10 @@ export function interpolate(easing: EasingFunction, start: number, end: number, 
  * Interpolates two `Vector2i` values with an easing curve (components rounded).
  *
  * @since 1.5.0
- * @param easing - Easing curve to apply to `t` before interpolation.
- * @param start - Value at `t = 0`.
- * @param end - Value at `t = 1`.
- * @param t - Normalized time in [0, 1]. Values outside this range are not clamped.
+ * @param easing – Easing curve to apply to `t` before interpolation.
+ * @param start – Value at `t = 0`.
+ * @param end – Value at `t = 1`.
+ * @param t – Normalized time in [0, 1]. Values outside this range are not clamped.
  * @returns Interpolated `Vector2i`.
  */
 // eslint-disable-next-line no-redeclare -- TypeScript call-signature overloads
@@ -243,10 +243,10 @@ export function interpolate(easing: EasingFunction, start: Vector2i, end: Vector
  * Interpolates two `Color32` values with an easing curve (channels rounded and clamped).
  *
  * @since 1.5.0
- * @param easing - Easing curve to apply to `t` before interpolation.
- * @param start - Value at `t = 0`.
- * @param end - Value at `t = 1`.
- * @param t - Normalized time in [0, 1]. Values outside this range are not clamped.
+ * @param easing – Easing curve to apply to `t` before interpolation.
+ * @param start – Value at `t = 0`.
+ * @param end – Value at `t = 1`.
+ * @param t – Normalized time in [0, 1]. Values outside this range are not clamped.
  * @returns Interpolated `Color32`.
  */
 // eslint-disable-next-line no-redeclare -- TypeScript call-signature overloads
@@ -255,10 +255,10 @@ export function interpolate(easing: EasingFunction, start: Color32, end: Color32
  * Interpolates two `Rect2i` values with an easing curve (components rounded).
  *
  * @since 1.5.0
- * @param easing - Easing curve to apply to `t` before interpolation.
- * @param start - Value at `t = 0`.
- * @param end - Value at `t = 1`.
- * @param t - Normalized time in [0, 1]. Values outside this range are not clamped.
+ * @param easing – Easing curve to apply to `t` before interpolation.
+ * @param start – Value at `t = 0`.
+ * @param end – Value at `t = 1`.
+ * @param t – Normalized time in [0, 1]. Values outside this range are not clamped.
  * @returns Interpolated `Rect2i`.
  */
 // eslint-disable-next-line no-redeclare -- TypeScript call-signature overloads

--- a/packages/blit386/src/utils/FrameCapture.test.ts
+++ b/packages/blit386/src/utils/FrameCapture.test.ts
@@ -139,7 +139,7 @@ describe('FrameCapture', () => {
     it('should set a pending flag after request', () => {
         const capture = new FrameCapture();
 
-        // Don't await - just queue the request.
+        // Don't await – just queue the request.
         void capture.request();
 
         expect(capture.hasPending()).toBe(true);

--- a/packages/blit386/src/utils/FrameCapture.ts
+++ b/packages/blit386/src/utils/FrameCapture.ts
@@ -20,7 +20,7 @@ type Reject = (reason: Error) => void;
 /**
  * Calculates the WebGPU-aligned byte size per row for a given image width.
  *
- * @param width - Image width in pixels.
+ * @param width – Image width in pixels.
  * @returns Byte count per row, padded to the GPU alignment boundary.
  */
 export function alignedBytesPerRow(width: number): number {
@@ -32,7 +32,7 @@ export function alignedBytesPerRow(width: number): number {
 /**
  * Swaps blue and red channels in a BGRA pixel array to produce RGBA (in place).
  *
- * @param data - Pixel array in BGRA order (4 bytes per pixel).
+ * @param data – Pixel array in BGRA order (4 bytes per pixel).
  */
 export function swizzleBGRAtoRGBA(data: Uint8ClampedArray): void {
     for (let i = 0; i < data.length; i += BYTES_PER_PIXEL) {
@@ -48,11 +48,11 @@ export function swizzleBGRAtoRGBA(data: Uint8ClampedArray): void {
 /**
  * Converts a raw pixel buffer into a PNG image Blob.
  *
- * @param buffer - Raw pixel data (potentially padded and in BGRA order).
- * @param width - Image width in pixels.
- * @param height - Image height in pixels.
- * @param paddedBytesPerRow - Bytes per row including GPU alignment padding.
- * @param isBGRA - Whether the pixel data needs BGRA-to-RGBA swizzling.
+ * @param buffer – Raw pixel data (potentially padded and in BGRA order).
+ * @param width – Image width in pixels.
+ * @param height – Image height in pixels.
+ * @param paddedBytesPerRow – Bytes per row including GPU alignment padding.
+ * @param isBGRA – Whether the pixel data needs BGRA-to-RGBA swizzling.
  * @returns PNG-encoded Blob.
  */
 export async function pixelBufferToPNG(
@@ -153,9 +153,9 @@ export class FrameCapture {
      * Call only when {@link hasPending} is true, after the render pass ends but
      * before submitting the command buffer.
      *
-     * @param device - WebGPU device for buffer creation.
-     * @param texture - The rendered canvas texture to capture.
-     * @param commandEncoder - Active command encoder to add the copy command to.
+     * @param device – WebGPU device for buffer creation.
+     * @param texture – The rendered canvas texture to capture.
+     * @param commandEncoder – Active command encoder to add the copy command to.
      */
     executeInEncoder(device: GPUDevice, texture: GPUTexture, commandEncoder: GPUCommandEncoder): void {
         this.width = texture.width;
@@ -181,7 +181,7 @@ export class FrameCapture {
     /**
      * Waits for GPU completion, reads back the staging buffer, and resolves the pending capture.
      *
-     * @param device - WebGPU device (used for onSubmittedWorkDone).
+     * @param device – WebGPU device (used for onSubmittedWorkDone).
      */
     async resolve(device: GPUDevice): Promise<void> {
         const resolve = this.pendingResolve;

--- a/packages/blit386/src/utils/HotReloadUrl.test.ts
+++ b/packages/blit386/src/utils/HotReloadUrl.test.ts
@@ -71,7 +71,7 @@ describe('HotReloadUrl', () => {
 
             try {
                 // A browser resolves <img src="images/hero.png"> against the document's own
-                // directory, not the domain root - the normalized key must match that, or a
+                // directory, not the domain root – the normalized key must match that, or a
                 // sheet loaded on a nested page would never be found by the hot-reload registry.
                 expect(normalizeAssetUrl('images/hero.png')).toBe('/games/my-game/images/hero.png');
             } finally {

--- a/packages/blit386/src/utils/HotReloadUrl.ts
+++ b/packages/blit386/src/utils/HotReloadUrl.ts
@@ -12,14 +12,14 @@
  * Appends a cache-busting query parameter carrying the current timestamp, so a
  * re-fetch of an unchanged URL bypasses the browser's HTTP cache.
  *
- * Inserted before any fragment identifier (`#...`) rather than after it - a query string
+ * Inserted before any fragment identifier (`#...`) rather than after it – a query string
  * appended past a fragment is invalid URL syntax and browsers treat it as part of the
  * fragment, so the parameter would never actually reach the server.
  *
  * The busted URL is only ever used for the actual `fetch`/`Image.src` request –
  * callers keep caching the result under the original, un-busted `url`.
  *
- * @param url - Original request URL.
+ * @param url – Original request URL.
  * @returns `url` with a `blit386-hmr=<timestamp>` query parameter inserted before any fragment.
  */
 export function appendCacheBustQuery(url: string): string {
@@ -41,7 +41,7 @@ export function appendCacheBustQuery(url: string): string {
  * own URL, or an explicit `<base href>`), not just its origin, so a page served from a nested
  * path (for example `/games/my-game/`) needs the same resolution here to produce a matching key.
  *
- * @param url - URL to normalize.
+ * @param url – URL to normalize.
  * @returns Normalized pathname, for example `/images/hero.png`.
  */
 export function normalizeAssetUrl(url: string): string {

--- a/packages/blit386/src/utils/PerlinNoise.ts
+++ b/packages/blit386/src/utils/PerlinNoise.ts
@@ -55,7 +55,7 @@ export class PerlinNoise {
     /**
      * Creates a Perlin-noise sampler. Omit `seed` to use `0` (same default as coordinate hashes).
      *
-     * @param seed - Any finite number; only its lower 32 bits affect the field.
+     * @param seed – Any finite number; only its lower 32 bits affect the field.
      * @since 1.5.0
      */
     public constructor(seed = 0) {
@@ -65,7 +65,7 @@ export class PerlinNoise {
     /**
      * Reseeds the noise field. Same seed restarts the same spatial pattern.
      *
-     * @param seed - Any finite number; only its lower 32 bits are used.
+     * @param seed – Any finite number; only its lower 32 bits are used.
      * @since 1.5.0
      */
     public seed(seed: number): void {
@@ -75,7 +75,7 @@ export class PerlinNoise {
     /**
      * Samples 1D Perlin noise at `x`.
      *
-     * @param x - Continuous world coordinate.
+     * @param x – Continuous world coordinate.
      * @returns Smooth value in approximately `[-1, 1]`.
      * @since 1.5.0
      */
@@ -96,8 +96,8 @@ export class PerlinNoise {
     /**
      * Samples 2D Perlin noise at `(x, y)`.
      *
-     * @param x - Continuous world X.
-     * @param y - Continuous world Y.
+     * @param x – Continuous world X.
+     * @param y – Continuous world Y.
      * @returns Smooth value in approximately `[-1, 1]`.
      * @since 1.5.0
      */
@@ -123,9 +123,9 @@ export class PerlinNoise {
     /**
      * Samples 3D Perlin noise at `(x, y, z)`.
      *
-     * @param x - Continuous world X.
-     * @param y - Continuous world Y.
-     * @param z - Continuous world Z.
+     * @param x – Continuous world X.
+     * @param y – Continuous world Y.
+     * @param z – Continuous world Z.
      * @returns Smooth value in approximately `[-1, 1]`.
      * @since 1.5.0
      */
@@ -164,10 +164,10 @@ export class PerlinNoise {
     /**
      * Fractal Brownian motion over {@link noise1D}.
      *
-     * @param x - Continuous world coordinate.
-     * @param octaves - Octave count (default `4`; floored, at least 1).
-     * @param persistence - Amplitude falloff per octave (default `0.5`).
-     * @param lacunarity - Frequency scale per octave (default `2`).
+     * @param x – Continuous world coordinate.
+     * @param octaves – Octave count (default `4`; floored, at least 1).
+     * @param persistence – Amplitude falloff per octave (default `0.5`).
+     * @param lacunarity – Frequency scale per octave (default `2`).
      * @returns Normalized fBm in approximately `[-1, 1]`.
      * @since 1.5.0
      */
@@ -183,11 +183,11 @@ export class PerlinNoise {
     /**
      * Fractal Brownian motion over {@link noise2D}.
      *
-     * @param x - Continuous world X.
-     * @param y - Continuous world Y.
-     * @param octaves - Octave count (default `4`; floored, at least 1).
-     * @param persistence - Amplitude falloff per octave (default `0.5`).
-     * @param lacunarity - Frequency scale per octave (default `2`).
+     * @param x – Continuous world X.
+     * @param y – Continuous world Y.
+     * @param octaves – Octave count (default `4`; floored, at least 1).
+     * @param persistence – Amplitude falloff per octave (default `0.5`).
+     * @param lacunarity – Frequency scale per octave (default `2`).
      * @returns Normalized fBm in approximately `[-1, 1]`.
      * @since 1.5.0
      */
@@ -204,12 +204,12 @@ export class PerlinNoise {
     /**
      * Fractal Brownian motion over {@link noise3D}.
      *
-     * @param x - Continuous world X.
-     * @param y - Continuous world Y.
-     * @param z - Continuous world Z.
-     * @param octaves - Octave count (default `4`; floored, at least 1).
-     * @param persistence - Amplitude falloff per octave (default `0.5`).
-     * @param lacunarity - Frequency scale per octave (default `2`).
+     * @param x – Continuous world X.
+     * @param y – Continuous world Y.
+     * @param z – Continuous world Z.
+     * @param octaves – Octave count (default `4`; floored, at least 1).
+     * @param persistence – Amplitude falloff per octave (default `0.5`).
+     * @param lacunarity – Frequency scale per octave (default `2`).
      * @returns Normalized fBm in approximately `[-1, 1]`.
      * @since 1.5.0
      */

--- a/packages/blit386/src/utils/Random.ts
+++ b/packages/blit386/src/utils/Random.ts
@@ -60,7 +60,7 @@ export class Random {
     /**
      * Creates a PRNG. Omit `seed` to time-seed from `Date.now()` (lower 32 bits).
      *
-     * @param seed - Any finite number; only its lower 32 bits affect the sequence.
+     * @param seed – Any finite number; only its lower 32 bits affect the sequence.
      * @since 1.5.0
      */
     public constructor(seed: number = Date.now()) {
@@ -86,7 +86,7 @@ export class Random {
      * Reseeds the generator. Same seed restarts the same sequence. Updates {@link seedValue} to the
      * normalized `seed`.
      *
-     * @param seed - Any finite number; only its lower 32 bits are used.
+     * @param seed – Any finite number; only its lower 32 bits are used.
      * @since 1.5.0
      */
     public seed(seed: number): void {
@@ -108,7 +108,7 @@ export class Random {
      * Restores a previously saved 32-bit generator state. Clears {@link seedValue} to `undefined`, since an
      * arbitrary saved state does not correspond to a known seed.
      *
-     * @param state - Value from {@link getState} (lower 32 bits used).
+     * @param state – Value from {@link getState} (lower 32 bits used).
      * @since 1.5.0
      */
     public setState(state: number): void {
@@ -160,8 +160,8 @@ export class Random {
     /**
      * Returns the next pseudo-random float in [min, max).
      *
-     * @param min - Inclusive lower bound.
-     * @param max - Exclusive upper bound.
+     * @param min – Inclusive lower bound.
+     * @param max – Exclusive upper bound.
      * @returns Float in [min, max).
      * @since 1.5.0
      */
@@ -172,8 +172,8 @@ export class Random {
     /**
      * Returns a pseudo-random integer in [0, maxExclusive) or [min, maxExclusive).
      *
-     * @param minOrMaxExclusive - When alone, exclusive upper bound from 0; otherwise inclusive min.
-     * @param maxExclusive - Exclusive upper bound when two arguments are passed.
+     * @param minOrMaxExclusive – When alone, exclusive upper bound from 0; otherwise inclusive min.
+     * @param maxExclusive – Exclusive upper bound when two arguments are passed.
      * @returns Whole number in the half-open range.
      * @since 1.5.0
      */
@@ -199,8 +199,8 @@ export class Random {
     /**
      * Returns a pseudo-random integer in [min, max] (inclusive on both ends).
      *
-     * @param min - Inclusive lower bound.
-     * @param max - Inclusive upper bound.
+     * @param min – Inclusive lower bound.
+     * @param max – Inclusive upper bound.
      * @returns Whole number in the closed range.
      * @since 1.5.0
      */
@@ -218,7 +218,7 @@ export class Random {
     /**
      * Returns true with the given probability.
      *
-     * @param probability - Chance in [0, 1]; defaults to 0.5.
+     * @param probability – Chance in [0, 1]; defaults to 0.5.
      * @returns True when the next unit float is less than `probability`.
      * @since 1.5.0
      */
@@ -239,7 +239,7 @@ export class Random {
     /**
      * Returns one element chosen uniformly from a non-empty array.
      *
-     * @param arr - Array to pick from; must contain at least one element.
+     * @param arr – Array to pick from; must contain at least one element.
      * @returns Chosen element.
      * @since 1.5.0
      */
@@ -254,7 +254,7 @@ export class Random {
     /**
      * Returns a new array with the same elements in shuffled order (Fisher-Yates).
      *
-     * @param arr - Source array (not mutated).
+     * @param arr – Source array (not mutated).
      * @returns Shuffled copy.
      * @since 1.5.0
      */
@@ -269,7 +269,7 @@ export class Random {
     /**
      * Shuffles an array in place (Fisher-Yates) and returns it.
      *
-     * @param arr - Array to mutate.
+     * @param arr – Array to mutate.
      * @returns The same array reference.
      * @since 1.5.0
      */
@@ -290,8 +290,8 @@ export class Random {
     /**
      * Returns one item chosen by relative weights.
      *
-     * @param items - Items to choose from.
-     * @param weights - Non-negative weights parallel to `items`; total must be greater than 0.
+     * @param items – Items to choose from.
+     * @param weights – Non-negative weights parallel to `items`; total must be greater than 0.
      * @returns Chosen item.
      * @since 1.5.0
      */
@@ -349,8 +349,8 @@ export class Random {
     /**
      * Returns a sample from an approximate normal distribution (Box-Muller, no spare).
      *
-     * @param mean - Distribution mean; defaults to 0.
-     * @param stddev - Standard deviation; defaults to 1.
+     * @param mean – Distribution mean; defaults to 0.
+     * @param stddev – Standard deviation; defaults to 1.
      * @returns Gaussian sample.
      * @since 1.5.0
      */
@@ -372,7 +372,7 @@ export class Random {
     /**
      * Returns a random integer point inside a rectangle (half-open, like {@link Rect2i.isContaining}).
      *
-     * @param rect - Rectangle to sample; must have positive width and height.
+     * @param rect – Rectangle to sample; must have positive width and height.
      * @returns New point with `x` in `[rect.x, rect.right)` and `y` in `[rect.y, rect.bottom)`.
      * @since 1.5.0
      */
@@ -386,8 +386,8 @@ export class Random {
      * Half-open bounds match {@link Rect2i.isContaining}: `x` in `[rect.x, rect.right)`,
      * `y` in `[rect.y, rect.bottom)`.
      *
-     * @param rect - Rectangle to sample; must have positive width and height.
-     * @param out - Vector to write into.
+     * @param rect – Rectangle to sample; must have positive width and height.
+     * @param out – Vector to write into.
      * @returns The same `out` reference.
      * @since 1.5.0
      */
@@ -403,8 +403,8 @@ export class Random {
      *
      * Per axis uses {@link int}: `x` in `[min.x, max.x)`, `y` in `[min.y, max.y)`.
      *
-     * @param min - Inclusive lower bound per axis.
-     * @param max - Exclusive upper bound per axis.
+     * @param min – Inclusive lower bound per axis.
+     * @param max – Exclusive upper bound per axis.
      * @returns New point in the half-open range.
      * @since 1.5.0
      */
@@ -417,9 +417,9 @@ export class Random {
      *
      * Per axis uses {@link int}: `x` in `[min.x, max.x)`, `y` in `[min.y, max.y)`.
      *
-     * @param min - Inclusive lower bound per axis.
-     * @param max - Exclusive upper bound per axis.
-     * @param out - Vector to write into.
+     * @param min – Inclusive lower bound per axis.
+     * @param max – Exclusive upper bound per axis.
+     * @param out – Vector to write into.
      * @returns The same `out` reference.
      * @since 1.5.0
      */

--- a/packages/blit386/src/utils/Rect2i.ts
+++ b/packages/blit386/src/utils/Rect2i.ts
@@ -17,10 +17,10 @@ export class Rect2i {
     /**
      * Creates an integer rectangle, truncating all inputs toward zero.
      *
-     * @param x - Left-edge X coordinate (defaults to 0).
-     * @param y - Top-edge Y coordinate (defaults to 0).
-     * @param width - Width in pixels (defaults to 0).
-     * @param height - Height in pixels (defaults to 0).
+     * @param x – Left-edge X coordinate (defaults to 0).
+     * @param y – Top-edge Y coordinate (defaults to 0).
+     * @param width – Width in pixels (defaults to 0).
+     * @param height – Height in pixels (defaults to 0).
      */
     constructor(
         /** Left edge X coordinate (defaults to 0). */
@@ -109,7 +109,7 @@ export class Rect2i {
     /**
      * Sets the position (top-left corner) from a vector.
      *
-     * @param value - New position vector.
+     * @param value – New position vector.
      */
     set position(value: Vector2i) {
         this.x = value.x | 0;
@@ -127,7 +127,7 @@ export class Rect2i {
     /**
      * Sets the size from a vector.
      *
-     * @param value - New size vector (x=width, y=height).
+     * @param value – New size vector (x=width, y=height).
      */
     set size(value: Vector2i) {
         this.width = value.x | 0;
@@ -136,7 +136,7 @@ export class Rect2i {
 
     /**
      * Returns a zero-sized rectangle at origin.
-     * Returns a cached frozen singleton - do not modify.
+     * Returns a cached frozen singleton – do not modify.
      *
      * @returns Rectangle at (0, 0) with size (0, 0) (cached).
      */
@@ -151,8 +151,8 @@ export class Rect2i {
      * If min > max on any axis, the resulting width/height will be negative,
      * which may cause unexpected behavior in intersection/containment tests.
      *
-     * @param min - Top-left corner.
-     * @param max - Bottom-right corner (exclusive; same half-open interval as {@link isContaining}).
+     * @param min – Top-left corner.
+     * @param max – Bottom-right corner (exclusive; same half-open interval as {@link isContaining}).
      * @returns New rectangle spanning from min to max.
      */
     static fromMinMax(min: Vector2i, max: Vector2i): Rect2i {
@@ -167,10 +167,10 @@ export class Rect2i {
      * Note: min coordinates must be less than or equal to max coordinates.
      * If min > max on any axis, the resulting width/height will be negative.
      *
-     * @param minX - Left-edge X coordinate.
-     * @param minY - Top-edge Y coordinate.
-     * @param maxX - Right-edge X coordinate.
-     * @param maxY - Bottom-edge Y coordinate.
+     * @param minX – Left-edge X coordinate.
+     * @param minY – Top-edge Y coordinate.
+     * @param maxX – Right-edge X coordinate.
+     * @param maxY – Bottom-edge Y coordinate.
      * @returns New rectangle spanning from (minX, minY) to (maxX, maxY).
      */
     static fromMinMaxXY(minX: number, minY: number, maxX: number, maxY: number): Rect2i {
@@ -183,8 +183,8 @@ export class Rect2i {
     /**
      * Creates a rectangle centered on a point with a given size.
      *
-     * @param center - Center point of the rectangle.
-     * @param size - Width and height as a vector.
+     * @param center – Center point of the rectangle.
+     * @param size – Width and height as a vector.
      * @returns New rectangle centered on the given point.
      */
     static fromCenterSize(center: Vector2i, size: Vector2i): Rect2i {
@@ -200,10 +200,10 @@ export class Rect2i {
      * Creates a rectangle centered on raw coordinates with a given size.
      * Zero allocation alternative to fromCenterSize() when you have raw coordinates.
      *
-     * @param centerX - Center X coordinate.
-     * @param centerY - Center Y coordinate.
-     * @param width - Width of the rectangle.
-     * @param height - Height of the rectangle.
+     * @param centerX – Center X coordinate.
+     * @param centerY – Center Y coordinate.
+     * @param width – Width of the rectangle.
+     * @param height – Height of the rectangle.
      * @returns New rectangle centered on the given point.
      */
     static fromCenterSizeXY(centerX: number, centerY: number, width: number, height: number): Rect2i {
@@ -222,10 +222,10 @@ export class Rect2i {
      * WARNING: Passing non-integer values will result in non-integer rect components.
      * Only use when you’re certain the values are already integers.
      *
-     * @param x - Left-edge X coordinate (must be integer).
-     * @param y - Top-edge Y coordinate (must be integer).
-     * @param width - Width in pixels (must be integer).
-     * @param height - Height in pixels (must be integer).
+     * @param x – Left-edge X coordinate (must be integer).
+     * @param y – Top-edge Y coordinate (must be integer).
+     * @param width – Width in pixels (must be integer).
+     * @param height – Height in pixels (must be integer).
      * @returns New Rect2i with the specified values.
      */
     static fromValuesUnchecked(x: number, y: number, width: number, height: number): Rect2i {
@@ -243,7 +243,7 @@ export class Rect2i {
      * Writes the top-left corner (min) to an existing vector.
      * Zero allocation alternative to the min getter.
      *
-     * @param out - Vector to write to.
+     * @param out – Vector to write to.
      * @returns The out vector for chaining.
      */
     minTo(out: Vector2i): Vector2i {
@@ -257,7 +257,7 @@ export class Rect2i {
      * Writes the bottom-right corner (exclusive max) to an existing vector.
      * Zero allocation alternative to the max getter.
      *
-     * @param out - Vector to write to.
+     * @param out – Vector to write to.
      * @returns The out vector for chaining.
      */
     maxTo(out: Vector2i): Vector2i {
@@ -271,7 +271,7 @@ export class Rect2i {
      * Writes the center point to an existing vector.
      * Zero allocation alternative to the center getter.
      *
-     * @param out - Vector to write to.
+     * @param out – Vector to write to.
      * @returns The out vector for chaining.
      */
     centerTo(out: Vector2i): Vector2i {
@@ -285,7 +285,7 @@ export class Rect2i {
      * Writes the position (top-left corner) to an existing vector.
      * Zero allocation alternative to the position getter.
      *
-     * @param out - Vector to write to.
+     * @param out – Vector to write to.
      * @returns The out vector for chaining.
      */
     positionTo(out: Vector2i): Vector2i {
@@ -299,7 +299,7 @@ export class Rect2i {
      * Writes the size (width, height) to an existing vector.
      * Zero allocation alternative to the size getter.
      *
-     * @param out - Vector to write to.
+     * @param out – Vector to write to.
      * @returns The out vector for chaining.
      */
     sizeTo(out: Vector2i): Vector2i {
@@ -313,7 +313,7 @@ export class Rect2i {
      * Tests if a point lies within this rectangle.
      * Uses half-open interval: includes min, excludes max.
      *
-     * @param point - Point to test.
+     * @param point – Point to test.
      * @returns True if point is inside the rectangle.
      */
     isContaining(point: Vector2i): boolean {
@@ -326,7 +326,7 @@ export class Rect2i {
      * Backward-compatible alias for {@link isContaining}.
      *
      * @deprecated Deprecated since 0.1.0 (2026-05-31). Use {@link isContaining} instead.
-     * @param point - Point to test.
+     * @param point – Point to test.
      * @returns True if point is inside the rectangle.
      */
     contains(point: Vector2i): boolean {
@@ -336,8 +336,8 @@ export class Rect2i {
     /**
      * Tests raw coordinates against this rectangle without allocating a vector.
      *
-     * @param px - X coordinate to test.
-     * @param py - Y coordinate to test.
+     * @param px – X coordinate to test.
+     * @param py – Y coordinate to test.
      * @returns True if point is inside the rectangle.
      */
     isContainingXY(px: number, py: number): boolean {
@@ -348,8 +348,8 @@ export class Rect2i {
      * Backward-compatible alias for {@link isContainingXY}.
      *
      * @deprecated Deprecated since 0.1.0 (2026-05-31). Use {@link isContainingXY} instead.
-     * @param px - X coordinate to test.
-     * @param py - Y coordinate to test.
+     * @param px – X coordinate to test.
+     * @param py – Y coordinate to test.
      * @returns True if point is inside the rectangle.
      */
     containsXY(px: number, py: number): boolean {
@@ -359,7 +359,7 @@ export class Rect2i {
     /**
      * Tests if this rectangle overlaps with another.
      *
-     * @param other - Rectangle to test against.
+     * @param other – Rectangle to test against.
      * @returns True if rectangles overlap.
      */
     isIntersecting(other: Rect2i): boolean {
@@ -375,7 +375,7 @@ export class Rect2i {
      * Backward-compatible alias for {@link isIntersecting}.
      *
      * @deprecated Deprecated since 0.1.0 (2026-05-31). Use {@link isIntersecting} instead.
-     * @param other - Rectangle to test against.
+     * @param other – Rectangle to test against.
      * @returns True if rectangles overlap.
      */
     intersects(other: Rect2i): boolean {
@@ -385,7 +385,7 @@ export class Rect2i {
     /**
      * Calculates the overlapping region of two rectangles.
      *
-     * @param other - Rectangle to intersect with.
+     * @param other – Rectangle to intersect with.
      * @returns New rectangle representing the overlap, or null if no overlap.
      */
     intersection(other: Rect2i): Rect2i | null {
@@ -405,8 +405,8 @@ export class Rect2i {
     /**
      * Calculates the overlapping region and writes it into an existing rectangle.
      *
-     * @param other - Rectangle to intersect with.
-     * @param out - Rectangle to write the result to.
+     * @param other – Rectangle to intersect with.
+     * @param out – Rectangle to write the result to.
      * @returns True if intersection exists (out is valid), false otherwise (out unchanged).
      */
     intersectTo(other: Rect2i, out: Rect2i): boolean {
@@ -429,8 +429,8 @@ export class Rect2i {
      * Backward-compatible alias for {@link intersectTo}.
      *
      * @deprecated Deprecated since 0.1.0 (2026-05-31). Use {@link intersectTo} instead.
-     * @param other - Rectangle to intersect with.
-     * @param out - Rectangle to write the result to.
+     * @param other – Rectangle to intersect with.
+     * @param out – Rectangle to write the result to.
      * @returns True if intersection exists (out is valid), false otherwise (out unchanged).
      */
     intersectionTo(other: Rect2i, out: Rect2i): boolean {
@@ -448,7 +448,7 @@ export class Rect2i {
      * {@link isIntersecting} first; if they don't overlap, the returned depths
      * may be zero or negative and aren't meaningful for resolution.
      *
-     * @param other - Rectangle to measure overlap with.
+     * @param other – Rectangle to measure overlap with.
      * @returns Vector with overlap depth in X and Y axes.
      */
     intersectionDepth(other: Rect2i): Vector2i {
@@ -473,8 +473,8 @@ export class Rect2i {
      * {@link isIntersecting} first; if they don't overlap, the returned depths
      * may be zero or negative and aren't meaningful for resolution.
      *
-     * @param other - Rectangle to measure overlap with.
-     * @param out - Vector to write the result to.
+     * @param other – Rectangle to measure overlap with.
+     * @param out – Vector to write the result to.
      * @returns The out vector for chaining.
      */
     intersectionDepthTo(other: Rect2i, out: Vector2i): Vector2i {
@@ -493,7 +493,7 @@ export class Rect2i {
     /**
      * Checks if this rectangle equals another (all components match).
      *
-     * @param other - Rectangle to compare with.
+     * @param other – Rectangle to compare with.
      * @returns True if position and size are identical.
      */
     isEqual(other: Rect2i): boolean {
@@ -504,7 +504,7 @@ export class Rect2i {
      * Backward-compatible alias for {@link isEqual}.
      *
      * @deprecated Deprecated since 0.1.0 (2026-05-31). Use {@link isEqual} instead.
-     * @param other - Rectangle to compare with.
+     * @param other – Rectangle to compare with.
      * @returns True if position and size are identical.
      */
     equals(other: Rect2i): boolean {
@@ -525,7 +525,7 @@ export class Rect2i {
      * Copies this rectangle's values to an existing rectangle.
      * Zero allocation alternative to clone().
      *
-     * @param out - Rectangle to write to.
+     * @param out – Rectangle to write to.
      * @returns The out rectangle for chaining.
      */
     cloneTo(out: Rect2i): Rect2i {
@@ -552,10 +552,10 @@ export class Rect2i {
      *
      * WARNING: Mutates this rectangle. Don't use on frozen/cached singletons.
      *
-     * @param x - New x position.
-     * @param y - New y position.
-     * @param width - New width.
-     * @param height - New height.
+     * @param x – New x position.
+     * @param y – New y position.
+     * @param width – New width.
+     * @param height – New height.
      * @returns This rectangle for chaining.
      */
     set(x: number, y: number, width: number, height: number): this {
@@ -573,8 +573,8 @@ export class Rect2i {
      *
      * WARNING: Mutates this rectangle. Don't use on frozen/cached singletons.
      *
-     * @param x - New x position.
-     * @param y - New y position.
+     * @param x – New x position.
+     * @param y – New y position.
      * @returns This rectangle for chaining.
      */
     setPosition(x: number, y: number): this {
@@ -590,8 +590,8 @@ export class Rect2i {
      *
      * WARNING: Mutates this rectangle. Don't use on frozen/cached singletons.
      *
-     * @param width - New width.
-     * @param height - New height.
+     * @param width – New width.
+     * @param height – New height.
      * @returns This rectangle for chaining.
      */
     setSize(width: number, height: number): this {
@@ -607,7 +607,7 @@ export class Rect2i {
      *
      * WARNING: Mutates this rectangle. Don't use on frozen/cached singletons.
      *
-     * @param other - Rectangle to copy from.
+     * @param other – Rectangle to copy from.
      * @returns This rectangle for chaining.
      */
     copyFrom(other: Rect2i): this {
@@ -625,8 +625,8 @@ export class Rect2i {
      *
      * WARNING: Mutates this rectangle. Don't use on frozen/cached singletons.
      *
-     * @param dx - X offset to add.
-     * @param dy - Y offset to add.
+     * @param dx – X offset to add.
+     * @param dy – Y offset to add.
      * @returns This rectangle for chaining.
      */
     translate(dx: number, dy: number): this {
@@ -642,7 +642,7 @@ export class Rect2i {
      *
      * WARNING: Mutates this rectangle. Don't use on frozen/cached singletons.
      *
-     * @param amount - Amount to expand (positive) or shrink (negative).
+     * @param amount – Amount to expand (positive) or shrink (negative).
      * @returns This rectangle for chaining.
      */
     expand(amount: number): this {
@@ -662,8 +662,8 @@ export class Rect2i {
      *
      * WARNING: Mutates this rectangle. Don't use on frozen/cached singletons.
      *
-     * @param horizontal - Amount to expand horizontally.
-     * @param vertical - Amount to expand vertically.
+     * @param horizontal – Amount to expand horizontally.
+     * @param vertical – Amount to expand vertically.
      * @returns This rectangle for chaining.
      */
     expandXY(horizontal: number, vertical: number): this {

--- a/packages/blit386/src/utils/RenderLimits.ts
+++ b/packages/blit386/src/utils/RenderLimits.ts
@@ -27,7 +27,7 @@ export class RenderDimensionLimitError extends Error {
     /**
      * Creates a render-dimension limit error.
      *
-     * @param message - User-facing validation message.
+     * @param message – User-facing validation message.
      */
     constructor(message: string) {
         super(message);
@@ -48,7 +48,7 @@ export interface RenderDimensionSettings {
 /**
  * Formats a render dimension for error messages.
  *
- * @param size - Size value to format.
+ * @param size – Size value to format.
  * @returns Size formatted as `WIDTHxHEIGHT`.
  */
 function formatSize(size: Vector2i | undefined | null): string {
@@ -66,8 +66,8 @@ function formatSize(size: Vector2i | undefined | null): string {
 /**
  * Validates a single render dimension against integer and engine allocation limits.
  *
- * @param field - Hardware settings field being checked.
- * @param size - Size value to validate.
+ * @param field – Hardware settings field being checked.
+ * @param size – Size value to validate.
  * @returns A user-facing error message when invalid, otherwise `null`.
  */
 export function validateDimension(field: RenderDimensionField, size: Vector2i | undefined | null): string | null {
@@ -106,7 +106,7 @@ export function validateDimension(field: RenderDimensionField, size: Vector2i | 
 /**
  * Validates all render dimensions in hardware settings before renderer allocation.
  *
- * @param settings - Hardware settings returned by `configure()` or defaults.
+ * @param settings – Hardware settings returned by `configure()` or defaults.
  * @returns A user-facing error message when invalid, otherwise `null`.
  */
 export function validateDimensions(settings: RenderDimensionSettings): string | null {
@@ -135,9 +135,9 @@ export function validateDimensions(settings: RenderDimensionSettings): string | 
 /**
  * Validates a render texture size against the current WebGPU adapter/device limit.
  *
- * @param field - Hardware settings field being checked.
- * @param size - Requested texture or drawing-buffer size.
- * @param maxTextureDimension2D - WebGPU `maxTextureDimension2D`, when exposed.
+ * @param field – Hardware settings field being checked.
+ * @param size – Requested texture or drawing-buffer size.
+ * @param maxTextureDimension2D – WebGPU `maxTextureDimension2D`, when exposed.
  * @returns A user-facing error message when invalid, otherwise `null`.
  */
 export function validateWebGPUTextureDimension(

--- a/packages/blit386/src/utils/Rng.ts
+++ b/packages/blit386/src/utils/Rng.ts
@@ -2,7 +2,7 @@
  * Minimal deterministic pseudo-random number generator (mulberry32), used by the audio
  * synthesis engine so identical seeds always produce identical noise output.
  *
- * Internal utility only - not exposed on the public `BT` namespace.
+ * Internal utility only – not exposed on the public `BT` namespace.
  */
 export class Rng {
     /** Internal 32-bit generator state, mutated on every {@link next} call. */
@@ -11,7 +11,7 @@ export class Rng {
     /**
      * Creates a PRNG seeded deterministically from `seed`.
      *
-     * @param seed - Any finite number; only its lower 32 bits affect the sequence.
+     * @param seed – Any finite number; only its lower 32 bits affect the sequence.
      */
     constructor(seed: number) {
         this.state = seed >>> 0;
@@ -36,8 +36,8 @@ export class Rng {
     /**
      * Returns the next pseudo-random float within a range.
      *
-     * @param min - Inclusive lower bound.
-     * @param max - Exclusive upper bound.
+     * @param min – Inclusive lower bound.
+     * @param max – Exclusive upper bound.
      * @returns Next value in the deterministic sequence, in [min, max).
      */
     nextRange(min: number, max: number): number {
@@ -47,8 +47,8 @@ export class Rng {
     /**
      * Returns the next pseudo-random whole number within an inclusive range.
      *
-     * @param min - Inclusive lower bound.
-     * @param max - Inclusive upper bound.
+     * @param min – Inclusive lower bound.
+     * @param max – Inclusive upper bound.
      * @returns Next whole number in the deterministic sequence, in [min, max].
      */
     nextInt(min: number, max: number): number {

--- a/packages/blit386/src/utils/SimplexNoise.ts
+++ b/packages/blit386/src/utils/SimplexNoise.ts
@@ -49,7 +49,7 @@ export class SimplexNoise {
     /**
      * Creates a simplex-noise sampler. Omit `seed` to use `0` (same default as coordinate hashes).
      *
-     * @param seed - Any finite number; only its lower 32 bits affect the field.
+     * @param seed – Any finite number; only its lower 32 bits affect the field.
      * @since 1.5.0
      */
     public constructor(seed = 0) {
@@ -59,7 +59,7 @@ export class SimplexNoise {
     /**
      * Reseeds the noise field. Same seed restarts the same spatial pattern.
      *
-     * @param seed - Any finite number; only its lower 32 bits are used.
+     * @param seed – Any finite number; only its lower 32 bits are used.
      * @since 1.5.0
      */
     public seed(seed: number): void {
@@ -69,8 +69,8 @@ export class SimplexNoise {
     /**
      * Samples 2D simplex noise at `(x, y)`.
      *
-     * @param x - Continuous world X.
-     * @param y - Continuous world Y.
+     * @param x – Continuous world X.
+     * @param y – Continuous world Y.
      * @returns Smooth value in approximately `[-1, 1]`.
      * @since 1.5.0
      */
@@ -130,9 +130,9 @@ export class SimplexNoise {
     /**
      * Samples 3D simplex noise at `(x, y, z)`.
      *
-     * @param x - Continuous world X.
-     * @param y - Continuous world Y.
-     * @param z - Continuous world Z.
+     * @param x – Continuous world X.
+     * @param y – Continuous world Y.
+     * @param z – Continuous world Z.
      * @returns Smooth value in approximately `[-1, 1]`.
      * @since 1.5.0
      */
@@ -249,11 +249,11 @@ export class SimplexNoise {
     /**
      * Fractal Brownian motion over {@link noise2D}.
      *
-     * @param x - Continuous world X.
-     * @param y - Continuous world Y.
-     * @param octaves - Octave count (default `4`; floored, at least 1).
-     * @param persistence - Amplitude falloff per octave (default `0.5`).
-     * @param lacunarity - Frequency scale per octave (default `2`).
+     * @param x – Continuous world X.
+     * @param y – Continuous world Y.
+     * @param octaves – Octave count (default `4`; floored, at least 1).
+     * @param persistence – Amplitude falloff per octave (default `0.5`).
+     * @param lacunarity – Frequency scale per octave (default `2`).
      * @returns Normalized fBm in approximately `[-1, 1]`.
      * @since 1.5.0
      */
@@ -270,12 +270,12 @@ export class SimplexNoise {
     /**
      * Fractal Brownian motion over {@link noise3D}.
      *
-     * @param x - Continuous world X.
-     * @param y - Continuous world Y.
-     * @param z - Continuous world Z.
-     * @param octaves - Octave count (default `4`; floored, at least 1).
-     * @param persistence - Amplitude falloff per octave (default `0.5`).
-     * @param lacunarity - Frequency scale per octave (default `2`).
+     * @param x – Continuous world X.
+     * @param y – Continuous world Y.
+     * @param z – Continuous world Z.
+     * @param octaves – Octave count (default `4`; floored, at least 1).
+     * @param persistence – Amplitude falloff per octave (default `0.5`).
+     * @param lacunarity – Frequency scale per octave (default `2`).
      * @returns Normalized fBm in approximately `[-1, 1]`.
      * @since 1.5.0
      */

--- a/packages/blit386/src/utils/Timer.test.ts
+++ b/packages/blit386/src/utils/Timer.test.ts
@@ -74,7 +74,7 @@ describe('Timer', () => {
             // Advance well past the interval so lastFiredTick is 1000.
             expect(timer.fireIfElapsed(1000)).toBe(true);
 
-            // Hard rewind to 0 - without the guard the timer would lock until tick 1005.
+            // Hard rewind to 0 – without the guard the timer would lock until tick 1005.
             expect(timer.fireIfElapsed(0)).toBe(false); // rewind detected, baseline reset to 0
 
             // Should now fire exactly intervalTicks later.

--- a/packages/blit386/src/utils/Timer.ts
+++ b/packages/blit386/src/utils/Timer.ts
@@ -22,7 +22,7 @@ export class Timer {
     /**
      * Creates a timer that fires once per fixed-tick interval.
      *
-     * @param intervalTicks - Number of ticks required between firings; must be a positive integer.
+     * @param intervalTicks – Number of ticks required between firings; must be a positive integer.
      */
     public constructor(intervalTicks: number) {
         if (!Number.isInteger(intervalTicks) || intervalTicks <= 0) {
@@ -36,7 +36,7 @@ export class Timer {
     /**
      * Returns true once per interval and advances the internal last-fired tick.
      *
-     * @param currentTick - Tick to evaluate against; defaults to engine tick counter.
+     * @param currentTick – Tick to evaluate against; defaults to engine tick counter.
      * @returns True when at least `intervalTicks` have elapsed since the last fire/reset.
      */
     public fireIfElapsed(currentTick: number = BTAPI.instance.getTicks()): boolean {
@@ -57,7 +57,7 @@ export class Timer {
      * Backward-compatible alias for {@link fireIfElapsed}.
      *
      * @deprecated Deprecated since 1.0.3 (2026-05-31). Use {@link fireIfElapsed} instead.
-     * @param currentTick - Tick to evaluate against; defaults to engine tick counter.
+     * @param currentTick – Tick to evaluate against; defaults to engine tick counter.
      * @returns True when at least `intervalTicks` have elapsed since the last fire/reset.
      */
     public tick(currentTick: number = BTAPI.instance.getTicks()): boolean {
@@ -67,7 +67,7 @@ export class Timer {
     /**
      * Resets the timer baseline to a tick value.
      *
-     * @param currentTick - Tick to reset against; defaults to engine tick counter.
+     * @param currentTick – Tick to reset against; defaults to engine tick counter.
      */
     public reset(currentTick: number = BTAPI.instance.getTicks()): void {
         this.lastFiredTick = currentTick;
@@ -76,7 +76,7 @@ export class Timer {
     /**
      * Returns ticks elapsed since this timer last fired or reset.
      *
-     * @param currentTick - Tick to compare against; defaults to engine tick counter.
+     * @param currentTick – Tick to compare against; defaults to engine tick counter.
      * @returns Number of elapsed ticks.
      */
     public elapsedTicks(currentTick: number = BTAPI.instance.getTicks()): number {
@@ -86,7 +86,7 @@ export class Timer {
     /**
      * Returns ticks remaining until the timer will fire.
      *
-     * @param currentTick - Tick to compare against; defaults to engine tick counter.
+     * @param currentTick – Tick to compare against; defaults to engine tick counter.
      * @returns Remaining ticks in `[0, intervalTicks]`.
      */
     public remainingTicks(currentTick: number = BTAPI.instance.getTicks()): number {

--- a/packages/blit386/src/utils/ValueNoise.ts
+++ b/packages/blit386/src/utils/ValueNoise.ts
@@ -33,7 +33,7 @@ export class ValueNoise {
     /**
      * Creates a value-noise sampler. Omit `seed` to use `0` (same default as coordinate hashes).
      *
-     * @param seed - Any finite number; only its lower 32 bits affect the field.
+     * @param seed – Any finite number; only its lower 32 bits affect the field.
      * @since 1.5.0
      */
     public constructor(seed = 0) {
@@ -43,7 +43,7 @@ export class ValueNoise {
     /**
      * Reseeds the noise field. Same seed restarts the same spatial pattern.
      *
-     * @param seed - Any finite number; only its lower 32 bits are used.
+     * @param seed – Any finite number; only its lower 32 bits are used.
      * @since 1.5.0
      */
     public seed(seed: number): void {
@@ -53,7 +53,7 @@ export class ValueNoise {
     /**
      * Samples 1D value noise at `x`.
      *
-     * @param x - Continuous world coordinate.
+     * @param x – Continuous world coordinate.
      * @returns Smooth value in `[-1, 1]`.
      * @since 1.5.0
      */
@@ -70,8 +70,8 @@ export class ValueNoise {
     /**
      * Samples 2D value noise at `(x, y)`.
      *
-     * @param x - Continuous world X.
-     * @param y - Continuous world Y.
+     * @param x – Continuous world X.
+     * @param y – Continuous world Y.
      * @returns Smooth value in `[-1, 1]`.
      * @since 1.5.0
      */
@@ -95,9 +95,9 @@ export class ValueNoise {
     /**
      * Samples 3D value noise at `(x, y, z)`.
      *
-     * @param x - Continuous world X.
-     * @param y - Continuous world Y.
-     * @param z - Continuous world Z.
+     * @param x – Continuous world X.
+     * @param y – Continuous world Y.
+     * @param z – Continuous world Z.
      * @returns Smooth value in `[-1, 1]`.
      * @since 1.5.0
      */
@@ -133,10 +133,10 @@ export class ValueNoise {
     /**
      * Fractal Brownian motion over {@link noise1D}.
      *
-     * @param x - Continuous world coordinate.
-     * @param octaves - Octave count (default `4`; floored, at least 1).
-     * @param persistence - Amplitude falloff per octave (default `0.5`).
-     * @param lacunarity - Frequency scale per octave (default `2`).
+     * @param x – Continuous world coordinate.
+     * @param octaves – Octave count (default `4`; floored, at least 1).
+     * @param persistence – Amplitude falloff per octave (default `0.5`).
+     * @param lacunarity – Frequency scale per octave (default `2`).
      * @returns Normalized fBm in approximately `[-1, 1]`.
      * @since 1.5.0
      */
@@ -152,11 +152,11 @@ export class ValueNoise {
     /**
      * Fractal Brownian motion over {@link noise2D}.
      *
-     * @param x - Continuous world X.
-     * @param y - Continuous world Y.
-     * @param octaves - Octave count (default `4`; floored, at least 1).
-     * @param persistence - Amplitude falloff per octave (default `0.5`).
-     * @param lacunarity - Frequency scale per octave (default `2`).
+     * @param x – Continuous world X.
+     * @param y – Continuous world Y.
+     * @param octaves – Octave count (default `4`; floored, at least 1).
+     * @param persistence – Amplitude falloff per octave (default `0.5`).
+     * @param lacunarity – Frequency scale per octave (default `2`).
      * @returns Normalized fBm in approximately `[-1, 1]`.
      * @since 1.5.0
      */
@@ -173,12 +173,12 @@ export class ValueNoise {
     /**
      * Fractal Brownian motion over {@link noise3D}.
      *
-     * @param x - Continuous world X.
-     * @param y - Continuous world Y.
-     * @param z - Continuous world Z.
-     * @param octaves - Octave count (default `4`; floored, at least 1).
-     * @param persistence - Amplitude falloff per octave (default `0.5`).
-     * @param lacunarity - Frequency scale per octave (default `2`).
+     * @param x – Continuous world X.
+     * @param y – Continuous world Y.
+     * @param z – Continuous world Z.
+     * @param octaves – Octave count (default `4`; floored, at least 1).
+     * @param persistence – Amplitude falloff per octave (default `0.5`).
+     * @param lacunarity – Frequency scale per octave (default `2`).
      * @returns Normalized fBm in approximately `[-1, 1]`.
      * @since 1.5.0
      */

--- a/packages/blit386/src/utils/Vector2i.bench.ts
+++ b/packages/blit386/src/utils/Vector2i.bench.ts
@@ -21,9 +21,9 @@ const BENCH_OPTIONS = {
 /**
  * Restores a mutable vector to a known baseline before in-place benchmarks.
  *
- * @param vector - Vector to reset.
- * @param x - X component to assign.
- * @param y - Y component to assign.
+ * @param vector – Vector to reset.
+ * @param x – X component to assign.
+ * @param y – Y component to assign.
  */
 function resetVector(vector: Vector2i, x: number, y: number): void {
     vector.x = x;

--- a/packages/blit386/src/utils/Vector2i.ts
+++ b/packages/blit386/src/utils/Vector2i.ts
@@ -29,8 +29,8 @@ export class Vector2i {
     /**
      * Creates an integer 2D vector, truncating inputs toward zero.
      *
-     * @param x - Horizontal component (defaults to 0).
-     * @param y - Vertical component (defaults to 0).
+     * @param x – Horizontal component (defaults to 0).
+     * @param y – Vertical component (defaults to 0).
      */
     constructor(
         /** Horizontal component (defaults to 0). */
@@ -56,7 +56,7 @@ export class Vector2i {
     /**
      * Sets width (x component), truncated to integer.
      *
-     * @param value - The new width value.
+     * @param value – The new width value.
      */
     set width(value: number) {
         this.x = value | 0;
@@ -73,7 +73,7 @@ export class Vector2i {
     /**
      * Sets height (y component), truncated to integer.
      *
-     * @param value - The new height value.
+     * @param value – The new height value.
      */
     set height(value: number) {
         this.y = value | 0;
@@ -81,7 +81,7 @@ export class Vector2i {
 
     /**
      * Returns a zero vector (0, 0).
-     * Returns a cached frozen singleton - do not modify.
+     * Returns a cached frozen singleton – do not modify.
      *
      * @returns Vector at origin (cached).
      */
@@ -91,7 +91,7 @@ export class Vector2i {
 
     /**
      * Returns a unit vector (1, 1).
-     * Returns a cached frozen singleton - do not modify.
+     * Returns a cached frozen singleton – do not modify.
      *
      * @returns Vector with both components set to 1 (cached).
      */
@@ -102,7 +102,7 @@ export class Vector2i {
     /**
      * Returns an up direction vector (0, -1).
      * In screen coordinates, Y increases downward, so up is negative.
-     * Returns a cached frozen singleton - do not modify.
+     * Returns a cached frozen singleton – do not modify.
      *
      * @returns Vector pointing up (cached).
      */
@@ -112,7 +112,7 @@ export class Vector2i {
 
     /**
      * Returns a down direction vector (0, 1).
-     * Returns a cached frozen singleton - do not modify.
+     * Returns a cached frozen singleton – do not modify.
      *
      * @returns Vector pointing down (cached).
      */
@@ -122,7 +122,7 @@ export class Vector2i {
 
     /**
      * Returns a left-direction vector (-1, 0).
-     * Returns a cached frozen singleton - do not modify.
+     * Returns a cached frozen singleton – do not modify.
      *
      * @returns Vector pointing left (cached).
      */
@@ -132,7 +132,7 @@ export class Vector2i {
 
     /**
      * Returns a right-direction vector (1, 0).
-     * Returns a cached frozen singleton - do not modify.
+     * Returns a cached frozen singleton – do not modify.
      *
      * @returns Vector pointing right (cached).
      */
@@ -144,8 +144,8 @@ export class Vector2i {
      * Creates a Vector2i from integer values without truncation.
      * Used internally in hot paths where values are guaranteed to be integers.
      *
-     * @param x - Horizontal component (must be integer).
-     * @param y - Vertical component (must be integer).
+     * @param x – Horizontal component (must be integer).
+     * @param y – Vertical component (must be integer).
      * @returns New Vector2i with the specified values.
      */
     public static fromXYUnchecked(x: number, y: number): Vector2i {
@@ -163,8 +163,8 @@ export class Vector2i {
      *
      * Note: |0 truncates toward zero (e.g., -1.7 becomes -1, not -2).
      *
-     * @param x - Floating-point x coordinate.
-     * @param y - Floating-point y coordinate.
+     * @param x – Floating-point x coordinate.
+     * @param y – Floating-point y coordinate.
      * @returns New integer vector.
      */
     static fromFloat(x: number, y: number): Vector2i {
@@ -174,8 +174,8 @@ export class Vector2i {
     /**
      * Calculates distance between two vectors.
      *
-     * @param a - First vector.
-     * @param b - Second vector.
+     * @param a – First vector.
+     * @param b – Second vector.
      * @returns Euclidean distance between a and b.
      */
     static distance(a: Vector2i, b: Vector2i): number {
@@ -189,8 +189,8 @@ export class Vector2i {
      * Calculates squared distance between two vectors.
      * Avoids the sqrt for performance.
      *
-     * @param a - First vector.
-     * @param b - Second vector.
+     * @param a – First vector.
+     * @param b – Second vector.
      * @returns Squared distance between a and b.
      */
     static sqrDistance(a: Vector2i, b: Vector2i): number {
@@ -202,10 +202,10 @@ export class Vector2i {
 
     /**
      * Calculates dot product of two vectors.
-     * The static version - use instance method a.dot(b) when you have vector instances.
+     * The static version – use instance method a.dot(b) when you have vector instances.
      *
-     * @param a - First vector.
-     * @param b - Second vector.
+     * @param a – First vector.
+     * @param b – Second vector.
      * @returns Scalar dot product.
      */
     static dotProduct(a: Vector2i, b: Vector2i): number {
@@ -216,9 +216,9 @@ export class Vector2i {
      * Linearly interpolates between two vectors.
      * Result is truncated to integers. t is clamped to [0, 1].
      *
-     * @param a - Start vector.
-     * @param b - End vector.
-     * @param t - Interpolation factor, clamped to [0, 1] (0 = a, 1 = b).
+     * @param a – Start vector.
+     * @param b – End vector.
+     * @param t – Interpolation factor, clamped to [0, 1] (0 = a, 1 = b).
      * @returns New interpolated vector.
      */
     static lerp(a: Vector2i, b: Vector2i, t: number): Vector2i {
@@ -231,10 +231,10 @@ export class Vector2i {
      * Linearly interpolates between two vectors and writes to the existing vector.
      * Zero allocation alternative to lerp(). t is clamped to [0, 1].
      *
-     * @param a - Start vector.
-     * @param b - End vector.
-     * @param t - Interpolation factor, clamped to [0, 1] (0 = a, 1 = b).
-     * @param out - Vector to write the result to.
+     * @param a – Start vector.
+     * @param b – End vector.
+     * @param t – Interpolation factor, clamped to [0, 1] (0 = a, 1 = b).
+     * @param out – Vector to write the result to.
      * @returns The out vector for chaining.
      */
     static lerpTo(a: Vector2i, b: Vector2i, t: number, out: Vector2i): Vector2i {
@@ -249,7 +249,7 @@ export class Vector2i {
     /**
      * Adds another vector and returns the result as a new vector.
      *
-     * @param other - Vector to add.
+     * @param other – Vector to add.
      * @returns New vector with summed components.
      */
     add(other: Vector2i): Vector2i {
@@ -260,8 +260,8 @@ export class Vector2i {
     /**
      * Adds raw `x` and `y` offsets and returns the result as a new vector.
      *
-     * @param x - X offset to add.
-     * @param y - Y offset to add.
+     * @param x – X offset to add.
+     * @param y – Y offset to add.
      * @returns New vector with summed components.
      */
     addXY(x: number, y: number): Vector2i {
@@ -272,30 +272,30 @@ export class Vector2i {
     /**
      * Subtracts another vector and returns the result as a new vector.
      *
-     * @param other - Vector to subtract.
+     * @param other – Vector to subtract.
      * @returns New vector with difference of components.
      */
     sub(other: Vector2i): Vector2i {
-        // Integer - integer = integer, use unchecked.
+        // Integer – integer = integer, use unchecked.
         return Vector2i.fromXYUnchecked(this.x - other.x, this.y - other.y);
     }
 
     /**
      * Subtracts raw `x` and `y` offsets and returns the result as a new vector.
      *
-     * @param x - X offset to subtract.
-     * @param y - Y offset to subtract.
+     * @param x – X offset to subtract.
+     * @param y – Y offset to subtract.
      * @returns New vector with difference of components.
      */
     subXY(x: number, y: number): Vector2i {
-        // Integer - integer = integer, use unchecked.
+        // Integer – integer = integer, use unchecked.
         return Vector2i.fromXYUnchecked(this.x - (x | 0), this.y - (y | 0));
     }
 
     /**
      * Multiplies both components by a scalar and returns a new vector.
      *
-     * @param scalar - Value to multiply both components by.
+     * @param scalar – Value to multiply both components by.
      * @returns New vector with scaled components.
      */
     mul(scalar: number): Vector2i {
@@ -305,7 +305,7 @@ export class Vector2i {
     /**
      * Performs component-wise multiplication with another vector.
      *
-     * @param other - Vector to multiply with.
+     * @param other – Vector to multiply with.
      * @returns New vector with multiplied components.
      */
     mulVec(other: Vector2i): Vector2i {
@@ -316,7 +316,7 @@ export class Vector2i {
     /**
      * Divides both components by a scalar and truncates toward zero.
      *
-     * @param scalar - Value to divide both components by.
+     * @param scalar – Value to divide both components by.
      * @returns New vector with divided and truncated components.
      * @throws Error if scalar is zero.
      */
@@ -349,7 +349,7 @@ export class Vector2i {
     /**
      * Returns the component-wise minimum of this vector and another.
      *
-     * @param other - Vector to compare with.
+     * @param other – Vector to compare with.
      * @returns New vector with minimum components.
      */
     min(other: Vector2i): Vector2i {
@@ -359,7 +359,7 @@ export class Vector2i {
     /**
      * Returns the component-wise maximum of this vector and another.
      *
-     * @param other - Vector to compare with.
+     * @param other – Vector to compare with.
      * @returns New vector with maximum components.
      */
     max(other: Vector2i): Vector2i {
@@ -369,8 +369,8 @@ export class Vector2i {
     /**
      * Clamps both components into a numeric range.
      *
-     * @param minVal - Minimum value for both components.
-     * @param maxVal - Maximum value for both components.
+     * @param minVal – Minimum value for both components.
+     * @param maxVal – Maximum value for both components.
      * @returns New vector with clamped components.
      */
     clamp(minVal: number, maxVal: number): Vector2i {
@@ -383,8 +383,8 @@ export class Vector2i {
     /**
      * Clamps both components into per-axis vector bounds.
      *
-     * @param minVec - Vector with minimum values.
-     * @param maxVec - Vector with maximum values.
+     * @param minVec – Vector with minimum values.
+     * @param maxVec – Vector with maximum values.
      * @returns New vector with clamped components.
      */
     clampVec(minVec: Vector2i, maxVec: Vector2i): Vector2i {
@@ -397,7 +397,7 @@ export class Vector2i {
     /**
      * Calculates the dot product with another vector.
      *
-     * @param other - Vector to dot with.
+     * @param other – Vector to dot with.
      * @returns Scalar dot product.
      */
     dot(other: Vector2i): number {
@@ -409,7 +409,7 @@ export class Vector2i {
      * Returns the z-component of the 3D cross-product if vectors were in XY plane.
      * Useful for determining which side of a line a point is on.
      *
-     * @param other - Vector to cross with.
+     * @param other – Vector to cross with.
      * @returns Scalar cross-product (positive = other is counter-clockwise from this).
      */
     cross(other: Vector2i): number {
@@ -438,8 +438,8 @@ export class Vector2i {
      * Adds another vector and writes the result to an existing vector.
      * Zero allocation alternative to add().
      *
-     * @param other - Vector to add.
-     * @param out - Vector to write the result to.
+     * @param other – Vector to add.
+     * @param out – Vector to write the result to.
      * @returns The out vector for chaining.
      */
     addTo(other: Vector2i, out: Vector2i): Vector2i {
@@ -453,8 +453,8 @@ export class Vector2i {
      * Subtracts another vector and writes the result to an existing vector.
      * Zero allocation alternative to sub().
      *
-     * @param other - Vector to subtract.
-     * @param out - Vector to write the result to.
+     * @param other – Vector to subtract.
+     * @param out – Vector to write the result to.
      * @returns The out vector for chaining.
      */
     subTo(other: Vector2i, out: Vector2i): Vector2i {
@@ -468,8 +468,8 @@ export class Vector2i {
      * Multiplies by scalar and writes the result to an existing vector.
      * Zero allocation alternative to mul().
      *
-     * @param scalar - Value to multiply by.
-     * @param out - Vector to write the result to.
+     * @param scalar – Value to multiply by.
+     * @param out – Vector to write the result to.
      * @returns The out vector for chaining.
      */
     mulTo(scalar: number, out: Vector2i): Vector2i {
@@ -483,8 +483,8 @@ export class Vector2i {
      * Divides by scalar and writes the result to an existing vector.
      * Zero allocation alternative to div().
      *
-     * @param scalar - Value to divide by.
-     * @param out - Vector to write the result to.
+     * @param scalar – Value to divide by.
+     * @param out – Vector to write the result to.
      * @returns The out vector for chaining.
      * @throws Error if scalar is zero.
      */
@@ -503,7 +503,7 @@ export class Vector2i {
      * Copies this vector's values to an existing vector.
      * Zero allocation alternative to clone().
      *
-     * @param out - Vector to write to.
+     * @param out – Vector to write to.
      * @returns The out vector for chaining.
      */
     cloneTo(out: Vector2i): Vector2i {
@@ -517,7 +517,7 @@ export class Vector2i {
      * Writes negated values to an existing vector.
      * Zero allocation alternative to negate().
      *
-     * @param out - Vector to write to.
+     * @param out – Vector to write to.
      * @returns The out vector for chaining.
      */
     negateTo(out: Vector2i): Vector2i {
@@ -531,7 +531,7 @@ export class Vector2i {
      * Writes absolute values to an existing vector.
      * Zero allocation alternative to abs().
      *
-     * @param out - Vector to write to.
+     * @param out – Vector to write to.
      * @returns The out vector for chaining.
      */
     absTo(out: Vector2i): Vector2i {
@@ -545,8 +545,8 @@ export class Vector2i {
      * Writes component-wise minimum to an existing vector.
      * Zero allocation alternative to min().
      *
-     * @param other - Vector to compare with.
-     * @param out - Vector to write to.
+     * @param other – Vector to compare with.
+     * @param out – Vector to write to.
      * @returns The out vector for chaining.
      */
     minTo(other: Vector2i, out: Vector2i): Vector2i {
@@ -560,8 +560,8 @@ export class Vector2i {
      * Writes component-wise maximum to an existing vector.
      * Zero allocation alternative to max().
      *
-     * @param other - Vector to compare with.
-     * @param out - Vector to write to.
+     * @param other – Vector to compare with.
+     * @param out – Vector to write to.
      * @returns The out vector for chaining.
      */
     maxTo(other: Vector2i, out: Vector2i): Vector2i {
@@ -575,9 +575,9 @@ export class Vector2i {
      * Writes clamped values to an existing vector.
      * Zero allocation alternative to clamp().
      *
-     * @param minVal - Minimum value for both components.
-     * @param maxVal - Maximum value for both components.
-     * @param out - Vector to write to.
+     * @param minVal – Minimum value for both components.
+     * @param maxVal – Maximum value for both components.
+     * @param out – Vector to write to.
      * @returns The out vector for chaining.
      */
     clampTo(minVal: number, maxVal: number, out: Vector2i): Vector2i {
@@ -596,7 +596,7 @@ export class Vector2i {
      *
      * WARNING: Mutates this vector. Don't use on frozen/cached singletons.
      *
-     * @param other - Vector to add.
+     * @param other – Vector to add.
      * @returns This vector for chaining.
      */
     addInPlace(other: Vector2i): this {
@@ -612,8 +612,8 @@ export class Vector2i {
      *
      * WARNING: Mutates this vector. Don't use on frozen/cached singletons.
      *
-     * @param x - X offset to add.
-     * @param y - Y offset to add.
+     * @param x – X offset to add.
+     * @param y – Y offset to add.
      * @returns This vector for chaining.
      */
     addXYInPlace(x: number, y: number): this {
@@ -629,7 +629,7 @@ export class Vector2i {
      *
      * WARNING: Mutates this vector. Don't use on frozen/cached singletons.
      *
-     * @param other - Vector to subtract.
+     * @param other – Vector to subtract.
      * @returns This vector for chaining.
      */
     subInPlace(other: Vector2i): this {
@@ -645,8 +645,8 @@ export class Vector2i {
      *
      * WARNING: Mutates this vector. Don't use on frozen/cached singletons.
      *
-     * @param x - X offset to subtract.
-     * @param y - Y offset to subtract.
+     * @param x – X offset to subtract.
+     * @param y – Y offset to subtract.
      * @returns This vector for chaining.
      */
     subXYInPlace(x: number, y: number): this {
@@ -662,7 +662,7 @@ export class Vector2i {
      *
      * WARNING: Mutates this vector. Don't use on frozen/cached singletons.
      *
-     * @param scalar - Value to multiply both components by.
+     * @param scalar – Value to multiply both components by.
      * @returns This vector for chaining.
      */
     mulInPlace(scalar: number): this {
@@ -678,7 +678,7 @@ export class Vector2i {
      *
      * WARNING: Mutates this vector. Don't use on frozen/cached singletons.
      *
-     * @param other - Vector to multiply with.
+     * @param other – Vector to multiply with.
      * @returns This vector for chaining.
      */
     mulVecInPlace(other: Vector2i): this {
@@ -694,7 +694,7 @@ export class Vector2i {
      *
      * WARNING: Mutates this vector. Don't use on frozen/cached singletons.
      *
-     * @param scalar - Value to divide both components by.
+     * @param scalar – Value to divide both components by.
      * @returns This vector for chaining.
      * @throws Error if scalar is zero.
      */
@@ -745,7 +745,7 @@ export class Vector2i {
      *
      * WARNING: Mutates this vector. Don't use on frozen/cached singletons.
      *
-     * @param other - Vector to compare with.
+     * @param other – Vector to compare with.
      * @returns This vector for chaining.
      */
     minInPlace(other: Vector2i): this {
@@ -761,7 +761,7 @@ export class Vector2i {
      *
      * WARNING: Mutates this vector. Don't use on frozen/cached singletons.
      *
-     * @param other - Vector to compare with.
+     * @param other – Vector to compare with.
      * @returns This vector for chaining.
      */
     maxInPlace(other: Vector2i): this {
@@ -777,8 +777,8 @@ export class Vector2i {
      *
      * WARNING: Mutates this vector. Don't use on frozen/cached singletons.
      *
-     * @param minVal - Minimum value for both components.
-     * @param maxVal - Maximum value for both components.
+     * @param minVal – Minimum value for both components.
+     * @param maxVal – Maximum value for both components.
      * @returns This vector for chaining.
      */
     clampInPlace(minVal: number, maxVal: number): this {
@@ -797,8 +797,8 @@ export class Vector2i {
      *
      * WARNING: Mutates this vector. Don't use on frozen/cached singletons.
      *
-     * @param minVec - Vector with minimum values.
-     * @param maxVec - Vector with maximum values.
+     * @param minVec – Vector with minimum values.
+     * @param maxVec – Vector with maximum values.
      * @returns This vector for chaining.
      */
     clampVecInPlace(minVec: Vector2i, maxVec: Vector2i): this {
@@ -814,8 +814,8 @@ export class Vector2i {
      *
      * WARNING: Mutates this vector. Don't use on frozen/cached singletons.
      *
-     * @param x - New x component.
-     * @param y - New y component.
+     * @param x – New x component.
+     * @param y – New y component.
      * @returns This vector for chaining.
      */
     set(x: number, y: number): this {
@@ -831,7 +831,7 @@ export class Vector2i {
      *
      * WARNING: Mutates this vector. Don't use on frozen/cached singletons.
      *
-     * @param other - Vector to copy from.
+     * @param other – Vector to copy from.
      * @returns This vector for chaining.
      */
     copyFrom(other: Vector2i): this {
@@ -863,7 +863,7 @@ export class Vector2i {
     /**
      * Calculates the Euclidean distance to another vector.
      *
-     * @param other - Target vector.
+     * @param other – Target vector.
      * @returns Distance between this and other.
      */
     distanceTo(other: Vector2i): number {
@@ -877,8 +877,8 @@ export class Vector2i {
      * Calculates the Euclidean distance to raw coordinates.
      * Avoids creating a temporary Vector2i.
      *
-     * @param x - Target X coordinate.
-     * @param y - Target Y coordinate.
+     * @param x – Target X coordinate.
+     * @param y – Target Y coordinate.
      * @returns Distance between this and the point.
      */
     distanceToXY(x: number, y: number): number {
@@ -892,7 +892,7 @@ export class Vector2i {
      * Calculates the squared distance to another vector.
      * Avoids the sqrt for performance. Useful for distance comparisons.
      *
-     * @param other - Target vector.
+     * @param other – Target vector.
      * @returns Squared distance between this and other.
      */
     sqrDistanceTo(other: Vector2i): number {
@@ -906,8 +906,8 @@ export class Vector2i {
      * Calculates the squared distance to raw coordinates.
      * Avoids the sqrt and temporary Vector2i allocation.
      *
-     * @param x - Target X coordinate.
-     * @param y - Target Y coordinate.
+     * @param x – Target X coordinate.
+     * @param y – Target Y coordinate.
      * @returns Squared distance between this and the point.
      */
     sqrDistanceToXY(x: number, y: number): number {
@@ -921,7 +921,7 @@ export class Vector2i {
      * Calculates the Manhattan (taxicab) distance to another vector.
      * Useful for tile-based movement costs.
      *
-     * @param other - Target vector.
+     * @param other – Target vector.
      * @returns Manhattan distance (|dx| + |dy|).
      */
     manhattanDistanceTo(other: Vector2i): number {
@@ -932,8 +932,8 @@ export class Vector2i {
      * Calculates the Manhattan distance to raw coordinates.
      * Avoids creating a temporary Vector2i.
      *
-     * @param x - Target X coordinate.
-     * @param y - Target Y coordinate.
+     * @param x – Target X coordinate.
+     * @param y – Target Y coordinate.
      * @returns Manhattan distance (|dx| + |dy|).
      */
     manhattanDistanceToXY(x: number, y: number): number {
@@ -944,7 +944,7 @@ export class Vector2i {
      * Calculates the Chebyshev distance to another vector.
      * Useful for 8-directional movement (king's move in chess).
      *
-     * @param other - Target vector.
+     * @param other – Target vector.
      * @returns Chebyshev distance max(|dx|, |dy|).
      */
     chebyshevDistanceTo(other: Vector2i): number {
@@ -955,8 +955,8 @@ export class Vector2i {
      * Calculates the Chebyshev distance to raw coordinates.
      * Avoids creating a temporary Vector2i.
      *
-     * @param x - Target X coordinate.
-     * @param y - Target Y coordinate.
+     * @param x – Target X coordinate.
+     * @param y – Target Y coordinate.
      * @returns Chebyshev distance max(|dx|, |dy|).
      */
     chebyshevDistanceToXY(x: number, y: number): number {
@@ -990,7 +990,7 @@ export class Vector2i {
     /**
      * Checks if this vector equals another vector component-wise.
      *
-     * @param other - Vector to compare with.
+     * @param other – Vector to compare with.
      * @returns True if both x and y components are equal.
      */
     isEqual(other: Vector2i): boolean {
@@ -1001,7 +1001,7 @@ export class Vector2i {
      * Backward-compatible alias for {@link isEqual}.
      *
      * @deprecated Deprecated since 0.1.0 (2026-05-31). Use {@link isEqual} instead.
-     * @param other - Vector to compare with.
+     * @param other – Vector to compare with.
      * @returns True if both x and y components are equal.
      */
     equals(other: Vector2i): boolean {
@@ -1012,8 +1012,8 @@ export class Vector2i {
      * Checks if this vector equals raw coordinates.
      * Avoids creating a temporary Vector2i for comparison.
      *
-     * @param x - X coordinate to compare.
-     * @param y - Y coordinate to compare.
+     * @param x – X coordinate to compare.
+     * @param y – Y coordinate to compare.
      * @returns True if components match the given coordinates.
      */
     isEqualXY(x: number, y: number): boolean {

--- a/packages/blit386/src/utils/devMode.ts
+++ b/packages/blit386/src/utils/devMode.ts
@@ -39,7 +39,7 @@ export interface DevModeSignals {
  * Resolves dev vs. release from already-gathered signals, in priority order: explicit
  * override, then the runtime dev global, then hot-reload activity, otherwise release.
  *
- * @param signals - See {@link DevModeSignals}.
+ * @param signals – See {@link DevModeSignals}.
  * @returns `true` for a dev build, `false` for release.
  */
 export function resolveDevMode(signals: DevModeSignals): boolean {
@@ -58,7 +58,7 @@ export function resolveDevMode(signals: DevModeSignals): boolean {
  * Reports whether this is a development build, gathering signals from `globalThis` (never a
  * bare `window` reference).
  *
- * @param override - Explicit override, if a caller offers one; always wins when defined.
+ * @param override – Explicit override, if a caller offers one; always wins when defined.
  * @returns `true` for a dev build, `false` for release.
  */
 export function isDevMode(override?: boolean): boolean {

--- a/packages/blit386/src/utils/errorMessages.ts
+++ b/packages/blit386/src/utils/errorMessages.ts
@@ -11,7 +11,7 @@ import { buildPathHint, extractExtension } from './urlHints';
 /**
  * Returns the canvas-not-found error message for the given canvas element ID.
  *
- * @param canvasID - The canvas element ID that was searched for.
+ * @param canvasID – The canvas element ID that was searched for.
  * @returns User-facing error string.
  */
 export function CANVAS_NOT_FOUND_MESSAGE(canvasID: string): string {
@@ -56,8 +56,8 @@ export const OVERLAY_NO_BACKEND =
 /**
  * Returns the error message for a render dimension that is not a positive whole-number pixel size.
  *
- * @param field - Hardware settings field that contains the invalid size.
- * @param size - Invalid size formatted as `WIDTHxHEIGHT`.
+ * @param field – Hardware settings field that contains the invalid size.
+ * @param size – Invalid size formatted as `WIDTHxHEIGHT`.
  * @returns User-facing error string.
  */
 export function renderDimensionInvalidError(field: string, size: string): string {
@@ -70,10 +70,10 @@ export function renderDimensionInvalidError(field: string, size: string): string
 /**
  * Returns the error message for a render dimension whose width or height exceeds engine limits.
  *
- * @param field - Hardware settings field that contains the invalid size.
- * @param size - Invalid size formatted as `WIDTHxHEIGHT`.
- * @param maxWidth - Maximum accepted width in pixels.
- * @param maxHeight - Maximum accepted height in pixels.
+ * @param field – Hardware settings field that contains the invalid size.
+ * @param size – Invalid size formatted as `WIDTHxHEIGHT`.
+ * @param maxWidth – Maximum accepted width in pixels.
+ * @param maxHeight – Maximum accepted height in pixels.
  * @returns User-facing error string.
  */
 export function renderDimensionTooLargeError(field: string, size: string, maxWidth: number, maxHeight: number): string {
@@ -85,9 +85,9 @@ export function renderDimensionTooLargeError(field: string, size: string, maxWid
 /**
  * Returns the error message for a render dimension whose total pixel area exceeds engine limits.
  *
- * @param field - Hardware settings field that contains the invalid size.
- * @param size - Invalid size formatted as `WIDTHxHEIGHT`.
- * @param maxPixels - Maximum accepted total pixels.
+ * @param field – Hardware settings field that contains the invalid size.
+ * @param size – Invalid size formatted as `WIDTHxHEIGHT`.
+ * @param maxPixels – Maximum accepted total pixels.
  * @returns User-facing error string.
  */
 export function renderDimensionAreaTooLargeError(field: string, size: string, maxPixels: number): string {
@@ -97,9 +97,9 @@ export function renderDimensionAreaTooLargeError(field: string, size: string, ma
 /**
  * Returns the error message for a render dimension that exceeds the active WebGPU texture limit.
  *
- * @param field - Hardware settings field that contains the invalid size.
- * @param size - Invalid size formatted as `WIDTHxHEIGHT`.
- * @param maxTextureDimension2D - WebGPU adapter/device texture dimension limit.
+ * @param field – Hardware settings field that contains the invalid size.
+ * @param size – Invalid size formatted as `WIDTHxHEIGHT`.
+ * @param maxTextureDimension2D – WebGPU adapter/device texture dimension limit.
  * @returns User-facing error string.
  */
 export function renderDimensionGPULimitError(field: string, size: string, maxTextureDimension2D: number): string {
@@ -112,7 +112,7 @@ export function renderDimensionGPULimitError(field: string, size: string, maxTex
 /**
  * Returns the error message for an `audioVoices` hardware setting outside the supported range.
  *
- * @param value - Invalid `audioVoices` value.
+ * @param value – Invalid `audioVoices` value.
  * @returns User-facing error string.
  */
 export function audioVoicesRangeError(value: number): string {
@@ -125,8 +125,8 @@ export function audioVoicesRangeError(value: number): string {
 /**
  * Returns the error message for an asset whose width or height is not a positive whole number.
  *
- * @param context - Asset label (for example `'sprite sheet'`).
- * @param size - Invalid size formatted as `WIDTHxHEIGHT`.
+ * @param context – Asset label (for example `'sprite sheet'`).
+ * @param size – Invalid size formatted as `WIDTHxHEIGHT`.
  * @returns User-facing error string.
  */
 export function assetDimensionInvalidError(context: string, size: string): string {
@@ -139,10 +139,10 @@ export function assetDimensionInvalidError(context: string, size: string): strin
 /**
  * Returns the error message for an asset whose width or height exceeds engine limits.
  *
- * @param context - Asset label (for example `'sprite sheet'`).
- * @param size - Invalid size formatted as `WIDTHxHEIGHT`.
- * @param maxWidth - Maximum accepted width in pixels.
- * @param maxHeight - Maximum accepted height in pixels.
+ * @param context – Asset label (for example `'sprite sheet'`).
+ * @param size – Invalid size formatted as `WIDTHxHEIGHT`.
+ * @param maxWidth – Maximum accepted width in pixels.
+ * @param maxHeight – Maximum accepted height in pixels.
  * @returns User-facing error string.
  */
 export function assetDimensionTooLargeError(
@@ -160,9 +160,9 @@ export function assetDimensionTooLargeError(
 /**
  * Returns the error message for an asset whose total pixel area exceeds engine limits.
  *
- * @param context - Asset label (for example `'sprite sheet'`).
- * @param size - Invalid size formatted as `WIDTHxHEIGHT`.
- * @param maxPixels - Maximum accepted total pixels.
+ * @param context – Asset label (for example `'sprite sheet'`).
+ * @param size – Invalid size formatted as `WIDTHxHEIGHT`.
+ * @param maxPixels – Maximum accepted total pixels.
  * @returns User-facing error string.
  */
 export function assetDimensionAreaTooLargeError(context: string, size: string, maxPixels: number): string {
@@ -175,7 +175,7 @@ export function assetDimensionAreaTooLargeError(context: string, size: string, m
 /**
  * Returns the error message when indexed pixel dimensions overflow safe allocation limits.
  *
- * @param size - Invalid size formatted as `WIDTHxHEIGHT`.
+ * @param size – Invalid size formatted as `WIDTHxHEIGHT`.
  * @returns User-facing error string.
  */
 export function assetIndexedPixelOverflowError(size: string): string {
@@ -185,10 +185,10 @@ export function assetIndexedPixelOverflowError(size: string): string {
 /**
  * Returns the error message when an indexed pixel buffer length does not match its dimensions.
  *
- * @param actualLength - Number of values supplied in the buffer.
- * @param width - Declared width in pixels.
- * @param height - Declared height in pixels.
- * @param expectedLength - Required number of values (`width * height`).
+ * @param actualLength – Number of values supplied in the buffer.
+ * @param width – Declared width in pixels.
+ * @param height – Declared height in pixels.
+ * @param expectedLength – Required number of values (`width * height`).
  * @returns User-facing error string.
  */
 export function assetIndexedPixelLengthError(
@@ -206,8 +206,8 @@ export function assetIndexedPixelLengthError(
 /**
  * Returns the error message when a `.btfont` JSON payload is too large to parse safely.
  *
- * @param byteLength - UTF-8 byte length of the JSON text.
- * @param maxBytes - Maximum accepted JSON size in bytes.
+ * @param byteLength – UTF-8 byte length of the JSON text.
+ * @param maxBytes – Maximum accepted JSON size in bytes.
  * @returns User-facing error string.
  */
 export function btfontJsonTooLargeError(byteLength: number, maxBytes: number): string {
@@ -233,8 +233,8 @@ export function btfontEmbeddedTextureFormatError(): string {
 /**
  * Returns the error message when an embedded `.btfont` texture payload exceeds the size cap.
  *
- * @param payloadLength - Base64 payload length in characters (after the data-URI prefix).
- * @param maxPayloadBytes - Maximum accepted embedded texture payload size.
+ * @param payloadLength – Base64 payload length in characters (after the data-URI prefix).
+ * @param maxPayloadBytes – Maximum accepted embedded texture payload size.
  * @returns User-facing error string.
  */
 export function btfontEmbeddedTextureTooLargeError(payloadLength: number, maxPayloadBytes: number): string {
@@ -248,8 +248,8 @@ export function btfontEmbeddedTextureTooLargeError(payloadLength: number, maxPay
 /**
  * Returns the error message when a `.btfont` file defines too many glyphs.
  *
- * @param count - Number of glyph entries found.
- * @param maxGlyphs - Maximum accepted glyph count.
+ * @param count – Number of glyph entries found.
+ * @param maxGlyphs – Maximum accepted glyph count.
  * @returns User-facing error string.
  */
 export function btfontGlyphCountTooLargeError(count: number, maxGlyphs: number): string {
@@ -289,7 +289,7 @@ function getBtfontMetricLabel(metricKey: string): string {
 /**
  * Returns the error message when a glyph entry is not a metric object.
  *
- * @param charLabel - Character label used in the message.
+ * @param charLabel – Character label used in the message.
  * @returns User-facing error string.
  */
 export function btfontGlyphEntryNotObjectError(charLabel: string): string {
@@ -302,9 +302,9 @@ export function btfontGlyphEntryNotObjectError(charLabel: string): string {
 /**
  * Returns the error message when a glyph metric is not a whole number.
  *
- * @param charLabel - Character label used in the message.
+ * @param charLabel – Character label used in the message.
  * @param metricKey - `.btfont` metric key (for example `w` or `adv`).
- * @param value - Invalid metric value.
+ * @param value – Invalid metric value.
  * @returns User-facing error string.
  */
 export function btfontGlyphMetricNotIntegerError(charLabel: string, metricKey: string, value: number): string {
@@ -319,7 +319,7 @@ export function btfontGlyphMetricNotIntegerError(charLabel: string, metricKey: s
 /**
  * Returns the error message when a glyph position is negative.
  *
- * @param charLabel - Character label used in the message.
+ * @param charLabel – Character label used in the message.
  * @returns User-facing error string.
  */
 export function btfontGlyphNegativePositionError(charLabel: string): string {
@@ -332,7 +332,7 @@ export function btfontGlyphNegativePositionError(charLabel: string): string {
 /**
  * Returns the error message when a glyph width or height is negative.
  *
- * @param charLabel - Character label used in the message.
+ * @param charLabel – Character label used in the message.
  * @returns User-facing error string.
  */
 export function btfontGlyphNegativeSizeError(charLabel: string): string {
@@ -342,7 +342,7 @@ export function btfontGlyphNegativeSizeError(charLabel: string): string {
 /**
  * Returns the error message when a glyph advance width is negative.
  *
- * @param charLabel - Character label used in the message.
+ * @param charLabel – Character label used in the message.
  * @returns User-facing error string.
  */
 export function btfontGlyphNegativeAdvanceError(charLabel: string): string {
@@ -352,11 +352,11 @@ export function btfontGlyphNegativeAdvanceError(charLabel: string): string {
 /**
  * Returns the error message when a glyph is larger than the engine allows.
  *
- * @param charLabel - Character label used in the message.
- * @param width - Glyph width in pixels.
- * @param height - Glyph height in pixels.
- * @param maxWidth - Maximum accepted width in pixels.
- * @param maxHeight - Maximum accepted height in pixels.
+ * @param charLabel – Character label used in the message.
+ * @param width – Glyph width in pixels.
+ * @param height – Glyph height in pixels.
+ * @param maxWidth – Maximum accepted width in pixels.
+ * @param maxHeight – Maximum accepted height in pixels.
  * @returns User-facing error string.
  */
 export function btfontGlyphSizeTooLargeError(
@@ -375,13 +375,13 @@ export function btfontGlyphSizeTooLargeError(
 /**
  * Returns the error message when a glyph rectangle falls outside the font texture.
  *
- * @param charLabel - Character label used in the message.
- * @param x - Glyph X position in the atlas.
- * @param y - Glyph Y position in the atlas.
- * @param width - Glyph width in pixels.
- * @param height - Glyph height in pixels.
- * @param atlasWidth - Texture atlas width in pixels.
- * @param atlasHeight - Texture atlas height in pixels.
+ * @param charLabel – Character label used in the message.
+ * @param x – Glyph X position in the atlas.
+ * @param y – Glyph Y position in the atlas.
+ * @param width – Glyph width in pixels.
+ * @param height – Glyph height in pixels.
+ * @param atlasWidth – Texture atlas width in pixels.
+ * @param atlasHeight – Texture atlas height in pixels.
  * @returns User-facing error string.
  */
 export function btfontGlyphOutsideAtlasError(
@@ -402,7 +402,7 @@ export function btfontGlyphOutsideAtlasError(
 /**
  * Returns the error message when a glyph area is too large to render safely.
  *
- * @param charLabel - Character label used in the message.
+ * @param charLabel – Character label used in the message.
  * @returns User-facing error string.
  */
 export function btfontGlyphAreaTooLargeError(charLabel: string): string {
@@ -423,7 +423,7 @@ export function noActivePaletteError(): string {
  * Returns the error message for a palette index that is negative or not a
  * whole number.
  *
- * @param index - The invalid index value that was supplied.
+ * @param index – The invalid index value that was supplied.
  * @returns User-facing error string.
  */
 export function paletteIndexNegativeError(index: number): string {
@@ -433,8 +433,8 @@ export function paletteIndexNegativeError(index: number): string {
 /**
  * Returns the error message for a palette index that exceeds the palette size.
  *
- * @param index - The out-of-range index that was supplied.
- * @param size - The number of colors in the active palette.
+ * @param index – The out-of-range index that was supplied.
+ * @param size – The number of colors in the active palette.
  * @returns User-facing error string.
  */
 export function paletteIndexOutOfRangeError(index: number, size: number): string {
@@ -444,7 +444,7 @@ export function paletteIndexOutOfRangeError(index: number, size: number): string
 /**
  * Returns the error message when `applyHUD` is called with `startSlot` less than 1.
  *
- * @param startSlot - The invalid start slot value that was supplied.
+ * @param startSlot – The invalid start slot value that was supplied.
  * @returns User-facing error string.
  */
 export function hudStartSlotError(startSlot: number): string {
@@ -454,9 +454,9 @@ export function hudStartSlotError(startSlot: number): string {
 /**
  * Returns the error message when the HUD preset slots would exceed the palette size.
  *
- * @param startSlot - The requested start slot.
- * @param count - Number of HUD slots needed.
- * @param size - The palette size.
+ * @param startSlot – The requested start slot.
+ * @param count – Number of HUD slots needed.
+ * @param size – The palette size.
  * @returns User-facing error string.
  */
 export function hudRangeError(startSlot: number, count: number, size: number): string {
@@ -470,10 +470,10 @@ export function hudRangeError(startSlot: number, count: number, size: number): s
  * Returns the error message for a sprite pixel whose color is absent from the
  * active palette.
  *
- * @param x - Pixel x coordinate within the source image.
- * @param y - Pixel y coordinate within the source image.
- * @param src - Source image label (e.g. `'sheet.png'` or `(unnamed)`).
- * @param hex - The color that was not found, as a lowercase hex string.
+ * @param x – Pixel x coordinate within the source image.
+ * @param y – Pixel y coordinate within the source image.
+ * @param src – Source image label (e.g. `'sheet.png'` or `(unnamed)`).
+ * @param hex – The color that was not found, as a lowercase hex string.
  * @returns User-facing error string.
  */
 export function spriteColorNotInPaletteError(x: number, y: number, src: string, hex: string): string {
@@ -503,7 +503,7 @@ const AUDIO_EXTENSIONS = new Set(['.mp3', '.ogg', '.wav', '.m4a', '.webm', '.aac
  * Suggests a common audio extension when a URL's extension does not look like
  * an audio file.
  *
- * @param url - Original URL string.
+ * @param url – Original URL string.
  * @returns Hint text, or an empty string when no hint applies.
  */
 function buildAudioClipExtensionHint(url: string): string {
@@ -520,7 +520,7 @@ function buildAudioClipExtensionHint(url: string): string {
 /**
  * Combines the path and extension hints for a failing audio clip URL.
  *
- * @param url - Failing audio clip path.
+ * @param url – Failing audio clip path.
  * @returns Combined hint text (or an empty string when no hint applies).
  */
 function buildAudioClipHints(url: string): string {
@@ -543,7 +543,7 @@ function buildAudioClipHints(url: string): string {
  * Returns the error message for a network- or CORS-level audio fetch failure,
  * where the request itself never completed.
  *
- * @param url - Audio file path or URL that failed to load.
+ * @param url – Audio file path or URL that failed to load.
  * @returns User-facing error string.
  */
 export function audioClipNetworkError(url: string): string {
@@ -558,8 +558,8 @@ export function audioClipNetworkError(url: string): string {
  * Returns the error message for an audio fetch that completed with a
  * non-successful HTTP status.
  *
- * @param url - Audio file path or URL that failed to load.
- * @param status - HTTP status code from the fetch response.
+ * @param url – Audio file path or URL that failed to load.
+ * @param status – HTTP status code from the fetch response.
  * @returns User-facing error string.
  */
 export function audioClipHttpError(url: string, status: number): string {
@@ -575,7 +575,7 @@ export function audioClipHttpError(url: string, status: number): string {
  * Returns the error message for an audio file that downloaded successfully
  * but could not be decoded.
  *
- * @param url - Audio file path or URL that failed to decode.
+ * @param url – Audio file path or URL that failed to decode.
  * @returns User-facing error string.
  */
 export function audioClipDecodeError(url: string): string {
@@ -605,7 +605,7 @@ const SYNTH_WAVEFORM_NAMES = SYNTH_WAVEFORMS.join(', ');
 /**
  * Returns the error message for a `SynthParams.waveform` that is not a supported waveform name.
  *
- * @param waveform - Invalid waveform value that was supplied.
+ * @param waveform – Invalid waveform value that was supplied.
  * @returns User-facing error string.
  */
 export function audioClipSynthInvalidWaveformError(waveform: string): string {
@@ -615,7 +615,7 @@ export function audioClipSynthInvalidWaveformError(waveform: string): string {
 /**
  * Returns the error message for a `SynthParams.duration` that is not a positive number.
  *
- * @param duration - Invalid duration value that was supplied.
+ * @param duration – Invalid duration value that was supplied.
  * @returns User-facing error string.
  */
 export function audioClipSynthNonPositiveDurationError(duration: number): string {
@@ -625,8 +625,8 @@ export function audioClipSynthNonPositiveDurationError(duration: number): string
 /**
  * Returns the error message for a `SynthParams.duration` that exceeds the supported maximum.
  *
- * @param duration - Invalid duration value that was supplied, in seconds.
- * @param maxDuration - Maximum accepted duration, in seconds.
+ * @param duration – Invalid duration value that was supplied, in seconds.
+ * @param maxDuration – Maximum accepted duration, in seconds.
  * @returns User-facing error string.
  */
 export function audioClipSynthDurationTooLongError(duration: number, maxDuration: number): string {
@@ -639,11 +639,11 @@ export function audioClipSynthDurationTooLongError(duration: number, maxDuration
 /**
  * Returns the error message for a target sample rate that is not a positive number.
  *
- * Surfaces only if the registered decode context reports an invalid sample rate - this should
+ * Surfaces only if the registered decode context reports an invalid sample rate – this should
  * never happen with a real `AudioContext`, but is validated the same way any other boundary
  * value is.
  *
- * @param sampleRate - Invalid sample rate value that was read from the decode context.
+ * @param sampleRate – Invalid sample rate value that was read from the decode context.
  * @returns User-facing error string.
  */
 export function audioClipSynthNonPositiveSampleRateError(sampleRate: number): string {
@@ -656,7 +656,7 @@ export function audioClipSynthNonPositiveSampleRateError(sampleRate: number): st
 /**
  * Returns the error message for a `SynthParams.frequency` that is not a positive number.
  *
- * @param frequency - Invalid frequency value that was supplied.
+ * @param frequency – Invalid frequency value that was supplied.
  * @returns User-facing error string.
  */
 export function audioClipSynthNonPositiveFrequencyError(frequency: number): string {
@@ -669,8 +669,8 @@ export function audioClipSynthNonPositiveFrequencyError(frequency: number): stri
  * Shared by envelope timings (`envelope.attack`, `envelope.decay`, `envelope.release`) and
  * vibrato parameters (`vibrato.rate`, `vibrato.depth`).
  *
- * @param field - Dotted field path that failed validation (for example `'envelope.attack'`).
- * @param value - Invalid negative value that was supplied.
+ * @param field – Dotted field path that failed validation (for example `'envelope.attack'`).
+ * @param value – Invalid negative value that was supplied.
  * @returns User-facing error string.
  */
 export function audioClipSynthNonNegativeFieldError(field: string, value: number): string {
@@ -680,7 +680,7 @@ export function audioClipSynthNonNegativeFieldError(field: string, value: number
 /**
  * Returns the error message for a `SynthEnvelope.sustain` outside the [0, 1] range.
  *
- * @param sustain - Invalid sustain value that was supplied.
+ * @param sustain – Invalid sustain value that was supplied.
  * @returns User-facing error string.
  */
 export function audioClipSynthSustainRangeError(sustain: number): string {
@@ -692,8 +692,8 @@ export function audioClipSynthSustainRangeError(sustain: number): string {
  *
  * Shared by `noiseMix` and `dutyCycle`.
  *
- * @param field - Field name that failed validation (for example `'noiseMix'`).
- * @param value - Invalid value that was supplied.
+ * @param field – Field name that failed validation (for example `'noiseMix'`).
+ * @param value – Invalid value that was supplied.
  * @returns User-facing error string.
  */
 export function audioClipSynthUnitRangeFieldError(field: string, value: number): string {
@@ -703,7 +703,7 @@ export function audioClipSynthUnitRangeFieldError(field: string, value: number):
 /**
  * Returns the error message for a `SynthPitchSweep.toFrequency` that is not a positive number.
  *
- * @param toFrequency - Invalid target frequency value that was supplied.
+ * @param toFrequency – Invalid target frequency value that was supplied.
  * @returns User-facing error string.
  */
 export function audioClipSynthPitchSweepFrequencyError(toFrequency: number): string {
@@ -721,9 +721,9 @@ export function audioClipSynthPitchSweepFrequencyError(toFrequency: number): str
  * `0 <= loopStart < loopEnd <= duration`. `loopStart`/`loopEnd` are `undefined` when missing
  * entirely, so the message still shows the caller exactly what was supplied.
  *
- * @param loopStart - Supplied loop region start in seconds, or `undefined` if omitted.
- * @param loopEnd - Supplied loop region end in seconds, or `undefined` if omitted.
- * @param duration - Duration in seconds of the buffer being played.
+ * @param loopStart – Supplied loop region start in seconds, or `undefined` if omitted.
+ * @param loopEnd – Supplied loop region end in seconds, or `undefined` if omitted.
+ * @param duration – Duration in seconds of the buffer being played.
  * @returns User-facing error string.
  */
 export function musicLoopRangeError(
@@ -750,8 +750,8 @@ export function randomPickEmptyError(): string {
 /**
  * Returns the error message for {@link Random.weighted} when items and weights lengths differ.
  *
- * @param itemCount - Number of items supplied.
- * @param weightCount - Number of weights supplied.
+ * @param itemCount – Number of items supplied.
+ * @param weightCount – Number of weights supplied.
  * @returns User-facing error string.
  */
 export function randomWeightedLengthError(itemCount: number, weightCount: number): string {
@@ -773,7 +773,7 @@ export function randomWeightedEmptyError(): string {
 /**
  * Returns the error message for {@link Random.weighted} when total weight is not positive.
  *
- * @param total - Sum of the supplied weights.
+ * @param total – Sum of the supplied weights.
  * @returns User-facing error string.
  */
 export function randomWeightedTotalError(total: number): string {
@@ -786,8 +786,8 @@ export function randomWeightedTotalError(total: number): string {
 /**
  * Returns the error message for an invalid half-open integer range on {@link Random.int}.
  *
- * @param min - Inclusive lower bound that was supplied.
- * @param maxExclusive - Exclusive upper bound that was supplied.
+ * @param min – Inclusive lower bound that was supplied.
+ * @param maxExclusive – Exclusive upper bound that was supplied.
  * @returns User-facing error string.
  */
 export function randomIntRangeError(min: number, maxExclusive: number): string {
@@ -800,8 +800,8 @@ export function randomIntRangeError(min: number, maxExclusive: number): string {
 /**
  * Returns the error message for an invalid inclusive integer range on {@link Random.intInclusive}.
  *
- * @param min - Inclusive lower bound that was supplied.
- * @param max - Inclusive upper bound that was supplied.
+ * @param min – Inclusive lower bound that was supplied.
+ * @param max – Inclusive upper bound that was supplied.
  * @returns User-facing error string.
  */
 export function randomIntInclusiveRangeError(min: number, max: number): string {

--- a/packages/blit386/src/utils/hash.ts
+++ b/packages/blit386/src/utils/hash.ts
@@ -15,7 +15,7 @@ const INV_2_32 = 1 / 4294967296;
 /**
  * MurmurHash3 32-bit finalizer (avalanche). Input is treated as unsigned.
  *
- * @param h - Mixed state to finalize.
+ * @param h – Mixed state to finalize.
  * @returns Well-distributed unsigned 32-bit value.
  */
 function finalize(h: number): number {
@@ -33,8 +33,8 @@ function finalize(h: number): number {
 /**
  * Deterministic uint32 hash of a 1D integer coordinate.
  *
- * @param x - Coordinate (truncated toward zero with `| 0`).
- * @param seed - World / stream seed (default `0`; lower 32 bits used).
+ * @param x – Coordinate (truncated toward zero with `| 0`).
+ * @param seed – World / stream seed (default `0`; lower 32 bits used).
  * @returns Unsigned 32-bit value in `[0, 2^32)`.
  * @since 1.5.0
  */
@@ -50,9 +50,9 @@ export function hash1i(x: number, seed = 0): number {
 /**
  * Deterministic uint32 hash of a 2D integer coordinate.
  *
- * @param x - X coordinate (truncated toward zero with `| 0`).
- * @param y - Y coordinate (truncated toward zero with `| 0`).
- * @param seed - World / stream seed (default `0`; lower 32 bits used).
+ * @param x – X coordinate (truncated toward zero with `| 0`).
+ * @param y – Y coordinate (truncated toward zero with `| 0`).
+ * @param seed – World / stream seed (default `0`; lower 32 bits used).
  * @returns Unsigned 32-bit value in `[0, 2^32)`.
  * @since 1.5.0
  */
@@ -70,10 +70,10 @@ export function hash2i(x: number, y: number, seed = 0): number {
 /**
  * Deterministic uint32 hash of a 3D integer coordinate.
  *
- * @param x - X coordinate (truncated toward zero with `| 0`).
- * @param y - Y coordinate (truncated toward zero with `| 0`).
- * @param z - Z coordinate (truncated toward zero with `| 0`).
- * @param seed - World / stream seed (default `0`; lower 32 bits used).
+ * @param x – X coordinate (truncated toward zero with `| 0`).
+ * @param y – Y coordinate (truncated toward zero with `| 0`).
+ * @param z – Z coordinate (truncated toward zero with `| 0`).
+ * @param seed – World / stream seed (default `0`; lower 32 bits used).
  * @returns Unsigned 32-bit value in `[0, 2^32)`.
  * @since 1.5.0
  */
@@ -93,8 +93,8 @@ export function hash3i(x: number, y: number, z: number, seed = 0): number {
 /**
  * Deterministic float hash of a 1D integer coordinate in `[0, 1)`.
  *
- * @param x - Coordinate (truncated toward zero with `| 0`).
- * @param seed - World / stream seed (default `0`; lower 32 bits used).
+ * @param x – Coordinate (truncated toward zero with `| 0`).
+ * @param seed – World / stream seed (default `0`; lower 32 bits used).
  * @returns Float in `[0, 1)`, derived from {@link hash1i}.
  * @since 1.5.0
  */
@@ -105,9 +105,9 @@ export function hash1(x: number, seed = 0): number {
 /**
  * Deterministic float hash of a 2D integer coordinate in `[0, 1)`.
  *
- * @param x - X coordinate (truncated toward zero with `| 0`).
- * @param y - Y coordinate (truncated toward zero with `| 0`).
- * @param seed - World / stream seed (default `0`; lower 32 bits used).
+ * @param x – X coordinate (truncated toward zero with `| 0`).
+ * @param y – Y coordinate (truncated toward zero with `| 0`).
+ * @param seed – World / stream seed (default `0`; lower 32 bits used).
  * @returns Float in `[0, 1)`, derived from {@link hash2i}.
  * @since 1.5.0
  */
@@ -118,10 +118,10 @@ export function hash2(x: number, y: number, seed = 0): number {
 /**
  * Deterministic float hash of a 3D integer coordinate in `[0, 1)`.
  *
- * @param x - X coordinate (truncated toward zero with `| 0`).
- * @param y - Y coordinate (truncated toward zero with `| 0`).
- * @param z - Z coordinate (truncated toward zero with `| 0`).
- * @param seed - World / stream seed (default `0`; lower 32 bits used).
+ * @param x – X coordinate (truncated toward zero with `| 0`).
+ * @param y – Y coordinate (truncated toward zero with `| 0`).
+ * @param z – Z coordinate (truncated toward zero with `| 0`).
+ * @param seed – World / stream seed (default `0`; lower 32 bits used).
  * @returns Float in `[0, 1)`, derived from {@link hash3i}.
  * @since 1.5.0
  */

--- a/packages/blit386/src/utils/noiseCommon.ts
+++ b/packages/blit386/src/utils/noiseCommon.ts
@@ -20,7 +20,7 @@ export const DEFAULT_LACUNARITY = 2;
 /**
  * Remaps an unsigned 32-bit hash into `[-1, 1)`.
  *
- * @param u - Unsigned 32-bit value from `hash*i`.
+ * @param u – Unsigned 32-bit value from `hash*i`.
  * @returns Float in `[-1, 1)`.
  */
 export function hashToSigned(u: number): number {
@@ -30,7 +30,7 @@ export function hashToSigned(u: number): number {
 /**
  * Perlin fade curve (smoothstep quintic): `6t^5 - 15t^4 + 10t^3`.
  *
- * @param t - Interpolation parameter in [0, 1].
+ * @param t – Interpolation parameter in [0, 1].
  * @returns Smoothed weight in [0, 1].
  */
 export function fade(t: number): number {
@@ -40,9 +40,9 @@ export function fade(t: number): number {
 /**
  * Linear interpolation.
  *
- * @param a - Start value.
- * @param b - End value.
- * @param t - Blend factor.
+ * @param a – Start value.
+ * @param b – End value.
+ * @param t – Blend factor.
  * @returns `a + t * (b - a)`.
  */
 export function lerp(a: number, b: number, t: number): number {
@@ -55,11 +55,11 @@ export function lerp(a: number, b: number, t: number): number {
  * Amplitude sum is normalized so the result stays in approximately `[-1, 1]` when
  * each octave sample is in `[-1, 1]`.
  *
- * @param sample - Unit-frequency noise sampler returning approximately `[-1, 1]`.
- * @param x - Sample coordinate.
- * @param octaves - Number of octaves (floored; at least 1).
- * @param persistence - Amplitude multiplier per octave.
- * @param lacunarity - Frequency multiplier per octave.
+ * @param sample – Unit-frequency noise sampler returning approximately `[-1, 1]`.
+ * @param x – Sample coordinate.
+ * @param octaves – Number of octaves (floored; at least 1).
+ * @param persistence – Amplitude multiplier per octave.
+ * @param lacunarity – Frequency multiplier per octave.
  * @returns Normalized fBm sample.
  */
 export function fbm1(
@@ -88,12 +88,12 @@ export function fbm1(
 /**
  * Fractal Brownian motion over a 2D noise sample function.
  *
- * @param sample - Unit-frequency noise sampler returning approximately `[-1, 1]`.
- * @param x - X coordinate.
- * @param y - Y coordinate.
- * @param octaves - Number of octaves (floored; at least 1).
- * @param persistence - Amplitude multiplier per octave.
- * @param lacunarity - Frequency multiplier per octave.
+ * @param sample – Unit-frequency noise sampler returning approximately `[-1, 1]`.
+ * @param x – X coordinate.
+ * @param y – Y coordinate.
+ * @param octaves – Number of octaves (floored; at least 1).
+ * @param persistence – Amplitude multiplier per octave.
+ * @param lacunarity – Frequency multiplier per octave.
  * @returns Normalized fBm sample.
  */
 export function fbm2(
@@ -123,13 +123,13 @@ export function fbm2(
 /**
  * Fractal Brownian motion over a 3D noise sample function.
  *
- * @param sample - Unit-frequency noise sampler returning approximately `[-1, 1]`.
- * @param x - X coordinate.
- * @param y - Y coordinate.
- * @param z - Z coordinate.
- * @param octaves - Number of octaves (floored; at least 1).
- * @param persistence - Amplitude multiplier per octave.
- * @param lacunarity - Frequency multiplier per octave.
+ * @param sample – Unit-frequency noise sampler returning approximately `[-1, 1]`.
+ * @param x – X coordinate.
+ * @param y – Y coordinate.
+ * @param z – Z coordinate.
+ * @param octaves – Number of octaves (floored; at least 1).
+ * @param persistence – Amplitude multiplier per octave.
+ * @param lacunarity – Frequency multiplier per octave.
  * @returns Normalized fBm sample.
  */
 export function fbm3(
@@ -192,9 +192,9 @@ export const GRAD3: readonly (readonly [number, number, number])[] = [
 /**
  * Dot product of a 2D gradient selected by hash bits.
  *
- * @param hash - Lattice hash (low bits select the gradient).
- * @param x - Offset from lattice point on X.
- * @param y - Offset from lattice point on Y.
+ * @param hash – Lattice hash (low bits select the gradient).
+ * @param x – Offset from lattice point on X.
+ * @param y – Offset from lattice point on Y.
  * @returns Gradient · (x, y).
  */
 export function grad2(hash: number, x: number, y: number): number {
@@ -206,10 +206,10 @@ export function grad2(hash: number, x: number, y: number): number {
 /**
  * Dot product of a 3D gradient selected by hash bits.
  *
- * @param hash - Lattice hash (low bits select the gradient).
- * @param x - Offset from lattice point on X.
- * @param y - Offset from lattice point on Y.
- * @param z - Offset from lattice point on Z.
+ * @param hash – Lattice hash (low bits select the gradient).
+ * @param x – Offset from lattice point on X.
+ * @param y – Offset from lattice point on Y.
+ * @param z – Offset from lattice point on Z.
  * @returns Gradient · (x, y, z).
  */
 export function grad3(hash: number, x: number, y: number, z: number): number {

--- a/packages/blit386/src/utils/urlHints.ts
+++ b/packages/blit386/src/utils/urlHints.ts
@@ -17,7 +17,7 @@ const EXPLICIT_PATH_PREFIXES = ['/', './'] as const;
  * Returns whether a URL already points at an explicit location: an absolute
  * URL, a special browser scheme, or a rooted/relative (`/`, `./`) path.
  *
- * @param url - Path or URL to inspect.
+ * @param url – Path or URL to inspect.
  * @returns True when no relative-path hint is needed.
  */
 export function hasExplicitLocation(url: string): boolean {
@@ -38,8 +38,8 @@ export function hasExplicitLocation(url: string): boolean {
 /**
  * Suggests common absolute and relative URL forms when the path looks ambiguous.
  *
- * @param url - Original URL string.
- * @param folderName - Typical folder prefix to suggest (for example `'fonts'` or `'audio'`).
+ * @param url – Original URL string.
+ * @param folderName – Typical folder prefix to suggest (for example `'fonts'` or `'audio'`).
  * @returns Hint text, or an empty string when the path already looks explicit.
  */
 export function buildPathHint(url: string, folderName: string): string {
@@ -56,7 +56,7 @@ export function buildPathHint(url: string, folderName: string): string {
  * Extracts the lowercase file extension (including the dot) from a URL,
  * ignoring any query string or fragment.
  *
- * @param url - Path or URL to inspect.
+ * @param url – Path or URL to inspect.
  * @returns Extension like `.png`, or an empty string when none is present.
  */
 export function extractExtension(url: string): string {

--- a/packages/blit386/src/vite/assets.ts
+++ b/packages/blit386/src/vite/assets.ts
@@ -36,8 +36,8 @@ export interface HandleAssetHotUpdateParams {
 /**
  * Maps an absolute file path to its served URL when it falls under one of `assetDirs`.
  *
- * @param file - Absolute file path.
- * @param assetDirs - Resolved, absolute asset directories.
+ * @param file – Absolute file path.
+ * @param assetDirs – Resolved, absolute asset directories.
  * @returns A leading-slash URL relative to the matching asset dir, or `null` when `file` is outside all of them.
  */
 export function resolveAssetUrl(file: string, assetDirs: readonly string[]): string | null {
@@ -55,8 +55,8 @@ export function resolveAssetUrl(file: string, assetDirs: readonly string[]): str
 /**
  * Looks up a file's asset kind by its lowercased extension.
  *
- * @param file - File path.
- * @param assetTypes - Extension-to-asset-kind lookup.
+ * @param file – File path.
+ * @param assetTypes – Extension-to-asset-kind lookup.
  * @returns The matched asset kind, or `null` when the extension is not registered.
  */
 export function assetTypeForFile(file: string, assetTypes: ReadonlyMap<string, AssetKind>): AssetKind | null {
@@ -68,11 +68,11 @@ export function assetTypeForFile(file: string, assetTypes: ReadonlyMap<string, A
  * `blit386:asset-changed` payload for a recognized asset kind, a `full-reload` for an
  * unrecognized one (when enabled), or defers to Vite's default handling otherwise.
  *
- * Only acts for the `'client'` environment - Vite's environment API fires `hotUpdate` once per
+ * Only acts for the `'client'` environment – Vite's environment API fires `hotUpdate` once per
  * environment (`'client'` and `'ssr'` by default; verified empirically against this repo's
  * installed Vite version), and this plugin has nothing SSR-specific to do.
  *
- * @param params - See {@link HandleAssetHotUpdateParams}.
+ * @param params – See {@link HandleAssetHotUpdateParams}.
  * @returns `[]` (suppressing Vite's default module-graph update) when this handler acted; `undefined` otherwise.
  */
 export function handleAssetHotUpdate(params: HandleAssetHotUpdateParams): [] | undefined {

--- a/packages/blit386/src/vite/index.ts
+++ b/packages/blit386/src/vite/index.ts
@@ -23,7 +23,7 @@ export type { AssetKind, Blit386PluginOptions, ResolvedBlit386PluginOptions } fr
  * Creates the `blit386/vite` dev-server plugin.
  *
  * @since 1.4.0
- * @param options - See {@link Blit386PluginOptions}; every field is optional.
+ * @param options – See {@link Blit386PluginOptions}; every field is optional.
  * @returns A Vite `Plugin`, active only in `serve` (dev-server) mode.
  *
  * @example
@@ -62,7 +62,7 @@ export function blit386(options?: Blit386PluginOptions): Plugin {
             return injectSnippet(code);
         },
 
-        // Method shorthand, not an arrow function - Vite needs its own `this` bound here for `this.environment`.
+        // Method shorthand, not an arrow function – Vite needs its own `this` bound here for `this.environment`.
         hotUpdate(update) {
             return handleAssetHotUpdate({
                 file: update.file,

--- a/packages/blit386/src/vite/options.ts
+++ b/packages/blit386/src/vite/options.ts
@@ -82,7 +82,7 @@ const DEFAULT_ASSET_TYPES: Record<string, AssetKind> = {
 /**
  * Default {@link Blit386PluginOptions.include} predicate: a module id under `/src/` ending a JS/TS extension.
  *
- * @param id - Module id, possibly with a `?query` suffix.
+ * @param id – Module id, possibly with a `?query` suffix.
  * @returns `true` when `id` (with any query suffix stripped) matches the default pattern.
  */
 export function defaultInclude(id: string): boolean {
@@ -94,8 +94,8 @@ export function defaultInclude(id: string): boolean {
 /**
  * Resolves user-provided {@link Blit386PluginOptions} against defaults, applying `root` to `assetDirs`.
  *
- * @param options - User-provided options, or `undefined` for all defaults.
- * @param root - Vite's resolved project root (absolute path).
+ * @param options – User-provided options, or `undefined` for all defaults.
+ * @param root – Vite's resolved project root (absolute path).
  * @returns Fully resolved options.
  */
 export function resolveOptions(options: Blit386PluginOptions | undefined, root: string): ResolvedBlit386PluginOptions {

--- a/packages/blit386/src/vite/transform.test.ts
+++ b/packages/blit386/src/vite/transform.test.ts
@@ -66,7 +66,7 @@ describe('checkPlainJsSyntax', () => {
     });
 
     it('is null (skipped) for a .ts module even with invalid plain-JS/TypeScript-only syntax', () => {
-        // Valid TypeScript, invalid as plain ES - acorn (an ES-only parser) would reject this if it
+        // Valid TypeScript, invalid as plain ES – acorn (an ES-only parser) would reject this if it
         // ran, which is exactly why .ts/.mts must be skipped rather than checked.
         const code = 'const x: number = 1;\n';
 
@@ -99,7 +99,7 @@ describe('injectSnippet', () => {
         const result = injectSnippet(codeWithExistingImport);
         const injectedPortion = result.code.slice(result.code.indexOf(INJECTION_MARKER));
 
-        // Two import declarations binding the same local name - even from the same source - is a
+        // Two import declarations binding the same local name – even from the same source – is a
         // SyntaxError in ES modules, so the injected import must use a different local name than the
         // entry module's own pre-existing `registerHotReload` import.
         expect(injectedPortion).toContain(

--- a/packages/blit386/src/vite/transform.ts
+++ b/packages/blit386/src/vite/transform.ts
@@ -4,7 +4,7 @@
  *
  * Also does a plain-JS entry's only syntax check (see {@link checkPlainJsSyntax}): Vite's own
  * default transform pipeline excludes `.js`/`.mjs` from server-side parsing, so without this a
- * broken entry module surfaces only as a caught client-side `import()` rejection - logged, but
+ * broken entry module surfaces only as a caught client-side `import()` rejection – logged, but
  * never shown in Vite's error overlay (BT-318).
  */
 
@@ -16,11 +16,11 @@ export const INJECTION_MARKER = '/* blit386:hot-reload-snippet */';
 
 /**
  * Snippet appended to a matched entry module, verbatim. The literal `import.meta.hot.accept()` call
- * must appear in the emitted source - Vite marks self-accepting modules by static analysis, so an
+ * must appear in the emitted source – Vite marks self-accepting modules by static analysis, so an
  * indirect call would not register self-acceptance and every edit would fall back to a full reload.
  *
  * `registerHotReload` is imported under a plugin-specific alias: importing it under its own name would
- * be a duplicate lexical declaration - a hard `SyntaxError` - if the entry module already imports or
+ * be a duplicate lexical declaration – a hard `SyntaxError` - if the entry module already imports or
  * declares a `registerHotReload` binding of its own (for example, a game that wired hot reload by hand
  * before adopting this plugin).
  *

--- a/packages/blit386/tests/visual/post-process.spec.ts
+++ b/packages/blit386/tests/visual/post-process.spec.ts
@@ -21,8 +21,8 @@ const MAX_DIFF = 0.01;
  * Loads the post-process fixture in the requested mode and waits until the
  * scene render has signalled completion (or initialization has failed).
  *
- * @param page - Playwright page handle.
- * @param mode - Fixture mode hash (matches a `case` in the fixture's switch).
+ * @param page – Playwright page handle.
+ * @param mode – Fixture mode hash (matches a `case` in the fixture's switch).
  * @returns `true` if the page initialized successfully; `false` when WebGPU
  *   was unavailable in the test environment.
  */
@@ -51,9 +51,9 @@ async function loadFixture(page: Page, mode: string): Promise<boolean> {
 /**
  * Common test runner: load fixture, take snapshot.
  *
- * @param page - Playwright page handle.
- * @param mode - Fixture mode hash.
- * @param snapshot - Snapshot file name.
+ * @param page – Playwright page handle.
+ * @param mode – Fixture mode hash.
+ * @param snapshot – Snapshot file name.
  */
 async function runMode(page: Page, mode: string, snapshot: string): Promise<void> {
     const ok = await loadFixture(page, mode);

--- a/packages/blit386/vite.config.ts
+++ b/packages/blit386/vite.config.ts
@@ -8,10 +8,10 @@ import dts from 'vite-plugin-dts';
  * Whether the dts plugin should run api-extractor's declaration rollup.
  *
  * Api-extractor's rollup crashes intermittently when a watch rebuild's per-file `.d.ts`
- * tree is still being rewritten as it starts reading it - see BT-426. It only ever needs
+ * tree is still being rewritten as it starts reading it – see BT-426. It only ever needs
  * to run for the final, non-watch production build.
  *
- * @param argv - The process argv to check for a `--watch` flag.
+ * @param argv – The process argv to check for a `--watch` flag.
  * @returns `false` under `--watch`, `true` otherwise.
  */
 export const resolveDtsRollupTypes = (argv: readonly string[]): boolean => !argv.includes('--watch');

--- a/packages/create-blit386/src/scaffold.ts
+++ b/packages/create-blit386/src/scaffold.ts
@@ -6,7 +6,7 @@
  *                        prettier.config.js + .prettierignore + scripts/prettier-plugin-compact-tables.mjs)
  *   - ../templates/js    (the JavaScript game + package.json + jsconfig)
  *   - ../templates/optional/* (wizard opt-in: CI, Cursor rules, Claude guide)
- *   - @blit386/kit content (AGENTS.md + docs/) - the single source for the AI/human guidance
+ *   - @blit386/kit content (AGENTS.md + docs/) – the single source for the AI/human guidance
  *
  * After emitting all files, scaffold writes `.blit/manifest.json` (the ownership manifest) and
  * `.blit/base/` (pristine copies of kit-owned and shared files) so future `blit agents sync` runs

--- a/packages/create-blit386/templates/base/scripts/prettier-plugin-compact-tables.mjs
+++ b/packages/create-blit386/templates/base/scripts/prettier-plugin-compact-tables.mjs
@@ -1,7 +1,7 @@
 /**
  * Prettier plugin: compact Markdown tables.
  *
- * You do not need to read or edit this file - it is tooling, not part of your game.
+ * You do not need to read or edit this file – it is tooling, not part of your game.
  *
  * Prettier normally pads every table cell out to the width of the widest cell in its column, so changing one word
  * rewrites every row of the table. This plugin keeps Prettier's whole Markdown printer and replaces only the `table`
@@ -63,7 +63,7 @@ const DELIMITERS = {
  *
  * Wrapping is disabled (`printWidth: Infinity`) because a table row is always one line: the row, not the print width,
  * decides where output breaks. Printing through `print` rather than slicing the source is what keeps Prettier's usual
- * inline normalization - emphasis style, escaping, link shortening - identical to stock output.
+ * inline normalization – emphasis style, escaping, link shortening – identical to stock output.
  *
  * @param {import('prettier').AstPath} cellPath Path positioned at a `tableCell` node.
  * @param {import('prettier').ParserOptions} options Resolved Prettier options for the file being formatted.
@@ -110,7 +110,7 @@ const printTable = (path, options, print) => {
 /**
  * Prettier's Markdown printer with the `table` case swapped out.
  *
- * Everything else - paragraphs, lists, code fences, prose wrapping - delegates to {@link basePrinter}, so this plugin
+ * Everything else – paragraphs, lists, code fences, prose wrapping – delegates to {@link basePrinter}, so this plugin
  * can only ever change table layout.
  *
  * @type {import('prettier').Printer}

--- a/packages/create-blit386/templates/js/src/game.js
+++ b/packages/create-blit386/templates/js/src/game.js
@@ -1,14 +1,14 @@
 // {{projectName}} - a tiny BLIT386 game called "Catcher".
 //
 // Move the paddle to catch the blocks falling from the top.
-// On a phone or tablet: drag or tap - the paddle centers under your finger.
+// On a phone or tablet: drag or tap – the paddle centers under your finger.
 // On a computer: move the mouse, or use the left and right arrow keys as a fallback.
 // Catch one: +1 point. Miss one: lose a life. Run out of lives and the game starts over.
 //
 // Every BLIT386 game is one class with up to four methods. We use three of them here:
 //   init()   - runs once at the start (we set up our colors here).
-//   update() - runs about 60 times a second (we move things and check for catches here).
-//   render() - runs about 60 times a second (we draw everything here).
+//   update() – runs about 60 times a second (we move things and check for catches here).
+//   render() – runs about 60 times a second (we draw everything here).
 //
 // Optional hooks you can add later: configure() for screen settings or to turn off the BLIT386
 // splash, onHotReload() to keep score across init() edits while the Vite plugin hot-reloads
@@ -55,7 +55,7 @@ class Game {
         this.screen = BT.displaySize;
 
         // Make a palette (a numbered set of colors) and choose four colors.
-        // Color32(red, green, blue) - each value goes from 0 (none) to 255 (full).
+        // Color32(red, green, blue) – each value goes from 0 (none) to 255 (full).
         const palette = BT.paletteCreate(16);
 
         palette.set(COLOR_BACKGROUND, new Color32(18, 22, 40)); // dark blue
@@ -83,7 +83,7 @@ class Game {
             // Subtracting half the paddle width shifts it left so it is balanced around the cursor or finger.
             this.paddlePos.x = BT.pointerPos(0).x - Math.floor(PADDLE_WIDTH / 2);
         } else {
-            // No pointer is active - fall back to the arrow keys (or a connected gamepad).
+            // No pointer is active – fall back to the arrow keys (or a connected gamepad).
             // BT.isDown() is true for every frame the button is held down, not just the frame it was pressed.
             if (BT.isDown(BT.BTN_LEFT, 0)) {
                 this.paddlePos.x -= PADDLE_SPEED;

--- a/packages/create-blit386/templates/ts/src/game.ts
+++ b/packages/create-blit386/templates/ts/src/game.ts
@@ -1,14 +1,14 @@
 // {{projectName}} - a tiny BLIT386 game called "Catcher".
 //
 // Move the paddle to catch the blocks falling from the top.
-// On a phone or tablet: drag or tap - the paddle centers under your finger.
+// On a phone or tablet: drag or tap – the paddle centers under your finger.
 // On a computer: move the mouse, or use the left and right arrow keys as a fallback.
 // Catch one: +1 point. Miss one: lose a life. Run out of lives and the game starts over.
 //
 // Every BLIT386 game is one class with up to four methods. We use three of them here:
 //   init()   - runs once at the start (we set up our colors here).
-//   update() - runs about 60 times a second (we move things and check for catches here).
-//   render() - runs about 60 times a second (we draw everything here).
+//   update() – runs about 60 times a second (we move things and check for catches here).
+//   render() – runs about 60 times a second (we draw everything here).
 //
 // Optional hooks you can add later: configure() for screen settings or to turn off the BLIT386
 // splash, onHotReload() to keep score across init() edits while the Vite plugin hot-reloads
@@ -54,7 +54,7 @@ class Game {
         this.screen = BT.displaySize;
 
         // Make a palette (a numbered set of colors) and choose four colors.
-        // Color32(red, green, blue) - each value goes from 0 (none) to 255 (full).
+        // Color32(red, green, blue) – each value goes from 0 (none) to 255 (full).
         const palette = BT.paletteCreate(16);
 
         palette.set(COLOR_BACKGROUND, new Color32(18, 22, 40)); // dark blue
@@ -82,7 +82,7 @@ class Game {
             // Subtracting half the paddle width shifts it left so it is balanced around the cursor or finger.
             this.paddlePos.x = BT.pointerPos(0).x - Math.floor(PADDLE_WIDTH / 2);
         } else {
-            // No pointer is active - fall back to the arrow keys (or a connected gamepad).
+            // No pointer is active – fall back to the arrow keys (or a connected gamepad).
             // BT.isDown() is true for every frame the button is held down, not just the frame it was pressed.
             if (BT.isDown(BT.BTN_LEFT, 0)) {
                 this.paddlePos.x -= PADDLE_SPEED;

--- a/packages/create-blit386/test/scaffold.test.mjs
+++ b/packages/create-blit386/test/scaffold.test.mjs
@@ -363,7 +363,7 @@ test('blit agents sync --check exits 0 when no files have drifted', () => {
             pmRunLint: 'npm run lint',
         });
 
-        // Nothing has been modified — check should pass with exit code 0.
+        // Nothing has been modified – check should pass with exit code 0.
         const result = execFileSync(process.execPath, [blitCli, 'agents', 'sync', '--check'], {
             cwd: project,
             encoding: 'utf8',

--- a/packages/demos/_partials/demo-shell.js
+++ b/packages/demos/_partials/demo-shell.js
@@ -87,7 +87,7 @@ const PAGE_SUFFIX = document.body.dataset.pageSuffix ?? '.html';
  * Build a same-directory link to another demo page. The directory is derived from
  * the current page's own pathname, so this resolves correctly under both dev
  * (/demos/<slug>.html) and the flattened production build (/<slug>).
- * @param {string} slug - Demo slug, e.g. "basics"
+ * @param {string} slug – Demo slug, e.g. "basics"
  * @returns {string}
  */
 function urlFor(slug) {
@@ -558,7 +558,7 @@ function buildCombobox(demos, currentIndex) {
     let isOpen = false;
 
     // When true, the input still shows the current demo label and has not been
-    // edited this open session — filter with an empty query so the full list
+    // edited this open session – filter with an empty query so the full list
     // appears (filtering by "Basics" would hide almost everything).
     let isPristine = true;
 

--- a/packages/demos/eslint.config.js
+++ b/packages/demos/eslint.config.js
@@ -65,7 +65,7 @@ export default [
         },
     },
 
-    // Demo source files (src/*.js) - browser environment, relaxed rules
+    // Demo source files (src/*.js) – browser environment, relaxed rules
     {
         files: ['src/**/*.js'],
         languageOptions: {
@@ -144,7 +144,7 @@ export default [
         },
     },
 
-    // Config files - relaxed JSDoc
+    // Config files – relaxed JSDoc
     {
         files: ['*.config.js', '*.config.mjs'],
         rules: {

--- a/packages/demos/plugins/demo-order.js
+++ b/packages/demos/plugins/demo-order.js
@@ -2,7 +2,7 @@
  * Canonical navigation order for demos.
  *
  * Filenames under `src/` are number-free kebab-case slugs (`basics.js`). This list is the
- * single source of truth for prev/next and fuzzy-combobox order — independent of discovery
+ * single source of truth for prev/next and fuzzy-combobox order – independent of discovery
  * order on disk. When adding a demo, append its slug here (never reintroduce a numeric
  * prefix). When retiring a demo, remove it from this list but keep its vintage mapping
  * forever (see `demo-vintage-urls.js`).

--- a/packages/demos/plugins/demo-registry.js
+++ b/packages/demos/plugins/demo-registry.js
@@ -20,9 +20,9 @@ export const NAV_HIDDEN_SLUGS = new Set(['barebones']);
 /**
  * Build the list of demos by scanning src/*.js for number-free kebab-case files.
  * Order comes from `DEMO_ORDER` (not filenames). Each entry's title defaults to
- * "BLIT386 Demo - Title Cased Topic" and may be overridden by a `@pageTitle ...` tag
+ * "BLIT386 Demo – Title Cased Topic" and may be overridden by a `@pageTitle ...` tag
  * in the JS file header. `navLabel` is always the short title (searchable, no number).
- * @param {string} rootDir - Absolute path to the project root (Vite's config.root).
+ * @param {string} rootDir – Absolute path to the project root (Vite's config.root).
  * @returns {Array<{
  *   slug: string,
  *   scriptFile: string,
@@ -98,7 +98,7 @@ export function buildRegistry(rootDir) {
 
 /**
  * Read the first HEADER_SCAN_BYTES of a file as UTF-8 text.
- * @param {string} path - Absolute file path
+ * @param {string} path – Absolute file path
  * @returns {string}
  */
 function readHeader(path) {
@@ -109,8 +109,8 @@ function readHeader(path) {
 
 /**
  * Derive the page title for a demo.
- * @param {string} slug - Kebab-case slug, e.g. "sprite-effects"
- * @param {string} header - First chunk of the JS source (to scan for @pageTitle)
+ * @param {string} slug – Kebab-case slug, e.g. "sprite-effects"
+ * @param {string} header – First chunk of the JS source (to scan for @pageTitle)
  * @returns {string}
  */
 function deriveTitle(slug, header) {
@@ -128,8 +128,8 @@ function deriveTitle(slug, header) {
  * "Flurry" or "PipBoy CRT". Strips a leading "BLIT386 Demo … - " prefix from `@pageTitle`
  * overrides that include it, so nav labels stay uniform regardless of how each demo's
  * `@pageTitle` is written.
- * @param {string} slug - Kebab-case slug, e.g. "sprite-effects"
- * @param {string} header - First chunk of the JS source (to scan for @pageTitle)
+ * @param {string} slug – Kebab-case slug, e.g. "sprite-effects"
+ * @param {string} header – First chunk of the JS source (to scan for @pageTitle)
  * @returns {string}
  */
 function deriveShortTitle(slug, header) {
@@ -144,7 +144,7 @@ function deriveShortTitle(slug, header) {
 
 /**
  * Title-case a kebab-case topic, e.g. "sprite-effects" -> "Sprite Effects".
- * @param {string} topic - Kebab-case topic
+ * @param {string} topic – Kebab-case topic
  * @returns {string}
  */
 function titleCaseTopic(topic) {

--- a/packages/demos/plugins/demo-vintage-urls.js
+++ b/packages/demos/plugins/demo-vintage-urls.js
@@ -2,7 +2,7 @@
  * Persistent mapping from every historical demo slug to its current slug.
  *
  * Keys are never removed. On a future rename, update the target (and add a new entry for
- * the slug being vacated). Structurally separate from `DEMO_ORDER` in `demo-order.js` —
+ * the slug being vacated). Structurally separate from `DEMO_ORDER` in `demo-order.js` –
  * order is navigation; this file is permanent URL compatibility.
  *
  * Targets that no longer exist on disk (retired demos) stay listed for history and must
@@ -38,7 +38,7 @@ export const VINTAGE_URLS = {
     '018-flurry': 'flurry',
     '019-palette-cycling': 'palette-cycling',
     '020-palette-fade': 'palette-fade',
-    // Retired — number stays unused; no `src/error-preview.js` on disk.
+    // Retired – number stays unused; no `src/error-preview.js` on disk.
     '021-error-preview': 'error-preview',
     '022-bitmap-font': 'bitmap-font',
     '023-crt-pipboy': 'crt-pipboy',

--- a/packages/demos/plugins/highlight-demo-source.js
+++ b/packages/demos/plugins/highlight-demo-source.js
@@ -37,7 +37,7 @@ function getHighlighter() {
 /**
  * Twoslash transformer configured for plain demo JS: allowJs/checkJs, resolve
  * `./shared/*` via vfsRoot = src/, and blit386 types from the workspace package.
- * @param {string} srcDir - Absolute path to the demos `src/` directory.
+ * @param {string} srcDir – Absolute path to the demos `src/` directory.
  * @returns {import('shiki').ShikiTransformer}
  */
 function createDemoTwoslash(srcDir) {
@@ -68,8 +68,8 @@ function createDemoTwoslash(srcDir) {
 /**
  * Highlight a demo source file to HTML (Shiki dual-theme + Twoslash hovers).
  * Results are cached by absolute path + mtime.
- * @param {string} sourcePath - Absolute path to the demo `.js` file.
- * @param {string} rootDir - Demos package root (parent of `src/`).
+ * @param {string} sourcePath – Absolute path to the demo `.js` file.
+ * @param {string} rootDir – Demos package root (parent of `src/`).
  * @returns {Promise<string>} Highlighted HTML (a `.shiki.twoslash` pre/code tree).
  */
 export async function highlightDemoSource(sourcePath, rootDir) {

--- a/packages/demos/plugins/virtual-demos.js
+++ b/packages/demos/plugins/virtual-demos.js
@@ -16,7 +16,7 @@ const IS_NEXT_CHANNEL = process.env.BLIT386_CHANNEL === 'next';
 const ROBOTS_NOINDEX_META = '<meta name="robots" content="noindex">';
 
 // id="channel-banner" lets layout.css hide this in embed mode (styles/layout.css,
-// html[data-embed='true']) - the shell iframe loads this same page at ?embed, so without
+// html[data-embed='true']) – the shell iframe loads this same page at ?embed, so without
 // that rule the banner would render a second time inside the canvas iframe.
 const CHANNEL_BANNER_HTML =
     '<div id="channel-banner" style="position:relative;padding:8px 16px;text-align:center;font:14px/1.4 system-ui,sans-serif;' +
@@ -66,7 +66,7 @@ export function virtualDemos() {
 
     /**
      * Find the registry entry whose virtual HTML path matches an absolute module id.
-     * @param {string} absPath - Absolute path, e.g. resolve(demosDir, "basics.html")
+     * @param {string} absPath – Absolute path, e.g. resolve(demosDir, "basics.html")
      * @returns {object | null}
      */
     function findEntryByAbsPath(absPath) {
@@ -80,7 +80,7 @@ export function virtualDemos() {
 
     /**
      * Find the registry entry for a demo slug.
-     * @param {string} slug - Demo slug, e.g. "basics"
+     * @param {string} slug – Demo slug, e.g. "basics"
      * @returns {object | null}
      */
     function findEntryBySlug(slug) {
@@ -95,7 +95,7 @@ export function virtualDemos() {
     /**
      * Find the registry entry whose source file is the given absolute path. Used by the watcher to
      * tell a top-level demo entry (src/<slug>.js) apart from a src/shared/*.js change.
-     * @param {string} absPath - Absolute path, e.g. resolve(srcDir, "basics.js")
+     * @param {string} absPath – Absolute path, e.g. resolve(srcDir, "basics.js")
      * @returns {object | null}
      */
     function findEntryBySourcePath(absPath) {
@@ -111,7 +111,7 @@ export function virtualDemos() {
      * Render a demo entry's dual-mode HTML page from the shared layout template
      * (shell banner + iframe, and embed canvas + Twoslash source). The nav list
      * includes `title` so the shell can update `document.title` on demo swaps.
-     * @param {object} entry - Registry entry (see buildRegistry's return type).
+     * @param {object} entry – Registry entry (see buildRegistry's return type).
      * @returns {Promise<string>}
      */
     async function renderHtml(entry) {
@@ -352,7 +352,7 @@ export function virtualDemos() {
 /**
  * Render the dev-only auto-generated index page listing every demo (served at /demos/).
  * Not part of the production build; see plugins/virtual-demos.js's configureServer middleware.
- * @param {Array<object>} registry - Full demo registry, as returned by buildRegistry.
+ * @param {Array<object>} registry – Full demo registry, as returned by buildRegistry.
  * @returns {string}
  */
 function renderIndexPage(registry) {
@@ -382,7 +382,7 @@ ${items}
 
 /**
  * Escape a string for safe interpolation into HTML text content/attributes.
- * @param {string} str - Raw text.
+ * @param {string} str – Raw text.
  * @returns {string}
  */
 function escapeHtml(str) {

--- a/packages/demos/scripts/check-demo-registry.mjs
+++ b/packages/demos/scripts/check-demo-registry.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * Enforce mutual consistency between demo files on disk, DEMO_ORDER, VINTAGE_URLS,
- * and NAV_HIDDEN_SLUGS. Failures exit 1 with clear messages — soft console.warns from
+ * and NAV_HIDDEN_SLUGS. Failures exit 1 with clear messages – soft console.warns from
  * buildRegistry are not enough for CI / preflight.
  *
  * Rules:
@@ -21,7 +21,7 @@ import { buildRegistry, NAV_HIDDEN_SLUGS } from '../plugins/demo-registry.js';
 import { RETIRED_SLUGS, VINTAGE_URLS } from '../plugins/demo-vintage-urls.js';
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
-// Mirrors plugins/demo-registry.js — kept local so this script can list files without
+// Mirrors plugins/demo-registry.js – kept local so this script can list files without
 // going through buildRegistry's soft-warn merge path.
 const FILENAME_PATTERN = /^([a-z][a-z0-9]*(?:-[a-z0-9]+)*)\.js$/;
 
@@ -58,7 +58,7 @@ function listDiskSlugs() {
 const diskSlugs = listDiskSlugs();
 const diskSlugSet = new Set(diskSlugs);
 
-// Mute buildRegistry's soft warns — this script reports the same issues as hard errors.
+// Mute buildRegistry's soft warns – this script reports the same issues as hard errors.
 const originalWarn = console.warn;
 console.warn = () => {};
 const registry = buildRegistry(ROOT);

--- a/packages/demos/scripts/generate-audio-loops.mjs
+++ b/packages/demos/scripts/generate-audio-loops.mjs
@@ -3,7 +3,7 @@
  * (music, audio-buses) and their retrofit reuse (snake-game, game-scene).
  * Run with: node scripts/generate-audio-loops.mjs
  *
- * No audio libraries or engine code are used here - this is a small standalone
+ * No audio libraries or engine code are used here – this is a small standalone
  * PCM synthesizer that writes 16-bit mono WAV files directly, matching the
  * "no new dependency" spirit of the rest of the demos toolchain.
  */
@@ -49,7 +49,7 @@ function triangleValue(phaseCycles) {
  * Square wave value in [-1, 1] at a given phase (in cycles), with a configurable duty cycle.
  *
  * @param {number} phaseCycles
- * @param {number} dutyCycle - Fraction of each cycle spent at +1, in [0, 1].
+ * @param {number} dutyCycle – Fraction of each cycle spent at +1, in [0, 1].
  * @returns {number}
  */
 function squareValue(phaseCycles, dutyCycle) {

--- a/packages/demos/src/audio-basics.js
+++ b/packages/demos/src/audio-basics.js
@@ -1,5 +1,5 @@
 /**
- * Audio Basics Demo - loading sounds, playing them, and the "click to allow sound" rule.
+ * Audio Basics Demo – loading sounds, playing them, and the "click to allow sound" rule.
  *
  * Part of the BLIT386 demo series.
  * Prerequisites:
@@ -9,7 +9,7 @@
  * Live version: https://demos.blit386.dev/audio-basics
  *
  * Every web browser refuses to make any sound at all until you click or press a key on
- * the page - this is called the "autoplay policy," and it exists so a page you just
+ * the page – this is called the "autoplay policy," and it exists so a page you just
  * opened cannot suddenly blast noise at you without asking first. BT.isAudioUnlocked
  * tells you whether that first click or key press has happened yet.
  *
@@ -27,11 +27,11 @@
  * The engine's built-in overlay can also show live audio meters: little bars that move
  * up and down with how loud each audio bus (main, music, sfx) is right now, plus a
  * count of how many sounds are playing at once. This demo turns that feature on with
- * `isOverlayAudioMetersEnabled: true` in configure() - open the overlay (see below) and
+ * `isOverlayAudioMetersEnabled: true` in configure() – open the overlay (see below) and
  * watch the meters jump every time a blip or pop plays.
  *
  * Try this:
- * - Click anywhere, or press any key, to unlock sound - watch the message at the top
+ * - Click anywhere, or press any key, to unlock sound – watch the message at the top
  *   change once you do.
  * - Press 1, 2, or 3 (or tap the matching button) to play a short "blip" at a low,
  *   normal, or high pitch.
@@ -85,9 +85,9 @@ const CLICK_MARKER_HALF_SIZE = 6;
 /**
  * Keeps a number from going below `min` or above `max`.
  *
- * @param {number} value - Number to restrict.
- * @param {number} min - Smallest allowed result.
- * @param {number} max - Largest allowed result.
+ * @param {number} value – Number to restrict.
+ * @param {number} min – Smallest allowed result.
+ * @param {number} max – Largest allowed result.
  * @returns {number}
  */
 function clamp(value, min, max) {
@@ -147,7 +147,7 @@ class Demo {
     async init() {
         // AudioClip.load() downloads a sound file and decodes it into a ready-to-play
         // buffer. That part works right away, even before the page is "unlocked" for
-        // sound - only actually hearing a sound (BT.soundPlay, below) waits for that.
+        // sound – only actually hearing a sound (BT.soundPlay, below) waits for that.
         this.blipClip = await AudioClip.load('/audio/blip.wav');
         this.popClip = await AudioClip.load('/audio/pop.wav');
 
@@ -166,7 +166,7 @@ class Demo {
      * Runs the UI kit's once-per-tick housekeeping, then reads pointer clicks.
      *
      * The pitch keys (1/2/3) are bound to the buttons declared in render() via their
-     * { key } option. ui.tick() is where the kit safely catches those presses - keyboard
+     * { key } option. ui.tick() is where the kit safely catches those presses – keyboard
      * "was it just pressed?" flags can only be read reliably here in update(), never in
      * render() (keyboard-input explains why in detail).
      */
@@ -174,12 +174,12 @@ class Demo {
         ui.tick();
 
         // BT.BTN_POINTER_A is the primary click (left mouse button, or a touchscreen
-        // tap). BT.isPressed fires only once, on the frame the click happens - the same
+        // tap). BT.isPressed fires only once, on the frame the click happens – the same
         // way pointer-basics and pointer-paint read their clicks.
         if (BT.isPressed(BT.BTN_POINTER_A, 0)) {
             const pos = BT.pointerPos(0);
 
-            // Skip clicks that land on a UI kit widget - tapping a pitch button should
+            // Skip clicks that land on a UI kit widget – tapping a pitch button should
             // only play its blip, not also fire a pop underneath the button.
             if (!ui.overWidget(pos.x, pos.y)) {
                 this.playPopAt(pos);
@@ -199,7 +199,7 @@ class Demo {
     render() {
         BT.clear(this.theme.bg);
 
-        // The click marker is scene drawing, not a widget - draw it first so the panels
+        // The click marker is scene drawing, not a widget – draw it first so the panels
         // always sit on top of it.
         this.renderClickMarker();
 
@@ -210,13 +210,13 @@ class Demo {
 
     /**
      * The status line in the top-left corner: the shared unlock reminder until audio is
-     * unlocked, then a plain reminder of the controls. A borderless group - just one
+     * unlocked, then a plain reminder of the controls. A borderless group – just one
      * line of text, no panel around it.
      */
     renderStatusLine() {
         ui.begin('topLeft');
 
-        // The shared "click to enable sound" row - it draws itself only while sound is
+        // The shared "click to enable sound" row – it draws itself only while sound is
         // still locked, and disappears on its own after the first click or key press.
         ui.audioUnlockHint();
 
@@ -248,7 +248,7 @@ class Demo {
 
     /**
      * Left-hand panel: one button per pitch preset, plus the pitch last played. Each
-     * button fires on click, tap, or its number key - ui.button() treats all three the
+     * button fires on click, tap, or its number key – ui.button() treats all three the
      * same, which is what makes this demo playable on a touchscreen.
      */
     renderKeyboardPanel() {
@@ -299,7 +299,7 @@ class Demo {
      * Plays the pop sound with a volume and pan taken from where the click landed, and
      * remembers everything the pointer panel and click marker show.
      *
-     * @param {Vector2i} pos - Where the click landed, in display pixels.
+     * @param {Vector2i} pos – Where the click landed, in display pixels.
      */
     playPopAt(pos) {
         const screen = BT.displaySize;

--- a/packages/demos/src/audio-buses.js
+++ b/packages/demos/src/audio-buses.js
@@ -1,5 +1,5 @@
 /**
- * Audio Buses Demo - mixer volume sliders, mute toggles, and a music-ducking alert.
+ * Audio Buses Demo – mixer volume sliders, mute toggles, and a music-ducking alert.
  *
  * Part of the BLIT386 demo series.
  * Prerequisites:
@@ -10,22 +10,22 @@
  *
  * Every sound in the engine flows through one of three "buses" before it reaches your
  * speakers: `main`, `music`, and `sfx`. Think of a bus like a volume knob that affects a
- * whole category of sound at once - turning down `music` fades every music track without
+ * whole category of sound at once – turning down `music` fades every music track without
  * touching sound effects, and turning down `main` fades everything together.
  *
- * Drag any of the three sliders below (mouse or finger - the whole UI is touch-friendly) to
+ * Drag any of the three sliders below (mouse or finger – the whole UI is touch-friendly) to
  * change that bus's volume with BT.audioVolumeSet(). Tap a Mute checkbox to silence a bus
- * with BT.audioMuteSet() - notice the slider value does not change when you mute; muting
+ * with BT.audioMuteSet() – notice the slider value does not change when you mute; muting
  * hides the volume, it does not erase it. BT.audioVolumeGet() and BT.isAudioMuted() read
  * those two things back separately.
  *
  * The Alert button plays a short sound effect while "ducking" (temporarily lowering) the
  * music bus's volume so the alert is easy to hear over the background music, then fades the
- * music back up afterward - the same trick movies and games use so an important sound is
+ * music back up afterward – the same trick movies and games use so an important sound is
  * never buried under the soundtrack.
  *
  * The panels, sliders, checkboxes, and the button all come from the shared UI kit in
- * src/shared/ui.js - the same look every demo in this series uses. The kit works
+ * src/shared/ui.js – the same look every demo in this series uses. The kit works
  * "immediate-mode" style: render() simply declares the widgets it wants each frame, and the
  * kit draws them and answers clicks and taps on the spot.
  *
@@ -98,7 +98,7 @@ class Demo {
             displaySize: new Vector2i(DISPLAY_W, DISPLAY_H),
             // Live per-bus level meters and a voice-count readout in the overlay (off by default).
             isOverlayAudioMetersEnabled: true,
-            // Space is the Alert shortcut - keep the page from scrolling when it is pressed.
+            // Space is the Alert shortcut – keep the page from scrolling when it is pressed.
             isCapturingKeyboardScroll: true,
         };
     }
@@ -113,7 +113,7 @@ class Demo {
         this.musicClip = await AudioClip.load('/audio/music-calm.wav');
 
         // BT.synthPreset.hit() is one of the six built-in sound recipes Synth Toy
-        // explores - a short, punchy stinger, a good fit for an alert.
+        // explores – a short, punchy stinger, a good fit for an alert.
         this.alertClip = await AudioClip.synth(BT.synthPreset.hit());
 
         this.palette = BT.paletteCreate(256);
@@ -126,7 +126,7 @@ class Demo {
         BT.paletteSet(this.palette);
 
         // Music started before the page is unlocked is "remembered" and begins the
-        // instant you click or press a key - unlike BT.soundPlay(), which drops sounds
+        // instant you click or press a key – unlike BT.soundPlay(), which drops sounds
         // played too early.
         BT.musicPlay(this.musicClip, { loop: true });
 
@@ -171,7 +171,7 @@ class Demo {
         ui.end();
 
         // The mixer panel, pinned just below the title strip. Width and height size
-        // themselves to the widest row and the number of rows - no layout math here.
+        // themselves to the widest row and the number of rows – no layout math here.
         ui.begin('topLeft', { y: 30 });
         ui.panel('Mixer');
 
@@ -181,12 +181,12 @@ class Demo {
 
         ui.separator();
 
-        // The button reports a click, a tap, or its Space shortcut - all three the same way.
+        // The button reports a click, a tap, or its Space shortcut – all three the same way.
         if (ui.button('Alert (Space)', { key: 'Space' })) {
             this.triggerAlert();
         }
 
-        // The shared "click to enable sound" row - it draws itself only while sound is
+        // The shared "click to enable sound" row – it draws itself only while sound is
         // still locked, and disappears on its own after the first click or key press.
         ui.audioUnlockHint();
 
@@ -203,7 +203,7 @@ class Demo {
     /**
      * One bus's controls: a volume slider and a mute checkbox.
      *
-     * The engine itself is the single source of truth here - every frame we read the
+     * The engine itself is the single source of truth here – every frame we read the
      * current volume and mute state back from the audio system, show them, and only write
      * a new value when the widget reports a change. That way the UI can never drift out of
      * sync with what the engine is actually doing (for example during the alert duck).

--- a/packages/demos/src/barebones.js
+++ b/packages/demos/src/barebones.js
@@ -1,5 +1,5 @@
 // The smallest possible BLIT386 demo: a single square that moves and jumps.
-// This is the "blank canvas" starter - every other demo in the series builds on this pattern.
+// This is the "blank canvas" starter – every other demo in the series builds on this pattern.
 //
 // What you will see:
 //   - A square that falls under gravity.
@@ -10,8 +10,8 @@
 //
 // The three methods every BLIT386 demo can have:
 //   init()   - called once at startup to set up colors and load resources.
-//   update() - called 60 times per second to move things and respond to input.
-//   render() - called 60 times per second to draw everything on screen.
+//   update() – called 60 times per second to move things and respond to input.
+//   render() – called 60 times per second to draw everything on screen.
 
 import { bootstrap, BT, Color32, Rect2i, Vector2i } from 'blit386';
 
@@ -40,12 +40,12 @@ class Demo {
     theme = null;
 
     // The player's current position on screen, in pixels.
-    // Vector2i stores two whole numbers (x and y) - no fractions needed for pixels.
+    // Vector2i stores two whole numbers (x and y) – no fractions needed for pixels.
     // Starting at (160, 120) puts the square roughly in the center of the 320x240 display.
     player = new Vector2i(160, 120);
 
     // How fast the player is currently falling, in pixels per tick.
-    // update() makes this number grow a little each tick - that steady growing IS gravity,
+    // update() makes this number grow a little each tick – that steady growing IS gravity,
     // which is why the square speeds up as it falls.
     fallSpeed = 0;
 
@@ -69,7 +69,7 @@ class Demo {
         this.palette = BT.paletteCreate(16);
 
         // Slot 1: the color we will use for the player square.
-        // RGB (18, 22, 32) is a very dark navy - almost black, like a night sky.
+        // RGB (18, 22, 32) is a very dark navy – almost black, like a night sky.
         this.palette.set(1, new Color32(18, 22, 32));
 
         // Slot 2: the color we will use to clear the screen each frame.
@@ -77,13 +77,13 @@ class Demo {
         this.palette.set(2, new Color32(32, 0, 128));
 
         // Install the shared UI theme (the colors every demo's buttons and labels use).
-        // It writes 12 colors starting at the slot we pass - slots 4..15 here, which fills
+        // It writes 12 colors starting at the slot we pass – slots 4..15 here, which fills
         // the rest of our small 16-color paint box exactly. This must happen before
         // BT.paletteSet() below, and before any ui.* drawing.
         this.theme = applyTheme(this.palette, 4);
 
         // Hand this palette to the engine. From now on, every draw call uses slot numbers,
-        // not Color32 objects - the engine looks up the actual color from the palette.
+        // not Color32 objects – the engine looks up the actual color from the palette.
         BT.paletteSet(this.palette);
 
         return true;
@@ -91,7 +91,7 @@ class Demo {
 
     /**
      * Called 60 times per second before render(). Reads input and moves the player.
-     * Think of this as the "physics" step - we calculate where things should be,
+     * Think of this as the "physics" step – we calculate where things should be,
      * but we do not draw anything here.
      */
     update() {
@@ -115,7 +115,7 @@ class Demo {
         }
 
         // render() only ASKS for a jump (by setting this flag when the on-screen A button
-        // is tapped) - here in update() we actually perform it, as an instant upward kick.
+        // is tapped) – here in update() we actually perform it, as an instant upward kick.
         if (this.jumpQueued) {
             this.fallSpeed = -3;
             this.jumpQueued = false;
@@ -132,7 +132,7 @@ class Demo {
 
         // Touch input: treat a tap on either half of the screen like a left or right press.
         // ui.tapIn() is true only on the single tick the tap lands, so one tap moves the
-        // square one pixel - a tiny nudge, which is fine for this starter demo.
+        // square one pixel – a tiny nudge, which is fine for this starter demo.
         // Skip taps that land on a UI widget (the on-screen A button sits in RIGHT_ZONE).
         if (ui.tapIn(LEFT_ZONE) && !this.isTapOverWidget()) {
             this.player.x--;
@@ -142,16 +142,16 @@ class Demo {
         }
 
         // Physics: gravity
-        // Each tick, fallSpeed grows by 0.1 pixels/tick - that steady growing is gravity,
+        // Each tick, fallSpeed grows by 0.1 pixels/tick – that steady growing is gravity,
         // and it makes the square fall faster and faster.
         // Without a floor to land on (not added here), the square eventually flies off screen.
         this.fallSpeed += 0.1;
 
         // Apply fall and lift, then round back to a whole pixel.
-        // Vector2i only truncates in its constructor (and width/height setters) - assigning
+        // Vector2i only truncates in its constructor (and width/height setters) – assigning
         // a float to .y directly would leave a fractional coordinate, which breaks the
         // integer-pixel contract every demo drawing call expects.
-        // Y increases downward in BLIT386 - 0 is the top edge of the screen.
+        // Y increases downward in BLIT386 – 0 is the top edge of the screen.
         this.player.y = Math.round(this.player.y + this.fallSpeed - this.liftSpeed);
     }
 
@@ -175,13 +175,13 @@ class Demo {
         // the square an instant upward kick instead of the build-up jump.
         ui.begin('bottomRight');
         if (ui.button('A', { width: 28 })) {
-            // render() only ASKS for the jump by raising this flag - update() performs it.
+            // render() only ASKS for the jump by raising this flag – update() performs it.
             this.jumpQueued = true;
         }
         ui.end();
 
         // Show a dim hint once the player has touched the screen at least once.
-        // No ui.panel() call means this group is just floating text - no box around it.
+        // No ui.panel() call means this group is just floating text – no box around it.
         if (ui.hasTouch()) {
             ui.begin('topLeft');
             ui.label('Tap left/right to move, tap A to hop', { color: 'dim' });

--- a/packages/demos/src/basics.js
+++ b/packages/demos/src/basics.js
@@ -1,5 +1,5 @@
 /**
- * Basics Demo - Your very first BLIT386 program!
+ * Basics Demo – Your very first BLIT386 program!
  *
  * Welcome! This demo teaches you the absolute basics of making things appear
  * on screen with the BLIT386 engine. You will learn:
@@ -19,7 +19,7 @@
  * This demo sets targetFPS to 30 in configure() (slower than the engine default of 60)
  * so motion is easy to follow. update() therefore runs about 30 times per second.
  *
- * IMPORTANT - update() vs. render():
+ * IMPORTANT – update() vs. render():
  *
  * update() runs at a FIXED rate (targetFPS from configure()). It is where you do
  * all game logic: move things, check wall collisions, count bounces. It may run
@@ -28,7 +28,7 @@
  *
  * render() runs ONCE per screen refresh (often 60 times per second on a laptop
  * screen, but it can be faster on 120 or 144 times-per-second monitors). It is
- * where you draw everything. NEVER put game logic here - only drawing code.
+ * where you draw everything. NEVER put game logic here – only drawing code.
  *
  * When you switch to a different browser tab, BOTH update() and render() pause
  * completely. The browser stops calling them to save battery. When you come
@@ -42,14 +42,14 @@
  * "import" loads tools from the BLIT386 engine library.
  * Think of it like opening a toolbox before you start building.
  *   - bootstrap: a helper that starts the engine and connects your demo to it
- *   - BT: the main engine object - you call BT.clear(), BT.drawSprite(), etc.
+ *   - BT: the main engine object – you call BT.clear(), BT.drawSprite(), etc.
  *   - Color32: represents a color with Red, Green, Blue (and optional Alpha)
  *   - SpriteSheet: a loaded image you can draw pieces of on screen (a "sprite")
  *   - Vector2i: a 2D point or direction using whole numbers (x, y)
  */
 import { bootstrap, BT, Color32, SpriteSheet, Vector2i } from 'blit386';
 
-// The shared demo UI kit - every demo in this series uses it for on-screen text and panels
+// The shared demo UI kit – every demo in this series uses it for on-screen text and panels
 // so they all look the same. applyTheme() installs the kit's colors into our palette, and
 // ui.* draws things like the hint label you see in the top-left corner.
 import { applyTheme, ui } from './shared/ui.js';
@@ -69,13 +69,13 @@ import { applyTheme, ui } from './shared/ui.js';
 /** @typedef {import('blit386').SpriteSheet} SpriteSheet */
 /** @typedef {import('blit386').Rect2i} Rect2i */
 
-// BLIT386 uses a "palette" - a numbered list of colors you choose BEFORE drawing.
+// BLIT386 uses a "palette" – a numbered list of colors you choose BEFORE drawing.
 // Think of it like an artist picking paint colors and laying them on a palette tray
 // before starting a painting. Each color gets a number (an "index").
 // When we draw, we say "use color number 1" instead of spelling out the color each time.
 //
 // Index 0 is always transparent (completely invisible). Our custom colors start at 1.
-const C_BG = 1; // Almost-black with a faint green tint - our screen background.
+const C_BG = 1; // Almost-black with a faint green tint – our screen background.
 const C_OVERLAY_BAR = 2; // Slightly lighter bar behind overlay text (easy to read on dark green).
 const C_OVERLAY_GREEN = 3; // Bright green for the position line in the overlay.
 const C_OVERLAY_AMBER = 4; // Amber (warm yellow) for the bounce count in the overlay.
@@ -92,30 +92,30 @@ const SPRITE_BASE = 10;
 const SPRITE_URL = '/sprites/logo-1.png';
 
 /**
- * Bouncing-sprite demo - a friendly first BLIT386 demo.
+ * Bouncing-sprite demo – a friendly first BLIT386 demo.
  *
  * Every BLIT386 demo is a class the engine drives. Three methods are required;
  * configure() and overlayRows() are optional extras this file also uses:
  *
- *   1. configure() - optional. If you define it, the engine calls it once at
+ *   1. configure() – optional. If you define it, the engine calls it once at
  *      the very start so you can change settings (FPS, overlay options, and more).
  *      If you skip it, you get sensible defaults (320x240, 640x480 output, 60 FPS).
  *
- *   2. init() - called once after hardware settings are ready. This is where you
+ *   2. init() – called once after hardware settings are ready. This is where you
  *      load images, set up colors, and pick starting positions. It uses "async"
  *      because loading files takes time, and we need to wait for them to finish
  *      (like waiting for a web page to load).
  *
- *   3. update() - called at the targetFPS rate (30 per second in this demo).
+ *   3. update() – called at the targetFPS rate (30 per second in this demo).
  *      This is where you move the sprite, flip speed when it hits a wall, and
  *      count bounces. It runs at a FIXED pace so motion matches on fast and slow
  *      computers. See the file header for the full explanation.
  *
- *   4. overlayRows() - optional. Feeds extra text lines into the engine overlay
+ *   4. overlayRows() – optional. Feeds extra text lines into the engine overlay
  *      (the HUD you toggle with the ~ key). Not required, but handy for live stats.
  *
- *   5. render() - called once per screen refresh to draw everything. Clear the
- *      screen, draw shapes, print text - all drawing goes here.
+ *   5. render() – called once per screen refresh to draw everything. Clear the
+ *      screen, draw shapes, print text – all drawing goes here.
  *
  * @implements {IBTDemo}
  */
@@ -142,7 +142,7 @@ class Demo {
 
     // "prevPos" remembers where the sprite was at the START of the most recent
     // update() tick, before that tick moved it. render() uses this together with
-    // BT.renderAlpha to draw the sprite smoothly between ticks - see the big comment
+    // BT.renderAlpha to draw the sprite smoothly between ticks – see the big comment
     // above render() below for the full explanation. It starts equal to pos (both
     // point at the same placeholder above) so the very first render() has nothing
     // to blend between; init() updates both again once the real starting position
@@ -209,7 +209,7 @@ class Demo {
 
             // Scrolling timing chart under the title row.
             // Green marks show update() time; amber marks show render() time.
-            // One mark per screen refresh - handy for seeing when work spikes.
+            // One mark per screen refresh – handy for seeing when work spikes.
             isOverlayTimingChartEnabled: true,
             overlayTimingChartHeight: 32,
 
@@ -251,12 +251,12 @@ class Demo {
         // A palette is like an artist's tray of paint colors laid out before painting.
         // We pick every color we need here so the engine knows about them in advance.
         // BT.paletteCreate(256) makes a new empty palette with room for 256 colors.
-        // 256 is a common size in retro-style games - plenty of slots for this demo.
+        // 256 is a common size in retro-style games – plenty of slots for this demo.
         this.palette = BT.paletteCreate(256);
 
         // Fill in the colors we need for background and overlay text.
         // palette.set(number, color) stores one color in a numbered slot.
-        // Color32(Red, Green, Blue) - each value is 0 to 255.
+        // Color32(Red, Green, Blue) – each value is 0 to 255.
         // 0 = none of that color, 255 = maximum of that color.
         this.palette.set(C_BG, new Color32(16, 28, 16)); // Almost-black, faint green tint.
 
@@ -280,7 +280,7 @@ class Demo {
         //
         // { sort: 'none' } keeps colors in the order they appear in the file
         // (left to right, top to bottom). The default would sort them darkest-first
-        // instead - fine for many games, but we keep file order here so the slots
+        // instead – fine for many games, but we keep file order here so the slots
         // match the PNG layout if you peek at the overlay palette grid.
         //
         // We "await" because reading the PNG takes a moment.
@@ -312,7 +312,7 @@ class Demo {
         // BT.displaySize is how big the screen is (320x240 with the defaults).
         // We subtract the sprite's size so the CENTER of the sprite is centered,
         // not its top-left corner.
-        // Math.floor() rounds down to a whole number - we need whole pixels
+        // Math.floor() rounds down to a whole number – we need whole pixels
         // because you cannot draw at position 160.5 on a pixel screen.
         const screen = BT.displaySize;
         const x = Math.floor(screen.x / 2 - this.size.x / 2);
@@ -331,7 +331,7 @@ class Demo {
      * Called at a fixed rate (30 times per second in this demo).
      *
      * This is where ALL game logic goes: moving things, checking collisions,
-     * counting scores, etc. Never draw anything here - that belongs in render().
+     * counting scores, etc. Never draw anything here – that belongs in render().
      *
      * update() may be called 0 to 8 times between screen refreshes:
      *   - Usually it runs about 30 times per second (our targetFPS).
@@ -348,7 +348,7 @@ class Demo {
         // --- Bounce logic (game rules live only in update(), never in render()) ---
         // Remember where the sprite was BEFORE this tick moves it. render() will use
         // this a moment from now to draw a smooth in-between position instead of a
-        // pop - see the big comment above render() below.
+        // pop – see the big comment above render() below.
         this.prevPos = this.pos;
 
         // Move the sprite by adding its speed to its position.
@@ -359,10 +359,10 @@ class Demo {
 
         // Wall test for left/right: pos is the sprite's TOP-LEFT corner.
         // The right edge of the sprite is at pos.x + size.x, so we compare against
-        // displaySize.x - size.x (the farthest right the top-left corner may go
+        // displaySize.x – size.x (the farthest right the top-left corner may go
         // while the whole sprite still fits on screen).
         //
-        // We only flip the speed here - we do not push the sprite back onto the
+        // We only flip the speed here – we do not push the sprite back onto the
         // edge. So for one tick it can sit one pixel past the wall, then travel
         // inward again. That is normal for this simple bounce.
         if (this.pos.x <= 0 || this.pos.x >= BT.displaySize.x - this.size.x) {
@@ -398,7 +398,7 @@ class Demo {
      * those values and draws the picture.
      *
      * IMPORTANT: render() runs once per screen refresh (your monitor's refresh
-     * rate - often 60, but 120 or 144 on gaming displays). Do NOT put game logic
+     * rate – often 60, but 120 or 144 on gaming displays). Do NOT put game logic
      * here because it would run at different speeds on different monitors.
      *
      * Every frame you must clear the screen and redraw everything from
@@ -407,10 +407,10 @@ class Demo {
      *
      * WHY THE SPRITE MIGHT LOOK LIKE IT STUTTERS WITHOUT THE FIX BELOW:
      * This demo sets targetFPS to 30 (see configure() above), but render() still
-     * runs at your monitor's full refresh rate - 60, 120, whatever your screen
+     * runs at your monitor's full refresh rate – 60, 120, whatever your screen
      * supports. That means update() (which moves the sprite) and render()
      * (which draws it) run at DIFFERENT speeds. On a 60-times-per-second monitor,
-     * render() runs roughly twice for every one update() - so if render() just
+     * render() runs roughly twice for every one update() – so if render() just
      * drew this.pos every time, the sprite would sit frozen for one refresh, then
      * hop forward, then sit frozen again. That hop-hop-hop motion is "stutter."
      *
@@ -418,7 +418,7 @@ class Demo {
      * individual film frames (say, one every two screen refreshes), and render()
      * is a projector that can run faster than the film advances. BT.renderAlpha
      * tells the projector how far along we are between "the last film frame" and
-     * "the next one" - a fraction from 0 (the last update() tick just finished) up
+     * "the next one" – a fraction from 0 (the last update() tick just finished) up
      * to just under 1 (the next update() tick is about to happen). We use it below
      * to blend prevPos (where the sprite WAS) toward pos (where it IS) so every
      * single render() draws the sprite at its true in-between position instead of
@@ -426,14 +426,14 @@ class Demo {
      */
     render() {
         // Clear the entire screen to the background color. This erases the previous frame.
-        // C_BG is palette index 1, which we set to (16, 28, 16) in init() - almost
+        // C_BG is palette index 1, which we set to (16, 28, 16) in init() – almost
         // black with a faint green tint.
         BT.clear(C_BG);
 
         // Blend prevPos toward pos by BT.renderAlpha to get the sprite's true position
         // at this exact render moment. Vector2i.lerp(a, b, t) walks a fraction t of the
         // way from a to b: t=0 gives a (prevPos), t=1 gives b (pos), and anything in
-        // between gives a smooth blend - exactly what BT.renderAlpha provides each frame.
+        // between gives a smooth blend – exactly what BT.renderAlpha provides each frame.
         const drawPos = Vector2i.lerp(this.prevPos, this.pos, BT.renderAlpha);
 
         // Draw the bouncing sprite at its smoothed position.
@@ -444,7 +444,7 @@ class Demo {
         //   - destinationPosition: WHERE on screen to draw it (the top-left corner).
         //   - paletteOffset: a number added to every pixel's palette index. We
         //     pass 0 here to use the original colors. Bigger numbers can swap to
-        //     alternate "team colors" - you will see this trick in a future demo.
+        //     alternate "team colors" – you will see this trick in a future demo.
         BT.drawSprite(this.spriteSheet, this.spriteRect, drawPos, 0);
 
         // On-canvas hint drawn with the shared UI kit. ui.begin()/ui.end() open and close
@@ -459,7 +459,7 @@ class Demo {
         ui.end();
 
         // Live stats (position, bounce count) come from overlayRows() in the engine HUD.
-        // The overlay also shows FPS, backend, and this demo's page title - we do not
+        // The overlay also shows FPS, backend, and this demo's page title – we do not
         // duplicate those strings here.
     }
 
@@ -470,7 +470,7 @@ class Demo {
      * palette grid, and these custom rows. Toggle it with the ~ key (Backquote on the
      * keyboard) or by clicking/tapping the symbol in the bottom-left corner.
      * Each row here is plain text plus a palette index for its color.
-     * We reuse overlayRowData every frame and only rewrite the strings - no new arrays.
+     * We reuse overlayRowData every frame and only rewrite the strings – no new arrays.
      *
      * @returns {readonly { leftText: string, textPaletteIndex: number }[]}
      */

--- a/packages/demos/src/bitmap-font.js
+++ b/packages/demos/src/bitmap-font.js
@@ -1,5 +1,5 @@
 /**
- * Bitmap Font Demo - load a proportional .btfont and compare it to the built-in system font.
+ * Bitmap Font Demo – load a proportional .btfont and compare it to the built-in system font.
  *
  * Part of the BLIT386 demo series.
  * Prerequisites:
@@ -8,7 +8,7 @@
  *
  * Live version: https://demos.blit386.dev/bitmap-font
  *
- * Earlier demos use BT.systemPrint() - the built-in 6x14 pixel system font that needs no file.
+ * Earlier demos use BT.systemPrint() – the built-in 6x14 pixel system font that needs no file.
  * This demo shows the ALTERNATIVE: loading a proportional bitmap font from a .btfont file.
  *
  * A "bitmap font" is a font where every letter is pre-drawn as a small picture
@@ -32,7 +32,7 @@
  *
  * The font-metadata caption in the bottom-right corner is drawn with the shared demo UI kit
  * (src/shared/ui.js), so it looks the same as the info panels in every other demo. The
- * showcase lines themselves are hand-drawn on purpose - they ARE the lesson.
+ * showcase lines themselves are hand-drawn on purpose – they ARE the lesson.
  */
 
 import { BitmapFont, bootstrap, BT, Color32, Vector2i } from 'blit386';
@@ -70,7 +70,7 @@ const RAINBOW_TEXT = 'Rainbow Animation!';
 // Dynamic slots: each character in RAINBOW_TEXT gets its own animated color slot.
 // We start at C_RAINBOW_BASE and reserve one slot per character.
 // update() computes each character's current hue and stores it here.
-// render() then reads the slot index - no Color32 math happens during drawing!
+// render() then reads the slot index – no Color32 math happens during drawing!
 const C_RAINBOW_BASE = 20; // first slot for the rainbow characters
 
 // Dynamic slot: placed immediately after the rainbow slots so it can never overlap them
@@ -106,7 +106,7 @@ class Demo {
     // We use it to control the speed of color animations.
     animTime = 0;
 
-    // Measured in init() from BT.systemPrintMeasure('M') - built-in system font is 6x14.
+    // Measured in init() from BT.systemPrintMeasure('M') – built-in system font is 6x14.
     systemCharWidth = 6;
     systemLineHeight = 14;
 
@@ -116,7 +116,7 @@ class Demo {
     /**
      * Sets up the color palette and downloads the bitmap font.
      * Screen size and FPS use engine defaultConfig() (no configure() in this demo).
-     * Notice the "await" keyword - we wait here until the font file is fully downloaded.
+     * Notice the "await" keyword – we wait here until the font file is fully downloaded.
      * The built-in system font (BT.systemPrint) skips this step entirely.
      * Returns true when the font has loaded successfully, or false if loading fails.
      *
@@ -161,7 +161,7 @@ class Demo {
 
         // Load the font file from the server.
         // .btfont is BLIT386's custom font format that includes glyph images.
-        // This is the step that BT.systemPrint() skips - the system font is built in.
+        // This is the step that BT.systemPrint() skips – the system font is built in.
         try {
             this.font = await BitmapFont.load('/fonts/PragmataPro14.btfont');
 
@@ -200,7 +200,7 @@ class Demo {
 
         // The alpha channel controls how opaque (visible) the text is.
         // At pulse=0 the text is nearly invisible; at pulse=1 it is fully opaque.
-        // RGB stays fixed at (100, 100, 255) - a medium blue - so only opacity changes.
+        // RGB stays fixed at (100, 100, 255) – a medium blue – so only opacity changes.
         this.palette.set(C_PULSE, new Color32(100, 100, 255, Math.floor(pulse * 255)));
 
         // Update the rainbow text character colors
@@ -209,7 +209,7 @@ class Demo {
         // init() finished successfully, and init() returns false when the font fails.
         // We learned about HSL (Hue, Saturation, Lightness) colors in the Colors demo:
         // https://demos.blit386.dev/colors
-        let charX = RAINBOW_ORIGIN_X; // Starting x position - same as where render() draws the rainbow text.
+        let charX = RAINBOW_ORIGIN_X; // Starting x position – same as where render() draws the rainbow text.
         for (let i = 0; i < RAINBOW_TEXT.length; i++) {
             // hue is a position on the color wheel (0=red, 120=green, 240=blue, 360=back to red).
             // Using charX (actual x position) matches the visual rhythm of the rainbow.
@@ -220,7 +220,7 @@ class Demo {
             this.palette.set(C_RAINBOW_BASE + i, Color32.fromHSL(hue, 100, 60));
 
             // Advance charX by this character's actual pixel width in the font.
-            // This is specific to BitmapFont - the system font advances a fixed systemCharWidth per character.
+            // This is specific to BitmapFont – the system font advances a fixed systemCharWidth per character.
             const glyph = this.font.getGlyph(RAINBOW_TEXT[i]);
             charX += glyph ? glyph.advance : 7;
         }
@@ -288,7 +288,7 @@ class Demo {
         let currentY = y;
 
         // Each color is looked up by offset: palette[1 + offset] = the desired color.
-        // C_RED_TEXT = 3, so offset = 3 - 1 = 2. That means palette[1 + 2] = palette[3] = red.
+        // C_RED_TEXT = 3, so offset = 3 – 1 = 2. That means palette[1 + 2] = palette[3] = red.
         // With BT.systemPrint() you would just write: BT.systemPrint(pos, C_RED_TEXT, text).
         BT.printFont(this.font, new Vector2i(10, currentY), 'Red Text', C_RED_TEXT - 1);
         currentY += lineHeight;
@@ -322,14 +322,14 @@ class Demo {
 
         // Loop through each character in the string one at a time.
         for (const char of RAINBOW_TEXT) {
-            // The palette offset for character i = C_RAINBOW_BASE + i - 1.
+            // The palette offset for character i = C_RAINBOW_BASE + i – 1.
             // This is because printFont offset N means palette[1 + N].
-            // We want palette[C_RAINBOW_BASE + i], so offset = C_RAINBOW_BASE + i - 1.
+            // We want palette[C_RAINBOW_BASE + i], so offset = C_RAINBOW_BASE + i – 1.
             BT.printFont(this.font, new Vector2i(x, y), char, C_RAINBOW_BASE - 1 + slotIndex);
 
             // Look up how wide this character is in the font's glyph table.
             // "advance" is the number of pixels to move right before drawing the next character.
-            // This is unique to BitmapFont - each letter has its own width in a proportional font.
+            // This is unique to BitmapFont – each letter has its own width in a proportional font.
             // The built-in system font always advances systemCharWidth pixels per character (6 by default).
             const glyph = this.font.getGlyph(char);
 
@@ -341,14 +341,14 @@ class Demo {
         return y + lineHeight + 4;
     }
 
-    // Draws text that pulses in opacity - it fades in and out in a smooth rhythm (alpha pulsing).
+    // Draws text that pulses in opacity – it fades in and out in a smooth rhythm (alpha pulsing).
     // The alpha value is pre-computed in update() using Math.sin and stored in palette slot C_PULSE.
     // This palette animation technique works exactly the same with BT.systemPrint().
     // y: the Y position to start drawing at.
     // lineHeight: how many pixels to move down between lines.
     // Returns the Y position after the text.
     renderPulsingText(y, lineHeight) {
-        // C_PULSE - 1 = 37. That means palette[1 + 37] = palette[38] = C_PULSE (the animated color).
+        // C_PULSE – 1 = 37. That means palette[1 + 37] = palette[38] = C_PULSE (the animated color).
         BT.printFont(this.font, new Vector2i(10, y), 'Pulsing Text', C_PULSE - 1);
 
         return y + lineHeight + 4;
@@ -367,7 +367,7 @@ class Demo {
         return y + lineHeight;
     }
 
-    // Demonstrates font.measureText() - which tells you exactly how wide a string will
+    // Demonstrates font.measureText() – which tells you exactly how wide a string will
     // be before you draw it. We draw an underline that is exactly the right length.
     // BT.systemPrint() does not have a measureText() equivalent; this is a BitmapFont-only feature.
     // y: the Y position to start drawing at.
@@ -377,11 +377,11 @@ class Demo {
         const measureText = 'Measured Width';
 
         // Ask the font how many pixels wide this string will be when drawn.
-        // The system font doesn't support this - it's a BitmapFont-specific feature.
+        // The system font doesn't support this – it's a BitmapFont-specific feature.
         const textWidth = this.font.measureText(measureText);
 
         // Draw the text in light gray.
-        // C_GRAY_TEXT - 1 = 6. That means palette[1 + 6] = palette[7] = C_GRAY_TEXT.
+        // C_GRAY_TEXT – 1 = 6. That means palette[1 + 6] = palette[7] = C_GRAY_TEXT.
         BT.printFont(this.font, new Vector2i(10, y), measureText, C_GRAY_TEXT - 1);
 
         // Draw an orange underline that is exactly as wide as the text we measured.
@@ -409,7 +409,7 @@ class Demo {
         // Give the group a background, border, and an amber title.
         ui.panel('Font Info');
 
-        // ui.kv() draws an aligned "KEY: value" row - the key dim, the value bright.
+        // ui.kv() draws an aligned "KEY: value" row – the key dim, the value bright.
         ui.kv('FONT', this.font.name);
         ui.kv('SIZE', `${this.font.size}pt`);
         ui.kv('GLYPHS', this.font.glyphCount);

--- a/packages/demos/src/coordinate-patterns.js
+++ b/packages/demos/src/coordinate-patterns.js
@@ -10,7 +10,7 @@
 // WHAT YOU WILL SEE
 // A world you can scroll around forever with the arrow keys, the on-screen D-pad, or a
 // swipe. Press "Jump far" to fling yourself thousands of tiles away, then "Home" to come
-// straight back - and find every tile exactly where you left it.
+// straight back – and find every tile exactly where you left it.
 //
 // Nothing was saved. The demo stores zero tiles. Each square works out what it is from
 // nothing but its own position.
@@ -34,8 +34,8 @@
 // Noise demo is for: https://demos.blit386.dev/noise
 //
 // WATCH THE LAYER SLIDER CLOSELY
-// The ground comes from hash2i, which only knows x and y - so sliding the layer leaves the
-// landscape untouched. The little rocks come from hash3i, which also knows the layer - so
+// The ground comes from hash2i, which only knows x and y – so sliding the layer leaves the
+// landscape untouched. The little rocks come from hash3i, which also knows the layer – so
 // they change completely. Same place, different detail: that is the third number at work.
 //
 // The engine splits work the usual way: update() moves things; render() only draws.
@@ -95,8 +95,8 @@ const TERRAIN_GRASS = 3;
  * There is no list of tiles anywhere in this demo. This function is the world: hand it a
  * position and it hands back the ground, the same answer every time, forever.
  *
- * @param {number} tx - Tile column. Can be any whole number, including huge and negative ones.
- * @param {number} ty - Tile row.
+ * @param {number} tx – Tile column. Can be any whole number, including huge and negative ones.
+ * @param {number} ty – Tile row.
  * @returns {number} One of the TERRAIN_* values.
  */
 function terrainAt(tx, ty) {
@@ -137,7 +137,7 @@ class Demo {
     theme = null;
 
     // Where we are looking, measured in world pixels. These two numbers are the only thing
-    // the demo remembers about the world - and they are a position, not a map.
+    // the demo remembers about the world – and they are a position, not a map.
     camX = 0;
     camY = 0;
 
@@ -145,7 +145,7 @@ class Demo {
     layer = 0;
 
     /**
-     * Builds the palette. There is no world to build - that is the whole idea.
+     * Builds the palette. There is no world to build – that is the whole idea.
      *
      * @returns {Promise<boolean>}
      */
@@ -179,7 +179,7 @@ class Demo {
         ui.tick();
 
         // Held keys and the on-screen D-pad both scroll. isKeyDown is "held right now", which
-        // is safe to read from either update() or render() - unlike a key press, which is a
+        // is safe to read from either update() or render() – unlike a key press, which is a
         // one-off event and must be read here.
         if (BT.isKeyDown('ArrowLeft') || ui.dpad.isDown('left')) {
             this.camX -= SCROLL_SPEED;
@@ -296,7 +296,7 @@ class Demo {
 
                 // The decoration is the only thing that knows about the layer. hash3i takes a
                 // third coordinate, so changing the layer gives a completely different answer
-                // for the very same tile - while the ground underneath, which came from
+                // for the very same tile – while the ground underneath, which came from
                 // hash2i, does not budge.
                 //
                 // A dot is too small to be worth trimming, so one that would poke outside the
@@ -321,7 +321,7 @@ class Demo {
         ui.panel('Travel');
 
         if (ui.button('Jump far', { key: 'KeyJ' })) {
-            // Thousands of tiles in one step. A world held in memory could not do this - there
+            // Thousands of tiles in one step. A world held in memory could not do this – there
             // would be nothing out there yet. Here there is nothing to prepare.
             this.camX += JUMP_DISTANCE;
             this.camY += JUMP_DISTANCE;

--- a/packages/demos/src/fonts.js
+++ b/packages/demos/src/fonts.js
@@ -1,8 +1,8 @@
 /**
- * Fonts Demo - built-in system font and palette-animated text.
+ * Fonts Demo – built-in system font and palette-animated text.
  *
  * Part of the BLIT386 demo series.
- * Prerequisites: Basics - https://demos.blit386.dev/basics
+ * Prerequisites: Basics – https://demos.blit386.dev/basics
  * Live version: https://demos.blit386.dev/fonts
  *
  * BT.systemPrint() draws text with the engine's built-in system font (6 pixels wide,
@@ -15,7 +15,7 @@
  *   - Pulsing text: animating alpha in update() on a single palette slot
  *
  * The title strip and the small pointer to Bitmap Font demo are chrome drawn by the shared UI kit
- * (src/shared/ui.js). The showcase lines themselves stay hand-rolled on purpose - drawing
+ * (src/shared/ui.js). The showcase lines themselves stay hand-rolled on purpose – drawing
  * text with BT.systemPrint() is the whole lesson of this demo.
  *
  * For custom bitmap fonts loaded from disk, variable glyph widths, and BT.printFont(),
@@ -47,14 +47,14 @@ const RAINBOW_TEXT = 'Rainbow Animation!';
 
 // Dynamic slots: one animated color per character in RAINBOW_TEXT.
 // update() computes each character's current hue and stores it here.
-// render() then reads the slot index - no Color32 math happens during drawing!
+// render() then reads the slot index – no Color32 math happens during drawing!
 const C_RAINBOW_BASE = 20; // first rainbow character; next slots follow contiguously
 
 // Dynamic slot: pulsing text changes alpha every frame (fades in and out in a smooth wave).
 // Always sits immediately after the last rainbow character slot.
 const C_PULSE = C_RAINBOW_BASE + RAINBOW_TEXT.length;
 
-// Filled in init() from BT.systemPrintMeasure - width of one monospace system glyph.
+// Filled in init() from BT.systemPrintMeasure – width of one monospace system glyph.
 let systemCharWidth = 6;
 
 /**
@@ -99,7 +99,7 @@ class Demo {
 
     /**
      * Sets up the color palette.
-     * Unlike Bitmap Font demo, there is no font to load - BT.systemPrint() needs nothing.
+     * Unlike Bitmap Font demo, there is no font to load – BT.systemPrint() needs nothing.
      *
      * @returns {Promise<boolean>} Returns true when ready.
      */
@@ -155,13 +155,13 @@ class Demo {
         // Adding 0.5 and multiplying by 0.5 shifts the range from [-1,1] to [0,1].
         const pulse = Math.sin(2 * Math.PI * 3 * this.animTime) * 0.5 + 0.5;
         // We drive the alpha (opacity) channel so the text fades in and out in a smooth wave.
-        // RGB stays fixed at (100, 100, 255) - a soft blue - while alpha goes from 0 to 255.
+        // RGB stays fixed at (100, 100, 255) – a soft blue – while alpha goes from 0 to 255.
         this.palette.set(C_PULSE, new Color32(100, 100, 255, Math.floor(pulse * 255)));
 
         // Update the rainbow text character colors
         // Each character gets a hue based on its horizontal position and the current time.
         // systemCharWidth comes from systemPrintMeasure in init() (6 pixels for this font).
-        let charX = 10; // Starting x position - same as where render() draws the rainbow text.
+        let charX = 10; // Starting x position – same as where render() draws the rainbow text.
         for (let i = 0; i < RAINBOW_TEXT.length; i++) {
             // hue is a position on the color wheel (0=red, 120=green, 240=blue, 360=back to red).
             // Using charX (actual x position) matches the visual rhythm of the rainbow.
@@ -181,7 +181,7 @@ class Demo {
 
         // Title strip across the top, drawn by the shared UI kit. begin('topBar') opens a
         // full-width 22-pixel band, panel() fills it and prints the amber title, and end()
-        // closes the group. This is chrome only - the lesson lives in the lines below.
+        // closes the group. This is chrome only – the lesson lives in the lines below.
         ui.begin('topBar');
         ui.panel('Fonts - BT.systemPrint() showcase');
         ui.end();
@@ -196,7 +196,7 @@ class Demo {
         this.renderSpecialCharacters(y);
 
         // A small dim caption in the bottom-left corner pointing to the next font lesson.
-        // No ui.panel() call inside the group means it is just floating text - no box.
+        // No ui.panel() call inside the group means it is just floating text – no box.
         ui.begin('bottomLeft');
         ui.label('To see how to load bitmap fonts from disk,', { color: 'dim' });
         ui.label('go to Bitmap Font demo', { color: 'dim' });
@@ -207,7 +207,7 @@ class Demo {
      * Draws the same four words, each in a different color.
      * Pass the palette slot number directly to BT.systemPrint() to change the text color.
      *
-     * @param {number} y - The Y position to start drawing at.
+     * @param {number} y – The Y position to start drawing at.
      * @returns {number} The Y position after the last line drawn.
      */
     renderColoredText(y) {
@@ -216,7 +216,7 @@ class Demo {
         // because they expect the original value to stay the same throughout the function.
         let currentY = y;
 
-        // BT.systemPrint(position, paletteSlot, text) - the slot number IS the color directly.
+        // BT.systemPrint(position, paletteSlot, text) – the slot number IS the color directly.
         // Compare to BT.printFont() in Bitmap Font demo which uses a 0-based palette offset per glyph.
         BT.systemPrint(new Vector2i(10, currentY), C_RED_TEXT, 'Red Text');
         const lineAdvance = BT.systemPrintMeasure('Red Text').y + 4;
@@ -241,7 +241,7 @@ class Demo {
      * The system font is monospace, so we step systemCharWidth pixels per character.
      * Colors were pre-computed in update().
      *
-     * @param {number} y - The Y position to start drawing at.
+     * @param {number} y – The Y position to start drawing at.
      * @returns {number} The Y position after the text.
      */
     renderRainbowText(y) {
@@ -269,12 +269,12 @@ class Demo {
      * Draws the pulsing-text line. The text fades in and out in a smooth rhythm (alpha pulsing).
      * The alpha value is pre-computed in update() using Math.sin and stored in palette slot C_PULSE.
      *
-     * @param {number} y - The Y position to start drawing at.
+     * @param {number} y – The Y position to start drawing at.
      * @returns {number} The Y position after the text.
      */
     renderPulsingText(y) {
         // C_PULSE holds an alpha (transparency) pulse precomputed in update():
-        // RGB stays fixed at (100, 100, 255) - a soft blue - and the alpha channel is
+        // RGB stays fixed at (100, 100, 255) – a soft blue – and the alpha channel is
         // animated from 0 to 255 with Math.sin(), so the text fades in and out smoothly
         // rather than shifting hue. The engine blends the palette color against the
         // background at draw time, which is what gives the pulse its smooth look.
@@ -287,7 +287,7 @@ class Demo {
      * Shows that the system font can draw special characters.
      * Last section before the overlay bars, so this helper does not return an updated y.
      *
-     * @param {number} y - The Y position to start drawing at.
+     * @param {number} y – The Y position to start drawing at.
      */
     renderSpecialCharacters(y) {
         BT.systemPrint(new Vector2i(10, y), C_GRAY_TEXT, 'Special: 3 x 4 = 12');

--- a/packages/demos/src/gamepad-input.js
+++ b/packages/demos/src/gamepad-input.js
@@ -1,5 +1,5 @@
 /**
- * Gamepad Input Demo - analog sticks, triggers, and face-button masks.
+ * Gamepad Input Demo – analog sticks, triggers, and face-button masks.
  *
  * Part of the BLIT386 demo series.
  * Prerequisites: Basics (https://demos.blit386.dev/basics),
@@ -17,7 +17,7 @@
  * The status panel on the right comes from the shared UI kit in src/shared/ui.js:
  * pip rows light up while buttons are physically held, key-value rows show the raw
  * stick axis numbers, and a meter bar fills with trigger pressure. The demo itself
- * still needs a real gamepad - the kit only draws the readouts (and shows a friendly
+ * still needs a real gamepad – the kit only draws the readouts (and shows a friendly
  * note on touch screens, where a gamepad is usually not available).
  *
  * Try this:
@@ -107,7 +107,7 @@ class Demo {
     // Pod/aim position at the START of the most recent update() tick, before this
     // tick's stick input moved them. render() blends between these and podPos/aimPos
     // using BT.renderAlpha so the pod and aim cursor glide smoothly between physics
-    // ticks instead of jumping - see "Interpolating render state with renderAlpha" in
+    // ticks instead of jumping – see "Interpolating render state with renderAlpha" in
     // the engine's docs/api-game-loop.md. Start equal to podPos/aimPos so the very
     // first frame does not blend in from a stale position.
     prevPodPos = this.podPos;
@@ -181,7 +181,7 @@ class Demo {
     update() {
         // Let the UI kit do its once-per-tick housekeeping first. This demo has no kit
         // buttons or key bindings, but ui.tick() also tracks whether the screen has ever
-        // been touched - that is what feeds the ui.hasTouch() hint drawn in render().
+        // been touched – that is what feeds the ui.hasTouch() hint drawn in render().
         ui.tick();
 
         // Ask the engine whether a gamepad is currently plugged in for this player slot.
@@ -190,7 +190,7 @@ class Demo {
         // "Edge detection": we only want to react the moment the gamepad is first connected,
         // not every single frame it stays connected. So we compare the current state
         // to what it was last frame (stored in wasConnected).
-        // If it just became true (false -> true), that is the "rising edge" - the instant of connection.
+        // If it just became true (false -> true), that is the "rising edge" – the instant of connection.
         if (connected && !this.wasConnected) {
             // Label this moment on the overlay timing chart so you can see exactly
             // which frame the gamepad was detected.
@@ -410,18 +410,18 @@ class Demo {
      * numbers, and a trigger pressure meter.
      *
      * Everything read here is HELD state or an axis value, both safe to read in render().
-     * Button EDGES (BT.isPressed - "did it go down this exact frame?") must stay in
+     * Button EDGES (BT.isPressed – "did it go down this exact frame?") must stay in
      * update(), where this demo already handles them (keyboard-input explains why).
      */
     renderStatusPanel() {
         // Bitmask OR: BT.BTN_A | BT.BTN_B builds one mask. isDown returns true when
-        // **either** button is held - handy for "press any of these" checks in games.
+        // **either** button is held – handy for "press any of these" checks in games.
         // The two single-button pips above it let you watch the OR happen live.
         const aHeld = BT.isDown(BT.BTN_A, PLAYER);
         const bHeld = BT.isDown(BT.BTN_B, PLAYER);
         const maskHeld = BT.isDown(BT.BTN_A | BT.BTN_B, PLAYER);
 
-        // Raw axis values for the readout rows - the same calls the movement code uses.
+        // Raw axis values for the readout rows – the same calls the movement code uses.
         const moveX = BT.getAxis(BT.AXIS_LEFT_X, PLAYER);
         const moveY = BT.getAxis(BT.AXIS_LEFT_Y, PLAYER);
         const aimX = BT.getAxis(BT.AXIS_RIGHT_X, PLAYER);
@@ -448,7 +448,7 @@ class Demo {
         ui.kv('RY', formatAxis(aimY));
 
         // The meter fills left-to-right with trigger pressure (0 = released, 1 = fully
-        // squeezed) - the same value that grows the pod.
+        // squeezed) – the same value that grows the pod.
         ui.meter('Throttle', throttle, { width: THROTTLE_METER_W });
         ui.end();
     }

--- a/packages/demos/src/input-map-remapping.js
+++ b/packages/demos/src/input-map-remapping.js
@@ -1,5 +1,5 @@
 /**
- * Input Map Remapping Demo - runtime `BT.inputMap` and `BT.inputMapReset`.
+ * Input Map Remapping Demo – runtime `BT.inputMap` and `BT.inputMapReset`.
  *
  * Part of the BLIT386 demo series.
  * Prerequisites: Basics (https://demos.blit386.dev/basics),
@@ -14,7 +14,7 @@
  * defaults, a custom map, and a cleared binding.
  *
  * Important: `BT.isKeyDown('KeyW')` only watches the real W key. Changing the map
- * does not rename keys - it changes which keys feed face buttons through
+ * does not rename keys – it changes which keys feed face buttons through
  * `BT.isDown(BT.BTN_*, player)`.
  *
  * The preset switches are shared-UI-kit buttons (src/shared/ui.js), so on a phone
@@ -86,11 +86,11 @@ class Demo {
     /** @type {Palette | null} */
     palette = null;
 
-    // Palette slot map returned by applyTheme() - theme.bg, theme.text, and friends.
+    // Palette slot map returned by applyTheme() – theme.bg, theme.text, and friends.
     /** @type {ReturnType<typeof applyTheme> | null} */
     theme = null;
 
-    // Human-readable name for the active preset (we track it ourselves - the
+    // Human-readable name for the active preset (we track it ourselves – the
     // engine does not expose a "get current map" API).
     presetLabel = '1 Defaults (engine tables)';
 
@@ -160,7 +160,7 @@ class Demo {
 
         // The reset button below is bound to Digit0, but the original demo also accepted
         // R as a second reset key. A kit button can only carry one key binding, so this
-        // alias stays here in update() (keyboard edges are safe to read here - never in
+        // alias stays here in update() (keyboard edges are safe to read here – never in
         // render()). `isKeyPressed` without a repeat rate only fires once per press.
         if (BT.isKeyPressed('KeyR')) {
             this.applyPresetDefaults();
@@ -192,7 +192,7 @@ class Demo {
 
         // The preset switcher lives in its own panel in the bottom-left corner. Each
         // ui.button() returns true on the one frame it is clicked, tapped, or its bound
-        // key goes down - all three inputs behave exactly the same.
+        // key goes down – all three inputs behave exactly the same.
         ui.begin('bottomLeft');
         ui.panel('Presets');
 
@@ -229,7 +229,7 @@ class Demo {
 
     /**
      * Custom layout: remap a few buttons, and give **two** keys for one direction
-     * so either key counts (OR) - hold Q **or** E and player 0 left should light.
+     * so either key counts (OR) – hold Q **or** E and player 0 left should light.
      */
     applyPresetCustom() {
         // Start from known defaults, then layer edits (order matters only for clarity).
@@ -242,7 +242,7 @@ class Demo {
         // until we reset (we replace the whole key list for that button).
         BT.inputMap(1, BT.BTN_UP, 'KeyI');
 
-        // Player 0: LEFT listens to **two** keys at once - first **or** second held counts.
+        // Player 0: LEFT listens to **two** keys at once – first **or** second held counts.
         BT.inputMap(0, BT.BTN_LEFT, 'KeyQ', 'KeyE');
 
         this.presetLabel = '2 Custom (P0: Z=A, Q|E=Lft | P1: I=Up)';
@@ -264,9 +264,9 @@ class Demo {
     /**
      * One player's panel: title, default-key hints, and a column of live face-button pips.
      *
-     * @param {number} player - 0 or 1.
-     * @param {number} originX - Left edge (pixels).
-     * @param {number} originY - Top edge (pixels).
+     * @param {number} player – 0 or 1.
+     * @param {number} originX – Left edge (pixels).
+     * @param {number} originY – Top edge (pixels).
      */
     renderPlayerPanel(player, originX, originY) {
         // Pin the group at an exact position and force both panels to the same width so
@@ -275,7 +275,7 @@ class Demo {
         ui.panel(player === 0 ? 'Player 0' : 'Player 1');
 
         // Which physical keys feed this player's face buttons out of the box. The custom
-        // preset changes some of these - that is the whole point of the demo.
+        // preset changes some of these – that is the whole point of the demo.
         if (player === 0) {
             ui.label('Default keys: W, A, S, D move', { color: 'dim' });
             ui.label('Space or B=A, N=B, 5=Start, Esc=Select', { color: 'dim' });
@@ -289,7 +289,7 @@ class Demo {
 
         // One read-only pip per logical face button. The pip lights up while the button
         // is held. `code` is a BT.BTN_* constant (Up, A, Start, ...), not a raw key
-        // string - the runtime map (changed by BT.inputMap) decides which physical keys
+        // string – the runtime map (changed by BT.inputMap) decides which physical keys
         // feed it. BT.isDown reads held state (not a press edge), so it is safe here in
         // render().
         for (let i = 0; i < FACE_BUTTONS.length; i++) {

--- a/packages/demos/src/keyboard-diagnostic.js
+++ b/packages/demos/src/keyboard-diagnostic.js
@@ -1,5 +1,5 @@
 /**
- * Keyboard Diagnostic - visual keyboard with press / hold / release feedback.
+ * Keyboard Diagnostic – visual keyboard with press / hold / release feedback.
  *
  * Part of the BLIT386 demo series.
  * Prerequisites: Keyboard Input (https://demos.blit386.dev/keyboard-input)
@@ -76,7 +76,7 @@ const KEY_GAP = 2; // Empty space between adjacent key caps, in pixels.
 
 /**
  * The whole keyboard picture as data: six rows of key descriptors, top to bottom.
- * addKeyRow() walks each row like laying tiles on a shelf - it keeps a running x
+ * addKeyRow() walks each row like laying tiles on a shelf – it keeps a running x
  * position, places a key, then moves right by the key's width plus KEY_GAP. A key
  * only needs extra fields when it breaks the pattern: `w` for wide caps (Backspace,
  * Enter, Space), `gapBefore` for the small gaps between F-key clusters, and `x`
@@ -277,7 +277,7 @@ class Demo {
     }
 
     update() {
-        // Let the UI kit track touch contacts first - ui.hasTouch() in render()
+        // Let the UI kit track touch contacts first – ui.hasTouch() in render()
         // relies on this housekeeping running every update tick.
         ui.tick();
 
@@ -348,7 +348,7 @@ class Demo {
         ui.kv('Tick', this.lastTick === null ? '-' : this.lastTick);
         ui.end();
 
-        // Edge counters: after a burst of fast taps both numbers must match - a
+        // Edge counters: after a burst of fast taps both numbers must match – a
         // mismatch means an edge was dropped somewhere.
         ui.begin('bottomRight');
         ui.panel();
@@ -410,8 +410,8 @@ class Demo {
      * Lays out one row of key caps from its descriptor, left to right.
      *
      * The running x position starts at the row's startX. For each key we first honor
-     * its quirks - jump to an absolute column (`x`) or skip a few extra pixels
-     * (`gapBefore`) - then place the cap and step right by its width plus the
+     * its quirks – jump to an absolute column (`x`) or skip a few extra pixels
+     * (`gapBefore`) – then place the cap and step right by its width plus the
      * standard KEY_GAP, ready for the next key.
      *
      * @param {KeyRow} row One entry of KEYBOARD_ROWS.

--- a/packages/demos/src/keyboard-input.js
+++ b/packages/demos/src/keyboard-input.js
@@ -1,5 +1,5 @@
 /**
- * Keyboard Input Demo - face buttons, raw keys, and typed text.
+ * Keyboard Input Demo – face buttons, raw keys, and typed text.
  *
  * Part of the BLIT386 demo series.
  * Prerequisites:
@@ -23,7 +23,7 @@
  *
  * The panels and readouts are drawn with the shared demo UI kit (src/shared/ui.js),
  * so this page looks like every other demo in the series. The inputs themselves stay
- * deliberately keyboard-only - there is no touch stand-in for a physical keyboard,
+ * deliberately keyboard-only – there is no touch stand-in for a physical keyboard,
  * so on a touch device the page shows a "needs a keyboard" notice instead.
  *
  * Try this:
@@ -32,7 +32,7 @@
  *   BT.isKeyPressed, no repeat rate). Press a different key and the counter resets.
  * - Hold Q to see isKeyDown; tap F and watch the release readout.
  * - Type letters into the buffer line at the bottom.
- * - If keys stop responding, click the canvas - focus may have moved to another
+ * - If keys stop responding, click the canvas – focus may have moved to another
  *   part of the page after you tabbed away.
  */
 
@@ -63,7 +63,7 @@ const PRESS_COUNTER_KEYS = [
 // Palette slots of three shared UI theme colors, for the overlay timing chart below.
 // applyTheme() in init() writes the twelve theme colors into slots 240-251 (its default
 // start slot), but configure() runs BEFORE init(), so the chart style cannot read
-// this.theme yet - we spell out where the colors will land: 244 = text, 245 = dim gray,
+// this.theme yet – we spell out where the colors will land: 244 = text, 245 = dim gray,
 // 247 = accent green.
 const THEME_TEXT_SLOT = 244;
 const THEME_DIM_SLOT = 245;
@@ -82,7 +82,7 @@ const TYPED_PANEL_WIDTH = 308; // The typed-text panel spans almost the full scr
 /**
  * Turns `KeyH` into `H`, `Digit5` into `5`, and leaves other codes readable.
  *
- * @param {string} code - KeyboardEvent.code value.
+ * @param {string} code – KeyboardEvent.code value.
  * @returns {string}
  */
 function formatKeyCode(code) {
@@ -166,7 +166,7 @@ class Demo {
         // applyTheme() installs the twelve shared UI colors (into high palette slots, far
         // above where scene art normally lives) and reports their slots, so render() can
         // clear the screen with the theme's background color. Every panel, pip, and text
-        // row on this page draws with these colors - no hand-picked HUD slots needed.
+        // row on this page draws with these colors – no hand-picked HUD slots needed.
         this.theme = applyTheme(this.palette);
 
         BT.paletteSet(this.palette);
@@ -199,7 +199,7 @@ class Demo {
      */
     update() {
         // The UI kit's once-per-tick housekeeping. This demo has no kit buttons, but
-        // ui.tick() is also where the kit notices touch contacts - ui.hasTouch() in
+        // ui.tick() is also where the kit notices touch contacts – ui.hasTouch() in
         // render() relies on it to know when to show the "needs a keyboard" notice.
         ui.tick();
 
@@ -268,7 +268,7 @@ class Demo {
         ui.end();
 
         // One borderless line right under the title. On a touch device it becomes a
-        // warning - this page has no on-screen substitute for a physical keyboard - and
+        // warning – this page has no on-screen substitute for a physical keyboard – and
         // otherwise it lists the default key maps as a quick reference. pad: 0 removes
         // the group's inner padding so the single line sits snug against its y position.
         ui.begin('topLeft', { y: NOTICE_Y, pad: 0 });
@@ -296,8 +296,8 @@ class Demo {
     /**
      * One player's mapped face buttons as a panel of lit/unlit pip rows.
      *
-     * @param {number} player - 0 or 1 (`BT.isDown` player index).
-     * @param {number} x - Left edge of the panel in display pixels.
+     * @param {number} player – 0 or 1 (`BT.isDown` player index).
+     * @param {number} x – Left edge of the panel in display pixels.
      */
     renderFacePanel(player, x) {
         // Pin the panel to its column; both player panels share the same top edge.
@@ -308,7 +308,7 @@ class Demo {
 
         // One read-only pip per button: filled while the button is held, hollow when it
         // is up. BT.isDown() reports held state (not a press edge), so reading it here
-        // in render() is safe - only press/release EDGES must stay in update().
+        // in render() is safe – only press/release EDGES must stay in update().
         for (let i = 0; i < buttons.length; i++) {
             const { label, code } = buttons[i];
 

--- a/packages/demos/src/logo-lowres.js
+++ b/packages/demos/src/logo-lowres.js
@@ -1,4 +1,4 @@
-// @pageTitle BLIT386 Demo - Logo Low-Res
+// @pageTitle BLIT386 Demo – Logo Low-Res
 //
 // Logo Low-Res: the BLIT386 logo on a very chunky low-res screen, wrapped
 // in the same Orava B/W CRT stack used in Sprite Effects demo.
@@ -6,7 +6,7 @@
 //
 // What you will see:
 //   - The logo sprite from Basics demo centered on a tiny 80x60 pixel canvas.
-//     That is one quarter of the usual 320x240 in each direction - even smaller
+//     That is one quarter of the usual 320x240 in each direction – even smaller
 //     than an old Game Boy screen (160x144).
 //   - The engine upscales that 80x60 picture 3x to 240x180 using nearest-neighbor
 //     filtering, so each logical pixel becomes a big hard-edged 3x3 block.
@@ -21,7 +21,7 @@
 //   The engine renders the 80x60 palette-indexed picture into a 240x180 RGBA buffer
 //   (the drawingBufferSize step). The CRT effects run AFTER that, on the RGBA buffer,
 //   so they see 240x180 pixels and can paint convincing curved-tube scanlines across
-//   the whole frame - even though the game itself only used 80x60 logical pixels.
+//   the whole frame – even though the game itself only used 80x60 logical pixels.
 //
 // Prerequisites: Basics (https://demos.blit386.dev/basics),
 //                Sprite Effects (https://demos.blit386.dev/sprite-effects).
@@ -67,7 +67,7 @@ import { isAvailable } from './shared/post-process-backend.js';
 // --- Screen dimensions ---
 
 // The logical drawing area where BT.draw* calls happen.
-// 80x60 is our tiny retro resolution - even smaller than a Game Boy screen (160x144).
+// 80x60 is our tiny retro resolution – even smaller than a Game Boy screen (160x144).
 const DISPLAY_W = 80;
 const DISPLAY_H = 60;
 
@@ -122,7 +122,7 @@ const BAND_WOBBLE_COOLDOWN_MIN = 100; // At least ~1.7 seconds between wobbles (
 const BAND_WOBBLE_COOLDOWN_MAX = 280; // Up to ~4.7 seconds between wobbles.
 const BAND_WOBBLE_ACTIVE_MIN = 3; // Wobble lasts at least 3 ticks (~0.05 s).
 const BAND_WOBBLE_ACTIVE_MAX = 10; // Wobble lasts up to 10 ticks (~0.17 s).
-const BAND_WOBBLE_INTENSITY = 0.11; // Peak strength - much milder than a full TV fault.
+const BAND_WOBBLE_INTENSITY = 0.11; // Peak strength – much milder than a full TV fault.
 
 /**
  * The BLIT386 logo centered on an 80x60 pixel canvas, upscaled 3x,
@@ -131,7 +131,7 @@ const BAND_WOBBLE_INTENSITY = 0.11; // Peak strength - much milder than a full T
  * @implements {IBTDemo}
  */
 class Demo {
-    // The color palette - a numbered list of every color this demo will use.
+    // The color palette – a numbered list of every color this demo will use.
     /** @type {Palette | null} */
     palette = null;
 
@@ -231,7 +231,7 @@ class Demo {
      * centers it, and (when WebGPU is available) registers the Orava CRT effects.
      *
      * "async" and "await" pause this function while the PNG downloads from the
-     * server - think of it like pressing Pause on a video and waiting for it to buffer.
+     * server – think of it like pressing Pause on a video and waiting for it to buffer.
      *
      * @returns {Promise<boolean>} true when everything is ready.
      */
@@ -240,7 +240,7 @@ class Demo {
         // BT.paletteCreate(256) makes a fresh numbered list with 256 empty color slots.
         this.palette = BT.paletteCreate(256);
 
-        // Color32(Red, Green, Blue) - each value is 0 (none) to 255 (maximum).
+        // Color32(Red, Green, Blue) – each value is 0 (none) to 255 (maximum).
         this.palette.set(C_BG, new Color32(160, 160, 160)); // Light gray background.
 
         // Read every unique color in the logo PNG and store them starting at SPRITE_BASE.
@@ -279,7 +279,7 @@ class Demo {
 
         // Pixel-tier: horizontal band shift that mimics a TV losing its horizontal hold.
         // This runs BEFORE the palette-to-RGBA resolve step, so it shifts the raw
-        // palette-index rows - each shifted row is then resolved to a different RGBA color.
+        // palette-index rows – each shifted row is then resolved to a different RGBA color.
         // intensity = 0 means no shift right now; it spikes up during H-HOLD faults.
         this.pixelGlitch = new PixelGlitch();
         this.pixelGlitch.bandHeight = 2; // Two logical-pixel-tall bands (our screen is only 60 px tall).
@@ -347,7 +347,7 @@ class Demo {
         this.flicker = new Flicker();
         this.flicker.amount = FLICKER_BASE;
 
-        // Bloom adds a soft glow around bright areas - the phosphor afterglow of a hot CRT.
+        // Bloom adds a soft glow around bright areas – the phosphor afterglow of a hot CRT.
         // spread controls the glow radius; glow controls how much it brightens the surroundings.
         this.bloom = new Bloom();
         this.bloom.spread = 2.2;
@@ -407,8 +407,8 @@ class Demo {
      * Called every tick from update() when WebGPU effects are active.
      *
      * The machine has two layers:
-     *   1. TV fault bursts - dramatic, infrequent, random type (H-HOLD, snow, etc.).
-     *   2. Band wobble - mild pixel-tier jitter, always separate from fault bursts.
+     *   1. TV fault bursts – dramatic, infrequent, random type (H-HOLD, snow, etc.).
+     *   2. Band wobble – mild pixel-tier jitter, always separate from fault bursts.
      */
     updateCrtEffects() {
         // Feed the current engine time into effects that need it for animation.
@@ -432,7 +432,7 @@ class Demo {
             this.glitchTicksLeft--;
 
             if (this.glitchTicksLeft <= 0) {
-                // Burst finished - schedule the next cooldown and reset band-wobble too.
+                // Burst finished – schedule the next cooldown and reset band-wobble too.
                 this.glitchCooldown = BT.random.int(GLITCH_COOLDOWN_MIN, GLITCH_COOLDOWN_MAX);
                 this.bandWobbleCooldown = BT.random.int(BAND_WOBBLE_COOLDOWN_MIN, BAND_WOBBLE_COOLDOWN_MAX);
             }
@@ -501,7 +501,7 @@ class Demo {
      * The envelope argument is a 0..1 value (bell-curve shaped) that controls
      * how strong the fault is at this moment in its lifetime.
      *
-     * @param {number} envelope - 0 at the start and end of a burst, peaks at 1 in the middle.
+     * @param {number} envelope – 0 at the start and end of a burst, peaks at 1 in the middle.
      */
     applyGlitchUniforms(envelope) {
         // peak is how strong this specific burst is, scaled by the bell-curve envelope.

--- a/packages/demos/src/music.js
+++ b/packages/demos/src/music.js
@@ -1,7 +1,7 @@
-// @pageTitle BLIT386 Demo - Music Playback
+// @pageTitle BLIT386 Demo – Music Playback
 
 /**
- * Music Demo - crossfading between two tracks and playing one with a seamless loop point.
+ * Music Demo – crossfading between two tracks and playing one with a seamless loop point.
  *
  * Part of the BLIT386 demo series.
  * Prerequisites:
@@ -10,23 +10,23 @@
  * Live version: https://demos.blit386.dev/music
  *
  * Sound effects (audio-basics, synth-toy) are short one-shot clips: press a key, hear a blip, done. Music
- * is different - it is meant to loop forever in the background, and switching from one
+ * is different – it is meant to loop forever in the background, and switching from one
  * track to another should not just cut off with a click. BT.musicPlay() handles both of
  * those jobs for you.
  *
  * This page has three buttons, each backed by a different AudioClip:
  * - Track A and Track B swap between two looping tunes. Each swap uses a different
- *   "crossfade" - a fade-out of the old track happening alongside (or after) a fade-in of
+ *   "crossfade" – a fade-out of the old track happening alongside (or after) a fade-in of
  *   the new one, so the music blends instead of jumping. Switching to Track A lets the old
  *   track fade all the way out first, waits a moment, then fades Track A in. Switching to
  *   Track B overlaps the two fades so they happen at the same time. Listen for the
- *   difference - one has a small silent gap in the middle, the other does not.
+ *   difference – one has a small silent gap in the middle, the other does not.
  * - Loop Demo plays a track that starts with a short intro passage, then loops forever from
- *   a chosen point onward - the intro only ever plays once, exactly like the opening jingle
+ *   a chosen point onward – the intro only ever plays once, exactly like the opening jingle
  *   of a real game level that then settles into its main tune.
  *
  * The title strip, track buttons, and status readout all come from the shared UI kit in
- * src/shared/ui.js - the same look every demo in this series uses, and it is fully
+ * src/shared/ui.js – the same look every demo in this series uses, and it is fully
  * touch-friendly: tap a button with a finger, click it with a mouse, or press its number
  * key, and the kit reports all three the same way.
  *
@@ -52,8 +52,8 @@ const DISPLAY_H = 240;
 const INTRO_LOOP_START_SECONDS = 1.5;
 const INTRO_LOOP_END_SECONDS = 7.9;
 
-// Fading to Track A: the old track fades all the way out first, then - after a short silent
-// gap - Track A fades in. `overlap: -1` is what creates that gap.
+// Fading to Track A: the old track fades all the way out first, then – after a short silent
+// gap – Track A fades in. `overlap: -1` is what creates that gap.
 const PROFILE_TO_A = { fadeMs: 800, overlap: -1, easeIn: 'linear', easeOut: 'linear' };
 
 // Fading to Track B: the new track fades in at the same time as the old one fades out
@@ -120,7 +120,7 @@ class Demo {
      * @returns {Promise<boolean>}
      */
     async init() {
-        // Load all three tracks at once - Promise.all waits for the slowest fetch, not
+        // Load all three tracks at once – Promise.all waits for the slowest fetch, not
         // the sum of three sequential downloads.
         [this.calmClip, this.upbeatClip, this.introLoopClip] = await Promise.all([
             AudioClip.load('/audio/music-calm.wav'),
@@ -139,7 +139,7 @@ class Demo {
 
         // Start with Track A playing so there is always music, even before you press
         // anything. BT.musicPlay() called before the page is unlocked is "remembered" and
-        // starts for real the instant you click or press a key - unlike BT.soundPlay(),
+        // starts for real the instant you click or press a key – unlike BT.soundPlay(),
         // which drops sounds played too early.
         this.playTrack('A');
 
@@ -151,7 +151,7 @@ class Demo {
      *
      * ui.tick() is what safely catches the number-key shortcuts bound to the buttons in
      * render(). Keyboard presses can only be read reliably here in update(), never in
-     * render() - the engine clears "was this just pressed?" flags once per tick, and that
+     * render() – the engine clears "was this just pressed?" flags once per tick, and that
      * tick always finishes before this frame's render() runs (keyboard-input explains
      * this in more detail). The kit latches the presses now so the buttons can answer
      * later, during render().
@@ -177,7 +177,7 @@ class Demo {
         ui.end();
 
         // The track panel, pinned just below the title strip. Width and height size
-        // themselves to the widest row and the number of rows - no layout math here.
+        // themselves to the widest row and the number of rows – no layout math here.
         ui.begin('topLeft', { y: 30 });
         ui.panel('Tracks');
 
@@ -196,11 +196,11 @@ class Demo {
 
     /**
      * Status rows inside the track panel: the unlock prompt (until sound is unlocked),
-     * then the currently playing track, its crossfade profile, and - only for the loop
-     * track - the loop boundaries in seconds.
+     * then the currently playing track, its crossfade profile, and – only for the loop
+     * track – the loop boundaries in seconds.
      */
     renderStatus() {
-        // The shared "click to enable sound" row - it draws itself only while sound is
+        // The shared "click to enable sound" row – it draws itself only while sound is
         // still locked, and disappears on its own after the first click or key press.
         ui.audioUnlockHint();
 
@@ -212,7 +212,7 @@ class Demo {
 
         // Look up the friendly name of whichever track is active. Array.find() walks the
         // list and returns the first entry the test function says yes to (or undefined if
-        // none matches - which here only happens before the first play).
+        // none matches – which here only happens before the first play).
         const active = TRACKS.find((track) => track.trackId === this.activeTrackId);
 
         ui.kv('Playing', active ? active.label : '-');
@@ -227,7 +227,7 @@ class Demo {
      * Starts the given track with its matching crossfade profile, unless it is already
      * playing (pressing the same button twice does nothing new).
      *
-     * @param {string} trackId - 'A', 'B', or 'loop'.
+     * @param {string} trackId – 'A', 'B', or 'loop'.
      */
     playTrack(trackId) {
         if (trackId === this.activeTrackId) {

--- a/packages/demos/src/named-colors.js
+++ b/packages/demos/src/named-colors.js
@@ -1,5 +1,5 @@
 /**
- * Named Colors Demo - Color32 named lookup table and custom registration APIs.
+ * Named Colors Demo – Color32 named lookup table and custom registration APIs.
  *
  * Part of the BLIT386 demo series.
  * Prerequisites: Basics (https://demos.blit386.dev/basics),
@@ -18,7 +18,7 @@
  *
  * The title strip, captions, and tips panel draw with the shared demo UI kit
  * (src/shared/ui.js), so this demo's chrome matches every other demo. The color
- * swatches themselves stay hand-drawn - their palette slots ARE the lesson.
+ * swatches themselves stay hand-drawn – their palette slots ARE the lesson.
  *
  * Live version: https://demos.blit386.dev/named-colors
  */
@@ -41,7 +41,7 @@ import { applyTheme, ui } from './shared/ui.js';
 // chart's bar colors, and the lesson's swatch slots.
 //
 // The chart slots exist because configure() runs BEFORE init() installs the theme, so the
-// chart style cannot point at theme slots - init() copies the matching theme colors here.
+// chart style cannot point at theme slots – init() copies the matching theme colors here.
 const C_CHART_UPDATE = 1; // Timing chart: update() bar (matches the theme's blue-gray border).
 const C_CHART_RENDER = 2; // Timing chart: render() bar (matches the theme's off-white text).
 const C_CHART_TAG = 3; // Timing chart: milestone tag labels (matches the theme's green accent).
@@ -120,7 +120,7 @@ class Demo {
         this.removeIfExists(CUSTOM_OPTIONAL_NAME);
 
         // registerColor adds a NEW entry to the global name table.
-        // It throws if the name is already taken - that is why we cleared above.
+        // It throws if the name is already taken – that is why we cleared above.
         // 'demo-dynamic' will be rewritten every tick with updateColor in update().
         Color32.registerColor(CUSTOM_DYNAMIC_NAME, new Color32(90, 170, 255));
 
@@ -193,7 +193,7 @@ class Demo {
 
         // Upper panel: hand-drawn background for the four color swatches. Kit panels size
         // themselves around kit rows only, so a frame around hand-drawn artwork keeps using
-        // BT.drawRectFill / BT.drawRect - but with the shared theme's panel colors.
+        // BT.drawRectFill / BT.drawRect – but with the shared theme's panel colors.
         BT.drawRectFill(new Rect2i(6, 32, 308, 126), this.theme.panel);
         BT.drawRect(new Rect2i(6, 32, 308, 126), this.theme.border);
 
@@ -267,7 +267,7 @@ class Demo {
      * @param {string} label
      */
     drawSwatch(x, y, colorIndex, label) {
-        // Fill the swatch with the palette slot we are demonstrating - the lesson itself.
+        // Fill the swatch with the palette slot we are demonstrating – the lesson itself.
         BT.drawRectFill(new Rect2i(x, y, SWATCH_W, SWATCH_H), colorIndex);
 
         // The outline and the label are chrome, so they use the shared UI theme colors.

--- a/packages/demos/src/noise.js
+++ b/packages/demos/src/noise.js
@@ -21,7 +21,7 @@
 //
 // WHAT YOU WILL LEARN
 //   - noise2D(x, y) gives a smooth value from -1 to 1 for any spot you ask about
-//   - Three flavors - Value, Perlin, and Simplex - each with a different character
+//   - Three flavors – Value, Perlin, and Simplex – each with a different character
 //   - "Octaves" means stacking the same noise again, smaller and fainter each time, which
 //     is what adds crags to smooth hills. That stack is called fbm
 //   - noise3D(x, y, z) uses the third number as time, which makes clouds drift
@@ -55,7 +55,7 @@ const KIND_NAMES = ['Value', 'Perlin', 'Simplex'];
 // 4 pixels is as fine as this demo goes, and that limit is measured rather than guessed.
 // Each block is one drawing instruction, so 4px blocks mean 4,800 of them per frame, which
 // the engine handles comfortably at a full 60 frames a second. Halving to 2px quadruples
-// that to 19,200 and the frame rate collapses to about one - the cost of a block is small,
+// that to 19,200 and the frame rate collapses to about one – the cost of a block is small,
 // but it is not free, and enough small costs add up to a stall.
 const BLOCK_SIZES = [8, 4];
 const DEFAULT_BLOCK_INDEX = 1;
@@ -164,7 +164,7 @@ class Demo {
             this.palette.set(C_TERRAIN_BASE + i, new Color32(r, g, b));
         }
 
-        // The gray ramp, evenly spaced from near-black to white. Dividing by (steps - 1)
+        // The gray ramp, evenly spaced from near-black to white. Dividing by (steps – 1)
         // makes the last step land exactly on 255.
         for (let i = 0; i < GRAY_STEPS; i++) {
             const level = Math.round((i / (GRAY_STEPS - 1)) * 235) + 20;
@@ -256,8 +256,8 @@ class Demo {
      * Asks one generator for a single value, in whichever way the controls call for.
      *
      * @param {ValueNoise | PerlinNoise | SimplexNoise} generator
-     * @param {number} nx - Position in the landscape, left to right.
-     * @param {number} ny - Position in the landscape, top to bottom.
+     * @param {number} nx – Position in the landscape, left to right.
+     * @param {number} ny – Position in the landscape, top to bottom.
      * @returns {number} A value from about -1 to 1.
      */
     sample(generator, nx, ny) {
@@ -272,7 +272,7 @@ class Demo {
         }
 
         // One octave means the plain noise, with no stacking at all. This is the honest
-        // starting point - everything above it is the same shape with detail piled on.
+        // starting point – everything above it is the same shape with detail piled on.
         if (this.octaves <= 1) {
             return generator.noise2D(nx, ny);
         }
@@ -285,7 +285,7 @@ class Demo {
     /**
      * Turns a 0-to-1 height into the palette slot that should be drawn.
      *
-     * @param {number} t - Height, where 0 is the lowest and 1 the highest.
+     * @param {number} t – Height, where 0 is the lowest and 1 the highest.
      * @returns {number} A palette slot number.
      */
     rampSlot(t) {

--- a/packages/demos/src/pixel-art.js
+++ b/packages/demos/src/pixel-art.js
@@ -1,4 +1,4 @@
-// Pixel Art Demo - draw tiny pictures from number grids and from math patterns.
+// Pixel Art Demo – draw tiny pictures from number grids and from math patterns.
 //
 // Written for young learners (around 12).
 //
@@ -99,8 +99,8 @@ const TREE_PALETTE_MAP = [null, C_TREE_DARK, C_TREE_LIGHT, C_TRUNK];
  * This is the one place that validates grid codes: 0 (empty) and anything
  * outside the map both come back as null, so callers only need one check.
  *
- * @param {(number | null)[]} paletteMap - Array of palette indices (null = transparent).
- * @param {number} code - The paint code from the grid.
+ * @param {(number | null)[]} paletteMap – Array of palette indices (null = transparent).
+ * @param {number} code – The paint code from the grid.
  * @returns {number | null} A palette index, or null if the code means "empty."
  */
 function indexFromPaletteMap(paletteMap, code) {
@@ -154,7 +154,7 @@ class Demo {
                 updateBarPaletteIndex: C_BG,
                 renderBarPaletteIndex: C_TAG,
                 warningPaletteIndex: C_TAG,
-                errorPaletteIndex: 4, // Slot 4 has no named constant - this demo leaves it unassigned.
+                errorPaletteIndex: 4, // Slot 4 has no named constant – this demo leaves it unassigned.
                 tagPaletteIndex: C_BG,
             },
         };
@@ -196,7 +196,7 @@ class Demo {
         // The overlay styles in configure() reuse C_TAG and C_BG, both set above.
 
         // Install the shared UI theme the kit draws the section captions with.
-        // It writes 12 colors starting at the slot we pass - slots 20..31 here, which
+        // It writes 12 colors starting at the slot we pass – slots 20..31 here, which
         // stay clear of the artwork colors (1-11) and fill the top of our 32-slot
         // palette exactly. Must happen before BT.paletteSet() below.
         this.theme = applyTheme(this.palette, 20);
@@ -216,7 +216,7 @@ class Demo {
         this.animTime += BT.deltaSeconds;
 
         // Update the checker pattern colors
-        // The checker squares use "lerp" (short for linear interpolation - smoothly blending
+        // The checker squares use "lerp" (short for linear interpolation – smoothly blending
         // between two colors). wave goes from 0 to 1 and back using Math.sin.
         // At wave=0 colorA is red; at wave=1 it is yellow. At wave=0 colorB is blue; at 1 it is cyan.
         // Both colors shift at the same time but in opposite directions, so they always contrast.
@@ -250,13 +250,13 @@ class Demo {
      *
      * BT.drawPixel() paints exactly one screen cell. To make each design cell bigger, we use two
      * more small loops (dx and dy) that stamp a scale-by-scale block of pixels. Another valid way
-     * is BT.drawRectFill() with width and height equal to scale - same math, one call per cell.
+     * is BT.drawRectFill() with width and height equal to scale – same math, one call per cell.
      *
-     * @param {number[][]} grid - Rows of paint codes; grid[row][col] matches graph-paper rows/columns.
-     * @param {(number | null)[]} paletteMap - paletteMap[code] is the palette index, or null to skip.
-     * @param {number} originX - Left edge where column 0 should appear on screen.
-     * @param {number} originY - Top edge where row 0 should appear on screen.
-     * @param {number} scale - How many screen pixels wide/tall each grid cell becomes.
+     * @param {number[][]} grid – Rows of paint codes; grid[row][col] matches graph-paper rows/columns.
+     * @param {(number | null)[]} paletteMap – paletteMap[code] is the palette index, or null to skip.
+     * @param {number} originX – Left edge where column 0 should appear on screen.
+     * @param {number} originY – Top edge where row 0 should appear on screen.
+     * @param {number} scale – How many screen pixels wide/tall each grid cell becomes.
      */
     drawGridWithScaledPixels(grid, paletteMap, originX, originY, scale) {
         // Outer loop: which row of the design (top row is row 0).
@@ -271,7 +271,7 @@ class Demo {
 
                 // Ask the helper which palette index this code means. It answers null for
                 // code 0 ("no ink here") and for any code outside the map, so this single
-                // check is all the guarding we need - skip and the background stays visible.
+                // check is all the guarding we need – skip and the background stays visible.
                 const paletteIndex = indexFromPaletteMap(paletteMap, code);
                 if (paletteIndex === null) {
                     continue;
@@ -296,7 +296,7 @@ class Demo {
      * Labels and draws the 8x8 heart on the left.
      */
     renderHeartSection() {
-        // Print the section caption with ui.caption() from the shared UI kit - the same
+        // Print the section caption with ui.caption() from the shared UI kit – the same
         // widget every demo in the series uses, so all captions look identical everywhere.
         ui.caption(10, 28, 'Heart 8x8 (number grid)');
 
@@ -323,7 +323,7 @@ class Demo {
     }
 
     /**
-     * Draws a checkerboard using only math inside nested loops - no picture array.
+     * Draws a checkerboard using only math inside nested loops – no picture array.
      * Colors slide around based on animTime (updated in update()) so you can see the clock moving.
      */
     renderCheckerPatternSection() {
@@ -337,7 +337,7 @@ class Demo {
         const startX = 12;
         const startY = 118;
 
-        // Outer loop picks the row of squares; inner loop picks the column - same nested idea as the art.
+        // Outer loop picks the row of squares; inner loop picks the column – same nested idea as the art.
         for (let row = 0; row < cells; row++) {
             for (let col = 0; col < cells; col++) {
                 // Checker rule: neighbors must look different, like a chessboard.

--- a/packages/demos/src/pointer-basics.js
+++ b/packages/demos/src/pointer-basics.js
@@ -1,7 +1,7 @@
 /**
- * Pointer Basics Demo - read mouse position, buttons, delta, and scroll wheel.
+ * Pointer Basics Demo – read mouse position, buttons, delta, and scroll wheel.
  *
- * Prerequisites: Basics - https://demos.blit386.dev/basics
+ * Prerequisites: Basics – https://demos.blit386.dev/basics
  *
  * Live version: https://demos.blit386.dev/pointer-basics
  *
@@ -45,7 +45,7 @@ const TRAIL_LENGTH = 24;
 
 // Multiplier applied to the raw scroll delta (BT.pointerScrollDelta) before it
 // is added to the scroll position. The browser reports scrolling in CSS pixels,
-// which adds up fast - shrinking each report to a quarter keeps one wheel click
+// which adds up fast – shrinking each report to a quarter keeps one wheel click
 // moving the meter a few pixels instead of a big jump. update() then clamps the
 // scroll position to [0, displayHeight] so the meter fill always stays between
 // empty and full.
@@ -61,7 +61,7 @@ class Demo {
     /** @type {Palette | null} */
     palette = null;
 
-    // Palette slot map returned by applyTheme() - theme.bg, theme.dim, and so
+    // Palette slot map returned by applyTheme() – theme.bg, theme.dim, and so
     // on. Filled in init(); used for the screen clear and the fallback hint.
     theme = null;
 
@@ -193,7 +193,7 @@ class Demo {
      * Readouts panel in the top-left: pointer position, delta, wheel delta,
      * whether slot 0 is active, and a meter showing the accumulated scroll
      * position. The raw BT.pointer* reads here are the whole point of the
-     * demo - pointer state (unlike keyboard edges) is safe to read from
+     * demo – pointer state (unlike keyboard edges) is safe to read from
      * render().
      */
     renderReadouts() {
@@ -254,7 +254,7 @@ class Demo {
     /**
      * A dim one-line note shown only after a touchscreen has been used.
      * Fingers can move the crosshair, but there is no touch equivalent of the
-     * scroll wheel or the extra mouse buttons - better to say so than to let
+     * scroll wheel or the extra mouse buttons – better to say so than to let
      * touch users hunt for something that cannot happen.
      */
     renderTouchNote() {

--- a/packages/demos/src/pointer-drag-flick.js
+++ b/packages/demos/src/pointer-drag-flick.js
@@ -1,9 +1,9 @@
 /**
- * Pointer Drag-and-Flick Demo - grab balls, drag them, release to throw.
+ * Pointer Drag-and-Flick Demo – grab balls, drag them, release to throw.
  *
  * Part of the BLIT386 demo series.
  * Prerequisites:
- *   Pointer Basics - https://demos.blit386.dev/pointer-basics
+ *   Pointer Basics – https://demos.blit386.dev/pointer-basics
  *   Pointer Paint  - https://demos.blit386.dev/pointer-paint
  *
  * Live version: https://demos.blit386.dev/pointer-drag-flick
@@ -14,7 +14,7 @@
  *
  *   - Three balls bounce around inside a closed box under gravity.
  *   - Click and HOLD on a ball to grab it (the ball follows the pointer).
- *   - RELEASE to throw it - the release-frame BT.pointerDelta becomes the
+ *   - RELEASE to throw it – the release-frame BT.pointerDelta becomes the
  *     ball's launch velocity.
  *
  * On a touchscreen each finger can grab its own ball; up to three balls can
@@ -36,7 +36,7 @@
  * The HUD (the title strip along the top and the per-slot pointer indicators in the
  * top-right corner) is drawn with the shared UI kit (src/shared/ui.js), so it uses the
  * same colors and layout as every other demo. The balls themselves keep their own scene
- * colors and are grabbed with raw pointer reads - the kit only handles the readouts.
+ * colors and are grabbed with raw pointer reads – the kit only handles the readouts.
  *
  * Coordinate convention: balls store position with sub-pixel precision
  * (floats) so physics integrates smoothly, but every render call rounds to
@@ -61,7 +61,7 @@ const DISPLAY_H = 240;
 const HUD_HEIGHT = 22;
 
 // Scene palette slots. Index 0 is always transparent. UI colors (panel, text, borders)
-// are no longer listed here - the shared UI kit installs them into high slots (240+)
+// are no longer listed here – the shared UI kit installs them into high slots (240+)
 // via applyTheme() in init(), so only the demo's own scene colors remain.
 const C_BALL_OUTLINE = 1; // outline drawn around any grabbed ball
 const C_BALL_HIGHLIGHT = 2; // tint for the ball under the mouse cursor when no slot is grabbing it
@@ -131,7 +131,7 @@ class Demo {
     palette = null;
 
     /**
-     * Palette slot map returned by applyTheme() - where the shared UI colors landed.
+     * Palette slot map returned by applyTheme() – where the shared UI colors landed.
      * Used for BT.clear(this.theme.bg) and the crosshair cursor color.
      *
      * @type {ReturnType<typeof applyTheme> | null}
@@ -150,7 +150,7 @@ class Demo {
      * prevX/prevY remember where each ball was at the START of the most recent
      * update() tick, before physics moved it. render() blends between prevX/prevY
      * and x/y using BT.renderAlpha so the ball glides smoothly across render
-     * frames instead of only moving once per physics tick - see "Interpolating
+     * frames instead of only moving once per physics tick – see "Interpolating
      * render state with renderAlpha" in the engine's docs/api-game-loop.md.
      *
      * @type {Array<{x: number, y: number, prevX: number, prevY: number, vx: number, vy: number, color: number, grabbedBy: number}>}
@@ -308,7 +308,7 @@ class Demo {
 
         const pos = BT.pointerPos(slot);
 
-        // Don't try to grab through the HUD - the press at HUD level is a
+        // Don't try to grab through the HUD – the press at HUD level is a
         // miss-click rather than a deliberate grab.
         if (pos.y < HUD_HEIGHT) {
             return;
@@ -386,7 +386,7 @@ class Demo {
      * more urgent pitch) and volume (faster flick = louder). BT.soundPlay's `pitch` option
      * is a playback-rate multiplier, the same trick Audio Basics uses for its blip sound.
      *
-     * @param {number} speed - Pre-clamp launch speed in px/tick, from Math.hypot(vx, vy).
+     * @param {number} speed – Pre-clamp launch speed in px/tick, from Math.hypot(vx, vy).
      */
     playWhoosh(speed) {
         const speedFraction = clamp(speed / MAX_THROW_SPEED, 0, 1);
@@ -405,7 +405,7 @@ class Demo {
         const slot = ball.grabbedBy;
 
         if (!BT.isPointerActive(slot)) {
-            // Pointer disappeared - drop the ball where it is.
+            // Pointer disappeared – drop the ball where it is.
             ball.grabbedBy = -1;
             ball.vx = 0;
             ball.vy = 0;
@@ -472,7 +472,7 @@ class Demo {
      * Plays the wall/floor bounce thud, skipping bounces too gentle to notice and scaling
      * volume with impact speed.
      *
-     * @param {number} impactSpeed - Absolute velocity component (px/tick) at the moment of impact.
+     * @param {number} impactSpeed – Absolute velocity component (px/tick) at the moment of impact.
      */
     playThud(impactSpeed) {
         if (impactSpeed < THUD_MIN_SPEED) {
@@ -485,7 +485,7 @@ class Demo {
 
     /**
      * The HUD, built from shared UI kit groups: the full-width title strip at the top
-     * (it doubles as the ceiling of the physics box - see HUD_HEIGHT), plus a compact
+     * (it doubles as the ceiling of the physics box – see HUD_HEIGHT), plus a compact
      * corner panel with one pip per pointer slot. A pip lights up while that slot
      * (M = mouse, T1-T3 = touch fingers) is grabbing a ball.
      */
@@ -496,14 +496,14 @@ class Demo {
 
         // Browsers refuse to play any sound until the page is clicked or a key
         // is pressed. This shared row shows the standard warm "enable sound"
-        // prompt and disappears on its own the moment audio unlocks - which
+        // prompt and disappears on its own the moment audio unlocks – which
         // here happens on the very first grab.
         ui.audioUnlockHint();
 
         ui.end();
 
         // Per-slot grab indicators, tucked into the top-right corner just below the
-        // strip. Balls may fly behind this panel - that is fine, it is a readout, not
+        // strip. Balls may fly behind this panel – that is fine, it is a readout, not
         // a wall. ui.pip() draws a small square that fills in while its state is true.
         const labels = ['M', 'T1', 'T2', 'T3'];
 
@@ -550,7 +550,7 @@ class Demo {
             // x/y by that fraction gives us the ball's position AT THIS EXACT RENDER
             // MOMENT, not just its position as of the last physics tick. Picture a movie:
             // physics ticks are the individual film frames, and render() is the projector
-            // running faster than the film advances - renderAlpha tells the projector how
+            // running faster than the film advances – renderAlpha tells the projector how
             // far to "tween" between the current frame and the next one so playback looks
             // smooth instead of jerky.
             const drawX = Math.round(ball.prevX + (ball.x - ball.prevX) * BT.renderAlpha);

--- a/packages/demos/src/pointer-paint.js
+++ b/packages/demos/src/pointer-paint.js
@@ -1,7 +1,7 @@
 /**
- * Pointer Paint Demo - multi-touch finger painting with mouse + up to 3 touches.
+ * Pointer Paint Demo – multi-touch finger painting with mouse + up to 3 touches.
  *
- * Prerequisites: Pointer Basics - https://demos.blit386.dev/pointer-basics
+ * Prerequisites: Pointer Basics – https://demos.blit386.dev/pointer-basics
  *
  * Live version: https://demos.blit386.dev/pointer-paint
  *
@@ -20,7 +20,7 @@
  * are tracked at once; a fourth simultaneous touch is dropped silently. Because
  * touch devices have no right or middle button, the shared UI kit
  * (src/shared/ui.js) draws a small panel with a Clear button and a Brush button
- * that do exactly the same thing as the mouse shortcuts - so the whole demo
+ * that do exactly the same thing as the mouse shortcuts – so the whole demo
  * works with fingers alone.
  *
  * What this demonstrates:
@@ -228,7 +228,7 @@ class Demo {
             }
 
             if (!this.painting[slot]) {
-                // Just started painting - seed last position so the first
+                // Just started painting – seed last position so the first
                 // stamp doesn't draw a line all the way from (0, 0).
                 this.lastPosX[slot] = pos.x;
                 this.lastPosY[slot] = pos.y;
@@ -385,7 +385,7 @@ class Demo {
         const name = BRUSH_NAMES[this.brushIndex];
         ui.kv('Brush', name);
 
-        // The Brush button cycles the size - the touch equivalent of the
+        // The Brush button cycles the size – the touch equivalent of the
         // middle-click shortcut in update(). Its label changes with the brush,
         // and the kit normally recognizes a widget by its label, so we give it
         // a stable id to keep it the "same" button across frames.
@@ -393,7 +393,7 @@ class Demo {
             this.cycleBrush();
         }
 
-        // The Clear button wipes the canvas - the touch equivalent of the
+        // The Clear button wipes the canvas – the touch equivalent of the
         // right-click shortcut in update(). Both paths call clearCanvas().
         if (ui.button('Clear')) {
             this.clearCanvas();

--- a/packages/demos/src/primitives.js
+++ b/packages/demos/src/primitives.js
@@ -1,7 +1,7 @@
 /**
- * Primitives Demo - shows all the basic shapes you can draw with BLIT386.
+ * Primitives Demo – shows all the basic shapes you can draw with BLIT386.
  *
- * Prerequisites: Basics - https://demos.blit386.dev/basics
+ * Prerequisites: Basics – https://demos.blit386.dev/basics
  * Live version: https://demos.blit386.dev/primitives
  *
  * "Primitives" means the simplest building blocks of drawing:
@@ -9,7 +9,7 @@
  * This demo shows each one with a live animation so you can see them in action.
  *
  * update() advances animTicks (logical time). render() reads animTicks to spin and slide shapes.
- * FPS and tick stats appear in the engine overlay automatically - this file does not draw them.
+ * FPS and tick stats appear in the engine overlay automatically – this file does not draw them.
  * The amber section captions are drawn with the shared UI kit (src/shared/ui.js), so they
  * look the same as the text in every other demo of the series.
  */
@@ -44,8 +44,8 @@ const C_STEEL = 11; // Steel blue: background squares in the clearRect grid
 // Dynamic palette slots for the rainbow pixel animation.
 // Each animated pixel needs its own slot so they can all be different colors.
 // update() will compute and store each pixel's current color in slots 20..69 every tick.
-// render() then simply passes the slot number to BT.drawPixel() - no Color32 needed there!
-const C_PIXEL_BASE = 20; // slot for pixel 0 = 20, pixel 1 = 21, ... last pixel = 20 + PIXEL_COUNT - 1
+// render() then simply passes the slot number to BT.drawPixel() – no Color32 needed there!
+const C_PIXEL_BASE = 20; // slot for pixel 0 = 20, pixel 1 = 21, ... last pixel = 20 + PIXEL_COUNT – 1
 
 // How many rainbow pixels renderPixel() draws. init(), update(), and renderPixel() all loop
 // over this same count, so it lives in one place instead of three repeated "50"s.
@@ -98,7 +98,7 @@ class Demo {
      */
     async init() {
         // Set up the color palette
-        // We pick all the colors we need BEFORE drawing anything - like an artist
+        // We pick all the colors we need BEFORE drawing anything – like an artist
         // squeezing paint onto a palette before picking up the brush.
         this.palette = BT.paletteCreate(256);
 
@@ -147,10 +147,10 @@ class Demo {
         // rotates forward by animTicks so it appears to cycle over time.
         // We compute the color here in update() and store it in the palette so that
         // render() can just say "use slot 20", "use slot 21", etc.
-        // This keeps ALL color math out of render() - the "palette animation" technique.
+        // This keeps ALL color math out of render() – the "palette animation" technique.
         for (let i = 0; i < PIXEL_COUNT; i++) {
             // hue is a position on the color wheel (0 = red, 120 = green, 240 = blue, 360 = back to red).
-            // Multiplying i by 17 applies a 17-degree stride on the wheel - the sequence wraps
+            // Multiplying i by 17 applies a 17-degree stride on the wheel – the sequence wraps
             // several times across the PIXEL_COUNT pixels, which makes a denser rainbow than
             // spacing hues evenly once around the circle.
             // Adding animTicks makes the whole rainbow rotate forward each tick.
@@ -184,7 +184,7 @@ class Demo {
     }
 
     /**
-     * Shows how BT.drawPixel() works - it draws a single colored dot.
+     * Shows how BT.drawPixel() works – it draws a single colored dot.
      * We draw a scattered pattern of dots, each with a different rainbow color.
      * The colors shift over time because update() rotates them each tick.
      */
@@ -197,7 +197,7 @@ class Demo {
 
         // Draw the pixels scattered across a small area.
         // The colors were already computed in update() and stored in palette slots 20..69.
-        // Here we just pass the slot index number - no Color32 math needed in render()!
+        // Here we just pass the slot index number – no Color32 math needed in render()!
         for (let i = 0; i < PIXEL_COUNT; i++) {
             // Use a formula to spread the pixels out so they don't all overlap.
             // Multiplying by 13 and 7 spreads them without an obvious pattern.
@@ -211,7 +211,7 @@ class Demo {
     }
 
     /**
-     * Shows how BT.drawLine() works - it draws a straight line between two points.
+     * Shows how BT.drawLine() works – it draws a straight line between two points.
      * We show three static lines (horizontal, vertical, diagonal) plus one that spins.
      */
     renderLine() {
@@ -249,7 +249,7 @@ class Demo {
     }
 
     /**
-     * Shows how BT.drawRect() works - it draws just the border of a rectangle (hollow).
+     * Shows how BT.drawRect() works – it draws just the border of a rectangle (hollow).
      * We draw three static rectangles in different colors plus one that pulses in size.
      */
     renderRectOutline() {
@@ -262,7 +262,7 @@ class Demo {
         BT.drawRect(new Rect2i(anchor.x + 50, anchor.y + 15, 30, 30), C_GREEN); // Green outline.
         BT.drawRect(new Rect2i(anchor.x + 90, anchor.y + 15, 25, 35), C_BLUE); // Blue outline.
 
-        // A yellow rectangle that pulses - it grows and shrinks over time.
+        // A yellow rectangle that pulses – it grows and shrinks over time.
         // Math.sin goes smoothly between -1 and +1, so adding 10 to 5*sin gives
         // a size that oscillates between 5 and 15. Math.floor rounds to whole pixels.
         const pulse = Math.floor(10 + Math.sin(this.animTicks * 0.1) * 5);
@@ -273,7 +273,7 @@ class Demo {
     }
 
     /**
-     * Shows how BT.drawRectFill() works - it fills a rectangle with solid color.
+     * Shows how BT.drawRectFill() works – it fills a rectangle with solid color.
      * Same as the outline demo but these rectangles are filled in.
      */
     renderRectFill() {
@@ -295,10 +295,10 @@ class Demo {
     }
 
     /**
-     * Shows how BT.clearRect() works - it erases a rectangle back to a specific color.
+     * Shows how BT.clearRect() works – it erases a rectangle back to a specific color.
      * We first draw a grid of blue squares, then erase a moving rectangular chunk.
      * The erased area reveals the background color underneath. Like drawRect(), it takes
-     * the rectangle first and the color index second - it just "paints over" instead of
+     * the rectangle first and the color index second – it just "paints over" instead of
      * drawing an outline or fill.
      */
     renderClearRect() {

--- a/packages/demos/src/random-basics.js
+++ b/packages/demos/src/random-basics.js
@@ -14,7 +14,7 @@
 //   2. Weighted   - a treasure chest where rare prizes really are rare
 //   3. Gaussian   - arrows landing near a target instead of anywhere at all
 //   4. Sign       - a coin flip that answers "left" or "right"
-//   5. Directions - two bugs walking a grid, one allowed 4 ways, the other allowed 8
+//   5. Directions – two bugs walking a grid, one allowed 4 ways, the other allowed 8
 //
 // WHAT YOU WILL LEARN
 //   - BT.random.shuffle() hands back a NEW mixed-up copy and leaves your list alone
@@ -25,7 +25,7 @@
 //   - BT.random.direction4() and direction8() hand back a ready-made step as a Vector2i
 //
 // A NOTE ON WHAT IS NOT HERE
-// The everyday tools - int(), float(), and pick() - already appear all over the other demos,
+// The everyday tools – int(), float(), and pick() – already appear all over the other demos,
 // so this one covers the ones you have not met yet. The Camera demo uses int() and
 // pointInRange() to scatter buildings: https://demos.blit386.dev/camera
 //
@@ -67,7 +67,7 @@ const C_CARD_BASE = 10;
 const CARD_COUNT = 8;
 
 // Card size, and how far apart their left edges sit. Eight cards at 34 pixels apart, starting
-// 22 pixels in, reach x = 294 - just inside the 320-pixel screen.
+// 22 pixels in, reach x = 294 – just inside the 320-pixel screen.
 const CARD_W = 26;
 const CARD_H = 34;
 const CARD_STRIDE = 34;
@@ -268,8 +268,8 @@ class Demo {
 
         this.ticks++;
 
-        // Number keys jump straight to a scene. Reading key presses here in update() - never
-        // in render() - is what keeps a quick tap from being missed.
+        // Number keys jump straight to a scene. Reading key presses here in update() – never
+        // in render() – is what keeps a quick tap from being missed.
         if (BT.isKeyPressed('Digit1')) {
             this.mode = MODE_SHUFFLE;
         }
@@ -409,7 +409,7 @@ class Demo {
 
         if (this.useGaussian) {
             // gaussian(middle, spread) clumps its answers around the middle value. Most land
-            // close to it, a few land further out, and the really wild ones are rare - the
+            // close to it, a few land further out, and the really wild ones are rare – the
             // same way most people are close to average height and giants are unusual.
             shot.x = TARGET_CENTER.x + Math.round(BT.random.gaussian(0, this.shotSpread));
             shot.y = TARGET_CENTER.y + Math.round(BT.random.gaussian(0, this.shotSpread));
@@ -458,11 +458,11 @@ class Demo {
             return;
         }
 
-        // direction4() hands back a Vector2i that is one step up, down, left, or right - the
+        // direction4() hands back a Vector2i that is one step up, down, left, or right – the
         // four ways a rook moves in chess. No diagonals.
         this.stepBug(this.bugA, BT.random.direction4(), BUG_AREA_A);
 
-        // direction8() adds the four diagonals, so this bug has eight choices - the way a king
+        // direction8() adds the four diagonals, so this bug has eight choices – the way a king
         // moves in chess. Its trail ends up looking rounder and less blocky.
         this.stepBug(this.bugB, BT.random.direction8(), BUG_AREA_B);
     }
@@ -471,8 +471,8 @@ class Demo {
      * Moves one bug by one step and remembers the position it left behind.
      *
      * @param {{ pos: Vector2i, trail: Array<Vector2i> }} bug
-     * @param {Vector2i} step - One step, from direction4() or direction8().
-     * @param {Rect2i} area - The square this bug is allowed to wander inside.
+     * @param {Vector2i} step – One step, from direction4() or direction8().
+     * @param {Rect2i} area – The square this bug is allowed to wander inside.
      */
     stepBug(bug, step, area) {
         // Remember where the bug was standing before it moved, so the trail grows behind it.
@@ -490,7 +490,7 @@ class Demo {
         // The limits are pulled in twice over. The last pixel inside a square is one short of
         // its width, so a square 120 wide starting at x = 24 ends at x = 143. Then BUG_REACH
         // comes off each end as well, because the position is the middle of the marker rather
-        // than its corner - without that the square would straddle the frame.
+        // than its corner – without that the square would straddle the frame.
         bug.pos = new Vector2i(
             clampInt(bug.pos.x + step.x * 3, area.x + BUG_REACH, area.x + area.width - 1 - BUG_REACH),
             clampInt(bug.pos.y + step.y * 3, area.y + BUG_REACH, area.y + area.height - 1 - BUG_REACH),
@@ -511,8 +511,8 @@ class Demo {
     /**
      * Draws one row of colored cards.
      *
-     * @param {Array<number>} cards - Card numbers, in the order they should appear.
-     * @param {number} y - Top edge of the row.
+     * @param {Array<number>} cards – Card numbers, in the order they should appear.
+     * @param {number} y – Top edge of the row.
      */
     renderCardRow(cards, y) {
         for (let i = 0; i < cards.length; i++) {
@@ -531,7 +531,7 @@ class Demo {
     renderWeighted() {
         ui.caption(112, 8, 'Treasure chest');
 
-        // The chest itself is just a box - the interesting part is what comes out of it.
+        // The chest itself is just a box – the interesting part is what comes out of it.
         BT.drawRectFill(new Rect2i(140, 22, 40, 16), C_DIM);
         BT.drawRect(new Rect2i(140, 22, 40, 16), C_INK);
 
@@ -546,7 +546,7 @@ class Demo {
     renderGaussian() {
         ui.caption(96, 8, 'Aim for the middle');
 
-        // Concentric squares stand in for a round target - the engine draws rectangles, lines,
+        // Concentric squares stand in for a round target – the engine draws rectangles, lines,
         // and pixels, so a "ring" here is a square outline.
         for (const radius of TARGET_RINGS) {
             BT.drawRect(
@@ -619,7 +619,7 @@ class Demo {
 
         if (ui.button('shuffleInPlace()', { key: 'KeyP' })) {
             // shuffleInPlace() mixes up the list you handed it. The top row jumps, and the old
-            // order is gone for good - there is no copy to go back to.
+            // order is gone for good – there is no copy to go back to.
             BT.random.shuffleInPlace(this.deck);
         }
 

--- a/packages/demos/src/seeded-worlds.js
+++ b/packages/demos/src/seeded-worlds.js
@@ -7,7 +7,7 @@
 //   Random Basics https://demos.blit386.dev/random-basics
 //
 // WHAT YOU WILL SEE
-// Two little worlds side by side. Each one was built out of random numbers - the hills, the
+// Two little worlds side by side. Each one was built out of random numbers – the hills, the
 // buildings, the trees, the stars. Above each world is the number it grew from, called its
 // "seed". Press the buttons to give either side a new seed and watch it rebuild.
 //
@@ -81,15 +81,15 @@ const BUILDING_TINTS = 4;
  *
  * This is the heart of the demo. Every random number it needs comes from BT.random, and
  * BT.random was just told where to start, so running this twice with the same seed walks
- * through the exact same numbers in the exact same order - and therefore builds the exact
+ * through the exact same numbers in the exact same order – and therefore builds the exact
  * same world.
  *
- * @param {number} seed - The number this world grows from.
+ * @param {number} seed – The number this world grows from.
  * @returns {{ seed: number, hills: Array<number>, buildings: Array<object>, trees: Array<object>, stars: Array<Vector2i> }}
  */
 function generateWorld(seed) {
     // This is the line that makes everything below repeatable. From here on the engine's
-    // random numbers are no longer a surprise - they are decided by `seed`.
+    // random numbers are no longer a surprise – they are decided by `seed`.
     BT.randomSeed(seed);
 
     // Stars first, scattered across the top two thirds of the box.
@@ -176,7 +176,7 @@ class Demo {
     // Slot map for the shared UI kit theme, filled in by applyTheme() during init().
     theme = null;
 
-    // The two worlds. Each remembers everything it was built from - that is the difference
+    // The two worlds. Each remembers everything it was built from – that is the difference
     // between this demo and the Coordinate Patterns one, which remembers nothing at all:
     // https://demos.blit386.dev/coordinate-patterns
     left = null;
@@ -193,7 +193,7 @@ class Demo {
     //
     // It cannot be the shared BT.random, because generateWorld() reseeds that one. Drawing the
     // next seed from a stream we just reseeded makes the answer a fixed consequence of the
-    // seed we reseeded it with - so "Copy left seed" followed by "New right" would hand back
+    // seed we reseeded it with – so "Copy left seed" followed by "New right" would hand back
     // the very same number every time, and the button would look broken.
     /** @type {Random | null} */
     seedPicker = null;
@@ -231,7 +231,7 @@ class Demo {
         this.seedPicker = new Random();
 
         // Nobody has chosen a seed yet. The engine seeded itself from the clock when it
-        // started up, and seedValue hands that number back - so we can build a world from
+        // started up, and seedValue hands that number back – so we can build a world from
         // it and still show which number it was.
         //
         // That is the part worth noticing: even the run you did not plan has a seed you can
@@ -265,7 +265,7 @@ class Demo {
         ui.caption(WORLD_LEFT_X, 8, `seed ${this.left.seed}`);
         ui.caption(WORLD_RIGHT_X, 8, `seed ${this.right.seed}`);
 
-        // When both seeds match, say so plainly - this is the moment the demo exists for.
+        // When both seeds match, say so plainly – this is the moment the demo exists for.
         if (this.left.seed === this.right.seed) {
             ui.caption(96, WORLD_Y + WORLD_H + 4, 'Same seed, same world', { color: 'accent' });
         } else if (this.seedsWereAutomatic) {
@@ -282,7 +282,7 @@ class Demo {
      * Draws one world inside its frame.
      *
      * @param {{ hills: Array<number>, buildings: Array<object>, trees: Array<object>, stars: Array<Vector2i> }} world
-     * @param {number} originX - Left edge of this world's box on screen.
+     * @param {number} originX – Left edge of this world's box on screen.
      */
     renderWorld(world, originX) {
         // Everything inside a world is stored in "world coordinates" starting at 0, so each
@@ -340,7 +340,7 @@ class Demo {
         }
 
         if (ui.button('Copy left seed', { key: 'KeyE' })) {
-            // Nothing about the right world is copied here - only the number. The world is
+            // Nothing about the right world is copied here – only the number. The world is
             // rebuilt from scratch, and it comes back identical because the number is the same.
             this.right = generateWorld(this.left.seed);
             this.seedsWereAutomatic = false;
@@ -374,7 +374,7 @@ class Demo {
         // intInclusive(a, b) can return b itself, unlike int(a, b) which stops just short of
         // it. For a seed range meant to read as "1000 to 9999", inclusive is what we want.
         //
-        // This comes from seedPicker rather than BT.random - see the field for why.
+        // This comes from seedPicker rather than BT.random – see the field for why.
         return this.seedPicker.intInclusive(SEED_MIN, SEED_MAX);
     }
 

--- a/packages/demos/src/shared/canvas-sprites.js
+++ b/packages/demos/src/shared/canvas-sprites.js
@@ -5,9 +5,9 @@
  * The recipe (used by the Sprites and Animation demos) goes:
  *
  *   1. Draw shapes onto an OffscreenCanvas with normal browser drawing calls.
- *   2. registerCanvasColors() - read the pixels back and give every unique
+ *   2. registerCanvasColors() – read the pixels back and give every unique
  *      color its own palette slot, so the engine can look each pixel up.
- *   3. canvasToImage() - turn the canvas into an Image the engine can upload
+ *   3. canvasToImage() – turn the canvas into an Image the engine can upload
  *      to the GPU as a SpriteSheet.
  *
  * Both demos used to carry identical private copies of these two functions;
@@ -26,7 +26,7 @@ import { Color32 } from 'blit386';
 async function canvasToImage(canvas) {
     // convertToBlob() packs the canvas pixels into a PNG file held in memory,
     // and createObjectURL() gives that in-memory file a temporary URL an
-    // Image element can load from - no server round trip involved.
+    // Image element can load from – no server round trip involved.
     const blob = await canvas.convertToBlob({ type: 'image/png' });
     const url = URL.createObjectURL(blob);
 
@@ -40,7 +40,7 @@ async function canvasToImage(canvas) {
             img.src = url;
         });
     } finally {
-        // The temporary URL holds the PNG bytes alive - release it now that
+        // The temporary URL holds the PNG bytes alive – release it now that
         // the image has its own copy of the pixels.
         URL.revokeObjectURL(url);
     }
@@ -48,15 +48,15 @@ async function canvasToImage(canvas) {
 
 /**
  * Scans canvas pixels and registers every unique opaque color into the palette.
- * Transparent pixels (alpha 0) are skipped - they map to slot 0 at draw time.
+ * Transparent pixels (alpha 0) are skipped – they map to slot 0 at draw time.
  * Call this only after the canvas holds exact, flat colors (no anti-aliased
  * blends), so the number of unique colors stays small and predictable.
  *
- * @param {import('blit386').Palette} palette - The palette to write into.
- * @param {OffscreenCanvasRenderingContext2D} ctx - The canvas to scan.
- * @param {number} w - Canvas width in pixels.
- * @param {number} h - Canvas height in pixels.
- * @param {number} startSlot - First palette slot to fill.
+ * @param {import('blit386').Palette} palette – The palette to write into.
+ * @param {OffscreenCanvasRenderingContext2D} ctx – The canvas to scan.
+ * @param {number} w – Canvas width in pixels.
+ * @param {number} h – Canvas height in pixels.
+ * @param {number} startSlot – First palette slot to fill.
  * @returns {Color32[]} The registered colors, in the order their slots were filled.
  */
 function registerCanvasColors(palette, ctx, w, h, startSlot) {

--- a/packages/demos/src/shared/ui-core.js
+++ b/packages/demos/src/shared/ui-core.js
@@ -1,18 +1,18 @@
 /**
- * Core of the shared demo UI kit - the frame lifecycle, layout math, and input plumbing.
+ * Core of the shared demo UI kit – the frame lifecycle, layout math, and input plumbing.
  *
  * The kit works like a tiny "immediate-mode" UI (the style made famous by Dear ImGui):
- * a demo does not build widget objects up front - it simply calls ui.panel(), ui.button(),
+ * a demo does not build widget objects up front – it simply calls ui.panel(), ui.button(),
  * ui.kv(), and so on every frame inside render(), and the kit draws and hit-tests them on
  * the spot. That keeps demo code short, but it needs two tricks to stay fast and correct:
  *
  * 1. Deferred drawing. A panel's final width and position are not known until its last row
  *    is declared (auto width comes from the widest row; a bottom-anchored panel is placed
- *    once its total height is known). So widgets never draw directly - they append small
+ *    once its total height is known). So widgets never draw directly – they append small
  *    "command" records with panel-relative coordinates to a preallocated pool, and ui.end()
  *    resolves the panel's origin and replays the commands through the real BT draw calls.
  *    All the pool objects are allocated once and reused, so steady-state rendering allocates
- *    nothing - the one performance rule that actually matters in render().
+ *    nothing – the one performance rule that actually matters in render().
  *
  * 2. One-frame-old hit rectangles. A widget cannot know its absolute position while it is
  *    being declared (see above), so interaction tests use the rectangle the widget ended up
@@ -21,7 +21,7 @@
  *
  * Input timing (why some things happen in update() and others in render()):
  * - Pointer press/release edges are snapshotted by the engine AFTER render() each display
- *   frame, so reading them from render() is safe - buttons hit-test right where they draw.
+ *   frame, so reading them from render() is safe – buttons hit-test right where they draw.
  * - Keyboard edges (BT.isKeyPressed) clear once per fixed-update tick, which runs BEFORE
  *   render(). Reading them from render() would randomly miss presses. The kit solves this
  *   with a small "mailbox": ui.tick() (called from update()) checks the keys widgets asked
@@ -32,7 +32,7 @@ import { BT, Rect2i, Vector2i } from 'blit386';
 
 import { T } from './ui-theme.js';
 
-// System font metric. The built-in font is a fixed 6x14 grid - every character advances
+// System font metric. The built-in font is a fixed 6x14 grid – every character advances
 // exactly FONT_W pixels, so a string's pixel width is simply text.length * FONT_W.
 const FONT_W = 6;
 
@@ -87,10 +87,10 @@ function createPendingHit() {
 /**
  * Is the point (px, py) inside the cached rectangle `rec`, grown by `inflate` pixels?
  *
- * @param {{ x: number, y: number, w: number, h: number }} rec - Cached absolute rectangle.
- * @param {number} px - Point x in display pixels.
- * @param {number} py - Point y in display pixels.
- * @param {number} inflate - Extra pixels of tolerance on every side.
+ * @param {{ x: number, y: number, w: number, h: number }} rec – Cached absolute rectangle.
+ * @param {number} px – Point x in display pixels.
+ * @param {number} py – Point y in display pixels.
+ * @param {number} inflate – Extra pixels of tolerance on every side.
  * @returns {boolean}
  */
 function hitContains(rec, px, py, inflate) {
@@ -104,7 +104,7 @@ function hitContains(rec, px, py, inflate) {
 
 /**
  * All mutable state for the immediate-mode UI. The facade in ui.js creates exactly one
- * instance - demos run one at a time, so a single shared context is all we need.
+ * instance – demos run one at a time, so a single shared context is all we need.
  */
 class UiContext {
     // Deferred draw commands for the group currently between begin() and end().
@@ -120,7 +120,7 @@ class UiContext {
     /**
      * Absolute widget rectangles from the previous frame, keyed by widget id (the label,
      * unless opts.id overrides it). Records are allocated on first sighting and then
-     * mutated in place forever - no per-frame allocation.
+     * mutated in place forever – no per-frame allocation.
      *
      * @type {Map<string, { x: number, y: number, w: number, h: number }>}
      */
@@ -154,7 +154,7 @@ class UiContext {
     /**
      * Update-side pointer tracking, refreshed at every tick(). The kit derives its own
      * press/release edges from the held state here, because the engine's pointer edges are
-     * per display frame - two fixed ticks in one frame would both see the same edge.
+     * per display frame – two fixed ticks in one frame would both see the same edge.
      *
      * @type {{
      *     wasDown: boolean, down: boolean, pressed: boolean, released: boolean,
@@ -259,7 +259,7 @@ class UiContext {
         }
 
         // Check every key a widget has asked about. BT.isKeyPressed() is trustworthy here
-        // (and only here - it clears once per tick, before render() runs). A press lands in
+        // (and only here – it clears once per tick, before render() runs). A press lands in
         // the mailbox and waits for the widget to pick it up during the next render.
         for (const code of this.watchedKeys) {
             if (BT.isKeyPressed(code)) {
@@ -343,7 +343,7 @@ class UiContext {
      *
      * @param {'topLeft' | 'topRight' | 'bottomLeft' | 'bottomRight' | 'topBar'} anchor -
      *   Where the finished group attaches on screen. Bottom anchors place the group so its
-     *   bottom edge sits at the margin - rows are still declared top to bottom, the whole
+     *   bottom edge sits at the margin – rows are still declared top to bottom, the whole
      *   block just "grows upward". 'topBar' is the classic full-width title strip.
      * @param {{ x?: number, y?: number, width?: number, margin?: number, pad?: number, kvCols?: number }} opts -
      *   x/y pin the group to a fixed position (overriding the anchor on that axis); width
@@ -400,7 +400,7 @@ class UiContext {
         const display = BT.displaySize;
 
         // Final width: fixed if the demo asked for one, the full screen for a top bar,
-        // otherwise the widest declared row - never wider than the screen allows.
+        // otherwise the widest declared row – never wider than the screen allows.
         let groupW;
 
         if (this.isTopBar) {
@@ -433,8 +433,8 @@ class UiContext {
     /**
      * Where does the group's left edge land? From the anchor, unless opts.x pinned it.
      *
-     * @param {import('blit386').Vector2i} display - The logical display size.
-     * @param {number} groupW - The group's final width.
+     * @param {import('blit386').Vector2i} display – The logical display size.
+     * @param {number} groupW – The group's final width.
      * @returns {number}
      */
     resolveOriginX(display, groupW) {
@@ -453,11 +453,11 @@ class UiContext {
 
     /**
      * Where does the group's top edge land? From the anchor, unless opts.y pinned it.
-     * Bottom anchors place the group so its BOTTOM edge sits at the margin - this is the
+     * Bottom anchors place the group so its BOTTOM edge sits at the margin – this is the
      * "grows upward" behavior: more rows push the top edge up, not the bottom edge down.
      *
-     * @param {import('blit386').Vector2i} display - The logical display size.
-     * @param {number} groupH - The group's final height.
+     * @param {import('blit386').Vector2i} display – The logical display size.
+     * @param {number} groupH – The group's final height.
      * @returns {number}
      */
     resolveOriginY(display, groupH) {
@@ -478,10 +478,10 @@ class UiContext {
      * Draws the closed group for real: panel background first, then every queued command
      * shifted by the group origin, and finally caches the absolute widget rectangles.
      *
-     * @param {number} originX - Group left edge in display pixels.
-     * @param {number} originY - Group top edge in display pixels.
-     * @param {number} groupW - Final group width.
-     * @param {number} groupH - Final group height.
+     * @param {number} originX – Group left edge in display pixels.
+     * @param {number} originY – Group top edge in display pixels.
+     * @param {number} groupW – Final group width.
+     * @param {number} groupH – Final group height.
      */
     flushGroup(originX, originY, groupW, groupH) {
         // Panel background and border draw first so every queued command lands on top.
@@ -533,8 +533,8 @@ class UiContext {
 
     /**
      * Drops any cached hit rectangle whose id was not flushed during the frame that just
-     * finished (see the call site in begin()). Widgets that disappeared - a panel that
-     * closed, a conditional row that stopped rendering - stop blocking taps and swipes at
+     * finished (see the call site in begin()). Widgets that disappeared – a panel that
+     * closed, a conditional row that stopped rendering – stop blocking taps and swipes at
      * their old location instead of leaving a permanent dead zone.
      */
     pruneHitRects() {
@@ -551,8 +551,8 @@ class UiContext {
      * Reserves a horizontal band inside the current group, advances the layout cursor, and
      * feeds the auto-width calculation.
      *
-     * @param {number} contentW - Width of the row's content, excluding the inner padding.
-     * @param {number} advance - How far the cursor moves down for the next row.
+     * @param {number} contentW – Width of the row's content, excluding the inner padding.
+     * @param {number} advance – How far the cursor moves down for the next row.
      * @returns {number} The row's top y, relative to the group origin.
      */
     addRow(contentW, advance) {
@@ -571,13 +571,13 @@ class UiContext {
     /**
      * Appends one draw command to the pool (growing it permanently on overflow).
      *
-     * @param {number} kind - CMD_RECT_FILL, CMD_RECT_STROKE, or CMD_TEXT.
-     * @param {number} x - X relative to the group origin.
-     * @param {number} y - Y relative to the group origin.
-     * @param {number} w - Width in pixels (rects), or 0 for text.
-     * @param {number} h - Height in pixels (rects), or 0 for text.
-     * @param {number} color - Palette index to draw with.
-     * @param {string} text - Text content (CMD_TEXT only).
+     * @param {number} kind – CMD_RECT_FILL, CMD_RECT_STROKE, or CMD_TEXT.
+     * @param {number} x – X relative to the group origin.
+     * @param {number} y – Y relative to the group origin.
+     * @param {number} w – Width in pixels (rects), or 0 for text.
+     * @param {number} h – Height in pixels (rects), or 0 for text.
+     * @param {number} color – Palette index to draw with.
+     * @param {string} text – Text content (CMD_TEXT only).
      */
     addCommand(kind, x, y, w, h, color, text = '') {
         if (this.commandCount === this.commands.length) {
@@ -604,11 +604,11 @@ class UiContext {
      * Registers the rectangle a widget occupies this frame (group-relative; end() converts
      * it to absolute screen coordinates and caches it for next frame's hit tests).
      *
-     * @param {string} id - Widget identity (its label unless opts.id overrides it).
-     * @param {number} x - X relative to the group origin.
-     * @param {number} y - Y relative to the group origin.
-     * @param {number} w - Width in pixels.
-     * @param {number} h - Height in pixels.
+     * @param {string} id – Widget identity (its label unless opts.id overrides it).
+     * @param {number} x – X relative to the group origin.
+     * @param {number} y – Y relative to the group origin.
+     * @param {number} w – Width in pixels.
+     * @param {number} h – Height in pixels.
      */
     addHit(id, x, y, w, h) {
         if (this.pendingHitCount === this.pendingHits.length) {
@@ -626,11 +626,11 @@ class UiContext {
 
     /**
      * Answers "is the pointer over / holding / just-pressing this widget?" using the cached
-     * one-frame-old rectangle. Safe to call from render() - see the file header.
+     * one-frame-old rectangle. Safe to call from render() – see the file header.
      *
      * The same reused result object is returned every time; read it before the next call.
      *
-     * @param {string} id - Widget identity.
+     * @param {string} id – Widget identity.
      * @returns {{ hover: boolean, held: boolean, activated: boolean }}
      */
     resolveInteraction(id) {
@@ -642,7 +642,7 @@ class UiContext {
 
         const rec = this.hitRects.get(id);
 
-        // No cached rectangle yet - the widget appeared this very frame. It becomes
+        // No cached rectangle yet – the widget appeared this very frame. It becomes
         // interactive next frame, one 60th of a second later.
         if (!rec) {
             return res;
@@ -683,7 +683,7 @@ class UiContext {
      * Drag handling for sliders: on a press inside the widget the slot is captured; while
      * captured, returns the pointer's x so the slider can map it to a value.
      *
-     * @param {string} id - Widget identity.
+     * @param {string} id – Widget identity.
      * @returns {number | null} Pointer x in display pixels while dragging, otherwise null.
      */
     resolveDrag(id) {
@@ -722,7 +722,7 @@ class UiContext {
      * render. Reading a press removes it from the mailbox, so it fires exactly once even
      * on displays that render more often than the fixed update runs.
      *
-     * @param {string | undefined} code - A KeyboardEvent.code value like 'Space' or 'KeyR'.
+     * @param {string | undefined} code – A KeyboardEvent.code value like 'Space' or 'KeyR'.
      * @returns {boolean} True when that key was pressed since the previous render.
      */
     consumeKey(code) {
@@ -739,8 +739,8 @@ class UiContext {
      * Is the point inside any cached widget rectangle? Gestures use this so a swipe or a
      * tap that starts on a button is left for the button to handle.
      *
-     * @param {number} px - Point x in display pixels.
-     * @param {number} py - Point y in display pixels.
+     * @param {number} px – Point x in display pixels.
+     * @param {number} py – Point y in display pixels.
      * @returns {boolean}
      */
     isInsideAnyWidget(px, py) {

--- a/packages/demos/src/shared/ui-dpad.js
+++ b/packages/demos/src/shared/ui-dpad.js
@@ -1,5 +1,5 @@
 /**
- * Virtual D-pad - four on-screen arrow keys for demos that need directional input on
+ * Virtual D-pad – four on-screen arrow keys for demos that need directional input on
  * phones and tablets, where there is no keyboard.
  *
  * The engine's face buttons (BT.BTN_UP and friends) are fed by keyboards and gamepads but
@@ -11,7 +11,7 @@
  *
  * By default ('show: auto') the D-pad stays invisible until the session sees its first
  * touch contact, so mouse-and-keyboard visitors never know it exists. It sits in the
- * bottom-right corner - the bottom-LEFT 17x13 corner belongs to the engine overlay's
+ * bottom-right corner – the bottom-LEFT 17x13 corner belongs to the engine overlay's
  * toggle, and most thumbs rest on the right half of a phone anyway.
  */
 
@@ -46,7 +46,7 @@ const pressedState = { up: false, down: false, left: false, right: false };
  * Update-side step, run inside ui.tick(): reads the live touch/mouse contacts against the
  * key rectangles cached by the last render and derives held + just-pressed per direction.
  *
- * @param {import('./ui-core.js').UiContext} ctx - The shared UI context.
+ * @param {import('./ui-core.js').UiContext} ctx – The shared UI context.
  */
 function stepDpad(ctx) {
     for (const dir of DIRECTIONS) {
@@ -66,7 +66,7 @@ function stepDpad(ctx) {
             }
         }
 
-        // "Pressed" means: held now, but not on the previous tick - a fresh touch.
+        // "Pressed" means: held now, but not on the previous tick – a fresh touch.
         pressedState[dir] = isHeld && !downState[dir];
         downState[dir] = isHeld;
     }
@@ -75,7 +75,7 @@ function stepDpad(ctx) {
 /**
  * Is a D-pad key currently held down? Read from update(), like BT.isDown.
  *
- * @param {'up' | 'down' | 'left' | 'right'} dir - Which key.
+ * @param {'up' | 'down' | 'left' | 'right'} dir – Which key.
  * @returns {boolean}
  */
 function dpadIsDown(dir) {
@@ -85,7 +85,7 @@ function dpadIsDown(dir) {
 /**
  * Was a D-pad key just pressed this tick? Read from update(), like BT.isPressed.
  *
- * @param {'up' | 'down' | 'left' | 'right'} dir - Which key.
+ * @param {'up' | 'down' | 'left' | 'right'} dir – Which key.
  * @returns {boolean}
  */
 function dpadIsPressed(dir) {
@@ -96,12 +96,12 @@ function dpadIsPressed(dir) {
  * Draws one arrow glyph as a stack of thin filled rectangles (the system font has no arrow
  * characters). A triangle is just rows that get wider away from the tip.
  *
- * @param {import('./ui-core.js').UiContext} ctx - The shared UI context (for its scratch rect).
- * @param {'up' | 'down' | 'left' | 'right'} dir - Which way the triangle points.
- * @param {number} keyX - Key top-left x.
- * @param {number} keyY - Key top-left y.
- * @param {number} size - Key size in pixels.
- * @param {number} color - Palette index for the glyph.
+ * @param {import('./ui-core.js').UiContext} ctx – The shared UI context (for its scratch rect).
+ * @param {'up' | 'down' | 'left' | 'right'} dir – Which way the triangle points.
+ * @param {number} keyX – Key top-left x.
+ * @param {number} keyY – Key top-left y.
+ * @param {number} size – Key size in pixels.
+ * @param {number} color – Palette index for the glyph.
  */
 function drawArrow(ctx, dir, keyX, keyY, size, color) {
     // The triangle spans about a third of the key and is centered inside it.
@@ -133,7 +133,7 @@ function drawArrow(ctx, dir, keyX, keyY, size, color) {
  * the widget itself decides whether it is visible. Self-contained: no ui.begin()/end()
  * needed around it.
  *
- * @param {import('./ui-core.js').UiContext} ctx - The shared UI context.
+ * @param {import('./ui-core.js').UiContext} ctx – The shared UI context.
  * @param {{ corner?: 'bottomRight' | 'bottomLeft' | 'topRight' | 'topLeft', size?: number,
  *   gap?: number, margin?: number, show?: 'auto' | 'always' }} [opts] - size is one key's
  *   width/height in pixels (default 34); gap is the space between keys; margin is the gap
@@ -172,12 +172,12 @@ function dpadWidget(ctx, opts = {}) {
 /**
  * Draws one D-pad key (face, border, arrow) and caches its hit rectangle.
  *
- * @param {import('./ui-core.js').UiContext} ctx - The shared UI context.
- * @param {'up' | 'down' | 'left' | 'right'} dir - Which key.
- * @param {number} baseX - Left edge of the whole cross.
- * @param {number} baseY - Top edge of the whole cross.
- * @param {number} step - Key size plus gap (one grid cell of the cross).
- * @param {number} size - Key size in pixels.
+ * @param {import('./ui-core.js').UiContext} ctx – The shared UI context.
+ * @param {'up' | 'down' | 'left' | 'right'} dir – Which key.
+ * @param {number} baseX – Left edge of the whole cross.
+ * @param {number} baseY – Top edge of the whole cross.
+ * @param {number} step – Key size plus gap (one grid cell of the cross).
+ * @param {number} size – Key size in pixels.
  */
 function drawKey(ctx, dir, baseX, baseY, step, size) {
     // Cross layout: up/down share the middle column, left/right the middle row.

--- a/packages/demos/src/shared/ui-gestures.js
+++ b/packages/demos/src/shared/ui-gestures.js
@@ -3,7 +3,7 @@
  *
  * Both build on the per-tick pointer records ui.tick() maintains in the shared context
  * (ui-core.js). They deliberately ignore presses that start on a widget or on the virtual
- * D-pad - a finger that lands on a button belongs to that button, not to a gesture.
+ * D-pad – a finger that lands on a button belongs to that button, not to a gesture.
  *
  * Usage, in a demo's update() after ui.tick():
  *
@@ -28,7 +28,7 @@ let swipeDir = null;
  * Update-side step, run inside ui.tick(): watches every pointer slot for a
  * press-move-release that qualifies as a swipe.
  *
- * @param {import('./ui-core.js').UiContext} ctx - The shared UI context.
+ * @param {import('./ui-core.js').UiContext} ctx – The shared UI context.
  */
 function stepGestures(ctx) {
     swipeDir = null;
@@ -46,7 +46,7 @@ function stepGestures(ctx) {
             continue;
         }
 
-        // Contact just ended - measure the total travel from where it started.
+        // Contact just ended – measure the total travel from where it started.
         const dx = tp.x - tp.downX;
         const dy = tp.y - tp.downY;
         const absX = Math.abs(dx);
@@ -79,8 +79,8 @@ function swipeResult() {
  * Did a press land inside `rect` on this update tick, away from every widget? Use this for
  * large invisible touch zones (for example "tap the left half of the screen to move left").
  *
- * @param {import('./ui-core.js').UiContext} ctx - The shared UI context.
- * @param {import('blit386').Rect2i} rect - The zone to test, in display pixels.
+ * @param {import('./ui-core.js').UiContext} ctx – The shared UI context.
+ * @param {import('blit386').Rect2i} rect – The zone to test, in display pixels.
  * @returns {boolean}
  */
 function tapIn(ctx, rect) {

--- a/packages/demos/src/shared/ui-theme.js
+++ b/packages/demos/src/shared/ui-theme.js
@@ -1,5 +1,5 @@
 /**
- * Shared UI theme - the one set of colors every demo's UI draws with.
+ * Shared UI theme – the one set of colors every demo's UI draws with.
  *
  * Demos used to pick their own HUD colors by hand, and over time those colors drifted apart:
  * one demo's panel was a slightly different blue than the next one's, headers were three
@@ -7,7 +7,7 @@
  *
  * applyTheme() writes the twelve colors into a demo's palette (by default into slots
  * 240-251, high above the low slots scene art normally grows up from) and registers a named
- * alias for each one - the same mechanism as the engine's own palette.applyHUD(). It also
+ * alias for each one – the same mechanism as the engine's own palette.applyHUD(). It also
  * fills the module-level `T` object with the resolved palette indices. Every other ui-*.js
  * module reads its colors from `T`, so no widget ever hardcodes a palette slot number.
  *
@@ -18,7 +18,7 @@
  *     BT.paletteSet(this.palette);
  *
  * The returned object maps each color to its palette slot ({ bg, panel, text, ... }), so a
- * demo can also use theme colors for its own drawing - most commonly BT.clear(theme.bg).
+ * demo can also use theme colors for its own drawing – most commonly BT.clear(theme.bg).
  */
 
 import { Color32 } from 'blit386';
@@ -49,7 +49,7 @@ const THEME_COLORS = [
 // `T` is a single module-level object, not per-palette state: calling applyTheme() again
 // (a second demo instance, a test harness, hot-reload) overwrites it in place for whatever
 // is currently reading it. That is safe today because ui-core.js and ui-dpad.js assume the
-// same "one demo runs at a time" model this whole kit is built on (see ui.js) - there is
+// same "one demo runs at a time" model this whole kit is built on (see ui.js) – there is
 // exactly one UiContext and it always draws with the most recently applied theme. It would
 // stop being safe the moment two palettes/themes need to be live at once (multiple demos in
 // one page, parallel unit tests); that scenario needs a themes-per-context redesign, not a
@@ -85,8 +85,8 @@ const T = {
 /**
  * Writes the twelve theme colors into `palette` and remembers where they landed.
  *
- * @param {import('blit386').Palette} palette - The palette the demo is about to activate.
- * @param {number} startSlot - First slot to write (the twelve colors fill startSlot..startSlot+11).
+ * @param {import('blit386').Palette} palette – The palette the demo is about to activate.
+ * @param {number} startSlot – First slot to write (the twelve colors fill startSlot..startSlot+11).
  *   The default (THEME_DEFAULT_START_SLOT, 240) sits at the top of a 256-slot palette, far
  *   away from scene colors, which conventionally grow up from slot 1. Demos whose effects
  *   animate high palette slots pass a different startSlot that stays clear of their animated
@@ -96,7 +96,7 @@ const T = {
  *   buttonHover: number }} The palette slot of each theme color, for the demo's own drawing.
  */
 function applyTheme(palette, startSlot = THEME_DEFAULT_START_SLOT) {
-    // Fail fast with clear messages - a wrong startSlot would otherwise show up later as
+    // Fail fast with clear messages – a wrong startSlot would otherwise show up later as
     // mysteriously wrong UI colors, which is much harder to track down.
     if (!Number.isInteger(startSlot) || startSlot < 1) {
         throw new Error(`applyTheme: startSlot must be an integer of at least 1, got ${startSlot}.`);

--- a/packages/demos/src/shared/ui-widgets.js
+++ b/packages/demos/src/shared/ui-widgets.js
@@ -3,11 +3,11 @@
  *
  * Every function here follows the same immediate-mode recipe (see ui-core.js for the big
  * picture): reserve a row with ctx.addRow(), queue draw commands with group-relative
- * coordinates, optionally register a hit rectangle, and - for interactive widgets - answer
+ * coordinates, optionally register a hit rectangle, and – for interactive widgets – answer
  * the caller right away using last frame's cached rectangle. Nothing here allocates in the
  * steady state; every object involved is pooled and reused.
  *
- * Demos never import this file directly - the ui.js facade wires these functions to the
+ * Demos never import this file directly – the ui.js facade wires these functions to the
  * one shared UiContext and exposes them as ui.panel(), ui.button(), and so on.
  */
 
@@ -43,7 +43,7 @@ function clamp(value, min, max) {
 /**
  * Translates a color role name ('dim', 'header', ...) into its theme palette slot.
  *
- * @param {string | undefined} role - One of 'text', 'dim', 'header', 'accent', 'warm', 'info'.
+ * @param {string | undefined} role – One of 'text', 'dim', 'header', 'accent', 'warm', 'info'.
  * @returns {number} A palette index from the shared theme.
  */
 function roleSlot(role) {
@@ -67,7 +67,7 @@ function roleSlot(role) {
  * Turns the current group into a bordered panel (background + border + optional amber
  * title). Call it right after ui.begin(), before any other widget.
  *
- * @param {import('./ui-core.js').UiContext} ctx - The shared UI context.
+ * @param {import('./ui-core.js').UiContext} ctx – The shared UI context.
  * @param {string} [title] - Panel title, drawn in the header color. Omit for a plain box.
  */
 function panel(ctx, title) {
@@ -98,8 +98,8 @@ function panel(ctx, title) {
 /**
  * One line of text.
  *
- * @param {import('./ui-core.js').UiContext} ctx - The shared UI context.
- * @param {string} text - The line to print.
+ * @param {import('./ui-core.js').UiContext} ctx – The shared UI context.
+ * @param {string} text – The line to print.
  * @param {{ color?: string }} [opts] - color picks a role: 'text' (default), 'dim',
  *   'header', 'accent', 'warm', or 'info'.
  */
@@ -111,17 +111,17 @@ function label(ctx, text, opts = {}) {
 }
 
 /**
- * A single line of floating text pinned at an exact screen position - the shared
+ * A single line of floating text pinned at an exact screen position – the shared
  * "section caption" the drawing demos print next to their artwork. Unlike label(),
  * which stacks rows inside the current begin()/end() group, caption() opens and
  * closes its own tiny one-row group, so demos call it on its own:
  *
  *     ui.caption(24, 40, 'Pixels');
  *
- * @param {import('./ui-core.js').UiContext} ctx - The shared UI context.
- * @param {number} x - Left edge of the caption in display pixels.
- * @param {number} y - Top edge of the caption in display pixels.
- * @param {string} text - The caption text.
+ * @param {import('./ui-core.js').UiContext} ctx – The shared UI context.
+ * @param {number} x – Left edge of the caption in display pixels.
+ * @param {number} y – Top edge of the caption in display pixels.
+ * @param {string} text – The caption text.
  * @param {{ color?: string }} [opts] - color picks a role; captions default to
  *   'header' (the amber title color shared by the whole demo series).
  */
@@ -129,19 +129,19 @@ function caption(ctx, x, y, text, opts = {}) {
     // Passing x and y pins the group to an exact spot next to the artwork (instead
     // of snapping it to a screen corner), and pad: 0 removes the group's built-in
     // inner padding so the text lands right at the requested position. With no
-    // panel() call the group has no box around it - just floating text.
+    // panel() call the group has no box around it – just floating text.
     ctx.begin('topLeft', { x, y, pad: 0 });
     label(ctx, text, { color: opts.color ?? 'header' });
     ctx.end();
 }
 
 /**
- * A "KEY: value" row - the key in dim gray, the value in bright text, aligned to a shared
+ * A "KEY: value" row – the key in dim gray, the value in bright text, aligned to a shared
  * value column so stacked kv rows line up.
  *
- * @param {import('./ui-core.js').UiContext} ctx - The shared UI context.
- * @param {string} key - Left-hand name.
- * @param {string | number} value - Right-hand value (numbers are printed as-is).
+ * @param {import('./ui-core.js').UiContext} ctx – The shared UI context.
+ * @param {string} key – Left-hand name.
+ * @param {string | number} value – Right-hand value (numbers are printed as-is).
  */
 function kv(ctx, key, value) {
     const valueText = String(value);
@@ -161,9 +161,9 @@ function kv(ctx, key, value) {
  *
  *     this.loop = ui.checkbox('Loop', this.loop);
  *
- * @param {import('./ui-core.js').UiContext} ctx - The shared UI context.
- * @param {string} text - The label next to the pip (also the widget's identity).
- * @param {boolean} value - The current on/off state.
+ * @param {import('./ui-core.js').UiContext} ctx – The shared UI context.
+ * @param {string} text – The label next to the pip (also the widget's identity).
+ * @param {boolean} value – The current on/off state.
  * @param {{ key?: string, id?: string }} [opts] - key binds a keyboard shortcut (a
  *   KeyboardEvent.code like 'KeyM'); id overrides the identity when two checkboxes share
  *   one label.
@@ -191,11 +191,11 @@ function checkbox(ctx, text, value, opts = {}) {
  * square (filled with the accent color when on, hollow otherwise, always
  * outlined) followed by its label.
  *
- * @param {import('./ui-core.js').UiContext} ctx - The shared UI context.
- * @param {number} rowY - The row's top edge, from ctx.addRow().
- * @param {boolean} on - Whether the pip is lit (filled).
- * @param {string} text - The label next to the pip.
- * @param {number} textColor - Palette slot for the label text.
+ * @param {import('./ui-core.js').UiContext} ctx – The shared UI context.
+ * @param {number} rowY – The row's top edge, from ctx.addRow().
+ * @param {boolean} on – Whether the pip is lit (filled).
+ * @param {string} text – The label next to the pip.
+ * @param {number} textColor – Palette slot for the label text.
  */
 function drawPipRow(ctx, rowY, on, text, textColor) {
     if (on) {
@@ -208,12 +208,12 @@ function drawPipRow(ctx, rowY, on, text, textColor) {
 
 /**
  * A read-only indicator row: the same pip-plus-label look as ui.checkbox(), but purely
- * visual - nothing happens when it is tapped. Use it to display live state the user does
+ * visual – nothing happens when it is tapped. Use it to display live state the user does
  * not set directly, like "is this key held down right now?".
  *
- * @param {import('./ui-core.js').UiContext} ctx - The shared UI context.
- * @param {string} text - The label next to the pip.
- * @param {boolean} on - Whether the pip is lit.
+ * @param {import('./ui-core.js').UiContext} ctx – The shared UI context.
+ * @param {string} text – The label next to the pip.
+ * @param {boolean} on – Whether the pip is lit.
  */
 function pip(ctx, text, on) {
     const contentW = PIP_LABEL_OFFSET + text.length * FONT_W;
@@ -227,8 +227,8 @@ function pip(ctx, text, on) {
  * A push button. Returns true on the frame it is clicked, tapped, or (when opts.key is
  * given) its keyboard shortcut was pressed.
  *
- * @param {import('./ui-core.js').UiContext} ctx - The shared UI context.
- * @param {string} text - The button label (also the widget's identity).
+ * @param {import('./ui-core.js').UiContext} ctx – The shared UI context.
+ * @param {string} text – The button label (also the widget's identity).
  * @param {{ key?: string, width?: number, id?: string }} [opts] - key binds a keyboard
  *   shortcut; width fixes the button width in pixels; id overrides the identity when two
  *   buttons share one label.
@@ -271,9 +271,9 @@ function button(ctx, text, opts = {}) {
  *
  *     volume = ui.slider('Music', volume);
  *
- * @param {import('./ui-core.js').UiContext} ctx - The shared UI context.
- * @param {string} text - The label above the bar (also the widget's identity).
- * @param {number} value - The current value.
+ * @param {import('./ui-core.js').UiContext} ctx – The shared UI context.
+ * @param {string} text – The label above the bar (also the widget's identity).
+ * @param {number} value – The current value.
  * @param {{ min?: number, max?: number, width?: number, id?: string }} [opts] - min/max
  *   bound the value (default 0..1); width sets the bar width in pixels; id overrides the
  *   identity.
@@ -308,7 +308,7 @@ function slider(ctx, text, value, opts = {}) {
     ctx.addCommand(CMD_TEXT, ctx.pad + barW - valueText.length * FONT_W, labelY + 1, 0, 0, T.text, valueText);
 
     // Bar row: an outline that fills up left-to-right in proportion to the value. An equal
-    // min/max (a zero-width range) has no meaningful fraction - draw the bar empty rather
+    // min/max (a zero-width range) has no meaningful fraction – draw the bar empty rather
     // than dividing by zero into NaN.
     const barY = ctx.addRow(barW, SLIDER_BAR_H + 4);
     const fillW = range === 0 ? 0 : Math.round(barW * ((nextValue - min) / range));
@@ -325,12 +325,12 @@ function slider(ctx, text, value, opts = {}) {
 }
 
 /**
- * A read-only progress/level bar (label row + bar row). Purely visual - for a draggable
+ * A read-only progress/level bar (label row + bar row). Purely visual – for a draggable
  * bar use ui.slider().
  *
- * @param {import('./ui-core.js').UiContext} ctx - The shared UI context.
- * @param {string | null} text - Label above the bar, or null for the bar alone.
- * @param {number} fraction - Fill amount from 0 (empty) to 1 (full).
+ * @param {import('./ui-core.js').UiContext} ctx – The shared UI context.
+ * @param {string | null} text – Label above the bar, or null for the bar alone.
+ * @param {number} fraction – Fill amount from 0 (empty) to 1 (full).
  * @param {{ color?: string, width?: number }} [opts] - color picks the fill role
  *   (default 'info'); width sets the bar width in pixels.
  */
@@ -357,14 +357,14 @@ function meter(ctx, text, fraction, opts = {}) {
  * The standard "enable sound" prompt every audio demo shows, kept in one place so
  * the wording and color can never drift between demos. Browsers refuse to play any
  * sound until the user interacts with the page, so this row reminds the user to
- * click or press a key. It draws only while audio is still locked - once
+ * click or press a key. It draws only while audio is still locked – once
  * BT.isAudioUnlocked flips true, the row disappears on its own. Call it inside a
  * ui.begin()/ui.end() group like any other row.
  *
  * Pass `opts.text` when the default sentence is too long for a tiny playfield
  * (for example Snake at 160x120).
  *
- * @param {import('./ui-core.js').UiContext} ctx - The shared UI context.
+ * @param {import('./ui-core.js').UiContext} ctx – The shared UI context.
  * @param {{ text?: string }} [opts] - Optional overrides. `text` replaces the default
  *   "Click or press a key to enable sound" wording.
  */
@@ -382,7 +382,7 @@ function audioUnlockHint(ctx, opts = {}) {
 /**
  * A thin horizontal rule across the group, for separating sections inside one panel.
  *
- * @param {import('./ui-core.js').UiContext} ctx - The shared UI context.
+ * @param {import('./ui-core.js').UiContext} ctx – The shared UI context.
  */
 function separator(ctx) {
     const rowY = ctx.addRow(0, 5);
@@ -395,7 +395,7 @@ function separator(ctx) {
 /**
  * Vertical breathing room between rows.
  *
- * @param {import('./ui-core.js').UiContext} ctx - The shared UI context.
+ * @param {import('./ui-core.js').UiContext} ctx – The shared UI context.
  * @param {number} [px] - How many pixels to skip (default 6).
  */
 function spacer(ctx, px = 6) {

--- a/packages/demos/src/shared/ui.js
+++ b/packages/demos/src/shared/ui.js
@@ -1,11 +1,11 @@
 /**
- * The shared demo UI kit - the one file demos import.
+ * The shared demo UI kit – the one file demos import.
  *
  *     import { applyTheme, ui } from './shared/ui.js';
  *
  * The kit is a tiny immediate-mode UI (in the spirit of Dear ImGui): demos declare panels
  * and widgets by calling ui.* every frame inside render(), and the kit lays out, draws, and
- * hit-tests them on the spot. There is nothing to create or destroy - a widget exists
+ * hit-tests them on the spot. There is nothing to create or destroy – a widget exists
  * because the demo mentioned it this frame.
  *
  * The three rules:
@@ -27,11 +27,11 @@
  *        ui.end();
  *
  * Widget identity: a widget is recognized across frames by its label. Two widgets with the
- * same label in one frame would answer each other's clicks - give one of them a unique
+ * same label in one frame would answer each other's clicks – give one of them a unique
  * { id: '...' } option in that case.
  *
  * Performance: widgets queue draw commands into preallocated pools and reuse every object,
- * so steady-state frames allocate nothing - safe to call from render() at 60 FPS.
+ * so steady-state frames allocate nothing – safe to call from render() at 60 FPS.
  */
 
 import { UiContext } from './ui-core.js';
@@ -103,12 +103,12 @@ const ui = {
     },
 
     /**
-     * A single line of floating text pinned at an exact screen position - the shared
+     * A single line of floating text pinned at an exact screen position – the shared
      * section caption the drawing demos print next to their artwork. Self-contained:
      * call it on its own, outside ui.begin()/ui.end().
      *
-     * @param {number} x - Left edge in display pixels.
-     * @param {number} y - Top edge in display pixels.
+     * @param {number} x – Left edge in display pixels.
+     * @param {number} y – Top edge in display pixels.
      * @param {string} text
      * @param {{ color?: string }} [opts] - Role; defaults to 'header' (series amber).
      */
@@ -186,7 +186,7 @@ const ui = {
      * A read-only level bar.
      *
      * @param {string | null} text
-     * @param {number} fraction - 0 (empty) to 1 (full).
+     * @param {number} fraction – 0 (empty) to 1 (full).
      * @param {{ color?: string, width?: number }} [opts]
      */
     meter(text, fraction, opts) {
@@ -208,7 +208,7 @@ const ui = {
     },
 
     /**
-     * Draws the virtual D-pad (self-contained - no begin()/end() needed). Call once per
+     * Draws the virtual D-pad (self-contained – no begin()/end() needed). Call once per
      * frame from render(); by default it appears only after the first touch contact.
      *
      * @param {{ corner?: string, size?: number, gap?: number, margin?: number, show?: 'auto' | 'always' }} [opts]
@@ -267,11 +267,11 @@ const ui = {
 
     /**
      * Is this point on top of any kit widget (buttons, sliders, the D-pad, ...)? Demos
-     * that paint or drag with the raw pointer use this to leave the UI alone - for example
+     * that paint or drag with the raw pointer use this to leave the UI alone – for example
      * a paint demo skips brush strokes that would land on its own Clear button.
      *
-     * @param {number} x - Point x in display pixels.
-     * @param {number} y - Point y in display pixels.
+     * @param {number} x – Point x in display pixels.
+     * @param {number} y – Point y in display pixels.
      * @returns {boolean}
      */
     overWidget(x, y) {

--- a/packages/demos/src/snake-game.js
+++ b/packages/demos/src/snake-game.js
@@ -1,5 +1,5 @@
 /**
- * Snake - grid snake with walls, food, keyboard steering, and PipBoy CRT post-processing.
+ * Snake – grid snake with walls, food, keyboard steering, and PipBoy CRT post-processing.
  *
  * Part of the BLIT386 demo series.
  * Prerequisites:
@@ -11,7 +11,7 @@
  *
  * Move with WASD or the arrow keys (both are mapped to player 0 face buttons). On a phone
  * or tablet, steer with the on-screen D-pad in the bottom-right corner (it appears at the
- * first touch) or simply swipe anywhere in the direction you want to go - both come from
+ * first touch) or simply swipe anywhere in the direction you want to go – both come from
  * the shared UI kit in src/shared/ui.js. Each food dot grows the snake and makes it
  * one step faster. Hitting the boundary wall or your own body ends the run; the game
  * restarts after two seconds.
@@ -156,7 +156,7 @@ class Demo {
     /**
      * Live handle for the looping music voice, or null before unlock / if music failed to
      * load. We use BT.soundPlay (not BT.musicPlay) so we can change pitch each time the
-     * snake speeds up - the music player has volume and crossfade controls, but no pitch.
+     * snake speeds up – the music player has volume and crossfade controls, but no pitch.
      *
      * @type {import('blit386').SoundRef | null}
      */
@@ -273,7 +273,7 @@ class Demo {
 
             // Hide the small "~" toggle hint in the bottom-left corner so the game
             // board stays clean. Players who want the stats overlay can still press
-            // the Backquote key (`) to show it and press ` again to hide it - hiding
+            // the Backquote key (`) to show it and press ` again to hide it – hiding
             // the hint does not turn the overlay off.
             isOverlayToggleHintVisible: false,
 
@@ -324,7 +324,7 @@ class Demo {
         // playable with sound effects but no music, instead of getting stuck on a blank
         // screen.
         //
-        // We only load here - we do not call BT.soundPlay yet. Browsers keep audio locked
+        // We only load here – we do not call BT.soundPlay yet. Browsers keep audio locked
         // until the first click or key press, and unlike BT.musicPlay (which remembers a
         // request while locked), BT.soundPlay would be dropped. update() starts the loop
         // the moment BT.isAudioUnlocked flips true.
@@ -351,7 +351,7 @@ class Demo {
         BT.paletteSet(this.palette);
 
         // CRT post-processing needs WebGPU. In software fallback mode we skip the whole
-        // effect chain - the snake game itself still runs fine without it.
+        // effect chain – the snake game itself still runs fine without it.
         this.effectsAvailable = isAvailable();
 
         if (this.effectsAvailable) {
@@ -430,7 +430,7 @@ class Demo {
 
         // Browsers keep all sound muted until the player clicks or presses a key. This
         // shared row shows a warm "enable sound" hint only while audio is still locked,
-        // then disappears on its own the moment a first move unlocks it - which is also
+        // then disappears on its own the moment a first move unlocks it – which is also
         // the same gesture that starts the snake moving, so the hint is usually only
         // visible for a single frame. The default sentence is too long for this 160-wide
         // playfield, so we pass a short override.
@@ -544,7 +544,7 @@ class Demo {
      * interval feels like a classic D-pad. The `this.dy !== 1` checks block a 180-degree
      * turn: you cannot go straight back into your body on the next step.
      *
-     * @param {'up' | 'down' | 'left' | 'right' | null} swipe - The swipe finished this
+     * @param {'up' | 'down' | 'left' | 'right' | null} swipe – The swipe finished this
      *   tick, if any (from ui.swipe() in update()).
      */
     pollDirectionInput(swipe) {
@@ -577,9 +577,9 @@ class Demo {
      * Combines the three ways to steer in one direction: the engine face button (keyboard
      * or gamepad), the on-screen touch D-pad key, and a swipe that way.
      *
-     * @param {number} button - The engine face button mask (BT.BTN_UP and friends).
-     * @param {'up' | 'down' | 'left' | 'right'} dir - The D-pad/swipe direction name.
-     * @param {'up' | 'down' | 'left' | 'right' | null} swipe - The swipe finished this tick.
+     * @param {number} button – The engine face button mask (BT.BTN_UP and friends).
+     * @param {'up' | 'down' | 'left' | 'right'} dir – The D-pad/swipe direction name.
+     * @param {'up' | 'down' | 'left' | 'right' | null} swipe – The swipe finished this tick.
      * @returns {boolean} True when any of the three pressed that direction this tick.
      */
     isSteerPressed(button, dir, swipe) {
@@ -634,7 +634,7 @@ class Demo {
     }
 
     /**
-     * @param {number} envelope - 0 -> 1 -> 0 over the glitch burst.
+     * @param {number} envelope – 0 -> 1 -> 0 over the glitch burst.
      */
     applyGlitchUniforms(envelope) {
         const peak = this.glitchPeak * envelope;
@@ -705,7 +705,7 @@ class Demo {
 
     /**
      * Starts the looping music voice once audio is unlocked, or restarts it if the voice
-     * was somehow lost. Safe to call every tick - it no-ops while already playing.
+     * was somehow lost. Safe to call every tick – it no-ops while already playing.
      *
      * Why BT.soundPlay instead of BT.musicPlay: only the SFX path exposes pitch (playback
      * rate), which is how we keep the beat tied to snake growth. The tradeoff is that
@@ -716,7 +716,7 @@ class Demo {
             return;
         }
 
-        // Already have a live looping voice - nothing to do.
+        // Already have a live looping voice – nothing to do.
         if (this.musicRef !== null && BT.isSoundPlaying(this.musicRef)) {
             return;
         }
@@ -756,7 +756,7 @@ class Demo {
         this.moveInterval = MOVE_INTERVAL_START;
         this.moveCooldown = this.moveInterval;
 
-        // Zero foods eaten - music returns to MUSIC_PITCH_AT_START for the new round.
+        // Zero foods eaten – music returns to MUSIC_PITCH_AT_START for the new round.
         this.growthCount = 0;
         this.syncMusicTempo();
 
@@ -790,7 +790,7 @@ class Demo {
         }
 
         for (let attempt = 0; attempt < 4000; attempt++) {
-            // int() with a single argument counts from 0, so int(CELLS_X) lands on any column from 0 to CELLS_X - 1
+            // int() with a single argument counts from 0, so int(CELLS_X) lands on any column from 0 to CELLS_X – 1
             // - exactly the valid grid positions.
             const x = BT.random.int(CELLS_X);
             const y = BT.random.int(CELLS_Y);
@@ -803,7 +803,7 @@ class Demo {
             }
         }
 
-        // Board full - no free cell found; (-1, -1) is a sentinel that render() sees and skips drawing the food dot.
+        // Board full – no free cell found; (-1, -1) is a sentinel that render() sees and skips drawing the food dot.
         this.food = { x: -1, y: -1 };
     }
 

--- a/packages/demos/src/synth-toy.js
+++ b/packages/demos/src/synth-toy.js
@@ -1,5 +1,5 @@
 /**
- * Synth Toy Demo - procedural chip-tune sound effects with no audio files at all.
+ * Synth Toy Demo – procedural chip-tune sound effects with no audio files at all.
  *
  * Prerequisites:
  *   Keyboard Input  https://demos.blit386.dev/keyboard-input
@@ -8,20 +8,20 @@
  * Live version: https://demos.blit386.dev/synth-toy
  *
  * Every sound on this page is built from scratch by the computer, the instant you press a
- * key or tap a button - there are no sound files to download. AudioClip.synth() takes a
+ * key or tap a button – there are no sound files to download. AudioClip.synth() takes a
  * small recipe called SynthParams (a waveform shape, a pitch, a length, and a few optional
  * knobs like an attack/decay/sustain/release envelope, a pitch sweep, and a noise mix) and
  * calculates every single sample of the resulting sound on the spot. BT.synthPreset bundles
- * six of these recipes for common game sounds - jump, pickup, explosion, laser, hit, and a
- * UI blip - tuned by hand so they sound right without you needing to pick every number
+ * six of these recipes for common game sounds – jump, pickup, explosion, laser, hit, and a
+ * UI blip – tuned by hand so they sound right without you needing to pick every number
  * yourself.
  *
  * The Randomize button goes the other way: instead of a hand-tuned recipe, it rolls a brand
  * new SynthParams object with every field chosen at random, inside safe ranges, and shows
  * you exactly what was rolled in the right-hand panel. Play it a few times and you will
- * hear (and see) how much variety a handful of numbers can produce - from a clean sine
+ * hear (and see) how much variety a handful of numbers can produce – from a clean sine
  * "boop" to a noisy sawtooth growl. (The synth engine also supports a vibrato wobble on top
- * of all this - this demo leaves it out to keep the panel small, but it is worth trying
+ * of all this – this demo leaves it out to keep the panel small, but it is worth trying
  * yourself.)
  *
  * The panels and buttons come from the shared UI kit in src/shared/ui.js, so every preset
@@ -33,18 +33,18 @@
  * The engine's built-in overlay also shows live audio meters: little bars that move
  * up and down with how loud each audio bus (main, music, sfx) is right now, plus a
  * count of how many sounds are playing at once. This demo turns that feature on with
- * `isOverlayAudioMetersEnabled: true` in configure() - watch the meters jump every time a
+ * `isOverlayAudioMetersEnabled: true` in configure() – watch the meters jump every time a
  * preset or a randomized sound plays.
  *
  * Try this:
- * - Click anywhere, or press any key, to unlock sound - watch the message at the top change
+ * - Click anywhere, or press any key, to unlock sound – watch the message at the top change
  *   once you do.
  * - Tap the preset buttons (or press J, P, E, L, H, or B) to hear the jump, pickup,
  *   explosion, laser, hit, and blip presets.
- * - Tap Randomize (or press R) to hear a randomized sound - watch the right-hand panel
+ * - Tap Randomize (or press R) to hear a randomized sound – watch the right-hand panel
  *   update with the waveform, frequency, duration, noise mix, and pitch sweep target that
  *   were rolled.
- * - Randomize again and again - notice how differently the exact same few lines of "roll a
+ * - Randomize again and again – notice how differently the exact same few lines of "roll a
  *   random number" code can make the engine sound each time.
  */
 
@@ -58,7 +58,7 @@ import { applyTheme, THEME_DEFAULT_START_SLOT, ui } from './shared/ui.js';
 /** @typedef {import('blit386').HardwareSettings} HardwareSettings */
 
 // The waveform shapes AudioClip.synth() accepts. The engine does not export this list as a
-// runtime value (only as a TypeScript type), so we spell it out here ourselves - the
+// runtime value (only as a TypeScript type), so we spell it out here ourselves – the
 // randomizer picks one of these five names at random for every roll.
 const SYNTH_WAVEFORMS = ['sine', 'square', 'triangle', 'sawtooth', 'noise'];
 
@@ -99,7 +99,7 @@ const RANDOM_PITCH_SWEEP_MIN_MULTIPLIER = 0.3;
 const RANDOM_PITCH_SWEEP_MAX_MULTIPLIER = 3.0;
 
 // Upper bound for the random seed handed to AudioClip.synth(). This seed only feeds the
-// engine's internal noise generator - it is not something we need to remember or reproduce
+// engine's internal noise generator – it is not something we need to remember or reproduce
 // here, so any number in this range works.
 const RANDOM_SEED_MAX = 1_000_000;
 
@@ -114,7 +114,7 @@ const RANDOM_SEED_MAX = 1_000_000;
 function buildRandomSynthParams() {
     // BT.random is the engine's shared random number generator. pick() draws one item out of a list, float()
     // returns a decimal between two values, bool() flips a weighted coin, and next() gives a plain decimal from
-    // 0 up to (but not including) 1 - which is exactly the range these normalized knobs want.
+    // 0 up to (but not including) 1 – which is exactly the range these normalized knobs want.
     const waveform = BT.random.pick(SYNTH_WAVEFORMS);
     const frequency = BT.random.float(RANDOM_FREQUENCY_MIN_HZ, RANDOM_FREQUENCY_MAX_HZ);
     const duration = BT.random.float(RANDOM_DURATION_MIN_S, RANDOM_DURATION_MAX_S);
@@ -135,7 +135,7 @@ function buildRandomSynthParams() {
         dutyCycle: BT.random.next(),
         seed: BT.random.int(RANDOM_SEED_MAX),
         // Only glide the pitch about half the time, and only when we do, add the field at
-        // all - AudioClip.synth() treats a missing pitchSweep as "stay at one pitch."
+        // all – AudioClip.synth() treats a missing pitchSweep as "stay at one pitch."
         ...(hasPitchSweep
             ? {
                   pitchSweep: {
@@ -190,7 +190,7 @@ class Demo {
             // (unfilled) track behind each audio meter bar, so it must match the screen
             // background or those seams would show up as a mismatched color. The shared UI
             // theme puts its background color at THEME_DEFAULT_START_SLOT (applyTheme()'s
-            // default start slot - see init() below); configure() runs before init(), so we
+            // default start slot – see init() below); configure() runs before init(), so we
             // reference the constant directly instead of calling applyTheme() early.
             overlayStyle: {
                 gapPaletteIndex: THEME_DEFAULT_START_SLOT,
@@ -205,7 +205,7 @@ class Demo {
      * @returns {Promise<boolean>}
      */
     async init() {
-        // AudioClip.synth() is async - it has to calculate every sample before it can hand
+        // AudioClip.synth() is async – it has to calculate every sample before it can hand
         // back a clip. Promise.all() starts all six calculations at once and waits for them
         // all to finish, the same way audio-basics preloads its sound files up front.
         this.presetClips = await Promise.all(PRESET_DEFINITIONS.map((def) => AudioClip.synth(def.factory())));
@@ -252,13 +252,13 @@ class Demo {
 
     /**
      * Shows the shared unlock reminder until audio is unlocked, then switches to a plain
-     * reminder of the controls. A borderless group - just one line of text pinned under
+     * reminder of the controls. A borderless group – just one line of text pinned under
      * the title strip.
      */
     renderUnlockPrompt() {
         ui.begin('topLeft', { y: 28 });
 
-        // The shared "click to enable sound" row - it draws itself only while sound is
+        // The shared "click to enable sound" row – it draws itself only while sound is
         // still locked, and disappears on its own after the first click or key press.
         ui.audioUnlockHint();
 
@@ -272,7 +272,7 @@ class Demo {
 
     /**
      * Left-hand panel: one button per preset, plus the last one played. Each button fires
-     * on click, tap, or its keyboard shortcut - ui.button() treats all three the same.
+     * on click, tap, or its keyboard shortcut – ui.button() treats all three the same.
      */
     renderPresetPanel() {
         ui.begin('bottomLeft');
@@ -345,14 +345,14 @@ class Demo {
         // The kit calls render() synchronously, and this handler cannot be async, so we
         // start the render-and-play and let it run in the background instead of waiting for
         // it. The .catch() just logs a problem instead of crashing the page, as a safety
-        // net - it should never actually trigger with the ranges above.
+        // net – it should never actually trigger with the ranges above.
         this.playRandomParams(params).catch((error) => console.error(error));
     }
 
     /**
      * Renders a SynthParams recipe into a clip and plays it.
      *
-     * @param {SynthParams} params - Recipe to render and play.
+     * @param {SynthParams} params – Recipe to render and play.
      * @returns {Promise<void>}
      */
     async playRandomParams(params) {

--- a/packages/kit/src/adapters.ts
+++ b/packages/kit/src/adapters.ts
@@ -149,8 +149,8 @@ export function collectDocs(root: string): GeneratedFile[] {
  *   - `.claude/settings.json`          (kit-owned; translated from content/hooks.manifest.json)
  *   - `.claude/hooks/{script}`         (kit-owned; copied verbatim)
  *
- * @param root - The kit root directory.
- * @param vars - Template variables used when rendering generated content.
+ * @param root – The kit root directory.
+ * @param vars – Template variables used when rendering generated content.
  * @returns The generated Claude Code files and their contents.
  */
 export function generateClaudeAdapter(root: string, vars: TemplateVars): GeneratedFile[] {

--- a/packages/kit/src/migrations/registry.ts
+++ b/packages/kit/src/migrations/registry.ts
@@ -14,8 +14,8 @@ import type { Migration } from './types';
  * Migrations shipped with this kit, oldest first.
  *
  * Safety: `BT.*` calls and the engine's distinctive object keys (`overlay*`, `detectDroppedFrames`) auto-apply. Renames
- * whose old name is generic enough to appear in unrelated code - common method words (`equals`, `contains`,
- * `intersects`, `tick`) and generic bootstrap keys (`canvasId`, `containerId`, `waitForDOMReady`) - are marked `review`:
+ * whose old name is generic enough to appear in unrelated code – common method words (`equals`, `contains`,
+ * `intersects`, `tick`) and generic bootstrap keys (`canvasId`, `containerId`, `waitForDOMReady`) – are marked `review`:
  * located and reported with a suggestion, but never rewritten automatically.
  */
 export const MIGRATIONS: readonly Migration[] = [

--- a/packages/kit/src/migrations/types.ts
+++ b/packages/kit/src/migrations/types.ts
@@ -1,5 +1,5 @@
 /**
- * Data model for engine migrations - the structured, machine-applicable form of `blit386`'s `docs/deprecations.md`.
+ * Data model for engine migrations – the structured, machine-applicable form of `blit386`'s `docs/deprecations.md`.
  *
  * A migration bundles a set of one-to-one identifier renames (a codemod) plus a human-readable summary of intent.
  * `blit migrate` and `blit upgrade` consume this to rewrite a game's source from old API names to current ones.

--- a/packages/website/content/docs/api/assets.mdx
+++ b/packages/website/content/docs/api/assets.mdx
@@ -3,7 +3,7 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Assets"
 description: "Sprite sheets, bitmap fonts, and asset loading."
-lastModified: "2026-07-28T16:49:29+02:00"
+lastModified: "2026-08-07T22:06:03+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/api-assets.md"
 ---
 

--- a/packages/website/content/docs/api/audio.mdx
+++ b/packages/website/content/docs/api/audio.mdx
@@ -3,7 +3,7 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Audio"
 description: "Audio buses, SFX voice pool, crossfading music, and procedural synthesis."
-lastModified: "2026-07-22T06:39:35+02:00"
+lastModified: "2026-08-08T13:36:09+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/api-audio.md"
 ---
 
@@ -106,7 +106,7 @@ gesture, and why no configure flag can skip this requirement.
 <Since symbol="AudioClip" />
 
 `AudioClip` decodes an audio file into a reusable `AudioBuffer`, exposing the winning source URL, duration, and sample
-rate. Loading and decoding work even while the audio context is locked (suspended, pre-gesture) - only real-time
+rate. Loading and decoding work even while the audio context is locked (suspended, pre-gesture) – only real-time
 playback needs an unlocked context. See [Preloading audio clips](/docs/guides/audio#preloading-audio-clips).
 
 ```ts twoslash
@@ -162,12 +162,12 @@ theme.unload(); // releases the decoded buffer; safe to call more than once
 - `AudioClip.load()` and `loadAll()` throw a beginner-friendly error covering network/CORS failures, HTTP status errors,
   unsupported container/codec decode failures, and loading before the engine has started.
 - Prefer a fallback list (for example `['theme.ogg', 'theme.mp3']`) for any clip whose primary format might not decode
-  in every browser - see [Audio formats](/docs/api/browser-support#audio-formats).
+  in every browser – see [Audio formats](/docs/api/browser-support#audio-formats).
 - Playing a loaded clip back as SFX is covered in [Playback (SFX)](#playback-sfx) below; as looping, crossfading music
   in [Playback (Music)](#playback-music).
 
 Under a Vite dev server with the `blit386/vite` plugin installed, editing an audio file under a watched asset directory
-(`public/` by default) swaps the decoded buffer inside the same `AudioClip` instance - demo-held references stay valid.
+(`public/` by default) swaps the decoded buffer inside the same `AudioClip` instance – demo-held references stay valid.
 Any SFX voice still playing the old buffer is stopped; if the replaced clip is the currently playing music track,
 playback restarts immediately (`fadeMs: 0`, no crossfade). `duration`/`sampleRate` reflect the buffer decoded at initial
 load and are not updated by a hot reload. See [Hot Reload](/docs/guides/hot-reload#asset-hot-replace-matrix) for the full
@@ -177,10 +177,10 @@ asset type matrix.
 
 <Since symbol="SynthParams" />
 
-`AudioClip.synth` renders a clip procedurally from a `SynthParams` descriptor - no source file, no network request, and
+`AudioClip.synth` renders a clip procedurally from a `SynthParams` descriptor – no source file, no network request, and
 no `OfflineAudioContext`. Rendering runs entirely on the CPU and is deterministic: identical params (including `seed`)
 always produce identical sample data, so a `SynthParams` object can be stored and replayed as a preset. Unlike
-[Loading](#loading), there is nothing to fetch or decode from the network - a synthesized clip is ready the instant
+[Loading](#loading), there is nothing to fetch or decode from the network – a synthesized clip is ready the instant
 `synth()` resolves, even before `BT.isAudioUnlocked` is `true` (see [Unlock state](#unlock-state) above).
 
 ```ts twoslash
@@ -222,7 +222,7 @@ const laser = await AudioClip.synth({
   }} />
 
 The release phase always finishes exactly at `duration`, even on a very short clip where the attack, decay, and release
-phases overlap - a percussive hit is never cut off mid-fade.
+phases overlap – a percussive hit is never cut off mid-fade.
 
 <Since symbol="SynthPitchSweep" />
 
@@ -260,7 +260,7 @@ BT.soundPlay(boom, { volume: 0.7 });
 <Callout title="Not cached, not deduplicated">
 
 Unlike `AudioClip.load()`, `AudioClip.synth()` never populates the URL-keyed resolved cache and never deduplicates
-concurrent calls - every call renders a fresh, independent `AudioBuffer`, even for byte-identical `params`. `unload()`
+concurrent calls – every call renders a fresh, independent `AudioBuffer`, even for byte-identical `params`. `unload()`
 still works the same way (releases the buffer, stops any voice playing it), it just has no cache entry to clear.
 
 </Callout>
@@ -271,7 +271,7 @@ still works the same way (releases the buffer, stops any voice playing it), it j
 
 `BT.synthPreset` bundles six ready-made `SynthParams` factories for common sound effects: `jump`, `pickup`, `explosion`,
 `laser`, `hit`, `blip`. Each takes an optional `seed` and applies small, bounded, deterministic jitter to a couple of
-hand-picked fields (frequency, duration, or noise mix) - the same seed always renders the exact same variant, so a
+hand-picked fields (frequency, duration, or noise mix) – the same seed always renders the exact same variant, so a
 preset stays reproducible even though it varies from call to call.
 
 ```ts twoslash
@@ -290,7 +290,7 @@ BT.soundPlay(menuBlip);
 BT.soundPlay(coin, { volume: 0.8 });
 ```
 
-Omitting `seed` (or passing `0`) always renders the same baseline variant - useful when you want a preset's default
+Omitting `seed` (or passing `0`) always renders the same baseline variant – useful when you want a preset's default
 character rather than per-play variation. See [Playback (SFX)](#playback-sfx) below for playing the resulting clip
 through the SFX voice pool, and [Design a sound](/docs/guides/audio#design-a-sound) in the Audio Guide for a walkthrough of
 tuning `SynthParams` by hand and storing presets as data.
@@ -305,7 +305,7 @@ tuning `SynthParams` by hand and storing presets as data.
 <Since symbol="BT.isSoundPlaying" />
 
 `BT.soundPlay` plays a loaded `AudioClip` through a fixed-size pool of SFX voices. Each call returns an opaque
-`SoundRef` handle - pass it to `BT.soundStop` and the per-sound volume, pitch, and pan controls.
+`SoundRef` handle – pass it to `BT.soundStop` and the per-sound volume, pitch, and pan controls.
 
 ```ts twoslash
 import { AudioClip, BT } from 'blit386';
@@ -335,17 +335,17 @@ BT.soundStop(ref, { fadeOutMs: 200 }); // fades out over 200 ms
 
 <Callout title="Voice cap and stealing">
 
-`HardwareSettings.audioVoices` (default `16`) sizes a fixed pool of voices - it never grows. When every voice is in use,
+`HardwareSettings.audioVoices` (default `16`) sizes a fixed pool of voices – it never grows. When every voice is in use,
 a new `BT.soundPlay` call steals the lowest-priority active voice at or below the incoming priority (ties broken by
 whichever voice started first). If every active voice outranks the incoming priority, the new sound is dropped silently:
 no throw, and the returned `SoundRef` is inert (`BT.isSoundPlaying` reports `false` for it immediately).
 
 Set `isOverlayAudioMetersEnabled: true` to see active/total voices, steal count, and drop count live in the overlay
-instead of reasoning about the pool from code - see [Audio meters](/docs/api/overlay#audio-meters-optional).
+instead of reasoning about the pool from code – see [Audio meters](/docs/api/overlay#audio-meters-optional).
 
 </Callout>
 
-A common pattern - vary pitch slightly per play so a repeated sound (footsteps, hits) doesn't sound robotic:
+A common pattern – vary pitch slightly per play so a repeated sound (footsteps, hits) doesn't sound robotic:
 
 ```ts twoslash
 import { AudioClip, BT } from 'blit386';
@@ -366,7 +366,7 @@ function playFootstep() {
 <Since symbol="BT.soundPanSet" />
 <Since symbol="BT.soundPanGet" />
 
-Per-sound controls, all silent no-ops on a stale or invalid `SoundRef` (already stopped, stolen, or completed - never
+Per-sound controls, all silent no-ops on a stale or invalid `SoundRef` (already stopped, stolen, or completed – never
 throws):
 
 ```ts twoslash
@@ -445,7 +445,7 @@ BT.musicPlay(battle, { fadeMs: 800, overlap: 0 }); // battle starts fading in ex
 BT.musicPlay(battle, { fadeMs: 800, overlap: -1 }); // an 800 ms silence gap between the two
 ```
 
-Calling `BT.musicPlay` again before a crossfade finishes immediately cuts the track that was already fading out - only
+Calling `BT.musicPlay` again before a crossfade finishes immediately cuts the track that was already fading out – only
 one crossfade is ever in flight, so rapid calls (menu navigation, quick scene changes) never pile up.
 
 ### Loop points
@@ -485,7 +485,7 @@ BT.musicVolumeGet(); // 0.4
 
 <Callout title="Remembered while locked, not dropped">
 
-Unlike `BT.soundPlay`, a `BT.musicPlay` call made before `BT.isAudioUnlocked` is `true` is not dropped - the engine
+Unlike `BT.soundPlay`, a `BT.musicPlay` call made before `BT.isAudioUnlocked` is `true` is not dropped – the engine
 remembers the most recent pending request and starts it automatically the instant the context unlocks. Calling
 `BT.musicPlay` again while still locked replaces the remembered request; only the latest survives to unlock.
 
@@ -501,7 +501,7 @@ intro-then-loop recipe.
 
 ## Hardware settings
 
-`audioVoices` (default `16`) caps the number of simultaneous SFX voices - see [Playback (SFX)](#playback-sfx) for the
+`audioVoices` (default `16`) caps the number of simultaneous SFX voices – see [Playback (SFX)](#playback-sfx) for the
 allocation and stealing policy. Documented in [Hardware settings](/docs/api/core#hardware-settings).
 
 <PageChangelog page="api/audio" />

--- a/packages/website/content/docs/api/browser-support.mdx
+++ b/packages/website/content/docs/api/browser-support.mdx
@@ -3,7 +3,7 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Browser Support"
 description: "WebGPU support matrix, automatic software fallback, and build toolchain."
-lastModified: "2026-07-28T16:49:29+02:00"
+lastModified: "2026-08-08T13:36:09+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/api-browser-support.md"
 ---
 
@@ -45,8 +45,8 @@ codec support follows the browser, not BLIT386.
 <Callout title="Point-in-time snapshot">
 
 Codec support shifts with browser updates. Treat this matrix as a snapshot and re-check the vendor release notes
-periodically. This is why `AudioClip.load()` accepts an ordered fallback list (for example
-`['theme.ogg', 'theme.mp3']`) - the engine tries each candidate in order until one decodes.
+periodically. This is why `AudioClip.load()` accepts an ordered fallback list (for example `['theme.ogg', 'theme.mp3']`)
+– the engine tries each candidate in order until one decodes.
 
 </Callout>
 
@@ -87,7 +87,7 @@ attempt `screen.orientation.lock()` after init; the default `'any'` skips the lo
 
 <Callout title="Silent no-op fallback">
 
-Lock support is uneven - Chrome on Android and Samsung Internet typically allow it; iOS Safari does not. When locking is
+Lock support is uneven – Chrome on Android and Samsung Internet typically allow it; iOS Safari does not. When locking is
 unsupported or rejected, the engine continues without unlocking or failing `init()`. Detection and `onOrientationChange`
 still work wherever `screen.orientation` exists.
 

--- a/packages/website/content/docs/api/core.mdx
+++ b/packages/website/content/docs/api/core.mdx
@@ -3,7 +3,7 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Core"
 description: "Bootstrap, initialization, and default configuration."
-lastModified: "2026-08-07T18:30:26+02:00"
+lastModified: "2026-08-08T10:05:04+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/api-core.md"
 ---
 

--- a/packages/website/content/docs/api/game-loop.mdx
+++ b/packages/website/content/docs/api/game-loop.mdx
@@ -3,7 +3,7 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Game Loop"
 description: "Fixed-timestep simulation timing, tick counters, and the Timer helper."
-lastModified: "2026-07-28T16:49:29+02:00"
+lastModified: "2026-08-08T13:36:09+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/api-game-loop.md"
 ---
 
@@ -82,9 +82,9 @@ sizeable fraction of render frames have zero preceding `update()` calls that fra
 
 `render()` frequently runs at a different cadence than `update()` (see the two sections above), so game state read
 during `render()` can be up to one fixed step stale. The accumulator introduced above always holds less than one
-`updateInterval` of leftover time once its whole-step chunks are removed for the frame - that remainder is exactly what
+`updateInterval` of leftover time once its whole-step chunks are removed for the frame – that remainder is exactly what
 the whole-step loop couldn't consume. Dividing that leftover by `updateInterval` gives, from first principles, how far
-the simulation has already progressed toward its next step - a fraction in `[0, 1)`. `BT.renderAlpha` exposes that
+the simulation has already progressed toward its next step – a fraction in `[0, 1)`. `BT.renderAlpha` exposes that
 fraction: `0` means a fixed update just completed, values approaching `1` mean the next update is imminent.
 
 ```ts twoslash

--- a/packages/website/content/docs/api/random.mdx
+++ b/packages/website/content/docs/api/random.mdx
@@ -3,7 +3,7 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Random"
 description: "Seeded Random PRNG, coordinate hashes, and Value/Perlin/Simplex pattern noise for procedural worlds."
-lastModified: "2026-07-30T18:24:43+02:00"
+lastModified: "2026-08-08T13:36:09+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/api-random.md"
 ---
 
@@ -110,7 +110,7 @@ rng.direction8(); // cardinals plus diagonals
 
 ## Coordinate hashing
 
-Stateless spatial lookups for chunked and procedural worlds. Same coordinates and seed always return the same value - no
+Stateless spatial lookups for chunked and procedural worlds. Same coordinates and seed always return the same value – no
 stored RNG state, so you do not need an instance per chunk. Complements `Random` (a sequence generator).
 
 <Since symbol="hash1i" />
@@ -163,7 +163,7 @@ classes are distinct from the post-process `Noise` display effect (GPU grain).
 | `PerlinNoise` | Same surface as `ValueNoise` (gradient Perlin) |
 | `SimplexNoise` | `noise2D` / `noise3D`, `fbm2D` / `fbm3D` (no 1D) |
 
-Omit the constructor seed (or pass `0`) for a fixed default world seed - same convention as `hash2i`. Call `seed(n)` to
+Omit the constructor seed (or pass `0`) for a fixed default world seed – same convention as `hash2i`. Call `seed(n)` to
 switch fields. fBm defaults: `octaves = 4`, `persistence = 0.5`, `lacunarity = 2`. Octave amplitudes are normalized so
 fBm stays in approximately `[-1, 1]`.
 

--- a/packages/website/content/docs/guides/audio.mdx
+++ b/packages/website/content/docs/guides/audio.mdx
@@ -3,7 +3,7 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Audio"
 description: "The audio subsystem layout, locked vs. unlocked gesture state, and web audio constraints."
-lastModified: "2026-07-28T16:49:29+02:00"
+lastModified: "2026-08-08T13:36:09+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/guide-audio.md"
 ---
 
@@ -25,7 +25,7 @@ src/assets/
 ```
 
 `AudioManager` is owned by the internal `BTAPI` singleton (created and torn down alongside pointer, keyboard, and
-gamepad input) and is never exposed to demo code directly - only through the `BT.audio*`/`BT.sound*`/`BT.music*` methods
+gamepad input) and is never exposed to demo code directly – only through the `BT.audio*`/`BT.sound*`/`BT.music*` methods
 and the `BT.isAudioUnlocked`/`BT.isMusicPlaying` getters documented in [API: Audio](/docs/api/audio). On `attach()`,
 `AudioManager` registers its Web Audio context in `audioDecodeContext.ts`, a small bridge that `AudioClip` reads from to
 decode audio data without needing a direct reference to `AudioManager` itself.
@@ -71,7 +71,7 @@ class Demo implements IBTDemo {
 
 ## Preloading audio clips
 
-`AudioClip.load()` downloads and decodes audio even while the context is locked (suspended, pre-gesture) - decoding only
+`AudioClip.load()` downloads and decodes audio even while the context is locked (suspended, pre-gesture) – decoding only
 needs a registered context, not an unlocked one. That makes a title screen or a loading state a good place to preload
 every clip a level needs, so they're ready the instant the player's first gesture unlocks audio. Poll
 [`BT.loadingAssetsCount`](/docs/api/assets#loading-assets) to show progress while image and audio loads are still in
@@ -94,26 +94,26 @@ class Demo implements IBTDemo {
 ```
 
 Prefer a fallback list (for example `['theme.ogg', 'theme.mp3']`) for any clip whose primary format might not decode in
-every browser - see [Audio formats](/docs/api/browser-support#audio-formats) for the current per-browser matrix.
+every browser – see [Audio formats](/docs/api/browser-support#audio-formats) for the current per-browser matrix.
 
 ## Web audio constraints
 
 Every major browser enforces an autoplay policy: an `AudioContext` starts `'suspended'` and stays that way until a user
-gesture calls `resume()`. This is a platform rule, not something BLIT386 can configure around - there is no flag to
+gesture calls `resume()`. This is a platform rule, not something BLIT386 can configure around – there is no flag to
 start audio unlocked, and none is planned.
 
 - Volume and mute calls made before the gesture are not lost; they update the engine's internal bus state and take
   effect immediately once the context resumes.
 - The gesture requirement is independent of the render backend. Unlocking audio has nothing to do with
-  `BT.activeBackend` or the WebGPU/Canvas 2D fallback described in [Browser Support](/docs/api/browser-support) - a demo
+  `BT.activeBackend` or the WebGPU/Canvas 2D fallback described in [Browser Support](/docs/api/browser-support) – a demo
   can be fully unlocked on the software renderer, or fully locked on WebGPU.
 - Loading and decoding clips is implemented via `AudioClip` (see [Loading](/docs/api/audio#loading)) and works regardless
   of lock state. `BT.soundPlay` (see [Playback (SFX)](/docs/api/audio#playback-sfx)) behaves differently from a pre-unlock
   bus call: `playSound()` drops the request entirely before unlock (no voice allocated, no throw, counted as a dropped
   SFX request), where `AudioManager.volumeSet()` (`BT.audioVolumeSet`) still updates the engine's internal bus state and
-  applies once the context resumes - it is only inaudible while locked, not dropped.
+  applies once the context resumes – it is only inaudible while locked, not dropped.
 - `BT.musicPlay` (see [Playback (Music)](/docs/api/audio#playback-music)) sits between those two behaviors: a pre-unlock
-  call isn't dropped like `BT.soundPlay`, but it isn't merely inaudible-and-applied like a bus call either - it is
+  call isn't dropped like `BT.soundPlay`, but it isn't merely inaudible-and-applied like a bus call either – it is
   remembered and starts automatically the instant the context unlocks. Calling `BT.musicPlay` again while still locked
   replaces the remembered request, so only the last call before unlock actually plays.
 
@@ -126,7 +126,7 @@ of each sound's own per-voice volume from `BT.soundVolumeSet`.
 The pool itself (`src/audio/VoicePool.ts`) is a fixed-size array sized by `HardwareSettings.audioVoices` - it never
 grows at runtime. Each `BT.soundPlay` call either claims a free slot or steals the lowest-priority active voice at or
 below the incoming priority; see [Playback (SFX)](/docs/api/audio#playback-sfx) for the exact policy and a worked example.
-This cap exists because each slot is a real `AudioBufferSourceNode -> GainNode -> StereoPannerNode` chain - letting the
+This cap exists because each slot is a real `AudioBufferSourceNode -> GainNode -> StereoPannerNode` chain – letting the
 pool grow unbounded would let a busy scene (an explosion with dozens of debris impacts, for example) spend unbounded CPU
 on nodes the player can't meaningfully hear over each other anyway.
 
@@ -135,7 +135,7 @@ To see the pool cap and stealing policy in action instead of reasoning about it 
 voices used/total, steal, and drop readout. See [Audio meters](/docs/api/overlay#audio-meters-optional) in the Overlay API
 reference.
 
-A sound that plays often (footsteps, hits, bullet casings) reads as repetitive at a fixed pitch - vary it slightly per
+A sound that plays often (footsteps, hits, bullet casings) reads as repetitive at a fixed pitch – vary it slightly per
 play instead:
 
 ```ts twoslash
@@ -155,7 +155,7 @@ function playFootstep() {
 ## Playing music
 
 `BT.musicPlay` (see [Playback (Music)](/docs/api/audio#playback-music)) drives a single looping music player through the
-`'music'` bus - there is no per-track handle to manage like `SoundRef`, and a second call crossfades from whatever is
+`'music'` bus – there is no per-track handle to manage like `SoundRef`, and a second call crossfades from whatever is
 currently playing into the new track instead of layering the two. Two patterns cover most games: switching tracks by
 game state, and looping a region after a one-shot intro.
 
@@ -190,7 +190,7 @@ function setGameState(next: GameState) {
 
 Reach for `overlap: 0` instead of the default simultaneous crossfade when the outgoing track should finish cleanly
 before the new one starts (a menu jingle that shouldn't blend into gameplay music), or `overlap: -1` for a deliberate
-beat of silence between tracks (a boss intro sting) - see [Crossfading](/docs/api/audio#crossfading) for the exact timing
+beat of silence between tracks (a boss intro sting) – see [Crossfading](/docs/api/audio#crossfading) for the exact timing
 math.
 
 ### Intro then loop
@@ -214,7 +214,7 @@ BT.musicPlay(theme, { loopStart: 8, loopEnd: 32 });
 
 ## Design a sound
 
-Beyond loading audio files, `AudioClip.synth` generates a clip entirely on the CPU from a `SynthParams` descriptor - no
+Beyond loading audio files, `AudioClip.synth` generates a clip entirely on the CPU from a `SynthParams` descriptor – no
 source file, no network fetch, and no `OfflineAudioContext`. Rendering is deterministic and synchronous: the same params
 (including `seed`) always produce the same samples, so a `SynthParams` value behaves like ordinary game data rather than
 a recorded asset. See [Synth](/docs/api/audio#synth) for the full field reference.
@@ -237,7 +237,7 @@ BT.soundPlay(zap);
 ```
 
 `BT.synthPreset` bundles ready-made starting points for common effects (`jump`, `pickup`, `explosion`, `laser`, `hit`,
-`blip`) - see [Presets](/docs/api/audio#presets) for the full list. Passing a different `seed` to a preset applies small,
+`blip`) – see [Presets](/docs/api/audio#presets) for the full list. Passing a different `seed` to a preset applies small,
 bounded jitter to a couple of its fields, so a repeated sound (footsteps, hits, pickups) doesn't sound identical every
 time, while staying reproducible for any given seed:
 
@@ -252,7 +252,7 @@ async function playFootstep(stepIndex: number) {
 }
 ```
 
-Because `SynthParams` is plain data (numbers, strings, and nested objects - no functions or class instances), a tuned
+Because `SynthParams` is plain data (numbers, strings, and nested objects – no functions or class instances), a tuned
 sound can be stored, checked into a level file, or embedded in a save alongside the rest of your game's JSON, then
 handed to `AudioClip.synth` whenever it's needed:
 

--- a/packages/website/content/docs/guides/game-loop.mdx
+++ b/packages/website/content/docs/guides/game-loop.mdx
@@ -3,7 +3,7 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Game Loop"
 description: "Smoothing motion between fixed update() steps using BT.renderAlpha and Vector2i.lerp."
-lastModified: "2026-07-13T18:09:45+02:00"
+lastModified: "2026-08-08T13:36:09+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/guide-game-loop.md"
 ---
 
@@ -50,7 +50,7 @@ class Player {
 ```
 
 `Vector2i.lerp` truncates its result to integer pixels (see [API: Core Types](/docs/api/core-types#vector2i)), so this only
-smooths motion that covers more than a pixel or two per tick - it doesn't add subpixel precision to a pixel-perfect
+smooths motion that covers more than a pixel or two per tick – it doesn't add subpixel precision to a pixel-perfect
 renderer. For a sprite moving `2` px/tick at `targetFPS: 60` on a `144` Hz display, it turns a visible 1-then-2-then-0
 px stutter into a steadier progression across render frames.
 

--- a/packages/website/content/docs/guides/hot-reload.mdx
+++ b/packages/website/content/docs/guides/hot-reload.mdx
@@ -3,7 +3,7 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Hot Reload"
 description: "The three hot-reload swap tiers, onHotReload semantics, asset hot-replace, and the blit386/vite plugin."
-lastModified: "2026-08-07T14:38:27+02:00"
+lastModified: "2026-08-08T13:36:09+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/guide-hot-reload.md"
 ---
 
@@ -16,14 +16,14 @@ tiers with worked examples, the asset hot-replace matrix, and the `blit386/vite`
 ## What hot reload replaces
 
 Without it, every saved change to a demo or game source file triggers a full page reload: the whole module graph
-re-evaluates, `bootstrap()` runs cold again, and every piece of runtime state is lost - the player's position, score,
+re-evaluates, `bootstrap()` runs cold again, and every piece of runtime state is lost – the player's position, score,
 current level, whatever was on screen. Editing an asset under `public/` (a sprite, a sound, a font) does nothing at all;
 the running instance keeps using whatever it already loaded.
 
 With the `blit386/vite` plugin installed, both of those become live updates instead. A code change injects new behavior
 into the already-running demo, preserving as much state as the change allows. An asset change replaces the
 already-loaded resource in place. A page reload still happens, but only for the handful of changes that are genuinely
-incompatible with swapping in place - see [What always forces a full reload](#what-always-forces-a-full-reload) below.
+incompatible with swapping in place – see [What always forces a full reload](#what-always-forces-a-full-reload) below.
 
 This is engine-side infrastructure. Nothing about it requires demo code to change - `onHotReload` is optional, and a
 demo that never implements it still gets prototype swaps and re-inits for free. It only affects local development;
@@ -32,7 +32,7 @@ demo that never implements it still gets prototype swaps and re-inits for free. 
 ## The three tiers
 
 `bootstrap()` decides which tier applies by comparing the newly re-evaluated demo class against the one currently
-running, every time Vite's HMR boundary re-evaluates the entry module. The decision is entirely mechanical - it is not
+running, every time Vite's HMR boundary re-evaluates the entry module. The decision is entirely mechanical – it is not
 configurable, and there is no way to force a different tier from demo code.
 
 ### Tier 1: method-only change
@@ -69,23 +69,23 @@ jump back to the origin.
 
 The `SPEED` case is the detail worth understanding: a Tier 1 swap does not touch `this.pos`, but it does replace
 `update` with a brand new function, freshly defined in the newly re-evaluated module. That new function closes over the
-new module's top-level scope - so the new value of `SPEED` takes effect on the very next tick, even though no field on
+new module's top-level scope – so the new value of `SPEED` takes effect on the very next tick, even though no field on
 the instance changed. Module-level constants referenced from methods are effectively live-editable.
 
 <Callout type="warn" title="A constant baked into an instance field by init() is not live-editable">
   The live-editable behavior above only holds while every reader of the constant is a method that runs fresh each
-  tick. If `init()` also reads the same constant to build data cached in an instance field - filling a scene buffer,
-  precomputing a lookup table, seeding a starting position - editing the constant is still a methods-only change as
+  tick. If `init()` also reads the same constant to build data cached in an instance field – filling a scene buffer,
+  precomputing a lookup table, seeding a starting position – editing the constant is still a methods-only change as
   far as the fingerprint in [Tier 2](#tier-2-initconstructor-change) is concerned: `init()`'s own source text did not
   change, only the value an unrelated top-level `const` resolves to. So the swap stays Tier 1, `init()` does not
-  re-run, and the instance field keeps whatever it was built from before the edit - while methods swapped in by the
+  re-run, and the instance field keeps whatever it was built from before the edit – while methods swapped in by the
   same save read the new value immediately. The two go out of sync until you force a Tier 2 path yourself (touch
   `init()`, the constructor, or a class field initializer) or fall back to a full page reload / dev server restart.
 </Callout>
 
 ### Tier 2: init/constructor change
 
-If `init()`, the constructor, or a class field initializer changed, a Tier 1 swap is not safe - the running instance was
+If `init()`, the constructor, or a class field initializer changed, a Tier 1 swap is not safe – the running instance was
 built by code that no longer exists. Instead, a fresh instance is constructed and its `init()` runs while the previous
 instance keeps driving the loop. Only once that succeeds does the engine swap the new instance in; a failed `init()`
 (returns `false`, or throws) leaves the previous instance running untouched, so a broken save never crashes your game.
@@ -131,13 +131,13 @@ class Demo implements IBTDemo {
 }
 ```
 
-Without the `onHotReload` hook, a Tier 2 swap still works - it just means every field resets to whatever `init()` sets
+Without the `onHotReload` hook, a Tier 2 swap still works – it just means every field resets to whatever `init()` sets
 it to, same as a cold boot. Implementing `onHotReload` is how you opt into carrying state across a re-init.
 
 ### Tier 3: hardware settings change
 
-If `configure()`'s return value differs from what is currently running - a different `displaySize`, backend, target
-frame rate, or any other field listed in [Hardware settings](/docs/api/core#hardware-settings) - neither swap is safe. Some
+If `configure()`'s return value differs from what is currently running – a different `displaySize`, backend, target
+frame rate, or any other field listed in [Hardware settings](/docs/api/core#hardware-settings) – neither swap is safe. Some
 of those changes mean recreating the canvas, the WebGPU device, or the audio graph, and there is no in-place path for
 that. The engine requests a full page reload instead, through Vite's `import.meta.hot.invalidate()`.
 
@@ -161,10 +161,10 @@ class Demo implements IBTDemo {
 }
 ```
 
-`onHotReload` never fires for a Tier 3 reload - the page is gone before there is anything left to notify.
+`onHotReload` never fires for a Tier 3 reload – the page is gone before there is anything left to notify.
 
 Running under `?backend=software` does not itself force a Tier 3 reload on every edit. The comparison accounts for the
-URL override on both sides, so only a genuine `configure()` change - not the override alone - triggers a full page
+URL override on both sides, so only a genuine `configure()` change – not the override alone – triggers a full page
 reload.
 
 ## The `blit386:hot-reload` DOM event
@@ -184,7 +184,7 @@ canvas.addEventListener('blit386:hot-reload', (event) => {
 ```
 
 This is a DOM event rather than a second `BT` callback API on purpose: `onHotReload` is for the demo class itself to
-react to its own state; the DOM event is for anything outside the demo class that wants to know a reload happened - a
+react to its own state; the DOM event is for anything outside the demo class that wants to know a reload happened – a
 browser extension, an in-page dev overlay, a Playwright test waiting for the swap to settle, or any other tooling that
 has no reason to import `blit386` at all. It fires whether or not the demo implements `onHotReload`.
 
@@ -196,14 +196,14 @@ event for anything it recognizes. The engine routes that event by file type:
 | Asset type | What happens |
 | --- | --- |
 | Image (`.png`, `.gif`, `.webp`, `.jpg`, `.jpeg`) | Every registered `SpriteSheet` built from that URL swaps its texture in place, re-running `indexize()` against the active palette when the sheet was already indexized. See the dimension-change caveat below. |
-| Audio (`.wav`, `.mp3`, `.ogg`, `.flac`) | The same `AudioClip` instance swaps its decoded buffer in place - demo-held references stay valid. Any SFX voice still playing the old buffer is stopped; if the replaced clip is the currently playing music track, playback restarts immediately (`fadeMs: 0`, no crossfade). `duration`/`sampleRate` reflect the buffer decoded at initial load and are not updated. |
-| Bitmap font (`.btfont`) | The same `BitmapFont` instance rebuilds its glyph tables and texture in place. `name`/`size`/`lineHeight`/`baseline` are frozen at their original values - only glyph data and the texture update. |
+| Audio (`.wav`, `.mp3`, `.ogg`, `.flac`) | The same `AudioClip` instance swaps its decoded buffer in place – demo-held references stay valid. Any SFX voice still playing the old buffer is stopped; if the replaced clip is the currently playing music track, playback restarts immediately (`fadeMs: 0`, no crossfade). `duration`/`sampleRate` reflect the buffer decoded at initial load and are not updated. |
+| Bitmap font (`.btfont`) | The same `BitmapFont` instance rebuilds its glyph tables and texture in place. `name`/`size`/`lineHeight`/`baseline` are frozen at their original values – only glyph data and the texture update. |
 | Palette | Nothing hot-reload-specific needed - `BT.palette` is already a live reference, so mutating a slot with `palette.set()` takes effect on the very next frame regardless of how the change was triggered. |
 | Anything else | Falls back to a full page reload (`fullReloadOnUnknownAssets`, default `true` - see [Plugin options](#plugin-options)). |
 
 <Callout title="Demo-held srcRects and dimension changes">
   If a hot-replaced image has different dimensions than the one it replaced, the sprite sheet's `size` updates to
-  match and its internal buffers rebuild accordingly - but any `Rect2i` a demo is holding onto as a `srcRect` into
+  match and its internal buffers rebuild accordingly – but any `Rect2i` a demo is holding onto as a `srcRect` into
   that sheet does not update itself. Reconciling a stale `srcRect` after a dimension change is the demo's own
   responsibility; keep sprite sheet dimensions stable during a hot-reload session, or recompute `srcRect`s from the
   sheet's current `width`/`height` in `onHotReload`.
@@ -220,7 +220,7 @@ Beyond the Tier 3 hardware-settings case above, three other situations always me
 swap:
 
 - Editing the engine's own source (a `blit386` dist rebuild). The hot-reload boundary lives in the demo/game's entry
-  module, not inside the engine bundle itself - a changed `blit386` dist is a different module identity as far as Vite's
+  module, not inside the engine bundle itself – a changed `blit386` dist is a different module identity as far as Vite's
   module graph is concerned, so there is nothing to swap into.
 - An asset change with an unrecognized extension, when `fullReloadOnUnknownAssets` is left at its default `true`.
 - Calling `bootstrap()` a second time with no Vite HMR context registered at all (for example, calling it twice by
@@ -228,7 +228,7 @@ swap:
   unstoppable game loop. Before 1.4.0, the same mistake silently started a second GameLoop.
 
 This is a deliberate design choice, not a current limitation: a hard reload is always a full page reload, so there is
-never a point in the engine's lifetime where a renderer needs to tear itself down and rebuild in place - the whole page,
+never a point in the engine's lifetime where a renderer needs to tear itself down and rebuild in place – the whole page,
 canvas, and WebGPU device go away and come back fresh instead. That is why `IRenderer` has no `dispose` method. Adding
 one would mean maintaining a teardown path that a real page reload already gives you for free.
 
@@ -265,14 +265,14 @@ runtime cost or behavior change to ship):
   `registerHotReload` is imported under a plugin-specific alias so the snippet cannot collide with an entry module that
   already binds `registerHotReload` itself (which would be a duplicate-declaration `SyntaxError`).
 
-  The literal `import.meta.hot.accept()` call has to appear in the emitted source - Vite marks a module self-accepting
+  The literal `import.meta.hot.accept()` call has to appear in the emitted source – Vite marks a module self-accepting
   by static analysis, so an indirect call would not register self-acceptance and every edit would fall back to a full
   reload regardless of which tier should have applied. You never write or call `registerHotReload` yourself; the plugin
   injects it, and the engine handles everything from there.
 
   For a plain `.js`/`.mjs` entry, the plugin also syntax-checks the module before injecting. Vite's own default
   transform pipeline excludes those extensions from server-side parsing, so without this a broken entry module would
-  surface only as a silently caught client-side error - Vite's error overlay would never appear. A `.ts`/`.mts` entry is
+  surface only as a silently caught client-side error – Vite's error overlay would never appear. A `.ts`/`.mts` entry is
   unaffected; it already gets real syntax validation from Vite's own transform.
 
 - Marks the build as dev for [`BT.isDevMode`](/docs/api/core#dev-vs-release-mode) via the snippet's
@@ -334,13 +334,13 @@ export default defineConfig({
 
 ## Future ideas
 
-Not implemented yet - notes for where this could go next:
+Not implemented yet – notes for where this could go next:
 
 - An overlay badge showing the current reload count and the last file that triggered it.
 - A `?hardreload` query parameter or a keyboard chord that forces a clean Tier 2 re-init on demand, without waiting for
   a source edit.
 - Live `.btfont` glyph-metric editing (today only the texture and glyph tables hot-reload; metrics come from the
-  descriptor JSON, which does already reload - this is about interactively nudging metrics from a tool, not a gap in
+  descriptor JSON, which does already reload – this is about interactively nudging metrics from a tool, not a gap in
   what already reloads).
 - Hot-editing a palette file directly, rather than only palette slot mutations already being live.
 - Resuming music at its previous playback position across a hot-reload restart, instead of restarting from the top.

--- a/packages/website/content/docs/guides/input.mdx
+++ b/packages/website/content/docs/guides/input.mdx
@@ -3,7 +3,7 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Input"
 description: "Pointer, keyboard, gamepad, and text-accumulation input in BLIT386."
-lastModified: "2026-07-28T16:49:29+02:00"
+lastModified: "2026-08-08T13:36:09+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/guide-input.md"
 ---
 
@@ -352,7 +352,7 @@ long as a pointer is over the band, independent of the configure flag.
 <Callout type="warn" title="Upgrading from 1.3.0 or earlier">
 
 Pointer wheel capture is opt-in as of 1.4.0. If your game relied on `BT.pointerScrollDelta` without setting
-`isCapturingPointerScroll: true` in `configure()`, add the flag - otherwise the delta stays zero and the host page
+`isCapturingPointerScroll: true` in `configure()`, add the flag – otherwise the delta stays zero and the host page
 scrolls normally.
 
 </Callout>

--- a/packages/website/content/docs/guides/splash.mdx
+++ b/packages/website/content/docs/guides/splash.mdx
@@ -3,13 +3,13 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "The BLIT386 Splash"
 description: "The BLIT386 splash: gating, the loading-screen hold, the palette handoff, and the skip."
-lastModified: "2026-08-06T19:21:58+02:00"
+lastModified: "2026-08-08T13:36:09+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/guide-splash.md"
 ---
 
 Every published BLIT386 game shows a short BLIT386 splash before it starts: a logo bitmap fading in on its own 16-step
 gray ramp, holding, then fading out into the game's palette. Release builds play it by default and development builds
-skip it by default - both are defaults you can override.
+skip it by default – both are defaults you can override.
 
 This guide covers when it plays and how to turn it off, the loading-screen behavior, the palette handoff, and the skip.
 The getters themselves – `BT.splashState` and `BT.isSplashVisible` – are in [API: Core](/docs/api/core#splash-state), and

--- a/packages/website/content/docs/performance/best-practices.mdx
+++ b/packages/website/content/docs/performance/best-practices.mdx
@@ -3,7 +3,7 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Performance Best Practices"
 description: "When and how to optimize demos: object allocation, batching, and hot-path guidance."
-lastModified: "2026-08-01T20:18:17+02:00"
+lastModified: "2026-08-07T22:12:53+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/performance-best-practices.md"
 ---
 

--- a/packages/website/content/docs/reference/changelog.mdx
+++ b/packages/website/content/docs/reference/changelog.mdx
@@ -3,7 +3,7 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Changelog"
 description: "Release history in Keep a Changelog style: what shipped, what broke, and when."
-lastModified: "2026-08-06T18:37:14+02:00"
+lastModified: "2026-08-08T13:36:09+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/changelog.md"
 ---
 
@@ -56,18 +56,18 @@ notes, including dependency bumps and CI changes omitted here for brevity.
 - The BLIT386 splash: a logo bitmap fading in on its own 16-step gray ramp, holding, and fading out before the game's
   first frame. Shown in release builds by default and disabled in development by default, with
   `HardwareSettings.isSplashEnabled` and the `?splash` / `?nosplash` URL flags to override either default. It doubles as
-  a loading screen - the game's `init()` runs concurrently and the hold extends until it settles - and hands off into
+  a loading screen – the game's `init()` runs concurrently and the hold extends until it settles – and hands off into
   the game's palette with a single continuous `BT.paletteFadeExposure`, so there is no cut. Any key, click, or tap
   skips, and that press is swallowed. New getters `BT.splashState` and `BT.isSplashVisible`, plus `splashColorDark` /
   `splashColorLight` for the ramp endpoints. The pixelated dissolve is WebGPU-only; the software backend gets the plain
   fade. See [the splash guide](/docs/guides/splash) and [Core](/docs/api/core#splash-state).
 
-## 1.4.0 - 2026-07-23
+## 1.4.0 – 2026-07-23
 
 ### Added
 
 - Engine-side hot-reload runtime: `registerHotReload` (wired automatically by the `blit386/vite` plugin), an optional
-  `IBTDemo.onHotReload(context)` hook, and a tiered hot-swap - a method-only prototype swap when only method bodies
+  `IBTDemo.onHotReload(context)` hook, and a tiered hot-swap – a method-only prototype swap when only method bodies
   changed, a full re-init when `init()` or the constructor changed, and a full page reload when hardware settings
   changed. Demo/game state persists across method and re-init swaps: ticks, camera, palette, and palette effects are
   never reset. This lands the engine half of BLIT386's HMR support; adoption in `blit386-demos`/`create-blit386` ships
@@ -79,9 +79,9 @@ notes, including dependency bumps and CI changes omitted here for brevity.
   runtime dependency on `vite` itself.
 - Engine-side asset hot-replace: `AssetLoader.evict`, plus internal routing in `HotRuntime.handleAssetChanged` for
   `blit386:asset-changed` events. A changed image, audio, or `.btfont` file under `public/` updates the running demo in
-  place - sprite sheets swap their texture (calling `indexize()` against the active palette when needed), audio clips
+  place – sprite sheets swap their texture (calling `indexize()` against the active palette when needed), audio clips
   swap their decoded buffer (stopping SFX voices on the old buffer and restarting the music player if the replaced clip
-  is the current track), and bitmap fonts rebuild their glyph tables and texture - all without a page reload. Adoption
+  is the current track), and bitmap fonts rebuild their glyph tables and texture – all without a page reload. Adoption
   in `blit386-demos`/`create-blit386` ships in a follow-up release.
 - Asset loading progress: `BT.loadingAssetsCount` is polled once per frame as a combined image+audio signal (the sum of
   `AssetLoader.loadingCount` and `AudioClip.loadingCount`) to drive a loading spinner or progress bar until it returns
@@ -98,14 +98,14 @@ notes, including dependency bumps and CI changes omitted here for brevity.
   `configure()` change triggers a reload, matching the behavior already seen under the default `webgpu` backend.
 - The `blit386/vite` plugin now syntax-checks a plain `.js`/`.mjs` entry module before injecting the hot-reload snippet.
   Vite's own default transform pipeline excludes those extensions from server-side parsing, so a broken entry module
-  previously surfaced only as a silently caught client-side error - Vite's error overlay never appeared. `.ts`/`.mts`
+  previously surfaced only as a silently caught client-side error – Vite's error overlay never appeared. `.ts`/`.mts`
   entries are unaffected; they already get real syntax validation from Vite's own transform.
 - `canvas.style.touch-action` was hardcoded to `none` on attach, blocking touch tap-hold-scroll past the canvas even
   when `HardwareSettings.isCapturingPointerScroll` was left at its default `false`. It is now gated by the same flag:
   `none` while pointer scroll capture is active (configure-time opt-in or the overlay's palette-band force), `pan-y`
   otherwise, updated live as either source of capture changes.
 
-## 1.3.1 - 2026-07-19
+## 1.3.1 – 2026-07-19
 
 ### Added
 
@@ -132,7 +132,7 @@ notes, including dependency bumps and CI changes omitted here for brevity.
 - The overlay's bottom-left toggle hit region shrinks from `48×48` to `17×13` pixels, matching the visible toggle icon
   more closely.
 
-## 1.3.0 - 2026-07-13
+## 1.3.0 – 2026-07-13
 
 The audio release: the engine gains a full sound subsystem, from bus mixing to procedural synthesis, plus render-time
 interpolation for smoother motion between fixed update steps.
@@ -149,12 +149,12 @@ interpolation for smoother motion between fixed update steps.
   getters), and generational `SoundRef` handles. `HardwareSettings.audioVoices` (default `16`, range `1`-`64`) sizes the
   pool.
 - Deterministic procedural synthesis via `AudioClip.synth(params)` - waveforms, an ADSR envelope, a linear pitch sweep,
-  vibrato, and noise mixing, rendered on the CPU with no source file - plus a preset library `BT.synthPreset` (`jump`,
+  vibrato, and noise mixing, rendered on the CPU with no source file – plus a preset library `BT.synthPreset` (`jump`,
   `pickup`, `explosion`, `laser`, `hit`, `blip`).
 - Crossfading music playback with configurable fade, overlap, and loop points: `BT.musicPlay`, `BT.musicStop`,
   `BT.musicVolumeSet` / `BT.musicVolumeGet`, and the `BT.isMusicPlaying` getter.
 - Overlay audio meters: a per-bus level band with a voices used/total, steal, and drop readout, gated by
-  `HardwareSettings.isOverlayAudioMetersEnabled` with lazy opt-in metering - no metering cost is paid unless the flag is
+  `HardwareSettings.isOverlayAudioMetersEnabled` with lazy opt-in metering – no metering cost is paid unless the flag is
   set.
 - `BT.renderAlpha` getter: the fractional interpolation factor in `[0, 1)` between fixed `update()` steps, for smoothing
   render state on high-refresh displays. See the new game-loop smoothing guide.
@@ -176,7 +176,7 @@ interpolation for smoother motion between fixed update steps.
 - The engine overlay's toggle key press is now sampled during the fixed-update tick instead of the render phase, fixing
   intermittently dropped toggle presses under rapid input on high-refresh displays.
 
-## 1.2.1 - 2026-06-20
+## 1.2.1 – 2026-06-20
 
 ### Fixed
 
@@ -190,7 +190,7 @@ interpolation for smoother motion between fixed update steps.
 - "See also" cross-reference sections added or expanded across 16 documentation files; `README.md` rewritten with a
   beginner-first voice.
 
-## 1.2.0 - 2026-06-19
+## 1.2.0 – 2026-06-19
 
 Package and API rename – the engine is now published as `blit386` (previously `blit-tech`).
 
@@ -207,7 +207,7 @@ Package and API rename – the engine is now published as `blit386` (previously 
   browsers (including Firefox on Linux) before the Canvas 2D fallback could activate. Access is now inlined at call
   sites.
 
-## 1.1.1 - 2026-06-07
+## 1.1.1 – 2026-06-07
 
 ### Fixed
 
@@ -218,13 +218,13 @@ Package and API rename – the engine is now published as `blit386` (previously 
 
 - Boolean queries and predicate methods normalized to `is*`/`has*` conventions: `isDown`, `isPressed`,
   `isPointerActive`, `isEqual`, `isContaining`, `isIntersecting`. `HardwareSettings` config flags renamed to
-  `isOverlayEnabled`, `isDetectingDroppedFrames`, and so on. Deprecated aliases keep the previous names working - see
+  `isOverlayEnabled`, `isDetectingDroppedFrames`, and so on. Deprecated aliases keep the previous names working – see
   the [Deprecation Timeline](/docs/reference/deprecations).
 - Asset system structural refactor across `BitmapFont`, `SpriteSheet`, `Palette`, `PaletteEffect`, and `SystemFont` -
   internal only, no public API change.
 - Documentation corrected and expanded across 45+ files; a new overlay guide added.
 
-## 1.1.0 - 2026-05-30
+## 1.1.0 – 2026-05-30
 
 The overlay release: the old software-mode ticker is replaced by a full engine HUD subsystem.
 
@@ -243,7 +243,7 @@ The overlay release: the old software-mode ticker is replaced by a full engine H
 - Breaking: every `statsOverlay*` setting, the `statsOverlayRows()` hook, and the `StatsOverlay*` exported types drop
   the `stats`/`StatsOverlay` prefix (for example `overlayEnabled`, `overlayRows()`, `OverlayRow`).
 
-## 1.0.5 - 2026-05-21
+## 1.0.5 – 2026-05-21
 
 ### Added
 
@@ -251,7 +251,7 @@ The overlay release: the old software-mode ticker is replaced by a full engine H
 
 ### Changed
 
-- `configure()` now accepts a partial `HardwareSettings` object - demos can override just `targetFPS` without spelling
+- `configure()` now accepts a partial `HardwareSettings` object – demos can override just `targetFPS` without spelling
   out every field. The engine merges the result with `defaultConfig()` via the new exported `mergeHardwareSettings()`.
 
 ### Security
@@ -259,7 +259,7 @@ The overlay release: the old software-mode ticker is replaced by a full engine H
 - `.btfont` embedded textures must now use `data:image/png;base64` with a 512 KiB payload cap; glyph metrics are
   validated before atlas decode begins. A new `AssetLimits` module centralizes these constants.
 
-## 1.0.4 - 2026-05-17
+## 1.0.4 – 2026-05-17
 
 `BT` namespace read-only properties changed from methods to ES getters.
 
@@ -281,7 +281,7 @@ The overlay release: the old software-mode ticker is replaced by a full engine H
   supply-chain hardening enabled (`minimum-release-age`, `block-exotic-subdeps`, `strict-dep-builds`). CI action tags
   pinned to commit SHAs.
 
-## 1.0.3 - 2026-05-16
+## 1.0.3 – 2026-05-16
 
 First stable release, closing out the 0.2.x prototype arc. The rendering stack is palette-first end to end, the input
 system is complete across pointer, keyboard, and gamepad, and the `BT` namespace reaches its stable shape.
@@ -312,7 +312,7 @@ system is complete across pointer, keyboard, and gamepad, and the `BT` namespace
 - Breaking: `IBlitTechDemo.queryHardware()` renamed to `configure()` and made optional; omitting it falls back to
   `defaultConfig()` (320×240 display, 640×480 canvas, 60 FPS, nearest-neighbor upscale).
 - Breaking: `Color32.white()`, `black()`, `transparent()`, and the other color-primary statics converted from
-  zero-argument methods to static getters returning frozen singletons - drop the call parentheses.
+  zero-argument methods to static getters returning frozen singletons – drop the call parentheses.
 - `BTAPI` split into three focused modules: `GameLoop` (fixed-timestep accumulator), `WebGPUContext`
   (adapter/device/context setup), delegated to by `BTAPI` itself.
 
@@ -322,7 +322,7 @@ system is complete across pointer, keyboard, and gamepad, and the `BT` namespace
   `buildErrorPreviewEntries`, `previewWebGPUErrors` - superseded by the `SoftwareRenderer` auto-fallback and a shared
   `errorMessages.ts` module.
 
-## 0.2.0 - 2025-12-22
+## 0.2.0 – 2025-12-22
 
 Pre-release published under the original `blit-tech` package name.
 
@@ -331,7 +331,7 @@ Pre-release published under the original `blit-tech` package name.
 - Bootstrap utilities for streamlined game initialization.
 - CI checks: commit message linting, bundle size monitoring, documentation link validation, spell checking with cspell.
 
-## 0.1.0 - 2025-12-13
+## 0.1.0 – 2025-12-13
 
 Initial pre-release published under the original `blit-tech` package name.
 

--- a/packages/website/scripts/__tests__/check-docs-sync.test.mjs
+++ b/packages/website/scripts/__tests__/check-docs-sync.test.mjs
@@ -110,7 +110,7 @@ describe('classifyDocsDiff', () => {
     test('returns drift for a body addition that happens to start with "lastModified:"', () => {
         // A code example demonstrating frontmatter, deep in the body, must not be
         // trusted just because the added line is lexically shaped like the real
-        // field - only a hunk starting near the file's top counts as frontmatter.
+        // field – only a hunk starting near the file's top counts as frontmatter.
         const diff = [
             FILE_HEADER,
             '@@ -42,3 +42,4 @@',

--- a/packages/website/scripts/__tests__/encode-video.test.mjs
+++ b/packages/website/scripts/__tests__/encode-video.test.mjs
@@ -14,7 +14,7 @@ import {
 } from '../encode-video.mjs';
 
 // Every assertion here is on argument arrays and the parser, so the suite runs without
-// ffmpeg or cwebp installed - which matters, because CI has neither.
+// ffmpeg or cwebp installed – which matters, because CI has neither.
 const options = { ...DEFAULTS, gop: 300, fps: undefined };
 
 /**

--- a/packages/website/scripts/encode-video.mjs
+++ b/packages/website/scripts/encode-video.mjs
@@ -7,8 +7,8 @@ import { pathToFileURL } from 'node:url';
 /**
  * Encode a screen capture into the two renditions `VideoEmbed` expects, plus a poster.
  *
- * Everything here is tuned for flat pixel-art screen capture - large areas of a single
- * color, hard edges, hard cuts - which compresses very differently from camera footage.
+ * Everything here is tuned for flat pixel-art screen capture – large areas of a single
+ * color, hard edges, hard cuts – which compresses very differently from camera footage.
  * See the comments on AV1_PARAMS and buildH264Args for what each tuning flag buys.
  *
  * Usage: pnpm run encode:video -- <input> --out <dir> [options]
@@ -110,7 +110,7 @@ const USAGE = `Usage: pnpm run encode:video -- <input> --out <dir> [options]
 /**
  * The encoder knobs. Declared once here so the test suite, which runs under `checkJs`, sees
  * the full shape rather than inferring it from DEFAULTS alone. The arg builders take only
- * this - they receive their input and output paths as separate arguments.
+ * this – they receive their input and output paths as separate arguments.
  *
  * @typedef {object} EncodeSettings
  * @property {string} posterAt Timestamp of the frame to lift as the poster, in any syntax
@@ -217,7 +217,7 @@ export function parseArgs(argv) {
  * @param {string | undefined} rateString The raw `stream=r_frame_rate` field, a `num/den`
  *   fraction such as `'30/1'` or `'60000/1001'`. A bare numerator is also accepted.
  * @returns {number | undefined} The frame rate, or undefined when the field is missing,
- *   malformed, or works out to a non-positive rate - ffprobe reports `0/0` for streams it
+ *   malformed, or works out to a non-positive rate – ffprobe reports `0/0` for streams it
  *   cannot determine. Callers substitute their own fallback.
  */
 export function parseFrameRate(rateString) {
@@ -312,7 +312,7 @@ export function buildAv1Args(input, output, options) {
 
 /**
  * H.264 High@4.0 fallback. `-tune animation` is the whole trick: x264's animation tune
- * exists for cel animation - flat color fields with hard edges - which is structurally
+ * exists for cel animation – flat color fields with hard edges – which is structurally
  * identical to pixel art. It relaxes deblocking, lowers psy-rd, and raises bframes/ref.
  * Do not stack `-x264-params` on top; that would override the tune with worse numbers.
  *
@@ -363,7 +363,7 @@ export function buildH264Args(input, output, options) {
 /**
  * Extract the poster frame. `-ss` goes before `-i`, which in ffmpeg 5+ is both fast and
  * frame-accurate. The same crop filter runs so the poster's dimensions match the video's
- * exactly - otherwise the browser stretches it.
+ * exactly – otherwise the browser stretches it.
  *
  * @param {string} input Source capture path.
  * @param {string} output Destination PNG path, converted to WebP in the next stage.
@@ -398,7 +398,7 @@ export function buildPosterFrameArgs(input, output, options) {
 
 /**
  * The dimensions VIDEO_FILTER will produce. The printed `<VideoEmbed>` snippet has to carry
- * these rather than the source dimensions - an odd-sized capture is cropped, and passing the
+ * these rather than the source dimensions – an odd-sized capture is cropped, and passing the
  * uncropped numbers as width/height would stretch the video in the browser.
  *
  * @param {number} width Source width in pixels, as probed. May be NaN if the probe failed.

--- a/packages/website/src/blog-post-date.ts
+++ b/packages/website/src/blog-post-date.ts
@@ -3,7 +3,7 @@
  *
  * The `core:get-creation-date` adapter (fumapress's own mechanism for this) only sees the
  * eagerly-loaded frontmatter preview, where `date` survives the Vite dev/RSC boundary as a
- * plain ISO string rather than the `Date` instance the adapter checks for - so it always
+ * plain ISO string rather than the `Date` instance the adapter checks for – so it always
  * returns undefined for async doc collections. Parsing the frontmatter value directly here
  * sidesteps that. `page.data` is typed `unknown` because the generic `PageData` type
  * (fumadocs-core) does not declare `date` - it is validated by the blog-specific schema

--- a/packages/website/src/components/blog-tags-page.tsx
+++ b/packages/website/src/components/blog-tags-page.tsx
@@ -8,7 +8,7 @@ const DefaultBlogTagPage = createBlogTagPage();
 /**
  * Thin wrappers around fumapress's default tags pages. `BlogLayout` no longer assigns
  * `[grid-area:main]` itself (the post page needs its content and its table-of-contents sidebar
- * in separate grid areas), so every other page rendered inside it - including these - now claims
+ * in separate grid areas), so every other page rendered inside it – including these – now claims
  * its own placement.
  */
 export function BlogTagsPage(props: ComponentProps<typeof DefaultBlogTagsPage>) {

--- a/packages/website/src/data/api-history.generated.json
+++ b/packages/website/src/data/api-history.generated.json
@@ -1451,7 +1451,7 @@
       "changes": [
         {
           "version": "1.4.0",
-          "note": "Calling `bootstrap()` again while already initialized now routes to a hot\nswap (via {@link registerHotReload}) when a Vite HMR context is registered, or logs a\ndouble-bootstrap guard and returns `false` otherwise - previously it silently started a\nsecond, unstoppable `GameLoop`."
+          "note": "Calling `bootstrap()` again while already initialized now routes to a hot\nswap (via {@link registerHotReload}) when a Vite HMR context is registered, or logs a\ndouble-bootstrap guard and returns `false` otherwise – previously it silently started a\nsecond, unstoppable `GameLoop`."
         }
       ],
       "deprecated": null,

--- a/scripts/check-agent-config.mjs
+++ b/scripts/check-agent-config.mjs
@@ -7,7 +7,7 @@
  * package-scoped rules, and every package carries its own AGENTS.md / CLAUDE.md.
  *
  * Repo root only:
- *   - `.agents/skills/*` symlink integrity - every entry must be a working
+ *   - `.agents/skills/*` symlink integrity – every entry must be a working
  *     symlink into `.claude/skills/<same-name>`, and every `.claude/skills/*`
  *     directory must have a matching symlink.
  *   - `.zed/settings.json` is present, parseable as JSON, and consistent with
@@ -19,7 +19,7 @@
  * Repo root and every package that carries an AGENTS.md or CLAUDE.md:
  *   - AGENTS.md still points at an existing CLAUDE.md.
  *
- * This is read-only - unlike `sync-doc-banners.mjs` it never writes fixes,
+ * This is read-only – unlike `sync-doc-banners.mjs` it never writes fixes,
  * it only reports drift for a human (or `pnpm run rules:sync`-style script)
  * to resolve.
  *
@@ -252,7 +252,7 @@ function readClaudeSkillDirNames(claudeSkillsDir) {
 }
 
 /**
- * Runs the symlink and Zed-settings checks against the repo root - the only place
+ * Runs the symlink and Zed-settings checks against the repo root – the only place
  * `.claude/skills`, `.agents/skills`, and `.zed/settings.json` live in this monorepo.
  *
  * @param {string} root Absolute path to the repo root.
@@ -296,10 +296,10 @@ function checkAgentsPointer(root) {
 }
 
 /**
- * A package counts as its own agent-config root if it carries either marker - not just
+ * A package counts as its own agent-config root if it carries either marker – not just
  * CLAUDE.md, so a package with AGENTS.md but a missing CLAUDE.md still gets checked (that
  * missing-pointer-target case is exactly what findAgentsPointerFailures exists to catch).
- * `.claude/rules` alone (no CLAUDE.md/AGENTS.md) does not make a package its own root - only
+ * `.claude/rules` alone (no CLAUDE.md/AGENTS.md) does not make a package its own root – only
  * the AGENTS.md <-> CLAUDE.md pointer is package-level in this monorepo.
  */
 const AGENT_CONFIG_MARKERS = ['CLAUDE.md', 'AGENTS.md'];

--- a/scripts/check-markdown-links.test.mjs
+++ b/scripts/check-markdown-links.test.mjs
@@ -42,7 +42,7 @@ describe('isIgnoredFile', () => {
         // On Windows, path.relative() returns backslash-separated paths;
         // isIgnoredFile delegates to normalizeRelSep before matching.
         // path.relative() never produces backslashes on POSIX, so we test
-        // normalizeRelSep directly — the helper that isIgnoredFile calls.
+        // normalizeRelSep directly – the helper that isIgnoredFile calls.
         const windowsRel = 'packages\\website\\content\\docs\\api\\renderer\\index.mdx';
         assert.equal(normalizeRelSep(windowsRel), 'packages/website/content/docs/api/renderer/index.mdx');
     });

--- a/scripts/prettier-plugin-compact-tables.mjs
+++ b/scripts/prettier-plugin-compact-tables.mjs
@@ -2,8 +2,8 @@
  * Prettier plugin: compact Markdown tables.
  *
  * Canonical copy: this file, at the repo root. Every package in this monorepo (`blit386`, `demos`, `website`, `kit`,
- * `create-blit386`) shares it via the root Prettier config - no per-package mirror needed. It is still hand-mirrored
- * into `_GAMES_/blit-ball`, which stays a separate repo outside this workspace - keep that copy identical. The
+ * `create-blit386`) shares it via the root Prettier config – no per-package mirror needed. It is still hand-mirrored
+ * into `_GAMES_/blit-ball`, which stays a separate repo outside this workspace – keep that copy identical. The
  * scaffolder template (`packages/create-blit386/templates/base/scripts/`) carries the same code under a
  * beginner-facing opening comment.
  *
@@ -67,7 +67,7 @@ const DELIMITERS = {
  *
  * Wrapping is disabled (`printWidth: Infinity`) because a table row is always one line: the row, not the print width,
  * decides where output breaks. Printing through `print` rather than slicing the source is what keeps Prettier's usual
- * inline normalization - emphasis style, escaping, link shortening - identical to stock output.
+ * inline normalization – emphasis style, escaping, link shortening – identical to stock output.
  *
  * @param {import('prettier').AstPath} cellPath Path positioned at a `tableCell` node.
  * @param {import('prettier').ParserOptions} options Resolved Prettier options for the file being formatted.
@@ -114,7 +114,7 @@ const printTable = (path, options, print) => {
 /**
  * Prettier's Markdown printer with the `table` case swapped out.
  *
- * Everything else - paragraphs, lists, code fences, prose wrapping - delegates to {@link basePrinter}, so this plugin
+ * Everything else – paragraphs, lists, code fences, prose wrapping – delegates to {@link basePrinter}, so this plugin
  * can only ever change table layout.
  *
  * @type {import('prettier').Printer} The custom printer implementation.

--- a/scripts/prettier-plugin-compact-tables.test.mjs
+++ b/scripts/prettier-plugin-compact-tables.test.mjs
@@ -12,7 +12,7 @@ import prettier from 'prettier';
  *
  * Most cases pass `parser` and `plugins` explicitly so a behavior failure points straight at the
  * plugin. That deliberately bypasses config resolution, so the `repository configuration` suite at
- * the bottom formats through `prettier.config.js` instead - without it, deleting the plugin from the
+ * the bottom formats through `prettier.config.js` instead – without it, deleting the plugin from the
  * config would leave every other case in this file green while the repo formatted padded tables.
  */
 const SCRIPTS_DIR = dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
## Summary

- Sweeps all 3,274 pre-existing dash-typography findings (3,250 hyphen-as-dash, 24 em-dash) across 229 files, flagged by `check-dash-typography.mjs` but never fixed because the checker only ever ran on staged files (lint-staged) and the commit message (commitlint), never repo-wide.
- Fixes the enforcement gap itself: `check-dash-typography` is now wired into `.husky/pre-push`'s root checks and CI's `quality-root` job, so the count cannot climb back up.

## Approach

The sweep reused the checker's own `findDashTypographyIssues`/`isIgnoredFile` detection (via a throwaway script, not committed) to replace each flagged character in place — hyphen -> en dash, em dash -> en dash — so the diff touches nothing but dash characters and cannot go beyond what the checker itself would flag.

Hand-reviewed before committing:
- No numeric range picked up added spacing (the checker's own hyphen-break regex already requires a space on both sides, so ranges like `10-20` were structurally immune).
- `packages/blit386/src/utils/errorMessages.ts` changes are confined to JSDoc `@param` lines, not the Tier 1 user-facing strings governed by `docs/voice.md`.
- Fixed one stale test regex (`packages/blit386/scripts/gen-api-history.test.mjs`) that asserted against a fixture comment's now-updated dash.
- Regenerated `docs/_api-history.json` after the JSDoc text changed.

## Test plan

- [x] `node scripts/check-dash-typography.mjs` (no args, repo-wide) returns zero findings
- [x] Full `preflight` passes for every package: `blit386`, `demos`, `website`, `kit`, `create-blit386`
- [x] Root-level checks pass: `format:check`, `docs:links`, `agents:check`, `check-dash-typography`
- [x] `.husky/pre-push` ran the full preflight cleanly on push
- [x] `.github/workflows/ci.yml` and `.husky/pre-push` YAML/shell validated (prettier + `bash -n`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)