### PR TITLE
fix(demos): stop asserting a hardcoded demo count in the OG capture test

### DIFF
--- a/packages/demos/scripts/__tests__/capture-og-image.test.mjs
+++ b/packages/demos/scripts/__tests__/capture-og-image.test.mjs
@@ -42,7 +42,10 @@ describe('parseArgs', () => {
         const options = parseArgs(['--all']);
 
         assert.deepEqual(options.slugs, DEMO_ORDER);
-        assert.equal(options.slugs.length, 47);
+        // Guards against DEMO_ORDER being empty, which deepEqual alone would accept.
+        // Deliberately not a hardcoded count: that has to be hand-bumped on every
+        // demo added or retired, and gets missed.
+        assert.ok(options.slugs.length > 0);
     });
 
     it('parses string, numeric, and boolean overrides', () => {


### PR DESCRIPTION
## What

Retiring the barebones demo took `DEMO_ORDER` from 47 slugs to 46, but `capture-og-image.test.mjs` still asserted the old count. `main` has been red since #533.

## Why this shape

The `assert.deepEqual(options.slugs, DEMO_ORDER)` on the line above already proves the real behavior – that `--all` expands to every ordered slug. The count assertion only added one thing `deepEqual` cannot catch: `DEMO_ORDER` being empty, which `deepEqual([], [])` would happily accept.

So it asserts that directly rather than restating a number that has to be hand-bumped every time a demo is added or retired, and gets missed.

## Test plan

- [x] `pnpm --filter blit386-demos run test` – 90 pass, 0 fail (was 89/1)
- [x] Verified `DEMO_ORDER.length` is 46 on `main`

Unblocks the 1.5.0 release (BT-418), whose pre-push preflight this was failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)