### PR TITLE
fix(repo): pin biome.json schema to CLI 2.5.6 and clear flagged lint findings

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.6/schema.json",
   "root": true,
   "vcs": {
     "enabled": true,

--- a/packages/create-blit386/test/scaffold.test.mjs
+++ b/packages/create-blit386/test/scaffold.test.mjs
@@ -86,8 +86,8 @@ test('scaffolds a runnable game project', () => {
 
         const manifest = JSON.parse(manifestRaw);
         assert.equal(manifest.name, 'my-game', 'package name should match the folder');
-        assert.ok(manifest.dependencies?.['blit386'], 'blit386 dependency is missing');
-        assert.equal(manifest.dependencies['blit386'], '^1.4.0', 'generated games should pin blit386 ^1.4.0');
+        assert.ok(manifest.dependencies?.blit386, 'blit386 dependency is missing');
+        assert.equal(manifest.dependencies.blit386, '^1.4.0', 'generated games should pin blit386 ^1.4.0');
         assert.ok(manifest.devDependencies?.['@blit386/kit'], '@blit386/kit devDependency is missing');
         assert.ok(manifest.devDependencies?.['@biomejs/biome'], '@biomejs/biome devDependency is missing');
         assert.equal(
@@ -95,7 +95,7 @@ test('scaffolds a runnable game project', () => {
             '^2.5.2',
             'generated games should pin @biomejs/biome ^2.5.2',
         );
-        assert.ok(manifest.devDependencies?.['prettier'], 'prettier devDependency is missing');
+        assert.ok(manifest.devDependencies?.prettier, 'prettier devDependency is missing');
         assert.ok(manifest.scripts?.format, 'format script is missing');
         assert.ok(manifest.scripts?.lint, 'lint script is missing');
         assert.ok(manifest.scripts?.build, 'build script is missing');
@@ -363,7 +363,7 @@ test('blit agents sync --check exits 0 when no files have drifted', () => {
             pmRunLint: 'npm run lint',
         });
 
-        // Nothing has been modified — check should pass with exit code 0.
+        // Nothing has been modified – check should pass with exit code 0.
         const result = execFileSync(process.execPath, [blitCli, 'agents', 'sync', '--check'], {
             cwd: project,
             encoding: 'utf8',
@@ -1079,8 +1079,8 @@ test('scaffolds a TypeScript project when language is ts', () => {
         const pkg = JSON.parse(readFileSync(join(project, 'package.json'), 'utf8'));
         assert.ok(pkg.devDependencies?.typescript, 'typescript should be a devDependency for TS projects');
         assert.ok(pkg.scripts?.typecheck, 'typecheck script should be present for TS projects');
-        assert.ok(pkg.dependencies?.['blit386'], 'blit386 should be a dependency');
-        assert.ok(!pkg.dependencies['blit386'].includes('workspace:*'), 'no workspace:* in blit386 dependency');
+        assert.ok(pkg.dependencies?.blit386, 'blit386 should be a dependency');
+        assert.ok(!pkg.dependencies.blit386.includes('workspace:*'), 'no workspace:* in blit386 dependency');
         assert.equal(pkg.devDependencies?.['@biomejs/biome'], '^2.5.2', 'TS scaffold should pin @biomejs/biome ^2.5.2');
 
         const biomeConfig = JSON.parse(readFileSync(join(project, 'biome.json'), 'utf8'));

--- a/packages/demos/biome.json
+++ b/packages/demos/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.6/schema.json",
   "root": false,
   "extends": ["../../biome.json"],
   "files": {

--- a/packages/website/biome.json
+++ b/packages/website/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.6/schema.json",
   "root": false,
   "extends": ["../../biome.json"],
   "files": {

--- a/packages/website/public/webmcp.js
+++ b/packages/website/public/webmcp.js
@@ -63,8 +63,8 @@
                 required: ['query'],
             },
             execute: async ({ query }) => {
-                const res = await fetch('/api/search?query=' + encodeURIComponent(query));
-                if (!res.ok) return { error: 'Search request failed: ' + res.status };
+                const res = await fetch(`/api/search?query=${encodeURIComponent(query)}`);
+                if (!res.ok) return { error: `Search request failed: ${res.status}` };
                 return await res.json();
             },
             annotations: { readOnlyHint: true },
@@ -81,7 +81,7 @@
             inputSchema: { type: 'object', properties: {} },
             execute: async () => {
                 const res = await fetch('/llms.txt');
-                if (!res.ok) return { error: 'Failed to fetch documentation summary: ' + res.status };
+                if (!res.ok) return { error: `Failed to fetch documentation summary: ${res.status}` };
                 return { content: await res.text() };
             },
             annotations: { readOnlyHint: true },


### PR DESCRIPTION
## Summary
- Re-pin `$schema` in the root, `packages/demos`, and `packages/website` `biome.json` from 2.5.5 to 2.5.6 via `biome migrate --write`, clearing the deserialize warning printed on every `biome check` run.
- Apply the unsafe `lint/complexity/useLiteralKeys` autofix in `packages/create-blit386/test/scaffold.test.mjs` (5 findings, e.g. `manifest.dependencies?.['blit386']` → `manifest.dependencies?.blit386`).
- Apply the unsafe `lint/style/useTemplate` autofix in `packages/website/public/webmcp.js` (3 findings, string concatenation → template literals).
- One incidental fix: an em dash on an unrelated line of `scaffold.test.mjs` that the repo's dash-typography pre-commit hook (BT-461 scope) blocked the commit on.

Scoped to BT-463 only — the 8 pre-existing `lint/style/noDescendingSpecificity` CSS warnings in `packages/demos/styles/{layout,demo-source}.css` are untouched (unrelated debt, not part of this ticket).

## Test plan
- [x] `npx biome check .` at repo root: 0 errors, 0 infos (deserialize warnings and the two files' findings are gone); 8 pre-existing CSS warnings remain, out of scope
- [x] `pnpm run test` in `packages/create-blit386`: 26/26 pass
- [x] `node --check packages/website/public/webmcp.js`: valid syntax
- [x] Pre-push preflight passed after building `blit386` (pre-existing unbuilt-workspace issue in this worktree, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)