### PR TITLE
docs(website): record why channel-headers can mutate the ASSETS response

### DIFF
--- a/packages/website/CLAUDE.md
+++ b/packages/website/CLAUDE.md
@@ -80,7 +80,10 @@ in under a second, and rewriting it would be churn with no gain.
   implementation would fail there for the wrong reason. Under Node the test can point `process.env.BLIT386_CHANNEL` at
   the opposite value from `c.env` and assert the binding still wins – which no `process.env` implementation can pass.
 
-Accepted gap: nothing here exercises `workerd`'s immutable response headers (see BT-464). Revisit the choice if `src/`
+Accepted gap: nothing here exercises `workerd`'s response-header mutability. BT-464 asked whether that gap hid a bug –
+`channel-headers.ts` mutates the `ASSETS` response in place, which the fetch spec forbids – and the answer was no:
+workerd does not enforce the `immutable` guard, confirmed against the deployed `blit386-next` Worker. The reasoning is
+recorded in `src/channel-headers.ts` beside the line in question; do not re-derive it. Revisit the choice if `src/`
 grows a Durable Object, KV, or any code that branches on real binding semantics rather than on a single `fetch`.
 
 Shared harness in `src/__test__/` (same convention as the engine package): `hono-context.ts` fakes the Hono context and

--- a/packages/website/content/docs/reference/testing.mdx
+++ b/packages/website/content/docs/reference/testing.mdx
@@ -3,7 +3,7 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Testing"
 description: "Testing tiers (unit, integration, visual) plus CPU benchmarks and WebGPU mocks."
-lastModified: "2026-08-02T08:54:14+02:00"
+lastModified: "2026-08-08T14:20:19+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/reference-testing.md"
 ---
 

--- a/packages/website/src/channel-headers.ts
+++ b/packages/website/src/channel-headers.ts
@@ -44,6 +44,21 @@ export function channelHeadersPlugin<C extends ConfigContext = ConfigContext>():
                     }
 
                     await next();
+
+                    // Mutates the downstream response in place, and that is verified rather than
+                    // assumed (BT-464). Hono does NOT clone here: `set res` only reconstructs when
+                    // `c.res` had already been read, and nothing upstream reads it, so after
+                    // `next()` this `c.res` is the very object `markdownNegotiationPlugin`
+                    // returned – which for a static asset is `c.env.ASSETS.fetch()`'s response.
+                    // Fetch-spec headers on such a response are guarded `immutable` and `set()`
+                    // would throw `TypeError: immutable`; workerd does not enforce that guard, so
+                    // the write lands. Confirmed against the deployed `blit386-next` Worker: an
+                    // image, a font, and a doc page all return 200 with `X-Robots-Tag: noindex`,
+                    // and Workers Logs records no exception for any of them.
+                    //
+                    // If a runtime or Hono upgrade ever does surface `TypeError: immutable` here,
+                    // the fix is to own the response rather than reorder the plugin chain:
+                    // `c.res = new Response(c.res.body, c.res)` before setting the header.
                     c.res.headers.set('x-robots-tag', 'noindex');
                 },
             ];


### PR DESCRIPTION
Closes BT-464.

BT-464 was a hypothesis, not a confirmed failure: `channel-headers.ts` ends its middleware with
`await next(); c.res.headers.set('x-robots-tag', 'noindex')`, and `markdownNegotiationPlugin`
(registered right after it) returns the `ASSETS` binding's response directly. Fetch-spec headers on
such a response are guarded `immutable`, so `set()` should throw `TypeError: immutable`.

## It does not reproduce

Against the deployed `blit386-next` Worker, with `wrangler tail blit386-next` running:

| Path | Status | `X-Robots-Tag` |
| --- | --- | --- |
| `/logo/og.png` | 200 | `noindex` |
| `/fonts/DepartureMono-Regular.woff2` | 200 | `noindex` |
| `/docs/getting-started` | 200 | `noindex` |

HEAD and GET both. Workers Logs recorded `"outcome": "ok"` and an empty `exceptions` array for every
one of them. `workerd` does not enforce the `immutable` guard, so the in-place write lands.

## The ticket's explanation was wrong

The ticket attributed the survival to Hono handing back a mutable clone. It does not. `set res` in
`hono@4.13.0` reconstructs only when `c.res` had already been read, nothing upstream reads it, and an
identity check confirms it:

```
c.res === inner (no clone): true
inner mutated? noindex
```

So the write succeeds because of the runtime, not the framework. Worth correcting rather than leaving
in the record, since a future reader could otherwise treat "Hono clones" as a guarantee.

## What changed

No code change – a defensive rewrite that was never needed is the worse outcome. Only:

- a comment in `src/channel-headers.ts` recording the mechanism, the evidence, and the fix to reach
  for (`c.res = new Response(c.res.body, c.res)`) if a runtime or Hono upgrade ever does surface the
  `TypeError`
- the matching correction to the accepted-gap note in `packages/website/CLAUDE.md`, which pointed at
  BT-464 as an open question
- a regenerated docs-mirror `lastModified` (the expected one-commit-behind self-correction)

Explicitly not done, per the ticket's out-of-scope list: no reordering of the plugin chain in
`press.config.tsx`, and no `@cloudflare/vitest-pool-workers`.

## Test plan

- [x] `pnpm --filter blit386-website run preflight` – green (needs `pnpm --filter blit386 run build`
      first in a fresh worktree, otherwise the Twoslash script tests fail on an unresolvable
      `blit386` import)
- [x] Live `curl` against `next.blit386.dev` for an image, a font, and a doc page, cross-checked
      against `wrangler tail blit386-next`
- [x] Hono `set res` identity check against the resolved `hono@4.13.0`
- [ ] No deploy needed – nothing executable changed

Unrelated observation while reading the `robots.txt` response: Cloudflare's zone-level managed
content block is prepended to it on `next.blit386.dev` and strips `X-Robots-Tag` on GET. The Worker's
disallow-all body is still served (the response ends in `User-agent: *` / `Disallow: /`, where
production ends in `Allow: /`), so the preview channel remains excluded from indexing. Not touched
here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
