### PR TITLE
fix(demos): build the engine automatically when packages/blit386/dist is missing

### DIFF
--- a/packages/demos/docs/EXTERNAL-DEVELOPER-SETUP.md
+++ b/packages/demos/docs/EXTERNAL-DEVELOPER-SETUP.md
@@ -81,6 +81,10 @@ Prerequisite: Node.js >= 22.18.0 (`engines` in the root `package.json`).
 
 ## Running the Demos
 
+The first `pnpm run dev`, `build`, `preview`, or `knip` in a fresh checkout or worktree builds the BLIT386 engine
+automatically if `packages/blit386/dist` is missing, so that first run may take a little longer than usual. There is no
+need to run `pnpm --filter blit386 run build` by hand first – the commands below already handle it.
+
 ### Standard Development
 
 ```bash
@@ -130,15 +134,16 @@ Cause: dependencies were not installed from the workspace root.
 Fix: run `pnpm install` from the repo root (`blit386/`), not from inside `packages/demos` alone – pnpm resolves
 `workspace:*` dependencies only when installed at the workspace root.
 
-### Demos won't start – "TypeError: Cannot read properties..."
+### `vite` / `knip` fails with "Cannot find module '.../blit386/dist/vite.js'"
 
-Cause: BLIT386 library not built
+Cause: the BLIT386 engine has never been built in this checkout – common right after `git clone` or `git worktree add`.
 
-Fix:
+Fix: `pnpm run dev`, `build`, `preview`, and `knip` in `packages/demos` detect this automatically and build the engine
+first, so simply re-running the command that failed is usually enough. To force a fresh rebuild yourself (for example
+after switching branches):
 
 ```bash
 cd packages/blit386
-pnpm install
 pnpm run build
 cd ../demos
 pnpm run dev

--- a/packages/demos/package.json
+++ b/packages/demos/package.json
@@ -33,10 +33,10 @@
     "node": ">=22.18.0"
   },
   "scripts": {
-    "dev": "vite",
+    "dev": "node scripts/ensure-engine-built.mjs && vite",
     "dev:watch": "pnpm --filter blit386 run build && concurrently -n \"lib,demos\" -c \"blue,green\" \"pnpm --filter blit386 run build:browser --watch\" \"pnpm run dev\"",
-    "build": "vite build",
-    "preview": "vite preview",
+    "build": "node scripts/ensure-engine-built.mjs && vite build",
+    "preview": "node scripts/ensure-engine-built.mjs && vite preview",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "biome format --write . && prettier --ignore-path ../../.prettierignore --write \"**/*.{md,mdx,yml,yaml}\"",
@@ -52,7 +52,7 @@
     "generate:audio-loops": "node scripts/generate-audio-loops.mjs",
     "test": "node --test \"scripts/__tests__/*.test.mjs\" \"plugins/__tests__/*.test.mjs\"",
     "preflight": "pnpm run format:check && pnpm run lint && pnpm run test && pnpm run spellcheck && pnpm run knip && pnpm run check:demo-registry && pnpm run check:demo-comment-links && pnpm run build",
-    "knip": "cd ../.. && knip --workspace packages/demos",
+    "knip": "node scripts/ensure-engine-built.mjs && cd ../.. && knip --workspace packages/demos",
     "knip:fix": "knip --fix",
     "clean": "rm -rf dist node_modules/.vite",
     "prepare": "husky",

--- a/packages/demos/scripts/__tests__/ensure-engine-built.test.mjs
+++ b/packages/demos/scripts/__tests__/ensure-engine-built.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+
+import { buildEngineBuildCommand, isEngineBuilt, resolveEngineViteEntry } from '../ensure-engine-built.mjs';
+
+describe('ensure-engine-built', () => {
+    describe('resolveEngineViteEntry', () => {
+        it('points at packages/blit386/dist/vite.js', () => {
+            const entry = resolveEngineViteEntry();
+
+            assert.ok(entry.endsWith(join('blit386', 'dist', 'vite.js')));
+            assert.ok(entry.includes(join('packages', 'blit386')));
+        });
+    });
+
+    describe('isEngineBuilt', () => {
+        it('is true when the vite entry file exists', () => {
+            assert.equal(
+                isEngineBuilt('/fake/packages/blit386/dist/vite.js', () => true),
+                true,
+            );
+        });
+
+        it('is false when the vite entry file is missing', () => {
+            assert.equal(
+                isEngineBuilt('/fake/packages/blit386/dist/vite.js', () => false),
+                false,
+            );
+        });
+    });
+
+    describe('buildEngineBuildCommand', () => {
+        it('runs the engine build through pnpm --filter, no shell', () => {
+            const { command, args, cwd } = buildEngineBuildCommand();
+
+            assert.equal(command, 'pnpm');
+            assert.deepEqual(args, ['--filter', 'blit386', 'run', 'build']);
+            assert.ok(cwd.endsWith(join('packages', 'demos')));
+        });
+    });
+});

--- a/packages/demos/scripts/ensure-engine-built.mjs
+++ b/packages/demos/scripts/ensure-engine-built.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+/**
+ * Build the BLIT386 engine automatically when `packages/blit386/dist` is missing – the case for
+ * every freshly created checkout or git worktree, since `dist/` is gitignored and only a build
+ * produces it. `vite.config.js` imports `blit386/vite` at the top of the file, unconditionally,
+ * so `dev`, `build`, `preview`, and `knip` (which loads `vite.config.js` via its own Vite plugin)
+ * all crash before that import is even reached if the engine has never been built. Run before
+ * each of those so the failure self-heals instead of surfacing as a confusing "Cannot find
+ * module" error partway through `git push`.
+ *
+ * A no-op once the engine is built – existsSync is the only cost on every normal run.
+ *
+ * Usage:
+ *   node scripts/ensure-engine-built.mjs
+ */
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const scriptDir = fileURLToPath(new URL('.', import.meta.url));
+
+const resolveEngineViteEntry = () => resolve(scriptDir, '..', '..', 'blit386', 'dist', 'vite.js');
+
+const isEngineBuilt = (engineViteEntry = resolveEngineViteEntry(), exists = existsSync) => exists(engineViteEntry);
+
+const buildEngineBuildCommand = () => ({
+    command: 'pnpm',
+    args: ['--filter', 'blit386', 'run', 'build'],
+    cwd: resolve(scriptDir, '..'),
+});
+
+const main = () => {
+    if (isEngineBuilt()) {
+        return;
+    }
+
+    console.log('packages/blit386/dist is missing – building the engine first...');
+
+    const { command, args, cwd } = buildEngineBuildCommand();
+    const result = spawnSync(command, args, { stdio: 'inherit', cwd });
+
+    if (result.status !== 0) {
+        process.exitCode = result.status ?? 1;
+        return;
+    }
+
+    if (!isEngineBuilt()) {
+        console.error('Engine build finished but packages/blit386/dist/vite.js is still missing.');
+        process.exitCode = 1;
+    }
+};
+
+export { buildEngineBuildCommand, isEngineBuilt, resolveEngineViteEntry };
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    main();
+}


