### PR TITLE
fix(website): repoint agent search surfaces at /mcp search_docs

### DIFF
--- a/packages/website/public/.well-known/agent-skills/blit386-docs/SKILL.md
+++ b/packages/website/public/.well-known/agent-skills/blit386-docs/SKILL.md
@@ -19,7 +19,7 @@ automatic Canvas 2D software fallback. All engine functionality is accessed thro
 | Documentation home | https://blit386.dev/docs | HTML |
 | Site summary for LLMs | https://blit386.dev/llms.txt | plain text |
 | Full site content | https://blit386.dev/llms-full.txt | plain text |
-| Search API | https://blit386.dev/api/search?query=<term> | JSON array |
+| MCP server (search, docs summary) | https://blit386.dev/mcp | JSON-RPC 2.0 |
 | Sitemap | https://blit386.dev/sitemap.xml | XML |
 
 ## Navigating the docs
@@ -30,13 +30,17 @@ Main documentation sections:
 - `/docs/getting-started` – Installation and first steps
 - `/docs/api/` – Full API reference for the `BT` namespace
 
-Use the search API to locate specific content:
+Use the MCP server's `search_docs` tool to locate specific content:
 
 ```text
-GET https://blit386.dev/api/search?query=palette+animation
+POST https://blit386.dev/mcp
+Content-Type: application/json
+
+{"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "search_docs", "arguments": {"query": "palette animation"}}}
 ```
 
-Returns a JSON array of matching pages with titles, URLs, and content excerpts.
+Returns matching pages with titles, URLs, and content excerpts. The server also exposes `get_docs_summary`, which
+returns the `llms.txt` summary. Call `tools/list` for the full tool schema.
 
 ## Core API concepts
 

--- a/packages/website/public/.well-known/agent-skills/index.json
+++ b/packages/website/public/.well-known/agent-skills/index.json
@@ -6,7 +6,7 @@
       "type": "skill-md",
       "description": "Navigate and query the BLIT386 documentation site at blit386.dev. Use when helping a developer learn the BLIT386 JavaScript/TypeScript library, find API references, or locate guides.",
       "url": "/.well-known/agent-skills/blit386-docs/SKILL.md",
-      "digest": "sha256:01f04847f296716f1b4f51fa24eab0b15fc85ca9195fad21ea43aadf5e1a499c"
+      "digest": "sha256:246eb311f2869ae348d299c6ada1ba2dc7142e826a9c887801973c2aaf357ec0"
     }
   ]
 }

--- a/packages/website/public/webmcp.js
+++ b/packages/website/public/webmcp.js
@@ -63,9 +63,22 @@
                 required: ['query'],
             },
             execute: async ({ query }) => {
-                const res = await fetch(`/api/search?query=${encodeURIComponent(query)}`);
+                const res = await fetch('/mcp', {
+                    method: 'POST',
+                    headers: { 'content-type': 'application/json' },
+                    body: JSON.stringify({
+                        jsonrpc: '2.0',
+                        id: 1,
+                        method: 'tools/call',
+                        params: { name: 'search_docs', arguments: { query } },
+                    }),
+                });
                 if (!res.ok) return { error: `Search request failed: ${res.status}` };
-                return await res.json();
+
+                const body = await res.json();
+                if (body.error) return { error: body.error.message };
+
+                return JSON.parse(body.result.content[0].text);
             },
             annotations: { readOnlyHint: true },
         },

