### PR TITLE
fix(deploy): pin the demos production deploy to the main branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,17 +56,29 @@ jobs:
         env:
           NODE_ENV: production
 
-      # `command` is the pre-merge command verbatim; workingDirectory is what keeps the
-      # relative `dist/` in it correct from the monorepo root. wranglerVersion and
-      # packageManager are pinned the same way on all four wrangler-action steps in this
-      # file (BT-441) - see deploy-website below for why the version is pinned at all.
+      # workingDirectory is what keeps the relative `dist/` in `command` correct from the
+      # monorepo root. wranglerVersion and packageManager are pinned the same way on all
+      # four wrangler-action steps in this file (BT-441) - see deploy-website below for why
+      # the version is pinned at all.
+      #
+      # `--branch=main` is load-bearing, not cosmetic. Without it wrangler infers the branch
+      # from git, and this job's only real trigger is a release tag push, which checks out a
+      # detached HEAD. The inferred branch is then `head`, which is not the project's
+      # production branch, so Pages files the upload as a *preview* deployment and
+      # demos.blit386.dev keeps serving the previous build. The job still reports success,
+      # because uploading is what succeeded. That is exactly what happened on the 1.5.0 tag
+      # (deployment alias `head.blit-tech-demos.pages.dev`); production stayed stale until a
+      # workflow_dispatch on main, where the inferred branch happened to be right.
+      #
+      # deploy-demos-next below does not need this: it only runs on push to main, so the
+      # inferred branch is already that project's production branch.
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: packages/demos
-          command: pages deploy dist/ --project-name=blit386-demos
+          command: pages deploy dist/ --project-name=blit386-demos --branch=main
           wranglerVersion: '4.114.0'
           packageManager: pnpm
 


### PR DESCRIPTION
Found while verifying the 1.5.0 production deploy.

## The bug

`deploy-demos` runs `pages deploy dist/ --project-name=blit386-demos` with no `--branch`. Its only real trigger is a release tag push, which checks out a **detached HEAD**, so wrangler infers the branch as `head`. That is not the project's production branch, so Cloudflare Pages files the upload as a **preview** deployment and `demos.blit386.dev` keeps serving the previous build.

The job reports success either way, because uploading is what succeeded. A green release, a stale site.

## Evidence, not theory

The 1.5.0 tag run ([31463206069](https://github.com/blit386/blit386/actions/runs/31463206069)) logged:

```
✨ Deployment complete! Take a peek over at https://809db316.blit-tech-demos.pages.dev
✨ Deployment alias URL: https://head.blit-tech-demos.pages.dev
```

`head.` is the tell. Afterwards, on production:

| URL | Before dispatch | After dispatch |
| --- | --- | --- |
| `demos.blit386.dev/palette-exposure-fade` (#471) | 404 | 200 |
| `demos.blit386.dev/sitemap.xml` (#496) | 404 | 200 |

Both shipped well inside the 1.5.0 window and were present in the built `dist/`. Re-running the *same command* via `workflow_dispatch` on `main` fixed both, because there the inferred branch happened to be the production one. Same artifact, same command, different ref, different outcome - which isolates the branch inference as the cause.

This was also the first production deploy `deploy.yml` has ever attempted; every prior run was a push to `main` hitting the `-next` jobs. So the bug has been latent since BT-406 added tag-driven deploys and only surfaced now.

## The fix

Pin `--branch=main` on the production job, with a comment explaining why it is load-bearing so nobody trims it as redundant later.

`deploy-demos-next` deliberately gets no equivalent change: it only runs on push to `main`, so its inferred branch is already that project's production branch.

## Assumption to confirm

This assumes the `blit386-demos` Pages project's production branch is `main`. That is what the successful dispatch demonstrated, but it is worth a glance at the project settings.

## Test plan

- [x] Prettier YAML parse passes (`pnpm run format:check`)
- [x] Both `pages deploy` commands verified after the edit; only the production one changed
- [ ] **Real verification is the next release tag** - a workflow that only fires on tags cannot be proven by a PR. Watch the next tag's deploy log for a production alias rather than `head.*`, or dispatch `deploy.yml` once to confirm nothing regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)