### PR TITLE
docs(repo): correct CI wiring for the root audit-only test scripts

### DIFF
--- a/.claude/skills/preflight/SKILL.md
+++ b/.claude/skills/preflight/SKILL.md
@@ -142,13 +142,15 @@ checks unconditionally on every push, since pnpm's per-package `--filter` dispat
 in `.github/workflows/ci.yml` (BT-461), so a repo-wide dash-typography regression fails both the push and CI, on top of
 the existing per-commit gates below.
 
-The following are not part of that pre-push gate – run them directly when auditing:
+The following are not part of that pre-push gate – run them directly when auditing. All four do run in CI, so a
+regression they would catch surfaces on the PR rather than at push time:
 
-- `pnpm run test:agent-config` – unit tests for the `agents:check` script itself
-- `pnpm run test:dash-typography` – unit tests for `check-dash-typography.mjs`
+- `pnpm run test:agent-config` – unit tests for the `agents:check` script itself. Runs in `quality-root` in
+  `.github/workflows/ci.yml`, which is gated only on the run not being a label event
+- `pnpm run test:dash-typography` – unit tests for `check-dash-typography.mjs`. Also runs in `quality-root`, alongside
+  the repo-wide `check-dash-typography` run described above
 - `pnpm run test:bump-lockstep` – unit tests for `scripts/bump-lockstep.mjs`, the lockstep version-bump script covering
-  `blit386`, `@blit386/kit`, and `create-blit386` (see `/release`)
-- `pnpm run test:shell-safety` – unit tests for `.claude/hooks/shell-safety.sh`. Unlike its neighbors above, this one
-  does run in CI: `quality-root` in `.github/workflows/ci.yml` runs it unconditionally, since `.claude/**` is in the
-  `shared` path filter (BT-439). `test:agent-config` and `test:dash-typography` are not yet wired into any CI job –
-  tracked separately in BT-445
+  `blit386`, `@blit386/kit`, and `create-blit386` (see `/release`). Runs in `build-test-scaffolder`, the one CI job that
+  exercises it – and that job is path-filtered, so it only fires when the `scaffolder` or `shared` filter matches
+- `pnpm run test:shell-safety` – unit tests for `.claude/hooks/shell-safety.sh`. Runs in `quality-root`, and
+  `.claude/**` is in the `shared` path filter (BT-439)


### PR DESCRIPTION
## Summary

The `preflight` skill's "not part of that pre-push gate" list claimed `test:agent-config` and `test:dash-typography`
were not wired into any CI job, tracked separately in BT-445. Both have since been wired into `quality-root` in
[`.github/workflows/ci.yml`](.github/workflows/ci.yml), so the claim was stale.

Verifying it surfaced a second problem: `test:bump-lockstep` runs in CI too, in `build-test-scaffolder`. That makes the
paragraph's whole framing wrong, not just one clause – it singled out `test:shell-safety` as the exception that
"unlike its neighbors above, this one does run in CI", when in fact all four scripts in the list run in CI. The only
distinction that still holds is the one the intro sentence already makes: these are outside the *pre-push* gate, not
outside CI.

## Changes

Rewrote the list so each bullet names the CI job that runs it and how that job is gated:

| Script | CI job | Gating |
| --- | --- | --- |
| `test:agent-config` | `quality-root` | not a label event |
| `test:dash-typography` | `quality-root` | not a label event |
| `test:bump-lockstep` | `build-test-scaffolder` | path-filtered on `scaffolder` or `shared` |
| `test:shell-safety` | `quality-root` | not a label event; `.claude/**` is in the `shared` filter (BT-439) |

Docs only – no script, workflow, or config behavior changes.

## Test plan

- [x] `node scripts/check-dash-typography.mjs .claude/skills/preflight/SKILL.md`
- [x] `pnpm run format:check` (exit 0; Prettier rewrapped one bullet, included in the commit)
- [x] `rg -n --hidden --glob '!.git/' "BT-445|not yet wired" .` returns no remaining hits
- [x] Each CI claim in the new table verified against `.github/workflows/ci.yml`

Note for future sweeps: a plain `rg -n "BT-445"` misses this file entirely – ripgrep skips hidden directories by
default, so any audit of agent config under `.claude/` needs `--hidden`.

Noticed while working on BT-243 (#559); deliberately kept out of that PR as unrelated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the preflight validation process.
  - Documented which audit checks run in continuous integration rather than during the pre-push workflow.
  - Added details about the relevant CI jobs and path-based conditions for configuration, typography, lockstep versioning, and shell-safety checks.
  - No user-facing product behavior or public APIs were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->