### PR TITLE
feat(website): replace script-src unsafe-inline with a per-request nonce

### DIFF
--- a/packages/blit386/docs/security/security-runbook.md
+++ b/packages/blit386/docs/security/security-runbook.md
@@ -96,6 +96,7 @@ When Opsera `compliance-audit` MCP is unavailable, gather evidence manually:
 | Secrets in repo | `.gitignore`, hooks blocking `.env`; `rg` for hardcoded tokens (no secret values in reports) |
 | CI integrity | `.github/workflows/*.yml` – pinned actions, least privilege |
 | Deploy headers (demos) | `packages/demos/public/_headers`, `curl -I` on deployed URLs |
+| Deploy headers (website) | `packages/website/public/_headers` plus the nonce'd CSP from `packages/website/src/csp-nonce.ts`; `curl -s -D - -o /dev/null https://blit386.dev/` must show a `nonce-` in `script-src` and no `'unsafe-inline'` (a GET, not `curl -I`) |
 | Ownership / bus factor | [Maintainers](#maintainers) (solo); optional `security-ownership-map` skill output (`summary.json`) |
 | MCP governance | `pnpm run security:mcp-preflight --governance-only` |
 

--- a/packages/website/CLAUDE.md
+++ b/packages/website/CLAUDE.md
@@ -46,12 +46,63 @@ for exploration.
 | Why every git subprocess passes `gitEnv()` | `scripts/git-env.mjs` |
 | MCP server | `src/mcp-server.ts`, `public/.well-known/mcp/server-card.json`, `content/mcp-server.mdx` |
 | Cloudflare security headers | `public/_headers` |
+| The CSP itself, and the nonce that replaces `'unsafe-inline'` | `src/csp.ts`, `src/csp-nonce.ts` – see Content-Security-Policy |
 
-Four Fumapress `ServerPlugin`s are local to this package rather than upstream: `channelHeadersPlugin`
-(`src/channel-headers.ts`), `markdownNegotiationPlugin` (`src/markdown-negotiation.ts`), `mcpServerPlugin`
-(`src/mcp-server.ts`), and `feedPlugin` (`src/feed.ts`) – plus the `blog-post-date` helper (`src/blog-post-date.ts`,
-which exists because the framework's adapter cannot read a post's `date` frontmatter). The rest of the chain in
-`press.config.tsx` is stock: flexsearch, blog, llms, sitemap, takumi OG images, and link validation.
+Five Fumapress `ServerPlugin`s are local to this package rather than upstream: `cspNoncePlugin` (`src/csp-nonce.ts`),
+`channelHeadersPlugin` (`src/channel-headers.ts`), `markdownNegotiationPlugin` (`src/markdown-negotiation.ts`),
+`mcpServerPlugin` (`src/mcp-server.ts`), and `feedPlugin` (`src/feed.ts`) – plus the `blog-post-date` helper
+(`src/blog-post-date.ts`, which exists because the framework's adapter cannot read a post's `date` frontmatter). The
+rest of the chain in `press.config.tsx` is stock: flexsearch, blog, llms, sitemap, takumi OG images, and link
+validation.
+
+## Content-Security-Policy
+
+`script-src` carries no `'unsafe-inline'` (BT-191). Inline scripts are allowed by a per-request nonce instead, which
+takes three pieces:
+
+| Piece | Role |
+| --- | --- |
+| `src/csp.ts` | The policy, defined once. `BASE_CSP` is the nonce-free form; `buildCsp(nonce)` adds the nonce to `script-src` |
+| `public/_headers` | Serves `BASE_CSP` on every response Cloudflare returns from the ASSETS binding. Fail-closed default |
+| `src/csp-nonce.ts` | Stamps a fresh nonce onto every `<script>` in a prerendered HTML response and replaces the header with `buildCsp(nonce)` |
+
+A nonce rather than hashes because the site renders statically (`mode: 'static'`): Waku's React bootstrap script and the
+RSC flight payload `rsc-html-stream` injects are both per-page, so no fixed hash list covers them, and Waku's
+`unstable_setNonce` only applies to request-time SSR. That leaves the Worker as the only place a nonce can be applied,
+via `HTMLRewriter`.
+
+Four things about this are load-bearing and easy to undo by accident:
+
+- **`public/_headers` duplicates `BASE_CSP` by hand** – a static Cloudflare config cannot import. `src/csp.test.ts`
+  compares the two character for character and fails if either is edited alone. Change the policy in `src/csp.ts` first,
+  then copy the new line across.
+- **`cspNoncePlugin` wraps the server entry's `fetch`, not a middleware.** A Fumapress `ServerPlugin` middleware never
+  sees the response it would need to rewrite: Fumapress's own composer (`fumapress/dist/router/index.js`,
+  `pluginsMiddleware`) keeps a downstream handler's returned `Response` in a local and returns it at the end, never
+  assigning `c.res`. After `await next()`, `c.res` is still Hono's placeholder, and only its _headers_ reach the real
+  response – merged in by Hono's `set res`. That is enough for `channelHeadersPlugin`'s `x-robots-tag`, and not enough
+  to stamp a body.
+- **The wrapper strips `etag` and `last-modified` from HTML, and `markdownNegotiationPlugin` strips `if-none-match` /
+  `if-modified-since` on the way in.** Both halves are needed. A `304` for HTML is unanswerable once nonces exist: the
+  client merges the `304`'s headers into its _stored_ body, so a fresh nonce lands on scripts carrying an older one and
+  the whole page is blocked. Dropping the validators stops new copies from being revalidatable; dropping the
+  conditionals stops copies cached before this shipped from getting a `304` today. `isHtmlAssetPath` in `src/csp.ts`
+  decides which paths pay for it – hashed JS, CSS, and fonts keep their `304`s.
+- **The rewriting needs a real parser.** `<script` occurs inside the RSC flight payload as ordinary JSON string data, so
+  a string replace corrupts pages. `HTMLRewriter` is a correctness requirement, not a convenience.
+
+Rolling out a policy change: build with `BLIT386_CSP_REPORT_ONLY=1` (picked up by `scripts/patch-wrangler.mjs` as a
+Worker var, the same mechanism as `BLIT386_CHANNEL`) and deploy to the `next` channel. That serves the new policy as
+`Content-Security-Policy-Report-Only` and enforces nothing, so violations show up in the console without a blank page.
+Never set it for production. The var is not wired into `.github/workflows/deploy.yml`, so this is a local build plus
+`pnpm run deploy` today.
+
+Verify a deployment with `curl -s -D - -o /dev/null <url> | grep -i content-security-policy`: the value must contain a
+`nonce-` term, and a second request must return a different one. It has to be a GET – `curl -I` sends `HEAD`, which has
+no body to stamp and correctly gets the nonce-free `BASE_CSP`.
+
+`style-src` still has `'unsafe-inline'` – Fumadocs and Tailwind both emit inline styles, and removing it was out of
+scope for BT-191.
 
 ## Test runners
 

--- a/packages/website/press.config.tsx
+++ b/packages/website/press.config.tsx
@@ -17,6 +17,7 @@ import { feedPlugin } from './src/feed';
 import { markdownNegotiationPlugin } from './src/markdown-negotiation';
 import { mcpServerPlugin } from './src/mcp-server';
 import { channelHeadersPlugin } from './src/channel-headers';
