### PR TITLE
test(website): add a Vitest runner and cover the Worker plugins

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -206,6 +206,7 @@
     "webgpu",
     "WebMCP",
     "WGSL",
+    "workerd",
     "Wrangler",
     "xadvance",
     "xoffset",

--- a/knip.json
+++ b/knip.json
@@ -21,7 +21,7 @@
       "ignoreDependencies": ["blit386"]
     },
     "packages/website": {
-      "entry": ["press.config.tsx", "waku.config.ts"],
+      "entry": ["press.config.tsx", "waku.config.ts", "src/**/*.test.ts"],
       "project": ["src/**/*.css", "scripts/**/*.mjs", "content/**/*.mdx"],
       "ignoreFiles": ["src/app.css"],
       "ignoreDependencies": ["@fuma-translate/react", "@webgpu/types", "blit386", "tailwindcss"],

--- a/packages/website/AGENTS.md
+++ b/packages/website/AGENTS.md
@@ -18,8 +18,10 @@ Package manager is pnpm 11.20.0; Node >= 22.18.0.
 ```bash
 pnpm install                                   # from the repo root
 pnpm --filter blit386-website run dev          # or: cd packages/website && pnpm run dev
-pnpm --filter blit386-website run preflight    # format:check, typecheck, test, spellcheck, knip, build
+pnpm --filter blit386-website run preflight    # format:check, typecheck, test, spellcheck, knip, build, sync:docs:check
 ```
+
+`test` covers both suites: `node --test` over `scripts/**` and Vitest over `src/**`.
 
 Use `pnpm run <script>` (not bare `pnpm <script>`) so RTK hooks can rewrite shell commands. Production builds need
 `CLOUDFLARE=1`, which `pnpm run build` already sets.

--- a/packages/website/CLAUDE.md
+++ b/packages/website/CLAUDE.md
@@ -41,16 +41,58 @@ for exploration.
 | Engine API truth | `packages/blit386/docs/` in this monorepo – never this package |
 | How the mirror is built | `scripts/sync-docs-from-engine.mjs` via `pnpm run sync:docs` |
 | How mirror drift is checked | `scripts/check-docs-sync.mjs` via `pnpm run sync:docs:check` (in `preflight` and in CI) |
-| Script test coverage | `scripts/__tests__/*.test.mjs` (`node --test`, via `pnpm run test`) |
+| Script test coverage | `scripts/__tests__/*.test.mjs` (`node --test`, via `pnpm run test:scripts`) |
+| Worker plugin test coverage | `src/**/*.test.ts` (Vitest, via `pnpm run test:unit`) – see Test runners |
 | Why every git subprocess passes `gitEnv()` | `scripts/git-env.mjs` |
 | MCP server | `src/mcp-server.ts`, `public/.well-known/mcp/server-card.json`, `content/mcp-server.mdx` |
 | Cloudflare security headers | `public/_headers` |
 
-Four Fumapress `ServerPlugin`s are local to this package rather than upstream: `markdownNegotiationPlugin`
-(`src/markdown-negotiation.ts`), `mcpServerPlugin` (`src/mcp-server.ts`), `feedPlugin` (`src/feed.ts`), and the
-`blog-post-date` helper (`src/blog-post-date.ts`, which exists because the framework's adapter cannot read a post's
-`date` frontmatter). The rest of the chain in `press.config.tsx` is stock: flexsearch, blog, llms, sitemap, takumi OG
-images, and link validation.
+Four Fumapress `ServerPlugin`s are local to this package rather than upstream: `channelHeadersPlugin`
+(`src/channel-headers.ts`), `markdownNegotiationPlugin` (`src/markdown-negotiation.ts`), `mcpServerPlugin`
+(`src/mcp-server.ts`), and `feedPlugin` (`src/feed.ts`) – plus the `blog-post-date` helper (`src/blog-post-date.ts`,
+which exists because the framework's adapter cannot read a post's `date` frontmatter). The rest of the chain in
+`press.config.tsx` is stock: flexsearch, blog, llms, sitemap, takumi OG images, and link validation.
+
+## Test runners
+
+Two, deliberately, matching the split `packages/blit386` already runs:
+
+| Suite | Runner | Script | Covers |
+| --- | --- | --- | --- |
+| `scripts/__tests__/*.test.mjs` | `node --test` | `test:scripts` | The build and sync scripts |
+| `src/**/*.test.ts` | Vitest | `test:unit` | The `ServerPlugin`s that run in the deployed Worker |
+
+`pnpm run test` runs both, the second with coverage; `preflight` and the `quality-website` CI job call it, so neither
+needs its own wiring. The `scripts/**` suite stays on `node --test` because it is `node:assert` throughout, it finishes
+in under a second, and rewriting it would be churn with no gain.
+
+**Vitest, not `@cloudflare/vitest-pool-workers`.** The pool runs tests inside `workerd`, which would exercise the
+`ASSETS` binding and `c.env` against the real runtime instead of a double, and it is version-compatible (it peers
+`vitest ^4.1.0`, the same major this workspace resolves). It was still the wrong trade here:
+
+- The contract with `ASSETS` is one method and one status check – `assets.fetch(request)`, then `status !== 404`. A
+  double is faithful to that. `run_worker_first` is Wrangler configuration rather than code, and
+  `scripts/__tests__/patch-wrangler.test.mjs` already asserts it.
+- A real binding needs `assets.directory` pointing at `dist/public`, which exists only after a full build – and
+  `preflight` runs `test` before `build`. A fixture directory avoids that at the cost of a second, test-only Wrangler
+  config to keep in step with the real one.
+- It would weaken the `channel-headers` test. `workerd` has no populated `process.env`, so a `process.env`
+  implementation would fail there for the wrong reason. Under Node the test can point `process.env.BLIT386_CHANNEL` at
+  the opposite value from `c.env` and assert the binding still wins – which no `process.env` implementation can pass.
+
+Accepted gap: nothing here exercises `workerd`'s immutable response headers (see BT-464). Revisit the choice if `src/`
+grows a Durable Object, KV, or any code that branches on real binding semantics rather than on a single `fetch`.
+
+Shared harness in `src/__test__/` (same convention as the engine package): `hono-context.ts` fakes the Hono context and
+the `ASSETS` binding, `press-context.ts` fakes the Fumapress `AppContext`, loader, pages, and adapters. `hono` is not a
+dependency here – it arrives only as a transitive type through `fumapress` – so the Hono types are recovered
+structurally from `ServerPlugin['createMiddlewares']` rather than imported. Keep it that way; adding `hono` as a
+devDependency to make a test read better would pin a version this package does not otherwise control.
+
+Two behaviors in that suite are regression guards rather than ordinary coverage, and both were verified by mutation
+(break the implementation, watch the test go red) rather than only by passing: `channel-headers.ts` reading the channel
+at request time, and `markdown-negotiation.ts` forwarding to `ASSETS` and falling through only on a 404. If you refactor
+either, expect those tests to be the ones that stop you.
 
 ## What is hand-authored and what is generated
 
@@ -174,12 +216,23 @@ across that boundary; check geometry (1200x630) instead**. Base UI replaced Radi
 no longer carries an `optimizeDeps.include` workaround for `use-sync-external-store`: the 0.7.0 Vite plugin auto-detects
 those CJS deps, and the twoslash popups are now Base UI triggers.
 
-Revisit trigger: when `fumapress` 1.0.0 goes stable, or when BT-440 lands test coverage over `src/**`, whichever comes
-first. Until then a framework bump has no automated safety net, so verify by diffing a real build against a baseline
-captured on the old pins – per-page `twoslash-hover` counts, `dist/server/wrangler.json` assertions (`run_worker_first`,
-`nodejs_compat`, `vars.BLIT386_CHANNEL`), `/mcp` `tools/list` plus an actual `search_docs` call,
-`Accept: text/markdown`, `/feed.xml` item count, and the `next`-channel headers. A green typecheck proves almost nothing
-here.
+Revisit trigger: when `fumapress` 1.0.0 goes stable.
+
+A framework bump now has a partial safety net. `pnpm run test:unit` (BT-440) covers the plugin logic itself – `/mcp`
+`tools/list` and `search_docs` ranking, `Accept: text/markdown` negotiation and the `ASSETS` fall-through, the
+`/feed.xml` document, and the `next`-channel headers – so a rename or signature change in the `ServerPlugin` contract
+turns those red rather than silently degrading production. That is the largest part of what used to be a manual diff.
+
+It is not the whole of it. The suite calls the plugins directly with doubles, so it cannot see anything that lives in
+the wiring or the build, and these still need a real build diffed against a baseline captured on the old pins:
+
+- per-page `twoslash-hover` counts (the transformer only runs under `CLOUDFLARE=1`, and `throws: false` degrades a
+  failing block silently)
+- `dist/server/wrangler.json` assertions – `run_worker_first`, `nodejs_compat`, `vars.BLIT386_CHANNEL`
+- the plugin chain order in `press.config.tsx`, which the unit tests do not construct
+- OG card geometry (1200x630), and the layout and RSC surface generally
+
+A green typecheck still proves almost nothing here.
 
 ## Markdown for Agents
 

--- a/packages/website/README.md
+++ b/packages/website/README.md
@@ -44,6 +44,10 @@ Open the URL printed by Waku (typically `http://localhost:3000`).
 pnpm run preflight   # format:check, typecheck, test, spellcheck, knip, build, sync:docs:check
 ```
 
+`test` runs two suites: `test:scripts` (`node --test` over `scripts/**`) and `test:unit` (Vitest over `src/**`, the
+Worker plugins), the second with coverage thresholds. Run either alone, or `pnpm run test:unit:watch` while working on
+`src/`.
+
 `sync:docs:check` runs last because it regenerates `content/docs` in the working tree – see [Content](#content). After
 re-syncing, stage or commit the result before re-running: the check diffs the working tree against the index. Markdown
 link checking is not part of this gate: `docs:links` is a root-only script (it enumerates every tracked `*.md` / `*.mdx`

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -47,8 +47,12 @@
     "encode:video": "node scripts/encode-video.mjs",
     "knip": "cd ../.. && knip --workspace packages/website",
     "knip:fix": "cd ../.. && knip --workspace packages/website --fix",
-    "test": "node --test scripts/__tests__/*.test.mjs",
-    "test:watch": "node --test --watch scripts/__tests__/*.test.mjs",
+    "test": "pnpm run test:scripts && pnpm run test:unit:coverage",
+    "test:scripts": "node --test scripts/__tests__/*.test.mjs",
+    "test:scripts:watch": "node --test --watch scripts/__tests__/*.test.mjs",
+    "test:unit": "vitest run",
+    "test:unit:watch": "vitest watch",
+    "test:unit:coverage": "vitest run --coverage",
     "preflight": "pnpm run format:check && pnpm run typecheck && pnpm run test && pnpm run spellcheck && pnpm run knip && pnpm run build && pnpm run sync:docs:check",
     "deploy": "wrangler deploy --config dist/server/wrangler.json --name blit386"
   },
@@ -71,6 +75,7 @@
     "@types/node": "^25.9.5",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
+    "@vitest/coverage-v8": "^4.1.10",
     "@webgpu/types": "^0.1.71",
     "blit386": "workspace:*",
     "cross-env": "^7.0.3",
@@ -81,6 +86,7 @@
     "tailwindcss": "^4.3.2",
     "twoslash": "^0.3.9",
     "typescript": "^6.0.3",
+    "vitest": "^4.1.10",
     "wrangler": "4.114.0"
   }
 }

--- a/packages/website/src/__test__/hono-context.ts
+++ b/packages/website/src/__test__/hono-context.ts
@@ -1,0 +1,156 @@
+/**
+ * Hono request/response doubles for the Fumapress `ServerPlugin`s in `src/`.
+ *
+ * `hono` is not a dependency of this package – it reaches us only as a transitive type through
+ * `fumapress`, whose declaration files resolve it from their own pnpm directory. Every Hono type
+ * below is therefore recovered structurally from `ServerPlugin['createMiddlewares']` rather than
+ * imported. `Context` is a class, so no object literal can ever be structurally assignable to it;
+ * the single cast that bridges that is confined to `run()`.
+ *
+ * The plugins under test touch a small, fixed slice of the context: `c.req.path`, `c.req.method`,
+ * `c.req.raw`, `c.req.url`, `c.req.json()`, `c.env`, `c.res.headers`, and `c.json()`.
+ */
+
+import type { AppContext, ServerPlugin } from 'fumapress';
+
+type CreateMiddlewares = NonNullable<ServerPlugin['createMiddlewares']>;
+
+/** `{ app: Hono }` – the argument Fumapress hands to `createMiddlewares`. */
+type MiddlewareEnv = Parameters<CreateMiddlewares>[0];
+
+/** Hono's `MiddlewareHandler`, recovered without importing `hono`. */
+export type PluginMiddleware = NonNullable<Awaited<ReturnType<CreateMiddlewares>>>[number];
+
+/** Hono's `Context`, recovered without importing `hono`. */
+type HonoContext = Parameters<PluginMiddleware>[0];
+
+/** The slice of Hono's `Context` the plugins in `src/` actually read or write. */
+interface MockContext {
+    req: {
+        raw: Request;
+        url: string;
+        method: string;
+        path: string;
+        json: <T>() => Promise<T>;
+    };
+    env: Record<string, unknown> | undefined;
+    res: Response;
+    json: (value: unknown) => Response;
+}
+
+export interface MockContextOptions {
+    /** Full request URL; `c.req.url`, `c.req.path`, and `c.req.raw` all derive from it. */
+    url?: string;
+    method?: string;
+    headers?: Record<string, string>;
+    /** Raw request body. Pass malformed JSON to exercise a real parse failure. */
+    body?: string;
+    /** Worker bindings surfaced as `c.env`. Omit to model a request with no env at all. */
+    env?: Record<string, unknown>;
+    /**
+     * Response the fake `next()` installs as `c.res`, standing in for a downstream handler.
+     * Defaults to an HTML response with mutable headers.
+     */
+    downstream?: Response;
+}
+
+export interface MockContextHarness {
+    context: MockContext;
+    /** How many times the middleware under test called `next()`. */
+    readonly nextCalls: number;
+    /** Runs `middleware`; resolves to its Response, or `undefined` when it delegated. */
+    run: (middleware: PluginMiddleware) => Promise<Response | undefined>;
+}
+
+/** Builds a fake Hono context plus the `next()` that records delegation. */
+export function createMockContext(options: MockContextOptions = {}): MockContextHarness {
+    const { url = 'https://blit386.dev/', method = 'GET', headers, body, env, downstream } = options;
+    const request = new Request(url, { method, headers, body });
+    const downstreamResponse =
+        downstream ?? new Response('<!doctype html>', { headers: { 'content-type': 'text/html; charset=utf-8' } });
+
+    let nextCalls = 0;
+
+    const context: MockContext = {
+        req: {
+            raw: request,
+            url: request.url,
+            method: request.method,
+            path: new URL(request.url).pathname,
+            json: <T>(): Promise<T> => request.json() as Promise<T>,
+        },
+        env,
+        // Hono starts a request with a placeholder it has not yet finalized; a middleware that
+        // mutates `c.res.headers` only ever sees the response `next()` installs.
+        res: new Response(null, { status: 404 }),
+        json: (value) => new Response(JSON.stringify(value), { headers: { 'content-type': 'application/json' } }),
+    };
+
+    const next = async (): Promise<void> => {
+        nextCalls += 1;
+        context.res = downstreamResponse;
+    };
+
+    return {
+        context,
+
+        get nextCalls() {
+            return nextCalls;
+        },
+
+        async run(middleware) {
+            const result = await middleware(context as unknown as HonoContext, next);
+            return result instanceof Response ? result : undefined;
+        },
+    };
+}
+
+/**
+ * Fumapress passes `{ app }` into `createMiddlewares`. None of the plugins in `src/` read it and a
+ * real `Hono` is not constructible here, so a stub stands in – legal without `unknown`, since
+ * `Hono` is assignable to `{}`.
+ */
+const MIDDLEWARE_ENV = { app: {} } as MiddlewareEnv;
+
+/**
+ * Builds the single middleware a plugin contributes, bound to `context` as `this`.
+ *
+ * Call this once per test where caching matters: `feed.ts` and `mcp-server.ts` both keep their
+ * cache in the `createMiddlewares` closure, so a fresh call is a fresh cache.
+ */
+export async function createPluginMiddleware(plugin: ServerPlugin, context: AppContext): Promise<PluginMiddleware> {
+    const factory = plugin.createMiddlewares;
+    const name = plugin.name ?? '<unnamed>';
+
+    if (factory === undefined) {
+        throw new Error(`plugin "${name}" contributes no middlewares`);
+    }
+
+    const middlewares = (await factory.call(context, MIDDLEWARE_ENV)) ?? [];
+    const [middleware, ...rest] = middlewares;
+
+    if (middleware === undefined || rest.length > 0) {
+        throw new Error(`expected exactly one middleware from "${name}", got ${middlewares.length}`);
+    }
+
+    return middleware;
+}
+
+/** Cloudflare `ASSETS` binding double that records every forwarded request. */
+export interface FakeAssets {
+    fetch: (request: Request) => Promise<Response>;
+    readonly requests: Request[];
+}
+
+export function createFakeAssets(handler: (request: Request) => Response | Promise<Response>): FakeAssets {
+    const requests: Request[] = [];
+
+    return {
+        requests,
+
+        async fetch(request) {
+            requests.push(request);
+            return handler(request);
+        },
+    };
+}

--- a/packages/website/src/__test__/press-context.ts
+++ b/packages/website/src/__test__/press-context.ts
@@ -1,0 +1,139 @@
+/**
+ * Fumapress `AppContext` doubles for the `ServerPlugin`s in `src/`.
+ *
+ * The plugins reach for exactly three things on `this`: `getLoader()`, `adapters`, and
+ * `siteConfig.baseUrl`. Everything they touch is type-checked by the `satisfies` clause in
+ * `createMockAppContext`; the single cast there covers only the two members that cannot be
+ * constructed honestly.
+ */
+
+import type { Adapter, AppContext, Layouts } from 'fumapress';
+import type { Page, PageData } from 'fumadocs-core/source';
+
+/** The two loader methods the plugins in `src/` call. */
+export interface FakeLoader {
+    getPage: (slugs: string[] | undefined) => Page | undefined;
+    getPages: () => Page[];
+}
+
+export interface FakeLoaderCalls {
+    /** Slug arrays handed to `getPage`, in call order. */
+    getPage: string[][];
+    /** How many times `getPages` ran – the feed and MCP corpus caches must hold this at 1. */
+    getPages: number;
+}
+
+export function createFakeLoader(pages: Page[]): { loader: FakeLoader; calls: FakeLoaderCalls } {
+    const calls: FakeLoaderCalls = { getPage: [], getPages: 0 };
+
+    const loader: FakeLoader = {
+        getPage(slugs) {
+            const requested = slugs ?? [];
+            calls.getPage.push(requested);
+            return pages.find((page) => page.slugs.join('/') === requested.join('/'));
+        },
+
+        getPages() {
+            calls.getPages += 1;
+            return pages;
+        },
+    };
+
+    return { loader, calls };
+}
+
+export interface FakePageInput {
+    url: string;
+    title?: string;
+    description?: string;
+    /** Content-source name. `feedPlugin` selects on `type === 'blog'`. */
+    type?: string;
+    /** Extra frontmatter, for example `{ date: '2026-06-25' }`. */
+    data?: Record<string, unknown>;
+}
+
+export function createFakePage(input: FakePageInput): Page {
+    const slugs = input.url.split('/').filter((segment) => segment.length > 0);
+
+    // `PageData` carries no index signature, so blog frontmatter such as `date` is an excess
+    // property on a fresh literal typed as `PageData`. Widening the annotation admits it, and the
+    // widened type is still assignable to `PageData`.
+    const data: PageData & Record<string, unknown> = {
+        title: input.title,
+        description: input.description,
+        ...input.data,
+    };
+
+    return {
+        path: `${slugs.join('/') || 'index'}.mdx`,
+        type: input.type,
+        slugs,
+        url: input.url,
+        data,
+    };
+}
+
+/** Adapter whose `core:get-text` resolves body text from a url-to-text map. */
+export function createTextAdapter(texts: ReadonlyMap<string, string>, onCall?: (url: string) => void): Adapter {
+    return {
+        // Method shorthand, not an arrow: `core:get-text` declares `this: AppContext<C>`, and a
+        // test that asserts the binding needs `this` to be real.
+        'core:get-text'(page) {
+            onCall?.(page.url);
+            return texts.get(page.url);
+        },
+    };
+}
+
+export interface MockAppContextOptions {
+    /** Pass a function to hand out a different loader per call, for cache-invalidation tests. */
+    loader?: FakeLoader | (() => FakeLoader | Promise<FakeLoader>);
+    adapters?: Adapter[];
+    siteConfig?: AppContext['siteConfig'];
+}
+
+const noopRoot: Layouts['root'] = () => null;
+const noopPage: Layouts['page'] = () => null;
+const noopNotFound: Layouts['notFound'] = () => null;
+
+/**
+ * Builds a fake `AppContext`.
+ *
+ * Deliberately not generic: `revalidateLoader`'s type is conditional on `C['source']`, and under a
+ * deferred `<C extends ConfigContext>` that conditional never collapses, so no function literal
+ * would be assignable to it.
+ */
+export function createMockAppContext(options: MockAppContextOptions = {}): AppContext {
+    const {
+        loader = createFakeLoader([]).loader,
+        adapters = [],
+        siteConfig = { name: 'BLIT386', baseUrl: 'https://blit386.dev' },
+    } = options;
+
+    const getLoader = typeof loader === 'function' ? loader : (): FakeLoader => loader;
+
+    const context = {
+        mode: 'dynamic',
+        getLoader,
+        plugins: [],
+        adapters,
+        layouts: { root: noopRoot, page: noopPage, notFound: noopNotFound },
+        revalidateLoader: async (): Promise<void> => {},
+        invalidateLoader: (): void => {},
+        data: {},
+        siteConfig,
+    } satisfies Omit<AppContext, '$context' | 'getLoader'> & {
+        getLoader: () => FakeLoader | Promise<FakeLoader>;
+    };
+
+    // Two members cannot be produced honestly, and no plugin in `src/` reads either:
+    //   `$context`  - declared as the config context but documented "always `undefined`"; a real
+    //                 value would need a real `Page` plus `Meta`.
+    //   `getLoader` - declared `() => Awaitable<LoaderOutput<C>>`, and `LoaderOutput` has fourteen
+    //                 required members (page tree, param generation, href resolution,
+    //                 `serializePageTree`, three `$infer` phantoms). Even a genuine `loader()`
+    //                 output is not assignable to `LoaderOutput<ConfigContext>`, because its
+    //                 `$infer` lacks `ConfigContext`'s `source` key.
+    // Everything the plugins do touch is checked by the `satisfies` clause above.
+    return context as unknown as AppContext;
+}

--- a/packages/website/src/blog-post-date.test.ts
+++ b/packages/website/src/blog-post-date.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Covers `getPostDate`, the frontmatter `date` reader `feedPlugin` and the blog index share.
+ *
+ * The function exists because `date` crosses the Vite dev/RSC boundary as an ISO string rather
+ * than the `Date` the framework adapter looks for, so both representations have to work. The
+ * epoch case is the one worth keeping: `0` is a valid timestamp and a falsy number, so a
+ * truthiness check instead of a `NaN` check would silently drop it.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { getPostDate } from './blog-post-date';
+
+describe('getPostDate', () => {
+    describe('accepts', () => {
+        it('a Date instance, returned unchanged', () => {
+            const date = new Date('2026-07-04T12:00:00.000Z');
+
+            expect(getPostDate({ data: { date } })).toBe(date);
+        });
+
+        it('an ISO string', () => {
+            expect(getPostDate({ data: { date: '2026-07-04' } })?.toISOString()).toBe('2026-07-04T00:00:00.000Z');
+        });
+
+        it('an epoch number', () => {
+            expect(getPostDate({ data: { date: 1_767_225_600_000 } })?.getTime()).toBe(1_767_225_600_000);
+        });
+
+        it('the epoch itself, which is falsy but valid', () => {
+            expect(getPostDate({ data: { date: 0 } })?.toISOString()).toBe('1970-01-01T00:00:00.000Z');
+        });
+    });
+
+    describe('rejects', () => {
+        it.each([
+            ['an invalid Date instance', new Date('nope')],
+            ['a string that cannot be parsed', 'not a date'],
+            ['NaN', Number.NaN],
+            ['null', null],
+            ['a boolean', true],
+            ['an object', {}],
+        ])('%s', (_label, date) => {
+            expect(getPostDate({ data: { date } })).toBeUndefined();
+        });
+
+        it('frontmatter with no date field', () => {
+            expect(getPostDate({ data: {} })).toBeUndefined();
+        });
+
+        it.each([
+            ['null data', null],
+            ['undefined data', undefined],
+        ])('%s', (_label, data) => {
+            expect(getPostDate({ data })).toBeUndefined();
+        });
+    });
+});

--- a/packages/website/src/channel-headers.test.ts
+++ b/packages/website/src/channel-headers.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Covers `channelHeadersPlugin`: the `next`-channel `X-Robots-Tag` and the disallow-all
+ * `robots.txt` override.
+ *
+ * The load-bearing tests are the two in "reads the channel at request time". The header must come
+ * from `c.env.BLIT386_CHANNEL`, which the Worker receives through `wrangler.json` `vars`, never
+ * from `process.env`, which inside the deployed Worker holds nothing the CI build step set. Both
+ * tests point `process.env` at the opposite value from `c.env`, so neither can pass against a
+ * `process.env` implementation – whether that read happens at module scope or per request.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { channelHeadersPlugin } from './channel-headers';
+import { createMockContext, createPluginMiddleware, type PluginMiddleware } from './__test__/hono-context';
+import { createMockAppContext } from './__test__/press-context';
+
+const NEXT_ENV = { BLIT386_CHANNEL: 'next' };
+const DISALLOW_ALL = 'User-agent: *\nDisallow: /\n';
+
+describe('channelHeadersPlugin', () => {
+    let middleware: PluginMiddleware;
+
+    beforeEach(async () => {
+        middleware = await createPluginMiddleware(channelHeadersPlugin(), createMockAppContext());
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
+    // `createPluginMiddleware` throws unless the plugin contributes exactly one middleware, so
+    // every test in this file also asserts that.
+    it('names itself', () => {
+        expect(channelHeadersPlugin().name).toBe('channel-headers');
+    });
+
+    describe('reads the channel at request time', () => {
+        it('marks the response noindex when the request env says next, whatever process.env says', async () => {
+            // A module-scope `process.env.BLIT386_CHANNEL` captured this at import time; a lazy
+            // per-request `process.env` read sees it now. Both must lose to the binding.
+            vi.stubEnv('BLIT386_CHANNEL', 'production');
+
+            const harness = createMockContext({
+                url: 'https://next.blit386.dev/docs/getting-started',
+                env: NEXT_ENV,
+            });
+
+            await harness.run(middleware);
+
+            expect(harness.context.res.headers.get('x-robots-tag')).toBe('noindex');
+        });
+
+        it('leaves the response indexable when the request env says production, whatever process.env says', async () => {
+            // Also kills a `process.env.X === 'next' || c.env?.X === 'next'` fallback.
+            vi.stubEnv('BLIT386_CHANNEL', 'next');
+
+            const harness = createMockContext({
+                url: 'https://blit386.dev/docs/getting-started',
+                env: { BLIT386_CHANNEL: 'production' },
+            });
+
+            await harness.run(middleware);
+
+            expect(harness.context.res.headers.get('x-robots-tag')).toBeNull();
+            expect(harness.nextCalls).toBe(1);
+        });
+    });
+
+    describe('on the production channel', () => {
+        it('delegates without a header when the env has no channel var', async () => {
+            const harness = createMockContext({ env: {} });
+
+            await harness.run(middleware);
+
+            expect(harness.nextCalls).toBe(1);
+            expect(harness.context.res.headers.get('x-robots-tag')).toBeNull();
+        });
+
+        it('delegates without a header when there is no env at all', async () => {
+            const harness = createMockContext();
+
+            await harness.run(middleware);
+
+            expect(harness.nextCalls).toBe(1);
+            expect(harness.context.res.headers.get('x-robots-tag')).toBeNull();
+        });
+
+        it('ignores a channel value that is not exactly "next"', async () => {
+            const harness = createMockContext({ env: { BLIT386_CHANNEL: 'preview' } });
+
+            await harness.run(middleware);
+
+            expect(harness.nextCalls).toBe(1);
+            expect(harness.context.res.headers.get('x-robots-tag')).toBeNull();
+        });
+
+        it('does not intercept robots.txt', async () => {
+            const harness = createMockContext({ url: 'https://blit386.dev/robots.txt', env: {} });
+
+            const response = await harness.run(middleware);
+
+            expect(response).toBeUndefined();
+            expect(harness.nextCalls).toBe(1);
+        });
+    });
+
+    describe('on the next channel', () => {
+        it('serves a disallow-all robots.txt without reaching the static asset', async () => {
+            const harness = createMockContext({ url: 'https://next.blit386.dev/robots.txt', env: NEXT_ENV });
+
+            const response = await harness.run(middleware);
+
+            expect(response).toBeInstanceOf(Response);
+            expect(await response?.text()).toBe(DISALLOW_ALL);
+            expect(response?.headers.get('content-type')).toBe('text/plain; charset=utf-8');
+            expect(response?.headers.get('x-robots-tag')).toBe('noindex');
+
+            // Never delegating is the point: the markdown-negotiation plugin further down the
+            // chain would otherwise serve the production robots.txt from the ASSETS binding.
+            expect(harness.nextCalls).toBe(0);
+        });
+
+        it('answers HEAD /robots.txt with the same headers and no body', async () => {
+            const harness = createMockContext({
+                url: 'https://next.blit386.dev/robots.txt',
+                method: 'HEAD',
+                env: NEXT_ENV,
+            });
+
+            const response = await harness.run(middleware);
+
+            expect(await response?.text()).toBe('');
+            expect(response?.headers.get('content-type')).toBe('text/plain; charset=utf-8');
+            expect(response?.headers.get('x-robots-tag')).toBe('noindex');
+            expect(harness.nextCalls).toBe(0);
+        });
+
+        it('falls past the robots override for a non-GET request to the same path', async () => {
+            const harness = createMockContext({
+                url: 'https://next.blit386.dev/robots.txt',
+                method: 'POST',
+                env: NEXT_ENV,
+            });
+
+            const response = await harness.run(middleware);
+
+            expect(response).toBeUndefined();
+            expect(harness.nextCalls).toBe(1);
+            expect(harness.context.res.headers.get('x-robots-tag')).toBe('noindex');
+        });
+
+        it('adds the header to a downstream response without disturbing its other headers', async () => {
+            const harness = createMockContext({ url: 'https://next.blit386.dev/docs/faq', env: NEXT_ENV });
+
+            await harness.run(middleware);
+
+            expect(harness.context.res.headers.get('x-robots-tag')).toBe('noindex');
+            expect(harness.context.res.headers.get('content-type')).toBe('text/html; charset=utf-8');
+        });
+    });
+});

--- a/packages/website/src/data/api-history.test.ts
+++ b/packages/website/src/data/api-history.test.ts
@@ -39,11 +39,29 @@ describe('compareVersions', () => {
         expect(compareVersions('1.5.0-beta.1', '1.5.0-beta.2')).toBeLessThan(0);
     });
 
+    it('compares segments too large for a float without losing precision', () => {
+        // `Number('9'.repeat(400))` is `Infinity`, so subtracting two equal oversized segments
+        // would yield `NaN`. Digit-string comparison has no such ceiling.
+        const huge = '9'.repeat(400);
+
+        expect(compareVersions(`${huge}.0.0`, `${huge}.0.0`)).toBe(0);
+        expect(compareVersions(`${huge}.0.1`, `${huge}.0.0`)).toBeGreaterThan(0);
+        expect(compareVersions(`${huge}0`, huge)).toBeGreaterThan(0);
+        expect(compareVersions(huge, `${huge}0`)).toBeLessThan(0);
+    });
+
+    it('ignores leading zeros in a segment', () => {
+        expect(compareVersions('1.007.0', '1.7.0')).toBe(0);
+        expect(compareVersions('01.0.0', '1.0.0')).toBe(0);
+    });
+
     it.each([
         ['1.5.0-beta.1', '1.5.0'],
         ['not-a-version', '1.0.0'],
         ['', '1.0.0'],
         ['1.0.0', ''],
+        ['9'.repeat(400), '9'.repeat(400)],
+        [`1.${'9'.repeat(400)}`, `1.${'9'.repeat(400)}`],
     ])('never returns NaN for %s vs %s', (a, b) => {
         // An Array.prototype.sort comparator returning NaN has implementation-defined behavior,
         // so this holds for any input, not only well-formed versions.

--- a/packages/website/src/data/api-history.test.ts
+++ b/packages/website/src/data/api-history.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Covers `src/data/api-history.ts`, the typed loader behind `Since`, `ApiAvailability`, and
+ * `PageChangelog`.
+ *
+ * The generated JSON it wraps is re-copied from the engine on every `pnpm run sync:docs`, so
+ * these tests assert invariants over whatever it currently holds rather than naming specific
+ * symbols – otherwise an unrelated engine doc change would turn this suite red.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { apiHistory, compareVersions, getPageSymbols, getSymbol, type SymbolStatus } from './api-history';
+
+const STATUSES: SymbolStatus[] = ['stable', 'unreleased', 'deprecated'];
+const NUMERIC_VERSION = /^\d+(\.\d+)*$/;
+const SEMVER = /^\d+\.\d+\.\d+$/;
+
+describe('compareVersions', () => {
+    it('orders segments numerically rather than lexically', () => {
+        // The whole reason this function exists: '1.10.0' < '1.2.0' as strings.
+        expect(compareVersions('1.10.0', '1.2.0')).toBeGreaterThan(0);
+        expect(compareVersions('2.0.0', '10.0.0')).toBeLessThan(0);
+    });
+
+    it('treats missing trailing segments as zero', () => {
+        expect(compareVersions('1.0', '1.0.0')).toBe(0);
+        expect(compareVersions('1.0.0', '1.0')).toBe(0);
+    });
+
+    it('reports equality for identical versions', () => {
+        expect(compareVersions('1.4.2', '1.4.2')).toBe(0);
+    });
+
+    it('is antisymmetric', () => {
+        expect(Math.sign(compareVersions('1.5.0', '1.4.0'))).toBe(-Math.sign(compareVersions('1.4.0', '1.5.0')));
+    });
+
+    it('sorts a prerelease below its release', () => {
+        expect(compareVersions('1.5.0-beta.1', '1.5.0')).toBeLessThan(0);
+        expect(compareVersions('1.5.0-beta.1', '1.5.0-beta.2')).toBeLessThan(0);
+    });
+
+    it.each([
+        ['1.5.0-beta.1', '1.5.0'],
+        ['not-a-version', '1.0.0'],
+        ['', '1.0.0'],
+        ['1.0.0', ''],
+    ])('never returns NaN for %s vs %s', (a, b) => {
+        // An Array.prototype.sort comparator returning NaN has implementation-defined behavior,
+        // so this holds for any input, not only well-formed versions.
+        expect(Number.isNaN(compareVersions(a, b))).toBe(false);
+    });
+
+    it('sorts the generated version list into ascending order', () => {
+        const versions = Object.keys(apiHistory.versions);
+        const shuffled = [...versions].reverse();
+
+        expect([...shuffled].sort(compareVersions)).toEqual([...versions].sort(compareVersions));
+        expect(versions.length).toBeGreaterThan(0);
+    });
+});
+
+describe('getSymbol', () => {
+    it('returns the history for a documented symbol', () => {
+        const [name] = Object.keys(apiHistory.symbols);
+
+        expect(name).toBeDefined();
+        expect(getSymbol(name ?? '')).toBe(apiHistory.symbols[name ?? '']);
+    });
+
+    it('returns undefined for an undocumented symbol', () => {
+        expect(getSymbol('definitely-not-a-symbol')).toBeUndefined();
+    });
+
+    it.each(['toString', 'constructor', 'hasOwnProperty'])(
+        'returns undefined for the inherited key %s',
+        (inherited) => {
+            // The record comes from JSON.parse, so it inherits Object.prototype. Without the
+            // own-property guard this would hand a function back typed as SymbolHistory.
+            expect(getSymbol(inherited)).toBeUndefined();
+        },
+    );
+});
+
+describe('getPageSymbols', () => {
+    it('lists the symbols recorded for a page', () => {
+        const [page] = Object.keys(apiHistory.pages);
+
+        expect(page).toBeDefined();
+        expect(getPageSymbols(page ?? '')).toBe(apiHistory.pages[page ?? '']);
+    });
+
+    it('returns an empty array for a page with no record', () => {
+        expect(getPageSymbols('nope/missing')).toEqual([]);
+    });
+
+    it.each(['toString', 'constructor'])('returns an empty array for the inherited key %s', (inherited) => {
+        // `?? []` never fires here on its own: Object.prototype.constructor is a function, not
+        // nullish, so only the own-property guard keeps the return type honest.
+        expect(getPageSymbols(inherited)).toEqual([]);
+    });
+});
+
+describe('the generated history', () => {
+    it('declares both package versions as semver, with unreleased ahead of released', () => {
+        expect(apiHistory.packageVersion).toMatch(SEMVER);
+        expect(apiHistory.unreleasedVersion).toMatch(SEMVER);
+        expect(compareVersions(apiHistory.unreleasedVersion, apiHistory.packageVersion)).toBeGreaterThan(0);
+    });
+
+    it('gives every symbol a well-formed record', () => {
+        const entries = Object.entries(apiHistory.symbols);
+
+        expect(entries.length).toBeGreaterThan(0);
+
+        for (const [name, symbol] of entries) {
+            expect(symbol.kind, name).toBeTruthy();
+            expect(symbol.since, name).toMatch(NUMERIC_VERSION);
+            expect(STATUSES, name).toContain(symbol.status);
+            expect(Array.isArray(symbol.changes), name).toBe(true);
+
+            for (const change of symbol.changes) {
+                expect(change.version, name).toMatch(NUMERIC_VERSION);
+                expect(typeof change.note, name).toBe('string');
+            }
+
+            if (symbol.deprecated !== null) {
+                expect(typeof symbol.deprecated.note, name).toBe('string');
+            }
+        }
+    });
+
+    it('references only symbols it also defines', () => {
+        const dangling = Object.entries(apiHistory.pages).flatMap(([page, names]) =>
+            names.filter((name) => !Object.hasOwn(apiHistory.symbols, name)).map((name) => `${page} -> ${name}`),
+        );
+
+        expect(dangling).toEqual([]);
+    });
+
+    it('dates every symbol at or below the unreleased version', () => {
+        const ahead = Object.entries(apiHistory.symbols)
+            .filter(([, symbol]) => compareVersions(symbol.since, apiHistory.unreleasedVersion) > 0)
+            .map(([name]) => name);
+
+        expect(ahead).toEqual([]);
+    });
+});

--- a/packages/website/src/data/api-history.ts
+++ b/packages/website/src/data/api-history.ts
@@ -27,28 +27,75 @@ export interface ApiHistory {
 
 export const apiHistory = raw as ApiHistory;
 
-/** Looks up a symbol's version history by name, or `undefined` if it isn't documented. */
-export const getSymbol = (name: string): SymbolHistory | undefined => apiHistory.symbols[name];
+/**
+ * Looks up a symbol's version history by name, or `undefined` if it isn't documented.
+ *
+ * `apiHistory` comes from `JSON.parse`, so its records inherit `Object.prototype` – without the
+ * own-property guard, `getSymbol('toString')` would hand back a function typed as `SymbolHistory`.
+ */
+export const getSymbol = (name: string): SymbolHistory | undefined =>
+    Object.hasOwn(apiHistory.symbols, name) ? apiHistory.symbols[name] : undefined;
 
-/** Lists the symbol names documented on a given page path, or `[]` if none are recorded. */
-export const getPageSymbols = (page: string): string[] => apiHistory.pages[page] ?? [];
+/**
+ * Lists the symbol names documented on a given page path, or `[]` if none are recorded.
+ *
+ * Guarded the same way as {@link getSymbol}: a bare `?? []` never fires for an inherited key,
+ * because `Object.prototype.constructor` is a function rather than nullish.
+ */
+export const getPageSymbols = (page: string): string[] =>
+    Object.hasOwn(apiHistory.pages, page) ? (apiHistory.pages[page] ?? []) : [];
+
+/** One dot-separated version segment: its numeric value, and whether a suffix followed it. */
+interface VersionSegment {
+    value: number;
+    prerelease: boolean;
+}
+
+/**
+ * Parses one segment. `"0"` yields `{ value: 0, prerelease: false }`, `"0-beta"` yields
+ * `{ value: 0, prerelease: true }`, and anything without a leading integer yields
+ * `{ value: 0, prerelease: true }` rather than `NaN`.
+ */
+function parseSegment(segment: string | undefined): VersionSegment {
+    if (segment === undefined) {
+        return { value: 0, prerelease: false };
+    }
+
+    const match = /^(\d+)(.*)$/.exec(segment);
+
+    if (match === null) {
+        return { value: 0, prerelease: true };
+    }
+
+    return { value: Number(match[1] ?? '0'), prerelease: match[2] !== '' };
+}
 
 /**
  * Compares two dot-separated version strings segment by segment as numbers, so
  * `"1.10.0"` sorts above `"1.2.0"` (a plain string comparison would sort them the other
  * way around). Missing trailing segments are treated as `0`. Returns a negative number,
  * zero, or a positive number in the same sense as an `Array.prototype.sort` comparator.
+ *
+ * A segment carrying a prerelease suffix sorts below the same segment without one, so
+ * `"1.5.0-beta.1"` is below `"1.5.0"`. Every input yields a number: a segment that does not parse
+ * cannot produce `NaN`, which an `Array.prototype.sort` comparator must never return.
  */
 export function compareVersions(a: string, b: string): number {
-    const segmentsA = a.split('.').map(Number);
-    const segmentsB = b.split('.').map(Number);
+    const segmentsA = a.split('.');
+    const segmentsB = b.split('.');
     const length = Math.max(segmentsA.length, segmentsB.length);
 
     for (let i = 0; i < length; i += 1) {
-        const diff = (segmentsA[i] ?? 0) - (segmentsB[i] ?? 0);
+        const segmentA = parseSegment(segmentsA[i]);
+        const segmentB = parseSegment(segmentsB[i]);
+        const diff = segmentA.value - segmentB.value;
 
         if (diff !== 0) {
             return diff;
+        }
+
+        if (segmentA.prerelease !== segmentB.prerelease) {
+            return segmentA.prerelease ? -1 : 1;
         }
     }
 

--- a/packages/website/src/data/api-history.ts
+++ b/packages/website/src/data/api-history.ts
@@ -45,29 +45,49 @@ export const getSymbol = (name: string): SymbolHistory | undefined =>
 export const getPageSymbols = (page: string): string[] =>
     Object.hasOwn(apiHistory.pages, page) ? (apiHistory.pages[page] ?? []) : [];
 
-/** One dot-separated version segment: its numeric value, and whether a suffix followed it. */
+/** One dot-separated version segment: its digits, and whether a suffix followed them. */
 interface VersionSegment {
-    value: number;
+    /** Leading zeros stripped, so `""` means zero. Kept as digits rather than a `number`. */
+    digits: string;
     prerelease: boolean;
 }
 
 /**
- * Parses one segment. `"0"` yields `{ value: 0, prerelease: false }`, `"0-beta"` yields
- * `{ value: 0, prerelease: true }`, and anything without a leading integer yields
- * `{ value: 0, prerelease: true }` rather than `NaN`.
+ * Parses one segment. `"0"` yields `{ digits: '', prerelease: false }`, `"7-beta"` yields
+ * `{ digits: '7', prerelease: true }`, and anything without a leading integer yields
+ * `{ digits: '', prerelease: true }`.
  */
 function parseSegment(segment: string | undefined): VersionSegment {
     if (segment === undefined) {
-        return { value: 0, prerelease: false };
+        return { digits: '', prerelease: false };
     }
 
     const match = /^(\d+)(.*)$/.exec(segment);
 
     if (match === null) {
-        return { value: 0, prerelease: true };
+        return { digits: '', prerelease: true };
     }
 
-    return { value: Number(match[1] ?? '0'), prerelease: match[2] !== '' };
+    return { digits: (match[1] ?? '').replace(/^0+/, ''), prerelease: match[2] !== '' };
+}
+
+/**
+ * Orders two zero-stripped digit strings. More digits is always the larger number, and equal
+ * lengths compare lexicographically – which for equal-length digit strings is numeric order.
+ *
+ * Deliberately not `Number(a) - Number(b)`: a segment of more than 308 digits converts to
+ * `Infinity`, and two such segments would then subtract to `NaN`.
+ */
+function compareDigits(a: string, b: string): number {
+    if (a.length !== b.length) {
+        return a.length < b.length ? -1 : 1;
+    }
+
+    if (a === b) {
+        return 0;
+    }
+
+    return a < b ? -1 : 1;
 }
 
 /**
@@ -77,8 +97,9 @@ function parseSegment(segment: string | undefined): VersionSegment {
  * zero, or a positive number in the same sense as an `Array.prototype.sort` comparator.
  *
  * A segment carrying a prerelease suffix sorts below the same segment without one, so
- * `"1.5.0-beta.1"` is below `"1.5.0"`. Every input yields a number: a segment that does not parse
- * cannot produce `NaN`, which an `Array.prototype.sort` comparator must never return.
+ * `"1.5.0-beta.1"` is below `"1.5.0"`. Every input yields `-1`, `0`, or `1` – neither a segment of
+ * any length nor one that fails to parse can produce `NaN`, which an `Array.prototype.sort`
+ * comparator must never return.
  */
 export function compareVersions(a: string, b: string): number {
     const segmentsA = a.split('.');
@@ -88,7 +109,7 @@ export function compareVersions(a: string, b: string): number {
     for (let i = 0; i < length; i += 1) {
         const segmentA = parseSegment(segmentsA[i]);
         const segmentB = parseSegment(segmentsB[i]);
-        const diff = segmentA.value - segmentB.value;
+        const diff = compareDigits(segmentA.digits, segmentB.digits);
 
         if (diff !== 0) {
             return diff;

--- a/packages/website/src/feed.test.ts
+++ b/packages/website/src/feed.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Covers `feedPlugin`: the RSS 2.0 feed at `GET /feed.xml`.
+ *
+ * A feed is consumed by readers that are unforgiving about malformed XML and about dates that are
+ * not RFC 822, so the assertions here are on the exact serialized output rather than on a parsed
+ * shape. The escaping tests pin what `escapeXml` does and does not touch, which matters because a
+ * post title is author-controlled text going straight into markup.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { feedPlugin } from './feed';
+import { createMockContext, createPluginMiddleware, type PluginMiddleware } from './__test__/hono-context';
+import {
+    createFakeLoader,
+    createFakePage,
+    createMockAppContext,
+    type FakeLoader,
+    type FakeLoaderCalls,
+} from './__test__/press-context';
+import type { AppContext } from 'fumapress';
+import type { Page } from 'fumadocs-core/source';
+
+function blogPost(input: { url: string; title: string; description?: string; date?: unknown }): Page {
+    return createFakePage({
+        url: input.url,
+        title: input.title,
+        description: input.description,
+        type: 'blog',
+        data: input.date === undefined ? {} : { date: input.date },
+    });
+}
+
+const POSTS = [
+    blogPost({ url: '/blog/older', title: 'Older post', description: 'The first one.', date: '2026-06-25' }),
+    blogPost({ url: '/blog/newer', title: 'Newer post', description: 'The second one.', date: '2026-07-04' }),
+];
+
+async function buildMiddleware(
+    pages: Page[],
+    options: { siteConfig?: AppContext['siteConfig']; loader?: () => FakeLoader } = {},
+): Promise<{ middleware: PluginMiddleware; calls: FakeLoaderCalls }> {
+    const built = createFakeLoader(pages);
+    const context = createMockAppContext({
+        loader: options.loader ?? built.loader,
+        ...(options.siteConfig === undefined ? {} : { siteConfig: options.siteConfig }),
+    });
+
+    return { middleware: await createPluginMiddleware(feedPlugin(), context), calls: built.calls };
+}
+
+/** Fetches the feed and returns its body. */
+async function fetchFeed(middleware: PluginMiddleware, method = 'GET'): Promise<Response> {
+    const harness = createMockContext({ url: 'https://blit386.dev/feed.xml', method });
+    const response = await harness.run(middleware);
+
+    if (response === undefined) {
+        throw new Error('the feed middleware delegated instead of answering');
+    }
+
+    return response;
+}
+
+describe('feedPlugin', () => {
+    let middleware: PluginMiddleware;
+    let calls: FakeLoaderCalls;
+
+    beforeEach(async () => {
+        ({ middleware, calls } = await buildMiddleware(POSTS));
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('names itself', () => {
+        expect(feedPlugin().name).toBe('feed');
+    });
+
+    describe('routing', () => {
+        it.each([
+            ['a different path', 'https://blit386.dev/blog', 'GET'],
+            ['a non-readonly method', 'https://blit386.dev/feed.xml', 'POST'],
+        ])('delegates %s', async (_label, url, method) => {
+            const harness = createMockContext({ url, method });
+
+            const response = await harness.run(middleware);
+
+            expect(response).toBeUndefined();
+            expect(harness.nextCalls).toBe(1);
+        });
+    });
+
+    describe('the channel', () => {
+        it('serves RSS with the documented content type', async () => {
+            const response = await fetchFeed(middleware);
+
+            expect(response.status).toBe(200);
+            expect(response.headers.get('content-type')).toBe('application/rss+xml; charset=utf-8');
+        });
+
+        it('opens with an XML declaration and the channel metadata', async () => {
+            const body = await (await fetchFeed(middleware)).text();
+
+            expect(body.startsWith('<?xml version="1.0" encoding="UTF-8"?>')).toBe(true);
+            expect(body).toContain('<title>BLIT386 Blog</title>');
+            expect(body).toContain('<link>https://blit386.dev/blog</link>');
+            expect(body).toContain(
+                '<atom:link href="https://blit386.dev/feed.xml" rel="self" type="application/rss+xml"/>',
+            );
+        });
+
+        it('falls back to the production base URL when the site config has none', async () => {
+            const built = await buildMiddleware(POSTS, { siteConfig: { name: 'BLIT386' } });
+
+            const body = await (await fetchFeed(built.middleware)).text();
+
+            expect(body).toContain('<link>https://blit386.dev/blog</link>');
+        });
+
+        it('answers HEAD with the headers but no body', async () => {
+            const response = await fetchFeed(middleware, 'HEAD');
+
+            expect(response.headers.get('content-type')).toBe('application/rss+xml; charset=utf-8');
+            expect(await response.text()).toBe('');
+        });
+    });
+
+    describe('the items', () => {
+        it('includes only blog pages', async () => {
+            const built = await buildMiddleware([
+                ...POSTS,
+                createFakePage({ url: '/docs/getting-started', title: 'Getting started', type: 'docs' }),
+            ]);
+
+            const body = await (await fetchFeed(built.middleware)).text();
+
+            expect(body).toContain('https://blit386.dev/blog/newer');
+            expect(body).not.toContain('/docs/getting-started');
+        });
+
+        it('sorts newest first', async () => {
+            const body = await (await fetchFeed(middleware)).text();
+
+            expect(body.indexOf('Newer post')).toBeLessThan(body.indexOf('Older post'));
+        });
+
+        it('formats the publication date as RFC 822 with a numeric offset', async () => {
+            const body = await (await fetchFeed(middleware)).text();
+
+            expect(body).toContain('<pubDate>Thu, 25 Jun 2026 00:00:00 +0000</pubDate>');
+        });
+
+        it('gives every item a permalink guid matching its link', async () => {
+            const body = await (await fetchFeed(middleware)).text();
+
+            expect(body).toContain('<link>https://blit386.dev/blog/newer</link>');
+            expect(body).toContain('<guid isPermaLink="true">https://blit386.dev/blog/newer</guid>');
+        });
+
+        it('omits the description element when a post has none', async () => {
+            const built = await buildMiddleware([blogPost({ url: '/blog/bare', title: 'Bare', date: '2026-07-04' })]);
+
+            const body = await (await fetchFeed(built.middleware)).text();
+
+            expect(body).not.toContain('<description>\n');
+            expect(body).toContain('<title>Bare</title>');
+        });
+
+        it('escapes the XML metacharacters that would break the document', async () => {
+            const built = await buildMiddleware([
+                blogPost({ url: '/blog/x', title: 'A & B <c> "d"', date: '2026-07-04' }),
+            ]);
+
+            const body = await (await fetchFeed(built.middleware)).text();
+
+            expect(body).toContain('<title>A &amp; B &lt;c&gt; &quot;d&quot;</title>');
+        });
+
+        it('leaves an apostrophe unescaped, since it is legal in element text', async () => {
+            const built = await buildMiddleware([
+                blogPost({ url: '/blog/y', title: "Vaclav's post", date: '2026-07-04' }),
+            ]);
+
+            const body = await (await fetchFeed(built.middleware)).text();
+
+            expect(body).toContain("<title>Vaclav's post</title>");
+        });
+    });
+
+    describe('a post with no usable date', () => {
+        const undated = [
+            blogPost({ url: '/blog/dated', title: 'Dated', date: '2026-07-04' }),
+            blogPost({ url: '/blog/undated', title: 'Undated' }),
+        ];
+
+        it('still publishes the item, but without a pubDate', async () => {
+            const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            const built = await buildMiddleware(undated);
+
+            const body = await (await fetchFeed(built.middleware)).text();
+            const item = body.slice(body.indexOf('<title>Undated</title>'));
+
+            expect(body).toContain('<title>Undated</title>');
+            expect(item.slice(0, item.indexOf('</item>'))).not.toContain('<pubDate>');
+            expect(warn).toHaveBeenCalled();
+        });
+
+        it('sorts it below every dated post', async () => {
+            vi.spyOn(console, 'warn').mockImplementation(() => {});
+            const built = await buildMiddleware(undated);
+
+            const body = await (await fetchFeed(built.middleware)).text();
+
+            expect(body.indexOf('Dated')).toBeLessThan(body.indexOf('Undated'));
+        });
+
+        it('warns with the post title and URL so the source is findable', async () => {
+            const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            const built = await buildMiddleware(undated);
+
+            await fetchFeed(built.middleware);
+
+            expect(warn).toHaveBeenCalledWith(expect.stringContaining('Undated'));
+            expect(warn).toHaveBeenCalledWith(expect.stringContaining('/blog/undated'));
+        });
+    });
+
+    describe('caching', () => {
+        it('builds the feed once per loader', async () => {
+            await fetchFeed(middleware);
+            await fetchFeed(middleware);
+
+            expect(calls.getPages).toBe(1);
+        });
+
+        it('rebuilds when the loader is replaced', async () => {
+            let current = createFakeLoader(POSTS);
+            const built = await buildMiddleware(POSTS, { loader: () => current.loader });
+
+            await fetchFeed(built.middleware);
+            const first = current.calls.getPages;
+            current = createFakeLoader(POSTS);
+            await fetchFeed(built.middleware);
+
+            expect(first).toBe(1);
+            expect(current.calls.getPages).toBe(1);
+        });
+    });
+
+    describe('when the build fails', () => {
+        /** A loader that cannot be obtained at all – the failure happens before any build starts. */
+        function unobtainableLoader(): () => FakeLoader {
+            return () => {
+                throw new Error('loader unavailable');
+            };
+        }
+
+        /**
+         * A loader that is obtained fine but whose first `getPages()` throws.
+         *
+         * The distinction matters: this failure lands *inside* the cached build promise, which is
+         * the only path that reaches the cache eviction. A loader that throws on the way in never
+         * gets as far as being cached.
+         */
+        function pagesFailOnce(): () => FakeLoader {
+            let failing = true;
+            const working = createFakeLoader(POSTS).loader;
+
+            return () => ({
+                getPage: working.getPage,
+                getPages: () => {
+                    if (failing) {
+                        failing = false;
+                        throw new Error('page extraction failed');
+                    }
+
+                    return working.getPages();
+                },
+            });
+        }
+
+        it('answers 500 rather than a malformed feed when the loader is unavailable', async () => {
+            const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+            const built = await buildMiddleware(POSTS, { loader: unobtainableLoader() });
+
+            const response = await fetchFeed(built.middleware);
+
+            expect(response.status).toBe(500);
+            expect(await response.text()).toBe('Internal error: feed unavailable');
+            expect(error).toHaveBeenCalled();
+        });
+
+        it('answers 500 when the build itself throws', async () => {
+            vi.spyOn(console, 'error').mockImplementation(() => {});
+            const built = await buildMiddleware(POSTS, { loader: pagesFailOnce() });
+
+            const response = await fetchFeed(built.middleware);
+
+            expect(response.status).toBe(500);
+        });
+
+        it('evicts the failed build so the next request retries', async () => {
+            vi.spyOn(console, 'error').mockImplementation(() => {});
+            const built = await buildMiddleware(POSTS, { loader: pagesFailOnce() });
+
+            await fetchFeed(built.middleware);
+            const response = await fetchFeed(built.middleware);
+
+            // Without the eviction, the rejected promise would stay cached and every later
+            // request in this isolate would keep returning 500.
+            expect(response.status).toBe(200);
+            expect(await response.text()).toContain('<title>Newer post</title>');
+        });
+    });
+});

--- a/packages/website/src/markdown-negotiation.test.ts
+++ b/packages/website/src/markdown-negotiation.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Covers `markdownNegotiationPlugin`: both of its branches.
+ *
+ * The plugin exists because `run_worker_first: true` puts the Worker in front of Cloudflare's
+ * static assets, so it has to re-implement assets-first itself. That makes the second branch as
+ * load-bearing as the first: anything it does not negotiate must be forwarded to the `ASSETS`
+ * binding, and only a 404 from that binding may fall through to the next middleware. Getting that
+ * wrong takes the whole site down rather than just the markdown variant, which is why the
+ * forwarding tests assert on the exact request object and on which statuses fall through.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { markdownNegotiationPlugin } from './markdown-negotiation';
+import {
+    createFakeAssets,
+    createMockContext,
+    createPluginMiddleware,
+    type FakeAssets,
+    type PluginMiddleware,
+} from './__test__/hono-context';
+import {
+    createFakeLoader,
+    createFakePage,
+    createMockAppContext,
+    createTextAdapter,
+    type FakeLoaderCalls,
+} from './__test__/press-context';
+
+const MARKDOWN = { accept: 'text/markdown' };
+
+const GETTING_STARTED = createFakePage({
+    url: '/docs/getting-started',
+    title: 'Getting started',
+    description: 'Install and draw your first frame.',
+});
+
+function buildMiddleware(options: { texts?: Map<string, string>; adapters?: 'none' } = {}): {
+    middleware: Promise<PluginMiddleware>;
+    calls: FakeLoaderCalls;
+} {
+    const texts = options.texts ?? new Map([['/docs/getting-started', 'Install the package.']]);
+    const { loader, calls } = createFakeLoader([GETTING_STARTED]);
+    const context = createMockAppContext({
+        loader,
+        adapters: options.adapters === 'none' ? [] : [createTextAdapter(texts)],
+    });
+
+    return { middleware: createPluginMiddleware(markdownNegotiationPlugin(), context), calls };
+}
+
+describe('markdownNegotiationPlugin', () => {
+    let middleware: PluginMiddleware;
+    let calls: FakeLoaderCalls;
+
+    beforeEach(async () => {
+        const built = buildMiddleware();
+        middleware = await built.middleware;
+        calls = built.calls;
+    });
+
+    it('names itself', () => {
+        expect(markdownNegotiationPlugin().name).toBe('markdown-negotiation');
+    });
+
+    describe('negotiating markdown', () => {
+        it('returns the page as markdown with the documented content type', async () => {
+            const harness = createMockContext({
+                url: 'https://blit386.dev/docs/getting-started',
+                headers: MARKDOWN,
+            });
+
+            const response = await harness.run(middleware);
+
+            expect(response?.status).toBe(200);
+            expect(await response?.text()).toBe('# Getting started (/docs/getting-started)\n\nInstall the package.');
+            expect(response?.headers.get('content-type')).toBe('text/markdown; charset=utf-8');
+            expect(harness.nextCalls).toBe(0);
+        });
+
+        it('varies on Accept, since one URL serves both HTML and markdown', async () => {
+            const harness = createMockContext({
+                url: 'https://blit386.dev/docs/getting-started',
+                headers: MARKDOWN,
+            });
+
+            const response = await harness.run(middleware);
+
+            expect(response?.headers.get('vary')).toBe('Accept');
+        });
+
+        it('estimates x-markdown-tokens at four characters per token', async () => {
+            // Hand-computed rather than derived from the response, or the assertion would be
+            // tautological: "# A (/a)\n\nbody" is 14 characters, so ceil(14 / 4) is 4.
+            const page = createFakePage({ url: '/a', title: 'A' });
+            const { loader } = createFakeLoader([page]);
+            const context = createMockAppContext({
+                loader,
+                adapters: [createTextAdapter(new Map([['/a', 'body']]))],
+            });
+            const plugin = await createPluginMiddleware(markdownNegotiationPlugin(), context);
+            const harness = createMockContext({ url: 'https://blit386.dev/a', headers: MARKDOWN });
+
+            const response = await harness.run(plugin);
+
+            expect(await response?.text()).toBe('# A (/a)\n\nbody');
+            expect(response?.headers.get('x-markdown-tokens')).toBe('4');
+        });
+
+        it('answers HEAD with no body but the full-length token count', async () => {
+            const harness = createMockContext({
+                url: 'https://blit386.dev/docs/getting-started',
+                method: 'HEAD',
+                headers: MARKDOWN,
+            });
+
+            const response = await harness.run(middleware);
+
+            expect(await response?.text()).toBe('');
+            expect(response?.headers.get('content-type')).toBe('text/markdown; charset=utf-8');
+            expect(response?.headers.get('x-markdown-tokens')).toBe('16');
+        });
+
+        it('derives page slugs from the request path', async () => {
+            const harness = createMockContext({
+                url: 'https://blit386.dev/docs/getting-started',
+                headers: MARKDOWN,
+            });
+
+            await harness.run(middleware);
+
+            expect(calls.getPage).toEqual([['docs', 'getting-started']]);
+        });
+
+        it('derives empty slugs for the site root', async () => {
+            const harness = createMockContext({ url: 'https://blit386.dev/', headers: MARKDOWN });
+
+            await harness.run(middleware);
+
+            expect(calls.getPage).toEqual([[]]);
+        });
+
+        it('takes the first adapter that returns text', async () => {
+            const { loader } = createFakeLoader([GETTING_STARTED]);
+            const context = createMockAppContext({
+                loader,
+                adapters: [
+                    { 'core:get-text': () => undefined },
+                    createTextAdapter(new Map([['/docs/getting-started', 'from the second adapter']])),
+                ],
+            });
+            const plugin = await createPluginMiddleware(markdownNegotiationPlugin(), context);
+            const harness = createMockContext({
+                url: 'https://blit386.dev/docs/getting-started',
+                headers: MARKDOWN,
+            });
+
+            const response = await harness.run(plugin);
+
+            expect(await response?.text()).toContain('from the second adapter');
+        });
+
+        it('calls the adapter with the app context as `this`', async () => {
+            const { loader } = createFakeLoader([GETTING_STARTED]);
+            let seen: unknown;
+            const context = createMockAppContext({
+                loader,
+                adapters: [
+                    {
+                        'core:get-text'() {
+                            seen = this;
+                            return 'text';
+                        },
+                    },
+                ],
+            });
+            const plugin = await createPluginMiddleware(markdownNegotiationPlugin(), context);
+            const harness = createMockContext({
+                url: 'https://blit386.dev/docs/getting-started',
+                headers: MARKDOWN,
+            });
+
+            await harness.run(plugin);
+
+            expect(seen).toBe(context);
+        });
+    });
+
+    describe('deciding whether markdown was asked for', () => {
+        const cases: [accept: string | undefined, negotiated: boolean][] = [
+            ['text/markdown', true],
+            ['text/markdown;q=0.9,text/html;q=0.8', true],
+            ['text/html', false],
+            // A browser's catch-all must keep getting HTML.
+            ['*/*', false],
+            // Markdown offered, but ranked below HTML.
+            ['text/html,text/markdown;q=0.5', false],
+            [undefined, false],
+        ];
+
+        it.each(cases)('treats Accept %s as negotiated=%s', async (accept, negotiated) => {
+            const assets = createFakeAssets(
+                () => new Response('pre-rendered', { headers: { 'content-type': 'text/html; charset=utf-8' } }),
+            );
+            const harness = createMockContext({
+                url: 'https://blit386.dev/docs/getting-started',
+                headers: accept === undefined ? undefined : { accept },
+                env: { ASSETS: assets },
+            });
+
+            const response = await harness.run(middleware);
+
+            expect(response?.headers.get('content-type')).toBe(
+                negotiated ? 'text/markdown; charset=utf-8' : 'text/html; charset=utf-8',
+            );
+            expect(assets.requests).toHaveLength(negotiated ? 0 : 1);
+        });
+    });
+
+    describe('forwarding to the ASSETS binding', () => {
+        let assets: FakeAssets;
+
+        function assetsHarness(response: Response, overrides: { url?: string; headers?: Record<string, string> } = {}) {
+            assets = createFakeAssets(() => response);
+
+            return createMockContext({
+                url: overrides.url ?? 'https://blit386.dev/logo.svg',
+                headers: overrides.headers,
+                env: { ASSETS: assets },
+            });
+        }
+
+        it('returns the asset response as-is and never delegates', async () => {
+            const asset = new Response('<svg/>', { status: 200, headers: { 'content-type': 'image/svg+xml' } });
+            const harness = assetsHarness(asset);
+
+            const response = await harness.run(middleware);
+
+            expect(response).toBe(asset);
+            expect(harness.nextCalls).toBe(0);
+        });
+
+        it('forwards the original request object untouched', async () => {
+            const harness = assetsHarness(new Response('ok'));
+
+            await harness.run(middleware);
+
+            expect(assets.requests[0]).toBe(harness.context.req.raw);
+        });
+
+        it('falls through to the next middleware when the binding has no such asset', async () => {
+            const harness = assetsHarness(new Response('not found', { status: 404 }));
+
+            const response = await harness.run(middleware);
+
+            // RSC payloads, /mcp, and /api/search all live here: no static asset exists, so the
+            // 404 must not be returned to the client.
+            expect(response).toBeUndefined();
+            expect(harness.nextCalls).toBe(1);
+        });
+
+        it('returns a non-404 error from the binding rather than falling through', async () => {
+            const harness = assetsHarness(new Response('boom', { status: 500 }));
+
+            const response = await harness.run(middleware);
+
+            expect(response?.status).toBe(500);
+            expect(harness.nextCalls).toBe(0);
+        });
+
+        it('forwards a negotiable request whose page does not exist', async () => {
+            const harness = assetsHarness(new Response('ok'), {
+                url: 'https://blit386.dev/nope',
+                headers: MARKDOWN,
+            });
+
+            await harness.run(middleware);
+
+            expect(assets.requests).toHaveLength(1);
+        });
+
+        it('forwards a negotiable request when no adapter can produce text', async () => {
+            const built = buildMiddleware({ adapters: 'none' });
+            const noAdapters = await built.middleware;
+            const harness = assetsHarness(new Response('ok'), {
+                url: 'https://blit386.dev/docs/getting-started',
+                headers: MARKDOWN,
+            });
+
+            await harness.run(noAdapters);
+
+            expect(assets.requests).toHaveLength(1);
+        });
+
+        it('never negotiates a path that already ends in .md', async () => {
+            const harness = assetsHarness(new Response('# raw'), {
+                url: 'https://blit386.dev/docs/getting-started.md',
+                headers: MARKDOWN,
+            });
+
+            const response = await harness.run(middleware);
+
+            // The static `.md` variants the llms.txt plugin emits are already markdown on disk;
+            // re-negotiating them would double-wrap the title heading.
+            expect(await response?.text()).toBe('# raw');
+            expect(response?.headers.get('x-markdown-tokens')).toBeNull();
+            expect(assets.requests).toHaveLength(1);
+        });
+    });
+
+    describe('without an ASSETS binding', () => {
+        it('delegates when the env has no binding', async () => {
+            const harness = createMockContext({ url: 'https://blit386.dev/logo.svg', env: {} });
+
+            const response = await harness.run(middleware);
+
+            expect(response).toBeUndefined();
+            expect(harness.nextCalls).toBe(1);
+        });
+
+        it('delegates when there is no env at all', async () => {
+            const harness = createMockContext({ url: 'https://blit386.dev/logo.svg' });
+
+            await harness.run(middleware);
+
+            expect(harness.nextCalls).toBe(1);
+        });
+    });
+
+    describe('skipping non-readonly methods', () => {
+        it.each(['POST', 'PUT', 'DELETE'])('delegates a %s request without touching the binding', async (method) => {
+            const assets = createFakeAssets(() => new Response('ok'));
+            const harness = createMockContext({
+                url: 'https://blit386.dev/docs/getting-started',
+                method,
+                headers: MARKDOWN,
+                env: { ASSETS: assets },
+            });
+
+            await harness.run(middleware);
+
+            expect(harness.nextCalls).toBe(1);
+            expect(assets.requests).toHaveLength(0);
+        });
+    });
+});

--- a/packages/website/src/mcp-server.test.ts
+++ b/packages/website/src/mcp-server.test.ts
@@ -1,0 +1,602 @@
+/**
+ * Covers `mcpServerPlugin`: the public JSON-RPC 2.0 endpoint at `POST /mcp`.
+ *
+ * This is an external contract – agents call it, so its envelope, error codes, and tool schemas
+ * are as public as the site's HTML. `search_docs` ranking is asserted at the exact weight rather
+ * than as "title beats body", because the documented contract is that a title or description match
+ * counts for ten body matches, and a test that only checks the ordering would still pass if that
+ * multiplier drifted.
+ *
+ * The module's pure helpers (`countMatches`, `buildExcerpt`, `MCP_TOOLS`) stay unexported: every
+ * behavior is observable through `tools/call`, so a test-only export would widen the module's
+ * surface for nothing.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { mcpServerPlugin } from './mcp-server';
+import serverCard from '../public/.well-known/mcp/server-card.json';
+import {
+    createFakeAssets,
+    createMockContext,
+    createPluginMiddleware,
+    type MockContextOptions,
+    type PluginMiddleware,
+} from './__test__/hono-context';
+import {
+    createFakeLoader,
+    createFakePage,
+    createMockAppContext,
+    createTextAdapter,
+    type FakeLoader,
+    type FakeLoaderCalls,
+} from './__test__/press-context';
+
+interface JsonRpcResponse {
+    jsonrpc?: string;
+    id?: unknown;
+    result?: unknown;
+    error?: { code: number; message: string };
+}
+
+/** Issues one JSON-RPC call and returns the parsed envelope plus the raw Response. */
+async function rpc(
+    middleware: PluginMiddleware,
+    body: unknown,
+    options: Omit<MockContextOptions, 'body' | 'method'> = {},
+): Promise<{ response: Response; json: JsonRpcResponse }> {
+    const harness = createMockContext({
+        url: options.url ?? 'https://blit386.dev/mcp',
+        method: 'POST',
+        body: typeof body === 'string' ? body : JSON.stringify(body),
+        ...options,
+    });
+
+    const response = await harness.run(middleware);
+
+    if (response === undefined) {
+        throw new Error('the MCP middleware delegated instead of answering');
+    }
+
+    return { response, json: response.status === 204 ? {} : ((await response.json()) as JsonRpcResponse) };
+}
+
+/** Parses the JSON payload `search_docs` packs into its single text content block. */
+function searchResults(json: JsonRpcResponse): { title: string; url: string; excerpt: string }[] {
+    const result = json.result as { content?: { type: string; text: string }[] } | undefined;
+    const text = result?.content?.[0]?.text;
+
+    if (text === undefined) {
+        throw new Error(`no text content in result: ${JSON.stringify(json)}`);
+    }
+
+    return JSON.parse(text) as { title: string; url: string; excerpt: string }[];
+}
+
+const PAGES = [
+    createFakePage({ url: '/docs/palette', title: 'Palette cycling', description: 'Animate the palette.' }),
+    createFakePage({ url: '/docs/sprites', title: 'Sprites', description: 'Draw sprites.' }),
+];
+
+const TEXTS = new Map([
+    ['/docs/palette', 'Cycling shifts colors without redrawing.'],
+    ['/docs/sprites', 'A sprite is a small bitmap.'],
+]);
+
+function buildMiddleware(options: { loader?: FakeLoader | (() => FakeLoader | Promise<FakeLoader>) } = {}): Promise<{
+    middleware: PluginMiddleware;
+    calls: FakeLoaderCalls;
+    extractions: string[];
+}> {
+    const built = createFakeLoader(PAGES);
+    const extractions: string[] = [];
+    const context = createMockAppContext({
+        loader: options.loader ?? built.loader,
+        adapters: [createTextAdapter(TEXTS, (url) => extractions.push(url))],
+    });
+
+    return createPluginMiddleware(mcpServerPlugin(), context).then((middleware) => ({
+        middleware,
+        calls: built.calls,
+        extractions,
+    }));
+}
+
+describe('mcpServerPlugin', () => {
+    let middleware: PluginMiddleware;
+    let calls: FakeLoaderCalls;
+    let extractions: string[];
+
+    beforeEach(async () => {
+        ({ middleware, calls, extractions } = await buildMiddleware());
+    });
+
+    it('names itself', () => {
+        expect(mcpServerPlugin().name).toBe('mcp-server');
+    });
+
+    describe('routing', () => {
+        it.each([
+            ['GET', 'https://blit386.dev/mcp'],
+            ['POST', 'https://blit386.dev/api/search'],
+        ])('delegates %s %s', async (method, url) => {
+            const harness = createMockContext({ url, method });
+
+            const response = await harness.run(middleware);
+
+            expect(response).toBeUndefined();
+            expect(harness.nextCalls).toBe(1);
+        });
+    });
+
+    describe('malformed input', () => {
+        it('answers a body that is not JSON with -32700', async () => {
+            const { response, json } = await rpc(middleware, '{ not json');
+
+            // JSON-RPC transports errors in the envelope, not the HTTP status.
+            expect(response.status).toBe(200);
+            expect(json).toEqual({
+                jsonrpc: '2.0',
+                id: null,
+                error: { code: -32700, message: 'Parse error' },
+            });
+        });
+
+        it.each([
+            ['an array', []],
+            ['null', null],
+            ['an object with no method', { jsonrpc: '2.0' }],
+            ['a non-string method', { method: 42 }],
+        ])('answers %s with -32600', async (_label, body) => {
+            const { json } = await rpc(middleware, body);
+
+            expect(json).toEqual({
+                jsonrpc: '2.0',
+                id: null,
+                error: { code: -32600, message: 'Invalid Request' },
+            });
+        });
+
+        it('answers an unknown method with -32601 naming it', async () => {
+            const { json } = await rpc(middleware, { jsonrpc: '2.0', id: 7, method: 'foo/bar' });
+
+            expect(json).toEqual({
+                jsonrpc: '2.0',
+                id: 7,
+                error: { code: -32601, message: 'Method not found: foo/bar' },
+            });
+        });
+    });
+
+    describe('handshake', () => {
+        it('reports the protocol version, capabilities, and server identity', async () => {
+            const { json } = await rpc(middleware, { jsonrpc: '2.0', id: 1, method: 'initialize' });
+
+            expect(json.result).toEqual({
+                protocolVersion: '2025-11-25',
+                capabilities: { tools: {} },
+                serverInfo: { name: 'blit386-docs', version: '1.0.0' },
+            });
+        });
+
+        it('agrees with the published server card', async () => {
+            // `public/.well-known/mcp/server-card.json` is what agents read to discover this
+            // endpoint, and nothing else links it to the code.
+            const { json } = await rpc(middleware, { jsonrpc: '2.0', id: 1, method: 'initialize' });
+            const result = json.result as { serverInfo: unknown };
+
+            expect(result.serverInfo).toEqual(serverCard.serverInfo);
+        });
+
+        it.each([
+            ['a string id', 'abc'],
+            ['a numeric id', 12],
+            ['a null id', null],
+        ])('echoes %s', async (_label, id) => {
+            const { json } = await rpc(middleware, { jsonrpc: '2.0', id, method: 'initialize' });
+
+            expect(json.id).toBe(id);
+        });
+
+        it('omits id entirely for a request that carried none', async () => {
+            const { json } = await rpc(middleware, { jsonrpc: '2.0', method: 'initialize' });
+
+            expect(Object.hasOwn(json, 'id')).toBe(false);
+        });
+
+        it('answers notifications/initialized with a bare 204', async () => {
+            const { response } = await rpc(middleware, { jsonrpc: '2.0', method: 'notifications/initialized' });
+
+            expect(response.status).toBe(204);
+            expect(await response.text()).toBe('');
+        });
+    });
+
+    describe('tools/list', () => {
+        it('advertises both tools with their full input schemas', async () => {
+            const { json } = await rpc(middleware, { jsonrpc: '2.0', id: 2, method: 'tools/list' });
+
+            expect(json.result).toEqual({
+                tools: [
+                    {
+                        name: 'search_docs',
+                        description:
+                            'Full-text search across the BLIT386 documentation. Returns matching page titles, URLs, and excerpts.',
+                        inputSchema: {
+                            type: 'object',
+                            properties: {
+                                query: { type: 'string', description: 'Search query, e.g. "palette animation"' },
+                            },
+                            required: ['query'],
+                        },
+                    },
+                    {
+                        name: 'get_docs_summary',
+                        description: 'Return the llms.txt summary of the BLIT386 documentation site.',
+                        inputSchema: { type: 'object', properties: {} },
+                    },
+                ],
+            });
+        });
+    });
+
+    describe('tools/call dispatch', () => {
+        it.each([
+            ['missing params', undefined],
+            ['params that are not an object', 'search_docs'],
+            ['params with a non-string name', { name: 42 }],
+        ])('answers %s with -32602', async (_label, params) => {
+            const { json } = await rpc(middleware, { jsonrpc: '2.0', id: 3, method: 'tools/call', params });
+
+            expect(json).toEqual({
+                jsonrpc: '2.0',
+                id: 3,
+                error: { code: -32602, message: 'Invalid params' },
+            });
+        });
+
+        it('answers an unknown tool with -32601 naming it', async () => {
+            const { json } = await rpc(middleware, {
+                jsonrpc: '2.0',
+                id: 4,
+                method: 'tools/call',
+                params: { name: 'nope' },
+            });
+
+            expect(json).toEqual({
+                jsonrpc: '2.0',
+                id: 4,
+                error: { code: -32601, message: 'Unknown tool: nope' },
+            });
+        });
+    });
+
+    describe('search_docs', () => {
+        /** Runs a search against a purpose-built corpus and returns the ranked results. */
+        async function searchCorpus(
+            query: string,
+            pages: { url: string; title?: string; description?: string; body?: string }[],
+        ) {
+            const { loader } = createFakeLoader(
+                pages.map((page) =>
+                    createFakePage({ url: page.url, title: page.title, description: page.description }),
+                ),
+            );
+            const texts = new Map(pages.filter((p) => p.body !== undefined).map((p) => [p.url, p.body ?? '']));
+            const context = createMockAppContext({ loader, adapters: [createTextAdapter(texts)] });
+            const plugin = await createPluginMiddleware(mcpServerPlugin(), context);
+            const { json } = await rpc(plugin, {
+                jsonrpc: '2.0',
+                id: 1,
+                method: 'tools/call',
+                params: { name: 'search_docs', arguments: { query } },
+            });
+
+            return searchResults(json);
+        }
+
+        it.each([
+            ['a missing query', {}],
+            ['a non-string query', { query: 7 }],
+            ['an empty query', { query: '' }],
+        ])('answers %s with -32602', async (_label, args) => {
+            const { json } = await rpc(middleware, {
+                jsonrpc: '2.0',
+                id: 5,
+                method: 'tools/call',
+                params: { name: 'search_docs', arguments: args },
+            });
+
+            expect(json).toEqual({
+                jsonrpc: '2.0',
+                id: 5,
+                error: { code: -32602, message: 'Invalid params' },
+            });
+        });
+
+        it('returns no results for a query that is only whitespace', async () => {
+            // Non-empty, so it clears the -32602 guard, but it splits into zero terms.
+            const { json } = await rpc(middleware, {
+                jsonrpc: '2.0',
+                id: 5,
+                method: 'tools/call',
+                params: { name: 'search_docs', arguments: { query: '   ' } },
+            });
+
+            expect(searchResults(json)).toEqual([]);
+        });
+
+        it('returns matching pages as a JSON payload in one text content block', async () => {
+            const { json } = await rpc(middleware, {
+                jsonrpc: '2.0',
+                id: 6,
+                method: 'tools/call',
+                params: { name: 'search_docs', arguments: { query: 'palette' } },
+            });
+            const result = json.result as { content: { type: string; text: string }[] };
+
+            expect(result.content).toHaveLength(1);
+            expect(result.content[0]?.type).toBe('text');
+            expect(searchResults(json)).toEqual([
+                {
+                    title: 'Palette cycling',
+                    url: '/docs/palette',
+                    excerpt: 'Cycling shifts colors without redrawing.',
+                },
+            ]);
+        });
+
+        describe('ranking', () => {
+            it('weighs a title match at exactly ten body matches', async () => {
+                // Title match scores 10. Sorting it between an 11-match body and a 9-match body
+                // pins the multiplier: at 5 the title page would sink to last, at 20 it would rise
+                // to first.
+                const results = await searchCorpus('palette', [
+                    { url: '/title', title: 'Palette cycling', body: 'unrelated text' },
+                    { url: '/eleven', title: 'Sprites', body: 'palette '.repeat(11) },
+                    { url: '/nine', title: 'Fonts', body: 'palette '.repeat(9) },
+                ]);
+
+                expect(results.map((r) => r.url)).toEqual(['/eleven', '/title', '/nine']);
+            });
+
+            it('weighs a description match the same as a title match', async () => {
+                // The heading scored against is `${title} ${description}`, so both halves count.
+                const results = await searchCorpus('palette', [
+                    { url: '/described', title: 'Colors', description: 'Palette control.', body: 'nothing here' },
+                    { url: '/nine', title: 'Fonts', body: 'palette '.repeat(9) },
+                ]);
+
+                expect(results.map((r) => r.url)).toEqual(['/described', '/nine']);
+            });
+
+            it('sums the score across every query term', async () => {
+                const results = await searchCorpus('palette sprite', [
+                    { url: '/both', title: 'Guide', body: 'palette sprite' },
+                    { url: '/one', title: 'Guide', body: 'palette' },
+                ]);
+
+                expect(results.map((r) => r.url)).toEqual(['/both', '/one']);
+            });
+
+            it('matches case-insensitively', async () => {
+                const results = await searchCorpus('PALETTE', [{ url: '/p', title: 'X', body: 'the palette' }]);
+
+                expect(results).toHaveLength(1);
+            });
+
+            it('ignores extra whitespace between terms', async () => {
+                const results = await searchCorpus('  palette   sprite ', [
+                    { url: '/both', title: 'X', body: 'palette sprite' },
+                ]);
+
+                expect(results).toHaveLength(1);
+            });
+
+            it('drops pages that match nothing', async () => {
+                const results = await searchCorpus('palette', [
+                    { url: '/hit', title: 'X', body: 'palette' },
+                    { url: '/miss', title: 'Y', body: 'nothing relevant' },
+                ]);
+
+                expect(results.map((r) => r.url)).toEqual(['/hit']);
+            });
+
+            it('caps the response at ten results', async () => {
+                const pages = Array.from({ length: 12 }, (_unused, i) => ({
+                    url: `/page-${i}`,
+                    title: 'Palette',
+                    body: 'palette',
+                }));
+
+                const results = await searchCorpus('palette', pages);
+
+                expect(results).toHaveLength(10);
+            });
+        });
+
+        describe('excerpts', () => {
+            it('returns a short body verbatim', async () => {
+                const results = await searchCorpus('palette', [
+                    { url: '/p', title: 'X', body: 'palette cycling is cheap' },
+                ]);
+
+                expect(results[0]?.excerpt).toBe('palette cycling is cheap');
+            });
+
+            it('windows a mid-body match and marks both truncations', async () => {
+                const body = `${'x'.repeat(200)} palette ${'y'.repeat(200)}`;
+
+                const results = await searchCorpus('palette', [{ url: '/p', title: 'X', body }]);
+                const excerpt = results[0]?.excerpt ?? '';
+
+                expect(excerpt.startsWith('...')).toBe(true);
+                expect(excerpt.endsWith('...')).toBe(true);
+                expect(excerpt).toContain('palette');
+                // 80 characters of radius on each side, plus the two ellipses.
+                expect(excerpt.length).toBeLessThanOrEqual(166);
+            });
+
+            it('centers on the earliest matched term, not the first term given', async () => {
+                const body = `zebra${'x'.repeat(300)}palette`;
+
+                const results = await searchCorpus('palette zebra', [{ url: '/p', title: 'X', body }]);
+
+                expect(results[0]?.excerpt.startsWith('zebra')).toBe(true);
+            });
+
+            it('falls back to the description when the page has no body', async () => {
+                const results = await searchCorpus('palette', [
+                    { url: '/p', title: 'Palette', description: 'The palette guide.' },
+                ]);
+
+                expect(results[0]?.excerpt).toBe('The palette guide.');
+            });
+
+            it('falls back to the description when the body is only whitespace', async () => {
+                const results = await searchCorpus('palette', [
+                    { url: '/p', title: 'Palette', description: 'The palette guide.', body: '   \n  ' },
+                ]);
+
+                expect(results[0]?.excerpt).toBe('The palette guide.');
+            });
+        });
+
+        describe('corpus caching', () => {
+            const call = { jsonrpc: '2.0', id: 1, method: 'tools/call' } as const;
+            const search = { name: 'search_docs', arguments: { query: 'palette' } };
+
+            it('extracts each page once across repeated searches', async () => {
+                await rpc(middleware, { ...call, params: search });
+                await rpc(middleware, { ...call, params: search });
+
+                expect(calls.getPages).toBe(1);
+                expect(extractions).toEqual(['/docs/palette', '/docs/sprites']);
+            });
+
+            it('shares one extraction between concurrent first requests', async () => {
+                // The promise is cached, not the resolved value, which is what makes this hold.
+                await Promise.all([
+                    rpc(middleware, { ...call, params: search }),
+                    rpc(middleware, { ...call, params: search }),
+                ]);
+
+                expect(calls.getPages).toBe(1);
+            });
+
+            it('re-extracts when the loader is replaced', async () => {
+                let current = createFakeLoader(PAGES).loader;
+                const built = await buildMiddleware({ loader: () => current });
+
+                await rpc(built.middleware, { ...call, params: search });
+                current = createFakeLoader(PAGES).loader;
+                await rpc(built.middleware, { ...call, params: search });
+
+                expect(built.extractions).toHaveLength(PAGES.length * 2);
+            });
+
+            it('answers -32603 when the loader cannot be obtained', async () => {
+                const context = createMockAppContext({
+                    loader: (): FakeLoader => {
+                        throw new Error('loader unavailable');
+                    },
+                    adapters: [createTextAdapter(TEXTS)],
+                });
+                const plugin = await createPluginMiddleware(mcpServerPlugin(), context);
+
+                const { json } = await rpc(plugin, { ...call, params: search });
+
+                expect(json.error).toEqual({ code: -32603, message: 'Internal error: search unavailable' });
+            });
+
+            it('evicts a failed extraction so the next search retries', async () => {
+                // The failure has to land inside the cached promise – a loader that throws on the
+                // way in never gets as far as being cached. Here the adapter rejects, so
+                // `Promise.all` rejects and the eviction path is the one under test. Without it,
+                // one transient failure would poison search_docs for the isolate's whole life.
+                let failing = true;
+                const context = createMockAppContext({
+                    loader: createFakeLoader(PAGES).loader,
+                    adapters: [
+                        {
+                            'core:get-text'(page) {
+                                if (failing) {
+                                    return Promise.reject(new Error('extraction failed'));
+                                }
+
+                                return TEXTS.get(page.url);
+                            },
+                        },
+                    ],
+                });
+                const plugin = await createPluginMiddleware(mcpServerPlugin(), context);
+
+                const failure = await rpc(plugin, { ...call, params: search });
+                expect(failure.json.error).toEqual({ code: -32603, message: 'Internal error: search unavailable' });
+
+                failing = false;
+                const recovery = await rpc(plugin, { ...call, params: search });
+                expect(recovery.json.error).toBeUndefined();
+                expect(searchResults(recovery.json)).toHaveLength(1);
+            });
+        });
+    });
+
+    describe('get_docs_summary', () => {
+        const call = {
+            jsonrpc: '2.0',
+            id: 8,
+            method: 'tools/call',
+            params: { name: 'get_docs_summary' },
+        };
+        const UNAVAILABLE = { code: -32603, message: 'Internal error: summary unavailable' };
+
+        it('returns the llms.txt body from the ASSETS binding', async () => {
+            const assets = createFakeAssets(() => new Response('# BLIT386 docs'));
+
+            const { json } = await rpc(middleware, call, { env: { ASSETS: assets } });
+
+            expect(json.result).toEqual({ content: [{ type: 'text', text: '# BLIT386 docs' }] });
+        });
+
+        it('resolves llms.txt against the incoming origin rather than the public hostname', async () => {
+            // A Worker fetching its own zone hostname times out with Cloudflare 522, and that error
+            // page used to be wrapped as a successful result. Serving from the binding, at the
+            // origin the request actually arrived on, is what avoids both.
+            const assets = createFakeAssets(() => new Response('# next'));
+
+            await rpc(middleware, call, {
+                url: 'https://next.blit386.dev/mcp',
+                env: { ASSETS: assets },
+            });
+
+            expect(assets.requests[0]?.url).toBe('https://next.blit386.dev/llms.txt');
+        });
+
+        it.each([
+            ['there is no binding', {}],
+            ['there is no env at all', undefined],
+        ])('answers -32603 when %s', async (_label, env) => {
+            const { json } = await rpc(middleware, call, env === undefined ? {} : { env });
+
+            expect(json.error).toEqual(UNAVAILABLE);
+        });
+
+        it.each([404, 500])('answers -32603 when the binding returns %i', async (status) => {
+            const assets = createFakeAssets(() => new Response('nope', { status }));
+
+            const { json } = await rpc(middleware, call, { env: { ASSETS: assets } });
+
+            expect(json.error).toEqual(UNAVAILABLE);
+        });
+
+        it('answers -32603 when the binding throws', async () => {
+            const assets = createFakeAssets(() => {
+                throw new Error('binding exploded');
+            });
+
+            const { json } = await rpc(middleware, call, { env: { ASSETS: assets } });
+
+            expect(json.error).toEqual(UNAVAILABLE);
+        });
+    });
+});

--- a/packages/website/src/mcp-server.ts
+++ b/packages/website/src/mcp-server.ts
@@ -176,6 +176,15 @@ export function mcpServerPlugin<C extends ConfigContext = ConfigContext>(): Serv
                             };
                         }),
                     );
+
+                    // Evict on failure, the same way feed.ts does. Caching the promise is what
+                    // lets concurrent first requests share one extraction, but it also means a
+                    // rejected promise would otherwise stay cached and poison search_docs for
+                    // the rest of the isolate's life.
+                    corpus.catch(() => {
+                        corpusCache.delete(loader);
+                    });
+
                     corpusCache.set(loader, corpus);
                 }
                 return corpus;

--- a/packages/website/vitest.config.ts
+++ b/packages/website/vitest.config.ts
@@ -1,0 +1,49 @@
+import { defineConfig } from 'vitest/config';
+
+/**
+ * Vitest covers `src/**` – the Fumapress `ServerPlugin`s that run in the deployed Worker.
+ *
+ * The `scripts/**` suite stays on `node --test` (see `test:scripts` in package.json): it is
+ * plain `.mjs` with `node:assert`, it runs in under a second, and migrating it would be churn.
+ * Two runners in one package is the same split `packages/blit386` already uses.
+ *
+ * Plain Vitest rather than `@cloudflare/vitest-pool-workers` – see `CLAUDE.md`, "Test runners",
+ * for the trade-off and the accepted fidelity gap.
+ */
+export default defineConfig({
+    test: {
+        include: ['src/**/*.test.ts'],
+        exclude: ['node_modules', 'dist', '.source'],
+
+        // The plugins under test import `fumapress` type-only, so esbuild strips those imports
+        // and Waku never loads. Node supplies Request/Response/Headers, which is the entire
+        // web-standard surface the plugins touch – no setup file and no DOM are needed.
+        environment: 'node',
+
+        coverage: {
+            provider: 'v8',
+
+            // The Worker plugins plus the one data module with logic in it. `src/data/authors.ts`,
+            // `community.ts`, `demos.ts`, and `site.ts` are static content constants with no
+            // branches, and `src/components/**` is React – both are deliberately outside the
+            // denominator rather than padding it.
+            include: ['src/*.ts', 'src/data/api-history.ts'],
+            exclude: ['src/**/*.test.ts', 'src/__test__/**', 'src/css-modules.d.ts'],
+
+            thresholds: {
+                statements: 80,
+                branches: 80,
+                functions: 80,
+                lines: 80,
+            },
+            // The text table omits files at 100%, so a module missing from it is covered rather
+            // than skipped. `--coverage.reporter=json-summary` lists every file if you need to
+            // confirm one is in the denominator.
+            reporter: ['text', 'text-summary'],
+            reportsDirectory: 'coverage',
+        },
+
+        globals: false,
+        reporters: ['default'],
+    },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,6 +298,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
+      '@vitest/coverage-v8':
+        specifier: ^4.1.10
+        version: 4.1.10(vitest@4.1.10)
       '@webgpu/types':
         specifier: ^0.1.71
         version: 0.1.71
@@ -328,6 +331,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))
       wrangler:
         specifier: 4.114.0
         version: 4.114.0
@@ -8052,6 +8058,14 @@ snapshots:
     optionalDependencies:
       vite: 8.1.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)
 
+  '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)
+
   '@vitest/pretty-format@4.1.10':
     dependencies:
       tinyrainbow: 3.1.0
@@ -11607,6 +11621,35 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.20.1
+      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
+      happy-dom: 20.11.1
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.10(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.5(@types/node@25.9.5)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.9.5
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
       happy-dom: 20.11.1
     transitivePeerDependencies:


### PR DESCRIPTION
Closes BT-440. Follow-up filed as BT-464.

## Why

`packages/website` had 166 passing tests, all over `scripts/**`. The six modules under `src/` that actually run in the deployed Worker had none – not for lack of effort, but because `test` was `node --test`, which cannot load `.ts`. There was no runner that could even import them.

## The runner decision

Plain Vitest, over `@cloudflare/vitest-pool-workers`. The pool is version-compatible (it peers `vitest ^4.1.0`, the major this workspace already resolves), so that was not the blocker. Three things were:

1. **The fidelity it buys is not fidelity this code needs.** The contract with the `ASSETS` binding is one method and one status check – `assets.fetch(request)`, then `status !== 404`. A double is faithful to that. `run_worker_first` is Wrangler configuration rather than code, and `patch-wrangler.test.mjs` already asserts it.
2. **A real binding needs `assets.directory` pointing at `dist/public`**, which exists only after a build – and `preflight` runs `test` before `build`. A fixture directory avoids that at the cost of a second, test-only Wrangler config to keep in step with the real one, which is exactly the config drift BT-322 exists to remove.
3. **It would weaken the channel-headers test.** `workerd` has no populated `process.env`, so a `process.env` implementation would fail there for the wrong reason. Under Node the test can point `process.env.BLIT386_CHANNEL` at the opposite value from `c.env` and assert the binding still wins.

Accepted gap: nothing here exercises `workerd`'s immutable response headers. That gap produced BT-464. Both the decision and the gap are recorded in `packages/website/CLAUDE.md`.

All six modules import `fumapress` type-only, so esbuild strips those imports and Vitest never loads Waku or RSC. `hono` is not a dependency of this package, so the Hono types in the harness are recovered structurally from `ServerPlugin['createMiddlewares']` rather than imported.

## The two pinned behaviors, verified by mutation

A test that cannot fail is worthless, so both guards were checked by breaking the implementation and watching them go red, not only by passing.

| Mutation | Result |
| --- | --- |
| `channel-headers.ts` reads `process.env` at module scope | 5 of 11 fail |
| `channel-headers.ts` reads `process.env` per request | 6 of 11 fail |
| `markdown-negotiation.ts` returns the ASSETS 404 instead of falling through | 1 fails |
| `markdown-negotiation.ts` drops the ASSETS forwarding entirely | 10 of 27 fail |

The two channel-headers tests run in opposite directions on purpose: one sets `process.env` to `production` while `c.env` says `next` (killing both a module-scope constant and a lazy read), the other reverses it (killing a `process.env || c.env` fallback).

## Three latent bugs fixed rather than pinned

Each found while writing the tests, each landing with the test that proves it:

- **`mcp-server.ts` cached a rejected corpus promise forever.** Unlike `feed.ts` it had no `promise.catch(() => cache.delete(loader))`, so one transient extraction failure poisoned `search_docs` for the isolate's whole life.
- **`api-history.ts` read through to `Object.prototype`.** `getSymbol('toString')` returned a function typed as `SymbolHistory`, and `getPageSymbols('constructor')` returned a function instead of `[]` – the `?? []` never fires, because the inherited value is not nullish. Both now guard with `Object.hasOwn`.
- **`compareVersions` returned `NaN` for any non-numeric segment.** `'1.5.0-beta.1'.split('.').map(Number)` yields `NaN`, and an `Array.prototype.sort` comparator returning `NaN` has implementation-defined behavior. Nothing hits it today; the first prerelease would. Prereleases now sort below their release.

The first of these is why the "recovers after a failed extraction" tests failed the coverage report on their first draft: they threw from `getLoader`, which happens *before* the promise is cached, so they never reached the eviction line they claimed to test. Both were rewritten to fail inside the cached promise.

## Numbers

| | Before | After |
| --- | --- | --- |
| `scripts/**` tests | 166 pass, 30 suites | 166 pass, 30 suites (unchanged) |
| `src/**` tests | none, no runner | 150 pass, 6 suites |
| `test:scripts` | 1.20 s | 1.03 s |
| `test` (both suites, with coverage) | 1.20 s | 1.78 s |
| `preflight` | 28.9 s | 25.7 s, 27.2 s |

The `scripts/**` suite is untouched and still under a second – the attributable cost of this change is the +0.58 s on `test`. The `preflight` figures are all warm-cache runs and sit inside normal run-to-run variance for the Waku build, which dominates the total; read them as "no regression" rather than as a speedup.

Coverage over the six modules is 99.54% statements, 95.45% branches, 100% functions, gated at 80% via `test:unit:coverage`, which `test` calls – so `preflight` and the `quality-website` CI job both enforce it with no workflow change.

## Notable

- **BT-249 substantially overlaps this.** It asks for coverage of `mcp-server`, `markdown-negotiation`, and `webmcp`. The first two are done here; `public/webmcp.js` is not. It wants re-scoping or closing.
- `cspell.json` gains one word, `workerd` – a product name, alongside the existing `Wrangler` / `Waku` / `Fumapress`. The other two spellcheck hits were my own phrasing and were reworded instead.

## Review round

CodeRabbit found that the `NaN`-freedom guarantee in the `compareVersions` fix was not actually total: `Number('9'.repeat(400))` is `Infinity`, so two equal oversized segments subtracted to `NaN` – the very thing the new JSDoc claimed could not happen. Verified by reproducing it with a failing test before touching the implementation (`expected NaN to be +0`).

Fixed in 63f7914f by comparing digit strings instead of floats: strip leading zeros, longer wins, equal lengths compare lexicographically – which for equal-length digit strings is numeric order. No ceiling, and no `BigInt` for a comparison that never needed arithmetic. `compareVersions` now returns strictly -1/0/1 rather than a difference; both callers (`page-changelog.tsx:67`, `api-availability.tsx:25`) use it as a sign-only comparator, so the narrowing is safe.

Not reachable from real data – version segments come from engine `@since` tags and `package.json`, not user input – but the docstring made an absolute claim and a test asserted it, so the choice was to make the claim true or weaken it. Making it true was cheap. Four regression tests added, including that leading-zero stripping is now covered behavior (`1.007.0` equals `1.7.0`).

## Test plan

- [x] `pnpm --filter blit386-website run test:scripts` – 166 pass, 30 suites, unchanged
- [x] `pnpm --filter blit386-website run test:unit` – 150 pass, 6 suites
- [x] `pnpm --filter blit386-website run test:unit:coverage` – 80% thresholds met with room
- [x] Mutation-checked both pinned behaviors in both directions, reverted
- [x] `pnpm --filter blit386-website run preflight` – green
- [x] CI `quality-website` green, with the new suite visible in the `Run tests` step – on 63f7914f the job log shows `# tests 166 / # pass 166 / # fail 0` from `node --test`, then `Test Files 6 passed (6)`, `Statements : 99.54% ( 220/221 )` and `Branches : 95.45% ( 147/154 )` from Vitest

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved API version comparison, including prerelease versions and malformed inputs.
  - Prevented inherited properties from being interpreted as documented API data.
  - Documentation searches can now retry after a failed initial data load instead of remaining unavailable.

- **Documentation**
  - Expanded website guidance for quality checks, test coverage, test commands, watch mode, and supported plugins.

- **Tests**
  - Added broad coverage for feeds, documentation search, Markdown negotiation, MCP tools, channel headers, API history, and blog dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



