### PR TITLE
fix(website): fix dark-mode CSS-module bugs and polish site-wide styling

### DIFF
--- a/packages/website/content/blog/audio-release-1-3-0.mdx
+++ b/packages/website/content/blog/audio-release-1-3-0.mdx
@@ -8,8 +8,6 @@ tags: [release, audio]
 author: vancura
 ---
 
-<AuthorByline author="vancura" />
-
 For three releases BLIT386 could draw a sprite, cycle a palette, warp the whole screen through a CRT shader, and then
 sit there in complete silence, like a very pretty aquarium. Every demo I built ended the same way: I got the pixels
 right, moved on to the sound, remembered there was no sound, and shipped it anyway. That gap is closed now. 1.3.0 is the

--- a/packages/website/content/blog/hello-world.mdx
+++ b/packages/website/content/blog/hello-world.mdx
@@ -8,8 +8,6 @@ tags: [announcement]
 author: vancura
 ---
 
-<AuthorByline author="vancura" />
-
 BLIT386 is a pixel-art rendering engine for TypeScript. Palette-indexed by default, WebGPU first, and when WebGPU is not
 there it quietly drops down to a Canvas 2D software renderer instead of falling over. It all runs in the browser – no
 server, nothing to deploy but static files.

--- a/packages/website/content/blog/hot-reload-release-1-4-0.mdx
+++ b/packages/website/content/blog/hot-reload-release-1-4-0.mdx
@@ -8,8 +8,6 @@ tags: [release, hot-reload]
 author: vancura
 ---
 
-<AuthorByline author="vancura" />
-
 The old loop went like this: you tweak a number in `update()`, hit save, the page blinks, and you are back at the title
 screen with a fresh palette, a camera at the origin, and a character standing exactly where they were not when you found
 the bug. So you walk them back. Twelve seconds, maybe fifteen, and you do it four hundred times a day. Nobody complains

--- a/packages/website/content/docs/reference/testing.mdx
+++ b/packages/website/content/docs/reference/testing.mdx
@@ -3,7 +3,7 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Testing"
 description: "Testing tiers (unit, integration, visual) plus CPU benchmarks and WebGPU mocks."
-lastModified: "2026-08-02T08:54:14+02:00"
+lastModified: "2026-08-08T14:20:19+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/reference-testing.md"
 ---
 

--- a/packages/website/press.config.tsx
+++ b/packages/website/press.config.tsx
@@ -13,7 +13,6 @@ import { blogPlugin } from 'fumapress/plugins/blog';
 import { takumiPlugin } from 'fumapress/plugins/takumi';
 import { createRootLayout } from 'fumapress/layouts/root';
 import { createDocsLayoutPage } from 'fumapress/layouts/docs';
-import { EditOnGitHub } from 'fumadocs-ui/layouts/docs/page';
 import { feedPlugin } from './src/feed';
 import { markdownNegotiationPlugin } from './src/markdown-negotiation';
 import { mcpServerPlugin } from './src/mcp-server';