+import { cspNoncePlugin } from './src/csp-nonce';
 import { AuthorByline } from './src/components/author-byline';
 import { BlogIndexPage } from './src/components/blog-index';
 import { BlogLayout } from './src/components/blog-layout';
@@ -384,8 +385,14 @@ export default defineConfig({
     // fallback serves most requests (including /robots.txt) directly from the ASSETS
     // binding and returns without calling next(), so a plugin registered after it would
     // never see those requests to override robots.txt or set a response header on them.
+    //
+    // cspNoncePlugin contributes no middleware at all – it wraps the server entry's fetch,
+    // outside the whole chain, because that is the only place the response body exists. Its
+    // position in this list is therefore cosmetic; it leads because it is outermost.
 
     .plugins(
+        cspNoncePlugin(),
+
         channelHeadersPlugin(),
 
         flexsearchPlugin(),

--- a/packages/website/public/_headers
+++ b/packages/website/public/_headers
@@ -1,12 +1,17 @@
 # Cloudflare Pages / Workers response headers for blit386.dev.
 # Copied to dist/public/ when present in public/.
 
+# The Content-Security-Policy below is the nonce-free base policy. It is a hand-written copy of
+# `BASE_CSP` in `src/csp.ts` – this file cannot import – and `src/csp.test.ts` fails if the two ever
+# drift apart. `script-src` has no `'unsafe-inline'`: prerendered HTML gets a per-request nonce
+# stamped onto every `<script>` by `src/csp-nonce.ts`, which replaces this header on those responses.
+
 /*
   Link: </llms.txt>; rel="describedby", </sitemap.xml>; rel="sitemap", </docs>; rel="service-doc", </.well-known/api-catalog>; rel="api-catalog", </auth.md>; rel="auth-md", </feed.xml>; rel="alternate"; type="application/rss+xml"
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: accelerometer=(), autoplay=(self), camera=(), display-capture=(), encrypted-media=(), fullscreen=(self), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), usb=()
-  Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; script-src 'self' 'unsafe-inline' https://plausible.io; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' https://fonts.vancura.dev; connect-src 'self' https://plausible.io; media-src 'self'; worker-src 'self' blob:; child-src 'none'; frame-src 'self' https://demos.blit386.dev; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests
+  Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; script-src 'self' https://plausible.io; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' https://fonts.vancura.dev; connect-src 'self' https://plausible.io; media-src 'self'; worker-src 'self' blob:; child-src 'none'; frame-src 'self' https://demos.blit386.dev; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests
 
 # Self-hosted blog media (see VideoEmbed). `autoplay=(self)`, `fullscreen=(self)`, and
 # `media-src 'self'` above exist for it. The post-slug path segment (for example

--- a/packages/website/scripts/__tests__/patch-wrangler.test.mjs
+++ b/packages/website/scripts/__tests__/patch-wrangler.test.mjs
@@ -73,6 +73,21 @@ describe('patchWranglerConfig', () => {
         assert.deepEqual(result.vars, { OTHER: 'value' });
     });
 
+    test('sets BLIT386_CSP_REPORT_ONLY=1 when isCspReportOnly is true', () => {
+        const result = patchWranglerConfig({ name: 'worker' }, { isCspReportOnly: true });
+        assert.deepEqual(result.vars, { BLIT386_CSP_REPORT_ONLY: '1' });
+    });
+
+    test('combines both channel vars', () => {
+        const result = patchWranglerConfig({ name: 'worker' }, { isNextChannel: true, isCspReportOnly: true });
+        assert.deepEqual(result.vars, { BLIT386_CHANNEL: 'next', BLIT386_CSP_REPORT_ONLY: '1' });
+    });
+
+    test('leaves vars untouched when neither flag is set', () => {
+        const result = patchWranglerConfig({ vars: { OTHER: 'value' } }, {});
+        assert.deepEqual(result.vars, { OTHER: 'value' });
+    });
+
     test('enables observability when the key is absent', () => {
         const result = patchWranglerConfig({ name: 'worker' });
         assert.deepEqual(result.observability, { enabled: true });

--- a/packages/website/scripts/patch-wrangler.mjs
+++ b/packages/website/scripts/patch-wrangler.mjs
@@ -29,21 +29,31 @@ const REPLACEMENT = "createRequire(import.meta.url ?? 'file:///worker.js')";
  * HTML's noindex meta, banner, and canonical URLs were correct regardless – those are
  * baked in once during the Node build, not re-evaluated in the Worker).
  *
+ * `isCspReportOnly` sets `BLIT386_CSP_REPORT_ONLY: '1'`, read the same request-time way
+ * by `src/csp-nonce.ts`. It downgrades the nonce-based CSP to
+ * `Content-Security-Policy-Report-Only` for a deployment, so a policy change can be
+ * measured against real traffic on next.blit386.dev before it is enforced on production.
+ * Never set it for the production build.
+ *
  * `observability.enabled` turns on Workers Logs. blit386.dev is a production site with a
  * live JSON-RPC endpoint (`/mcp`) and a request-time markdown-negotiation path in front of
  * every doc URL; without this there is no way to see a runtime error in either without
  * reproducing it locally.
- * @param {{ isNextChannel?: boolean }} [options]
+ * @param {{ isNextChannel?: boolean, isCspReportOnly?: boolean }} [options]
  */
 export const patchWranglerConfig = (config, options = {}) => {
-    const { isNextChannel = false } = options;
+    const { isNextChannel = false, isCspReportOnly = false } = options;
     const existingFlags = Array.isArray(config.compatibility_flags) ? config.compatibility_flags : [];
     const flags = existingFlags.includes(REQUIRED_FLAG) ? existingFlags : [...existingFlags, REQUIRED_FLAG];
     const assets =
         config.assets && config.assets.run_worker_first !== true
             ? { ...config.assets, run_worker_first: true }
             : config.assets;
-    const vars = isNextChannel ? { ...config.vars, BLIT386_CHANNEL: 'next' } : config.vars;
+    const extraVars = {
+        ...(isNextChannel ? { BLIT386_CHANNEL: 'next' } : {}),
+        ...(isCspReportOnly ? { BLIT386_CSP_REPORT_ONLY: '1' } : {}),
+    };
+    const vars = Object.keys(extraVars).length > 0 ? { ...config.vars, ...extraVars } : config.vars;
     const observability = { ...config.observability, enabled: true };
     return {
         ...config,
@@ -63,7 +73,11 @@ export const patchRequireMetaUrl = (content) => content.replace(PATTERN, REPLACE
 
 const main = () => {
     const isNextChannel = process.env.BLIT386_CHANNEL === 'next';
-    const patchedConfig = patchWranglerConfig(JSON.parse(readFileSync(WRANGLER_CONFIG, 'utf8')), { isNextChannel });
+    const isCspReportOnly = process.env.BLIT386_CSP_REPORT_ONLY === '1';
+    const patchedConfig = patchWranglerConfig(JSON.parse(readFileSync(WRANGLER_CONFIG, 'utf8')), {
+        isNextChannel,
+        isCspReportOnly,
+    });
     writeFileSync(WRANGLER_CONFIG, `${JSON.stringify(patchedConfig, null, 2)}\n`);
 
     // Scan the whole server bundle recursively, not just dist/server/assets: the

--- a/packages/website/src/csp-nonce.test.ts
+++ b/packages/website/src/csp-nonce.test.ts
@@ -1,0 +1,307 @@
+/**
+ * Covers `cspNoncePlugin`.
+ *
+ * The plugin wraps the server entry's `fetch`, so these tests call it the way Cloudflare does –
+ * `fetch(request, env, ctx)` – with a stub entry standing in for Waku's.
+ *
+ * `HTMLRewriter` is a workerd global and this package runs plain Vitest on Node (`vitest.config.ts`,
+ * "Test runners" in CLAUDE.md), so the plugin takes a rewriter factory and these tests inject a
+ * double. That draws the fidelity line deliberately: everything the plugin decides – when to stamp,
+ * what nonce, which headers survive – is asserted here, while the HTML parsing stays Cloudflare's and
+ * is covered by the `wrangler dev` pass in CLAUDE.md.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { BASE_CSP } from './csp';
+import { cspNoncePlugin, type CspNonceOptions, type HtmlRewriterLike } from './csp-nonce';
+
+const REPORT_ONLY_ENV = { BLIT386_CSP_REPORT_ONLY: '1' };
+
+/** What `public/_headers` has already applied by the time the Worker sees an asset response. */
+const ASSET_HEADERS = {
+    'content-type': 'text/html; charset=utf-8',
+    'content-security-policy': BASE_CSP,
+    'cache-control': 'public, max-age=0, must-revalidate',
+    etag: '"87eaabf8441fbd725e14f88ea6debca3"',
+    'last-modified': 'Wed, 20 Aug 2026 10:00:00 GMT',
+};
+
+interface RewriterSpy {
+    /** Selectors the plugin registered a handler for. */
+    readonly selectors: string[];
+    /** Every `nonce` stamped onto a `<script>`, one entry per element seen. */
+    readonly stamped: string[];
+    createRewriter: NonNullable<CspNonceOptions['createRewriter']>;
+}
+
+/**
+ * A rewriter double that records what the plugin asked for and replays the handler against two
+ * pretend `<script>` elements, so a plugin that registers a handler but never stamps is caught.
+ */
+function createRewriterSpy(): RewriterSpy {
+    const selectors: string[] = [];
+    const stamped: string[] = [];
+
+    return {
+        selectors,
+        stamped,
+
+        createRewriter() {
+            const rewriter: HtmlRewriterLike = {
+                on(selector, handlers) {
+                    selectors.push(selector);
+
+                    for (let index = 0; index < 2; index += 1) {
+                        handlers.element({
+                            setAttribute(name, value) {
+                                if (name === 'nonce') {
+                                    stamped.push(value);
+                                }
+                            },
+                        });
+                    }
+
+                    return rewriter;
+                },
+
+                transform(response) {
+                    return response;
+                },
+            };
+
+            return rewriter;
+        },
+    };
+}
+
+type EntryFetch = (request: Request, env?: unknown, ctx?: unknown) => Response | Promise<Response>;
+
+type StubEntry = { fetch: () => Response; defaultExport: { fetch: () => Response } };
+
+/** Applies the plugin to a stub of Waku's Cloudflare entry. */
+function patchEntry(downstream: Response, options: CspNonceOptions = {}): StubEntry {
+    const entry: StubEntry = { fetch: () => downstream, defaultExport: { fetch: () => downstream } };
+    const patched = cspNoncePlugin(options).unstable_onServerEntry?.(
+        entry as unknown as Parameters<NonNullable<ReturnType<typeof cspNoncePlugin>['unstable_onServerEntry']>>[0],
+    );
+
+    if (patched === undefined) {
+        throw new Error('cspNoncePlugin contributed no server-entry wrapper');
+    }
+
+    return patched as unknown as StubEntry;
+}
+
+/**
+ * The `fetch` Cloudflare actually invokes on the deployed Worker.
+ *
+ * `dist/server/index.js` re-exports `entry.defaultExport`, not `entry`, so this is the path that has
+ * to be stamped for any of this to reach production. `entry.fetch` is covered separately below.
+ */
+function wrap(downstream: Response, options: CspNonceOptions = {}): EntryFetch {
+    return patchEntry(downstream, options).defaultExport.fetch as EntryFetch;
+}
+
+function htmlResponse(headers: Record<string, string> = {}, init: ResponseInit = {}): Response {
+    return new Response('<!doctype html><script></script>', { headers: { ...ASSET_HEADERS, ...headers }, ...init });
+}
+
+/** The nonce inside a serialized policy. */
+function nonceOf(policy: string | null): string {
+    const match = policy?.match(/'nonce-([^']+)'/);
+    if (!match?.[1]) {
+        throw new Error(`no nonce in policy: ${policy}`);
+    }
+
+    return match[1];
+}
+
+describe('cspNoncePlugin', () => {
+    it('names itself', () => {
+        expect(cspNoncePlugin().name).toBe('csp-nonce');
+    });
+
+    describe('prerendered HTML', () => {
+        it('stamps every script with the nonce it puts in the header', async () => {
+            const spy = createRewriterSpy();
+            const response = await wrap(htmlResponse(), { createRewriter: spy.createRewriter })(
+                new Request('https://blit386.dev/'),
+            );
+
+            const nonce = nonceOf(response.headers.get('content-security-policy'));
+
+            expect(spy.selectors).toEqual(['script']);
+            expect(spy.stamped).toEqual([nonce, nonce]);
+        });
+
+        it('wins over the base policy the ASSETS response already carries', async () => {
+            const spy = createRewriterSpy();
+            const response = await wrap(htmlResponse(), { createRewriter: spy.createRewriter })(
+                new Request('https://blit386.dev/'),
+            );
+
+            // public/_headers applied BASE_CSP inside ASSETS.fetch; without a nonce it would block
+            // every inline script on the page.
+            expect(response.headers.get('content-security-policy')).not.toBe(BASE_CSP);
+            expect(response.headers.get('content-security-policy')).toContain("'nonce-");
+        });
+
+        it('serves a policy with no unsafe-inline', async () => {
+            const response = await wrap(htmlResponse(), { createRewriter: createRewriterSpy().createRewriter })(
+                new Request('https://blit386.dev/'),
+            );
+
+            const policy = response.headers.get('content-security-policy') ?? '';
+
+            expect(policy.split('; ').find((entry) => entry.startsWith('script-src '))).not.toContain(
+                "'unsafe-inline'",
+            );
+        });
+
+        it('uses a fresh nonce per request', async () => {
+            const spy = createRewriterSpy();
+            const first = await wrap(htmlResponse(), { createRewriter: spy.createRewriter })(
+                new Request('https://blit386.dev/'),
+            );
+            const second = await wrap(htmlResponse(), { createRewriter: spy.createRewriter })(
+                new Request('https://blit386.dev/'),
+            );
+
+            expect(nonceOf(first.headers.get('content-security-policy'))).not.toBe(
+                nonceOf(second.headers.get('content-security-policy')),
+            );
+        });
+
+        it('drops the validators that would let a 304 pair a new nonce with a cached body', async () => {
+            const response = await wrap(htmlResponse(), { createRewriter: createRewriterSpy().createRewriter })(
+                new Request('https://blit386.dev/'),
+            );
+
+            expect(response.headers.get('etag')).toBeNull();
+            expect(response.headers.get('last-modified')).toBeNull();
+        });
+
+        it('preserves the status and the headers other plugins set', async () => {
+            const response = await wrap(htmlResponse({ 'x-robots-tag': 'noindex' }, { status: 404 }), {
+                createRewriter: createRewriterSpy().createRewriter,
+            })(new Request('https://blit386.dev/nope'));
+
+            // Waku's rendered 404 carries the same inline bootstrap scripts as any other page.
+            expect(response.status).toBe(404);
+            expect(response.headers.get('x-robots-tag')).toBe('noindex');
+            expect(response.headers.get('content-security-policy')).toContain("'nonce-");
+        });
+    });
+
+    describe('leaves alone what it must not rewrite', () => {
+        it.each([
+            ['JSON', 'application/json'],
+            ['markdown', 'text/markdown; charset=utf-8'],
+            ['plain text', 'text/plain; charset=utf-8'],
+        ])('passes a %s response through untouched', async (_label, contentType) => {
+            const spy = createRewriterSpy();
+            const downstream = new Response('{}', { headers: { 'content-type': contentType, etag: '"x"' } });
+            const response = await wrap(downstream, { createRewriter: spy.createRewriter })(
+                new Request('https://blit386.dev/llms.txt'),
+            );
+
+            // The base policy from public/_headers is the right one for these.
+            expect(response.headers.get('content-security-policy')).toBeNull();
+            expect(response.headers.get('etag')).toBe('"x"');
+            expect(spy.stamped).toEqual([]);
+        });
+
+        it('passes a HEAD response through untouched', async () => {
+            const spy = createRewriterSpy();
+            const downstream = new Response(null, { headers: ASSET_HEADERS });
+            const response = await wrap(downstream, { createRewriter: spy.createRewriter })(
+                new Request('https://blit386.dev/', { method: 'HEAD' }),
+            );
+
+            expect(response.headers.get('content-security-policy')).toBe(BASE_CSP);
+            expect(spy.stamped).toEqual([]);
+        });
+
+        it('passes a 304 through untouched', async () => {
+            // A 304 has no body to stamp, so pairing it with a fresh nonce would block every script
+            // in the body the browser already has. markdown-negotiation.ts stops HTML 304s upstream;
+            // this is the second line of defense.
+            const spy = createRewriterSpy();
+            const downstream = new Response(null, { status: 304, headers: ASSET_HEADERS });
+            const response = await wrap(downstream, { createRewriter: spy.createRewriter })(
+                new Request('https://blit386.dev/'),
+            );
+
+            expect(response.headers.get('etag')).toBe(ASSET_HEADERS.etag);
+            expect(spy.stamped).toEqual([]);
+        });
+
+        it('passes HTML through untouched where there is no HTMLRewriter', async () => {
+            // Node: `waku build`'s prerender pass, linkValidationPlugin, and `waku dev`. None of
+            // them serve the public/_headers policy, so there is nothing to stamp.
+            const response = await wrap(htmlResponse())(new Request('https://blit386.dev/'));
+
+            expect(response.headers.get('content-security-policy')).toBe(BASE_CSP);
+            expect(response.headers.get('etag')).toBe(ASSET_HEADERS.etag);
+        });
+    });
+
+    describe('report-only rollout', () => {
+        it('reports instead of enforcing when the binding says so', async () => {
+            const response = await wrap(htmlResponse(), { createRewriter: createRewriterSpy().createRewriter })(
+                new Request('https://next.blit386.dev/'),
+                REPORT_ONLY_ENV,
+            );
+
+            // The base policy has to go too, or it would block the very scripts the report is
+            // meant to be measuring.
+            expect(response.headers.get('content-security-policy')).toBeNull();
+            expect(nonceOf(response.headers.get('content-security-policy-report-only'))).toBeTruthy();
+        });
+
+        it('enforces when the binding is absent', async () => {
+            const response = await wrap(htmlResponse(), { createRewriter: createRewriterSpy().createRewriter })(
+                new Request('https://blit386.dev/'),
+            );
+
+            expect(response.headers.get('content-security-policy-report-only')).toBeNull();
+            expect(response.headers.get('content-security-policy')).toContain("'nonce-");
+        });
+
+        it('enforces for any value other than the documented one', async () => {
+            const response = await wrap(htmlResponse(), { createRewriter: createRewriterSpy().createRewriter })(
+                new Request('https://blit386.dev/'),
+                { BLIT386_CSP_REPORT_ONLY: 'true' },
+            );
+
+            expect(response.headers.get('content-security-policy-report-only')).toBeNull();
+        });
+    });
+});
+
+describe('which fetch gets wrapped', () => {
+    // `entry.defaultExport.fetch` is the deployed Worker's; `entry.fetch` is what `waku build`'s
+    // prerender pass and linkValidationPlugin call. Wrapping one and not the other is a silent
+    // no-op in exactly the environment that matters, so both are pinned.
+    it.each([
+        ['the deployed Worker entry', (entry: StubEntry) => entry.defaultExport.fetch],
+        ['the build-time entry', (entry: StubEntry) => entry.fetch],
+    ])('stamps through %s', async (_label, pick) => {
+        const entry = patchEntry(htmlResponse(), { createRewriter: createRewriterSpy().createRewriter });
+        const response = await (pick(entry) as EntryFetch)(new Request('https://blit386.dev/'));
+
+        expect(response.headers.get('content-security-policy')).toContain("'nonce-");
+    });
+
+    it('tolerates an adapter that exposes no defaultExport', () => {
+        const entry = { fetch: () => htmlResponse() };
+
+        expect(() =>
+            cspNoncePlugin().unstable_onServerEntry?.(
+                entry as unknown as Parameters<
+                    NonNullable<ReturnType<typeof cspNoncePlugin>['unstable_onServerEntry']>
+                >[0],
+            ),
+        ).not.toThrow();
+    });
+});

--- a/packages/website/src/csp-nonce.ts
+++ b/packages/website/src/csp-nonce.ts
@@ -1,0 +1,184 @@
+import type { ConfigContext, ServerPlugin } from 'fumapress';
+import { buildCsp, generateNonce } from './csp';
+
+/**
+ * The slice of Cloudflare's `HTMLRewriter` this plugin uses.
+ *
+ * Declared locally rather than pulled from `@cloudflare/workers-types`, the same way
+ * `markdown-negotiation.ts` declares `AssetsBinding`: this package's `tsconfig.json` compiles with
+ * `lib: ["dom", ...]`, and the Workers types collide with it wholesale.
+ */
+interface RewriterElement {
+    setAttribute: (name: string, value: string) => void;
+}
+
+export interface HtmlRewriterLike {
+    on: (selector: string, handlers: { element: (element: RewriterElement) => void }) => HtmlRewriterLike;
+    transform: (response: Response) => Response;
+}
+
+declare const HTMLRewriter: new () => HtmlRewriterLike;
+
+/** `1` in the `BLIT386_CSP_REPORT_ONLY` Worker var switches a deployment to report-only. */
+const REPORT_ONLY_ENABLED = '1';
+
+interface CspEnv {
+    BLIT386_CSP_REPORT_ONLY?: string;
+}
+
+/** The Worker's `fetch`, as Cloudflare calls it. */
+type EntryFetch = (request: Request, env?: unknown, ctx?: unknown) => Response | Promise<Response>;
+
+export interface CspNonceOptions {
+    /**
+     * Builds the rewriter. Exists so `csp-nonce.test.ts` can inject a double – `HTMLRewriter` is a
+     * workerd global and this package runs plain Vitest on Node (see `vitest.config.ts`). The real
+     * HTML parsing is Cloudflare's and is covered by the `wrangler dev` pass in `CLAUDE.md`.
+     */
+    createRewriter?: () => HtmlRewriterLike;
+}
+
+/**
+ * The rewriter to use, or `undefined` where there is none.
+ *
+ * `HTMLRewriter` only exists in workerd. This same entry is also fetched under Node: once per page
+ * while `waku build` prerenders the site, again by `linkValidationPlugin`, and again under
+ * `waku dev`. None of those serve the `public/_headers` policy in the first place, so having no
+ * rewriter there is not a degraded mode – there is simply nothing to stamp.
+ */
+function resolveRewriterFactory(override?: () => HtmlRewriterLike): (() => HtmlRewriterLike) | undefined {
+    if (override !== undefined) {
+        return override;
+    }
+
+    return typeof HTMLRewriter === 'undefined' ? undefined : () => new HTMLRewriter();
+}
+
+/**
+ * Decides whether a response is prerendered HTML that needs a nonce.
+ *
+ * A null body rules out both `HEAD` and `304 Not Modified`; the explicit 304 check is belt-and-braces
+ * in case a runtime ever hands back an empty-but-present stream. Status is otherwise unconstrained so
+ * that Waku's rendered 404 page – which carries the same inline bootstrap scripts as any other page –
+ * is stamped too.
+ */
+function isStampableHtml(response: Response, method: string): boolean {
+    if (method !== 'GET' || response.body === null || response.status === 304) {
+        return false;
+    }
+
+    return response.headers.get('content-type')?.toLowerCase().startsWith('text/html') === true;
+}
+
+/**
+ * Stamps `nonce` onto every `<script>` and serves the matching policy.
+ *
+ * Removing `etag` and `last-modified` is load-bearing, not tidying. HTML is served
+ * `cache-control: public, max-age=0, must-revalidate`, so with a validator present the browser would
+ * revalidate, get a `304`, and apply that response's *fresh* nonce header to its *cached* body – whose
+ * scripts carry the previous nonce. Every script on the page would then be blocked. Without a
+ * validator there is nothing to revalidate with, so a body and its header always arrive together. The
+ * cost is a full HTML body instead of a 304 on repeat visits; at `max-age=0` the round trip happened
+ * either way.
+ */
+function stampNonce(response: Response, createRewriter: () => HtmlRewriterLike, reportOnly: boolean): Response {
+    const nonce = generateNonce();
+
+    // A real tokenizer, not a string replace. `<script` occurs inside the RSC flight payload as
+    // ordinary JSON string data (any docs page discussing CSP contains it literally), and only a
+    // parser knows that script raw-text state ends at `</script` alone.
+    const transformed = createRewriter()
+        .on('script', {
+            // Kept trivial on purpose: a throwing handler truncates an already-streaming body.
+            element(element) {
+                element.setAttribute('nonce', nonce);
+            },
+        })
+        .transform(response);
+
+    const headers = new Headers(response.headers);
+
+    if (reportOnly) {
+        // Rollout mode: measure a policy against real traffic on next.blit386.dev without risking a
+        // blank page. Nothing is enforced here – the base policy that `public/_headers` applied has
+        // to go too, or it would block the very scripts the report is meant to be measuring.
+        headers.delete('content-security-policy');
+        headers.set('content-security-policy-report-only', buildCsp(nonce));
+    } else {
+        headers.set('content-security-policy', buildCsp(nonce));
+    }
+
+    headers.delete('etag');
+    headers.delete('last-modified');
+
+    return new Response(transformed.body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers,
+    });
+}
+
+/** Wraps one `fetch` so its HTML responses come back stamped. */
+function wrapFetch(inner: EntryFetch, options: CspNonceOptions): EntryFetch {
+    return async (request, env, ctx) => {
+        const response = await inner(request, env, ctx);
+        const createRewriter = resolveRewriterFactory(options.createRewriter);
+
+        if (createRewriter === undefined || !isStampableHtml(response, request.method)) {
+            return response;
+        }
+
+        const reportOnly = (env as CspEnv | undefined)?.BLIT386_CSP_REPORT_ONLY === REPORT_ONLY_ENABLED;
+
+        return stampNonce(response, createRewriter, reportOnly);
+    };
+}
+
+/**
+ * Allows the site's inline scripts by a per-request nonce, so `script-src` never needs
+ * `'unsafe-inline'` (BT-191).
+ *
+ * The site renders statically (`mode: 'static'` in `press.config.tsx`), so its HTML is a build
+ * artifact: Waku's React bootstrap script and the RSC flight payload `rsc-html-stream` injects are
+ * both per-page, no fixed hash list can cover them, and Waku's own `unstable_setNonce` only applies
+ * to request-time SSR. That leaves the Worker as the only place a nonce can be applied.
+ *
+ * This wraps the server entry's `fetch` rather than contributing a middleware, because a Fumapress
+ * `ServerPlugin` middleware never sees the response it would need to rewrite. Fumapress runs plugin
+ * middlewares through its own composer (`fumapress/dist/router/index.js`, `pluginsMiddleware`), which
+ * keeps a downstream handler's returned `Response` in a local and returns it at the end – it never
+ * assigns `c.res`. So after `await next()`, `c.res` is still Hono's placeholder, and only its
+ * *headers* survive, merged onto the real response by Hono's `set res`. That is enough for
+ * `channelHeadersPlugin`'s `x-robots-tag`, and not enough here: stamping needs the body.
+ *
+ * The server entry is the outermost hook, and its `fetch` is called with `(request, env, ...)` –
+ * which is also where the `BLIT386_CSP_REPORT_ONLY` var arrives, the same request-time binding read
+ * `channelHeadersPlugin` documents for `BLIT386_CHANNEL`.
+ */
+export function cspNoncePlugin<C extends ConfigContext = ConfigContext>(
+    options: CspNonceOptions = {},
+): ServerPlugin<C> {
+    return {
+        name: 'csp-nonce',
+
+        unstable_onServerEntry(entry) {
+            // Both, deliberately. `entry.defaultExport.fetch` is what Cloudflare invokes on the
+            // deployed Worker – `dist/server/index.js` re-exports it – while `entry.fetch` is the
+            // one `waku build`'s prerender and `linkValidationPlugin` call. Patching only the
+            // former would leave the build path unwrapped; patching only the latter (the obvious
+            // reading of "the entry's fetch") silently does nothing in production.
+            //
+            // Mutated in place rather than spread into copies, the same way `linkValidationPlugin`
+            // patches `entry.build`: these objects are the adapter's, and a copy would drop
+            // anything on them that is not a plain own enumerable property.
+            entry.fetch = wrapFetch(entry.fetch as EntryFetch, options) as typeof entry.fetch;
+
+            const { defaultExport } = entry as { defaultExport?: { fetch?: EntryFetch } };
+            if (defaultExport?.fetch !== undefined) {
+                defaultExport.fetch = wrapFetch(defaultExport.fetch, options);
+            }
+
+            return entry;
+        },
+    };
+}

--- a/packages/website/src/csp.test.ts
+++ b/packages/website/src/csp.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Covers `src/csp.ts`, and – more importantly – guards the one copy of the policy that TypeScript
+ * cannot see: the `Content-Security-Policy` line in `public/_headers`.
+ *
+ * That file is a static Cloudflare config with no import mechanism, so its CSP has to be a
+ * hand-written duplicate of `BASE_CSP`. "Drift guard" below is what keeps the duplicate honest; it
+ * fails the moment either side is edited alone.
+ */
+
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { BASE_CSP, buildCsp, generateNonce, isHtmlAssetPath } from './csp';
+
+const HEADERS_FILE = new URL('../public/_headers', import.meta.url);
+const NONCE = 'AbCdEfGhIjKlMnOpQrStUw==';
+
+/** The `script-src` directive alone, from a serialized policy. */
+function scriptSrc(policy: string): string {
+    const directive = policy.split('; ').find((entry) => entry.startsWith('script-src '));
+    if (directive === undefined) {
+        throw new Error(`no script-src in policy: ${policy}`);
+    }
+
+    return directive;
+}
+
+/** The CSP value `public/_headers` serves under its `/*` rule. */
+function headersFileCsp(): string {
+    const line = readFileSync(HEADERS_FILE, 'utf8')
+        .split('\n')
+        .find((entry) => entry.trimStart().startsWith('Content-Security-Policy:'));
+
+    if (line === undefined) {
+        throw new Error('public/_headers declares no Content-Security-Policy');
+    }
+
+    return line.trim().slice('Content-Security-Policy:'.length).trim();
+}
+
+describe('buildCsp', () => {
+    it('allows no inline scripts in the base policy', () => {
+        expect(scriptSrc(BASE_CSP)).toBe("script-src 'self' https://plausible.io");
+    });
+
+    it('adds the nonce to script-src and changes nothing else', () => {
+        const withNonce = buildCsp(NONCE);
+
+        expect(scriptSrc(withNonce)).toBe(`script-src 'self' 'nonce-${NONCE}' https://plausible.io`);
+        expect(withNonce.replace(` 'nonce-${NONCE}'`, '')).toBe(BASE_CSP);
+    });
+
+    it('never emits unsafe-inline for scripts, with or without a nonce', () => {
+        expect(scriptSrc(BASE_CSP)).not.toContain("'unsafe-inline'");
+        expect(scriptSrc(buildCsp(NONCE))).not.toContain("'unsafe-inline'");
+    });
+
+    it('keeps the directives the blog media and demo embeds depend on', () => {
+        // CLAUDE.md, "Blog media": these were once 'none' and blocked playback outright.
+        expect(BASE_CSP).toContain("media-src 'self'");
+        expect(BASE_CSP).toContain('frame-src');
+        expect(BASE_CSP).toContain('https://demos.blit386.dev');
+    });
+});
+
+describe('drift guard', () => {
+    it('serves exactly BASE_CSP from public/_headers', () => {
+        expect(headersFileCsp()).toBe(BASE_CSP);
+    });
+
+    it('has no unsafe-inline in the script-src that public/_headers actually ships', () => {
+        // Asserted against the file rather than the builder, so a hand edit cannot slip through
+        // even if BASE_CSP were changed to match it.
+        expect(scriptSrc(headersFileCsp())).not.toContain("'unsafe-inline'");
+    });
+});
+
+describe('generateNonce', () => {
+    it('returns at least 128 bits of base64', () => {
+        expect(atob(generateNonce())).toHaveLength(16);
+    });
+
+    it('returns a different value every call', () => {
+        const nonces = new Set(Array.from({ length: 100 }, () => generateNonce()));
+
+        expect(nonces.size).toBe(100);
+    });
+
+    it('produces a nonce that needs no CSP quoting', () => {
+        // A base64 nonce can contain `+`, `/`, and `=`, all legal in a CSP source expression;
+        // anything outside that set would need escaping the header format does not offer.
+        expect(generateNonce()).toMatch(/^[A-Za-z0-9+/]+={0,2}$/);
+    });
+});
+
+describe('isHtmlAssetPath', () => {
+    it.each(['/', '/docs', '/docs/getting-started', '/blog/hot-reload-release-1-4-0', '/index.html', '/showcase'])(
+        'treats %s as HTML',
+        (pathname) => {
+            expect(isHtmlAssetPath(pathname)).toBe(true);
+        },
+    );
+
+    it.each([
+        '/assets/entry-BujZVH9j.js',
+        '/assets/style-abc123.css',
+        '/fonts/DepartureMono-Regular.woff2',
+        '/media/blog/hot-reload-release-1-4-0/clip.mp4',
+        '/llms.txt',
+        '/sitemap.xml',
+        '/feed.xml',
+        '/docs/getting-started.md',
+        '/favicon.ico',
+    ])('treats %s as a non-HTML asset', (pathname) => {
+        expect(isHtmlAssetPath(pathname)).toBe(false);
+    });
+
+    it('errs toward HTML for an extensionless non-HTML route', () => {
+        // /.well-known/api-catalog is JSON but has no extension to go on. Erring this way costs it
+        // its 304s and nothing else; erring the other way would risk a stale body against a fresh
+        // nonce, which is a blank page.
+        expect(isHtmlAssetPath('/.well-known/api-catalog')).toBe(true);
+    });
+
+    it('ignores a dot in an earlier segment', () => {
+        expect(isHtmlAssetPath('/.well-known/agent-skills/blit386')).toBe(true);
+    });
+
+    it('is case-insensitive about the extension', () => {
+        expect(isHtmlAssetPath('/logo.PNG')).toBe(false);
+    });
+});

--- a/packages/website/src/csp.ts
+++ b/packages/website/src/csp.ts
@@ -1,0 +1,142 @@
+/**
+ * The site's Content-Security-Policy, defined once.
+ *
+ * Two surfaces serve this policy and they must not drift apart:
+ *
+ * - `public/_headers` applies {@link BASE_CSP} to every response Cloudflare serves from the ASSETS
+ *   binding – images, fonts, `.md` routes, JSON. It is the fail-closed default.
+ * - `src/csp-nonce.ts` replaces that header on prerendered HTML with `buildCsp(nonce)`, whose
+ *   `script-src` carries a fresh per-request nonce.
+ *
+ * `public/_headers` is a static file that cannot import anything, so its CSP line is a hand-written
+ * copy of {@link BASE_CSP}. `csp.test.ts` reads the file and asserts the two are character-identical,
+ * which is what makes the copy safe (see `.claude/rules/named-constants.md`).
+ *
+ * Why a nonce rather than hashes: the site is prerendered (`mode: 'static'` in `press.config.tsx`),
+ * and Waku's React bootstrap script plus the RSC flight payload that `rsc-html-stream` injects are
+ * both per-page, so no fixed hash list can cover them. Waku's own `unstable_setNonce` is
+ * request-time SSR only and does nothing under static rendering, hence the Worker-side stamping.
+ *
+ * Deliberately no `'strict-dynamic'`: every chunk this site loads is same-origin and already covered
+ * by `'self'`, while `'strict-dynamic'` would void both `'self'` and the `https://plausible.io`
+ * allowance. Worth revisiting only if third-party scripts ever start loading further scripts.
+ */
+
+/** Placeholder occupying the nonce's slot in {@link CSP_DIRECTIVES}; removed when no nonce is given. */
+const NONCE_PLACEHOLDER = '<nonce>';
+
+/** How many random bytes back a nonce. The CSP spec asks for at least 128 bits of entropy. */
+const NONCE_BYTES = 16;
+
+/**
+ * Every directive, in the order they are serialized.
+ *
+ * `script-src` is the one BT-191 changed: it used to carry `'unsafe-inline'`, which let any injected
+ * `<script>` in an HTML response execute and undercut most of the rest of this policy.
+ *
+ * Load-bearing entries that must not be tightened (see `CLAUDE.md`, "Blog media"): `media-src 'self'`
+ * for the self-hosted blog clips, and `frame-src https://demos.blit386.dev` for embedded demos.
+ * `style-src 'unsafe-inline'` remains – Fumadocs and Tailwind both emit inline styles, and removing it
+ * is a separate piece of work from BT-191.
+ */
+const CSP_DIRECTIVES: readonly (readonly [directive: string, ...sources: string[]])[] = [
+    ['default-src', "'self'"],
+    ['base-uri', "'self'"],
+    ['object-src', "'none'"],
+    ['script-src', "'self'", NONCE_PLACEHOLDER, 'https://plausible.io'],
+    ['style-src', "'self'", "'unsafe-inline'"],
+    ['img-src', "'self'", 'data:', 'blob:'],
+    ['font-src', "'self'", 'https://fonts.vancura.dev'],
+    ['connect-src', "'self'", 'https://plausible.io'],
+    ['media-src', "'self'"],
+    ['worker-src', "'self'", 'blob:'],
+    ['child-src', "'none'"],
+    ['frame-src', "'self'", 'https://demos.blit386.dev'],
+    ['form-action', "'self'"],
+    ['frame-ancestors', "'none'"],
+    ['upgrade-insecure-requests'],
+];
+
+/**
+ * Serializes the policy, substituting `nonce` into `script-src`.
+ *
+ * @param nonce Base64 nonce to allow inline scripts with. Omit for the nonce-free base policy.
+ * @returns The `Content-Security-Policy` header value.
+ */
+export function buildCsp(nonce?: string): string {
+    return CSP_DIRECTIVES.map(([directive, ...sources]) =>
+        [
+            directive,
+            ...sources.flatMap((source) => {
+                if (source !== NONCE_PLACEHOLDER) {
+                    return [source];
+                }
+
+                return nonce === undefined ? [] : [`'nonce-${nonce}'`];
+            }),
+        ].join(' '),
+    ).join('; ');
+}
+
+/**
+ * The policy `public/_headers` serves, with no nonce.
+ *
+ * Every response the Worker does not rewrite gets this, and so does any HTML the Worker somehow
+ * misses – in which case the page fails closed (blank) rather than silently losing its protection.
+ */
+export const BASE_CSP = buildCsp();
+
+/** Generates a fresh per-request nonce. */
+export function generateNonce(): string {
+    const bytes = crypto.getRandomValues(new Uint8Array(NONCE_BYTES));
+
+    return btoa(String.fromCharCode(...bytes));
+}
+
+/**
+ * File extensions served as something other than HTML.
+ *
+ * Anything else – `/`, `/docs/getting-started`, `/blog/`, an explicit `.html` – is a prerendered page.
+ * The list errs toward "not HTML" only for extensions this site actually emits, because the costly
+ * mistake runs the other way: an HTML path misread as an asset keeps its conditional request headers
+ * and can end up serving a stale body against a fresh nonce (see `isHtmlAssetPath`).
+ */
+const NON_HTML_EXTENSIONS = new Set([
+    'css',
+    'ico',
+    'js',
+    'json',
+    'map',
+    'md',
+    'mp4',
+    'png',
+    'svg',
+    'txt',
+    'webp',
+    'woff2',
+    'xml',
+]);
+
+/**
+ * Whether a path is served as prerendered HTML.
+ *
+ * Used to decide which requests must not be answered with a `304`. A conditional request for HTML is
+ * unanswerable once nonces are in play: RFC 9111 has the client merge the `304`'s headers into its
+ * *stored* body, so a fresh `Content-Security-Policy` would land on a body whose scripts carry an
+ * older nonce – or none at all, for a copy cached before this shipped – and every script on the page
+ * would be blocked until that file's hash changed. `markdown-negotiation.ts` therefore drops the
+ * conditional headers on the way to the ASSETS binding for these paths, and only these: hashed JS,
+ * CSS, and fonts genuinely rely on `304`s.
+ *
+ * @param pathname Request path, without query or hash.
+ */
+export function isHtmlAssetPath(pathname: string): boolean {
+    const lastSegment = pathname.slice(pathname.lastIndexOf('/') + 1);
+    const dot = lastSegment.lastIndexOf('.');
+
+    if (dot <= 0) {
+        return true;
+    }
+
+    return !NON_HTML_EXTENSIONS.has(lastSegment.slice(dot + 1).toLowerCase());
+}

--- a/packages/website/src/markdown-negotiation.test.ts
+++ b/packages/website/src/markdown-negotiation.test.ts
@@ -247,6 +247,51 @@ describe('markdownNegotiationPlugin', () => {
             expect(assets.requests[0]).toBe(harness.context.req.raw);
         });
 
+        describe('conditional headers', () => {
+            const CONDITIONAL = {
+                'if-none-match': '"87eaabf8441fbd725e14f88ea6debca3"',
+                'if-modified-since': 'Wed, 20 Aug 2026 10:00:00 GMT',
+            };
+
+            it('strips them for an HTML page so the binding cannot answer 304', async () => {
+                // csp-nonce.ts stamps a fresh nonce into every HTML body. A 304 would hand the
+                // client that nonce's CSP to merge into a *stored* body carrying a different one,
+                // blocking every script on the page.
+                const harness = assetsHarness(new Response('<!doctype html>'), {
+                    url: 'https://blit386.dev/docs/getting-started',
+                    headers: CONDITIONAL,
+                });
+
+                await harness.run(middleware);
+
+                expect(assets.requests[0]?.headers.get('if-none-match')).toBeNull();
+                expect(assets.requests[0]?.headers.get('if-modified-since')).toBeNull();
+            });
+
+            it('keeps the rest of the request intact while stripping them', async () => {
+                const harness = assetsHarness(new Response('<!doctype html>'), {
+                    url: 'https://blit386.dev/',
+                    headers: { ...CONDITIONAL, 'accept-language': 'en-GB' },
+                });
+
+                await harness.run(middleware);
+
+                expect(assets.requests[0]?.url).toBe('https://blit386.dev/');
+                expect(assets.requests[0]?.headers.get('accept-language')).toBe('en-GB');
+            });
+
+            it('keeps them for a hashed asset, which relies on 304s', async () => {
+                const harness = assetsHarness(new Response('ok'), {
+                    url: 'https://blit386.dev/assets/entry-BujZVH9j.js',
+                    headers: CONDITIONAL,
+                });
+
+                await harness.run(middleware);
+
+                expect(assets.requests[0]?.headers.get('if-none-match')).toBe(CONDITIONAL['if-none-match']);
+            });
+        });
+
         it('falls through to the next middleware when the binding has no such asset', async () => {
             const harness = assetsHarness(new Response('not found', { status: 404 }));
 

--- a/packages/website/src/markdown-negotiation.ts
+++ b/packages/website/src/markdown-negotiation.ts
@@ -1,5 +1,6 @@
 import type { ConfigContext, ServerPlugin } from 'fumapress';
 import { isMarkdownPreferred } from 'fumadocs-core/negotiation';
+import { isHtmlAssetPath } from './csp';
 
 // Cloudflare Static Assets binding (declared as `ASSETS` in dist/server/wrangler.json).
 // Waku forwards the Worker `env` into the Hono app, so it is reachable via `c.env`.
@@ -12,6 +13,27 @@ interface AssetsBinding {
 // is acceptable and avoids shipping a tokenizer into the Worker.
 function estimateTokens(text: string): number {
     return Math.ceil(text.length / 4);
+}
+
+/**
+ * The request to forward to the ASSETS binding.
+ *
+ * Identical to the incoming one except for HTML, where the conditional headers are dropped so the
+ * binding cannot answer `304`. `csp-nonce.ts` stamps a fresh per-request nonce into every HTML body,
+ * and a `304` would hand the client that nonce's `Content-Security-Policy` to merge into a *stored*
+ * body carrying a different one – blocking every script on the page. Only HTML pays for this: hashed
+ * JS, CSS, and fonts keep their conditionals and their `304`s.
+ */
+function assetRequest(request: Request, pathname: string): Request {
+    if (!isHtmlAssetPath(pathname)) {
+        return request;
+    }
+
+    const headers = new Headers(request.headers);
+    headers.delete('if-none-match');
+    headers.delete('if-modified-since');
+
+    return new Request(request, { headers });
 }
 
 /**
@@ -73,7 +95,7 @@ export function markdownNegotiationPlugin<C extends ConfigContext = ConfigContex
                     // Otherwise emulate assets-first: serve the pre-built static asset.
                     const assets = (c.env as { ASSETS?: AssetsBinding } | undefined)?.ASSETS;
                     if (assets) {
-                        const response = await assets.fetch(c.req.raw);
+                        const response = await assets.fetch(assetRequest(c.req.raw, c.req.path));
                         if (response.status !== 404) {
                             return response;
                         }


### PR DESCRIPTION
Closes BT-191. Supersedes the never-implemented proposal in #5.

## Why

`public/_headers` shipped `script-src 'self' 'unsafe-inline' https://plausible.io`. Confirmed live before the change – `curl -sI https://blit386.dev/` returned exactly that – so any injected `<script>` in an HTML response executed, undercutting most of the rest of the policy.

Hashes were not an option. The site renders statically (`mode: 'static'`), and Waku's React bootstrap script plus the RSC flight payload `rsc-html-stream` injects are both per-page, so no fixed hash list covers them. Waku's `unstable_setNonce` only applies to request-time SSR. That leaves the Worker as the only place a nonce can be applied, via `HTMLRewriter`.

## What

- **`src/csp.ts`** – the policy defined once. `BASE_CSP` is the nonce-free form, `buildCsp(nonce)` inserts `'nonce-…'` into `script-src`. `public/_headers` keeps a hand-written copy as the fail-closed base for everything the Worker does not rewrite; a drift test pins the two character for character.
- **`src/csp-nonce.ts`** – stamps a fresh per-request nonce onto every `<script>` and serves the matching header.
- **`src/markdown-negotiation.ts`** – drops `if-none-match` / `if-modified-since` for HTML paths.
- **`scripts/patch-wrangler.mjs`** – wires a `BLIT386_CSP_REPORT_ONLY` var for the rollout pass.

## Three findings worth reviewing

**It is not a `ServerPlugin` middleware, and cannot be.** Fumapress runs plugin middlewares through its own composer (`fumapress/dist/router/index.js`, `pluginsMiddleware`), which keeps a downstream handler's returned `Response` in a local and returns it at the end – it never assigns `c.res`. After `await next()` you hold Hono's placeholder, whose *headers* reach the real response through Hono's `set res` merge (which is why `channelHeadersPlugin` works) but whose body never does. Stamping needs the body, so this wraps the server entry's `fetch` instead.

**Both fetches are patched.** `entry.defaultExport.fetch` is what Cloudflare invokes on the deployed Worker – `dist/server/index.js` re-exports it – while `entry.fetch` is what the prerender pass and `linkValidationPlugin` call. Patching only `entry.fetch` (the obvious reading) is a silent no-op in production; a test pins each path.

**A 304 for HTML is unanswerable once nonces exist.** RFC 9111 has the client merge a 304's headers into its *stored* body, so a fresh nonce would land on scripts carrying an older one – or none, for a copy cached before this ships – and every script on the page would be blocked. Both halves are needed: the wrapper drops `etag`/`last-modified` on the way out, and `markdownNegotiationPlugin` drops the conditionals on the way in. Hashed JS, CSS, and fonts keep both and keep their 304s.

## Verification

`pnpm run preflight` green in `packages/website` (216 unit + 194 script tests).

Under `wrangler dev` (real workerd, real `HTMLRewriter`):

- `/`, `/docs`, a deep docs page, `/blog`, `/showcase`, a blog post with a video, and the dynamic 404 all stamp every `<script>` with one nonce matching the header.
- A fresh nonce per request.
- Conditional HTML requests never return 304; a hashed asset still does.
- `.txt`, `.md`, and JS keep the base policy and their validators.
- `curl -I` (HEAD) correctly gets the nonce-free base policy – worth knowing, since it makes the naive verification command report a false failure.

In-browser, zero CSP violations and zero hydration errors, with every inline script confirmed to have run: `__WAKU_HYDRATE__` true, `window.plausible` a function, next-themes applying a stored theme pre-paint, client-side routing working, JSON-LD parsing, search returning 200.

Report-only mode verified too: no enforcing header, the nonce'd policy served as `Content-Security-Policy-Report-Only`, body still stamped, non-HTML untouched.

## Test plan

- [ ] Build with `BLIT386_CSP_REPORT_ONLY=1` and deploy to `next.blit386.dev`; walk the pages above with DevTools open and confirm zero violation reports.
- [ ] Deploy enforcing to production; `curl -s -D - -o /dev/null https://blit386.dev/` shows a `nonce-` term and no `'unsafe-inline'`, and a second request returns a different nonce.
- [ ] Confirm Plausible events still arrive in the dashboard.
- [ ] Validate JSON-LD on a docs page and a blog post in the Rich Results Test.

## Out of scope

`style-src 'unsafe-inline'` stays – Fumadocs and Tailwind both emit inline styles, and nonces do not cover inline style *attributes*. Tracked separately.

The `BLIT386_CSP_REPORT_ONLY` var is not wired into `.github/workflows/deploy.yml`, so the report-only pass is a local build plus `pnpm run deploy`. Documented in `packages/website/CLAUDE.md` rather than changing the deploy workflow here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Added per-request CSP nonces to HTML scripts.
  * Removed `'unsafe-inline'` from enforced script policies.
  * Added report-only CSP configuration support.
  * Added CSP validation for deployment headers.

* **Performance & Reliability**
  * Improved HTML caching behavior by preventing stale conditional responses when nonces change.
  * Preserved conditional requests for static assets.

* **Documentation**
  * Documented CSP deployment, verification, rollout, and local development behavior.

* **Tests**
  * Added comprehensive coverage for CSP headers, nonce handling, caching, and report-only mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->