### PR TITLE
test(website): add unit coverage for public/webmcp.js

### DIFF
--- a/packages/website/CLAUDE.md
+++ b/packages/website/CLAUDE.md
@@ -60,7 +60,7 @@ Two, deliberately, matching the split `packages/blit386` already runs:
 | Suite | Runner | Script | Covers |
 | --- | --- | --- | --- |
 | `scripts/__tests__/*.test.mjs` | `node --test` | `test:scripts` | The build and sync scripts |
-| `src/**/*.test.ts` | Vitest | `test:unit` | The `ServerPlugin`s that run in the deployed Worker |
+| `src/**/*.test.ts` | Vitest | `test:unit` | The `ServerPlugin`s that run in the deployed Worker, plus `public/webmcp.js` |
 
 `pnpm run test` runs both, the second with coverage; `preflight` and the `quality-website` CI job call it, so neither
 needs its own wiring. The `scripts/**` suite stays on `node --test` because it is `node:assert` throughout, it finishes
@@ -96,6 +96,18 @@ Two behaviors in that suite are regression guards rather than ordinary coverage,
 (break the implementation, watch the test go red) rather than only by passing: `channel-headers.ts` reading the channel
 at request time, and `markdown-negotiation.ts` forwarding to `ASSETS` and falling through only on a 404. If you refactor
 either, expect those tests to be the ones that stop you.