--- a/packages/website/src/webmcp.test.ts
+++ b/packages/website/src/webmcp.test.ts
@@ -67,7 +67,7 @@ function createAssignMock() {
 }
 
 function createFetchMock() {
-    return vi.fn(async (_input: string): Promise<FetchResponse> => ({ ok: true, status: 200 }));
+    return vi.fn(async (_input: string, _init?: RequestInit): Promise<FetchResponse> => ({ ok: true, status: 200 }));
 }
 
 function stubBrowserGlobals(
@@ -240,13 +240,31 @@ describe('webmcp.js', () => {
             expect(findTool(tools, 'search_documentation').annotations?.readOnlyHint).toBe(true);
         });
 
-        it('fetches the encoded query and returns the parsed results', async () => {
-            fetchMock.mockResolvedValue({ ok: true, status: 200, json: async () => ({ results: ['a'] }) });
+        it('calls the /mcp search_docs tool and returns the parsed results', async () => {
+            const results = [{ title: 'Palette', url: '/docs/api/palette', excerpt: '...' }];
+            fetchMock.mockResolvedValue({
+                ok: true,
+                status: 200,
+                json: async () => ({
+                    jsonrpc: '2.0',
+                    id: 1,
+                    result: { content: [{ type: 'text', text: JSON.stringify(results) }] },
+                }),
+            });
 
             const result = await findTool(tools, 'search_documentation').execute({ query: 'palette & animation' });
 
-            expect(fetchMock).toHaveBeenCalledWith('/api/search?query=palette%20%26%20animation');
-            expect(result).toEqual({ results: ['a'] });
+            expect(fetchMock).toHaveBeenCalledWith('/mcp', {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify({
+                    jsonrpc: '2.0',
+                    id: 1,
+                    method: 'tools/call',
+                    params: { name: 'search_docs', arguments: { query: 'palette & animation' } },
+                }),
+            });
+            expect(result).toEqual(results);
         });
 
         it('reports the status without parsing the body when the request fails', async () => {
@@ -257,6 +275,22 @@ describe('webmcp.js', () => {
 
             expect(result).toEqual({ error: 'Search request failed: 500' });
             expect(json).not.toHaveBeenCalled();
+        });
+
+        it('reports the JSON-RPC error message when the tool call fails', async () => {
+            fetchMock.mockResolvedValue({
+                ok: true,
+                status: 200,
+                json: async () => ({
+                    jsonrpc: '2.0',
+                    id: 1,
+                    error: { code: -32602, message: 'Invalid params' },
+                }),
+            });
+
+            const result = await findTool(tools, 'search_documentation').execute({ query: 'anything' });
+
+            expect(result).toEqual({ error: 'Invalid params' });
         });
     });
 


### PR DESCRIPTION
## Summary

BT-247 reported three broken agent-facing discovery artifacts. Two turned out to already be fixed or non-issues on
the current `main`; this PR fixes the third:

- **Stale sha256 digest** – already corrected by a prior commit (f8e3412), which also added a regression test
  (`agent-skills-manifest.test.mjs`) that recomputes every manifest entry's digest from disk. This PR keeps the
  manifest digest in sync with the `SKILL.md` edit below.
- **Dead `/api/search`** – fixed. `public/webmcp.js`'s `search_documentation` tool and the published `SKILL.md` both
  routed agents to `fetch('/api/search?query=')`, which was removed when search went `mode: 'static'`. The path
  doesn't 404 – `flexsearchPlugin()` happens to write its static search-index blob to that exact static-asset path –
  so the dead endpoint was silently returning an unrelated ~8 MB JSON blob instead of erroring. Both now call the
  `/mcp` JSON-RPC `search_docs` tool instead.
- **Dead `/llms-full.txt`** – verified in a local production build (`pnpm run build`); `fumapress`'s `llmsPlugin`
  generates it automatically (no option needed) and it resolves with real content (~418 KB) on the current
  `fumapress@0.7.3` pin. No change needed; `SKILL.md` continues to advertise it.

## Checklist

1. Every commit is DCO signed off (`git commit -s` adds `Signed-off-by: ...`).
2. PR title follows Conventional Commits: `fix(website): ...`
3. `pnpm --filter blit386-website run preflight`-equivalent checks pass locally (format, typecheck, test:scripts,
   test:unit, spellcheck, build) – see test plan below. The repo-wide `docs:links` step in the local pre-push hook
   fails in this sandboxed session only because its egress proxy blocks third-party hosts (linear.app, discord.gg,
   tailwindcss.com, ...) by organization policy; none of the failing links are in files this PR touches, and CI runs
   the same check with real network access.
4. Documentation: no `packages/blit386/docs/` or guide changes needed – this only touches the site's own
   `public/webmcp.js` and `public/.well-known/` artifacts, whose usage is already documented in `content/mcp-server.mdx`.
5. No renderer output changed; `test:visual` not applicable.
6. AI-assisted commit includes `Co-Authored-By: Claude <noreply@anthropic.com>`.

## Test plan

- [x] `pnpm --filter blit386-website run test:scripts` – 166 tests pass, including the digest regression test
- [x] `pnpm --filter blit386-website run test:unit` – 167 tests pass, including new/updated `webmcp.test.ts` coverage
      for the `/mcp`-based `search_documentation` tool (success, HTTP failure, and JSON-RPC error paths)
- [x] `pnpm --filter blit386-website run typecheck`
- [x] `pnpm --filter blit386-website run spellcheck`
- [x] `pnpm --filter blit386-website run build` – confirmed `dist/public/llms-full.txt` is generated with real content
- [ ] Follow-up (out of scope here, tracked by BT-248): CI validation that every well-known/webmcp-advertised URL
      actually resolves in the deployed site, so this class of drift is caught automatically instead of by manual
      audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_015SnzEKKzqDHs47uTr4oRdn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Documentation search now uses the MCP server for searches and summaries.
  - Added support for discovering available documentation tools.
  - Improved handling and display of search errors.

- **Documentation**
  - Added examples for searching documentation through MCP.
  - Updated guidance for retrieving documentation summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->