### PR TITLE
fix(content): restore missing meta tags on blog posts and the blog index

### DIFF
--- a/packages/website/press.config.tsx
+++ b/packages/website/press.config.tsx
@@ -33,7 +33,7 @@ import { HomeHero } from './src/components/home-hero';
 import { ApiAvailability } from './src/components/api-availability';
 import { PageChangelog } from './src/components/page-changelog';
 import { Since } from './src/components/since-badge';
-import { SITE_NAME } from './src/data/site';
+import { FEDIVERSE_HANDLE, SITE_NAME, TWITTER_HANDLE } from './src/data/site';
 import defaultMdxComponents, { createRelativeLink } from 'fumadocs-ui/mdx';
 import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 import { File, Files, Folder } from 'fumadocs-ui/components/files';
@@ -51,11 +51,6 @@ const IS_NEXT_CHANNEL = process.env.BLIT386_CHANNEL === 'next';
 
 const SITE_BASE_URL = IS_NEXT_CHANNEL ? 'https://next.blit386.dev' : 'https://blit386.dev';
 const PRODUCTION_SITE_URL = 'https://blit386.dev';
-
-// Same accounts linked from src/data/community.ts – kept as separate literals here because
-// that file's shape (CommunityDestination[]) has no field for a bare handle, only a profile URL.
-const TWITTER_HANDLE = '@blit386';
-const FEDIVERSE_HANDLE = '@blit386@mastodon.gamedev.place';
 
 // Reads and caches the Departure Mono font file used for Open Graph image generation
 // (`takumiPlugin` below), so disk access happens once per Worker isolate rather than per request.

--- a/packages/website/src/components/blog-index.tsx
+++ b/packages/website/src/components/blog-index.tsx
@@ -2,8 +2,12 @@ import { getPressContext } from 'fumapress';
 import { getBlogContext } from 'fumapress/plugins/blog';
 import Link from 'fumadocs-core/link';
 import { getPostDate } from '../blog-post-date';
+import { CHANNEL_DESCRIPTION } from '../feed';
+import { renderBlogIndexMeta } from './blog-page-meta';
 import styles from './blog-index.module.css';
 import layoutStyles from './blog-layout.module.css';
