### PR TITLE
fix(ci): close the website preflight gate gap and drop the duplicate lint step

### DIFF
--- a/.claude/skills/preflight/SKILL.md
+++ b/.claude/skills/preflight/SKILL.md
@@ -82,15 +82,26 @@ No unit tests here by design – see `/test demos`.
 - `spellcheck` – cspell on `content/` and `src/`
 - `knip` – unused exports/deps
 - `build` – `CLOUDFLARE=1 waku build`
+- `sync:docs:check` – regenerates `content/docs` from `packages/blit386/docs/` and fails when the mirror drifted
+
+`sync:docs:check` is deliberately last: it rewrites `content/docs` in the working tree, so any gate after it would be
+reading regenerated rather than committed content. The `quality-website` CI job places it last for the same reason
+(after its `wait-all:` join). If it fails, run `pnpm run sync:docs`, then **stage or commit** the result – the check
+diffs the working tree against the index, so an unstaged regeneration still reads as drift. On a push, where everything
+is committed, this never comes up.
+
+That job does not lint this package – its `lint` is `biome check .`, which the repo-wide `pnpm run format:check` in
+`quality-root` already covers. Local `format:check` here still runs Biome, so preflight loses nothing.
 
 No MCP security preflight here (unlike `blit386` – see `/security-run`).
 
 Preflight runs under `.husky/pre-push`, which git invokes with `GIT_DIR` exported. It outranks both `cwd` and `-C`, so
-any git subprocess a preflight step spawns for some other directory retargets the repo being pushed from – `git init` in
-a fixture repo then writes `bare = true` into the shared `.git/config` and breaks git in every checkout. The hook clears
-git's `--local-env-vars` before dispatching, and every git call in `packages/website/scripts/` must pass `env: gitEnv()`
-([`packages/website/scripts/git-env.mjs`](../../../packages/website/scripts/git-env.mjs)); the same scrub is inline in
-`packages/blit386/scripts/gen-api-history.test.mjs`. Guarded by `packages/website/scripts/__tests__/git-env.test.mjs`.
+any git subprocess a preflight step spawns for some other directory silently acts on the repo being pushed from instead
+– `git init` in a fixture repo then writes `bare = true` into the shared `.git/config` and breaks git in every checkout.
+The hook clears git's `--local-env-vars` before dispatching, and every git call in `packages/website/scripts/` must pass
+`env: gitEnv()` ([`packages/website/scripts/git-env.mjs`](../../../packages/website/scripts/git-env.mjs)); the same
+scrub is inline in `packages/blit386/scripts/gen-api-history.test.mjs`. Guarded by
+`packages/website/scripts/__tests__/git-env.test.mjs`.
 
 ## packages/kit and packages/create-blit386
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -670,10 +670,12 @@ jobs:
       - name: Build engine (workspace dependency)
         run: pnpm --filter blit386 run build
 
-      - name: Lint code
-        run: pnpm --filter blit386-website run lint
-        background: true
-
+      # No lint step: this package's `lint` is `biome check .`, and quality-root's
+      # repo-wide `format:check` already runs `biome check .` from the root across every
+      # package - confirmed by the root run reporting diagnostics in
+      # packages/website/public/webmcp.js. Unlike quality-engine and quality-demos, whose
+      # `lint` is ESLint and adds coverage nothing else provides, a step here would be a
+      # second pass over the same files with the same tool.
       - name: Type check
         run: pnpm --filter blit386-website run typecheck
         background: true

