### PR TITLE
fix(demos): match en dash and hyphen in navLabel prefix strip

### DIFF
--- a/packages/demos/package.json
+++ b/packages/demos/package.json
@@ -48,7 +48,7 @@
     "check:demo-registry": "node scripts/check-demo-registry.mjs",
     "capture:demo": "node scripts/capture-demo-clip.mjs",
     "generate:audio-loops": "node scripts/generate-audio-loops.mjs",
-    "test": "node --test scripts/__tests__/*.test.mjs",
+    "test": "node --test scripts/__tests__/*.test.mjs plugins/__tests__/*.test.mjs",
     "preflight": "pnpm run format:check && pnpm run lint && pnpm run test && pnpm run spellcheck && pnpm run knip && pnpm run check:demo-registry && pnpm run build",
     "knip": "cd ../.. && knip --workspace packages/demos",
     "knip:fix": "knip --fix",

--- a/packages/demos/plugins/__tests__/demo-registry.test.mjs
+++ b/packages/demos/plugins/__tests__/demo-registry.test.mjs
@@ -1,0 +1,21 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { deriveShortTitle } from '../demo-registry.js';
+
+describe('deriveShortTitle', () => {
+    test('strips a BLIT386 Demo prefix written with an en dash', () => {
+        const header = '// @pageTitle BLIT386 Demo – PipBoy CRT\n';
+        assert.equal(deriveShortTitle('crt-pipboy', header), 'PipBoy CRT');
+    });
+
+    test('strips a BLIT386 Demo prefix written with an ASCII hyphen', () => {
+        const header = '// @pageTitle BLIT386 Demo - PipBoy CRT\n';
+        assert.equal(deriveShortTitle('crt-pipboy', header), 'PipBoy CRT');
+    });
+
+    test('falls back to the title-cased slug when there is no @pageTitle override', () => {
+        const header = '// A demo with no page title override.\n';
+        assert.equal(deriveShortTitle('sprite-effects', header), 'Sprite Effects');
+    });
+});

--- a/packages/demos/plugins/demo-registry.js
+++ b/packages/demos/plugins/demo-registry.js
@@ -9,7 +9,7 @@ const FILENAME_PATTERN = /^([a-z][a-z0-9]*(?:-[a-z0-9]+)*)\.js$/;
 const PAGE_TITLE_PATTERN = /@pageTitle\s+(.+?)(?:\s*\*\/|\r?\n|$)/;
 // Strip a branded `@pageTitle` prefix (with or without a legacy NNN / 00a id) so nav labels
 // stay short regardless of how each demo's override is written.
-const PAGE_TITLE_PREFIX_PATTERN = /^BLIT386 Demo (?:(?:[0-9]{3}|00a) )?-\s*/;
+const PAGE_TITLE_PREFIX_PATTERN = /^BLIT386 Demo (?:(?:[0-9]{3}|00a) )?[-–]\s*/;
 const HEADER_SCAN_BYTES = 2000;
 
 // Demos excluded from the banner's fuzzy combobox and prev/next chain. They remain fully
@@ -132,7 +132,7 @@ function deriveTitle(slug, header) {
  * @param {string} header – First chunk of the JS source (to scan for @pageTitle)
  * @returns {string}
  */
-function deriveShortTitle(slug, header) {
+export function deriveShortTitle(slug, header) {
     const override = header.match(PAGE_TITLE_PATTERN);
 
     if (override) {


### PR DESCRIPTION
## Summary
- `PAGE_TITLE_PREFIX_PATTERN` only matched an ASCII hyphen, but every `@pageTitle` override (`crt-pipboy`, `crt-toggle`, `music`, `logo-lowres`) uses an en dash, so `deriveShortTitle`'s `.replace()` was a silent no-op and `navLabel` kept the full branded prefix instead of the bare topic (BT-465).
- Widened the pattern to accept either dash character. Left the demo headers as-is — they must use an en dash per `scripts/check-dash-typography.mjs`.
- Exported `deriveShortTitle` and added a regression test covering both dash characters plus the no-`@pageTitle` fallback path.

## Test plan
- [x] `pnpm run test` (packages/demos) — new `deriveShortTitle` cases pass alongside the existing suite
- [x] Reproduced BT-465: `buildRegistry` now reports `navLabel` as `PipBoy CRT`, `CRT Toggle`, `Music Playback`, `Logo Low-Res` for the four affected slugs
- [x] `pnpm run preflight` (packages/demos) — format, lint, tests, spellcheck, knip, registry check, build all pass