### PR TITLE
fix(website): detect untracked generated docs pages in sync check

### DIFF
--- a/packages/website/scripts/__tests__/check-docs-sync.test.mjs
+++ b/packages/website/scripts/__tests__/check-docs-sync.test.mjs
@@ -1,7 +1,14 @@
-import { describe, test } from 'node:test';
+import { after, describe, test } from 'node:test';
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { gitEnv } from '../git-env.mjs';
 
-const { classifyDocsDiff } = await import('../check-docs-sync.mjs');
+const { classifyDocsDiff, findUntrackedGeneratedPages, listUntrackedDocsFiles } = await import(
+    '../check-docs-sync.mjs'
+);
 
 const FILE_HEADER = [
     'diff --git a/packages/website/content/docs/guides/splash.mdx b/packages/website/content/docs/guides/splash.mdx',
@@ -121,5 +128,66 @@ describe('classifyDocsDiff', () => {
         ].join('\n');
 
         assert.equal(classifyDocsDiff(diff), 'drift');
+    });
+});
+
+describe('findUntrackedGeneratedPages', () => {
+    const PAGES = [
+        { src: 'guide-splash.md', path: 'guides/splash', description: 'The splash screen.' },
+        { src: 'guide-new-page.md', path: 'guides/new-page', description: 'A brand-new guide.' },
+    ];
+
+    test('flags an untracked file whose path matches a newly published sitemap page', () => {
+        const untrackedFiles = ['content/docs/guides/new-page.mdx'];
+
+        assert.deepEqual(findUntrackedGeneratedPages(untrackedFiles, PAGES), ['content/docs/guides/new-page.mdx']);
+    });
+
+    test('ignores an untracked file under content/docs that matches no sitemap page', () => {
+        // A hand-authored draft (e.g. a new content/docs/faq.mdx in progress) is not a
+        // generated page, so it must not be reported by this check.
+        const untrackedFiles = ['content/docs/faq.mdx'];
+
+        assert.deepEqual(findUntrackedGeneratedPages(untrackedFiles, PAGES), []);
+    });
+
+    test('returns an empty list when there are no untracked files', () => {
+        assert.deepEqual(findUntrackedGeneratedPages([], PAGES), []);
+    });
+
+    test('flags only the untracked files that match, leaving unrelated ones out', () => {
+        const untrackedFiles = ['content/docs/guides/new-page.mdx', 'content/docs/faq.mdx'];
+
+        assert.deepEqual(findUntrackedGeneratedPages(untrackedFiles, PAGES), ['content/docs/guides/new-page.mdx']);
+    });
+});
+
+describe('listUntrackedDocsFiles', () => {
+    /** @type {string} */
+    let repoDir;
+
+    after(() => {
+        rmSync(repoDir, { recursive: true, force: true });
+    });
+
+    test('lists an untracked generated page under content/docs, excluding tracked files', () => {
+        repoDir = mkdtempSync(join(tmpdir(), 'check-docs-sync-untracked-'));
+        const env = gitEnv({ GIT_AUTHOR_NAME: 'Test', GIT_AUTHOR_EMAIL: 'test@example.com' });
+        /** @type {(args: string[]) => string} */
+        const run = (args) => execFileSync('git', args, { cwd: repoDir, env, encoding: 'utf8', stdio: 'pipe' });
+
+        run(['init', '--quiet']);
+        run(['config', 'user.email', 'test@example.com']);
+        run(['config', 'user.name', 'Test']);
+
+        const guidesDir = join(repoDir, 'content', 'docs', 'guides');
+        mkdirSync(guidesDir, { recursive: true });
+        writeFileSync(join(guidesDir, 'splash.mdx'), '---\ntitle: "The BLIT386 Splash"\n---\n\nBody.\n');
+        run(['add', 'content/docs/guides/splash.mdx']);
+        run(['commit', '--quiet', '-m', 'initial commit']);
+
+        writeFileSync(join(guidesDir, 'new-page.mdx'), '---\ntitle: "New Page"\n---\n\nBody.\n');
+
+        assert.deepEqual(listUntrackedDocsFiles(repoDir), ['content/docs/guides/new-page.mdx']);
     });
 });

--- a/packages/website/scripts/check-docs-sync.mjs
+++ b/packages/website/scripts/check-docs-sync.mjs
@@ -24,6 +24,7 @@
 import { execFileSync } from 'node:child_process';
 import { pathToFileURL } from 'node:url';
 import { gitEnv } from './git-env.mjs';
+import { PAGES } from './sync-docs-from-engine.mjs';
 
 const DIFF_FILE_HEADER_PATTERN = /^(?:\+\+\+ |--- )/u;
 const HUNK_HEADER_PATTERN = /^@@ -(\d+)(?:,\d+)? \+\d+(?:,\d+)? @@/u;