--- a/packages/blit386/docs/reference-testing.md
+++ b/packages/blit386/docs/reference-testing.md
@@ -280,7 +280,7 @@ consumes the engine as `workspace:*`, and `website` includes `packages/blit386/d
 | `benchmark` | engine | On `main` push or PRs labeled `perf`: `pnpm run bench:json`, PR regression compare (25% threshold) |
 | `quality-demos` | demos | `lint`, `spellcheck`, `knip`, `check:demo-registry` |
 | `build-demos` | demos | Builds the engine first (workspace dependency), then the demos bundle |
-| `quality-website` | website | `lint`, `typecheck`, `spellcheck`, `test`, `knip`, and `sync:docs:check` |
+| `quality-website` | website | `typecheck`, `spellcheck`, `test`, `knip`, and `sync:docs:check` (no `lint`: the package's `lint` is `biome check .`, which `quality-root`'s repo-wide `format:check` already covers) |
 | `build-website` | website | `pnpm run build` (sets `CLOUDFLARE=1`, so Twoslash runs) |
 | `quality-kit` / `build-test-kit` | kit | `typecheck`, `knip`; then build and `node --test` |
 | `quality-scaffolder` / `build-test-scaffolder` | scaffolder | `typecheck`, `knip`; then build kit, build scaffolder, run its tests |
@@ -289,8 +289,11 @@ Jobs needing full git history ask the shared setup action for it: `quality-engin
 `fetch-depth: 0` plus `fetch-tags: true` (release dates come from tags, and the API-history generator walks history with
 `git log --follow`), and `quality-website` takes `fetch-depth: 0` for the same `--follow` reason in the docs mirror.
 
-`sync:docs:check` runs here and nowhere else. It could not run before the monorepo merge, because the docs-site
-repository had no engine checkout to sync against – so a stale published mirror was only ever caught by hand.
+`sync:docs:check` runs here and, since BT-438, as the final gate of `packages/website`'s own `preflight`, so a local run
+is no longer laxer than CI. It runs last in both places for the same reason: it regenerates `content/docs` in the
+working tree, so anything reading that tree afterwards would be reading regenerated rather than committed content. It
+could not run at all before the monorepo merge, because the docs-site repository had no engine checkout to sync against
+– so a stale published mirror was only ever caught by hand.
 
 The four workflow files are `ci.yml`, `pr-checks.yml`, `dco.yml`, and `deploy.yml`; CodeQL runs from GitHub's default
 setup rather than a checked-in workflow. On pull requests, `pr-checks.yml` complements `ci.yml` with Conventional

--- a/packages/website/CLAUDE.md
+++ b/packages/website/CLAUDE.md
@@ -8,9 +8,10 @@ Shared monorepo conventions (no emoji, dash typography, American English, commit
 tables, …) live in the root [`CLAUDE.md`](../../CLAUDE.md) – read together with this file.
 
 Scripts are `pnpm run <script>` from this package's directory (or `pnpm --filter blit386-website run <script>` from the
-repo root); `package.json` is the list and `pnpm run preflight` is the gating set (it includes the build). Production
-builds require `CLOUDFLARE=1`, which `pnpm run build` already sets. Shell commands are rewritten by `rtk hook claude` –
-prefer `rtk read` / `rtk grep` over native Read/Grep for exploration.
+repo root); `package.json` is the list and `pnpm run preflight` is the gating set (it includes the build and, last of
+all, the docs-mirror check – see Documentation mirror). Production builds require `CLOUDFLARE=1`, which `pnpm run build`
+already sets. Shell commands are rewritten by `rtk hook claude` – prefer `rtk read` / `rtk grep` over native Read/Grep
+for exploration.
 
 ## Critical Rules
 
@@ -39,7 +40,7 @@ prefer `rtk read` / `rtk grep` over native Read/Grep for exploration.
 | Generated MDX loader | `.source/` (gitignored; run `fumadocs-mdx` or `pnpm run typecheck`) |
 | Engine API truth | `packages/blit386/docs/` in this monorepo – never this package |
 | How the mirror is built | `scripts/sync-docs-from-engine.mjs` via `pnpm run sync:docs` |
-| How mirror drift is checked in CI | `scripts/check-docs-sync.mjs` via `pnpm run sync:docs:check` |
+| How mirror drift is checked | `scripts/check-docs-sync.mjs` via `pnpm run sync:docs:check` (in `preflight` and in CI) |
 | Script test coverage | `scripts/__tests__/*.test.mjs` (`node --test`, via `pnpm run test`) |
 | Why every git subprocess passes `gitEnv()` | `scripts/git-env.mjs` |
 | MCP server | `src/mcp-server.ts`, `public/.well-known/mcp/server-card.json`, `content/mcp-server.mdx` |
