### PR TITLE
feat(kit): ship the blit386.dev docs MCP into generated games

### DIFF
--- a/packages/create-blit386/.claude/rules/template-structure.md
+++ b/packages/create-blit386/.claude/rules/template-structure.md
@@ -8,7 +8,8 @@
   typed.
 - `templates/optional/` – wizard opt-in extras (currently only the GitHub Actions CI workflow). Cursor and Claude
   configs are generated from the kit IR (`packages/kit/src/adapters.ts`) at scaffold time, not copied from static
-  templates.
+  templates. That includes the documentation-MCP configs (`.mcp.json` for Claude Code, `.cursor/mcp.json` for Cursor) –
+  do not add a static template for them.
 - Placeholders use `{{name}}` tokens; unknown tokens must stay visible if mis-typed.
 - Rename `gitignore` → `.gitignore`, `editorconfig` → `.editorconfig`, and `prettierignore` → `.prettierignore`, and
   strip `.tmpl` extensions, during the scaffold copy (`mapOutputName`).

--- a/packages/create-blit386/CLAUDE.md
+++ b/packages/create-blit386/CLAUDE.md
@@ -25,9 +25,12 @@ TypeScript strict, built with tsup, Biome for lint and format (no ESLint here), 
    (`.claude/hooks/session-start.sh`) that installs dependencies and runs `blit doctor` when a fresh remote/web session
    starts. Cursor gets `.cursor/rules/*.mdc`, `.cursor/commands/<name>.md` (the same skills with frontmatter stripped),
    `.cursor/hooks.json`, and `.cursor/hooks/shell-safety.sh` – Cursor has no SessionStart-equivalent event, so it does
-   not get the bootstrap hook. Every path an adapter emits is built from `packages/kit/src/ownership.ts`, the single
-   source both packages classify against; `content/agents.config.json` is a descriptive summary of the same set, read by
-   no code. Within `.claude/hooks/` / `.cursor/hooks/`, which specific scripts land in a given project is decided by
+   not get the bootstrap hook. Each adapter also emits a documentation-MCP config registering the `blit386-docs` server
+   at `https://blit386.dev/mcp`: Claude gets `.mcp.json` and Cursor gets `.cursor/mcp.json`. The two entries differ by
+   one key on purpose – Claude Code skips a remote entry that has a `url` but no `type`, while for Cursor a `type` marks
+   a local stdio server. Every path an adapter emits is built from `packages/kit/src/ownership.ts`, the single source
+   both packages classify against; `content/agents.config.json` is a descriptive summary of the same set, read by no
+   code. Within `.claude/hooks/` / `.cursor/hooks/`, which specific scripts land in a given project is decided by
    `content/hooks.manifest.json` – only a script one of that adapter's own hook entries actually references gets copied
    (all under `packages/kit/`).
 5. Kit content (`AGENTS.md` + `docs/`) is copied **verbatim** – `copyFileSync` / `cpSync`, so `{{placeholder}}` tokens

--- a/packages/create-blit386/CREATE_BLIT386_DESIGN.md
+++ b/packages/create-blit386/CREATE_BLIT386_DESIGN.md
@@ -285,6 +285,7 @@ Capability matrix (what each adapter emits from the same source):
 | On-demand actions (skills) | described in prose | `.claude/skills/<name>/SKILL.md` | `.cursor/commands` or scoped rules | reads `AGENTS.md` |
 | Deterministic guardrails (hooks) | prose warning only | `.claude/settings.json` hooks (PreToolUse / PostToolUse) | `.cursor/hooks.json` (afterFileEdit, beforeShellExecution, `failClosed`) – richest | `.zed/settings.json` tool_permissions |
 | Lockfile / .env block | prose warning | settings.json PreToolUse | hooks.json `failClosed` | settings.json `always_deny` |
+| Live docs lookup (MCP) | prose pointer + the `ask-the-docs` skill | `.mcp.json` (`type: http` required) | `.cursor/mcp.json` (`url` only; a `type` marks stdio) | n/a |
 
 This formalizes exactly what the engine repos do by hand today. Reuse the output to clean up the engine repos too.
 
@@ -1124,3 +1125,20 @@ ships both at `^1.4.0`.
   `generateClaudeAdapter` emits `.claude/settings.json` (PreToolUse / PostToolUse) and copies `content/hooks/` into
   `.claude/hooks/`. `shell-safety.sh` speaks both Cursor permission JSON and Claude exit-2 / permissionDecision
   protocols. Ownership classifiers treat `.claude/hooks/` as kit-owned; scaffold twin tests cover settings.json.
+- 2026-08-21: Round 27 (BT-253). Docs MCP into generated games. Both adapters now emit a documentation-MCP config
+  registering `blit386-docs` at `https://blit386.dev/mcp` – `.mcp.json` for Claude Code, `.cursor/mcp.json` for Cursor –
+  and a new `ask-the-docs` kit skill plus an `AGENTS.md` managed-region rewrite teach an assistant the three live-docs
+  routes (MCP `search_docs` / `get_docs_summary`, `llms.txt`, `Accept: text/markdown`). The old "go read GitHub" pointer
+  is demoted to last resort. Three decisions worth keeping: (1) no `content/mcp.manifest.json` – one server with no
+  per-adapter divergence beyond a single key does not earn a manifest plus parser plus schema; revisit when a second
+  server appears. (2) The generated `.claude/settings.json` does not pre-approve the server in its MCP enable list – the
+  approval prompt is Claude Code's consent boundary for a network server, the scaffolder is not the party entitled to
+  answer it, and a checked-in settings file's approvals are ignored in an untrusted folder anyway. (3) The two configs
+  differ by one key deliberately: Claude Code skips a remote entry with a `url` and no `type`, while for Cursor a `type`
+  marks a local stdio server. Both are kit-owned, so `blit agents sync` refreshes them and three-way merges a user's own
+  added servers. Both paths are declared in `packages/kit/src/ownership.ts` alongside the other generated-project paths,
+  so the emitters and the classifier cannot disagree about them. `.mcp.json` is the one Claude path the `.claude/`
+  prefix does not cover, so `AGENT_PATHS` names it outright; a hand-written one is still safe, because those predicates
+  read manifest entries and an untracked file is caught by `runAddAgent`'s collision check instead.
+  `packages/kit/test/mcp-config.test.mjs` guards the server name and URL against
+  `packages/website/public/.well-known/mcp/server-card.json`.

--- a/packages/create-blit386/CREATE_BLIT386_DESIGN.md
+++ b/packages/create-blit386/CREATE_BLIT386_DESIGN.md
@@ -285,7 +285,7 @@ Capability matrix (what each adapter emits from the same source):
 | On-demand actions (skills) | described in prose | `.claude/skills/<name>/SKILL.md` | `.cursor/commands` or scoped rules | reads `AGENTS.md` |
 | Deterministic guardrails (hooks) | prose warning only | `.claude/settings.json` hooks (PreToolUse / PostToolUse) | `.cursor/hooks.json` (afterFileEdit, beforeShellExecution, `failClosed`) – richest | `.zed/settings.json` tool_permissions |
 | Lockfile / .env block | prose warning | settings.json PreToolUse | hooks.json `failClosed` | settings.json `always_deny` |
-| Live docs lookup (MCP) | prose pointer + the `ask-the-docs` skill | `.mcp.json` (`type: http` required) | `.cursor/mcp.json` (`url` only; a `type` marks stdio) | n/a |
+| Live docs lookup (MCP) | prose pointer | `.mcp.json` (`type: http` required) | `.cursor/mcp.json` (`url` only; a `type` marks stdio) | n/a |
 
 This formalizes exactly what the engine repos do by hand today. Reuse the output to clean up the engine repos too.
 
