### PR TITLE
chore(release): regenerate the api history manifest for 1.5.0

### DIFF
--- a/packages/blit386/docs/_api-history.json
+++ b/packages/blit386/docs/_api-history.json
@@ -1,5 +1,5 @@
 {
-  "packageVersion": "1.4.0",
+  "packageVersion": "1.5.0",
   "unreleasedVersion": "1.5.0",
   "versions": {
     "0.1.0": "2025-12-13T11:02:41+01:00",


### PR DESCRIPTION
## Summary

`Code Quality (engine)` has been failing on `main` since the 1.5.0 release merged
([#536](https://github.com/blit386/blit386/pull/536), [run 31459783639](https://github.com/blit386/blit386/actions/runs/31459783639)).
The release bumped the engine to 1.5.0 but left `packages/blit386/docs/_api-history.json` at
`packageVersion: "1.4.0"`, so `api:history:check` fails.

It went unnoticed because that job only runs when engine or shared paths change – the two commits that landed on main
afterwards were website-only, so CI skipped it. It resurfaced on
[#537](https://github.com/blit386/blit386/pull/537), a root-level change that triggers every package's quality job.

Regenerated with `pnpm run api:history`, which is what the check's own error message prescribes. The result is a
one-line change to `packageVersion`.

## Test plan

- [x] `pnpm --filter blit386 run api:history:check` – "docs/_api-history.json is up to date"
- [x] Full engine preflight green via the `pre-push` hook
- [x] Diff is a single line: `packageVersion` 1.4.0 to 1.5.0

## Follow-up, not in this PR

`UNRELEASED_VERSION` in `packages/blit386/scripts/gen-api-history.mjs:48` is still `'1.5.0'`, now a shipped version.
Advancing it to the next target belongs to the release procedure, and changing it here would restamp version dates
beyond a build fix.