### PR TITLE
docs(blit386): move ApiAvailability tables below content, above changelog

### DIFF
--- a/packages/blit386/docs/api-assets.md
+++ b/packages/blit386/docs/api-assets.md
@@ -14,8 +14,6 @@ Sprite sheets, bitmap fonts, and asset loading.
 
 Looking for audio assets? `AudioClip` loading is documented separately in [API: Audio](api-audio.md#loading).
 
-<ApiAvailability page="api/assets" />
-
 ## Asset size limits
 
 Sprite sheets, font atlases, and raw indexed buffers share the same decoded-size policy as render configuration (`8192`
@@ -296,6 +294,10 @@ BT.systemPrintMeasure('Score: 100'); // → Vector2i (pixel width, height)
 - The engine draws its own overlay (present FPS, target FPS, draw calls, frame/update()/render() timings, backend,
   resolution, demo title) after each `render()` when `isOverlayEnabled` is true; see [Overlay Guide](guide-overlay.md).
 - For styled variable-width text, use a bitmap font instead.
+
+## API history
+
+<ApiAvailability page="api/assets" />
 
 <PageChangelog page="api/assets" />
 

--- a/packages/blit386/docs/api-audio.md
+++ b/packages/blit386/docs/api-audio.md
@@ -13,8 +13,6 @@
 Bus volume, mute, and the browser autoplay-unlock state. For the higher-level subsystem walkthrough (bus graph layout,
 locked vs. unlocked, and web autoplay constraints), see the [Audio Guide](guide-audio.md).
 
-<ApiAvailability page="api/audio" />
-
 The audio graph has three buses: `'sfx'` and `'music'` feed into `'main'`, which feeds the browser's audio destination.
 All three are independently controllable.
 
@@ -506,6 +504,10 @@ intro-then-loop recipe.
 
 `audioVoices` (default `16`) caps the number of simultaneous SFX voices – see [Playback (SFX)](#playback-sfx) for the
 allocation and stealing policy. Documented in [Hardware settings](api-core.md#hardware-settings).
+
+## API history
+
+<ApiAvailability page="api/audio" />
 
 <PageChangelog page="api/audio" />
 

--- a/packages/blit386/docs/api-browser-support.md
+++ b/packages/blit386/docs/api-browser-support.md
@@ -15,8 +15,6 @@ automatically; it also runs on browsers that do not expose WebGPU globals at all
 Nightly). Use `BT.activeBackend` to read which backend actually started (`'webgpu'`, `'software'`, or `null` before
 init).
 
-<ApiAvailability page="api/browser-support" />
-
 | Browser | Version | Status |
 | --- | --- | --- |
 | Chrome/Edge | 113+ | Enabled by default |
@@ -113,6 +111,10 @@ BLIT386's `render()` runs on `requestAnimationFrame`, so this halves the render 
 correct; only the visible frame rate drops, and the overlay's frame-metrics row shows the resulting `x2` (or higher)
 suffix on `update()`. Turning off Low Power Mode restores a clean `60 fps` ceiling on WebKit (capped by its own "prefer
 page rendering updates near 60 fps" policy, not the display's full refresh rate).
+
+## API history
+
+<ApiAvailability page="api/browser-support" />
 
 <PageChangelog page="api/browser-support" />
 

--- a/packages/blit386/docs/api-camera.md
+++ b/packages/blit386/docs/api-camera.md
@@ -12,8 +12,6 @@
 
 The camera applies a global pixel offset to all subsequent draw calls. Integer only – pass `Vector2i`, never floats.
 
-<ApiAvailability page="api/camera" />
-
 <Since symbol="BT.cameraSet" />
 <Since symbol="BT.camera" />
 <Since symbol="BT.cameraReset" />
@@ -66,6 +64,10 @@ Two more camera-driven demos: parallax scrolling and a scrolling tile grid.
 <DemoEmbed demo="011-starfield" title="BLIT386 starfield parallax demo" />
 
 <DemoEmbed demo="012-tilemap" title="BLIT386 tilemap demo" />
+
+## API history
+
+<ApiAvailability page="api/camera" />
 
 <PageChangelog page="api/camera" />
 

--- a/packages/blit386/docs/api-core-types.md
+++ b/packages/blit386/docs/api-core-types.md
@@ -12,8 +12,6 @@
 
 The integer-coordinate primitives shared across the engine: `Vector2i`, `Rect2i`, and `Color32`.
 
-<ApiAvailability page="api/core-types" />
-
 ## Vector2i
 
 <Since symbol="Vector2i" />
@@ -184,6 +182,10 @@ about eight levels near black. Convert, do the math, convert back – do not use
 `BT.paletteFadeExposure` is these helpers applied to a whole palette; see [Palette](api-palette.md).
 
 <DemoEmbed demo="032-named-colors" title="BLIT386 named colors demo" />
+
+## API history
+
+<ApiAvailability page="api/core-types" />
 
 <PageChangelog page="api/core-types" />
 

--- a/packages/blit386/docs/api-core.md
+++ b/packages/blit386/docs/api-core.md
@@ -25,8 +25,6 @@ The rest of the core API surface lives in dedicated pages: [Overlay](api-overlay
   API for hand-wired or existing projects.
 </Callout>
 
-<ApiAvailability page="api/core" />
-
 ## Bootstrap
 
 <Since symbol="bootstrap" />
@@ -496,6 +494,10 @@ enabled, WebGPU backend, `16` SFX voices, and other defaults documented in the t
 ## Putting it together
 
 <DemoEmbed demo="014-game-scene" title="BLIT386 game scene capstone demo" />
+
+## API history
+
+<ApiAvailability page="api/core" />
 
 <PageChangelog page="api/core" />
 

--- a/packages/blit386/docs/api-easing.md
+++ b/packages/blit386/docs/api-easing.md
@@ -16,8 +16,6 @@ interpolate `number` / `Vector2i` / `Color32` / `Rect2i` values with `interpolat
 Curve math matches [RetroBlit](https://www.badcastle.com/retroblit.html) by Martin Cietwierkowski (`Ease` class, Robert
 Penner's easing equations).
 
-<ApiAvailability page="api/easing" />
-
 <Since symbol="EasingFunction" />
 <Since symbol="applyEasing" />
 <Since symbol="interpolate" />
@@ -76,6 +74,10 @@ const bounds = interpolate('sine-in-out', new Rect2i(0, 0, 16, 16), new Rect2i(4
 ```
 
 <DemoEmbed demo="020-palette-fade" title="BLIT386 palette fade and flash demo" />
+
+## API history
+
+<ApiAvailability page="api/easing" />
 
 <PageChangelog page="api/easing" />
 

--- a/packages/blit386/docs/api-game-loop.md
+++ b/packages/blit386/docs/api-game-loop.md
@@ -12,8 +12,6 @@
 
 Fixed-timestep simulation timing, tick counters, and the `Timer` helper.
 
-<ApiAvailability page="api/game-loop" />
-
 BLIT386 runs two independent cadences:
 
 | Concept | Where | Meaning |
@@ -132,6 +130,10 @@ spawn.intervalTicks; // readonly interval size
 
 `Timer.fireIfElapsed()` advances the internal baseline on each true return. Pass `BT.ticks` explicitly only when you
 need a specific snapshot; the default is the engine tick counter.
+
+## API history
+
+<ApiAvailability page="api/game-loop" />
 
 <PageChangelog page="api/game-loop" />
 

--- a/packages/blit386/docs/api-overlay.md
+++ b/packages/blit386/docs/api-overlay.md
@@ -32,8 +32,6 @@ back in with `isOverlayVisibleAtStart: true` in `configure()` until authors choo
 
 </Callout>
 
-<ApiAvailability page="api/overlay" />
-
 ## Anatomy
 
 The overlay body stacks, top to bottom: title and backend rows, an optional timing chart, the frame-metrics rows, any
@@ -337,6 +335,10 @@ function configure(): Partial<HardwareSettings> {
   };
 }
 ```
+
+## API history
+
+<ApiAvailability page="api/overlay" />
 
 <PageChangelog page="api/overlay" />
 

--- a/packages/blit386/docs/api-palette.md
+++ b/packages/blit386/docs/api-palette.md
@@ -15,8 +15,6 @@ Palette setup, built-in presets, HUD preset, serialization, and palette effects.
 The palette is the single color authority for all rendering. Index `0` is always transparent and is never drawn. Set an
 active palette with `BT.paletteSet()` before any draw calls. Valid sizes: `2, 4, 16, 32, 64, 128, 256`.
 
-<ApiAvailability page="api/palette" />
-
 ## Palette addressing
 
 A palette is a fixed-size table of color slots (positions `0` through `size - 1`). Docs and APIs use three related
@@ -329,6 +327,10 @@ Effects that auto-remove (fade, flash) clean up when their duration elapses. `pa
 `paletteClearEffects()` is called.
 
 </Callout>
+
+## API history
+
+<ApiAvailability page="api/palette" />
 
 <PageChangelog page="api/palette" />
 

--- a/packages/blit386/docs/api-random.md
+++ b/packages/blit386/docs/api-random.md
@@ -15,8 +15,6 @@ seed always produces the same sequence across platforms. Stateless `hash1i` / `h
 per-coordinate randomness for chunked worlds without storing an RNG per cell. `ValueNoise`, `PerlinNoise`, and
 `SimplexNoise` add smooth pattern-based fields for terrain, clouds, and organic motion.
 
-<ApiAvailability page="api/random" />
-
 <Since symbol="Random" />
 
 ```ts twoslash
@@ -218,6 +216,10 @@ unsigned 32-bit value, the same representation `getState()` uses, not necessaril
 clears it, since jumping to an arbitrary saved state does not correspond to any known seed. `clone()` copies it verbatim
 (including `undefined`), matching the identical stream a clone produces. `fork()`'s child always reports `undefined` – a
 fork is a new stream and should not claim a seed its caller never chose.
+
+## API history
+
+<ApiAvailability page="api/random" />
 
 <PageChangelog page="api/random" />
 

--- a/packages/blit386/docs/api-rendering.md
+++ b/packages/blit386/docs/api-rendering.md
@@ -18,8 +18,6 @@ All draw calls require a palette to be active (`BT.paletteSet(palette)` before t
 Palette addressing: primitives and `BT.systemPrint` use an absolute `paletteIndex`. Sprites and `BT.printFont` use an
 optional `paletteOffset` added to stored texel indices. See [Palette addressing](api-palette.md#palette-addressing).
 
-<ApiAvailability page="api/rendering" />
-
 ## Primitives
 
 <Since symbol="BT.clear" />
@@ -290,6 +288,10 @@ await BT.downloadFrame('screenshot-001.png'); // custom filename
 `'blit386'`. Demos should use `BT.captureFrame()` and `BT.downloadFrame()` only.
 
 </Callout>
+
+## API history
+
+<ApiAvailability page="api/rendering" />
 
 <PageChangelog page="api/rendering" />
 

--- a/packages/blit386/docs/guide-audio.md
+++ b/packages/blit386/docs/guide-audio.md
@@ -13,8 +13,6 @@
 Bus volume, mute, and worked examples live in [API: Audio](api-audio.md). This guide maps the internal subsystem, the
 locked/unlocked gesture state, and the web platform constraints that shape it.
 
-<ApiAvailability page="guides/audio" />
-
 ## Subsystem layout
 
 ```text
@@ -279,6 +277,10 @@ const explosion = await AudioClip.synth(restored);
 ```
 
 <DemoEmbed demo="041-synth-toy" title="BLIT386 synth toy demo" />
+
+## API history
+
+<ApiAvailability page="guides/audio" />
 
 <PageChangelog page="guides/audio" />
 

--- a/packages/blit386/docs/guide-bitmap-fonts.md
+++ b/packages/blit386/docs/guide-bitmap-fonts.md
@@ -13,8 +13,6 @@
 BLIT386 ships with a built-in system font and supports custom `.btfont` bitmap fonts with variable-width glyphs,
 per-character offsets, Unicode characters, and either embedded or external textures.
 
-<ApiAvailability page="guides/bitmap-fonts" />
-
 ## Built-in system font
 
 The engine includes a 6×14 monospace bitmap font covering printable ASCII (characters 32–126). It requires no file
@@ -439,6 +437,10 @@ for (let i = 0; i < text.length; i++) {
 </Accordion>
 
 </Accordions>
+
+## API history
+
+<ApiAvailability page="guides/bitmap-fonts" />
 
 <PageChangelog page="guides/bitmap-fonts" />
 

--- a/packages/blit386/docs/guide-game-loop.md
+++ b/packages/blit386/docs/guide-game-loop.md
@@ -13,8 +13,6 @@
 Fixed-step timing, tick counters, and `BT.renderAlpha` are documented in [API: Game Loop](api-game-loop.md). This guide
 walks through the standard pattern for smoothing motion when `render()` doesn't land exactly on an `update()` step.
 
-<ApiAvailability page="guides/game-loop" />
-
 ## Why motion can look stale or jittery
 
 `update()` runs at a fixed rate (`targetFPS`); `render()` runs at whatever rate `requestAnimationFrame` delivers, which
@@ -91,6 +89,10 @@ class Player {
 
 Color transitions (palette flashes, tinted hit-feedback) can be interpolated the same way with `Color32.lerp` /
 `Color32#lerp` - see [API: Core Types](api-core-types.md#color32).
+
+## API history
+
+<ApiAvailability page="guides/game-loop" />
 
 <PageChangelog page="guides/game-loop" />
 

--- a/packages/blit386/docs/guide-hot-reload.md
+++ b/packages/blit386/docs/guide-hot-reload.md
@@ -14,8 +14,6 @@
 [API: Core](api-core.md#hot-reload). This guide covers the dev-loop hot reload enabled by the plugin, the three swap
 tiers with worked examples, the asset hot-replace matrix, and the `blit386/vite` plugin that wires it all up.
 
-<ApiAvailability page="guides/hot-reload" />
-
 ## What hot reload replaces
 
 Without it, every saved change to a demo or game source file triggers a full page reload: the whole module graph
@@ -352,6 +350,10 @@ Not implemented yet – notes for where this could go next:
 - Verifying compatibility with StackBlitz/WebContainers. The plugin is built entirely on Vite's public dev-server plugin
   API with no Node-only assumptions beyond what any Vite plugin already requires, so this is expected to work, but it
   has not been verified hands-on yet.
+
+## API history
+
+<ApiAvailability page="guides/hot-reload" />
 
 <PageChangelog page="guides/hot-reload" />
 

--- a/packages/blit386/docs/guide-input.md
+++ b/packages/blit386/docs/guide-input.md
@@ -17,8 +17,6 @@ buttons), gamepad (up to four players via `navigator.getGamepads()`), and text a
 All pointer coordinates are returned in logical display space (the `displaySize` from `configure()` or
 `defaultConfig()`), independent of the canvas's CSS or backing-buffer size.
 
-<ApiAvailability page="guides/input" />
-
 ## Pointer slot model
 
 The engine tracks up to four simultaneous pointers:
@@ -470,6 +468,10 @@ Coordinates are clamped to `[0, displaySize - 1]` on each axis. The conversion i
 </Accordion>
 
 </Accordions>
+
+## API history
+
+<ApiAvailability page="guides/input" />
 
 <PageChangelog page="guides/input" />
 

--- a/packages/blit386/docs/guide-overlay.md
+++ b/packages/blit386/docs/guide-overlay.md
@@ -17,8 +17,6 @@ title. Demos should not duplicate this text.
 Configure-time flags, style objects, and worked examples live in [API: Overlay](api-overlay.md). This guide maps the
 internal subsystem and common integration patterns.
 
-<ApiAvailability page="guides/overlay" />
-
 ## Subsystem layout
 
 ```text
@@ -126,6 +124,10 @@ character width before drawing. Without this, a value's digit count changing bet
 `16.7`, or the `update()` step suffix like `x3` appearing only when the fixed-update loop runs a catch-up burst) would
 shift every later segment on that row, since segments are drawn left to right based on the previous segment's rendered
 width. Padding keeps the `|` dividers and the segments after them in place regardless of how the values change.
+
+## API history
+
+<ApiAvailability page="guides/overlay" />
 
 <PageChangelog page="guides/overlay" />
 

--- a/packages/blit386/docs/guide-palette-presets.md
+++ b/packages/blit386/docs/guide-palette-presets.md
@@ -15,8 +15,6 @@ Exact built-in color data for `Palette` preset factories and `palette.applyHUD()
 All preset hex values are lowercase `RRGGBB` (no `#`), matching `src/assets/palettes/presetData.ts` and
 `src/assets/palettes/hudData.ts`.
 
-<ApiAvailability page="guides/palette-presets" />
-
 <!-- cspell:disable -->
 
 <Callout type="warn" title="Slot mapping (important)">
@@ -242,6 +240,10 @@ slots keep their constructor default (black).
   { hex: '6496c8', name: 'hud_code' },
 ];
 ```
+
+## API history
+
+<ApiAvailability page="guides/palette-presets" />
 
 <PageChangelog page="guides/palette-presets" />
 

--- a/packages/blit386/docs/guide-palette.md
+++ b/packages/blit386/docs/guide-palette.md
@@ -19,8 +19,6 @@ This guide covers the end-to-end workflow: setup, indexed sprites, palette offse
 For terminology (slot vs. `paletteIndex` vs. `paletteOffset`) and when to call `BT.paletteSet()` vs. mutating
 `BT.palette`, see [Palette addressing](api-palette.md#palette-addressing) in the API palette reference.
 
-<ApiAvailability page="guides/palette" />
-
 <Steps>
 
 <Step>
@@ -283,6 +281,10 @@ For benchmark workflow and CI thresholds, see [Performance Testing](performance-
 </Step>
 
 </Steps>
+
+## API history
+
+<ApiAvailability page="guides/palette" />
 
 <PageChangelog page="guides/palette" />
 

--- a/packages/blit386/docs/guide-post-process-effects.md
+++ b/packages/blit386/docs/guide-post-process-effects.md
@@ -27,8 +27,6 @@ your own, the bundled presets, and the upstream attribution.
 For how logical, drawing buffer, CSS cap, and effect tier map to `HardwareSettings` and `BT` getters, see
 [Resolution model](api-core.md#resolution-model) in the core API docs.
 
-<ApiAvailability page="guides/post-process-effects" />
-
 ## Quick start
 
 ```ts twoslash
@@ -479,6 +477,10 @@ PR to add a verifiable author / URL / license header.
 </Accordion>
 
 </Accordions>
+
+## API history
+
+<ApiAvailability page="guides/post-process-effects" />
 
 <PageChangelog page="guides/post-process-effects" />
 

--- a/packages/blit386/docs/guide-random.md
+++ b/packages/blit386/docs/guide-random.md
@@ -15,8 +15,6 @@ lives in [API: Random](api-random.md). This guide walks through the ideas behind
 how a seed reproduces a whole run, when to split off an independent stream, and how to build worlds from coordinates
 instead of a sequence.
 
-<ApiAvailability page="guides/random" />
-
 ## Deterministic by default
 
 The engine core makes zero `Math.random()` calls, so a run only varies where you introduce randomness. `BT.random` is
@@ -175,6 +173,10 @@ BT.random.int(150, 420);
 BT.random.pick(['glitch', 'noise', 'static']);
 BT.random.bool(0.25);
 ```
+
+## API history
+
+<ApiAvailability page="guides/random" />
 
 <PageChangelog page="guides/random" />
 

--- a/packages/website/content/docs/api/assets.mdx
+++ b/packages/website/content/docs/api/assets.mdx
@@ -3,13 +3,11 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Assets"
 description: "Sprite sheets, bitmap fonts, and asset loading."
-lastModified: "2026-08-07T22:06:03+02:00"
+lastModified: "2026-08-08T20:51:38+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/api-assets.md"
 ---
 
 Looking for audio assets? `AudioClip` loading is documented separately in [API: Audio](/docs/api/audio#loading).
-
-<ApiAvailability page="api/assets" />
 
 ## Asset size limits
 
@@ -291,6 +289,10 @@ BT.systemPrintMeasure('Score: 100'); // → Vector2i (pixel width, height)
 - The engine draws its own overlay (present FPS, target FPS, draw calls, frame/update()/render() timings, backend,
   resolution, demo title) after each `render()` when `isOverlayEnabled` is true; see [Overlay Guide](/docs/guides/overlay).
 - For styled variable-width text, use a bitmap font instead.
+
+## API history
+
+<ApiAvailability page="api/assets" />
 
 <PageChangelog page="api/assets" />
 

--- a/packages/website/content/docs/api/audio.mdx
+++ b/packages/website/content/docs/api/audio.mdx
@@ -3,14 +3,12 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Audio"
 description: "Audio buses, SFX voice pool, crossfading music, and procedural synthesis."
-lastModified: "2026-08-08T13:36:09+02:00"
+lastModified: "2026-08-08T20:51:38+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/api-audio.md"
 ---
 
 Bus volume, mute, and the browser autoplay-unlock state. For the higher-level subsystem walkthrough (bus graph layout,
 locked vs. unlocked, and web autoplay constraints), see the [Audio Guide](/docs/guides/audio).
-
-<ApiAvailability page="api/audio" />
 
 The audio graph has three buses: `'sfx'` and `'music'` feed into `'main'`, which feeds the browser's audio destination.
 All three are independently controllable.
@@ -503,6 +501,10 @@ intro-then-loop recipe.
 
 `audioVoices` (default `16`) caps the number of simultaneous SFX voices – see [Playback (SFX)](#playback-sfx) for the
 allocation and stealing policy. Documented in [Hardware settings](/docs/api/core#hardware-settings).
+
+## API history
+
+<ApiAvailability page="api/audio" />
 
 <PageChangelog page="api/audio" />
 

--- a/packages/website/content/docs/api/browser-support.mdx
+++ b/packages/website/content/docs/api/browser-support.mdx
@@ -3,7 +3,7 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Browser Support"
 description: "WebGPU support matrix, automatic software fallback, and build toolchain."
-lastModified: "2026-08-08T13:36:09+02:00"
+lastModified: "2026-08-08T20:51:38+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/api-browser-support.md"
 ---
 
@@ -11,8 +11,6 @@ The WebGPU renderer is the default. When WebGPU is unavailable the engine falls 
 automatically; it also runs on browsers that do not expose WebGPU globals at all (for example Firefox on Linux without
 Nightly). Use `BT.activeBackend` to read which backend actually started (`'webgpu'`, `'software'`, or `null` before
 init).
-
-<ApiAvailability page="api/browser-support" />
 
 | Browser | Version | Status |
 | --- | --- | --- |
@@ -110,6 +108,10 @@ BLIT386's `render()` runs on `requestAnimationFrame`, so this halves the render 
 correct; only the visible frame rate drops, and the overlay's frame-metrics row shows the resulting `x2` (or higher)
 suffix on `update()`. Turning off Low Power Mode restores a clean `60 fps` ceiling on WebKit (capped by its own "prefer
 page rendering updates near 60 fps" policy, not the display's full refresh rate).
+
+## API history
+
+<ApiAvailability page="api/browser-support" />
 
 <PageChangelog page="api/browser-support" />
 

--- a/packages/website/content/docs/api/camera.mdx
+++ b/packages/website/content/docs/api/camera.mdx
@@ -3,13 +3,11 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Camera"
 description: "The camera's global pixel offset and world-clamp helpers."
-lastModified: "2026-07-10T16:19:01+02:00"
+lastModified: "2026-08-08T20:51:38+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/api-camera.md"
 ---
 
 The camera applies a global pixel offset to all subsequent draw calls. Integer only – pass `Vector2i`, never floats.
-
-<ApiAvailability page="api/camera" />
 
 <Since symbol="BT.cameraSet" />
 <Since symbol="BT.camera" />
@@ -63,6 +61,10 @@ Two more camera-driven demos: parallax scrolling and a scrolling tile grid.
 <DemoEmbed demo="011-starfield" title="BLIT386 starfield parallax demo" />
 
 <DemoEmbed demo="012-tilemap" title="BLIT386 tilemap demo" />
+
+## API history
+
+<ApiAvailability page="api/camera" />
 
 <PageChangelog page="api/camera" />
 

--- a/packages/website/content/docs/api/core-types.mdx
+++ b/packages/website/content/docs/api/core-types.mdx
@@ -3,13 +3,11 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Core Types"
 description: "The integer core types: Vector2i, Rect2i, and Color32."
-lastModified: "2026-08-05T18:46:46+02:00"
+lastModified: "2026-08-08T20:51:38+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/api-core-types.md"
 ---
 
 The integer-coordinate primitives shared across the engine: `Vector2i`, `Rect2i`, and `Color32`.
-
-<ApiAvailability page="api/core-types" />
 
 ## Vector2i
 
@@ -181,6 +179,10 @@ about eight levels near black. Convert, do the math, convert back – do not use
 `BT.paletteFadeExposure` is these helpers applied to a whole palette; see [Palette](/docs/api/palette).
 
 <DemoEmbed demo="032-named-colors" title="BLIT386 named colors demo" />
+
+## API history
+
+<ApiAvailability page="api/core-types" />
 
 <PageChangelog page="api/core-types" />
 

--- a/packages/website/content/docs/api/core.mdx
+++ b/packages/website/content/docs/api/core.mdx
@@ -3,7 +3,7 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Core"
 description: "Bootstrap, initialization, and default configuration."
-lastModified: "2026-08-08T10:05:04+02:00"
+lastModified: "2026-08-08T20:51:38+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/api-core.md"
 ---
 
@@ -19,8 +19,6 @@ The rest of the core API surface lives in dedicated pages: [Overlay](/docs/api/o
   documents the `bootstrap()`
   API for hand-wired or existing projects.
 </Callout>
-
-<ApiAvailability page="api/core" />
 
 ## Bootstrap
 
@@ -491,6 +489,10 @@ enabled, WebGPU backend, `16` SFX voices, and other defaults documented in the t
 ## Putting it together
 
 <DemoEmbed demo="014-game-scene" title="BLIT386 game scene capstone demo" />
+
+## API history
+
+<ApiAvailability page="api/core" />
 
 <PageChangelog page="api/core" />
 

--- a/packages/website/content/docs/api/easing.mdx
+++ b/packages/website/content/docs/api/easing.mdx
@@ -3,7 +3,7 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Easing"
 description: "Named easing curves and interpolate() for number, Vector2i, Color32, and Rect2i."
-lastModified: "2026-07-28T16:49:29+02:00"
+lastModified: "2026-08-08T20:51:38+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/api-easing.md"
 ---
 
@@ -12,8 +12,6 @@ interpolate `number` / `Vector2i` / `Color32` / `Rect2i` values with `interpolat
 
 Curve math matches [RetroBlit](https://www.badcastle.com/retroblit.html) by Martin Cietwierkowski (`Ease` class, Robert
 Penner's easing equations).
-
-<ApiAvailability page="api/easing" />
 
 <Since symbol="EasingFunction" />
 <Since symbol="applyEasing" />
@@ -73,6 +71,10 @@ const bounds = interpolate('sine-in-out', new Rect2i(0, 0, 16, 16), new Rect2i(4
 ```
 
 <DemoEmbed demo="020-palette-fade" title="BLIT386 palette fade and flash demo" />
+
+## API history
+
+<ApiAvailability page="api/easing" />
 
 <PageChangelog page="api/easing" />
 

--- a/packages/website/content/docs/api/game-loop.mdx
+++ b/packages/website/content/docs/api/game-loop.mdx
@@ -3,13 +3,11 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Game Loop"
 description: "Fixed-timestep simulation timing, tick counters, and the Timer helper."
-lastModified: "2026-08-08T13:36:09+02:00"
+lastModified: "2026-08-08T20:51:38+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/api-game-loop.md"
 ---
 
 Fixed-timestep simulation timing, tick counters, and the `Timer` helper.
-
-<ApiAvailability page="api/game-loop" />
 
 BLIT386 runs two independent cadences:
 
@@ -129,6 +127,10 @@ spawn.intervalTicks; // readonly interval size
 
 `Timer.fireIfElapsed()` advances the internal baseline on each true return. Pass `BT.ticks` explicitly only when you
 need a specific snapshot; the default is the engine tick counter.
+
+## API history
+
+<ApiAvailability page="api/game-loop" />
 
 <PageChangelog page="api/game-loop" />
 

--- a/packages/website/content/docs/api/overlay.mdx
+++ b/packages/website/content/docs/api/overlay.mdx
@@ -3,7 +3,7 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Overlay"
 description: "Engine overlay HUD configure flags, style objects, and worked examples."
-lastModified: "2026-07-23T10:26:02+02:00"
+lastModified: "2026-08-08T20:51:38+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/api-overlay.md"
 ---
 
@@ -28,8 +28,6 @@ Upgrading demos now starts with the overlay body hidden. Teaching demos that rel
 back in with `isOverlayVisibleAtStart: true` in `configure()` until authors choose otherwise.
 
 </Callout>
-
-<ApiAvailability page="api/overlay" />
 
 ## Anatomy
 
@@ -334,6 +332,10 @@ function configure(): Partial<HardwareSettings> {
   };
 }
 ```
+
+## API history
+
+<ApiAvailability page="api/overlay" />
 
 <PageChangelog page="api/overlay" />
 

--- a/packages/website/content/docs/api/palette.mdx
+++ b/packages/website/content/docs/api/palette.mdx
@@ -3,14 +3,12 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Palette"
 description: "Palette setup, built-in presets, HUD preset, serialization, and palette effects."
-lastModified: "2026-08-05T20:32:58+02:00"
+lastModified: "2026-08-08T20:51:38+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/api-palette.md"
 ---
 
 The palette is the single color authority for all rendering. Index `0` is always transparent and is never drawn. Set an
 active palette with `BT.paletteSet()` before any draw calls. Valid sizes: `2, 4, 16, 32, 64, 128, 256`.
-
-<ApiAvailability page="api/palette" />
 
 ## Palette addressing
 
@@ -324,6 +322,10 @@ Effects that auto-remove (fade, flash) clean up when their duration elapses. `pa
 `paletteClearEffects()` is called.
 
 </Callout>
+
+## API history
+
+<ApiAvailability page="api/palette" />
 
 <PageChangelog page="api/palette" />
 

--- a/packages/website/content/docs/api/random.mdx
+++ b/packages/website/content/docs/api/random.mdx
@@ -3,7 +3,7 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Random"
 description: "Seeded Random PRNG, coordinate hashes, and Value/Perlin/Simplex pattern noise for procedural worlds."
-lastModified: "2026-08-08T13:36:09+02:00"
+lastModified: "2026-08-08T20:51:38+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/api-random.md"
 ---
 
@@ -11,8 +11,6 @@ Seeded, deterministic pseudo-random numbers for demos and games. The `Random` cl
 seed always produces the same sequence across platforms. Stateless `hash1i` / `hash2i` / `hash3i` (and float forms) give
 per-coordinate randomness for chunked worlds without storing an RNG per cell. `ValueNoise`, `PerlinNoise`, and
 `SimplexNoise` add smooth pattern-based fields for terrain, clouds, and organic motion.
-
-<ApiAvailability page="api/random" />
 
 <Since symbol="Random" />
 
@@ -215,6 +213,10 @@ unsigned 32-bit value, the same representation `getState()` uses, not necessaril
 clears it, since jumping to an arbitrary saved state does not correspond to any known seed. `clone()` copies it verbatim
 (including `undefined`), matching the identical stream a clone produces. `fork()`'s child always reports `undefined` – a
 fork is a new stream and should not claim a seed its caller never chose.
+
+## API history
+
+<ApiAvailability page="api/random" />
 
 <PageChangelog page="api/random" />
 

--- a/packages/website/content/docs/api/rendering.mdx
+++ b/packages/website/content/docs/api/rendering.mdx
@@ -3,7 +3,7 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Rendering"
 description: "Primitives, sprites, text, post-process effects, and frame capture."
-lastModified: "2026-07-28T16:49:29+02:00"
+lastModified: "2026-08-08T20:51:38+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/api-rendering.md"
 ---
 
@@ -12,8 +12,6 @@ All draw calls require a palette to be active (`BT.paletteSet(palette)` before t
 
 Palette addressing: primitives and `BT.systemPrint` use an absolute `paletteIndex`. Sprites and `BT.printFont` use an
 optional `paletteOffset` added to stored texel indices. See [Palette addressing](/docs/api/palette#palette-addressing).
-
-<ApiAvailability page="api/rendering" />
 
 ## Primitives
 
@@ -285,6 +283,10 @@ await BT.downloadFrame('screenshot-001.png'); // custom filename
 `'blit386'`. Demos should use `BT.captureFrame()` and `BT.downloadFrame()` only.
 
 </Callout>
+
+## API history
+
+<ApiAvailability page="api/rendering" />
 
 <PageChangelog page="api/rendering" />
 

--- a/packages/website/content/docs/guides/audio.mdx
+++ b/packages/website/content/docs/guides/audio.mdx
@@ -3,14 +3,12 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Audio"
 description: "The audio subsystem layout, locked vs. unlocked gesture state, and web audio constraints."
-lastModified: "2026-08-08T13:36:09+02:00"
+lastModified: "2026-08-08T20:51:38+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/guide-audio.md"
 ---
 
 Bus volume, mute, and worked examples live in [API: Audio](/docs/api/audio). This guide maps the internal subsystem, the
 locked/unlocked gesture state, and the web platform constraints that shape it.
-
-<ApiAvailability page="guides/audio" />
 
 ## Subsystem layout
 
@@ -276,6 +274,10 @@ const explosion = await AudioClip.synth(restored);
 ```
 
 <DemoEmbed demo="041-synth-toy" title="BLIT386 synth toy demo" />
+
+## API history
+
+<ApiAvailability page="guides/audio" />
 
 <PageChangelog page="guides/audio" />
 

--- a/packages/website/content/docs/guides/bitmap-fonts.mdx
+++ b/packages/website/content/docs/guides/bitmap-fonts.mdx
@@ -3,14 +3,12 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Bitmap Fonts"
 description: "The system font and custom .btfont bitmap fonts: format, loading, and BMFont conversion."
-lastModified: "2026-07-11T10:57:07Z"
+lastModified: "2026-08-08T20:51:38+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/guide-bitmap-fonts.md"
 ---
 
 BLIT386 ships with a built-in system font and supports custom `.btfont` bitmap fonts with variable-width glyphs,
 per-character offsets, Unicode characters, and either embedded or external textures.
-
-<ApiAvailability page="guides/bitmap-fonts" />
 
 ## Built-in system font
 
@@ -436,6 +434,10 @@ for (let i = 0; i < text.length; i++) {
 </Accordion>
 
 </Accordions>
+
+## API history
+
+<ApiAvailability page="guides/bitmap-fonts" />
 
 <PageChangelog page="guides/bitmap-fonts" />
 

--- a/packages/website/content/docs/guides/game-loop.mdx
+++ b/packages/website/content/docs/guides/game-loop.mdx
@@ -3,14 +3,12 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Game Loop"
 description: "Smoothing motion between fixed update() steps using BT.renderAlpha and Vector2i.lerp."
-lastModified: "2026-08-08T13:36:09+02:00"
+lastModified: "2026-08-08T20:51:38+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/guide-game-loop.md"
 ---
 
 Fixed-step timing, tick counters, and `BT.renderAlpha` are documented in [API: Game Loop](/docs/api/game-loop). This guide
 walks through the standard pattern for smoothing motion when `render()` doesn't land exactly on an `update()` step.
-
-<ApiAvailability page="guides/game-loop" />
 
 ## Why motion can look stale or jittery
 
@@ -88,6 +86,10 @@ class Player {
 
 Color transitions (palette flashes, tinted hit-feedback) can be interpolated the same way with `Color32.lerp` /
 `Color32#lerp` - see [API: Core Types](/docs/api/core-types#color32).
+
+## API history
+
+<ApiAvailability page="guides/game-loop" />
 
 <PageChangelog page="guides/game-loop" />
 

--- a/packages/website/content/docs/guides/hot-reload.mdx
+++ b/packages/website/content/docs/guides/hot-reload.mdx
@@ -3,15 +3,13 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Hot Reload"
 description: "The three hot-reload swap tiers, onHotReload semantics, asset hot-replace, and the blit386/vite plugin."
-lastModified: "2026-08-08T13:36:09+02:00"
+lastModified: "2026-08-08T20:51:38+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/guide-hot-reload.md"
 ---
 
 `HotContext`, `registerHotReload`, `HotReloadContext`, and `IBTDemo.onHotReload` live in
 [API: Core](/docs/api/core#hot-reload). This guide covers the dev-loop hot reload enabled by the plugin, the three swap
 tiers with worked examples, the asset hot-replace matrix, and the `blit386/vite` plugin that wires it all up.
-
-<ApiAvailability page="guides/hot-reload" />
 
 ## What hot reload replaces
 
@@ -349,6 +347,10 @@ Not implemented yet – notes for where this could go next:
 - Verifying compatibility with StackBlitz/WebContainers. The plugin is built entirely on Vite's public dev-server plugin
   API with no Node-only assumptions beyond what any Vite plugin already requires, so this is expected to work, but it
   has not been verified hands-on yet.
+
+## API history
+
+<ApiAvailability page="guides/hot-reload" />
 
 <PageChangelog page="guides/hot-reload" />
 

--- a/packages/website/content/docs/guides/input.mdx
+++ b/packages/website/content/docs/guides/input.mdx
@@ -3,7 +3,7 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Input"
 description: "Pointer, keyboard, gamepad, and text-accumulation input in BLIT386."
-lastModified: "2026-08-08T13:36:09+02:00"
+lastModified: "2026-08-08T20:51:38+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/guide-input.md"
 ---
 
@@ -13,8 +13,6 @@ buttons), gamepad (up to four players via `navigator.getGamepads()`), and text a
 
 All pointer coordinates are returned in logical display space (the `displaySize` from `configure()` or
 `defaultConfig()`), independent of the canvas's CSS or backing-buffer size.
-
-<ApiAvailability page="guides/input" />
 
 ## Pointer slot model
 
@@ -467,6 +465,10 @@ Coordinates are clamped to `[0, displaySize - 1]` on each axis. The conversion i
 </Accordion>
 
 </Accordions>
+
+## API history
+
+<ApiAvailability page="guides/input" />
 
 <PageChangelog page="guides/input" />
 

--- a/packages/website/content/docs/guides/overlay.mdx
+++ b/packages/website/content/docs/guides/overlay.mdx
@@ -3,7 +3,7 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Overlay"
 description: "The engine overlay HUD: metrics, timing chart, palette grid, toggle, and layout."
-lastModified: "2026-07-28T16:49:29+02:00"
+lastModified: "2026-08-08T20:51:38+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/guide-overlay.md"
 ---
 
@@ -13,8 +13,6 @@ title. Demos should not duplicate this text.
 
 Configure-time flags, style objects, and worked examples live in [API: Overlay](/docs/api/overlay). This guide maps the
 internal subsystem and common integration patterns.
-
-<ApiAvailability page="guides/overlay" />
 
 ## Subsystem layout
 
@@ -123,6 +121,10 @@ character width before drawing. Without this, a value's digit count changing bet
 `16.7`, or the `update()` step suffix like `x3` appearing only when the fixed-update loop runs a catch-up burst) would
 shift every later segment on that row, since segments are drawn left to right based on the previous segment's rendered
 width. Padding keeps the `|` dividers and the segments after them in place regardless of how the values change.
+
+## API history
+
+<ApiAvailability page="guides/overlay" />
 
 <PageChangelog page="guides/overlay" />
 

--- a/packages/website/content/docs/guides/palette-presets.mdx
+++ b/packages/website/content/docs/guides/palette-presets.mdx
@@ -3,7 +3,7 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Palette Presets"
 description: "Exact color data for the built-in Palette presets and the HUD preset."
-lastModified: "2026-07-07T17:38:09+02:00"
+lastModified: "2026-08-08T20:51:38+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/guide-palette-presets.md"
 ---
 
@@ -11,8 +11,6 @@ Exact built-in color data for `Palette` preset factories and `palette.applyHUD()
 
 All preset hex values are lowercase `RRGGBB` (no `#`), matching `src/assets/palettes/presetData.ts` and
 `src/assets/palettes/hudData.ts`.
-
-<ApiAvailability page="guides/palette-presets" />
 
 
 
@@ -239,6 +237,10 @@ slots keep their constructor default (black).
   { hex: '6496c8', name: 'hud_code' },
 ];
 ```
+
+## API history
+
+<ApiAvailability page="guides/palette-presets" />
 
 <PageChangelog page="guides/palette-presets" />
 

--- a/packages/website/content/docs/guides/palette.mdx
+++ b/packages/website/content/docs/guides/palette.mdx
@@ -3,7 +3,7 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Palette"
 description: "The palette-first rendering workflow: setup, slot offsets, and palette effects."
-lastModified: "2026-08-05T19:54:35+02:00"
+lastModified: "2026-08-08T20:51:38+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/guide-palette.md"
 ---
 
@@ -15,8 +15,6 @@ This guide covers the end-to-end workflow: setup, indexed sprites, palette offse
 
 For terminology (slot vs. `paletteIndex` vs. `paletteOffset`) and when to call `BT.paletteSet()` vs. mutating
 `BT.palette`, see [Palette addressing](/docs/api/palette#palette-addressing) in the API palette reference.
-
-<ApiAvailability page="guides/palette" />
 
 <Steps>
 
@@ -280,6 +278,10 @@ For benchmark workflow and CI thresholds, see [Performance Testing](/docs/perfor
 </Step>
 
 </Steps>
+
+## API history
+
+<ApiAvailability page="guides/palette" />
 
 <PageChangelog page="guides/palette" />
 

--- a/packages/website/content/docs/guides/post-process-effects.mdx
+++ b/packages/website/content/docs/guides/post-process-effects.mdx
@@ -3,7 +3,7 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Post-Process Effects"
 description: "The two-tier post-process effect system, built-in effects, and CRT presets."
-lastModified: "2026-07-08T09:19:37+02:00"
+lastModified: "2026-08-08T20:51:38+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/guide-post-process-effects.md"
 ---
 
@@ -23,8 +23,6 @@ your own, the bundled presets, and the upstream attribution.
 
 For how logical, drawing buffer, CSS cap, and effect tier map to `HardwareSettings` and `BT` getters, see
 [Resolution model](/docs/api/core#resolution-model) in the core API docs.
-
-<ApiAvailability page="guides/post-process-effects" />
 
 ## Quick start
 
@@ -476,6 +474,10 @@ PR to add a verifiable author / URL / license header.
 </Accordion>
 
 </Accordions>
+
+## API history
+
+<ApiAvailability page="guides/post-process-effects" />
 
 <PageChangelog page="guides/post-process-effects" />
 

--- a/packages/website/content/docs/guides/random.mdx
+++ b/packages/website/content/docs/guides/random.mdx
@@ -3,7 +3,7 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Random"
 description: "Seeded determinism in practice: reproducible runs, independent streams, and procedural worlds from coordinates."
-lastModified: "2026-07-30T18:33:40+02:00"
+lastModified: "2026-08-08T20:51:38+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/guide-random.md"
 ---
 
@@ -11,8 +11,6 @@ The full surface – every `Random` method, the `BT.random` engine default, coor
 lives in [API: Random](/docs/api/random). This guide walks through the ideas behind it: why the engine stays deterministic,
 how a seed reproduces a whole run, when to split off an independent stream, and how to build worlds from coordinates
 instead of a sequence.
-
-<ApiAvailability page="guides/random" />
 
 ## Deterministic by default
 
@@ -172,6 +170,10 @@ BT.random.int(150, 420);
 BT.random.pick(['glitch', 'noise', 'static']);
 BT.random.bool(0.25);
 ```
+
+## API history
+
+<ApiAvailability page="guides/random" />
 
 <PageChangelog page="guides/random" />
 

--- a/packages/website/content/docs/reference/testing.mdx
+++ b/packages/website/content/docs/reference/testing.mdx
@@ -3,7 +3,7 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Testing"
 description: "Testing tiers (unit, integration, visual) plus CPU benchmarks and WebGPU mocks."
-lastModified: "2026-08-02T08:54:14+02:00"
+lastModified: "2026-08-08T14:20:19+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/reference-testing.md"
 ---
 


### PR DESCRIPTION
## Summary

- Moves the `<ApiAvailability>` symbol table from the top of every published doc page to the bottom, directly above `<PageChangelog>`, under a new `## API history` heading.
- Applies to all 21 `docs/*.md` pages that carry a real `<ApiAvailability>` tag. `documentation-and-versioning-guide.md`'s only occurrence is prose (a code-block example illustrating the convention), so it was left untouched.
- Regenerates the `packages/website/content/docs/` mirror via `pnpm run sync:docs` (source of truth stays `packages/blit386/docs/`).

Closes BT-466.

## Test plan

- [x] `pnpm run preflight` in `packages/blit386` – passes
- [x] `pnpm run preflight` in `packages/website` – passes (`sync:docs:check` clean modulo the expected one-commit `lastModified` lag)
- [x] Spot-checked rendered pages locally (`waku dev`): [`/docs/api/core`](http://localhost:3001/docs/api/core) and [`/docs/guides/audio`](http://localhost:3001/docs/guides/audio) – table and changelog now render together under "API history", directly above "See also"
- [x] Root pre-push checks (`docs:links`, `agents:check`, `check-dash-typography`) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)