@@ -1125,20 +1125,19 @@ ships both at `^1.4.0`.
   `generateClaudeAdapter` emits `.claude/settings.json` (PreToolUse / PostToolUse) and copies `content/hooks/` into
   `.claude/hooks/`. `shell-safety.sh` speaks both Cursor permission JSON and Claude exit-2 / permissionDecision
   protocols. Ownership classifiers treat `.claude/hooks/` as kit-owned; scaffold twin tests cover settings.json.
-- 2026-08-21: Round 27 (BT-253). Docs MCP into generated games. Both adapters now emit a documentation-MCP config
-  registering `blit386-docs` at `https://blit386.dev/mcp` – `.mcp.json` for Claude Code, `.cursor/mcp.json` for Cursor –
-  and a new `ask-the-docs` kit skill plus an `AGENTS.md` managed-region rewrite teach an assistant the three live-docs
-  routes (MCP `search_docs` / `get_docs_summary`, `llms.txt`, `Accept: text/markdown`). The old "go read GitHub" pointer
-  is demoted to last resort. Three decisions worth keeping: (1) no `content/mcp.manifest.json` – one server with no
-  per-adapter divergence beyond a single key does not earn a manifest plus parser plus schema; revisit when a second
-  server appears. (2) The generated `.claude/settings.json` does not pre-approve the server in its MCP enable list – the
-  approval prompt is Claude Code's consent boundary for a network server, the scaffolder is not the party entitled to
-  answer it, and a checked-in settings file's approvals are ignored in an untrusted folder anyway. (3) The two configs
-  differ by one key deliberately: Claude Code skips a remote entry with a `url` and no `type`, while for Cursor a `type`
-  marks a local stdio server. Both are kit-owned, so `blit agents sync` refreshes them and three-way merges a user's own
-  added servers. Both paths are declared in `packages/kit/src/ownership.ts` alongside the other generated-project paths,
-  so the emitters and the classifier cannot disagree about them. `.mcp.json` is the one Claude path the `.claude/`
-  prefix does not cover, so `AGENT_PATHS` names it outright; a hand-written one is still safe, because those predicates
-  read manifest entries and an untracked file is caught by `runAddAgent`'s collision check instead.
-  `packages/kit/test/mcp-config.test.mjs` guards the server name and URL against
-  `packages/website/public/.well-known/mcp/server-card.json`.
+- 2026-08-21: Round 27 (BT-253). Docs MCP into generated games – see the "Live docs lookup" row of the §4 capability
+  matrix for what each adapter emits. A new `ask-the-docs` kit skill and an `AGENTS.md` managed-region rewrite teach an
+  assistant the three live-docs routes (MCP `search_docs` / `get_docs_summary`, `llms.txt`, `Accept: text/markdown`),
+  and the old "go read GitHub" pointer is demoted to last resort. Three decisions worth keeping: (1) no
+  `content/mcp.manifest.json` – one server with no per-adapter divergence beyond a single key does not earn a manifest
+  plus parser plus schema; revisit when a second server appears. (2) The generated `.claude/settings.json` does not
+  pre-approve the server in its MCP enable list – the approval prompt is Claude Code's consent boundary for a network
+  server, the scaffolder is not the party entitled to answer it, and a checked-in settings file's approvals are ignored
+  in an untrusted folder anyway. (3) The two configs differ by one key deliberately: Claude Code skips a remote entry
+  with a `url` and no `type`, while for Cursor a `type` marks a local stdio server. Both are kit-owned, so
+  `blit agents sync` refreshes them and three-way merges a user's own added servers. Both paths are declared in
+  `packages/kit/src/ownership.ts` alongside the other generated-project paths, so the emitters and the classifier cannot
+  disagree about them. `.mcp.json` is the one Claude path the `.claude/` prefix does not cover, so `AGENT_PATHS` names
+  it outright; a hand-written one is still safe, because those predicates read manifest entries and an untracked file is
+  caught by `runAddAgent`'s collision check instead. `packages/kit/test/mcp-config.test.mjs` guards the server name and
+  URL against `packages/website/public/.well-known/mcp/server-card.json`.

--- a/packages/create-blit386/README.md
+++ b/packages/create-blit386/README.md
@@ -27,9 +27,11 @@ Works with npm, pnpm, yarn, or bun – the scaffolder uses whichever you ran it 
   project-local bin, so invoke it through `npx`.
 
 If you pick an AI assistant in the wizard, the scaffolder also generates its config (Claude: `CLAUDE.md` + `.claude/`
-including `settings.json` hooks; Cursor: `.cursor/` including `hooks.json`) from the kit's canonical content, and
-`npx blit agents sync` keeps it current. Did not pick one at the start? Run `npx blit agents add claude` or
-`npx blit agents add cursor` later to set it up.
+including `settings.json` hooks, plus `.mcp.json`; Cursor: `.cursor/` including `hooks.json` and `mcp.json`) from the
+kit's canonical content, and `npx blit agents sync` keeps it current. The MCP config registers the BLIT386 documentation
+server, so your assistant can search the live docs at blit386.dev instead of guessing; Claude Code asks once whether to
+allow it. Did not pick one at the start? Run `npx blit agents add claude` or `npx blit agents add cursor` later to set
+it up.
 
 ## Options
 

--- a/packages/create-blit386/templates/base/README.md
+++ b/packages/create-blit386/templates/base/README.md
@@ -74,7 +74,8 @@ the usual suspects: blank screens, "command not found," forgotten `await`, and m
 - `AGENTS.md` – a short home base for you or an AI assistant.
 - `docs/` – friendly guides: getting started, the game loop, drawing, input, colors, randomness and world generation,
   hot reload, and fixing problems.