+
+`src/webmcp.test.ts` covers `public/webmcp.js`, the browser-side WebMCP bridge – a different shape of problem from the
+four `ServerPlugin`s above, since it is a plain `<script defer>` (`press.config.tsx`), not `type="module"`, with no
+`import`/`export` of its own. It is deliberately outside `tsconfig.json`'s `include` (it targets `document.modelContext`
+/ `navigator.modelContext`, an experimental API with no `lib.dom.d.ts` types), so the test reads the file as text and
+runs it with `vm.runInThisContext({ filename })` against stubbed `document` / `navigator` / `window` / `fetch` rather
+than statically or dynamically `import`-ing it – TS refuses to import a non-module script anyway, and doing so would
+pull the file back into the type-checked program. The `filename` option is required, not cosmetic: without it,
+`@vitest/coverage-v8` attributes execution to an anonymous `evalmachine` script and `public/webmcp.js` reports 0%
+despite full coverage. `public/webmcp.js` is included in `vitest.config.ts`'s `coverage.include` for exactly this reason
+– it is the one file under `public/` with real branching logic (the `navigate` tool's path-injection guards), unlike the
+static `.well-known/` JSON.
 
 ## What is hand-authored and what is generated
 

--- a/packages/website/src/webmcp.test.ts
+++ b/packages/website/src/webmcp.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Covers the WebMCP bridge script served at `/webmcp.js`.
+ *
+ * It is a browser-side IIFE with no exports and is deliberately outside `tsconfig.json`'s
+ * `include` – it targets `document.modelContext` / `navigator.modelContext`, an experimental
+ * WebMCP API with no `lib.dom.d.ts` types, and typechecking it would mean either widening the
+ * ambient globals or sprinkling `any`. Statically or dynamically `import`-ing it from a test would
+ * pull it back into the TypeScript program (and TS refuses anyway – a script with no
+ * `import`/`export` statements of its own is not a module); `press.config.tsx` also loads it as a
+ * plain `<script defer src="/webmcp.js">`, not `type="module"`, so an ESM import would not even
+ * match how the browser runs it. Each test instead reads the file as text once (`WEBMCP_SOURCE`,
+ * from a hardcoded relative path to this repo's own file – never interpolated with external
+ * input) and runs it with `vm.runInThisContext`, Node's primitive for evaluating trusted source
+ * against the current global scope, so it sees that test's stubbed `document` / `navigator` /
+ * `window` / `fetch` exactly as a real `<script>` load would.
+ *
+ * The `navigate` tool's origin check is the one regression guard worth calling out. Checking
+ * `path.startsWith('//')` alone does not stop every protocol-relative bypass: the URL spec's
+ * parser treats a backslash the same as a forward slash for the `https:` scheme, so
+ * `new URL('/\\evil.com', 'https://blit386.dev')` resolves to `https://evil.com` even though the
+ * string never contains `//`. The `resolved.origin !== window.location.origin` check after
+ * resolution is what actually blocks it – the "backslash bypass" case below exercises that string
+ * to prove the origin check, not the prefix check, is carrying the guarantee.
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { runInThisContext } from 'node:vm';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type ToolCallOptions = { signal: AbortSignal };
+
+interface ToolDefinition {
+    name: string;
+    title: string;
+    description: string;
+    inputSchema: Record<string, unknown>;
+    execute: (args?: Record<string, unknown>) => Promise<unknown>;
+    annotations?: { readOnlyHint?: boolean };
+}
+
+interface FetchResponse {
+    ok: boolean;
+    status: number;
+    json?: () => Promise<unknown>;
+    text?: () => Promise<string>;
+}
+
+const WEBMCP_PATH = fileURLToPath(new URL('../public/webmcp.js', import.meta.url));
+const WEBMCP_SOURCE = readFileSync(WEBMCP_PATH, 'utf8');
+
+function expectDefined<T>(value: T | undefined, message: string): T {
+    if (value === undefined) throw new Error(message);
+    return value;
+}
+
+function createRegisterToolMock() {
+    return vi.fn(async (_tool: ToolDefinition, _opts: ToolCallOptions) => {});
+}
+
+function createAddEventListenerMock() {
+    return vi.fn((_type: string, _listener: () => void, _options?: { once?: boolean }) => {});
+}
+
+function createAssignMock() {
+    return vi.fn((_url: URL) => {});
+}
+
+function createFetchMock() {
+    return vi.fn(async (_input: string): Promise<FetchResponse> => ({ ok: true, status: 200 }));
+}
+
+function stubBrowserGlobals(
+    options: {
+        modelContext?: { registerTool: ReturnType<typeof createRegisterToolMock> };
+        navigatorModelContext?: { registerTool: ReturnType<typeof createRegisterToolMock> };
+    } = {},
+) {
+    const addEventListener = createAddEventListenerMock();
+    const assign = createAssignMock();
+    const location = { origin: 'https://blit386.dev', assign };
+    const fetchMock = createFetchMock();
+
+    vi.stubGlobal('document', { modelContext: options.modelContext });
+    vi.stubGlobal('navigator', { modelContext: options.navigatorModelContext });
+    vi.stubGlobal('window', { addEventListener, location });
+    vi.stubGlobal('fetch', fetchMock);
+
+    return { addEventListener, assign, location, fetchMock };
+}
+
+function loadWebmcp(): void {
+    // The `filename` here is what lets @vitest/coverage-v8 attribute execution back to the real
+    // source file – without it, V8 reports coverage against an anonymous "evalmachine" script and
+    // `public/webmcp.js` shows 0% despite every test exercising it.
+    runInThisContext(WEBMCP_SOURCE, { filename: WEBMCP_PATH });
+}
+
+async function registerAndGetTools(registerTool: ReturnType<typeof createRegisterToolMock>): Promise<ToolDefinition[]> {
+    loadWebmcp();
+    await vi.waitFor(() => expect(registerTool).toHaveBeenCalledTimes(3));
+    return registerTool.mock.calls.map(([tool]) => tool);
+}
+
+function findTool(tools: ToolDefinition[], name: string): ToolDefinition {
+    return expectDefined(
+        tools.find((candidate) => candidate.name === name),
+        `${name} tool was not registered`,
+    );
+}
+
+describe('webmcp.js', () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    describe('bootstrapping', () => {
+        it('does nothing when neither document nor navigator expose modelContext', () => {
+            const { addEventListener } = stubBrowserGlobals();
+
+            loadWebmcp();
+
+            expect(addEventListener).not.toHaveBeenCalled();
+        });
+
+        it('prefers document.modelContext over navigator.modelContext', async () => {
+            const documentRegisterTool = createRegisterToolMock();
+            const navigatorRegisterTool = createRegisterToolMock();
+            stubBrowserGlobals({
+                modelContext: { registerTool: documentRegisterTool },
+                navigatorModelContext: { registerTool: navigatorRegisterTool },
+            });
+
+            loadWebmcp();
+            await vi.waitFor(() => expect(documentRegisterTool).toHaveBeenCalledTimes(3));
+
+            expect(navigatorRegisterTool).not.toHaveBeenCalled();
+        });
+
+        it('falls back to navigator.modelContext when document has none', async () => {
+            const navigatorRegisterTool = createRegisterToolMock();
+            stubBrowserGlobals({ navigatorModelContext: { registerTool: navigatorRegisterTool } });
+
+            loadWebmcp();
+
+            await vi.waitFor(() => expect(navigatorRegisterTool).toHaveBeenCalledTimes(3));
+        });
+
+        it('registers all three tools under one AbortSignal, and aborts it on unload', async () => {
+            const registerTool = createRegisterToolMock();
+            const { addEventListener } = stubBrowserGlobals({ modelContext: { registerTool } });
+
+            loadWebmcp();
+            await vi.waitFor(() => expect(registerTool).toHaveBeenCalledTimes(3));
+
+            const names = registerTool.mock.calls.map(([tool]) => tool.name);
+            expect(names).toEqual(['navigate', 'search_documentation', 'get_documentation_summary']);
+
+            const signals = registerTool.mock.calls.map(([, opts]) => opts.signal);
+            expect(new Set(signals).size).toBe(1);
+            const [firstSignal] = signals;
+            const signal = expectDefined(firstSignal, 'expected at least one registerTool call');
+            expect(signal.aborted).toBe(false);
+
+            expect(addEventListener).toHaveBeenCalledWith('unload', expect.any(Function), { once: true });
+            const firstCall = expectDefined(
+                addEventListener.mock.calls[0],
+                'expected addEventListener to have been called',
+            );
+            const [, onUnload] = firstCall;
+            onUnload();
+
+            expect(signal.aborted).toBe(true);
+        });
+    });
+
+    describe('navigate', () => {
+        let assign: ReturnType<typeof createAssignMock>;
+        let tools: ToolDefinition[];
+
+        beforeEach(async () => {
+            const registerTool = createRegisterToolMock();
+            const stubs = stubBrowserGlobals({ modelContext: { registerTool } });
+            assign = stubs.assign;
+            tools = await registerAndGetTools(registerTool);
+        });
+
+        it('resolves a site-relative path and navigates to it', async () => {
+            const result = await findTool(tools, 'navigate').execute({ path: '/docs/getting-started' });
+
+            expect(result).toEqual({ navigating: true, path: '/docs/getting-started' });
+            expect(assign).toHaveBeenCalledTimes(1);
+            const firstCall = expectDefined(
+                assign.mock.calls[0],
+                'expected window.location.assign to have been called',
+            );
+            const [resolvedUrl] = firstCall;
+            expect(String(resolvedUrl)).toBe('https://blit386.dev/docs/getting-started');
+        });
+
+        it.each<[string, unknown]>([
+            ['a non-string path', 42],
+            ['a path with no leading slash', 'docs/getting-started'],
+            ['a literal protocol-relative path', '//evil.com'],
+            ['a backslash bypass of the // check', '/\\evil.com'],
+        ])('rejects %s without navigating', async (_label, path) => {
+            const result = await findTool(tools, 'navigate').execute({ path });
+
+            expect(result).toEqual({ error: 'Invalid path: must be a site-relative path starting with /' });
+            expect(assign).not.toHaveBeenCalled();
+        });
+
+        it('rejects a path the URL constructor cannot parse', async () => {
+            class ThrowingUrl {
+                constructor() {
+                    throw new TypeError('invalid URL');
+                }
+            }
+            vi.stubGlobal('URL', ThrowingUrl);
+
+            const result = await findTool(tools, 'navigate').execute({ path: '/anything' });
+
+            expect(result).toEqual({ error: 'Invalid path: must be a site-relative path starting with /' });
+            expect(assign).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('search_documentation', () => {
+        let fetchMock: ReturnType<typeof createFetchMock>;
+        let tools: ToolDefinition[];
+
+        beforeEach(async () => {
+            const registerTool = createRegisterToolMock();
+            const stubs = stubBrowserGlobals({ modelContext: { registerTool } });
+            fetchMock = stubs.fetchMock;
+            tools = await registerAndGetTools(registerTool);
+        });
+
+        it('is read-only', () => {
+            expect(findTool(tools, 'search_documentation').annotations?.readOnlyHint).toBe(true);
+        });
+
+        it('fetches the encoded query and returns the parsed results', async () => {
+            fetchMock.mockResolvedValue({ ok: true, status: 200, json: async () => ({ results: ['a'] }) });
+
+            const result = await findTool(tools, 'search_documentation').execute({ query: 'palette & animation' });
+
+            expect(fetchMock).toHaveBeenCalledWith('/api/search?query=palette%20%26%20animation');
+            expect(result).toEqual({ results: ['a'] });
+        });
+
+        it('reports the status without parsing the body when the request fails', async () => {
+            const json = vi.fn();
+            fetchMock.mockResolvedValue({ ok: false, status: 500, json });
+
+            const result = await findTool(tools, 'search_documentation').execute({ query: 'anything' });
+
+            expect(result).toEqual({ error: 'Search request failed: 500' });
+            expect(json).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('get_documentation_summary', () => {
+        let fetchMock: ReturnType<typeof createFetchMock>;
+        let tools: ToolDefinition[];
+
+        beforeEach(async () => {
+            const registerTool = createRegisterToolMock();
+            const stubs = stubBrowserGlobals({ modelContext: { registerTool } });
+            fetchMock = stubs.fetchMock;
+            tools = await registerAndGetTools(registerTool);
+        });
+
+        it('is read-only', () => {
+            expect(findTool(tools, 'get_documentation_summary').annotations?.readOnlyHint).toBe(true);
+        });
+
+        it('fetches /llms.txt and wraps the body as content', async () => {
+            fetchMock.mockResolvedValue({ ok: true, status: 200, text: async () => '# BLIT386 docs' });
+
+            const result = await findTool(tools, 'get_documentation_summary').execute();
+
+            expect(fetchMock).toHaveBeenCalledWith('/llms.txt');
+            expect(result).toEqual({ content: '# BLIT386 docs' });
+        });
+
+        it('reports the status when the fetch fails', async () => {
+            fetchMock.mockResolvedValue({ ok: false, status: 404 });
+
+            const result = await findTool(tools, 'get_documentation_summary').execute();
+
+            expect(result).toEqual({ error: 'Failed to fetch documentation summary: 404' });
+        });
+    });
+});

--- a/packages/website/vitest.config.ts
+++ b/packages/website/vitest.config.ts
@@ -23,11 +23,12 @@ export default defineConfig({
         coverage: {
             provider: 'v8',
 
-            // The Worker plugins plus the one data module with logic in it. `src/data/authors.ts`,
-            // `community.ts`, `demos.ts`, and `site.ts` are static content constants with no
-            // branches, and `src/components/**` is React – both are deliberately outside the
-            // denominator rather than padding it.
-            include: ['src/*.ts', 'src/data/api-history.ts'],
+            // The Worker plugins plus the one data module with logic in it, plus the WebMCP bridge
+            // script (a browser IIFE, not a Worker plugin, hence living under `public/` rather
+            // than `src/`). `src/data/authors.ts`, `community.ts`, `demos.ts`, and `site.ts` are
+            // static content constants with no branches, and `src/components/**` is React – both
+            // are deliberately outside the denominator rather than padding it.
+            include: ['src/*.ts', 'src/data/api-history.ts', 'public/webmcp.js'],
             exclude: ['src/**/*.test.ts', 'src/__test__/**', 'src/css-modules.d.ts'],
 
             thresholds: {


### PR DESCRIPTION
## Summary

- Closes the last gap in [BT-249](https://linear.app/vancura/issue/BT-249/add-test-coverage-for-publicwebmcpjs-path-injection-guards-tool): `mcp-server.ts` and `markdown-negotiation.ts` are already covered by BT-440 ([#513](https://github.com/blit386/blit386/pull/513)); this adds `src/webmcp.test.ts` for the remaining uncovered surface, `public/webmcp.js` (the browser-side WebMCP bridge).
- `webmcp.js` runs as a plain `<script defer>`, not an ES module, so the test reads it as text and evaluates it with `vm.runInThisContext({ filename })` against stubbed `document`/`navigator`/`window`/`fetch` rather than `import`-ing it — that keeps it out of the type-checked program (it targets an experimental API with no `lib.dom.d.ts` types) while still letting `@vitest/coverage-v8` attribute execution back to the real file.
- Adds `public/webmcp.js` to `vitest.config.ts`'s `coverage.include` so a regression here now fails the 80% threshold gate.
- Documents the harness choice in `packages/website/CLAUDE.md`.

## Test plan

- [x] `pnpm run test` — 166/166 passing (16 new tests for `webmcp.js`, covering tool registration precedence/`AbortSignal` wiring, the `navigate` tool's path-injection guards including a backslash bypass of the naive `//` check, and success/failure paths for `search_documentation`/`get_documentation_summary`)
- [x] `public/webmcp.js` at 100% statements/branches/functions/lines
- [x] `pnpm run preflight` (format, typecheck, spellcheck, knip, build, docs-sync) — all green
- [x] Pre-push checks (full-repo docs:links, agents:check, dash-typography) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive automated coverage for the WebMCP browser integration.
  * Verified model-context selection, tool registration, unload behavior, navigation security, documentation searches, and error handling.
  * Included the browser script in coverage reporting.
* **Documentation**
  * Updated testing guidance for the browser integration, including execution, browser API stubs, and coverage requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->