### PR DESCRIPTION
## Summary

- A fresh git worktree has never run the engine build, so `packages/demos/vite.config.js`'s top-level `import { blit386 } from 'blit386/vite'` crashes before command resolution even starts. This broke `dev`, `build`, `preview`, and `knip` — and `knip` is what the pre-push hook and CI's `quality-demos` job both run, so it failed pushes and CI with a "Cannot find module" error that read like a dependency bug rather than a missing build step.
- `dev`, `build`, `preview`, and `knip` in `packages/demos` now run a small guard script (`scripts/ensure-engine-built.mjs`) first, which builds `packages/blit386` only when its `dist/` is missing, then proceeds. It's a no-op once the engine is built, so `dev:watch` and normal builds are unaffected.
- `packages/demos/docs/EXTERNAL-DEVELOPER-SETUP.md` documents the new self-healing behavior and its troubleshooting entry now matches the real failure shape.

## Notes for reviewers

- The issue as originally filed (BT-399) described a hardcoded `../blit386/dist` path assuming a sibling checkout, from before the monorepo merge. That's already fixed for free by the merge — confirmed live, not something this PR touches. The issue's own 2026-08-10 follow-up comment re-diagnosed the bug this PR actually fixes.
- Bonus: CI's `quality-demos` job's `knip` step is verifiably broken today for the same reason (reproduced locally) — its own comment claiming it's safe without an engine build is wrong specifically for the `knip` step. This PR fixes that too, for free, since CI calls through the same `package.json` `knip` script. No `.github/workflows/ci.yml` change needed or included.
- The issue's "second, smaller papercut" (`pnpm install` in a worktree walking up to a parent workspace and installing sibling repos) does not reproduce in the current nested-worktree layout and was dropped from scope after confirming with the issue owner.

Closes BT-399.

## Test plan

- [x] `rm -rf packages/blit386/dist && pnpm run knip` from `packages/demos` — auto-builds, then passes (this is the exact pre-push failure mode from the issue)
- [x] `rm -rf packages/blit386/dist && pnpm run build` from `packages/demos` — clean build succeeds
- [x] `rm -rf packages/blit386/dist && pnpm run dev` from `packages/demos` — auto-builds, serves in a real browser with no resolve errors, demo renders correctly, `blit386` resolves via `packages/blit386/dist/blit386.js`
- [x] `pnpm run dev:watch` behavior unchanged (still builds unconditionally as its own prefix; guard on `dev` is a no-op once dist exists)
- [x] `node --test packages/demos/scripts/__tests__/ensure-engine-built.test.mjs` — new unit tests (4/4) pass
- [x] `pnpm run preflight` in `packages/demos` from a clean `dist/` state — full gate passes, engine built exactly once, not re-triggered by later steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Demo development, builds, previews, and analysis now automatically build the BLIT386 engine when needed.
  * Added clear error handling when the engine build fails or expected output is missing.

* **Documentation**
  * Updated the setup guide with automatic build behavior and troubleshooting instructions.

* **Tests**
  * Added coverage for engine detection, build commands, and Vite entry resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->