### PR TITLE
chore(release): 1.5.0

### DIFF
--- a/packages/blit386/docs/changelog.md
+++ b/packages/blit386/docs/changelog.md
@@ -19,7 +19,7 @@ This page is editorial – release highlights and migration notes, not an exhaus
 `guides/*` reference page, or [GitHub Releases](https://github.com/blit386/blit386/releases) for the full PR-by-PR
 notes, including dependency bumps and CI changes omitted here for brevity.
 
-## Unreleased
+## 1.5.0 – 2026-08-11
 
 ### Added
 
@@ -46,9 +46,9 @@ notes, including dependency bumps and CI changes omitted here for brevity.
   a post-production crossfade. It interpolates each RGB channel in linear light instead of in encoded values (which is a
   straight scaling of light when one end of the fade is black), and offsets each entry's schedule by its luminance, so
   bright entries rise first and hold longest while dark entries arrive late and crush early – toe and shoulder behavior
-  from one knob, `highlightLead` (`0` is a plain linear-light fade, default `0.5`). Every entry still lands exactly on
-  the target, so nothing drifts. Note the effect is per palette index, not per pixel. See
-  [Palette](api-palette.md#exposure-fade) and [Palette guide](guide-palette.md).
+  from one knob, `highlightLead` (`0` is a plain linear-light fade, default `0.5`) on the exported `ExposureFadeOptions`
+  bag. Every entry still lands exactly on the target, so nothing drifts. Note the effect is per palette index, not per
+  pixel. See [Palette](api-palette.md#exposure-fade) and [Palette guide](guide-palette.md).
 - `Color32#toLinear` / `#toSrgb`, plus `#toLinearInPlace` / `#toSrgbInPlace`, converting between encoded sRGB and linear
   light with the real sRGB piecewise transfer function (straight toe below the 0.04045 breakpoint), not a bare 2.2
   power. Channels stay 8-bit, so treat linear light as a working space, not a storage format.
@@ -61,9 +61,9 @@ notes, including dependency bumps and CI changes omitted here for brevity.
   `HardwareSettings.isSplashEnabled` and the `?splash` / `?nosplash` URL flags to override either default. It doubles as
   a loading screen – the game's `init()` runs concurrently and the hold extends until it settles – and hands off into
   the game's palette with a single continuous `BT.paletteFadeExposure`, so there is no cut. Any key, click, or tap
-  skips, and that press is swallowed. New getters `BT.splashState` and `BT.isSplashVisible`, plus `splashColorDark` /
-  `splashColorLight` for the ramp endpoints. The pixelated dissolve is WebGPU-only; the software backend gets the plain
-  fade. See [the splash guide](guide-splash.md) and [Core](api-core.md#splash-state).
+  skips, and that press is swallowed. New getters `BT.splashState` (a `SplashState`) and `BT.isSplashVisible`, plus
+  `splashColorDark` / `splashColorLight` for the ramp endpoints. The pixelated dissolve is WebGPU-only; the software
+  backend gets the plain fade. See [the splash guide](guide-splash.md) and [Core](api-core.md#splash-state).
 - `BitmapFont` fallback-glyph support: a `.btfont` file (or the built-in system font) can include a glyph keyed by
   `U+FFFD` (the Unicode replacement character), and it is substituted for any character missing its own glyph instead of
   the character silently vanishing. See [Bitmap Fonts guide](guide-bitmap-fonts.md#fallback-glyph).

--- a/packages/blit386/package.json
+++ b/packages/blit386/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blit386",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "type": "module",
   "description": "A palette-first WebGPU retro engine for TypeScript, inspired by RetroBlit.",
   "author": {

--- a/packages/blit386/src/core/BTAPI.ts
+++ b/packages/blit386/src/core/BTAPI.ts
@@ -75,7 +75,7 @@ export class BTAPI {
     public static readonly VERSION_MAJOR = 1;
 
     /** Minor version number. */
-    public static readonly VERSION_MINOR = 4;
+    public static readonly VERSION_MINOR = 5;
 
     /** Patch version number. */
     public static readonly VERSION_PATCH = 0;

--- a/packages/create-blit386/package.json
+++ b/packages/create-blit386/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-blit386",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Scaffold a new BLIT386 game in seconds.",
   "author": {
     "name": "Václav Vančura",

--- a/packages/create-blit386/src/scaffold.ts
+++ b/packages/create-blit386/src/scaffold.ts
@@ -23,7 +23,7 @@ import { type GeneratedFile, generateClaudeAdapter, generateCursorAdapter } from
 const require = createRequire(import.meta.url);
 
 /** blit386 version range written into the generated package.json. */
-const BLIT386_RANGE = '^1.4.0';
+const BLIT386_RANGE = '^1.5.0';
 
 /** Output directory names for optional wizard templates. */
 const GITHUB_DIR = '.github';

--- a/packages/create-blit386/test/scaffold.test.mjs
+++ b/packages/create-blit386/test/scaffold.test.mjs
@@ -87,7 +87,7 @@ test('scaffolds a runnable game project', () => {
         const manifest = JSON.parse(manifestRaw);
         assert.equal(manifest.name, 'my-game', 'package name should match the folder');
         assert.ok(manifest.dependencies?.blit386, 'blit386 dependency is missing');
-        assert.equal(manifest.dependencies.blit386, '^1.4.0', 'generated games should pin blit386 ^1.4.0');
+        assert.equal(manifest.dependencies.blit386, '^1.5.0', 'generated games should pin blit386 ^1.5.0');
         assert.ok(manifest.devDependencies?.['@blit386/kit'], '@blit386/kit devDependency is missing');
         assert.ok(manifest.devDependencies?.['@biomejs/biome'], '@biomejs/biome devDependency is missing');
         assert.equal(

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blit386/kit",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Canonical BLIT386 AI docs (AGENTS.md + local docs) and the blit project CLI.",
   "author": {
     "name": "Václav Vančura",
@@ -21,7 +21,7 @@
     "node": ">=22.18.0"
   },
   "blit386": {
-    "engineRange": "^1.4.0"
+    "engineRange": "^1.5.0"
   },
   "bin": {
     "blit": "./dist/cli.js"

--- a/packages/kit/test/doctor.test.mjs
+++ b/packages/kit/test/doctor.test.mjs
@@ -55,7 +55,7 @@ function runDoctor(cwd) {
 }
 
 test('blit doctor reports a compatible engine range', () => {
-    const root = makeGame('1.4.0');
+    const root = makeGame('1.5.0');
     try {
         const { exitCode, output } = runDoctor(root);
         assert.equal(exitCode, 0);

--- a/packages/website/content/docs/reference/changelog.mdx
+++ b/packages/website/content/docs/reference/changelog.mdx
@@ -16,7 +16,7 @@ This page is editorial – release highlights and migration notes, not an exhaus
 `guides/*` reference page, or [GitHub Releases](https://github.com/blit386/blit386/releases) for the full PR-by-PR
 notes, including dependency bumps and CI changes omitted here for brevity.
 
-## Unreleased
+## 1.5.0 – 2026-08-11
 
 ### Added
 
@@ -43,9 +43,9 @@ notes, including dependency bumps and CI changes omitted here for brevity.
   a post-production crossfade. It interpolates each RGB channel in linear light instead of in encoded values (which is a
   straight scaling of light when one end of the fade is black), and offsets each entry's schedule by its luminance, so
   bright entries rise first and hold longest while dark entries arrive late and crush early – toe and shoulder behavior
-  from one knob, `highlightLead` (`0` is a plain linear-light fade, default `0.5`). Every entry still lands exactly on
-  the target, so nothing drifts. Note the effect is per palette index, not per pixel. See
-  [Palette](/docs/api/palette#exposure-fade) and [Palette guide](/docs/guides/palette).
+  from one knob, `highlightLead` (`0` is a plain linear-light fade, default `0.5`) on the exported `ExposureFadeOptions`
+  bag. Every entry still lands exactly on the target, so nothing drifts. Note the effect is per palette index, not per
+  pixel. See [Palette](/docs/api/palette#exposure-fade) and [Palette guide](/docs/guides/palette).
 - `Color32#toLinear` / `#toSrgb`, plus `#toLinearInPlace` / `#toSrgbInPlace`, converting between encoded sRGB and linear
   light with the real sRGB piecewise transfer function (straight toe below the 0.04045 breakpoint), not a bare 2.2
   power. Channels stay 8-bit, so treat linear light as a working space, not a storage format.
@@ -58,9 +58,9 @@ notes, including dependency bumps and CI changes omitted here for brevity.
   `HardwareSettings.isSplashEnabled` and the `?splash` / `?nosplash` URL flags to override either default. It doubles as
   a loading screen – the game's `init()` runs concurrently and the hold extends until it settles – and hands off into
   the game's palette with a single continuous `BT.paletteFadeExposure`, so there is no cut. Any key, click, or tap
-  skips, and that press is swallowed. New getters `BT.splashState` and `BT.isSplashVisible`, plus `splashColorDark` /
-  `splashColorLight` for the ramp endpoints. The pixelated dissolve is WebGPU-only; the software backend gets the plain
-  fade. See [the splash guide](/docs/guides/splash) and [Core](/docs/api/core#splash-state).
+  skips, and that press is swallowed. New getters `BT.splashState` (a `SplashState`) and `BT.isSplashVisible`, plus
+  `splashColorDark` / `splashColorLight` for the ramp endpoints. The pixelated dissolve is WebGPU-only; the software
+  backend gets the plain fade. See [the splash guide](/docs/guides/splash) and [Core](/docs/api/core#splash-state).
 - `BitmapFont` fallback-glyph support: a `.btfont` file (or the built-in system font) can include a glyph keyed by
   `U+FFFD` (the Unicode replacement character), and it is substituted for any character missing its own glyph instead of
   the character silently vanishing. See [Bitmap Fonts guide](/docs/guides/bitmap-fonts#fallback-glyph).


### PR DESCRIPTION
The 1.5.0 lockstep bump (BT-418, section 5). `blit386`, `@blit386/kit`, and `create-blit386` all move to 1.5.0.

## What `pnpm run bump -- 1.5.0` changed

Dry run listed six targets, all as expected:

| Target | previous | next |
| --- | --- | --- |
| `packages/blit386/package.json` | `1.4.0` | `1.5.0` |
| `packages/blit386/src/core/BTAPI.ts` (`VERSION_MAJOR`/`MINOR`/`PATCH`) | `1.4.0` | `1.5.0` |
| `packages/kit/package.json` | `1.4.0` | `1.5.0` |
| `packages/kit/package.json (blit386.engineRange)` | `^1.5.0` | `^1.5.0` |
| `packages/create-blit386/package.json` | `1.4.0` | `1.5.0` |
| `packages/create-blit386/src/scaffold.ts (BLIT386_RANGE)` | `^1.5.0` | `^1.5.0` |

The two no-op rows are the derived ranges, which were already at `^1.5.0` in the working tree before this branch.

Also here: the changelog `## Unreleased` heading becomes `## 1.5.0 – 2026-08-11`, the two exported types that had `_api-history.json` entries but no changelog mention (`ExposureFadeOptions`, `SplashState`) are now named, and the website docs mirror is regenerated. The kit `doctor` and scaffolder pin fixtures move with the ranges they assert against – the scaffolder one is load-bearing, since its test runs against `dist/` and only fails once that is rebuilt.

## SemVer: minor

New engine API, no break in the engine's own public API. The engine anchors semver. No migration registered – nothing was renamed or removed in 1.5.0.

## Known red check: `api:history:check`

Expected, and deliberately not fixed here. `_api-history.json`'s `packageVersion` still reads `1.4.0` while `package.json` now says `1.5.0`.

Regenerating the manifest is a post-release step: it only runs after the `1.5.0` tag exists and `UNRELEASED_VERSION` moves to `1.5.1`. Doing it now would leave `packageVersion` claiming a version that is not on npm; doing it with `UNRELEASED_VERSION` already bumped would flip all 19 of this release's symbols from `unreleased` straight to `stable` with null dates. Both are silent corruptions, so the check stays red until the tag exists.

## Test plan

- [x] `pnpm run security:audit` – no known vulnerabilities
- [x] `pnpm run test:bump-lockstep` – 24 pass
- [x] `pnpm run format:check`, `docs:links`, `agents:check`, `test:agent-config`
- [x] `pnpm --filter blit386 run preflight` – green through `api:since:check`; fails only at `api:history:check` as above
- [x] `pnpm --filter @blit386/kit run typecheck` + `test` – 31 pass
- [x] `pnpm --filter create-blit386 run build` + `test` – 26 pass (rebuilt `dist/` first, which is what caught the stale pin assertion)
- [x] `pnpm --filter blit386-website run sync:docs:check` – mirror matches
- [ ] `pnpm --filter blit386 run test:visual` – **not run.** Playwright pins `channel: 'chrome'` and Google Chrome is not installed on this machine; CI does not run the visual suite either. Flagged rather than worked around.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Documented the `highlightLead` exposure-fade option and its default value.
  * Clarified the type returned by the splash-screen state property.

* **Release**
  * Released version 1.5.0.
  * Updated generated projects and compatibility checks to use the 1.5 release line.
  * Incremented the API minor version to reflect the release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->