### PR TITLE
feat(content): link changelog {@link} tags to their symbol anchor

### DIFF
--- a/packages/blit386/docs/api-random.md
+++ b/packages/blit386/docs/api-random.md
@@ -181,8 +181,9 @@ simplex.noise3D(1, 2, 3);
 ```
 
 Value noise interpolates hashed corner values (smooth but can look blocky at low frequency). Perlin uses lattice
-gradients ([Ken Perlin, SIGGRAPH 2002](https://mrl.cs.nyu.edu/~perlin/paper445.pdf)). Simplex reduces directional
-artifacts on square grids
+gradients
+([Ken Perlin, SIGGRAPH 2002](https://web.archive.org/web/20201223081217/https://mrl.cs.nyu.edu/~perlin/paper445.pdf)).
+Simplex reduces directional artifacts on square grids
 ([Stefan Gustavson](https://web.archive.org/web/20200929015611/http://weber.itn.liu.se/~stegu/simplexnoise/simplexnoise.pdf)).
 
 ## State and streams

--- a/packages/website/content/docs/api/random.mdx
+++ b/packages/website/content/docs/api/random.mdx
@@ -178,8 +178,9 @@ simplex.noise3D(1, 2, 3);
 ```
 
 Value noise interpolates hashed corner values (smooth but can look blocky at low frequency). Perlin uses lattice