@@ -71,12 +72,16 @@ in the engine package's `docs/_sitemap.json` and writes matching MDX into `conte
 script, owns which docs publish, their URL, sidebar order, and subtitle** – the script carries no per-page knowledge, so
 adding a page means editing the manifest in `packages/blit386` and re-running the sync, with no change here.
 
-`pnpm run sync:docs` regenerates and formats. `pnpm run sync:docs:check` fails on drift and **is enforced in CI** – it
-runs in the `quality-website` job of `.github/workflows/ci.yml`, gated on the `website` path filter, which includes
-`packages/blit386/docs/**`. So editing an engine doc without re-syncing turns the pull request red. Still run it
-yourself after touching engine docs; CI is the backstop, not the workflow. The source resolves from `ENGINE_DOCS_DIR`
-(default `../blit386/docs`, which already resolves correctly to the sibling `packages/blit386/docs` in this monorepo).
-`sync:docs:watch` re-syncs on every change alongside `pnpm run dev`.
+`pnpm run sync:docs` regenerates and formats. `pnpm run sync:docs:check` fails on drift and **is enforced both locally
+and in CI**: it is the last gate of `pnpm run preflight`, and the last step of the `quality-website` job in
+`.github/workflows/ci.yml`, gated on the `website` path filter, which includes `packages/blit386/docs/**`. So editing an
+engine doc without re-syncing fails the push and turns the pull request red. It runs last in both places because it
+regenerates `content/docs` in the working tree – any gate after it would be reading regenerated rather than committed
+content, which is also why CI puts it after the parallel join rather than inside it. The check diffs the working tree
+against the index, so after re-syncing you must stage or commit the regenerated mirror before `preflight` goes green –
+an unstaged `sync:docs` result still reads as drift. That costs nothing on a push, where everything is committed
+already. The source resolves from `ENGINE_DOCS_DIR` (default `../blit386/docs`, which already resolves correctly to the
+sibling `packages/blit386/docs` in this monorepo). `sync:docs:watch` re-syncs on every change alongside `pnpm run dev`.
 
 That job checks out with `fetch-depth: 0`. The generator reads each page's `lastModified` with `git log --follow`, to
 see past the commit that moved the engine into `packages/blit386/`, and `--follow` finds nothing on a shallow clone.

--- a/packages/website/README.md
+++ b/packages/website/README.md
@@ -41,8 +41,14 @@ Open the URL printed by Waku (typically `http://localhost:3000`).
 ## Quality checks
 
 ```bash
-pnpm run preflight   # format:check, lint, typecheck, test, spellcheck, knip, build
+pnpm run preflight   # format:check, typecheck, test, spellcheck, knip, build, sync:docs:check
 ```
