### PR TITLE
chore(release): regenerate the api history manifest after the 1.5.0 tag

### DIFF
--- a/packages/blit386/docs/_api-history.json
+++ b/packages/blit386/docs/_api-history.json
@@ -1,6 +1,6 @@
 {
   "packageVersion": "1.5.0",
-  "unreleasedVersion": "1.5.0",
+  "unreleasedVersion": "1.5.1",
   "versions": {
     "0.1.0": "2025-12-13T11:02:41+01:00",
     "0.2.0": "2025-12-22T16:19:15+01:00",
@@ -12,7 +12,8 @@
     "1.3.0": "2026-07-13T17:36:26+02:00",
     "1.3.1": "2026-07-19T18:11:00+02:00",
     "1.4.0": "2026-07-23T12:32:13+02:00",
-    "1.5.0": null
+    "1.5.0": "2026-08-11T06:51:18+02:00",
+    "1.5.1": null
   },
   "symbols": {
     "AssetLoader": {
@@ -568,7 +569,7 @@
       "since": "1.5.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "BT.isDown": {
       "kind": "method",
@@ -645,7 +646,7 @@
       "since": "1.5.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "BT.keyDown": {
       "kind": "method",
@@ -762,7 +763,7 @@
       "since": "1.5.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "BT.paletteFadeRange": {
       "kind": "method",
@@ -848,14 +849,14 @@
       "since": "1.5.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "BT.randomSeed": {
       "kind": "method",
       "since": "1.5.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "BT.renderAlpha": {
       "kind": "getter",
@@ -946,7 +947,7 @@
       "since": "1.5.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "BT.spritesRefresh": {
       "kind": "method",
@@ -1089,7 +1090,7 @@
       "since": "1.5.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "Flicker": {
       "kind": "class",
@@ -1254,7 +1255,7 @@
       "since": "1.5.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "PixelGlitch": {
       "kind": "class",
@@ -1289,7 +1290,7 @@
       "since": "1.5.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "Rect2i": {
       "kind": "class",
@@ -1317,7 +1318,7 @@
       "since": "1.5.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "SoundParamSetOptions": {
       "kind": "interface",
@@ -1352,7 +1353,7 @@
       "since": "1.5.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "SpriteSheet": {
       "kind": "class",
@@ -1415,7 +1416,7 @@
       "since": "1.5.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "Vector2i": {
       "kind": "class",
@@ -1509,49 +1510,49 @@
       "since": "1.5.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "hash1i": {
       "kind": "function",
       "since": "1.5.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "hash2": {
       "kind": "function",
       "since": "1.5.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "hash2i": {
       "kind": "function",
       "since": "1.5.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "hash3": {
       "kind": "function",
       "since": "1.5.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "hash3i": {
       "kind": "function",
       "since": "1.5.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "interpolate": {
       "kind": "function",
       "since": "1.5.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "mergeHardwareSettings": {
       "kind": "function",

--- a/packages/blit386/scripts/gen-api-history.mjs
+++ b/packages/blit386/scripts/gen-api-history.mjs
@@ -45,7 +45,7 @@ const PACKAGE_JSON_PATH = join(ROOT, 'package.json');
  * (it is not yet tagged), so it is a maintained constant: bump it by hand in the same commit
  * that bumps `package.json` `version` after a release ships.
  */
-const UNRELEASED_VERSION = '1.5.0';
+const UNRELEASED_VERSION = '1.5.1';
 
 /** Compiler options used when no real tsconfig is supplied (fixture / unit-test programs). */
 export const DEFAULT_TEST_COMPILER_OPTIONS = {

--- a/packages/website/content/docs/reference/changelog.mdx
+++ b/packages/website/content/docs/reference/changelog.mdx
@@ -3,7 +3,7 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Changelog"
 description: "Release history in Keep a Changelog style: what shipped, what broke, and when."
-lastModified: "2026-08-10T19:32:05+02:00"
+lastModified: "2026-08-11T06:37:16+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/changelog.md"
 ---
 

--- a/packages/website/src/data/api-history.generated.json
+++ b/packages/website/src/data/api-history.generated.json
@@ -1,6 +1,6 @@
 {
-  "packageVersion": "1.4.0",
-  "unreleasedVersion": "1.5.0",
+  "packageVersion": "1.5.0",
+  "unreleasedVersion": "1.5.1",
   "versions": {
     "0.1.0": "2025-12-13T11:02:41+01:00",
     "0.2.0": "2025-12-22T16:19:15+01:00",
@@ -12,7 +12,8 @@
     "1.3.0": "2026-07-13T17:36:26+02:00",
     "1.3.1": "2026-07-19T18:11:00+02:00",
     "1.4.0": "2026-07-23T12:32:13+02:00",
-    "1.5.0": null
+    "1.5.0": "2026-08-11T06:51:18+02:00",
+    "1.5.1": null
   },
   "symbols": {
     "AssetLoader": {
@@ -568,7 +569,7 @@
       "since": "1.5.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "BT.isDown": {
       "kind": "method",
@@ -645,7 +646,7 @@
       "since": "1.5.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "BT.keyDown": {
       "kind": "method",
@@ -762,7 +763,7 @@
       "since": "1.5.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "BT.paletteFadeRange": {
       "kind": "method",
@@ -848,14 +849,14 @@
       "since": "1.5.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "BT.randomSeed": {
       "kind": "method",
       "since": "1.5.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "BT.renderAlpha": {
       "kind": "getter",
@@ -946,7 +947,7 @@
       "since": "1.5.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "BT.spritesRefresh": {
       "kind": "method",
@@ -1089,7 +1090,7 @@
       "since": "1.5.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "Flicker": {
       "kind": "class",
@@ -1254,7 +1255,7 @@
       "since": "1.5.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "PixelGlitch": {
       "kind": "class",
@@ -1289,7 +1290,7 @@
       "since": "1.5.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "Rect2i": {
       "kind": "class",
@@ -1317,7 +1318,7 @@
       "since": "1.5.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "SoundParamSetOptions": {
       "kind": "interface",
@@ -1352,7 +1353,7 @@
       "since": "1.5.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "SpriteSheet": {
       "kind": "class",
@@ -1415,7 +1416,7 @@
       "since": "1.5.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "Vector2i": {
       "kind": "class",
@@ -1509,49 +1510,49 @@
       "since": "1.5.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "hash1i": {
       "kind": "function",
       "since": "1.5.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "hash2": {
       "kind": "function",
       "since": "1.5.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "hash2i": {
       "kind": "function",
       "since": "1.5.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "hash3": {
       "kind": "function",
       "since": "1.5.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "hash3i": {
       "kind": "function",
       "since": "1.5.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "interpolate": {
       "kind": "function",
       "since": "1.5.0",
       "changes": [],
       "deprecated": null,
-      "status": "unreleased"
+      "status": "stable"
     },
     "mergeHardwareSettings": {
       "kind": "function",


### PR DESCRIPTION
BT-418 section 8, the post-release step. Now correct to run, because the `1.5.0` tag exists.

## What changed

`UNRELEASED_VERSION` goes `1.5.0` -> `1.5.1`, and `docs/_api-history.json` is regenerated. Result:

- All **19** symbols introduced in 1.5.0 flip from `unreleased` to `stable`
- `versions["1.5.0"]` picks up its real tag date, `2026-08-11T06:51:18+02:00`
- The `null` placeholder moves to the new `1.5.1` key
- Every other release date is untouched (verified `1.4.0` still reads `2026-07-23`)

## Why the order mattered

Both alternatives fail silently rather than loudly:

- Regenerating **before** the tag leaves `versions["1.5.0"]` as `null`, so the availability tables render a released version with no date.
- Bumping `UNRELEASED_VERSION` **before** the tag makes the generator's "future and untagged -> unreleased" rule never fire, flipping all 19 symbols straight to `stable` with a `null` date, claiming they shipped when they had not.

This is why `api:history:check` was deliberately left red on #536.

## Fixes the live docs

blit386.dev currently renders every 1.5.0 symbol as unreleased, because production was built from the tagged commit, which predates this change. The mirror (`packages/website/src/data/api-history.generated.json`) is resynced here.

That fix does **not** reach production on merge - pushes to `main` only deploy `next.*`. A `workflow_dispatch` run of `deploy.yml` on `main` is needed after this lands, which will also pick up the 1.5.0 blog post from #538 (also missing from production for the same reason).

## Test plan

- [x] `pnpm --filter blit386 run api:history:check`
- [x] `pnpm --filter blit386 run api:since:check`
- [x] `pnpm --filter blit386 run test:api-history`
- [x] `pnpm --filter blit386 run preflight` - **fully green now**, including the `api:history:check` link that failed on #536. 2752 tests pass.
- [x] `pnpm --filter blit386-website run sync:docs` - mirror regenerated; the only other delta is a `lastModified` timestamp, which the sync check tolerates by design (#479)

🤖 Generated with [Claude Code](https://claude.com/claude-code)