+
+const BLOG_TITLE = 'Blog';
 
 interface BlogIndexPageProps {
     lang?: string;
@@ -22,7 +26,7 @@ interface BlogPostSummary {
  */
 export async function BlogIndexPage({ lang }: BlogIndexPageProps) {
     const ctx = getPressContext();
-    const { isBlog } = getBlogContext();
+    const { isBlog, indexPath } = getBlogContext();
     const source = await ctx.getLoader();
     const pages = source.getPages(lang).filter((page) => isBlog.call(ctx, page));
 
@@ -36,29 +40,38 @@ export async function BlogIndexPage({ lang }: BlogIndexPageProps) {
     posts.sort((a, b) => (b.date?.getTime() ?? 0) - (a.date?.getTime() ?? 0));
 
     return (
-        <div className={`not-prose ${layoutStyles.main} ${styles.index}`}>
-            <div className={styles.header}>
-                <h1 className={styles.heading}>Blog</h1>
+        <>
+            {renderBlogIndexMeta(
+                ctx,
+                typeof indexPath === 'string' ? indexPath : '/blog',
+                BLOG_TITLE,
+                CHANNEL_DESCRIPTION,
+            )}
 
-                {/*{tagsPath !== false && (
-                    <Link href={tagsPath} className={styles.tagsLink}>
-                        All Tags
-                    </Link>
-                )}*/}
+            <div className={`not-prose ${layoutStyles.main} ${styles.index}`}>
+                <div className={styles.header}>
+                    <h1 className={styles.heading}>{BLOG_TITLE}</h1>
+
+                    {/*{tagsPath !== false && (
+                        <Link href={tagsPath} className={styles.tagsLink}>
+                            All Tags
+                        </Link>
+                    )}*/}
+                </div>
+
+                <div className={styles.grid}>
+                    {posts.map((post) => (
+                        <Link key={post.url} href={post.url} className={`group ${styles.card}`}>
+                            <div className={styles.info}>
+                                <span className={styles.cardTitle}>{post.title}</span>
+                                {post.description && <span className={styles.cardDescription}>{post.description}</span>}
+                            </div>
+
+                            {post.date && <span className={styles.cardDate}>{post.date.toDateString()}</span>}
+                        </Link>
+                    ))}
+                </div>
             </div>
-
-            <div className={styles.grid}>
-                {posts.map((post) => (
-                    <Link key={post.url} href={post.url} className={`group ${styles.card}`}>
-                        <div className={styles.info}>
-                            <span className={styles.cardTitle}>{post.title}</span>
-                            {post.description && <span className={styles.cardDescription}>{post.description}</span>}
-                        </div>
-
-                        {post.date && <span className={styles.cardDate}>{post.date.toDateString()}</span>}
-                    </Link>
-                ))}
-            </div>
-        </div>
+        </>
     );
 }

--- a/packages/website/src/components/blog-page-meta.tsx
+++ b/packages/website/src/components/blog-page-meta.tsx
@@ -1,0 +1,79 @@
+import { Fragment } from 'react';
+import type { AppContext } from 'fumapress';
+import { FEDIVERSE_HANDLE, TWITTER_HANDLE } from '../data/site';
+
+type MetaPage = AppContext['$context']['page'];
+
+/**
+ * Reconstructs fumapress's internal `renderPageMeta` (`title`, `og:title`/`og:description`,
+ * the site's `meta.page()` block from `press.config.tsx`, and every `ctx.data['core:page-meta']`
+ * hook – notably `takumiPlugin`'s `og:image`/`width`/`height`/`twitter:card`). That function
+ * itself is not part of fumapress's public API, only exercised internally by the framework's own
+ * `docsPageLayout` and stock blog layout – `BlogPage` replaces the latter with a hand-rolled
+ * component (for the docs-style TOC sidebar, see its own doc comment) and lost this call in the
+ * process. `getPressContext()`'s public `AppContext` type exposes both pieces (`metaConfig` and
+ * `data`) needed to rebuild it without reaching into fumapress internals.
+ */
+export function renderBlogPostMeta(page: MetaPage, ctx: AppContext) {
+    return (
+        <>
+            <title>{page.data.title}</title>
+            <meta property="og:title" content={page.data.title} />
+            {page.data.description && <meta property="og:description" content={page.data.description} />}
+            {ctx.metaConfig?.page?.call(ctx, page)}
+            {ctx.data['core:page-meta']?.map((hook, i) => (
+                // biome-ignore lint/suspicious/noArrayIndexKey: hooks come from the static plugin chain (press.config.tsx .plugins(...)), never reordered at runtime
+                <Fragment key={i}>{hook(page)}</Fragment>
+            ))}
+        </>
+    );
+}
+
+/**
+ * Same gap as `renderBlogPostMeta` above, but for the `/blog` index: fumapress's own stock
+ * `createBlogIndexPage()` never calls `renderPageMeta` either (there is no single `Page` to key it
+ * off), so this is not a parity fix so much as filling a real gap – the index shipped with no
+ * `<title>` at all. Deliberately excludes `ctx.data['core:page-meta']`: `takumiPlugin` only
+ * generates an OG image per content-loader page (`packages/blit386/docs/...`, `content/blog/...`),
+ * and the index is a plugin-created route rather than one of those, so calling that hook here
+ * would emit an `og:image` pointing at a URL that 404s.
+ */
+export function renderBlogIndexMeta(ctx: AppContext, indexPath: string, title: string, description: string) {
+    const url = ctx.siteConfig.baseUrl ? `${ctx.siteConfig.baseUrl}${indexPath}` : indexPath;
+    const twitterTitle = `${ctx.siteConfig.name} – ${title}`;
+
+    // Escape </ so a field value containing "</script>" cannot terminate the tag, mirroring
+    // press.config.tsx's meta.page(). \/ is a valid JSON escape, so parsers handle it correctly.
+    const jsonLd = JSON.stringify({
+        '@context': 'https://schema.org',
+        '@type': 'Blog',
+        name: title,
+        description,
+        url,
+    }).replaceAll('</', '<\\/');
+
+    return (
+        <>
+            <title>{title}</title>
+            <meta name="description" content={description} />
+
+            <meta property="og:title" content={title} />
+            <meta property="og:description" content={description} />
+            <meta property="og:url" content={url} />
+            <meta property="og:type" content="website" />
+            <meta property="og:site_name" content={ctx.siteConfig.name} />
+
+            <meta name="twitter:title" content={twitterTitle} />
+            <meta name="twitter:description" content={description} />
+            <meta name="twitter:site" content={TWITTER_HANDLE} />
+            <meta name="twitter:creator" content={TWITTER_HANDLE} />
+
+            <meta name="fediverse:creator" content={FEDIVERSE_HANDLE} />
+
+            <link rel="canonical" href={url} />
+
+            {/* biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD requires raw script content; data is static site copy, not user input */}
+            <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: jsonLd }} />
+        </>
+    );
+}

--- a/packages/website/src/components/blog-page.tsx
+++ b/packages/website/src/components/blog-page.tsx
@@ -6,6 +6,7 @@ import { DocsBody, DocsDescription, DocsPage, DocsTitle } from 'fumadocs-ui/layo
 import type { TOCItemType } from 'fumadocs-core/toc';
 import Link from 'fumadocs-core/link';
 import { AuthorByline } from './author-byline';
+import { renderBlogPostMeta } from './blog-page-meta';
 import styles from './blog-page.module.css';
 
 type BlogPost = AppContext['$context']['page'];
@@ -67,36 +68,40 @@ export async function BlogPage({ page }: BlogPageProps) {
     const [body, toc] = await Promise.all([renderBody(ctx, page), renderToc(ctx, page)]);
 
     return (
-        <DocsPage toc={toc} breadcrumb={{ enabled: false }} footer={{ enabled: false }}>
-            <div className={styles.header}>
-                {indexPath !== false && (
-                    <Link href={indexPath} className={styles.backLink}>
-                        Back to Blog
-                    </Link>
-                )}
+        <>
+            {renderBlogPostMeta(page, ctx)}
 
-                <DocsTitle>{data.title}</DocsTitle>
-                <DocsDescription>{data.description}</DocsDescription>
+            <DocsPage toc={toc} breadcrumb={{ enabled: false }} footer={{ enabled: false }}>
+                <div className={styles.header}>
+                    {indexPath !== false && (
+                        <Link href={indexPath} className={styles.backLink}>
+                            Back to Blog
+                        </Link>
+                    )}
 
-                {data.author && <AuthorByline author={data.author} />}
+                    <DocsTitle>{data.title}</DocsTitle>
+                    <DocsDescription>{data.description}</DocsDescription>
 
-                {/*{(date || (tags && tags.length > 0)) && (
-                    <div className={styles.meta}>
-                        {date && <span className={styles.date}>{date.toDateString()}</span>}
+                    {data.author && <AuthorByline author={data.author} />}
 
-                        {tagsPath !== false &&
-                            tags?.map((tag) => (
-                                <Link key={tag} href={`${tagsPath}/${tag}`} className={styles.tag}>
-                                    {tag}
-                                </Link>
-                            ))}
-                    </div>
-                )}*/}
-            </div>
+                    {/*{(date || (tags && tags.length > 0)) && (
+                        <div className={styles.meta}>
+                            {date && <span className={styles.date}>{date.toDateString()}</span>}
 
-            <div className={styles.body}>
-                <DocsBody>{body}</DocsBody>
-            </div>
-        </DocsPage>
+                            {tagsPath !== false &&
+                                tags?.map((tag) => (
+                                    <Link key={tag} href={`${tagsPath}/${tag}`} className={styles.tag}>
+                                        {tag}
+                                    </Link>
+                                ))}
+                        </div>
+                    )}*/}
+                </div>
+
+                <div className={styles.body}>
+                    <DocsBody>{body}</DocsBody>
+                </div>
+            </DocsPage>
+        </>
     );
 }

--- a/packages/website/src/data/site.ts
+++ b/packages/website/src/data/site.ts
@@ -4,3 +4,11 @@
  * the footer copyright line, so the brand string is never mirrored independently.
  */
 export const SITE_NAME = 'BLIT386';
+
+/**
+ * Social handles used in per-page meta tags (`press.config.tsx`, `blog-index.tsx`). Kept as
+ * separate literals from `src/data/community.ts` because that file's shape
+ * (`CommunityDestination[]`) has no field for a bare handle, only a profile URL.
+ */
+export const TWITTER_HANDLE = '@blit386';
+export const FEDIVERSE_HANDLE = '@blit386@mastodon.gamedev.place';

--- a/packages/website/src/feed.ts
+++ b/packages/website/src/feed.ts
@@ -3,7 +3,9 @@ import { getPostDate } from './blog-post-date';
 
 const FEED_URL = '/feed.xml';
 const CHANNEL_TITLE = 'BLIT386 Blog';
-const CHANNEL_DESCRIPTION = 'Updates and articles from the BLIT386 blog.';
+
+/** Single source of truth for the blog's description – also used as its og:description/twitter:description (blog-index.tsx). */
+export const CHANNEL_DESCRIPTION = 'Updates and articles from the BLIT386 blog.';
 
 function escapeXml(text: string): string {
     return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');


### PR DESCRIPTION
## Summary

- `/blog` and `/blog/<slug>` shipped with no `<title>`, `og:*`, description, canonical link, or JSON-LD - the hand-rolled `BlogPage`/`BlogIndexPage` components never called fumapress's internal `renderPageMeta`, unlike the framework's own stock blog and docs layouts.
- Added `packages/website/src/components/blog-page-meta.tsx`, which reconstructs that output from the public `AppContext` API (`ctx.metaConfig`, `ctx.data['core:page-meta']`) since `renderPageMeta` itself isn't exported. Both pages now reach full head-tag parity with `/docs` and `/showcase`, including the `og:image`/`twitter:card` tags for individual posts.
- Moved `TWITTER_HANDLE`/`FEDIVERSE_HANDLE` into `src/data/site.ts` and exported `CHANNEL_DESCRIPTION` from `feed.ts` so `press.config.tsx` and the blog components share one source instead of duplicating the values.
- Follow-up filed as [BT-472](https://linear.app/vancura/issue/BT-472/blog-tag-pages-have-no-meta-tags-and-the-blog-listing-has-no-og-image): `/blog/tags` and `/blog/tags/<tag>` still have no meta tags (an upstream fumapress gap in its own stock tag layouts, not introduced here), and `/blog` itself still has no `og:image` (no image is generated for it - only content-loader pages get one).

## Test plan

- [x] `pnpm run preflight` in `packages/website` (format, typecheck, tests, spellcheck, knip, build, docs-sync check) - passing
- [x] Full production build (`CLOUDFLARE=1 waku build`), head tags for `/blog` and every `/blog/<slug>` grepped from the built HTML and diffed against `/showcase` - matching shape
- [x] `blog/tags/index.html` spot-checked to confirm the pre-existing upstream gap (tracked in BT-472) is unrelated to this change
- [x] Pre-push checks (root format, docs links, agent config, dash typography) - passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added richer metadata to blog index and post pages, including social sharing, canonical links, and structured data.
  * Added support for configured Twitter and Fediverse profile metadata.
  * Improved consistency of blog titles and descriptions across pages.
* **Refactor**
  * Centralized site and channel metadata for reuse across the website.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->