@@ -81,7 +80,7 @@ const rootLayout = createRootLayout({
 
 /**
  * Page-data shape carried by the `docs` collection's schema `.extend()` in `source.config.ts`:
- * `lastModified` and `editUrl` are injected into every synced page's frontmatter by
+ * `lastModified` is injected into every synced page's frontmatter by
  * `scripts/sync-docs-from-engine.mjs`. `createDocsLayoutPage` is generic over `ConfigContext`
  * but defaults to a bare `PageData`, so this narrows `page.data` for the `render()` callback
  * below without threading the full multi-source (`docs` + `blog`) content type through it.
@@ -96,7 +95,6 @@ interface DocsPageData extends PageData {
      * `rawLastModified(page)` below rather than trusting `page.data.lastModified` directly.
      */
     lastModified?: Date;
-    editUrl?: string;
 }
 
 /**
@@ -121,13 +119,12 @@ interface DocsLayoutContext extends ConfigContext {
 const docsPageLayout = createDocsLayoutPage<DocsLayoutContext>({
     /**
      * Renders the doc body ourselves (instead of leaving it to the default `render-body`
-     * fallback) so an "Edit on GitHub" link can be appended after it.
+     * fallback) so the last-updated date can be appended after it.
      *
-     * `getGitHubFileUrl` (the framework's built-in edit-link resolver) is intentionally not
-     * used: it needs `siteConfig.git`, which is unset here, and even if set it would compute a
-     * URL into this package's generated MDX rather than the true source in `packages/blit386`.
-     * `editUrl` is injected into each page's frontmatter by `sync-docs-from-engine.mjs`
-     * instead (see `CLAUDE.md`, Documentation mirror), so it is read directly from `page.data`.
+     * There is deliberately no "Edit on GitHub" link here: this is a single-maintainer site,
+     * so the link's only ever audience already has the source open locally, and the
+     * framework's built-in resolver (`getGitHubFileUrl`) would have pointed at this package's
+     * generated MDX rather than the true source in `packages/blit386` regardless.
      */
     async render(page) {
         let body: ReactNode;
@@ -144,8 +141,6 @@ const docsPageLayout = createDocsLayoutPage<DocsLayoutContext>({
         if (body === undefined) {
             throw new Error('[press.config] docsPageLayout: no adapter could render this page body');
         }
-
-        const editUrl = page.data.editUrl;
 
         // Deliberately NOT returning `lastModified` here to feed the framework's own
         // `<PageLastUpdate>` (rendered automatically by `createDocsLayoutPage` whenever
@@ -187,7 +182,6 @@ const docsPageLayout = createDocsLayoutPage<DocsLayoutContext>({
             body: (
                 <>
                     {body}
-                    {editUrl && <EditOnGitHub href={editUrl} />}
                     {formattedLastModified && (
                         <p className="text-sm text-fd-muted-foreground">Last updated on {formattedLastModified}</p>
                     )}

--- a/packages/website/src/app.css
+++ b/packages/website/src/app.css
@@ -103,11 +103,41 @@
     @apply font-heading font-normal;
 }
 
+/* Native text selection: same accent-on/inverted-code treatment as an active row in the
+   command palette ([role='dialog'] & [aria-selected='true'] above) and a hovered
+   [data-card], so highlighting text reads as part of this site rather than the browser
+   default blue. Dark-mode forks use an explicit `.dark` ancestor prefix rather than the
+   `dark:` variant: `@apply dark:...` compiles to `&:where(.dark, .dark *)` appended after
+   the pseudo-element, which is invalid there - there is no self-or-ancestor match to make
+   against `::selection` in that position, so the fork silently never applied.
+
+   `:is()`, not `:where()`, on the code selector list: `:where()` always carries zero
+   specificity, so the code-specific color lost to the plain `.dark ::selection` class
+   selector below it. `:is()` takes on the specificity of its most specific branch instead,
+   so it reliably wins - the code-base rule is placed after `.dark ::selection` so it beats
+   it on source order too, for the (0,1,1)-vs-(0,1,1) tie that `:is()` alone doesn't resolve. */
+::selection {
+    @apply bg-fd-accent text-white;
+}
+
+.dark ::selection {
+    @apply text-black;
+}
+
+:is(code, .shiki, .shiki *)::selection {
+    @apply bg-white text-fd-primary;
+}
+
+.dark :is(code, .shiki, .shiki *)::selection {
+    @apply bg-black;
+}
+
 .shiki code {
     @apply leading-loose rounded-none;
 }
 
 #nd-sidebar,
+#nd-sidebar-mobile,
 #nd-toc {
     @apply select-none;
 }
@@ -154,9 +184,26 @@
     @apply h-24;
 }
 
-#nd-subnav {
-    --fd-header-height: 80px;
+/* fumadocs-ui computes --fd-docs-row-2 (the mobile "Features" TOC-popover's sticky top
+   offset) on #nd-docs-layout itself, from --fd-header-height inherited at THAT scope - not
+   from whatever #nd-subnav (the actual mobile logo bar, sized via the same variable) sets
+   on itself. A local override on #nd-subnav alone resizes the bar but never reaches back up
+   to #nd-docs-layout, so the default 56px baseline stays in the row-2 calc while the real
+   bar is 80px tall: the TOC-popover sticks 24px too high and scrolls in under the bar
+   instead of below it. Setting it here instead, where the calc actually reads it, both fixes
+   the offset and cascades down into #nd-subnav's own height (no local override needed there).
 
+   Scoped to the same `max-md` (< 768px) range #nd-subnav itself uses (`md:hidden` on the bar,
+   `max-md:layout:[...]` on its own height): #nd-subnav is unrendered at md and above, so an
+   unconditional override here reserved 80px of dead space in the row-2 calc on tablet too,
+   pushing the TOC-popover down with nothing above it to justify the gap. */
+@media (width < 48rem) {
+    #nd-docs-layout {
+        --fd-header-height: 80px;
+    }
+}
+
+#nd-subnav {
     & button {
         @apply rounded-none transition-none cursor-pointer hover:text-white dark:hover:text-black;
     }
@@ -185,7 +232,8 @@
     }
 
     & h1 {
-        @apply text-[66px] antialiased uppercase mt-7 leading-16;
+        @apply text-[66px] max-xl:text-[44px] max-sm:text-[22px] antialiased uppercase mt-7;
+        @apply leading-16 max-xl:leading-11 max-sm:leading-6;
     }
 }
 
@@ -314,6 +362,13 @@ code {
         @apply font-sans;
     }
 
+    /* Same divider as the one above the page's first content (.prose.flex-1's own
+       border-t-fd-card border-2 pt-8) - repeated before every h2 so each section break
+       reads the same way, not just the very first one. */
+    & h2 {
+        @apply border-t-2 border-t-fd-card pt-10;
+    }
+
     & table {
         @apply rounded-none border-2 border-fd-card;
 
@@ -335,7 +390,7 @@ code {
     }
 
     & [data-card] {
-        @apply rounded-none pb-9 transition-none;
+        @apply rounded-none pb-9 transition-none select-none;
         @apply shadow-[0_2px_var(--color-fd-background),0_4px_var(--color-fd-card)];
 
         & h3,
@@ -352,6 +407,10 @@ code {
                 & h3,
                 & h4 {
                     @apply text-white dark:text-black;
+                }
+
+                & code {
+                    @apply bg-white text-fd-primary dark:bg-black;
                 }
             }
         }
@@ -510,4 +569,15 @@ code {
     & .shiki {
         @apply bg-fd-popover;
     }
+}
+
+/* fumadocs-twoslash ships z-index:50 on .fd-twoslash-popover itself, but that element
+   is the Base UI Popup, not the fixed-position Positioner that actually controls
+   page-level stacking (see the "Radix positioning wrapper" note above) - a z-index on a
+   statically positioned inner box has no effect on stacking order. Target the wrapper
+   structurally, since Base UI does not expose a stable class/attribute for it here, and
+   go above every other z-index this site sets (search dialog and popover primitive both
+   cap at 50) so the popover always wins. */
+:has(> .fd-twoslash-popover) {
+    z-index: 60 !important;
 }

--- a/packages/website/src/app.css
+++ b/packages/website/src/app.css
@@ -579,5 +579,5 @@ code {
    go above every other z-index this site sets (search dialog and popover primitive both
    cap at 50) so the popover always wins. */
 :has(> .fd-twoslash-popover) {
-    z-index: 60 !important;
+    z-index: 60;
 }

--- a/packages/website/src/components/author-byline.tsx
+++ b/packages/website/src/components/author-byline.tsx
@@ -23,7 +23,7 @@ export function AuthorByline({ author }: AuthorBylineProps) {
     }
 
     return (
-        <div className={`not-prose ${styles.container}`}>
+        <div className={`not-prose mb-0! pb-0! ${styles.container}`}>
             {entry.avatar && (
                 <img
                     src={entry.avatar}

--- a/packages/website/src/components/blog-index.module.css
+++ b/packages/website/src/components/blog-index.module.css
@@ -1,3 +1,5 @@
+/** biome-ignore-all lint/correctness/noUnknownPseudoClass: :global() is valid CSS Modules syntax Biome's linter doesn't recognize yet, even though its parser accepts it */
+
 @reference '../app.css';
 
 .index {

--- a/packages/website/src/components/blog-index.module.css
+++ b/packages/website/src/components/blog-index.module.css
@@ -9,7 +9,8 @@
 }
 
 .heading {
-    @apply text-[66px] uppercase antialiased leading-16 text-fd-foreground;
+    @apply text-[66px] max-xl:text-[44px] max-sm:text-[22px] uppercase antialiased text-fd-foreground;
+    @apply leading-16 max-xl:leading-11 max-sm:leading-6;
 }
 
 .tagsLink {
@@ -28,17 +29,42 @@
 }
 
 .cardTitle {
-    @apply font-departure text-[22px] uppercase antialiased leading-6 text-balance group-hover:text-fd-background;
+    @apply font-departure text-[22px] uppercase antialiased leading-6 text-balance;
+
+    @media (hover: hover) {
+        :global(.group):hover & {
+            @apply text-fd-background;
+        }
+    }
 }
 
 .cardDescription {
-    @apply text-sm text-balance group-hover:text-fd-background;
+    @apply text-sm text-balance;
+
+    @media (hover: hover) {
+        :global(.group):hover & {
+            @apply text-fd-background;
+        }
+    }
 }
 
 .cardDate {
-    @apply mt-auto text-xs group-hover:text-fd-background;
+    @apply mt-auto text-xs;
+
+    @media (hover: hover) {
+        :global(.group):hover & {
+            @apply text-fd-background;
+        }
+    }
 }
 
 .card {
-    @apply flex flex-col gap-4 overflow-hidden bg-fd-card p-4 hover:bg-fd-accent;
+    @apply flex flex-col gap-4 bg-fd-card p-4 transition-none select-none;
+    @apply shadow-[0_2px_var(--color-fd-background),0_4px_var(--color-fd-card)];
+
+    @media (hover: hover) {
+        &:hover {
+            @apply bg-fd-accent shadow-[0_2px_var(--color-fd-background),0_4px_var(--color-fd-primary)];
+        }
+    }
 }

--- a/packages/website/src/components/blog-page.module.css
+++ b/packages/website/src/components/blog-page.module.css
@@ -4,8 +4,13 @@
     @apply mb-4 flex flex-col gap-2;
 }
 
+/* Matches the docs breadcrumb pill (#nd-page > div.text-sm a in app.css): same
+   bg-fd-card chip, py-1.5 px-3 padding, and stepped shadow, so the "back" link reads as
+   the same kind of small nav pill instead of a bare underlined text link. */
 .backLink {
-    @apply w-fit text-sm text-fd-muted-foreground hover:text-fd-accent-foreground;
+    @apply w-fit rounded-none py-1.5 px-3 text-sm font-medium text-fd-foreground transition-opacity;
+    @apply bg-fd-card hover:opacity-80;
+    @apply shadow-[0_2px_var(--color-fd-background),0_4px_var(--color-fd-card)];
 }
 
 .meta {
@@ -18,4 +23,11 @@
 
 .tag {
     @apply rounded-lg bg-fd-primary px-1.5 py-0.5 text-fd-primary-foreground;
+}
+
+/* End-of-post mark: a filled box glued to the end of the last block, magazine-style.
+   Scoped to .prose > *:last-child so it lands on whatever the post actually ends with
+   (paragraph, list, code block, ...) without touching individual post MDX. */
+.body :global(.prose) > *:last-child::after {
+    @apply mt-4 mb-15 block content-['■'];
 }

--- a/packages/website/src/components/blog-page.module.css
+++ b/packages/website/src/components/blog-page.module.css
@@ -1,3 +1,5 @@
+/** biome-ignore-all lint/correctness/noUnknownPseudoClass: :global() is valid CSS Modules syntax Biome's linter doesn't recognize yet, even though its parser accepts it */
+
 @reference '../app.css';
 
 .header {

--- a/packages/website/src/components/blog-page.tsx
+++ b/packages/website/src/components/blog-page.tsx
@@ -5,6 +5,7 @@ import { getBlogContext } from 'fumapress/plugins/blog';
 import { DocsBody, DocsDescription, DocsPage, DocsTitle } from 'fumadocs-ui/layouts/docs/page';
 import type { TOCItemType } from 'fumadocs-core/toc';
 import Link from 'fumadocs-core/link';
+import { AuthorByline } from './author-byline';
 import styles from './blog-page.module.css';
 
 type BlogPost = AppContext['$context']['page'];
@@ -62,7 +63,7 @@ async function renderToc(ctx: AppContext, page: BlogPost): Promise<TOCItemType[]
 export async function BlogPage({ page }: BlogPageProps) {
     const ctx = getPressContext();
     const { indexPath } = getBlogContext();
-    const data = page.data as { title: string; description?: string; tags?: string[] };
+    const data = page.data as { title: string; description?: string; tags?: string[]; author?: string };
     const [body, toc] = await Promise.all([renderBody(ctx, page), renderToc(ctx, page)]);
 
     return (
@@ -76,6 +77,8 @@ export async function BlogPage({ page }: BlogPageProps) {
 
                 <DocsTitle>{data.title}</DocsTitle>
                 <DocsDescription>{data.description}</DocsDescription>
+
+                {data.author && <AuthorByline author={data.author} />}
 
                 {/*{(date || (tags && tags.length > 0)) && (
                     <div className={styles.meta}>
@@ -91,7 +94,9 @@ export async function BlogPage({ page }: BlogPageProps) {
                 )}*/}
             </div>
 
-            <DocsBody>{body}</DocsBody>
+            <div className={styles.body}>
+                <DocsBody>{body}</DocsBody>
+            </div>
         </DocsPage>
     );
 }

--- a/packages/website/src/components/community-connect.module.css
+++ b/packages/website/src/components/community-connect.module.css
@@ -1,7 +1,7 @@
 @reference '../app.css';
 
 .heading {
-    @apply mb-4 text-xl font-semibold text-fd-foreground;
+    @apply mb-4 text-2xl font-normal text-fd-foreground;
 }
 
 .comingSoon {

--- a/packages/website/src/components/demo-showcase.module.css
+++ b/packages/website/src/components/demo-showcase.module.css
@@ -44,10 +44,13 @@
 }
 
 .card {
-    @apply flex flex-col overflow-hidden bg-fd-card hover:bg-fd-accent;
+    @apply flex flex-col bg-fd-card p-0.5 transition-none select-none;
+    @apply shadow-[0_2px_var(--color-fd-background),0_4px_var(--color-fd-card)];
 
     @media (hover: hover) {
         &:hover {
+            @apply bg-fd-accent shadow-[0_2px_var(--color-fd-background),0_4px_var(--color-fd-primary)];
+
             & .cardTitle,
             & .cardDescription {
                 @apply text-fd-background;

--- a/packages/website/src/components/page-changelog.module.css
+++ b/packages/website/src/components/page-changelog.module.css
@@ -8,12 +8,44 @@
     @apply flex flex-col gap-2;
 }
 
+/* Matches real prose h3 (e.g. FAQ page: DegularText, 20px, font-normal, 32px leading) -
+   this heading opts out of prose styling via the wrapping not-prose, so it has to be
+   replicated explicitly rather than inherited. */
 .versionHeading {
-    @apply text-lg font-semibold text-fd-foreground;
+    @apply text-[20px] font-normal leading-8 text-fd-foreground;
 }
 
 .versionDate {
     @apply text-sm font-normal text-fd-muted-foreground;
+}
+
+/* A version with no release date hasn't shipped yet - flag it in red instead of the
+   usual fd-primary accent, so an unreleased entry reads as "not out yet" rather than
+   blending in with released ones.
+
+   :global(.dark) prefix, not the `dark:` variant: `@apply dark:...` compiles to
+   `&:where(.dark, .dark *)`, and CSS Modules scoping then locally hashes that literal
+   `.dark` token (it can't tell it's meant to reference the real, unscoped <html> class),
+   so it never matches and the dark-mode color silently never applied. Same failure mode
+   as the `.group` fix in blog-index.module.css, different mechanism. */
+.unreleased {
+    & .versionHeading {
+        @apply text-red-600;
+    }
+
+    & .added {
+        @apply border-red-600 text-red-600;
+    }
+}
+
+:global(.dark) .unreleased {
+    & .versionHeading {
+        @apply text-red-400;
+    }
+
+    & .added {
+        @apply border-red-400 text-red-400;
+    }
 }
 
 .eventList {

--- a/packages/website/src/components/page-changelog.module.css
+++ b/packages/website/src/components/page-changelog.module.css
@@ -1,3 +1,5 @@
+/** biome-ignore-all lint/correctness/noUnknownPseudoClass: :global() is valid CSS Modules syntax Biome's linter doesn't recognize yet, even though its parser accepts it */
+
 @reference '../app.css';
 
 .changelog {
@@ -17,35 +19,6 @@
 
 .versionDate {
     @apply text-sm font-normal text-fd-muted-foreground;
-}
-
-/* A version with no release date hasn't shipped yet - flag it in red instead of the
-   usual fd-primary accent, so an unreleased entry reads as "not out yet" rather than
-   blending in with released ones.
-
-   :global(.dark) prefix, not the `dark:` variant: `@apply dark:...` compiles to
-   `&:where(.dark, .dark *)`, and CSS Modules scoping then locally hashes that literal
-   `.dark` token (it can't tell it's meant to reference the real, unscoped <html> class),
-   so it never matches and the dark-mode color silently never applied. Same failure mode
-   as the `.group` fix in blog-index.module.css, different mechanism. */
-.unreleased {
-    & .versionHeading {
-        @apply text-red-600;
-    }
-
-    & .added {
-        @apply border-red-600 text-red-600;
-    }
-}
-
-:global(.dark) .unreleased {
-    & .versionHeading {
-        @apply text-red-400;
-    }
-
-    & .added {
-        @apply border-red-400 text-red-400;
-    }
 }
 
 .eventList {
@@ -79,4 +52,37 @@
 
 .note {
     @apply text-fd-muted-foreground;
+}
+
+/* A version with no release date hasn't shipped yet - flag it in red instead of the
+   usual fd-primary accent, so an unreleased entry reads as "not out yet" rather than
+   blending in with released ones.
+
+   :global(.dark) prefix, not the `dark:` variant: `@apply dark:...` compiles to
+   `&:where(.dark, .dark *)`, and CSS Modules scoping then locally hashes that literal
+   `.dark` token (it can't tell it's meant to reference the real, unscoped <html> class),
+   so it never matches and the dark-mode color silently never applied. Same failure mode
+   as the `.group` fix in blog-index.module.css, different mechanism.
+
+   Declared after .added (not just after .category) so its higher-specificity `& .added`
+   override reads later than the base rule it overrides - Biome's noDescendingSpecificity
+   flags the reverse order as likely-unintended, even though it works correctly either way. */
+.unreleased {
+    & .versionHeading {
+        @apply text-red-600;
+    }
+
+    & .added {
+        @apply border-red-600 text-red-600;
+    }
+}
+
+:global(.dark) .unreleased {
+    & .versionHeading {
+        @apply text-red-400;
+    }
+
+    & .added {
+        @apply border-red-400 text-red-400;
+    }
 }

--- a/packages/website/src/components/page-changelog.tsx
+++ b/packages/website/src/components/page-changelog.tsx
@@ -96,7 +96,7 @@ export function PageChangelog({ page }: PageChangelogProps) {
                 const date = formatVersionDate(apiHistory.versions[version]);
 
                 return (
-                    <section key={version} className={styles.version}>
+                    <section key={version} className={`${styles.version} ${date ? '' : styles.unreleased}`}>
                         <h3 className={styles.versionHeading}>
                             {version}
                             {date && <span className={styles.versionDate}> – {date}</span>}

--- a/packages/website/src/components/since-badge.module.css
+++ b/packages/website/src/components/since-badge.module.css
@@ -1,11 +1,26 @@
 @reference '../app.css';
 
 .badge {
-    @apply inline-flex items-center px-2 pt-0.5 pb-0.75 mb-1 mr-1 border;
+    @apply inline-flex items-center px-2 pt-0.5 pb-0.75 mb-1 mr-1 border select-none;
     @apply whitespace-nowrap uppercase font-departure antialiased text-[11px] leading-5;
 
     & code {
         @apply opacity-100 normal-case pr-1;
+    }
+
+    /* `<Since>` renders a bare span with no wrapping element - a run of consecutive
+       badges (one page symbol per line in the source docs) sits directly in the prose
+       flow with nothing but its own mb-1 between instances, so the whole stack reads as
+       stuck to the content above and below it. Padding a wrapping element would need
+       editing every doc source that stacks Since badges; this reaches the same result by
+       giving just the first and last badge in a run extra margin instead. A standalone
+       badge matches both and gets margin on both sides. */
+    &:not(.badge + .badge) {
+        @apply mt-4;
+    }
+
+    &:not(:has(+ .badge)) {
+        @apply mb-4;
     }
 }
 
@@ -13,8 +28,16 @@
     @apply border-fd-primary text-fd-primary;
 }
 
+/* Matches .stable's bordered, unfilled treatment (no bg utility - the page's own
+   background shows through, which reads as black in dark mode) - just red instead of
+   fd-primary, to flag "not shipped yet". :global(.dark), not the dark: variant - see the
+   note on .unreleased in page-changelog.module.css for why. */
 .unreleased {
-    @apply bg-fd-muted text-fd-muted-foreground;
+    @apply border-red-600 text-red-600;
+}
+
+:global(.dark) .unreleased {
+    @apply border-red-400 text-red-400;
 }
 
 .deprecated {

--- a/packages/website/src/components/since-badge.module.css
+++ b/packages/website/src/components/since-badge.module.css
@@ -1,3 +1,5 @@
+/** biome-ignore-all lint/correctness/noUnknownPseudoClass: :global() is valid CSS Modules syntax Biome's linter doesn't recognize yet, even though its parser accepts it */
+
 @reference '../app.css';
 
 .badge {

--- a/packages/website/src/data/authors.ts
+++ b/packages/website/src/data/authors.ts
@@ -17,13 +17,6 @@ export const authors: Record<string, AuthorEntry> = {
     vancura: {
         name: 'Vaclav Vancura',
         url: 'https://vancura.dev',
-        socials: [
-            {
-                platform: 'github',
-                url: 'https://github.com/vancura',
-                label: 'vancura',
-            },
-        ],
     },
 };
 


### PR DESCRIPTION
## Summary

AuthorByline now renders from blog-page.tsx, driven by each post's `author`
frontmatter field, instead of being invoked inline in the MDX body. The
`<AuthorByline author="vancura" />` line that used to open every post is
dead weight now that the byline renders itself.