-gradients ([Ken Perlin, SIGGRAPH 2002](https://mrl.cs.nyu.edu/~perlin/paper445.pdf)). Simplex reduces directional
-artifacts on square grids
+gradients
+([Ken Perlin, SIGGRAPH 2002](https://web.archive.org/web/20201223081217/https://mrl.cs.nyu.edu/~perlin/paper445.pdf)).
+Simplex reduces directional artifacts on square grids
 ([Stefan Gustavson](https://web.archive.org/web/20200929015611/http://weber.itn.liu.se/~stegu/simplexnoise/simplexnoise.pdf)).
 
 ## State and streams

--- a/packages/website/content/docs/api/random.mdx
+++ b/packages/website/content/docs/api/random.mdx
@@ -3,7 +3,7 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Random"
 description: "Seeded Random PRNG, coordinate hashes, and Value/Perlin/Simplex pattern noise for procedural worlds."
-lastModified: "2026-08-08T20:51:38+02:00"
+lastModified: "2026-08-09T16:20:34+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/api-random.md"
 ---
 

--- a/packages/website/src/components/page-changelog.module.css
+++ b/packages/website/src/components/page-changelog.module.css
@@ -39,7 +39,7 @@
 }
 
 .changed {
-    @apply bg-fd-card text-fd-card-foreground;
+    @apply border-fd-primary text-fd-primary;
 }
 
 .deprecated {
@@ -52,6 +52,10 @@
 
 .note {
     @apply text-fd-muted-foreground;
+
+    & a {
+        @apply underline underline-offset-2 hover:text-fd-primary;
+    }
 }
 
 /* A version with no release date hasn't shipped yet - flag it in red instead of the
@@ -72,8 +76,13 @@
         @apply text-red-600;
     }
 
-    & .added {
+    & .added,
+    & .changed {
         @apply border-red-600 text-red-600;
+
+        &:after {
+            @apply pl-2 content-['–_Unreleased'];
+        }
     }
 }
 
@@ -82,7 +91,8 @@
         @apply text-red-400;
     }
 
-    & .added {
+    & .added,
+    & .changed {
         @apply border-red-400 text-red-400;
     }
 }

--- a/packages/website/src/components/page-changelog.tsx
+++ b/packages/website/src/components/page-changelog.tsx
@@ -1,4 +1,14 @@
-import { apiHistory, compareVersions, getPageSymbols, getSymbol } from '../data/api-history';
+import Link from 'fumadocs-core/link';
+import { Fragment } from 'react';
+import type { ReactNode } from 'react';
+import {
+    apiHistory,
+    compareVersions,
+    getPageSymbols,
+    getSymbol,
+    resolveSymbolLink,
+    symbolAnchorId,
+} from '../data/api-history';
 import styles from './page-changelog.module.css';
 
 interface PageChangelogProps {
@@ -67,6 +77,47 @@ function groupByVersion(events: ChangeEvent[]): [string, ChangeEvent[]][] {
     return [...byVersion.entries()].sort(([a], [b]) => compareVersions(b, a));
 }
 
+const LINK_TAG_PATTERN = /\{@link\s+([^}]+)\}/gu;
+
+/**
+ * Renders a change note, turning any `{@link Name}` / `{@link Name.member}` JSDoc tag into a real
+ * link straight to the `<Since>` badge for `Name` (or its base symbol) – see
+ * {@link resolveSymbolLink} and `since-badge.tsx`'s `id={symbolAnchorId(symbol)}`. An
+ * unresolvable target (e.g. a deprecated helper with no `<Since>` tag of its own) falls back to
+ * plain text rather than a dead link.
+ */
+function renderNote(note: string): ReactNode {
+    const parts: ReactNode[] = [];
+    let lastIndex = 0;
+
+    for (const match of note.matchAll(LINK_TAG_PATTERN)) {
+        const [tag, name] = match;
+        const index = match.index;
+
+        if (index > lastIndex) {
+            parts.push(note.slice(lastIndex, index));
+        }
+
+        const target = name === undefined ? undefined : resolveSymbolLink(name.trim());
+
+        parts.push(
+            target ? (
+                <Link key={index} href={`/docs/${target.page}#${symbolAnchorId(target.symbol)}`}>
+                    {name?.trim()}
+                </Link>
+            ) : (
+                (name?.trim() ?? tag)
+            ),
+        );
+
+        lastIndex = index + tag.length;
+    }
+
+    parts.push(note.slice(lastIndex));
+
+    return <Fragment>{parts}</Fragment>;
+}
+
 /** Formats a version's release date for display, or `null` if it is missing or invalid. */
 function formatVersionDate(iso: string | null | undefined): string | null {
     if (!iso) {
@@ -109,7 +160,7 @@ export function PageChangelog({ page }: PageChangelogProps) {
                                         {event.category}
                                     </span>
                                     <code className={styles.symbol}>{event.symbol}</code>
-                                    {event.note && <span className={styles.note}>{event.note}</span>}
+                                    {event.note && <span className={styles.note}>{renderNote(event.note)}</span>}
                                 </li>
                             ))}
                         </ul>

--- a/packages/website/src/components/since-badge.module.css
+++ b/packages/website/src/components/since-badge.module.css
@@ -5,6 +5,10 @@
 .badge {
     @apply inline-flex items-center px-2 pt-0.5 pb-0.75 mb-1 mr-1 border select-none;
     @apply whitespace-nowrap uppercase font-departure antialiased text-[11px] leading-5;
+    /* Matches fumadocs-ui's own heading offset (`heading.js`'s `scroll-m-28`), so a
+       `{@link}` jump to a badge's id lands below the sticky header the same way a jump to a
+       heading anchor does. */
+    @apply scroll-m-28;
 
     & code {
         @apply opacity-100 normal-case pr-1;

--- a/packages/website/src/components/since-badge.tsx
+++ b/packages/website/src/components/since-badge.tsx
@@ -1,4 +1,4 @@
-import { getSymbol } from '../data/api-history';
+import { getSymbol, symbolAnchorId } from '../data/api-history';
 import styles from './since-badge.module.css';
 
 interface SinceProps {
@@ -10,9 +10,13 @@ interface SinceProps {
  * if it is unreleased or deprecated. Renders nothing if `symbol` is not found in the
  * generated API history – a missing or misspelled symbol name silently omits the badge
  * rather than failing the docs build.
+ *
+ * Carries `id={symbolAnchorId(symbol)}` so a `{@link Name}` tag elsewhere on the site (see
+ * `page-changelog.tsx`'s `renderNote`) can link straight to it instead of just the page.
  */
 export function Since({ symbol }: SinceProps) {
     const entry = getSymbol(symbol);
+    const id = symbolAnchorId(symbol);
 
     if (!entry) {
         return null;
@@ -20,7 +24,7 @@ export function Since({ symbol }: SinceProps) {
 
     if (entry.status === 'unreleased') {
         return (
-            <span className={`not-prose ${styles.badge} ${styles.unreleased}`} title={symbol}>
+            <span id={id} className={`not-prose ${styles.badge} ${styles.unreleased}`} title={symbol}>
                 <code className={styles.symbol}>{symbol}</code> Unreleased
             </span>
         );
@@ -30,7 +34,7 @@ export function Since({ symbol }: SinceProps) {
         const deprecatedVersion = entry.deprecated?.version;
 
         return (
-            <span className={`not-prose ${styles.badge} ${styles.deprecated}`} title={symbol}>
+            <span id={id} className={`not-prose ${styles.badge} ${styles.deprecated}`} title={symbol}>
                 <code className={styles.symbol}>{symbol}</code> Deprecated
                 {deprecatedVersion ? ` ${deprecatedVersion}` : ''}
             </span>
@@ -38,7 +42,7 @@ export function Since({ symbol }: SinceProps) {
     }
 
     return (
-        <span className={`not-prose ${styles.badge} ${styles.stable}`} title={symbol}>
+        <span id={id} className={`not-prose ${styles.badge} ${styles.stable}`} title={symbol}>
             <code className={styles.symbol}>{symbol}</code> Since {entry.since}
         </span>
     );

--- a/packages/website/src/data/api-history.ts
+++ b/packages/website/src/data/api-history.ts
@@ -45,6 +45,54 @@ export const getSymbol = (name: string): SymbolHistory | undefined =>
 export const getPageSymbols = (page: string): string[] =>
     Object.hasOwn(apiHistory.pages, page) ? (apiHistory.pages[page] ?? []) : [];
 
+/** Reverse of `apiHistory.pages`: symbol name -> the page it is documented on. Built once, lazily. */
+let symbolPageIndex: Map<string, string> | undefined;
+
+function getSymbolPageIndex(): Map<string, string> {
+    if (!symbolPageIndex) {
+        symbolPageIndex = new Map();
+
+        for (const [page, symbols] of Object.entries(apiHistory.pages)) {
+            for (const name of symbols) {
+                symbolPageIndex.set(name, page);
+            }
+        }
+    }
+
+    return symbolPageIndex;
+}
+
+/**
+ * Turns a documented symbol name into the `id` its `<Since>` badge renders (see
+ * `since-badge.tsx`), and the fragment a link should target to jump straight to it. `.` is not
+ * a valid bare token in a URL fragment some tooling round-trips through query-string parsing, so
+ * it is replaced with `-`; case is left untouched since fragments are matched case-sensitively
+ * against the rendered `id`.
+ */
+export const symbolAnchorId = (name: string): string => name.replaceAll('.', '-');
+
+/** Where a `{@link Name}` / `{@link Name.member}` target is documented. */
+export interface SymbolLink {
+    page: string;
+    /** The resolved symbol's own name – e.g. `HardwareSettings` for a `HardwareSettings.foo` link – for use with {@link symbolAnchorId}. */
+    symbol: string;
+}
+
+/**
+ * Resolves a `{@link Name}` or `{@link Name.member}` target to the page and symbol it is
+ * documented under, or `undefined` when neither the full name nor its base symbol (before the
+ * first `.`) is tracked in `apiHistory.pages` – e.g. a deprecated helper that never received a
+ * `<Since>` tag of its own.
+ */
+export function resolveSymbolLink(name: string): SymbolLink | undefined {
+    const index = getSymbolPageIndex();
+    const base = name.split('.', 1)[0] ?? name;
+    const symbol = index.has(name) ? name : base;
+    const page = index.get(symbol);
+
+    return page ? { page, symbol } : undefined;
+}
+
 /** One dot-separated version segment: its digits, and whether a suffix followed them. */
 interface VersionSegment {
     /** Leading zeros stripped, so `""` means zero. Kept as digits rather than a `number`. */


### PR DESCRIPTION
## Summary

- `PageChangelog` was rendering `{@link Name}` / `{@link Name.member}` JSDoc tags as literal text (e.g. `Added {@link HardwareSettings.isOverlayToggleHitDebugVisible}.`). Those tags now parse into real links.
- Each link resolves to the page the symbol is documented on and jumps straight to that symbol's `<Since>` badge via a new `id`, rather than just landing at the top of the page.
- An unresolvable target (e.g. a deprecated helper with no `<Since>` tag of its own) falls back to plain text instead of a dead link.
- Also converts the `.unreleased` red-flag styling in `page-changelog.module.css` to pure Tailwind (`content-['–_Unreleased']` instead of a raw `content:` declaration).
- Includes `docs(blit386): fix dead Perlin paper link with an archive.org snapshot`, already on this branch.

## Test plan

- [x] `pnpm run preflight` (website) – format, typecheck, tests, spellcheck, knip, build, `sync:docs:check`
- [x] Verified in-browser: `{@link HardwareSettings.isOverlayToggleHitDebugVisible}` on `/docs/api/core` resolves to `/docs/api/core#HardwareSettings`, which points at the `HardwareSettings` `Since 0.1.0` badge
- [x] Root-level pre-push checks (format, docs:links, agents:check, dash typography) passed on push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Changelog notes now link directly to documented API symbols and members when available.
  - Stability, deprecation, and unreleased badges can be linked directly and remain visible below the sticky header.
  - API documentation links now support member-specific anchors.

- **Style**
  - Improved changelog styling for changed and unreleased entries, including dark mode.
  - Added clearer link underlines and hover states.

- **Documentation**
  - Updated Perlin noise attribution with an archived source link and improved formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->