### PR TITLE
feat(skills): add release-review for reconciling the release ticket

### DIFF
--- a/.agents/skills/release-review
+++ b/.agents/skills/release-review
@@ -1,0 +1,1 @@
+../../.claude/skills/release-review

--- a/.claude/skills/release-review/SKILL.md
+++ b/.claude/skills/release-review/SKILL.md
@@ -22,8 +22,13 @@ so – there is no useful repo-only subset of this skill.
 /release-review BT-418
 ```
 
-With no argument, find the release ticket yourself: `list_issues` on the BLIT386 team for the current milestone and pick
-the one titled `Release engine <version>`. Confirm the choice with the user before editing anything.
+With no argument, resolve the milestone before the ticket. Call `list_milestones` on the BLIT386 project and pick the
+one whose version matches the release being prepared – do not assume the highest number and do not assume the most
+recently created. Then call `list_issues` for the BLIT386 team requesting the `projectMilestone` field and keep only the
+issues on that milestone; `list_issues` has no milestone parameter, so that filtering is yours to do. From those, pick
+the issue titled `Release engine <version>`.
+
+Show the user both the milestone you selected and the ticket you matched, and get confirmation before editing anything.
 
 ## What this skill does not do
 
@@ -41,8 +46,14 @@ This skill covers what `/release` never looks at: Linear, and the agent-facing f
 
 ## 1. Get the inventory from `/release`, do not re-derive it
 
-Read `.claude/skills/release/SKILL.md` and run its steps 2 through 7 – last tag, commits since, merged PRs with their
+Read `.claude/skills/release/SKILL.md` and follow its steps 2 through 7 – last tag, commits since, merged PRs with their
 changed files, direct pushes, per-package grouping. Answer its step 1 version question with the milestone's version.
+
+Those steps are read-only inventory, and running them from here must stay that way. The allowed set is `git describe`,
+`git log`, `git rev-list`, `gh pr list`, `gh repo view`, and `gh api repos/<repo>/commits/<sha>/pulls`, plus local
+parsing of what they return. Run nothing outside it. If a step in that range has grown a command that writes a file,
+creates a branch, or publishes anything, stop and report it instead of running it – a review must not mutate what it is
+reviewing.
 
 **Stop before step 8.** Writing `RELEASE.md` belongs to the release, not to the review. What you want is the grouped PR
 list and the direct-push list as data.
@@ -114,6 +125,10 @@ with the `linear-issue` skill rather than burying it in a checkbox.
 - A bare identifier outside a fenced block becomes a live mention, which is what you want. Inside a fenced block it
   stays literal, so starting prompts survive intact. Verify after saving rather than assuming.
 - `save_issue` echoes the whole issue back, which for a punch list can exceed the tool-result limit. That is a display
-  failure, not a save failure – confirm the result by grepping the saved tool-result file for a phrase you just wrote.
-- `git show --name-only --format=` prints no file names. Use
-  `git diff-tree --no-commit-id --name-only -r -m --first-parent <sha>`, which also handles merge commits.
+  failure, not a save failure. Verify with `get_issue` – it is the authoritative read, and it is what confirms the
+  persisted body, the checkbox state, and that the decision records survived. On a ticket large enough that the echo was
+  truncated, check the sections you touched rather than the whole body.
+- `git show --name-only --format=` prints no file names, and `git diff-tree -m --first-parent <sha>` over-reports on a
+  merge commit – on one of this repo's merges it returned three files, a lockfile and two `package.json`s, that the
+  first-parent diff does not contain. Use `git diff-tree --no-commit-id --name-only -r <sha>^1 <sha>`, which compares
+  the commit against its first parent and is correct for both squash commits and merges.

--- a/.claude/skills/release-review/SKILL.md
+++ b/.claude/skills/release-review/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: release-review
+description:
+  'Reconcile a Linear release ticket with what the repo and the milestone actually say, before running /release. Use
+  when a release is close and the punch-list ticket needs to be trusted again: stale checkboxes, scope that moved
+  milestone, counts that have drifted, issues on the milestone the ticket never mentions, and open PRs that still have
+  to land.'
+---
+
+# Release Review
+
+A release punch list is written once and read months later. Between those two moments the scope moves, features land
+without anyone ticking a box, issues get pushed to the next milestone, and stated counts go stale. This skill makes the
+ticket trustworthy again so `/release` can be run against it.
+
+Requires the Linear MCP tools (`get_issue`, `list_issues`, `save_issue`, `list_milestones`). Without them, stop and say
+so – there is no useful repo-only subset of this skill.
+
+## Usage
+
+```text
+/release-review BT-418
+```
+
+With no argument, find the release ticket yourself: `list_issues` on the BLIT386 team for the current milestone and pick
+the one titled `Release engine <version>`. Confirm the choice with the user before editing anything.
+
+## What this skill does not do
+
+`/release` already owns the repo-facing half, and reimplementing it is the main way this skill goes wrong:
+
+| Job | Owner |
+| --- | --- |
+| Merged-PR inventory since the last tag, grouped by package | `/release` steps 2-7 |
+| Direct pushes to `main` with no associated PR | `/release` step 5 |
+| Per-symbol docs coverage across engine docs, kit content, website mirror | `/release`, "Verify docs coverage" |
+| Changelog cross-checked against `_api-history.json` | `/release`, "Mark the changelog as released" |
+| Bump, publish, tag, API-history regeneration | `/release`, "After RELEASE.md" |
+
+This skill covers what `/release` never looks at: Linear, and the agent-facing files under `.claude/rules/`.
+
+## 1. Get the inventory from `/release`, do not re-derive it
+
+Read `.claude/skills/release/SKILL.md` and run its steps 2 through 7 – last tag, commits since, merged PRs with their
+changed files, direct pushes, per-package grouping. Answer its step 1 version question with the milestone's version.
+
+**Stop before step 8.** Writing `RELEASE.md` belongs to the release, not to the review. What you want is the grouped PR
+list and the direct-push list as data.
+
+## 2. Reconcile the ticket against Linear
+
+Pull every issue identifier the ticket mentions, plus every issue on the release milestone, and compare. Each row below
+produced a real finding the last time this ran:
+
+| Check | What it looks like |
+| --- | --- |
+| Scope that moved milestone | The ticket lists a ticket as shipping; that ticket now sits on the next milestone |
+| Checkbox versus status | Unchecked boxes for issues that are Done, and "(In Progress)" annotations long out of date |
+| Milestone issues the ticket omits | Open issues on the milestone named nowhere in the punch list |
+| Status contradicting shipped code | An issue reverted to Todo while its code is on `main` – check the source, not the ticket |
+| Wrong-state issues on the milestone | Duplicate or Canceled issues still counting toward the burn-down |
+
+For scope that moved, do not simply delete it. Move it into the ticket's deferred section with the date and a sentence
+on what its absence means for this release – a release that quietly loses a feature is worse than one that records why.
+
+## 3. Reconcile the ticket against the repo
+
+Every number and file path a punch list states is a claim with a shelf life. Verify each one and rewrite it with the
+date you checked:
+
+- Symbol counts: `unreleased` entries in `packages/blit386/docs/_api-history.json`
+- Commit count between the last tag and `main`
+- Pre-bump values the bump script rewrites: `BTAPI.VERSION_MAJOR` / `MINOR` / `PATCH`, kit `blit386.engineRange`,
+  `scaffold.ts`'s `BLIT386_RANGE`
+- Named files: confirm each path exists and holds what the ticket says. A doc item can be satisfied in a different file
+  than the one named – when it is, say so explicitly, or the next reader duplicates the content into the named file
+
+## 4. The blind spots
+
+Three classes of problem sit outside both `/release` and the ticket's own checklist:
+
+- **Agent-facing rules.** `/release` greps `docs/*.md` and kit content, never `packages/*/.claude/rules/`. Rules that
+  enumerate the public surface by name go stale silently, and a stale enumeration is worse than an absent one: the next
+  session reads a complete-looking list and concludes a real symbol is not public. Check every rule that names API.
+- **Open PRs that must land.** `/release` only sees merged PRs. An open PR that changes behavior on an existing public
+  method belongs to this release, not the next one. List them in the ticket with the reason they gate the bump.
+- **Closed-but-not-merged PRs.** A gate phrased as "resolve or merge open PR #N" is satisfied when that PR is closed as
+  superseded. Check the state of every PR the ticket names rather than assuming it is still open.
+
+## 5. Patch the ticket
+
+Use `save_issue` with `patch` operations, never a full-body resend – see mechanics below.
+
+Four rules:
+
+1. **Never tick a box you did not verify.** A wrongly ticked box is worse than a stale unchecked one.
+2. **Never delete a decision record.** Counts and checkboxes are derivable and safe to rewrite. "Deferred deliberately
+   because it is a catalog, not a commitment" is not derivable and must survive.
+3. **Date every verification you write in.** "Re-verified 2026-08-10" tells the next reader how much to trust it.
+4. **Report milestone and status corrections, do not apply them.** Moving another issue's milestone is the user's call.
+
+## 6. Report
+
+Lead with what is genuinely still open – that is the answer the user wants. Then the corrections you made, then the
+milestone and status fixes you are recommending but did not apply. If the review found work worth its own issue, file it
+with the `linear-issue` skill rather than burying it in a checkbox.
+
+## Linear mechanics that bite
+
+- `patch` anchors must match the current content **exactly once**, and one failing operation aborts the whole call with
+  nothing saved. Re-read with `get_issue` and copy anchors from that output rather than from memory.
+- Never wrap an identifier in your own `<issue id="...">` element. Write the bare `BT-470` and let Linear resolve it;
+  wrapping it produces nested elements that render badly.
+- A bare identifier outside a fenced block becomes a live mention, which is what you want. Inside a fenced block it
+  stays literal, so starting prompts survive intact. Verify after saving rather than assuming.
+- `save_issue` echoes the whole issue back, which for a punch list can exceed the tool-result limit. That is a display
+  failure, not a save failure – confirm the result by grepping the saved tool-result file for a phrase you just wrote.
+- `git show --name-only --format=` prints no file names. Use
+  `git diff-tree --no-commit-id --name-only -r -m --first-parent <sha>`, which also handles merge commits.


### PR DESCRIPTION
## What

Adds `/release-review`, a maintainer skill that reconciles a Linear release ticket with what the repo and the milestone actually say, before `/release` runs.

## Why

Reviewing BT-418 ahead of 1.5.0 turned up a full cycle of drift in the punch list:

- Scope that had moved to the 1.6.0 milestone was still listed as shipping (BT-415, BT-391, BT-416, BT-388)
- Features had landed with their boxes unchecked, and "(In Progress)" annotations were months stale
- Stated counts were wrong: 13 vs 19 `unreleased` symbols, 1,180 vs 1,396 commits
- Two issues on the 1.5.0 milestone (BT-449, BT-458) were named nowhere in the punch list
- An engine rule that enumerates the public API by name had silently missed four symbols (now BT-470)

None of that is covered today. `/release` is entirely repo-facing and never reads Linear; `/issue-audit` is GitHub-only. So the reconciliation happened by hand, and roughly half of it duplicated `/release` steps 2-7 along the way.

## Design

The skill covers only the gap, and says so explicitly:

- **Delegates** the merged-PR inventory, direct-push detection, and per-symbol docs coverage back to `/release` rather than reimplementing them
- **Adds** the Linear reconciliation and the two blind spots `/release` has: `packages/*/.claude/rules/`, and open or closed-not-merged PRs
- **Reports** milestone and status corrections instead of applying them, since moving another issue's milestone is the maintainer's call
- Never ticks a checkbox it did not verify, and never deletes a decision record

It also captures the Linear MCP mechanics that cost the most time, so the next run does not rediscover them: `patch` anchors abort the whole call on a single miss, wrapping an identifier in your own `<issue>` element produces nested markup, and `git show --name-only --format=` prints nothing.

## Test plan

- [x] `pnpm run agents:check` passes with the new `.agents/skills/release-review` symlink
- [x] `npx cspell` clean (reworded prose rather than adding to the dictionary)
- [x] `npx prettier --check` clean, including compact-table formatting
- [x] `node scripts/check-dash-typography.mjs` clean
- [x] Full pre-push preflight green across the four changed-package chains
- [ ] Reviewer: sanity-check that the delegation boundary against `/release` reads correctly, since the whole point is not duplicating it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for reviewing release readiness, including verification steps, milestone checks, and reporting expectations.
  * Standardized operational procedures for validating release information before publication.

* **Chores**
  * No changes to product functionality or the end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->