@@ -78,8 +79,50 @@ const classifyDocsDiff = (diffText) => {
     return isSafe ? 'lastModifiedOnly' : 'drift';
 };
 
+/**
+ * List untracked, non-ignored files under `content/docs`. `git diff` (used above) never reports
+ * an untracked path at all, so a brand-new mirror page that `sync:docs` wrote but nobody staged
+ * is invisible to `classifyDocsDiff` – this is the other half of what a clean verdict must check.
+ */
+const listUntrackedDocsFiles = (cwd = process.cwd()) =>
+    execFileSync('git', ['ls-files', '--others', '--exclude-standard', '--', 'content/docs'], {
+        cwd,
+        encoding: 'utf8',
+        env: gitEnv(),
+    })
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0);
+
+/**
+ * Narrow a list of untracked files to the ones that are actually generated pages, by
+ * cross-referencing the sitemap manifest's published-page entries (a page's `path` is already
+ * `<section>/<topic>`, and `sync-docs-from-engine.mjs` writes it to `content/docs/<path>.mdx`).
+ * An untracked file that matches no sitemap page – a hand-authored draft, for instance – is out
+ * of scope for this check and is left out.
+ */
+const findUntrackedGeneratedPages = (untrackedFiles, pages = PAGES) => {
+    const expected = new Set(pages.map((page) => `content/docs/${page.path}.mdx`));
+
+    return untrackedFiles.filter((file) => expected.has(file));
+};
+
 const main = () => {
     execFileSync('pnpm', ['run', 'sync:docs'], { stdio: 'inherit' });
+
+    const untrackedGeneratedPages = findUntrackedGeneratedPages(listUntrackedDocsFiles());
+
+    if (untrackedGeneratedPages.length > 0) {
+        console.error(
+            'Docs mirror has newly generated page(s) missing from the commit (untracked):\n\n' +
+                untrackedGeneratedPages.map((file) => `  ${file}`).join('\n') +
+                '\n\nThese were just written by `pnpm run sync:docs` from a page added to ' +
+                '`packages/blit386/docs/_sitemap.json`. Run `git add` on the file(s) above and commit them.\n',
+        );
+        process.exitCode = 1;
+
+        return;
+    }
 
     const diff = execFileSync('git', ['diff', '--no-color', '--', 'content/docs'], {
         encoding: 'utf8',
@@ -113,7 +156,7 @@ const main = () => {
     process.exitCode = 1;
 };
 
-export { classifyDocsDiff };
+export { classifyDocsDiff, listUntrackedDocsFiles, findUntrackedGeneratedPages };
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
     main();

--- a/packages/website/scripts/sync-docs-from-engine.mjs
+++ b/packages/website/scripts/sync-docs-from-engine.mjs
@@ -572,6 +572,7 @@ export {
     getLastModified,
     editUrlFor,
     renderPage,
+    PAGES,
 };
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {


### PR DESCRIPTION
## Summary

- `check-docs-sync.mjs` classified `content/docs` drift from `git diff` alone, which never reports untracked paths, so a newly published page (added to `packages/blit386/docs/_sitemap.json`) that `pnpm run sync:docs` regenerates as a brand-new, unstaged `content/docs/*.mdx` file produced an empty diff and a false `clean` verdict, even though the generated page never made it into the commit.
- Adds `listUntrackedDocsFiles` (`git ls-files --others --exclude-standard -- content/docs`) and `findUntrackedGeneratedPages`, which cross-references untracked files against the sitemap's published-page entries so only genuine generated pages are flagged, not unrelated hand-authored drafts also living under `content/docs`.
- The existing `clean` / `lastModifiedOnly` / `drift` classification of tracked changes (`classifyDocsDiff`) is untouched.

Fixes BT-473. Predates PR #548 and is unrelated to that PR's merge-commit/`lastModified` policy changes.

## Test plan

- [x] `pnpm --filter blit386-website run test:scripts` — new and existing tests pass (73/73 in the docs-sync + sync-docs-from-engine suites)
- [x] `pnpm --filter blit386-website run preflight` — full package preflight green (format, typecheck, tests, spellcheck, knip, build, `sync:docs:check`)
- [x] Manual repro: added a throwaway page to `packages/blit386/docs/_sitemap.json`, ran `sync:docs` (generated an untracked `.mdx`), confirmed `sync:docs:check` now fails and names the untracked file (exit 1) — previously exited 0 with "Docs mirror matches the engine source." Reverted the scratch sitemap edit and generated file afterward.
- [x] `sync:docs:check` on the real, clean working tree still passes (no false positives)
- [x] Pre-push hook (full monorepo preflight + root checks) passed on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Documentation sync checks now detect generated documentation pages that are missing from commits.
  - Added clearer validation messages identifying untracked documentation files.
  - Improved filtering to distinguish tracked, unrelated, and generated documentation files.

- **Tests**
  - Expanded coverage for untracked generated pages and filesystem-based documentation discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->