+
+`sync:docs:check` runs last because it regenerates `content/docs` in the working tree – see [Content](#content). After
+re-syncing, stage or commit the result before re-running: the check diffs the working tree against the index. Markdown
+link checking is not part of this gate: `docs:links` is a root-only script (it enumerates every tracked `*.md` / `*.mdx`
+via `git ls-files` regardless of the directory it runs in), so run `pnpm run docs:links` from the repo root. CI runs it
+once in the `quality-root` job.
 
 ## Production build and deploy
 
@@ -78,9 +84,9 @@ pnpm run sync:docs:watch   # watch packages/blit386/docs and re-sync on every ch
 ```
 
 The engine docs directory resolves from `ENGINE_DOCS_DIR` and defaults to the sibling package path `../blit386/docs`.
-`sync:docs:check` is enforced in CI – it runs as the last step of the `quality-website` job in
-`.github/workflows/ci.yml` – but still run it yourself after changing engine docs rather than relying on CI to catch
-drift.
+`sync:docs:check` is enforced in two places, both as the last step: `pnpm run preflight` here, and the `quality-website`
+job in `.github/workflows/ci.yml`. It goes last because it regenerates `content/docs` in the working tree, so any check
+that ran after it would be reading regenerated rather than committed content.
 
 Never hand-edit a generated page – edit the engine source and re-run `sync:docs`. The same applies to
 `src/data/api-history.generated.json`, which the script copies from `packages/blit386`. See `CLAUDE.md` (Documentation

--- a/packages/website/content/docs/reference/testing.mdx
+++ b/packages/website/content/docs/reference/testing.mdx
@@ -277,7 +277,7 @@ consumes the engine as `workspace:*`, and `website` includes `packages/blit386/d
 | `benchmark` | engine | On `main` push or PRs labeled `perf`: `pnpm run bench:json`, PR regression compare (25% threshold) |
 | `quality-demos` | demos | `lint`, `spellcheck`, `knip`, `check:demo-registry` |
 | `build-demos` | demos | Builds the engine first (workspace dependency), then the demos bundle |
-| `quality-website` | website | `lint`, `typecheck`, `spellcheck`, `test`, `knip`, and `sync:docs:check` |
+| `quality-website` | website | `typecheck`, `spellcheck`, `test`, `knip`, and `sync:docs:check` (no `lint`: the package's `lint` is `biome check .`, which `quality-root`'s repo-wide `format:check` already covers) |
 | `build-website` | website | `pnpm run build` (sets `CLOUDFLARE=1`, so Twoslash runs) |
 | `quality-kit` / `build-test-kit` | kit | `typecheck`, `knip`; then build and `node --test` |
 | `quality-scaffolder` / `build-test-scaffolder` | scaffolder | `typecheck`, `knip`; then build kit, build scaffolder, run its tests |
@@ -286,8 +286,11 @@ Jobs needing full git history ask the shared setup action for it: `quality-engin
 `fetch-depth: 0` plus `fetch-tags: true` (release dates come from tags, and the API-history generator walks history with
 `git log --follow`), and `quality-website` takes `fetch-depth: 0` for the same `--follow` reason in the docs mirror.
 
-`sync:docs:check` runs here and nowhere else. It could not run before the monorepo merge, because the docs-site
-repository had no engine checkout to sync against – so a stale published mirror was only ever caught by hand.
+`sync:docs:check` runs here and, since BT-438, as the final gate of `packages/website`'s own `preflight`, so a local run
+is no longer laxer than CI. It runs last in both places for the same reason: it regenerates `content/docs` in the
+working tree, so anything reading that tree afterwards would be reading regenerated rather than committed content. It
+could not run at all before the monorepo merge, because the docs-site repository had no engine checkout to sync against
+– so a stale published mirror was only ever caught by hand.
 
 The four workflow files are `ci.yml`, `pr-checks.yml`, `dco.yml`, and `deploy.yml`; CodeQL runs from GitHub's default
 setup rather than a checked-in workflow. On pull requests, `pr-checks.yml` complements `ci.yml` with Conventional

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -49,7 +49,7 @@
     "knip:fix": "cd ../.. && knip --workspace packages/website --fix",
     "test": "node --test scripts/__tests__/*.test.mjs",
     "test:watch": "node --test --watch scripts/__tests__/*.test.mjs",
-    "preflight": "pnpm run format:check && pnpm run typecheck && pnpm run test && pnpm run spellcheck && pnpm run knip && pnpm run build",
+    "preflight": "pnpm run format:check && pnpm run typecheck && pnpm run test && pnpm run spellcheck && pnpm run knip && pnpm run build && pnpm run sync:docs:check",
     "deploy": "wrangler deploy --config dist/server/wrangler.json --name blit386"
   },
   "dependencies": {

--- a/packages/website/scripts/sync-docs-from-engine.mjs
+++ b/packages/website/scripts/sync-docs-from-engine.mjs
@@ -17,9 +17,10 @@
  *
  * The generated files are committed artifacts: never hand-edit them. Edit the
  * canonical source in `packages/blit386/docs/` and re-run `pnpm run sync:docs`.
- * `pnpm run sync:docs:check` fails when the mirror drifts from the source and
- * is enforced in the `quality-website` job of `.github/workflows/ci.yml` – but
- * still run it yourself after changing engine docs rather than relying on CI.
+ * `pnpm run sync:docs:check` fails when the mirror drifts from the source and is
+ * enforced in two places, last in both: `pnpm run preflight` here, and the
+ * `quality-website` job of `.github/workflows/ci.yml`. Last, because it
+ * regenerates `content/docs` in the working tree.
  *
  * Source location resolves from `ENGINE_DOCS_DIR` (used by CI); locally it
  * defaults to the sibling package path `../blit386/docs`.


### PR DESCRIPTION
Closes BT-438. Part of the BT-322 website-package cleanup; follows BT-437 (#506), which settled which scripts still exist.

## Problem

Three things disagreed about what the website quality gate is.

1. **Local preflight was laxer than CI.** `preflight` ran six gates; the `quality-website` job ran those plus `sync:docs:check`. Editing an engine doc under `packages/blit386/docs/` without re-syncing gave a green local run and a red PR.
2. **CI linted the package twice.** `quality-root` runs the repo-wide `format:check`, whose Biome half is `biome check .` from the root and already walks every package. `quality-website` then ran `pnpm --filter blit386-website run lint`, which is `biome check .` again over a subset of the same files.
3. **README documented a gate that does not exist.** It listed `lint` among the preflight gates. Preflight never ran it.

## Changes

- `preflight` gains `sync:docs:check`, **last** in the chain.
- The `Lint code` step is removed from `quality-website`, with a comment recording why – in the shape `quality-demos` uses for its own `No typecheck:` note.
- `README.md` lists exactly the gates that run, in order, and points at the root `pnpm run docs:links` for link checking (BT-437 removed the package-scoped copy).
- Docs brought in line: the CI-job table in `packages/blit386/docs/reference-testing.md` and its generated mirror, the website `CLAUDE.md` documentation-mirror section, the `sync-docs-from-engine.mjs` header, and the `preflight` skill.

## Why `sync:docs:check` goes last

`check-docs-sync.mjs` shells out to `sync:docs`, which rewrites `content/docs` in the working tree, then classifies the diff. `ci.yml` already puts it after the `wait-all:` join for exactly this reason. Preflight is a serial chain, so there is no concurrency – but the hazard applies sequentially in one direction: any gate placed after it reads a regenerated rather than a committed tree, and `format:check`, `spellcheck`, and `build` all read `content/docs`. Last is the faithful translation. The cost is that drift is the last thing you learn about rather than the first; the fix is a one-command `pnpm run sync:docs`, so correctness of what the other gates measured wins.

One consequence worth knowing, now documented in three places: the check diffs the working tree against the **index**, so a re-sync has to be staged before preflight goes green. On a push, where everything is committed, it never comes up.

## Test plan

- [x] **The gate bites.** Appended a body line to `packages/blit386/docs/reference-testing.md` without re-syncing; `pnpm --filter blit386-website run preflight` exited 1 at `sync:docs:check` with the deliberate line in the reported diff. Reverted.
- [x] **Green preflight.** `pnpm --filter blit386-website run preflight` exits 0, working tree clean. The residual `lastModified`-only churn is the tolerated case the check is designed to pass and self-corrects on the next sync.
- [x] `pnpm run format:check` and `pnpm run docs:links` from the repo root, plus `pnpm --filter blit386 run spellcheck` for the engine-doc edit.
- [x] `.husky/pre-push` ran the full chain on push.
- [ ] CI green, with no `Lint code` step in the `Code Quality (website)` job log and `Check docs mirror is in sync with the engine` still its last step.

## Out of scope, noted

`sync:docs` also rewrites `src/data/api-history.generated.json`, but `check-docs-sync.mjs` only diffs `content/docs`, so drift in that one file regenerates silently instead of failing. That is true in CI today and unchanged here.