-- [blit386.dev](https://blit386.dev) – the full BLIT386 documentation site. If you set up an AI assistant, it can search
-  this site directly – that is what the `.mcp.json` (or `.cursor/mcp.json`) file in this folder is for.
+- [blit386.dev](https://blit386.dev) – the full BLIT386 documentation site. If you set up Claude Code or Cursor, it can
+  search this site directly – that is what the `.mcp.json` file here (Claude Code) or `.cursor/mcp.json` (Cursor) is
+  for.
 - [blit386.dev/llms.txt](https://blit386.dev/llms.txt) – the whole site's contents as one plain text file, handy for
   skimming or pasting into a chat.

--- a/packages/create-blit386/templates/base/README.md
+++ b/packages/create-blit386/templates/base/README.md
@@ -74,4 +74,7 @@ the usual suspects: blank screens, "command not found," forgotten `await`, and m
 - `AGENTS.md` – a short home base for you or an AI assistant.
 - `docs/` – friendly guides: getting started, the game loop, drawing, input, colors, randomness and world generation,
   hot reload, and fixing problems.
-- [blit386.dev](https://blit386.dev) – the full BLIT386 documentation site.
+- [blit386.dev](https://blit386.dev) – the full BLIT386 documentation site. If you set up an AI assistant, it can search
+  this site directly – that is what the `.mcp.json` (or `.cursor/mcp.json`) file in this folder is for.
+- [blit386.dev/llms.txt](https://blit386.dev/llms.txt) – the whole site's contents as one plain text file, handy for
+  skimming or pasting into a chat.

--- a/packages/create-blit386/test/scaffold.test.mjs
+++ b/packages/create-blit386/test/scaffold.test.mjs
@@ -156,6 +156,8 @@ test('scaffolds without --yes when no interactive terminal is attached', () => {
         assert.ok(existsSync(join(project, 'package.json')), 'non-TTY run should still scaffold the project');
         assert.ok(existsSync(join(project, 'src', 'game.js')), 'non-TTY run should emit the game file');
         assert.ok(!existsSync(join(project, 'CLAUDE.md')), 'non-TTY run should use the default of no AI assistant');
+        assert.ok(!existsSync(join(project, '.mcp.json')), 'no assistant means no Claude MCP config');
+        assert.ok(!existsSync(join(project, '.cursor', 'mcp.json')), 'no assistant means no Cursor MCP config');
         assert.ok(!existsSync(join(project, '.github')), 'non-TTY run should use the default of no CI');
     } finally {
         rmSync(work, { recursive: true, force: true });
@@ -251,6 +253,18 @@ test('scaffold copies optional CI and agent files when requested', () => {
             existsSync(join(project, '.claude', 'hooks', 'session-start.sh')),
             '.claude/hooks/session-start.sh should be generated',
         );
+
+        // The docs-MCP config. Claude Code skips a remote entry that has a url but no type, so the type
+        // is load-bearing, not decoration.
+        const claudeMcp = JSON.parse(readFileSync(join(project, '.mcp.json'), 'utf8'));
+        assert.deepEqual(
+            Object.keys(claudeMcp.mcpServers),
+            ['blit386-docs'],
+            '.mcp.json should declare exactly the blit386-docs server',
+        );
+        assert.equal(claudeMcp.mcpServers['blit386-docs'].type, 'http', 'Claude MCP entry needs an explicit type');
+        assert.equal(claudeMcp.mcpServers['blit386-docs'].url, 'https://blit386.dev/mcp');
+        assertNoPlaceholders(project, '.mcp.json');
 
         const claudeSettings = JSON.parse(readFileSync(join(project, '.claude', 'settings.json'), 'utf8'));
         assert.ok(Array.isArray(claudeSettings.hooks?.PostToolUse), 'settings.json should have PostToolUse entries');
@@ -399,6 +413,24 @@ test('scaffold copies optional CI and agent files when requested', () => {
         const runCmd = readFileSync(join(cursorProject, '.cursor', 'commands', 'run.md'), 'utf8');
         assert.ok(!runCmd.includes('{{'), 'run command should not have unrendered placeholders');
 
+        // The same docs-MCP server, in Cursor's shape: a type there would mark a local stdio server,
+        // so the remote entry carries the url alone.
+        const cursorMcp = JSON.parse(readFileSync(join(cursorProject, '.cursor', 'mcp.json'), 'utf8'));
+        assert.deepEqual(
+            Object.keys(cursorMcp.mcpServers),
+            ['blit386-docs'],
+            '.cursor/mcp.json should declare exactly the blit386-docs server',
+        );
+        assert.equal(cursorMcp.mcpServers['blit386-docs'].url, 'https://blit386.dev/mcp');
+        assert.ok(!('type' in cursorMcp.mcpServers['blit386-docs']), 'Cursor MCP entry should not carry a type');
+
+        // Each adapter ships its own assistant's config path and not the other's.
+        assert.ok(!existsSync(join(cursorProject, '.mcp.json')), 'a Cursor project should not get Claude .mcp.json');
+        assert.ok(
+            !existsSync(join(project, '.cursor', 'mcp.json')),
+            'a Claude project should not get .cursor/mcp.json',
+        );
+
         // Cursor has no SessionStart-equivalent hook event, so the manifest's session-start
         // entry (Claude-only) should not appear here.
         assert.ok(
@@ -534,6 +566,14 @@ test('scaffold agent files match @blit386/kit/adapters memory output', () => {
 
             assert.ok(generated.length > 0, `${agent} adapter should emit files`);
 
+            // The loop below only checks what the adapter claims to emit, so it would happily pass on an
+            // adapter that stopped emitting the MCP config entirely. Pin its presence explicitly.
+            const mcpPath = agent === 'claude' ? '.mcp.json' : '.cursor/mcp.json';
+            assert.ok(
+                generated.some((file) => file.path === mcpPath),
+                `${agent} adapter should emit ${mcpPath}`,
+            );
+
             for (const file of generated) {
                 const onDisk = join(project, file.path);
                 assert.ok(existsSync(onDisk), `scaffold should have written ${file.path}`);
@@ -657,6 +697,7 @@ test('blit agents sync (full) changes nothing on a freshly scaffolded Claude pro
         const ruleBefore = readFileSync(join(project, '.claude', 'rules', 'blit-api-names.md'), 'utf8');
         const claudeBefore = readFileSync(join(project, 'CLAUDE.md'), 'utf8');
         const settingsBefore = readFileSync(join(project, '.claude', 'settings.json'), 'utf8');
+        const mcpBefore = readFileSync(join(project, '.mcp.json'), 'utf8');
 
         const { exitCode, output } = runBlit(project, ['agents', 'sync']);
 
@@ -677,6 +718,12 @@ test('blit agents sync (full) changes nothing on a freshly scaffolded Claude pro
             readFileSync(join(project, '.claude', 'settings.json'), 'utf8'),
             settingsBefore,
             'generated settings.json should be byte-identical after sync',
+        );
+        // A .mcp.json misclassified as user-owned would go stale here instead of being refreshed.
+        assert.equal(
+            readFileSync(join(project, '.mcp.json'), 'utf8'),
+            mcpBefore,
+            'generated .mcp.json should be byte-identical after sync',
         );
         assert.ok(!existsSync(join(project, 'CLAUDE.md.new')), 'no .new conflict file should be created');
 
@@ -706,6 +753,7 @@ test('blit agents sync (full) changes nothing on a freshly scaffolded Cursor pro
 
         const hooksBefore = readFileSync(join(project, '.cursor', 'hooks.json'), 'utf8');
         const ruleBefore = readFileSync(join(project, '.cursor', 'rules', 'blit-api-names.mdc'), 'utf8');
+        const mcpBefore = readFileSync(join(project, '.cursor', 'mcp.json'), 'utf8');
 
         const { exitCode, output } = runBlit(project, ['agents', 'sync']);
 
@@ -720,6 +768,11 @@ test('blit agents sync (full) changes nothing on a freshly scaffolded Cursor pro
             readFileSync(join(project, '.cursor', 'rules', 'blit-api-names.mdc'), 'utf8'),
             ruleBefore,
             'generated cursor rule should be byte-identical after sync',
+        );
+        assert.equal(
+            readFileSync(join(project, '.cursor', 'mcp.json'), 'utf8'),
+            mcpBefore,
+            'generated .cursor/mcp.json should be byte-identical after sync',
         );
     } finally {
         rmSync(work, { recursive: true, force: true });
@@ -853,6 +906,7 @@ test('blit agents add claude sets up Claude files in a project that did not pick
 
         // No agent was chosen, so none of the Claude files exist yet.
         assert.ok(!existsSync(join(project, 'CLAUDE.md')), 'CLAUDE.md should be absent before add');
+        assert.ok(!existsSync(join(project, '.mcp.json')), '.mcp.json should be absent before add');
 
         const { exitCode, output } = runBlit(project, ['agents', 'add', 'claude']);
         assert.equal(exitCode, 0, 'add claude should exit 0');
@@ -872,6 +926,7 @@ test('blit agents add claude sets up Claude files in a project that did not pick
             existsSync(join(project, '.claude', 'hooks', 'shell-safety.sh')),
             '.claude/hooks/shell-safety.sh should be created',
         );
+        assert.ok(existsSync(join(project, '.mcp.json')), '.mcp.json should be created');
 
         // The new files are recorded in the manifest, so a drift check is clean.
         const manifest = JSON.parse(readFileSync(join(project, '.blit', 'manifest.json'), 'utf8'));
@@ -880,6 +935,11 @@ test('blit agents add claude sets up Claude files in a project that did not pick
             'CLAUDE.md should be recorded in the manifest',
         );
         assert.ok(existsSync(join(project, '.blit', 'base', 'CLAUDE.md')), 'a pristine base copy should be written');
+
+        const mcpEntry = manifest.files.find((f) => f.path === '.mcp.json');
+        assert.ok(mcpEntry, '.mcp.json should be recorded in the manifest');
+        assert.equal(mcpEntry.class, 'kit-owned', '.mcp.json should be kit-owned so sync keeps it current');
+        assert.ok(existsSync(join(project, '.blit', 'base', '.mcp.json')), '.mcp.json should get a base copy');
 
         const drift = runBlit(project, ['agents', 'sync', '--check']);
         assert.equal(drift.exitCode, 0, 'sync --check should be clean right after add');
@@ -912,6 +972,12 @@ test('blit agents add cursor sets up Cursor files and a later sync is clean', ()
             '.cursor/rules should be created',
         );
         assert.ok(existsSync(join(project, '.cursor', 'commands', 'run.md')), '.cursor/commands should be created');
+        assert.ok(existsSync(join(project, '.cursor', 'mcp.json')), '.cursor/mcp.json should be created');
+
+        const manifest = JSON.parse(readFileSync(join(project, '.blit', 'manifest.json'), 'utf8'));
+        const mcpEntry = manifest.files.find((f) => f.path === '.cursor/mcp.json');
+        assert.ok(mcpEntry, '.cursor/mcp.json should be recorded in the manifest');
+        assert.equal(mcpEntry.class, 'kit-owned', '.cursor/mcp.json should be kit-owned so sync keeps it current');
 
         // A full sync on the freshly added agent changes nothing.
         const sync = runBlit(project, ['agents', 'sync']);
@@ -1066,6 +1132,124 @@ test('blit agents sync does not flag a clean-merged kit file as drift', { skip: 
 
         const check2 = runBlit(project, ['agents', 'sync', '--check']);
         assert.equal(check2.exitCode, 0, 'still in sync after a second sync');
+    } finally {
+        rmSync(work, { recursive: true, force: true });
+    }
+});
+
+test('the scaffolded MCP config is recorded as kit-owned in the manifest', () => {
+    const work = mkdtempSync(join(tmpdir(), 'cbt-mcp-class-'));
+
+    try {
+        for (const [agent, mcpPath] of [
+            ['claude', '.mcp.json'],
+            ['cursor', '.cursor/mcp.json'],
+        ]) {
+            const project = join(work, `${agent}-mcp-class`);
+            scaffold({
+                targetDir: project,
+                projectName: `${agent}-mcp-class`,
+                pmInstall: 'npm install',
+                pmRunDev: 'npm run dev',
+                pmRunBuild: 'npm run build',
+                pmRunFormat: 'npm run format',
+                pmRunLint: 'npm run lint',
+                agent,
+            });
+
+            const manifest = JSON.parse(readFileSync(join(project, '.blit', 'manifest.json'), 'utf8'));
+            const entry = manifest.files.find((f) => f.path === mcpPath);
+
+            // A user-owned misclassification is silent: the file scaffolds fine and then never updates
+            // again, so the game keeps pointing at whatever the docs server looked like on day one.
+            assert.ok(entry, `${mcpPath} should be recorded in the manifest`);
+            assert.equal(entry.class, 'kit-owned', `${mcpPath} should be kit-owned`);
+
+            const onDisk = createHash('sha256')
+                .update(readFileSync(join(project, ...mcpPath.split('/'))))
+                .digest('hex');
+            assert.equal(entry.sha256, onDisk, `${mcpPath} manifest hash should match the file on disk`);
+            assert.ok(existsSync(join(project, '.blit', 'base', ...mcpPath.split('/'))), 'a base copy is needed');
+        }
+    } finally {
+        rmSync(work, { recursive: true, force: true });
+    }
+});
+
+test('blit agents sync keeps a user-added MCP server in .mcp.json', { skip: !hasGit }, () => {
+    const work = mkdtempSync(join(tmpdir(), 'cbt-mcp-merge-'));
+
+    try {
+        const project = join(work, 'mcp-merge-game');
+        scaffold({
+            targetDir: project,
+            projectName: 'mcp-merge-game',
+            pmInstall: 'npm install',
+            pmRunDev: 'npm run dev',
+            pmRunBuild: 'npm run build',
+            pmRunFormat: 'npm run format',
+            pmRunLint: 'npm run lint',
+            agent: 'claude',
+        });
+
+        // .mcp.json is the natural place for a user to register their own servers. Being kit-owned, it
+        // goes through the three-way merge, so their entry has to survive a sync that regenerates it.
+        const mcpPath = join(project, '.mcp.json');
+        const config = JSON.parse(readFileSync(mcpPath, 'utf8'));
+        config.mcpServers['my-server'] = { type: 'http', url: 'https://example.test/mcp' };
+        writeFileSync(mcpPath, `${JSON.stringify(config, null, 2)}\n`);
+
+        const sync = runBlit(project, ['agents', 'sync']);
+        assert.equal(sync.exitCode, 0, 'a clean merge should exit 0');
+        assert.ok(!existsSync(`${mcpPath}.new`), 'a clean merge should not leave a .new conflict copy');
+
+        const merged = JSON.parse(readFileSync(mcpPath, 'utf8'));
+        assert.ok(merged.mcpServers['my-server'], 'the user server must survive the sync');
+        assert.ok(merged.mcpServers['blit386-docs'], 'the kit server must still be there');
+
+        const check = runBlit(project, ['agents', 'sync', '--check']);
+        assert.equal(check.exitCode, 0, 'a clean-merged .mcp.json must not be reported as drift');
+    } finally {
+        rmSync(work, { recursive: true, force: true });
+    }
+});
+
+test('blit agents add claude aborts safely on a hand-written .mcp.json', () => {
+    const work = mkdtempSync(join(tmpdir(), 'cbt-mcp-collision-'));
+
+    try {
+        const project = join(work, 'mcp-collision-game');
+        scaffold({
+            targetDir: project,
+            projectName: 'mcp-collision-game',
+            pmInstall: 'npm install',
+            pmRunDev: 'npm run dev',
+            pmRunBuild: 'npm run build',
+            pmRunFormat: 'npm run format',
+            pmRunLint: 'npm run lint',
+        });
+
+        // The user already registered an unrelated MCP server before asking for Claude. That file is
+        // theirs, so the add is all-or-nothing: nothing is written except the .new copy.
+        const mcpPath = join(project, '.mcp.json');
+        const userContent = `${JSON.stringify({ mcpServers: { mine: { type: 'http', url: 'https://example.test/mcp' } } }, null, 2)}\n`;
+        writeFileSync(mcpPath, userContent);
+
+        const { exitCode, output } = runBlit(project, ['agents', 'add', 'claude']);
+
+        assert.equal(readFileSync(mcpPath, 'utf8'), userContent, 'the user .mcp.json must not be overwritten');
+        assert.ok(existsSync(`${mcpPath}.new`), 'the kit version should be saved as .mcp.json.new');
+        assert.ok(output.includes('.mcp.json.new'), 'output should mention the .new copy');
+        assert.notEqual(exitCode, 0, 'a needs-review collision should exit non-zero');
+        assert.ok(!existsSync(join(project, 'CLAUDE.md')), 'an aborted add must not write the other Claude files');
+
+        const sync = runBlit(project, ['agents', 'sync']);
+        assert.equal(sync.exitCode, 0, 'sync should still succeed after an aborted add');
+        assert.equal(
+            readFileSync(mcpPath, 'utf8'),
+            userContent,
+            'a later sync must not overwrite the user .mcp.json after an aborted add',
+        );
     } finally {
         rmSync(work, { recursive: true, force: true });
     }

--- a/packages/kit/CLAUDE.md
+++ b/packages/kit/CLAUDE.md
@@ -17,13 +17,15 @@ The `blit` CLI is a project-local bin inside every generated game: `blit run`, `
 
 Generated games receive `AGENTS.md`, nine beginner docs from `content/docs/` (`getting-started`, `basics`, `drawing`,
 `input`, `palette`, `random`, `audio`, `hot-reload`, `when-something-breaks`), and the game-author skills in
-`content/skills/`. These are not copies of the engine's full `docs/` tree – they teach the starter game and point to
-GitHub for deep API reference.
+`content/skills/`. These are not copies of the engine's full `docs/` tree – they teach the starter game and route
+anything deeper to the live documentation at blit386.dev: the `blit386-docs` MCP server (`search_docs`,
+`get_docs_summary`), `https://blit386.dev/llms.txt`, or any doc page fetched with `Accept: text/markdown`. GitHub is the
+last resort, for when the documentation itself falls short.
 
 The whole of `content/` is the shipped IR, not just `AGENTS.md` + `docs/`: it also carries `rules/`, `skills/` (24
-game-author capability skills plus the `run`, `fix`, and `migrate` workflow skills), `hooks/shell-safety.sh` +
-`hooks.manifest.json`, and `agents.config.json`. Skills and rules are discovered by directory scan in `src/adapters.ts`
-– adding a skill folder is enough, nothing registers it by name.
+game-author capability skills plus the `run`, `fix`, `migrate`, and `ask-the-docs` workflow skills),
+`hooks/shell-safety.sh` + `hooks.manifest.json`, and `agents.config.json`. Skills and rules are discovered by directory
+scan in `src/adapters.ts` – adding a skill folder is enough, nothing registers it by name.
 
 Kit content must be self-contained. Skills and docs may reference only `packages/blit386` (the engine) and other local
 kit files. Do not reference the `packages/demos` package, its demo slugs, or its URLs – that package may be archived in
@@ -65,11 +67,13 @@ here – review in the same pass, not later. Run `/kit-audit` to walk the checkl
 | `content/skills/use-noise/SKILL.md` | `hash*` functions, `ValueNoise` / `PerlinNoise` / `SimplexNoise`, fBm defaults |
 | `content/skills/move-and-time/SKILL.md` | Clock getters, `Timer`, the `EasingFunction` curve list, `interpolate` |
 | `content/skills/animate-the-palette/SKILL.md` | Cycle / fade / exposure fade / flash / swap, `highlightLead` |
+| `content/skills/ask-the-docs/SKILL.md` | The docs MCP tool set, `llms.txt`, or the site's markdown negotiation changes |
 | `content/skills/*/SKILL.md` | Other game-author skills; each demonstrates a slice of the `BT` surface |
 | `content/hooks/shell-safety.sh` | Shell commands the hook blocks in a generated game (Cursor + Claude protocols) |
 | `content/hooks/session-start.sh` | Dependency install + `blit doctor` checkup a fresh remote/web session runs (Claude-only; Cursor has no SessionStart-equivalent event) |
 | `content/hooks.manifest.json` | Canonical hook intent; Cursor `hooks.json` and Claude `settings.json` derive from it |
 | `content/agents.config.json` | Descriptive only – no code reads it. The executable source for what each adapter emits is `src/ownership.ts` (paths + classes) plus `src/adapters.ts`; review this file when those change |
+| `src/adapters.ts` (docs-MCP config) | `packages/website/public/.well-known/mcp/server-card.json` changes name, URL, or transport |
 
 While auditing, confirm every skill directory appears in the skills table in `README.md` – that is the only human-facing
 list of what ships, and it has no automated guard.
@@ -84,8 +88,11 @@ list of what ships, and it has no automated guard.
    it together with `BLIT386_RANGE` in `packages/create-blit386/src/scaffold.ts`, and `pnpm run bump:check` fails the
    build when either drifts. Any other literal this package uses to describe the engine or the scaffolder follows the
    same derive-or-document discipline: file classes and generated-project paths live once in `src/ownership.ts`, which
-   `create-blit386` imports through `@blit386/kit/adapters`. See root `.claude/rules/named-constants.md` for the shared
-   policy
+   `create-blit386` imports through `@blit386/kit/adapters`. Same discipline, one boundary further out:
+   `MCP_SERVER_NAME` and `MCP_SERVER_URL` in `src/adapters.ts` are a documented copy of
+   `packages/website/public/.well-known/mcp/server-card.json`, which this package cannot import;
+   `test/mcp-config.test.mjs` compares the two, so the copy fails loudly instead of drifting. See root
+   `.claude/rules/named-constants.md` for the shared policy
 
 ## Where to find information
 
@@ -93,6 +100,7 @@ list of what ships, and it has no automated guard.
 | --- | --- |
 | What does the `blit` CLI do? | `src/cli.ts`, `README.md` |
 | How are agent files generated? | `src/adapters.ts`; every path it emits is built from `src/ownership.ts`, and the scaffolder writes them to disk |
+| Docs-MCP config shipped into games | `buildMcpConfig` in `src/adapters.ts`; canonical server definition lives in `packages/website` |
 | What do `blit agents sync` / `add` do? | `src/commands/agents.ts` (drift `--check` + write path, `runAddAgent`) |
 | How do API migrations / codemods work? | `src/migrations/` (registry + codemod engine), `src/commands/migrate.ts` |
 | Sync ownership model / manifest | `.blit/manifest.json` (classes + `vars`), `src/commands/agents.ts` |

--- a/packages/kit/README.md
+++ b/packages/kit/README.md
@@ -33,7 +33,10 @@ The kit behind [BLIT386](https://www.npmjs.com/package/blit386) game projects: t
   ownership classes are defined once in `src/ownership.ts`. The same manifest drives Cursor's `.cursor/hooks.json` and
   Claude Code's `.claude/settings.json` (format-on-edit + block-dangerous-shell). Claude Code also gets a SessionStart
   hook that installs dependencies and runs `blit doctor` when a fresh remote/web session starts, so a scaffolded game
-  works without manual setup; Cursor has no SessionStart-equivalent event, so it does not get this hook.
+  works without manual setup; Cursor has no SessionStart-equivalent event, so it does not get this hook. Both adapters
+  also emit a documentation-MCP config – `.mcp.json` for Claude Code, `.cursor/mcp.json` for Cursor – registering the
+  `blit386-docs` server at `https://blit386.dev/mcp` so an assistant can search the live docs. Claude Code asks once
+  whether to allow it.
 
 ## The game-author skills
 
@@ -46,6 +49,7 @@ there you can also invoke one by name (`/add-sprite`).
 | `structure-a-game` | The shape of a game: `configure`, `init`, `update`, `render` – and what the engine does not do for you |
 | `run` | Start the dev server and see the game |
 | `fix` | The game crashes, shows a black screen, or behaves oddly |
+| `ask-the-docs` | Look something up that the local `docs/` folder does not cover, using the live docs at blit386.dev |
 | `use-hot-reload` | Keep playing while you edit code or assets (`blit386/vite`, `onHotReload`) |
 | `use-dev-mode` | Gate debug HUDs, cheat keys, and verbose logging on `BT.isDevMode` |
 | `draw-shapes` | Rectangles, lines, pixels, and clearing the screen |

--- a/packages/kit/content/AGENTS.md
+++ b/packages/kit/content/AGENTS.md
@@ -69,8 +69,18 @@ bootstrap(Game);
 | Turn off the BLIT386 splash, or see it during development | `docs/basics.md` (The splash) |
 | Fix a blank screen, an error, a broken change | `docs/when-something-breaks.md` |
 
-The full engine reference lives at https://github.com/blit386/blit386 – only go there if these local docs do not answer
-the question.
+When these local docs come up short, the live documentation at https://blit386.dev has the full engine reference, and
+this game already knows how to query it:
+
+- Ask the `blit386-docs` MCP server. If you set up Claude Code or Cursor, it is already configured (`.mcp.json` for
+  Claude Code, `.cursor/mcp.json` for Cursor) and gives your assistant two tools: `search_docs` (full-text search – page
+  titles, URLs, and excerpts) and `get_docs_summary` (the whole site's contents in one compact block).
+- No MCP server? Fetch https://blit386.dev/llms.txt for the same summary as one plain text file.
+- Reading a page? Request its URL with the header `Accept: text/markdown` and the site returns markdown instead of HTML
+  – far less to wade through.
+
+The `ask-the-docs` skill walks an assistant through all three. The source code lives at
+https://github.com/blit386/blit386 – go there only when the documentation itself does not answer the question.
 
 ## Running the game
 
@@ -103,9 +113,12 @@ commented example in `src/game.js` / `src/game.ts`); edits to `configure()` scre
 ## Working with an AI assistant
 
 If you use Claude Code, open `CLAUDE.md` for the full project guide. Rules loaded automatically from `.claude/rules/`
-tell Claude the engine's naming conventions. Skills in `.claude/skills/` are loaded on demand.
+tell Claude the engine's naming conventions. Skills in `.claude/skills/` are loaded on demand. `.mcp.json` points Claude
+Code at the BLIT386 documentation server; Claude Code asks once whether to allow it, and saying yes lets your assistant
+search the live docs.
 
-If you use Cursor, `.cursor/rules/` loads rules automatically when you open the project.
+If you use Cursor, `.cursor/rules/` loads rules automatically when you open the project, and `.cursor/mcp.json` points
+it at the same documentation server.
 
 For other assistants (Zed, Copilot, Windsurf, and others), this file is your assistant's home base.
 

--- a/packages/kit/content/agents.config.json
+++ b/packages/kit/content/agents.config.json
@@ -8,7 +8,8 @@
         ".claude/rules/{name}.md",
         ".claude/skills/{name}/SKILL.md",
         ".claude/settings.json",
-        ".claude/hooks/{script}"
+        ".claude/hooks/{script}",
+        ".mcp.json"
       ]
     },
     "cursor": {
@@ -17,7 +18,8 @@
         ".cursor/rules/{name}.mdc",
         ".cursor/hooks.json",
         ".cursor/hooks/{script}",
-        ".cursor/commands/{name}.md"
+        ".cursor/commands/{name}.md",
+        ".cursor/mcp.json"
       ]
     }
   }

--- a/packages/kit/content/skills/ask-the-docs/SKILL.md
+++ b/packages/kit/content/skills/ask-the-docs/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: ask-the-docs
+description:
+  Look up BLIT386 detail the project's own files do not cover, using the live documentation at blit386.dev – the
+  blit386-docs MCP server, the llms.txt summary, or a doc page fetched as markdown. Use whenever AGENTS.md and the local
+  docs/ folder do not answer the question, an engine API or option is unfamiliar, or the user asks about something newer
+  than this game's BLIT386 version.
+---
+
+# Ask the docs
+
+Look up BLIT386 detail the project's own files do not cover, using the live documentation at blit386.dev.
+
+## When to use
+
+Use when `AGENTS.md` and the `docs/` folder do not answer the question – an API you cannot find, an option that is not
+listed, or something added to the engine after this game was created.
+
+## Read the local docs first
+
+The guides in `docs/` are already on disk, cost nothing to open, and describe the BLIT386 version this game actually
+pins in `package.json`. `AGENTS.md` has a table telling you which one to open. Go to the network only after that table
+comes up empty.
+
+## Three ways to reach the live docs
+
+### 1. The blit386-docs MCP server
+
+This project ships its configuration, so your assistant should already have it. Two tools:
+
+- `search_docs` – full-text search across the whole documentation site. Give it a short query such as
+  `palette animation` or `gamepad deadzone`. It returns page titles, URLs, and excerpts.
+- `get_docs_summary` – the whole site's contents in one compact block. Reach for this when you do not yet know what to
+  search for.
+
+In Claude Code the server is configured in `.mcp.json`, and Claude Code asks once whether to allow it – saying yes is
+what turns this on. In Cursor it is configured in `.cursor/mcp.json`.
+
+### 2. The plain-text summary
+
+Fetch https://blit386.dev/llms.txt for the same site summary as one plain text file. This is the fallback when the MCP
+server is not available. Find the page you need in it, then fetch that page.
+
+### 3. Any doc page as markdown
+
+Request a page URL with the header `Accept: text/markdown` and the site returns markdown instead of HTML – no
+navigation, no menus, far less to read:
+
+```bash
+curl -sH 'Accept: text/markdown' https://blit386.dev/docs
+```
+
+## Notes
+
+- The live site documents the newest BLIT386. This game pins a version in `package.json`, so something you find there
+  may not exist here yet. Check the pinned version before using an API the local docs never mention, and run
+  `npx blit doctor` if you are unsure what is installed.
+- The docs server is read-only. It searches and returns documentation; it cannot change anything in your game.
+- The source code lives at https://github.com/blit386/blit386. Go there only when the documentation itself does not
+  answer the question.
+- Found something the local docs do not cover? Write it into the "Your notes" section of `AGENTS.md` so nobody has to
+  look it up twice.

--- a/packages/kit/src/adapters.ts
+++ b/packages/kit/src/adapters.ts
@@ -13,6 +13,7 @@ import { fileURLToPath } from 'node:url';
 import {
     AGENTS_MD,
     CLAUDE_HOOKS_DIR,
+    CLAUDE_MCP_JSON,
     CLAUDE_MD,
     CLAUDE_RULES_DIR,
     CLAUDE_SETTINGS_JSON,
@@ -20,6 +21,7 @@ import {
     CURSOR_COMMANDS_DIR,
     CURSOR_HOOKS_DIR,
     CURSOR_HOOKS_JSON,
+    CURSOR_MCP_JSON,
     CURSOR_RULES_DIR,
     DOCS_DIR,
 } from './ownership';
@@ -32,6 +34,19 @@ export { type AgentKind, type FileClass, classifyFile, hasAgentFiles, isAgentPat
 /** Managed-region markers shared by AGENTS.md and CLAUDE.md. */
 const MANAGED_START = '<!-- blit-kit:managed:start -->';
 const MANAGED_END = '<!-- blit-kit:managed:end -->';
+
+/**
+ * The blit386.dev documentation MCP server that every generated game registers with its assistant.
+ *
+ * MANUAL-SYNC HAZARD: the canonical definition of this server lives in the website package, at
+ * `packages/website/public/.well-known/mcp/server-card.json` (and `packages/website/src/mcp-server.ts`).
+ * `@blit386/kit` ships standalone and cannot import across that boundary, so these two literals are a
+ * deliberate copy. `packages/kit/test/mcp-config.test.mjs` compares them against the server card, so an
+ * edit on either side that is not mirrored on the other fails the kit test suite rather than shipping
+ * a generated game that points at a dead endpoint.
+ */
+const MCP_SERVER_NAME = 'blit386-docs';
+const MCP_SERVER_URL = 'https://blit386.dev/mcp';
 
 /** A regenerated file: a project-relative path (forward slashes) and its full content. */
 export interface GeneratedFile {
@@ -177,6 +192,7 @@ export function collectDocs(root: string): GeneratedFile[] {
  *   - `.claude/skills/{name}/SKILL.md` (kit-owned)
  *   - `.claude/settings.json`          (kit-owned; translated from content/hooks.manifest.json)
  *   - `.claude/hooks/{script}`         (kit-owned; copied verbatim)
+ *   - `.mcp.json`                      (kit-owned; the blit386.dev documentation MCP server)
  *
  * @param root – The kit root directory.
  * @param vars – Template variables used when rendering generated content.
@@ -262,6 +278,8 @@ export function generateClaudeAdapter(root: string, vars: TemplateVars): Generat
         files.push({ path: CLAUDE_SETTINGS_JSON, content: `${JSON.stringify(claudeSettings, null, 2)}\n` });
         claudeHookScripts = referencedHookScripts(manifest, 'claude');
     }
+
+    files.push(mcpConfigFile('claude'));
 
     const hooksScriptsDir = join(contentRoot, 'hooks');
     if (existsSync(hooksScriptsDir)) {
@@ -433,12 +451,50 @@ function buildClaudeSettings(manifest: HooksManifest, vars: TemplateVars): Claud
     return { hooks };
 }
 
+/** Which assistant's MCP configuration file to build. */
+type McpTarget = 'claude' | 'cursor';
+
+/** One remote MCP server entry. */
+interface McpServerEntry {
+    /** Transport marker. Required by Claude Code, omitted for Cursor – see `buildMcpConfig`. */
+    type?: string;
+    url: string;
+}
+
+/** The `mcpServers` wrapper both assistants read. */
+interface McpConfigJson {
+    mcpServers: Record<string, McpServerEntry>;
+}
+
+/**
+ * Build the documentation-MCP configuration for one assistant.
+ *
+ * The two entries differ by one key on purpose, and the difference is not cosmetic:
+ * Claude Code rejects a remote entry that has a `url` but no `type` and skips the server entirely,
+ * while for Cursor a `type` is the marker of a local stdio server – adding one there would make it
+ * misread a remote HTTP endpoint. Do not harmonize the two shapes.
+ */
+function buildMcpConfig(target: McpTarget): McpConfigJson {
+    const entry: McpServerEntry = target === 'claude' ? { type: 'http', url: MCP_SERVER_URL } : { url: MCP_SERVER_URL };
+
+    return { mcpServers: { [MCP_SERVER_NAME]: entry } };
+}
+
+/** The MCP configuration file for one assistant, at that assistant's conventional path. */
+function mcpConfigFile(target: McpTarget): GeneratedFile {
+    return {
+        path: target === 'claude' ? CLAUDE_MCP_JSON : CURSOR_MCP_JSON,
+        content: `${JSON.stringify(buildMcpConfig(target), null, 2)}\n`,
+    };
+}
+
 /**
  * Generate the Cursor adapter files from the kit IR:
  *   - `.cursor/rules/{name}.mdc`      (kit-owned; MDC frontmatter preserved)
  *   - `.cursor/hooks.json`            (kit-owned; translated from content/hooks.manifest.json)
  *   - `.cursor/hooks/{script}`        (kit-owned; copied verbatim)
  *   - `.cursor/commands/{name}.md`    (kit-owned, one per skill)
+ *   - `.cursor/mcp.json`              (kit-owned; the blit386.dev documentation MCP server)
  */
 export function generateCursorAdapter(root: string, vars: TemplateVars): GeneratedFile[] {
     const contentRoot = join(root, 'content');
@@ -465,6 +521,8 @@ export function generateCursorAdapter(root: string, vars: TemplateVars): Generat
         files.push({ path: CURSOR_HOOKS_JSON, content: `${JSON.stringify(cursorHooks, null, 2)}\n` });
         cursorHookScripts = referencedHookScripts(manifest, 'cursor');
     }
+
+    files.push(mcpConfigFile('cursor'));
 
     const hooksScriptsDir = join(contentRoot, 'hooks');
     if (existsSync(hooksScriptsDir)) {

--- a/packages/kit/src/ownership.ts
+++ b/packages/kit/src/ownership.ts
@@ -33,12 +33,22 @@ export const CLAUDE_SKILLS_DIR = `${CLAUDE_DIR}skills/`;
 export const CLAUDE_HOOKS_DIR = `${CLAUDE_DIR}hooks/`;
 export const CLAUDE_SETTINGS_JSON = `${CLAUDE_DIR}settings.json`;
 
+/**
+ * Claude Code's MCP server configuration. Project root, not under `.claude/` – that is Claude Code's
+ * own convention, so this is the one Claude path the `CLAUDE_DIR` prefix does not cover and
+ * `AGENT_PATHS` has to name outright.
+ */
+export const CLAUDE_MCP_JSON = '.mcp.json';
+
 /** Root of Cursor's generated configuration. */
 export const CURSOR_DIR = '.cursor/';
 export const CURSOR_RULES_DIR = `${CURSOR_DIR}rules/`;
 export const CURSOR_HOOKS_DIR = `${CURSOR_DIR}hooks/`;
 export const CURSOR_COMMANDS_DIR = `${CURSOR_DIR}commands/`;
 export const CURSOR_HOOKS_JSON = `${CURSOR_DIR}hooks.json`;
+
+/** Cursor's MCP server configuration. */
+export const CURSOR_MCP_JSON = `${CURSOR_DIR}mcp.json`;
 
 /** Beginner docs, copied from the kit's own `content/docs/`. */
 export const DOCS_DIR = 'docs/';
@@ -56,7 +66,7 @@ export type FileClass = 'kit-owned' | 'shared' | 'user-owned';
 const SHARED_FILES: readonly string[] = [AGENTS_MD, CLAUDE_MD];
 
 /** Exact paths the kit owns outright. */
-const KIT_OWNED_FILES: readonly string[] = [CLAUDE_SETTINGS_JSON, CURSOR_HOOKS_JSON];
+const KIT_OWNED_FILES: readonly string[] = [CLAUDE_SETTINGS_JSON, CLAUDE_MCP_JSON, CURSOR_HOOKS_JSON, CURSOR_MCP_JSON];
 
 /** Directories whose entire contents the kit owns, trailing slash included. */
 const KIT_OWNED_DIRS: readonly string[] = [
@@ -113,9 +123,20 @@ export function isKitManaged(fileClass: FileClass): boolean {
  */
 export type AgentKind = 'claude' | 'cursor';
 
-/** Exact paths and directory prefixes each assistant's generated files occupy. */
+/**
+ * Exact paths and directory prefixes each assistant's generated files occupy.
+ *
+ * Every path an adapter emits must match here, or `hasAgentFiles` under-reports and a sync skips that
+ * assistant's files – `test/ownership.test.mjs` pins that invariant. Claude needs `CLAUDE_MCP_JSON`
+ * spelled out because it sits at the project root rather than under `.claude/`; Cursor's `mcp.json`
+ * is already covered by the `CURSOR_DIR` prefix.
+ *
+ * These are manifest paths, not disk paths: every caller passes `.blit/manifest.json` entries, so a
+ * hand-written `.mcp.json` the kit never tracked cannot make an assistant look already set up. The
+ * untracked case is handled separately, by `runAddAgent`'s collision check.
+ */
 const AGENT_PATHS: Record<AgentKind, { readonly files: readonly string[]; readonly dirs: readonly string[] }> = {
-    claude: { files: [CLAUDE_MD], dirs: [CLAUDE_DIR] },
+    claude: { files: [CLAUDE_MD, CLAUDE_MCP_JSON], dirs: [CLAUDE_DIR] },
     cursor: { files: [], dirs: [CURSOR_DIR] },
 };
 

--- a/packages/kit/test/mcp-config.test.mjs
+++ b/packages/kit/test/mcp-config.test.mjs
@@ -1,0 +1,69 @@
+/**
+ * Guards the documentation-MCP configuration the adapters emit into every generated game.
+ *
+ * The server name and URL in `src/adapters.ts` are a deliberate copy of the canonical definition in
+ * the website package, which the kit cannot import across the package boundary. These tests compare
+ * the two, so an edit on either side that is not mirrored on the other fails here instead of shipping
+ * a generated game that points at a dead endpoint.
+ *
+ * Imports the built dist module; the package `pretest` script runs `pnpm run build` first.
+ */
+
+import { strict as assert } from 'node:assert';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { classifyFile, generateClaudeAdapter, generateCursorAdapter, kitRoot } from '../dist/adapters.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+/** The website's published server card – the canonical definition these adapters mirror. */
+const SERVER_CARD_PATH = join(here, '..', '..', 'website', 'public', '.well-known', 'mcp', 'server-card.json');
+
+/** `packages/website` is not part of the published kit tarball, so skip rather than throw outside the monorepo. */
+const hasServerCard = existsSync(SERVER_CARD_PATH);
+
+/** Template vars are irrelevant to the MCP config, but the generators require them. */
+const VARS = {
+    pmInstall: 'npm install',
+    pmRunDev: 'npm run dev',
+    pmRunBuild: 'npm run build',
+    pmRunFormat: 'npm run format',
+    pmRunLint: 'npm run lint',
+};
+
+/** Parse the single MCP config an adapter emits at `path`. */
+function readEmittedConfig(generated, path) {
+    const file = generated.find((f) => f.path === path);
+    assert.ok(file, `adapter should emit ${path}`);
+    assert.ok(file.content.endsWith('\n'), `${path} should end with a newline`);
+    return JSON.parse(file.content);
+}
+
+test('the emitted MCP configs match the website server card', { skip: !hasServerCard }, () => {
+    const card = JSON.parse(readFileSync(SERVER_CARD_PATH, 'utf8'));
+    const name = card.serverInfo.name;
+
+    const claude = readEmittedConfig(generateClaudeAdapter(kitRoot(), VARS), '.mcp.json');
+    const cursor = readEmittedConfig(generateCursorAdapter(kitRoot(), VARS), '.cursor/mcp.json');
+
+    // Each config declares exactly the one server the card describes, at the card's URL.
+    assert.deepEqual(Object.keys(claude.mcpServers), [name]);
+    assert.deepEqual(Object.keys(cursor.mcpServers), [name]);
+    assert.equal(claude.mcpServers[name].url, card.url);
+    assert.equal(cursor.mcpServers[name].url, card.url);
+
+    // The two entries differ by one key on purpose. Claude Code skips a remote entry that has a `url`
+    // but no `type`; for Cursor a `type` marks a local stdio server and would misread this one. Do not
+    // "harmonize" the shapes to make this test pass – fix the adapter instead.
+    assert.equal(card.transport.type, 'streamable-http');
+    assert.equal(claude.mcpServers[name].type, 'http', 'Claude Code needs the http alias of streamable-http');
+    assert.ok(!('type' in cursor.mcpServers[name]), 'Cursor infers the transport from url; a type would mark stdio');
+});
+
+test('both MCP configs are kit-owned, so agents sync keeps them current', () => {
+    assert.equal(classifyFile('.mcp.json'), 'kit-owned');
+    assert.equal(classifyFile('.cursor/mcp.json'), 'kit-owned');
+});

--- a/packages/website/CLAUDE.md
+++ b/packages/website/CLAUDE.md
@@ -274,6 +274,11 @@ A JSON-RPC 2.0 endpoint at `/mcp` (streamable-HTTP, no auth), with two tools: `s
 body matches. It deliberately does **not** build a FlexSearch index in-process – that exceeds the Worker CPU limit
 (error 1102), the same reason site search runs in static mode.
 
+`public/.well-known/mcp/server-card.json` has a downstream copy. `@blit386/kit` generates the same server name and URL
+into every scaffolded game (`.mcp.json` for Claude Code, `.cursor/mcp.json` for Cursor) and cannot import across the
+package boundary, so the values are duplicated in `packages/kit/src/adapters.ts`. Renaming the server or moving the
+endpoint means editing both; `packages/kit/test/mcp-config.test.mjs` compares them and fails when they disagree.
+
 ## Blog media
 
 Short screen captures are self-hosted, not embedded from a video platform.


### PR DESCRIPTION
Closes BT-253.

The docs site has exposed a `/mcp` server for engine-API questions for a while, but nothing reached a scaffolded game. A beginner's assistant got 9 static local docs plus one line in `AGENTS.md` saying "the full engine reference lives at github.com", and never learned the live-docs query path existed.

## What ships into a generated game

Both adapters now emit a documentation-MCP config from one shared builder in `packages/kit/src/adapters.ts`:

| File | Entry | Why the difference |
| --- | --- | --- |
| `.mcp.json` | `{"type": "http", "url": ...}` | Claude Code skips a remote entry that has a `url` but no `type` |
| `.cursor/mcp.json` | `{"url": ...}` | For Cursor a `type` marks a local stdio server |

Plus a new `ask-the-docs` kit skill (auto-registers into both adapters, so it lands as a Claude skill and a Cursor command) and an `AGENTS.md` managed-region rewrite teaching the three live-docs routes: MCP `search_docs` / `get_docs_summary`, `https://blit386.dev/llms.txt`, and `Accept: text/markdown` on any doc page. GitHub is demoted to a last resort. `CLAUDE.md` picks all of it up for free via managed-region synthesis.

Both paths are declared in `src/ownership.ts` alongside the other generated-project paths, so the emitters and the classifier cannot disagree. Both are `kit-owned`, so `blit agents sync` refreshes them and three-way merges servers the user adds themselves. `.mcp.json` is the one Claude path the `.claude/` prefix does not cover, so `AGENT_PATHS` names it outright.

## Decisions worth reviewing

- **No `enabledMcpjsonServers` pre-approval.** The approval prompt is Claude Code's consent boundary for a network server, and a scaffolder is not the party entitled to answer it. A checked-in settings file's approvals are ignored in an untrusted folder anyway, so it would buy roughly one keystroke. The new skill explains the prompt instead.
- **No `content/mcp.manifest.json`.** One server, no per-adapter divergence beyond a single key. A manifest plus parser plus schema interface is not earned yet; the standing decision (revisit when a second server appears) is recorded in `packages/kit/CLAUDE.md` and the design doc.

## Testing

New `packages/kit/test/mcp-config.test.mjs` is a cross-package drift guard: it compares the emitted server name and URL against `packages/website/public/.well-known/mcp/server-card.json` (which the kit cannot import) and pins the intentional Claude/Cursor `type` asymmetry so nobody harmonizes the two shapes.

Three new scaffolder tests: manifest ownership class with sha256 match, a user-added server surviving a sync through the three-way merge, and `agents add claude` aborting safely on a hand-written `.mcp.json`. Extended the non-TTY negatives, both halves of the optional-files test, cross-adapter negatives, the adapter-parity test, and both sync-is-noop tests.

Suites: kit 45 passing, create-blit386 32 passing.

## Verified against the live server

Not just asserted in tests -- the three routes the new content teaches all resolve today:

- `tools/list` on `https://blit386.dev/mcp` returns exactly `search_docs` and `get_docs_summary`
- `search_docs` for "palette animation" returns real hits
- `/llms.txt` -> 200, `text/plain`
- `Accept: text/markdown` on `/docs` -> 200, `text/markdown; charset=utf-8`

Also scaffolded both a Claude and a Cursor game and confirmed the config content, manifest class, `.blit/base/` copy, `agents sync --check` exit 0, and that neither adapter gets the other's file.

## Test plan

- [x] `pnpm --filter @blit386/kit run test` (45 passing)
- [x] `pnpm --filter create-blit386 run test` (32 passing)
- [x] Both typechecks, `format:check`, `agents:check`, `docs:links`, `check-dash-typography`, `bump:check`
- [x] Manual scaffold + `blit agents add` for both adapters
- [ ] Open Claude Code in a generated project, confirm the `blit386-docs` approval prompt appears and `/mcp` lists both tools -- the one handshake no automated test covers

## Notes for review

- Rebased onto current `main` after #560 landed the shared `ownership.ts`. An earlier draft of this branch hoisted `classifyFile` into `adapters.ts` independently; that work is dropped in favor of #560's cleaner module, and this PR only adds the two MCP paths to it.
- `packages/website/CLAUDE.md` gains 5 lines recording the downstream copy of the server card. No website source changes.
- Two follow-ups filed rather than folded in: BT-474 (`mcp-server.mdx` points Claude Code users at the wrong config file -- a real doc bug) and BT-475 (`blit agents add` could merge a pre-existing JSON config instead of colliding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic BLIT386 documentation MCP configuration for Claude Code and Cursor projects.
  * Added the `ask-the-docs` assistant skill for searching local and live documentation.
  * Added documentation lookup through MCP tools, `llms.txt`, and Markdown resources.

* **Documentation**
  * Updated setup guides with assistant configuration details, permissions, lookup workflows, and troubleshooting guidance.

* **Bug Fixes**
  * Improved configuration synchronization while preserving existing assistant server settings and handling file conflicts safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->