### PR TITLE
docs(root): require named constants for repeated literal comparisons

### DIFF
--- a/.claude/rules/named-constants.md
+++ b/.claude/rules/named-constants.md
@@ -1,0 +1,80 @@
+---
+paths: [packages/*/src/**, packages/*/templates/**, packages/*/scripts/**, packages/*/test/**, scripts/**]
+---
+
+# Named constants over repeated literals
+
+A string or numeric literal that is **compared** – `===`, `switch`, a discriminant check, an `includes()` membership
+test – at more than one call site, or that crosses a file or package boundary, gets one exported named constant, or in
+TypeScript one literal-union type, that every site imports. Never re-type the literal.
+
+Typo drift in a re-typed literal is silent: nothing throws, nothing fails to build, a branch just quietly stops being
+taken. Where a literal-union type already exists the compiler catches that, which is why most of this repo's domain tags
+(`Backend`, `AudioBus`, `EffectTier`, `EasingFunction`) are already safe. This rule is about everything the compiler is
+not watching.
+
+## Reach for the existing type first
+
+Before adding a constant, check whether a literal-union type already describes the domain. Widening that union is better
+than standing a parallel constant next to it – the union is the enforcement mechanism, and two sources of truth for one
+domain is the problem this rule exists to prevent, not a fix for it.
+
+Name the constant by what it means, not by where it lives; in `packages/blit386/src/**` that naming is governed by
+[internal-scoped-naming.md](../../packages/blit386/.claude/rules/internal-scoped-naming.md).
+
+## When it applies
+
+| Situation | Applies |
+| --- | --- |
+| The same literal compared in two or more files | yes |
+| The same literal compared twice in one file | yes |
+| A literal that names something in another package (a version range, a marker string, a file class) | yes |
+| A literal that also has to appear in a shader source, a JSON config, or a generated project file | yes – see below |
+| A literal used exactly once | no |
+| Structural values (`0`, `1`, `-1`) as an index, a length, or a bound | no |
+| A test that deliberately hardcodes the expected wire value | no – pinning the literal is the point of the assertion |
+| The constant's own definition site | no |
+
+## Crossing out of TypeScript
+
+The hardest version of this is a value that has to exist somewhere the compiler cannot follow: a WGSL or GLSL shader
+source string, a JSON config in a sibling package, an HTML template, a file the scaffolder writes into a generated game.
+
+Two options, and only two:
+
+- **Thread the constant through.** Interpolate it into the shader template, derive the JSON at build time, generate the
+  file from the same constant the runtime reads.
+- **Document the duplication as a manual-sync hazard, at both sites.** A comment on each copy naming the other one, plus
+  a line in whatever document governs that workflow.
+
+Two silent hardcoded copies are not an option. That is the exact shape of every drift this rule was written from.
+
+## What this rule would have caught
+
+`GLITCH_TYPES` in `packages/demos` is re-typed as a bare array literal in five demo files. Three of them (`crt-pipboy`,
+`snake-game`, `basics-enhanced`) list `hshift`, `chromasplit`, `noise`, `flicker`, `interference`; two of them
+(`sprite-effects`, `logo-lowres`) have already diverged to a variant that drops `chromasplit` and adds `vroll`. Every
+`this.glitchType === 'hshift'` branch re-types the literal a sixth, seventh, eighth time. Nothing in the toolchain can
+tell an intentional variant from a typo here, because plain JavaScript demos have no compiler backstop at all.
+
+## What doing it right looks like
+
+The engine version range genuinely has to exist twice: `BLIT386_RANGE` in `packages/create-blit386/src/scaffold.ts` pins
+the engine in a freshly scaffolded game's `package.json`, and `blit386.engineRange` in `packages/kit/package.json` tells
+`blit doctor` which engine the kit's guides describe. Different mechanisms, different consumers, same value.
+
+They stay in step because `scripts/bump-lockstep.mjs` writes both and `packages/create-blit386/PUBLISHING.md` records
+that both are derived, never hand-edited. That is the threading option, done properly: one place decides the value, the
+coupling is written down, and a reviewer who edits one copy by hand is told so.
+
+## Per-package notes
+
+- `packages/demos` is plain JavaScript with no compiler safety net, so shared values live in `src/shared/` next to
+  `ui-theme.js` and `post-process-backend.js`, not re-typed per demo.
+- `packages/blit386` should widen an existing literal-union type wherever one covers the domain, and interpolate any
+  numeric sentinel shared with a WGSL source into the shader template rather than typing it twice.
+- `packages/kit` and `packages/create-blit386` describe each other constantly – version ranges, file classes, marker
+  strings, ownership manifests. Any literal one package uses to talk about the other is derived or documented, never
+  copied.
+
+Full shared-conventions list: [CLAUDE.md](../../CLAUDE.md).

--- a/.claude/rules/named-constants.md
+++ b/.claude/rules/named-constants.md
@@ -1,12 +1,25 @@
 ---
-paths: [packages/*/src/**, packages/*/templates/**, packages/*/scripts/**, packages/*/test/**, scripts/**]
+paths:
+  [
+    packages/*/src/**,
+    packages/*/templates/**,
+    packages/*/content/**,
+    packages/*/scripts/**,
+    packages/*/test/**,
+    packages/*/package.json,
+    scripts/**,
+  ]
 ---
 
 # Named constants over repeated literals
 
 A string or numeric literal that is **compared** – `===`, `switch`, a discriminant check, an `includes()` membership
-test – at more than one call site, or that crosses a file or package boundary, gets one exported named constant, or in
-TypeScript one literal-union type, that every site imports. Never re-type the literal.
+test – at more than one call site gets one named constant, or in TypeScript one literal-union type, that every site
+reads. Never re-type the literal.
+
+Scope the constant to its consumers. Repeats inside a single file stay a module-local `const`; the moment a second file
+or a second package needs the value, export it once and import it everywhere. Do not export a constant nothing outside
+its own file reads.
 
 Typo drift in a re-typed literal is silent: nothing throws, nothing fails to build, a branch just quietly stops being
 taken. Where a literal-union type already exists the compiler catches that, which is why most of this repo's domain tags
@@ -27,7 +40,7 @@ Name the constant by what it means, not by where it lives; in `packages/blit386/
 | Situation | Applies |
 | --- | --- |
 | The same literal compared in two or more files | yes |
-| The same literal compared twice in one file | yes |
+| The same literal compared twice in one file | yes – as a module-local `const`, not an export |
 | A literal that names something in another package (a version range, a marker string, a file class) | yes |
 | A literal that also has to appear in a shader source, a JSON config, or a generated project file | yes – see below |
 | A literal used exactly once | no |

--- a/.claude/rules/named-constants.md
+++ b/.claude/rules/named-constants.md
@@ -14,8 +14,8 @@ paths:
 # Named constants over repeated literals
 
 A string or numeric literal that is **compared** – `===`, `switch`, a discriminant check, an `includes()` membership
-test – at more than one call site gets one named constant, or in TypeScript one literal-union type, that every site
-reads. Never re-type the literal.
+test – at more than one comparison site gets one named constant, or in TypeScript one literal-union type constraining
+every use. Never re-type the literal.
 
 Scope the constant to its consumers. Repeats inside a single file stay a module-local `const`; the moment a second file
 or a second package needs the value, export it once and import it everywhere. Do not export a constant nothing outside

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,8 @@ are touching together with this file.
 - No emoji anywhere – code, docs, commits, PR titles, errors, logs.
 - Use the en dash (–) for parenthetical breaks and ranges; never the em dash or a double hyphen as a dash substitute.
 - American English spelling, with documented spec-mandated exceptions (see `CLAUDE.md`).
+- Named constants over repeated literals – a literal compared at two or more call sites, or crossing a file or package
+  boundary, gets one shared constant or literal-union type (see `.claude/rules/named-constants.md`).
 - Package manager is pnpm, not npm or yarn; use `pnpm run <script>` so shell-rewrite hooks apply.
 - All commits require DCO sign-off (`git commit -s`); Conventional Commits format (`<type>(<scope>): <description>`).
 - `main` is protected – land changes through a PR; release tags carry no `v` prefix.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,8 +21,8 @@ are touching together with this file.
 - No emoji anywhere – code, docs, commits, PR titles, errors, logs.
 - Use the en dash (–) for parenthetical breaks and ranges; never the em dash or a double hyphen as a dash substitute.
 - American English spelling, with documented spec-mandated exceptions (see `CLAUDE.md`).
-- Named constants over repeated literals – a literal compared at two or more call sites, or crossing a file or package
-  boundary, gets one shared constant or literal-union type (see `.claude/rules/named-constants.md`).
+- Named constants over repeated literals – a literal compared at two or more comparison sites, or crossing a file or
+  package boundary, gets one shared constant or literal-union type (see `.claude/rules/named-constants.md`).
 - Package manager is pnpm, not npm or yarn; use `pnpm run <script>` so shell-rewrite hooks apply.
 - All commits require DCO sign-off (`git commit -s`); Conventional Commits format (`<type>(<scope>): <description>`).
 - `main` is protected – land changes through a PR; release tags carry no `v` prefix.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,8 @@ are touching together with this file.
 - Use the en dash (–) for parenthetical breaks and ranges; never the em dash or a double hyphen as a dash substitute.
 - American English spelling, with documented spec-mandated exceptions (see `CLAUDE.md`).
 - Named constants over repeated literals – a literal compared at two or more comparison sites, or crossing a file or
-  package boundary, gets one shared constant or literal-union type (see `.claude/rules/named-constants.md`).
+  package boundary, gets one shared constant or, in TypeScript, one literal-union type (see
+  `.claude/rules/named-constants.md`).
 - Package manager is pnpm, not npm or yarn; use `pnpm run <script>` so shell-rewrite hooks apply.
 - All commits require DCO sign-off (`git commit -s`); Conventional Commits format (`<type>(<scope>): <description>`).
 - `main` is protected – land changes through a PR; release tags carry no `v` prefix.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,10 +35,11 @@ These apply to every package; a package's own `CLAUDE.md` adds to them, never co
   names correctly spelled with a British `s`/`c` in their own spec (Web Audio's `AnalyserNode`, the CSS-mirroring
   `gray`/`grey` alias in `packages/blit386/src/utils/Color32.ts`) – do not "fix" those.
 - Named constants over repeated literals – a string or numeric literal compared (`===`, `switch`, a discriminant check)
-  at more than one call site, or crossing a file or package boundary, gets one exported constant or literal-union type
-  that every site imports. A copy that has to live outside TypeScript (a shader source string, a sibling package's JSON,
-  a generated project file) is threaded through from that constant or documented as a manual-sync hazard at both sites –
-  never left as two silent copies. Full policy: `.claude/rules/named-constants.md`.
+  at more than one call site gets one named constant or literal-union type that every site reads: module-local while the
+  repeats stay inside one file, exported once a second file or package needs it. A copy that has to live outside
+  TypeScript (a shader source string, a sibling package's JSON, a generated project file) is threaded through from that
+  constant or documented as a manual-sync hazard at both sites – never left as two silent copies. Full policy:
+  `.claude/rules/named-constants.md`.
 - Conventional Commits: `<type>(<scope>): <description>`. The type enum is commitlint-enforced; scope is convention only
   – see each package's own `CLAUDE.md` for the scopes its history actually uses.
 - DCO sign-off on every commit: `git commit -s`. AI-assisted commits carry

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,11 @@ These apply to every package; a package's own `CLAUDE.md` adds to them, never co
 - American English spelling in prose, JSDoc, and this project's own identifiers. Exempt: third-party or spec-mandated
   names correctly spelled with a British `s`/`c` in their own spec (Web Audio's `AnalyserNode`, the CSS-mirroring
   `gray`/`grey` alias in `packages/blit386/src/utils/Color32.ts`) – do not "fix" those.
+- Named constants over repeated literals – a string or numeric literal compared (`===`, `switch`, a discriminant check)
+  at more than one call site, or crossing a file or package boundary, gets one exported constant or literal-union type
+  that every site imports. A copy that has to live outside TypeScript (a shader source string, a sibling package's JSON,
+  a generated project file) is threaded through from that constant or documented as a manual-sync hazard at both sites –
+  never left as two silent copies. Full policy: `.claude/rules/named-constants.md`.
 - Conventional Commits: `<type>(<scope>): <description>`. The type enum is commitlint-enforced; scope is convention only
   – see each package's own `CLAUDE.md` for the scopes its history actually uses.
 - DCO sign-off on every commit: `git commit -s`. AI-assisted commits carry

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,10 +35,10 @@ These apply to every package; a package's own `CLAUDE.md` adds to them, never co
   names correctly spelled with a British `s`/`c` in their own spec (Web Audio's `AnalyserNode`, the CSS-mirroring
   `gray`/`grey` alias in `packages/blit386/src/utils/Color32.ts`) – do not "fix" those.
 - Named constants over repeated literals – a string or numeric literal compared (`===`, `switch`, a discriminant check)
-  at more than one call site gets one named constant or literal-union type that every site reads: module-local while the
-  repeats stay inside one file, exported once a second file or package needs it. A copy that has to live outside
-  TypeScript (a shader source string, a sibling package's JSON, a generated project file) is threaded through from that
-  constant or documented as a manual-sync hazard at both sites – never left as two silent copies. Full policy:
+  at more than one comparison site gets one named constant or literal-union type constraining every use: module-local
+  while the repeats stay inside one file, exported once a second file or package needs it. A copy that has to live
+  outside TypeScript (a shader source string, a sibling package's JSON, a generated project file) is threaded through
+  from that constant or documented as a manual-sync hazard at both sites – never left as two silent copies. Full policy:
   `.claude/rules/named-constants.md`.
 - Conventional Commits: `<type>(<scope>): <description>`. The type enum is commitlint-enforced; scope is convention only
   – see each package's own `CLAUDE.md` for the scopes its history actually uses.

--- a/packages/blit386/CLAUDE.md
+++ b/packages/blit386/CLAUDE.md
@@ -97,6 +97,10 @@ Class member order is enforced by `perfectionist/sort-classes` with `type: 'unso
 preserves the hand-tuned order inside each group; `pnpm run lint:fix` applies it. Region markers (`// #region`) are
 banned. Full layout: `.claude/rules/ts-file-structure.md`.
 
+Widen an existing literal-union type (`Backend`, `AudioBus`, `EffectTier`, `EasingFunction`) rather than adding a second
+literal beside it, and interpolate any numeric sentinel shared with a WGSL source into the shader template instead of
+typing it in both places. Shared policy: root `.claude/rules/named-constants.md`.
+
 ## Writing docs
 
 Everything about authoring `docs/` – prose house style, which Fumadocs components may appear, the twoslash requirement

--- a/packages/create-blit386/CLAUDE.md
+++ b/packages/create-blit386/CLAUDE.md
@@ -48,6 +48,9 @@ are in [`.claude/rules/template-structure.md`](.claude/rules/template-structure.
 3. Integer coordinates – generated games use `Vector2i` / `Rect2i` via blit386
 4. Use the `BT` namespace in generated game code, never `BTAPI`
 5. Named exports only in this package's own TypeScript; no default exports
+6. Literals that describe another package are derived or documented, never copied – `BLIT386_RANGE` in `src/scaffold.ts`
+   is written by `scripts/bump-lockstep.mjs` (repo root) alongside `packages/kit`'s `blit386.engineRange`, and
+   `PUBLISHING.md` records the coupling. Shared policy: root `.claude/rules/named-constants.md`
 
 ## Where to find information
 

--- a/packages/demos/CLAUDE.md
+++ b/packages/demos/CLAUDE.md
@@ -16,6 +16,9 @@ tables, …) live in the root [`CLAUDE.md`](../../CLAUDE.md) – read together w
   prefer-immutability default does not apply to per-frame demo state
 - Relaxed linting versus the engine: JSDoc is not required (though class-level `@implements {IBTDemo}` is encouraged)
   and console logging is allowed. Clarity beats ceremony
+- Shared literals live in `src/shared/` – plain JS has no compiler backstop, so a label, state name, or type string
+  compared in more than one demo gets one exported constant beside `ui-theme.js` and `post-process-backend.js`, never a
+  re-typed copy per demo. Shared policy: root `.claude/rules/named-constants.md`
 
 ## Layout
 

--- a/packages/kit/CLAUDE.md
+++ b/packages/kit/CLAUDE.md
@@ -79,6 +79,10 @@ list of what ships, and it has no automated guard.
 2. Integer coordinates – generated games use `Vector2i` / `Rect2i` via blit386
 3. Use the `BT` namespace in generated game code, never `BTAPI`
 4. Named exports only in this package's own TypeScript; no default exports
+5. `blit386.engineRange` in `package.json` is derived, not hand-edited – `scripts/bump-lockstep.mjs` (repo root) writes
+   it together with `BLIT386_RANGE` in `packages/create-blit386/src/scaffold.ts`. Any other literal this package uses to
+   describe the engine or the scaffolder follows the same derive-or-document discipline: root
+   `.claude/rules/named-constants.md`
 
 ## Where to find information
 


### PR DESCRIPTION
## Why

The BT-313 literal-comparison audit found this codebase is well protected wherever a TypeScript literal-union type exists, but nothing written down tells an agent (or a human) to reach for a shared named constant instead of re-typing a literal at a second call site. Two clusters had already drifted silently for exactly that reason. BT-314 is sequenced first in the epic so the fixes in BT-315/316/317 get written the way we want future code written, not merely cleaned up once.

## What lands

New `.claude/rules/named-constants.md` (path-scoped, modeled on `docs-sync-required.md`):

- A string or numeric literal **compared** (`===`, `switch`, a discriminant check, an `includes()` test) at more than one call site, or crossing a file or package boundary, gets one exported constant – or in TypeScript one literal-union type – that every site imports.
- Widen an existing union rather than standing a parallel constant beside it.
- An explicit "when it does not apply" table (single use, structural `0`/`1`/`-1`, tests that deliberately pin a wire value).
- Crossing out of TypeScript (WGSL/GLSL source strings, sibling-package JSON, generated project files) allows exactly two options: thread the constant through, or document the duplication as a manual-sync hazard at both sites. Two silent copies is the failure mode.

Summaries pointing at it in root `CLAUDE.md` (Shared conventions) and `AGENTS.md` (Rules that matter most), plus short package-local notes where the hazard is concrete: `packages/demos` (plain JS, no compiler backstop, shared values go in `src/shared/`), `packages/kit` and `packages/create-blit386` (the derived engine version range), `packages/blit386` (widen a union; interpolate WGSL sentinels).

The rule cites both live audit clusters: `GLITCH_TYPES`, re-typed across five demos with two variants already diverged, and the `BLIT386_RANGE` / `blit386.engineRange` pair, which stays correct only because `scripts/bump-lockstep.mjs` derives both and `PUBLISHING.md` records the coupling – that one is cited as the good pattern.

## Deviations from the issue checklist

The issue predates the monorepo merge and targets four repo roots plus `.cursor/rules/` mirrors. Confirmed with the repo owner before implementing:

| Issue asks for | Reality now | Decision |
| --- | --- | --- |
| Rule duplicated into 4 `CLAUDE.md` files | Shared rules live once in `.claude/rules/`; packages "add to, never contradict" root | One shared rule + root summary + concrete package notes |
| Mirror into each repo's `.cursor/rules/` | No `.cursor/` exists here; the only Cursor surface is the kit adapter emitting into *generated games* from `packages/kit/content/rules/` | Skipped – kit content is engine-usage rules for beginners and carries its own drift discipline |
| Update parent `_BLIT386_/CLAUDE.md` "Shared Rules (All Repos)" | Outside this repo, and that section no longer exists | Skipped |

## Test plan

Documentation only – no source changes, and `.claude/rules/**` has no parity checker by design (`check-agent-config.mjs` mirrors `.claude/skills` into `.agents/skills` and treats rules as package-local). No new automated test is warranted.

- [x] `pnpm run format` / `format:check`
- [x] `pnpm run agents:check` and `pnpm run test:agent-config` (25 tests)
- [x] `pnpm run docs:links` (157 files)
- [x] `check-dash-typography.mjs` and `cspell` on every changed file
- [x] Full pre-push preflight across all 6 workspace projects
- [x] Manual: relative links resolve from `.claude/rules/`; no `file:line` references that would rot; compact tables left one-space-padded; root/AGENTS summaries say the same thing as the rule in fewer words

Refs BT-314

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added repository-wide guidance for managing repeated and cross-boundary literal values.
  * Documented synchronization conventions across TypeScript, shaders, configuration, generated files, and publishing workflows.
  * Added package-specific guidance for demos, engine ranges, scaffolding, and version values.
  * Clarified when existing literal-union types should be extended instead of duplicated.
  * Added examples covering shared constants, consumer-scoped values, and valid exemptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->