### PR TITLE
chore(config): remove stale website biome, knip, and gitignore entries

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -21,17 +21,10 @@
       "ignoreDependencies": ["blit386"]
     },
     "packages/website": {
-      "entry": ["press.config.tsx", "source.config.ts", "waku.config.ts"],
-      "project": ["src/**/*.css", "scripts/**/*.mjs"],
-      "ignore": [".source/**", "src/pages.gen.ts", "dist/**", "scripts/prettier-plugin-compact-tables.mjs"],
+      "entry": ["press.config.tsx", "waku.config.ts"],
+      "project": ["src/**/*.css", "scripts/**/*.mjs", "content/**/*.mdx"],
       "ignoreFiles": ["src/app.css"],
-      "ignoreDependencies": [
-        "@fuma-translate/react",
-        "@webgpu/types",
-        "blit386",
-        "react-server-dom-webpack",
-        "tailwindcss"
-      ],
+      "ignoreDependencies": ["@fuma-translate/react", "@webgpu/types", "blit386", "tailwindcss"],
       "ignoreBinaries": ["ffprobe"]
     },
     "packages/create-blit386": {

--- a/packages/website/.gitignore
+++ b/packages/website/.gitignore
@@ -1,73 +1,11 @@
-# System files
-.DS_Store
-Thumbs.db
-
-# Dependencies
-node_modules/
-.pnpm-store/
-
-# Build output
-dist/
-build/
-
 # Fumapress / Fumadocs generated
 .source/
 src/pages.gen.ts
-
-# Local env and secrets
-.env
-.env.*
-!.env.example
-
-# Generated files
-vite.config.*.timestamp-*
-
-# TypeScript
-*.tsbuildinfo
-
-# Claude Code (skills, rules, settings.json are tracked)
-.claude/settings.local.json
-.claude/memory/
-.claude/worktrees/
-
-# MCP configs (local secrets)
-.mcp.json
-mcp.json
-
-# Other AI assistants (local only)
-.codex/
-.aider*
-.continue/
-.windsurf/
-ai-rules/
-.rules
-
-# IDE and editor files
-.vscode/
-.idea/
-*.iml
-.cursor/
-.zed/*
-!.zed/settings.json
-*.swp
-*.swo
-*~
 
 # Raw screen-capture sources. Only the encoded output under public/media/ is committed;
 # the multi-hundred-MB .mov originals stay local (see scripts/encode-video.mjs).
 captures/
 
-# Logs and scratch
-*.log
-pnpm-debug.log*
-
-# Superpowers skill scratch (task briefs, review diffs, progress ledger)
-.superpowers/
-
-# Cache
-.cache/
-.knip-output.json
-.wrangler/
-
 # Wrangler local state
+.wrangler/
 .dev.vars

--- a/packages/website/biome.json
+++ b/packages/website/biome.json
@@ -8,12 +8,8 @@
       "*.{ts,tsx}",
       "content/**/meta.json",
       "scripts/**/*.mjs",
-      ".claude/**/*.json",
-      ".github/**/*.json",
       "*.json",
       "*.jsonc",
-      "commitlint.config.js",
-      "prettier.config.js",
       "!content/docs/*"
     ]
   },
@@ -34,15 +30,5 @@
         }
       }
     }
-  ],
-  "linter": {
-    "rules": {
-      "style": {
-        "noNonNullAssertion": "warn"
-      },
-      "suspicious": {
-        "noExplicitAny": "warn"
-      }
-    }
-  }
+  ]
 }


### PR DESCRIPTION
## Summary

Three `packages/website` config files carried leftovers from before the monorepo merge. Sub-issue of [BT-322](https://linear.app/vancura/issue/BT-322/website-package-cleanup); closes [BT-436](https://linear.app/vancura/issue/BT-436/remove-stale-website-biome-knip-and-gitignore-entries).

- **`biome.json`**: `files.includes` named four paths that don't exist in this package (`.claude/**/*.json`, `.github/**/*.json`, `commitlint.config.js`, `prettier.config.js` – all moved to the repo root during the merge). Removed.
- **`biome.json`** rule severities: `noNonNullAssertion`/`noExplicitAny` were downgraded to `warn` with no max-warnings gate to enforce it and zero real usage of either pattern in this package's TS/JS (verified via grep – the only hits were Tailwind `!important` in CSS). Restored to the root's `error`.
- **`knip.json`**: the `packages/website` workspace block resolved its 7 configuration hints – `ignore` entries already covered by `.gitignore` or a path that never existed here, an `entry` pattern the Fumadocs plugin already provides (`source.config.ts`), an `ignoreDependencies` entry knip no longer needs, and a compiled `.mdx` extension excluded from the `project` glob (added `content/**/*.mdx`).
- **`packages/website/.gitignore`**: trimmed from roughly 60% duplication of the root file, plus a dead "other AI assistants" block and `.cursor/`, down to the five entries genuinely specific to this package (`.source/`, `src/pages.gen.ts`, `captures/`, `.wrangler/`, `.dev.vars`).

## Test plan

- [x] `pnpm install` (full) followed by `pnpm --filter blit386-website run build`, then `git status` – stays clean, nothing previously ignored appears untracked
- [x] `pnpm --filter blit386-website run knip` – 0 configuration hints, 0 issues
- [x] `pnpm --filter blit386-website run preflight` – green
- [x] `pnpm run format:check` (root) – green (pre-existing `packages/demos` CSS specificity warnings are unrelated)
- [x] `biome check .` in `packages/website` after restoring rule severities to `error` – 0 errors, 4 pre-existing infos

🤖 Generated with [Claude Code](https://claude.com/claude-code)