### PR TITLE
docs: close 1.5.0 documentation gaps and refresh website lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Already have a project and just want the engine in it? That path starts at
 
 | Package | npm | What it is |
 | --- | --- | --- |
-| [`packages/blit386`](packages/blit386) | [`blit386`](https://www.npmjs.com/package/blit386) | The engine: palette, sprites, text, input, audio, post-process effects |
+| [`packages/blit386`](packages/blit386) | [`blit386`](https://www.npmjs.com/package/blit386) | The engine: palette, sprites, text, input, audio, seeded random, easing, post-process effects |
 | [`packages/create-blit386`](packages/create-blit386) | [`create-blit386`](https://www.npmjs.com/package/create-blit386) | The scaffolder behind `npm create blit386@latest` |
 | [`packages/kit`](packages/kit) | [`@blit386/kit`](https://www.npmjs.com/package/@blit386/kit) | What a generated game gets: starter docs, game-author skills, the `blit` CLI |
 | [`packages/demos`](packages/demos) | not published | The examples running at demos.blit386.dev |

--- a/packages/blit386/README.md
+++ b/packages/blit386/README.md
@@ -148,7 +148,8 @@ bootstrap(Game);
 
 - Draw with numbers, not pixels: A 256-color paint box; every primitive and sprite is just a slot index.
 - Animate colors, not geometry: Cycle, fade, flash, and swap give you water, lava, and lightning for the cost of one
-  tiny palette upload.
+  tiny palette upload. `BT.paletteFadeExposure` goes further and fades in linear light like an iris pull, so highlights
+  hold and shadows crush instead of everything dimming at one flat rate.
 - Retro palettes in the box: VGA, CGA, C64, Game Boy, PICO-8, and NES presets.
 - Recolor without redrawing: Palette offsets turn one sprite sheet into team colors, day and night, or power-up states –
   no duplicate textures.
@@ -159,9 +160,18 @@ bootstrap(Game);
   main) with volume, mute, and fades, synthesize blips and booms from scratch or reach for a built-in preset, and read
   live levels off the overlay's audio meters – all while tracking the browser's autoplay-gesture unlock honestly instead
   of pretending it doesn't exist.
+- Worlds that come back the same: a seeded PRNG (`BT.random`, `BT.randomSeed`) with the draws games actually reach for –
+  picks, shuffles, weighted drops, points in a rect – plus Value, Perlin, and Simplex noise and stateless coordinate
+  hashes for chunked terrain that needs no stored generator.
+- Motion with a shape: the full easing family set – sine, cubic, quartic, quintic, expo, circ, back, elastic, bounce –
+  and `interpolate()` across numbers, `Vector2i`, `Color32`, and `Rect2i`.
 - Loading progress: `BT.loadingAssetsCount` tracks in-flight image and audio loads so you can drive a loading screen.
+- A splash that is also a loading screen: the BLIT386 logo fades in on its own gray ramp while your `init()` runs, holds
+  until assets settle, then hands off into your palette with no cut. On in release builds, off in development, and any
+  key skips it.
 - Mobile polish: wake lock, screen orientation lock and detection, and opt-in pointer and keyboard scroll capture.
-- Hot reload: the `blit386/vite` plugin swaps code and assets in place during development without a full page reload.
+- Hot reload: the `blit386/vite` plugin swaps code and assets in place during development without a full page reload,
+  and marks the build so `BT.isDevMode` can gate debug-only code out of what you ship.
 
 ## Get started
 
@@ -215,6 +225,7 @@ important pages:
 | [API: Core](docs/api-core.md) | bootstrap, init, default configuration |
 | [API: Game Loop](docs/api-game-loop.md) | tick timing, present FPS, Timer |
 | [Game Loop Guide](docs/guide-game-loop.md) | render-time interpolation, smoothing motion |
+| [API: Easing](docs/api-easing.md) | easing curve families, interpolate for numbers, points, colors, rects |
 | [API: Random](docs/api-random.md) | seeded PRNG, coordinate hashes, Value/Perlin/Simplex noise |
 | [Random Guide](docs/guide-random.md) | reproducible runs, independent streams, procedural worlds |
 | [API: Camera](docs/api-camera.md) | global pixel offset, world-clamp helpers |
@@ -228,6 +239,7 @@ important pages:
 | [API: Browser Support](docs/api-browser-support.md) | WebGPU matrix, wake lock, orientation, build toolchain |
 | [Input Guide](docs/guide-input.md) | pointer, keyboard, gamepad, scroll capture |
 | [Hot Reload Guide](docs/guide-hot-reload.md) | blit386/vite plugin, hot-swap, asset hot-replace |
+| [Splash Guide](docs/guide-splash.md) | the BLIT386 splash, gating, loading-screen hold, palette handoff |
 | [Palette Guide](docs/guide-palette.md) | the palette-first workflow, offsets, and effects |
 | [Audio Guide](docs/guide-audio.md) | loading, playing, and designing sound |
 | [Bitmap Fonts](docs/guide-bitmap-fonts.md) | .btfont format, BMFont conversion |

--- a/packages/kit/content/skills/add-text/SKILL.md
+++ b/packages/kit/content/skills/add-text/SKILL.md
@@ -45,6 +45,24 @@ render() {
 }
 ```
 
+## Missing characters (engine 1.5.0+)
+
+The built-in font covers plain ASCII plus dashes, arrows, media icons, uppercase Greek, and a few symbols. Any character
+it does not have draws as a fallback glyph, so you see a marker instead of the character quietly disappearing.
+
+A custom `.btfont` only gets that safety net if it defines its own glyph keyed by `U+FFFD` (the Unicode replacement
+character). Without one, a missing character is skipped and the pen does not move – so the next character draws on top
+of the one before it, and the whole line looks scrambled rather than merely incomplete.
+
+```js
+if (!this.font.hasGlyph('é')) {
+  // This character has no glyph of its own in the font.
+}
+```
+
+`hasGlyph()` answers whether a character has its _own_ glyph, not whether the fallback would cover it. That is
+deliberate – use it to check what a font really contains.
+
 ## Key calls
 
 - `BT.systemPrint(pos, slot, text)` (method) – built-in 6x14 font.
@@ -52,6 +70,7 @@ render() {
 - `BitmapFont.load(url)` (static, async) – load a `.btfont` file.
 - `BT.printFont(font, pos, text, paletteOffset?)` (method) – draw with a loaded font; `paletteOffset` shifts the glyph
   colors.
+- `font.hasGlyph(char)` (method) – true when the font has its own glyph for that character.
 
 ## Notes
 

--- a/packages/website/content/community.mdx
+++ b/packages/website/content/community.mdx
@@ -34,9 +34,9 @@ ecosystem.
 
 Releases, new demos, and project news are posted through these channels:
 
-- **[X](https://x.com/blit386)**
-- **[Bluesky](https://bsky.app/profile/blit386.bsky.social)**
 - **[Mastodon](https://mastodon.gamedev.place/@blit386)**
-- **GitHub releases** – [github.com/blit386/blit386/releases](https://github.com/blit386/blit386/releases)
+- **[Bluesky](https://bsky.app/profile/blit386.bsky.social)**
+- **[X](https://x.com/blit386)**
+- **[GitHub releases](https://github.com/blit386/blit386/releases)**
 
 The GitHub releases page is the most reliable source – every version bump gets a release note with a changelog.

--- a/packages/website/src/data/community.ts
+++ b/packages/website/src/data/community.ts
@@ -10,12 +10,6 @@ export type CommunityDestination = {
 
 export const communityDestinations: CommunityDestination[] = [
     {
-        label: 'GitHub Discussions',
-        platform: 'github',
-        url: 'https://github.com/blit386/blit386/discussions',
-        external: true,
-    },
-    {
         label: 'Discord',
         platform: 'discord',
         url: 'https://discord.gg/tC2wGt88Uj',
@@ -43,6 +37,12 @@ export const communityDestinations: CommunityDestination[] = [
         label: 'GitHub Releases',
         platform: 'github',
         url: 'https://github.com/blit386/blit386/releases',
+        external: true,
+    },
+    {
+        label: 'GitHub Discussions',
+        platform: 'github',
+        url: 'https://github.com/blit386/blit386/discussions',
         external: true,
     },
     {

--- a/packages/website/src/data/demos.ts
+++ b/packages/website/src/data/demos.ts
@@ -29,13 +29,6 @@ export const flagshipDemos: readonly DemoEntry[] = [
         href: 'https://demos.blit386.dev/basics',
     },
     {
-        title: 'Pixel Art',
-        description:
-            'Draw sprites and shapes through a shared 256-entry indexed palette for pixel-perfect 2D rendering.',
-        thumbnail: '/demos/thumb-pixel-art.webp',
-        href: 'https://demos.blit386.dev/pixel-art',
-    },
-    {
         title: 'Patterns',
         description: 'Animated mathematical art from primitives alone: spirals, Lissajous curves, waves, and a tunnel.',
         thumbnail: '/demos/thumb-patterns.webp',
@@ -68,22 +61,10 @@ export const flagshipDemos: readonly DemoEntry[] = [
         href: 'https://demos.blit386.dev/palette-cycling',
     },
     {
-        title: 'CRT Pip-Boy',
-        description: 'Full-screen CRT scanline and phosphor post-process pass running on the WebGPU backend.',
-        thumbnail: '/demos/thumb-crt-pipboy.webp',
-        href: 'https://demos.blit386.dev/crt-pipboy',
-    },
-    {
         title: 'Snake Game',
         description: 'A complete playable game: input handling, game-state loop, collision, and score rendering.',
         thumbnail: '/demos/thumb-snake-game.webp',
         href: 'https://demos.blit386.dev/snake-game',
-    },
-    {
-        title: 'Basics Enhanced',
-        description: 'Primitives, text, and sprites side-by-side – a quick tour of the core drawing API.',
-        thumbnail: '/demos/thumb-basics-enhanced.webp',
-        href: 'https://demos.blit386.dev/basics-enhanced',
     },
     {
         title: 'Hypercube',


### PR DESCRIPTION
Pre-release documentation pass for 1.5.0 (BT-418, section 3). Closes the two coverage gaps found auditing the 1.5.0 surface against `main`, so the bump PR that follows is purely mechanical.

## Kit content: BitmapFont fallback glyphs

#528 is a **behavior change on an existing public method** – `getGlyph()` / `getGlyphByCode()` / `measureText()` now substitute a `U+FFFD` fallback instead of returning `null`, while `hasGlyph()` deliberately keeps reporting true glyph presence. The engine docs cover it well; kit content did not mention glyphs at all (`grep -rni "glyph" packages/kit/content/` returned one unrelated hit).

That matters more than a missing symbol would: kit content ships inside every scaffolded game and is what a game author's assistant reads. `add-text` gains a "Missing characters" section – including the part that actually bites, that a custom `.btfont` without its own `U+FFFD` glyph still drops the character *and* fails to advance the pen, so the next character overdraws the one before it – plus `hasGlyph()` in its key-calls list.

## README feature lists

`packages/blit386/README.md`'s "What makes it fun" predated the whole 1.5.0 surface. Adds seeded random and noise, the full easing family set plus `interpolate()`, the splash, and `BT.isDevMode` (folded into the hot-reload bullet, since the vite plugin is what sets the marker), and extends the palette bullet with `BT.paletteFadeExposure`.

Its documentation table was also missing rows for `docs/api-easing.md` and `docs/guide-splash.md` though both files exist. Root `README.md`'s engine cell picks up random and easing.

Deliberately **not** changed: root `CLAUDE.md`'s "Where the detail lives". Its axis is cross-cutting process concerns (versioning, security runbook, RTK policy), not a subsystem index – there is no palette or audio row either.

## Website

Drops three retired entries from `flagshipDemos` and reorders the community destinations.

## Test plan

- [x] `pnpm run format:check`, `agents:check`, `test:agent-config`
- [x] `pnpm --filter @blit386/kit run typecheck` + `test` (31 pass)
- [x] `pnpm --filter create-blit386 run typecheck` + `test` (26 pass)
- [x] `pnpm --filter blit386-website run typecheck` + `test`
- [x] `pnpm --filter blit386 run spellcheck` (282 files, 0 issues)
- [x] Pre-push preflight green (needed #534 first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)