### PR TITLE
chore(repo): exclude playwright report output from prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -12,6 +12,11 @@ node_modules/
 # Build outputs
 dist/
 
+# Test runner output (generated locally by `test:visual`, gitignored). Formatting
+# these makes the next format:check fail on files nobody authored.
+playwright-report/
+test-results/
+
 # Agent scratch space (not ours to format)
 .git/
 .remember/


### PR DESCRIPTION
## Summary

`playwright-report/` and `test-results/` are gitignored (`.gitignore` line 32) but were never added to
`.prettierignore`. Any local run of `pnpm --filter blit386 run test:visual` leaves generated Markdown in those
directories, so the very next `pnpm --filter blit386 run format:check` – the first link in the engine's `preflight`
chain – failed with roughly 22 "Code style issues found" warnings on files nobody authored. It reads like a real
formatting regression and is not one.

Both directories are now excluded, in the existing entry style, in a section next to the build-outputs block.

## Test plan

The visual suite itself needs real Google Chrome (`channel: 'chrome'` in `packages/blit386/playwright.config.ts`), so
verification used the equivalent dummy-file reproduction:

- [x] Negative control: a deliberately malformed `packages/blit386/playwright-report/data/x.md` fails
      `prettier --check` (exit 1) when unignored, confirming the file type is in scope for the gate
- [x] With the fix, the same dummy plus `packages/blit386/test-results/foo/y.md` leave
      `pnpm --filter blit386 run format:check` green ("All matched files use Prettier code style!", Biome clean over
      282 files)
- [x] Root gate clean: `pnpm run format:check`, `pnpm run agents:check`, `pnpm run check-dash-typography`,
      `pnpm run docs:links`
- [x] Dummy directories removed; the diff is `.prettierignore` only