### PR TITLE
feat(website): fix the twoslash WORKERS_CI gate gap and enable opt-in dev popups

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -134,17 +134,21 @@ reviews:
     - path: 'packages/website/scripts/**'
       instructions: >-
         Build/CI helpers (`sync-docs-from-engine.mjs`, `watch-engine-docs.mjs`, `patch-wrangler.mjs`,
-        `patch-html-title.mjs`, `encode-video.mjs`) plus `scripts/__tests__`. The sync script is MDX-aware and owns the
-        Documentation mirror – it must not gain a hard-coded per-page list (publish set lives in
+        `patch-html-title.mjs`, `encode-video.mjs`, `twoslash-config.mjs`) plus `scripts/__tests__`. The sync script is
+        MDX-aware and owns the Documentation mirror – it must not gain a hard-coded per-page list (publish set lives in
         `packages/blit386/docs/_sitemap.json`). American English; no emoji; keep `pnpm run <script>` command forms
         accurate. Tests use `node --test` via `pnpm run test`.
     - path: 'packages/website/{press.config.tsx,source.config.ts,waku.config.ts}'
       instructions: >-
         Site wiring: Fumapress plugins/layouts/`GLOBAL_HEAD` (`press.config.tsx`), fumadocs-mdx collections and Twoslash
         (`source.config.ts`), Waku/Vite plugins (`waku.config.ts`). MDX components used in engine docs must be
-        registered in `fumadocsMdx({ getMdxComponents })`. Twoslash is gated on `CLOUDFLARE` (production builds only) –
-        do not "fix" that by enabling it in dev. American English; no emoji. When plugins or routing change, check
-        whether `CLAUDE.md` / `README.md` still match (see root `.claude/rules/docs-sync-required.md`).
+        registered in `fumadocsMdx({ getMdxComponents })`. The Twoslash gate lives in `isTwoslashEnabled()`
+        (`scripts/twoslash-config.mjs`) and covers `CLOUDFLARE`, `WORKERS_CI`, and `BLIT386_TWOSLASH` – do not re-inline
+        an env check in `source.config.ts`, and do not "simplify" the adapter-var truthiness, which deliberately mirrors
+        Waku's own `getDefaultAdapter()`. Dev stays off by default (`pnpm run dev:twoslash` is the opt-in); do not turn
+        it on in `dev`, for the measured reasons in `packages/website/CLAUDE.md`, Twoslash. American English; no emoji.
+        When plugins or routing change, check whether `CLAUDE.md` / `README.md` still match (see root
+        `.claude/rules/docs-sync-required.md`).
     - path: 'packages/website/content/**'
       instructions: >-
         Hand-authored MDX and meta (landing, showcase, community, mcp-server, blog, and docs hub pages such as

--- a/packages/website/AGENTS.md
+++ b/packages/website/AGENTS.md
@@ -36,7 +36,9 @@ Use `pnpm run <script>` (not bare `pnpm <script>`) so RTK hooks can rewrite shel
 - Twoslash type-on-hover popups are gated by `isTwoslashEnabled()` in `scripts/twoslash-config.mjs`, which is true for
   `CLOUDFLARE` or `WORKERS_CI` and can be forced either way with `BLIT386_TWOSLASH`. Popups are absent from a plain
   `pnpm run dev`; `pnpm run dev:twoslash` turns them on for one page at a time (browsing many pages OOMs – see
-  `CLAUDE.md`, Twoslash), and `pnpm run build && pnpm run start` is the faithful full-site preview.
+  `CLAUDE.md`, Twoslash), and `pnpm run build && pnpm run start` is the faithful full-site preview. Build the engine
+  first (`pnpm --filter blit386 run build`) for any of those – Twoslash reads `packages/blit386/dist`, and
+  `throws: false` turns a missing build into silently plain code blocks rather than an error.
 - Documentation ships with the change – update `content/` and run `pnpm run docs:links` from the repo root when adding
   links.
 

--- a/packages/website/AGENTS.md
+++ b/packages/website/AGENTS.md
@@ -24,7 +24,7 @@ pnpm --filter blit386-website run preflight    # format:check, typecheck, test, 
 `test` covers both suites: `node --test` over `scripts/**` and Vitest over `src/**`.
 
 Use `pnpm run <script>` (not bare `pnpm <script>`) so RTK hooks can rewrite shell commands. Production builds need
-`CLOUDFLARE=1`, which `pnpm run build` already sets.
+`CLOUDFLARE=1`, which `pnpm run build` already sets; `WORKERS_CI` also counts, and `BLIT386_TWOSLASH` overrides both.
 
 ## Rules that matter most
 
@@ -33,8 +33,10 @@ Use `pnpm run <script>` (not bare `pnpm <script>`) so RTK hooks can rewrite shel
   `pnpm run sync:docs`.
 - No MDX comments. Prettier formats `.mdx` with the Markdown parser, so remark reads `{/* ... */}` as emphasis and
   rewrites it to `{/_ ... _/}`, which renders as visible italic text on the page. Delete the note or make it real prose.
-- Twoslash type-on-hover popups are gated on `!!process.env.CLOUDFLARE` (a memory workaround, not a build-mode check),
-  so popups are absent from a plain `pnpm run dev` – use `pnpm run build && pnpm run start` to see the real thing.
+- Twoslash type-on-hover popups are gated by `isTwoslashEnabled()` in `scripts/twoslash-config.mjs`, which is true for
+  `CLOUDFLARE` or `WORKERS_CI` and can be forced either way with `BLIT386_TWOSLASH`. Popups are absent from a plain
+  `pnpm run dev`; `pnpm run dev:twoslash` turns them on for one page at a time (browsing many pages OOMs – see
+  `CLAUDE.md`, Twoslash), and `pnpm run build && pnpm run start` is the faithful full-site preview.
 - Documentation ships with the change – update `content/` and run `pnpm run docs:links` from the repo root when adding
   links.
 
@@ -46,7 +48,7 @@ Hand-authored: `content/index.mdx`, `content/blog/**`, and a handful of top-leve
 
 ## Where to go next
 
-[`CLAUDE.md`](CLAUDE.md) has the full "Where to Find Information" routing table, documentation-mirror mechanics,
-Twoslash memory-constraint detail, and blog-media conventions.
+[`CLAUDE.md`](CLAUDE.md) has the full "Where to Find Information" routing table, documentation-mirror mechanics, the
+Twoslash gate and its measured dev cost, and blog-media conventions.
 
 Condensed, always-applicable agent rules also live in the root `.claude/rules/*.md`.

--- a/packages/website/CLAUDE.md
+++ b/packages/website/CLAUDE.md
@@ -10,8 +10,8 @@ tables, …) live in the root [`CLAUDE.md`](../../CLAUDE.md) – read together w
 Scripts are `pnpm run <script>` from this package's directory (or `pnpm --filter blit386-website run <script>` from the
 repo root); `package.json` is the list and `pnpm run preflight` is the gating set (it includes the build and, last of
 all, the docs-mirror check – see Documentation mirror). Production builds require `CLOUDFLARE=1`, which `pnpm run build`
-already sets. Shell commands are rewritten by `rtk hook claude` – prefer `rtk read` / `rtk grep` over native Read/Grep
-for exploration.
+already sets; `WORKERS_CI` works too, and `BLIT386_TWOSLASH` overrides either (see Twoslash). Shell commands are
+rewritten by `rtk hook claude` – prefer `rtk read` / `rtk grep` over native Read/Grep for exploration.
 
 ## Critical Rules
 
@@ -36,6 +36,7 @@ for exploration.
 | --- | --- |
 | Site and plugin config, layouts, global head, MDX component map | `press.config.tsx` |
 | MDX collection config, Twoslash wiring | `source.config.ts` |
+| Twoslash gate, compiler options | `scripts/twoslash-config.mjs` |
 | Waku / Vite plugins | `waku.config.ts` |
 | Generated MDX loader | `.source/` (gitignored; run `fumadocs-mdx` or `pnpm run typecheck`) |
 | Engine API truth | `packages/blit386/docs/` in this monorepo – never this package |
@@ -182,21 +183,60 @@ block that fails compilation degrades to plain highlighting instead of crashing 
 
 `blit386` is a `workspace:*` devDependency (BT-414), not a pinned npm version – Twoslash resolves its type declarations
 from `packages/blit386/dist`, so a doc can reference and validate unreleased engine API before it ships, and the engine
-must be built (`pnpm --filter blit386 run build`) before this package's `build` in every CI/deploy job that runs one.
-Because `throws: false` swallows a failing block into plain highlighting rather than an error, a regression here is
-silent. `grep -c twoslash-hover "dist/public/docs/<page>/index.html"` after a build (`<page>` is a placeholder, e.g.
+must be built (`pnpm --filter blit386 run build`) before this package's `build` in every CI/deploy job that runs one –
+and now before `pnpm run dev:twoslash` too, since dev can run the transformer as well. Because `throws: false` swallows
+a failing block into plain highlighting rather than an error, a regression here is silent.
+`grep -c twoslash-hover "dist/public/docs/<page>/index.html"` after a build (`<page>` is a placeholder, e.g.
 `api/random`; keep it quoted or the shell reads `<`/`>` as redirection) is only a page-wide smoke check, not proof a
 specific block typechecked – a page with several blocks can show a nonzero count while one block still silently failed
 (see BT-427). To confirm one block specifically, grep the built HTML for a distinctive identifier from that block's
 source and check whether it renders as a hoverable `twoslash-hover` token instead of plain syntax-highlighted text.
 
-Dev-mode skip (memory constraint): the transformer is gated on `!!process.env.CLOUDFLARE`. `blit386.d.ts` is ~192 KB and
-imports WebGPU types; across the several dozen MDX files the TypeScript language service accumulates over 4 GB during
-`waku dev` and OOMs. `NODE_ENV` is not a usable signal because `source.config.ts` is evaluated by the fumadocs-mdx Vite
-plugin before Vite writes `NODE_ENV=production`. So Twoslash runs whenever `CLOUDFLARE` is truthy – in practice that
-means `pnpm run build` (which sets `CLOUDFLARE=1`), or any other command launched with `CLOUDFLARE=1` in the
-environment. Popups are absent from a plain `pnpm run dev` – use `pnpm run build && pnpm run start` to preview the real
-thing.
+### The gate
+
+`isTwoslashEnabled()` in `scripts/twoslash-config.mjs` decides whether the transformer runs. Absent an override it
+mirrors `getDefaultAdapter()` in `waku/dist/lib/utils/config.js` exactly – true for `CLOUDFLARE` **or** `WORKERS_CI`,
+read for plain truthiness, so `CLOUDFLARE=0` counts as on. That asymmetry is deliberate: the contract is "Twoslash runs
+iff Waku selected its Cloudflare adapter", and checking only `CLOUDFLARE` is what let a Cloudflare Workers Builds run
+ship the site with every popup missing, silently, because `throws: false` degrades rather than errors (BT-188).
+`BLIT386_TWOSLASH` is the human escape hatch and gets human semantics: set it to force Twoslash on in dev, or to
+`0`/`false` to force it off during a build for a faster loop. `NODE_ENV` is not a usable signal because
+`source.config.ts` is evaluated by the fumadocs-mdx Vite plugin before Vite writes `NODE_ENV=production`.
+
+Keep the check in `twoslash-config.mjs`; do not re-inline an env read into `source.config.ts`.
+`scripts/__tests__/twoslash-enabled.test.mjs` pins every case, including the `package.json` copies of the env-var names
+– the only copies that live outside TypeScript.
+
+### Dev mode and its real cost (measured 2026-08-21, M4 Max / 64 GB, Node 26.7.0)
+
+`pnpm run dev:twoslash` turns popups on locally. It is **not** the default, and it carries `--max-old-space-size=8192`,
+because dev-mode Twoslash is genuinely expensive – though not for the reason this file asserted until BT-188 measured
+it.
+
+**The language service is cheap.** `fumadocs-twoslash` memoizes the twoslasher in a module-level `cachedInstance`, and
+`twoslash` caches the virtual TS environment keyed on a hash of the compiler options – every block here uses the same
+options, so exactly **one** language service serves the whole process, not one per MDX file. Replaying all 155 blocks
+through it peaks at **318 MB RSS / 120 MB heap** in 4.0 s, p50 8 ms per block, and the heap is flat: three full sweeps
+end at 318, 322, 323 MB. Dev is lazier still – with `async: true` the eager pass reads frontmatter only, so Twoslash
+runs per page you actually open. `blit386.d.ts` is **288,348 bytes**, not the ~192 KB previously claimed here.
+
+**The rendered payload is what costs.** A twoslashed page serves **~6.8 MB of HTML against ~0.6 MB plain** (`api/audio`
+carries 215 hover tokens), and the dev server retains roughly **2 GB of RSS per distinct page visited**, monotonically.
+The OOM stack tops out in `JsonStringify`/`ApplyReplacerFunction` – RSC payload serialization – not in TypeScript. So
+the growth is unbounded in pages browsed and no fixed heap fixes a full sweep: the 4 GB default dies after 2 pages, 8 GB
+after 4.
+
+**What that means in practice.** Editing one page is fine and is the workflow the script is for: first load of
+`api/audio` takes 5.3 s and settles at ~4.7 GB, then five edit-and-reload cycles hold at 2.7 s and plateau around 5.9 GB
+with all 215 popups intact. **Browsing the whole docs section under `dev:twoslash` will OOM.** Restart the server if you
+need to move on to another heavy page. For a faithful full-site preview use `pnpm run build && pnpm run start`, which is
+single-shot and streams to disk.
+
+Two options measured and rejected, so nobody re-tries them: `fsCache: false` is worse on both axes (353 MB peak, p50 18
+ms), and `cache: false` – a fresh environment per block – costs 388 MB and 31 s for a 24x latency regression. Both are
+already-correct defaults. Per-block opt-in was also considered and does not apply: every Twoslash block lives in the
+generated mirror owned by `packages/blit386/docs/`, so a dev-only fence marker would have to ship into the published
+engine docs – and lazy dev compilation already gives per-page opt-in for free.
 
 ## Dependency pins
 
@@ -244,8 +284,8 @@ turns those red rather than silently degrading production. That is the largest p
 It is not the whole of it. The suite calls the plugins directly with doubles, so it cannot see anything that lives in
 the wiring or the build, and these still need a real build diffed against a baseline captured on the old pins:
 
-- per-page `twoslash-hover` counts (the transformer only runs under `CLOUDFLARE=1`, and `throws: false` degrades a
-  failing block silently)
+- per-page `twoslash-hover` counts (the transformer only runs when `isTwoslashEnabled()` is true, and `throws: false`
+  degrades a failing block silently)
 - `dist/server/wrangler.json` assertions – `run_worker_first`, `nodejs_compat`, `vars.BLIT386_CHANNEL`
 - the plugin chain order in `press.config.tsx`, which the unit tests do not construct
 - OG card geometry (1200x630), and the layout and RSC surface generally

--- a/packages/website/README.md
+++ b/packages/website/README.md
@@ -13,7 +13,7 @@ Beyond rendering MDX, the site ships a few things worth knowing about:
 
 - Full engine API reference and guides, generated from `packages/blit386` (see [Content](#content) below).
 - Twoslash type-on-hover popups in TypeScript code blocks (on in production builds; `pnpm run dev:twoslash` enables them
-  locally, one page at a time – see `CLAUDE.md`, Twoslash).
+  locally, one page at a time – see [Development](#development) and `CLAUDE.md`, Twoslash).
 - An MCP server at `/mcp` so AI assistants can search the docs; setup instructions live on the site at `/mcp-server`.
 - `Accept: text/markdown` content negotiation: any canonical doc URL returns clean markdown to agents that ask for it,
   and `/llms.txt` summarizes the whole site.
@@ -38,6 +38,19 @@ pnpm run dev
 ```
 
 Open the URL printed by Waku (typically `http://localhost:3000`).
+
+`pnpm run dev` leaves Twoslash off. To get type-on-hover popups locally, build the engine first and use the opt-in
+script – Twoslash resolves its declarations from `packages/blit386/dist`, and because the transformer runs with
+`throws: false`, skipping that build degrades every block to plain highlighting **silently**:
+
+```bash
+pnpm --filter blit386 run build
+pnpm run dev:twoslash
+```
+
+It is deliberately not the default: it carries an 8 GB heap and holds for one page at a time, so browsing the whole docs
+section under it will run out of memory. `pnpm run build && pnpm run start` is the faithful full-site preview. See
+`CLAUDE.md`, Twoslash for the measurements.
 
 ## Quality checks
 

--- a/packages/website/README.md
+++ b/packages/website/README.md
@@ -12,7 +12,8 @@ Workers.
 Beyond rendering MDX, the site ships a few things worth knowing about:
 
 - Full engine API reference and guides, generated from `packages/blit386` (see [Content](#content) below).
-- Twoslash type-on-hover popups in TypeScript code blocks (production builds only – see `CLAUDE.md`, Twoslash).
+- Twoslash type-on-hover popups in TypeScript code blocks (on in production builds; `pnpm run dev:twoslash` enables them
+  locally, one page at a time – see `CLAUDE.md`, Twoslash).
 - An MCP server at `/mcp` so AI assistants can search the docs; setup instructions live on the site at `/mcp-server`.
 - `Accept: text/markdown` content negotiation: any canonical doc URL returns clean markdown to agents that ask for it,
   and `/llms.txt` summarizes the whole site.

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -32,6 +32,7 @@
   "packageManager": "pnpm@11.20.0",
   "scripts": {
     "dev": "waku dev",
+    "dev:twoslash": "cross-env BLIT386_TWOSLASH=1 NODE_OPTIONS=--max-old-space-size=8192 waku dev",
     "build": "fumadocs-mdx && cross-env CLOUDFLARE=1 waku build",
     "postbuild": "node scripts/patch-wrangler.mjs && node scripts/patch-html-title.mjs",
     "start": "wrangler dev --config dist/server/wrangler.json",

--- a/packages/website/scripts/__tests__/twoslash-enabled.test.mjs
+++ b/packages/website/scripts/__tests__/twoslash-enabled.test.mjs
@@ -1,0 +1,77 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { isTwoslashEnabled, TWOSLASH_ENV_VAR } from '../twoslash-config.mjs';
+
+describe('isTwoslashEnabled (BT-188)', () => {
+    test('is off when nothing is set', () => {
+        assert.equal(isTwoslashEnabled({}), false);
+    });
+
+    test('is on for CLOUDFLARE', () => {
+        assert.equal(isTwoslashEnabled({ CLOUDFLARE: '1' }), true);
+    });
+
+    test('is on for WORKERS_CI', () => {
+        // The BT-188 regression guard. Waku selects its Cloudflare adapter on either
+        // var, so a Cloudflare Workers Builds run used to produce a build with every
+        // Twoslash popup missing, and silently, because `throws: false` degrades a
+        // failing block to plain highlighting rather than erroring.
+        assert.equal(isTwoslashEnabled({ WORKERS_CI: '1' }), true);
+    });
+
+    test(`is on for ${TWOSLASH_ENV_VAR} alone, with no adapter var present`, () => {
+        assert.equal(isTwoslashEnabled({ [TWOSLASH_ENV_VAR]: '1' }), true);
+    });
+
+    test(`${TWOSLASH_ENV_VAR}=0 overrides an adapter var`, () => {
+        assert.equal(isTwoslashEnabled({ CLOUDFLARE: '1', [TWOSLASH_ENV_VAR]: '0' }), false);
+    });
+
+    test(`${TWOSLASH_ENV_VAR}=false is off, case-insensitively`, () => {
+        assert.equal(isTwoslashEnabled({ [TWOSLASH_ENV_VAR]: 'false' }), false);
+        assert.equal(isTwoslashEnabled({ [TWOSLASH_ENV_VAR]: 'FALSE' }), false);
+    });
+
+    test(`an empty ${TWOSLASH_ENV_VAR} falls through to adapter detection`, () => {
+        assert.equal(isTwoslashEnabled({ [TWOSLASH_ENV_VAR]: '' }), false);
+        assert.equal(isTwoslashEnabled({ [TWOSLASH_ENV_VAR]: '', CLOUDFLARE: '1' }), true);
+    });
+
+    test('CLOUDFLARE=0 is on, deliberately mirroring Waku', () => {
+        // Not a bug to fix: getDefaultAdapter() in waku/dist/lib/utils/config.js reads
+        // these vars for plain truthiness, so CLOUDFLARE=0 still selects the Cloudflare
+        // adapter. The gate must agree with the adapter, not with intent.
+        assert.equal(isTwoslashEnabled({ CLOUDFLARE: '0' }), true);
+    });
+
+    test('reads process.env when called with no argument', (t) => {
+        const original = process.env.CLOUDFLARE;
+        t.after(() => {
+            if (original === undefined) delete process.env.CLOUDFLARE;
+            else process.env.CLOUDFLARE = original;
+        });
+
+        process.env.CLOUDFLARE = '1';
+        assert.equal(isTwoslashEnabled(), true);
+    });
+});
+
+describe('package.json scripts stay in sync with the gate', () => {
+    const scripts = JSON.parse(readFileSync(join(import.meta.dirname, '../../package.json'), 'utf8')).scripts;
+
+    test('dev:twoslash sets the env var the gate reads', () => {
+        // The only copy of TWOSLASH_ENV_VAR that lives outside TypeScript, so nothing
+        // but this assertion keeps the two spellings honest.
+        assert.match(scripts['dev:twoslash'], new RegExp(`${TWOSLASH_ENV_VAR}=1\\b`));
+    });
+
+    test('dev leaves Twoslash off', () => {
+        assert.equal(scripts.dev.includes(TWOSLASH_ENV_VAR), false);
+    });
+
+    test('build still sets CLOUDFLARE=1', () => {
+        assert.match(scripts.build, /CLOUDFLARE=1\b/);
+    });
+});

--- a/packages/website/scripts/__tests__/twoslash-webgpu-types.test.mjs
+++ b/packages/website/scripts/__tests__/twoslash-webgpu-types.test.mjs
@@ -1,7 +1,7 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
 import { twoslasher } from 'twoslash';
-import { TWOSLASH_COMPILER_OPTIONS } from '../twoslash-compiler-options.mjs';
+import { TWOSLASH_COMPILER_OPTIONS } from '../twoslash-config.mjs';
 
 // The `Effect` interface example from packages/blit386/docs/guide-post-process-effects.md.
 const EFFECT_INTERFACE_EXAMPLE = `import type { Effect, EffectTier, Vector2i } from 'blit386';

--- a/packages/website/scripts/twoslash-compiler-options.mjs
+++ b/packages/website/scripts/twoslash-compiler-options.mjs
@@ -1,5 +1,0 @@
-// Shared between source.config.ts's transformerTwoslash call and
-// scripts/__tests__/twoslash-webgpu-types.test.mjs, so the regression test
-// exercises the same compiler options the production build uses (BT-431)
-// instead of a copy that could drift out of sync.
-export const TWOSLASH_COMPILER_OPTIONS = { types: ['@webgpu/types', 'node'] };

--- a/packages/website/scripts/twoslash-config.mjs
+++ b/packages/website/scripts/twoslash-config.mjs
@@ -1,0 +1,39 @@
+// Twoslash gate and compiler options, shared between source.config.ts's
+// transformerTwoslash call and scripts/__tests__/, so the regression tests
+// exercise the same configuration the production build uses (BT-431, BT-188)
+// instead of a copy that could drift out of sync.
+
+// Explicit human override, honored in both directions: set it to turn Twoslash
+// on in dev (`pnpm run dev:twoslash`), or to '0'/'false' to turn it off during a
+// production build for a faster iteration loop. Also read from package.json, so
+// scripts/__tests__/twoslash-enabled.test.mjs asserts the two copies agree.
+export const TWOSLASH_ENV_VAR = 'BLIT386_TWOSLASH';
+
+const EXPLICIT_OFF = new Set(['0', 'false']);
+
+export const TWOSLASH_COMPILER_OPTIONS = { types: ['@webgpu/types', 'node'] };
+
+/**
+ * Whether the Twoslash transformer should run.
+ *
+ * Absent an explicit override the contract is "Twoslash runs iff Waku selected its Cloudflare adapter", so the
+ * fallback mirrors `getDefaultAdapter()` in `waku/dist/lib/utils/config.js` exactly – including its plain-truthiness
+ * quirk, under which `CLOUDFLARE=0` still selects the Cloudflare adapter. Do not "fix" that asymmetry: these are
+ * machine signals, and diverging from Waku is what let a `WORKERS_CI` build ship every popup missing and silent
+ * (BT-188). `TWOSLASH_ENV_VAR` is the escape hatch for humans and gets human semantics.
+ *
+ * `NODE_ENV` is not usable as the signal: `source.config.ts` is evaluated by the fumadocs-mdx Vite plugin before Vite
+ * writes `NODE_ENV=production` into the environment.
+ *
+ * @param {Record<string, string | undefined>} [env] Environment to read; defaults to `process.env`.
+ * @returns {boolean}
+ */
+export function isTwoslashEnabled(env = process.env) {
+    const override = env[TWOSLASH_ENV_VAR];
+
+    if (override !== undefined && override !== '') {
+        return !EXPLICIT_OFF.has(override.toLowerCase());
+    }
+
+    return Boolean(env.CLOUDFLARE || env.WORKERS_CI);
+}

--- a/packages/website/source.config.ts
+++ b/packages/website/source.config.ts
@@ -2,16 +2,20 @@ import { defineConfig, defineDocs } from 'fumadocs-mdx/config';
 import { blogMetaSchema, blogPageSchema, metaSchema, pageSchema } from 'fumapress/adapters/mdx/schema';
 import { transformerTwoslash } from 'fumadocs-twoslash';
 import { z } from 'zod';
-import { TWOSLASH_COMPILER_OPTIONS } from './scripts/twoslash-compiler-options.mjs';
+import { isTwoslashEnabled, TWOSLASH_COMPILER_OPTIONS } from './scripts/twoslash-config.mjs';
 
-// Twoslash spins up a TypeScript language service that loads blit386.d.ts plus
-// WebGPU types for every MDX file. Across the several dozen MDX files in content/ the
-// cumulative heap exceeds Node's default 4 GB limit and the dev server OOMs.
-// Skip it during `waku dev`;
-// production builds set CLOUDFLARE=1 (single-shot, survives the memory spike).
-// NODE_ENV is not a reliable signal here: source.config.ts is evaluated by the
-// fumadocs-mdx Vite plugin before Vite writes NODE_ENV=production into the env.
-const isProductionBuild = !!process.env.CLOUDFLARE;
+// Gated in scripts/twoslash-config.mjs: on for CLOUDFLARE or WORKERS_CI (Waku's own
+// adapter-selection vars, so this tracks "is this a Cloudflare build"), with
+// BLIT386_TWOSLASH overriding either way. Keep the check there rather than inlining an
+// env read here: covering only CLOUDFLARE is what let a WORKERS_CI build ship every
+// popup missing and silent (BT-188).
+//
+// Dev is opt-in (`pnpm run dev:twoslash`) because the annotated page payload is huge,
+// not because the language service is: one shared service handles all 155 blocks in
+// ~320 MB, but a twoslashed page renders ~6.8 MB of HTML against ~0.6 MB plain, and the
+// dev server retains roughly 2 GB per distinct page visited. Measurements and the
+// resulting usage limits: CLAUDE.md, Twoslash.
+const twoslashEnabled = isTwoslashEnabled();
 
 export default defineConfig({
     mdxOptions: {
@@ -19,7 +23,7 @@ export default defineConfig({
             themes: { light: 'github-light', dark: 'github-dark' },
             defaultColor: false,
             langs: ['js', 'jsx', 'ts', 'tsx'],
-            transformers: isProductionBuild
+            transformers: twoslashEnabled
                 ? [
                       transformerTwoslash({
                           throws: false,


### PR DESCRIPTION
Closes BT-188.

BT-188 asked us to either make dev-mode Twoslash work within a reasonable memory budget or document why it stays build-only. Measuring it first turned up something better and something worse than expected: **the documented rationale was wrong**, and **the gate had a silent latent bug**.

## The rationale was wrong

`source.config.ts` and `CLAUDE.md` both claimed Twoslash "spins up a TypeScript language service that loads `blit386.d.ts` plus WebGPU types **for every MDX file**" and that the cumulative heap "exceeds Node's default 4 GB limit". Neither half holds:

- `fumadocs-twoslash` memoizes the twoslasher in a module-level `cachedInstance`, and `twoslash` caches the virtual TS environment keyed on a hash of the compiler options. Every block here uses the same options, so **one** language service serves the whole process.
- With `async: true` the eager dev pass reads frontmatter only (`only === 'frontmatter'` returns before `buildMDX` is imported), so the transformer runs **per page opened**, not across the whole collection.

Measured on M4 Max / 64 GB / Node 26.7.0, replaying all 155 blocks through one shared service:

| | |
| --- | --- |
| Peak RSS / heap | **318 MB** / 120 MB |
| Wall, 155 blocks | 4.0 s, p50 **8 ms**/block |
| Heap across 3 full sweeps | 318 → 322 → 323 MB (flat, no leak) |
| `blit386.d.ts` | **288,348 bytes**, not the ~192 KB claimed |

## What actually costs

The rendered payload, not the type checking. A twoslashed page serves **~6.8 MB of HTML against ~0.6 MB plain** (`api/audio` carries 215 hover tokens), and the dev server retains roughly **2 GB RSS per distinct page visited**. The OOM stack tops out in `JsonStringify` / `ApplyReplacerFunction` (RSC payload serialization), not in TypeScript. That growth is unbounded in pages browsed, so no fixed heap survives a full sweep: 4 GB dies after 2 pages, 8 GB after 4.

Editing one page is stable, though, and that is the real workflow: first load of `api/audio` takes 5.3 s and settles at ~4.7 GB, then five edit-and-reload cycles hold at 2.7 s and plateau around 5.9 GB with all 215 popups intact. So `pnpm run dev:twoslash` ships with `--max-old-space-size=8192` baked in, and `CLAUDE.md` states plainly that browsing the whole docs section under it will OOM.

Two knobs measured and **rejected**, recorded so nobody retries them: `fsCache: false` is worse on both axes (353 MB peak, p50 18 ms), and `cache: false` costs 388 MB and a 24x latency regression. The issue's per-file opt-in idea is closed as not applicable, since every block lives in the generated mirror owned by `packages/blit386/docs/`.

## The latent bug

Waku selects its Cloudflare adapter on `CLOUDFLARE` **or** `WORKERS_CI` (`waku/dist/lib/utils/config.js`), but the gate only checked the first. A Cloudflare Workers Builds run would therefore ship the site with every popup missing, and silently, because `throws: false` degrades a failing block to plain highlighting rather than erroring.

Proven by building both ways:

| Build | Before | After |
| --- | --- | --- |
| `WORKERS_CI=1` | **0 / 0 / 0** | **215 / 102 / 105** |

(`api/audio` / `api/assets` / `api/random`, exit 0 in every case.)

`isTwoslashEnabled()` now mirrors Waku's `getDefaultAdapter()` exactly, including its plain-truthiness quirk where `CLOUDFLARE=0` still selects the Cloudflare adapter. That asymmetry is deliberate and commented: the contract is "Twoslash runs iff Waku selected the Cloudflare adapter", not "iff someone meant yes". `BLIT386_TWOSLASH` is the human escape hatch and gets human semantics, honored in both directions.

`.coderabbit.yaml` previously instructed reviewers not to "fix" the gate by enabling it in dev, which would have blocked this PR; it now points at the measured rationale and guards the parts that must not drift.

## Test plan

- [x] `pnpm --filter blit386-website run preflight` exit 0 (format, typecheck, 203/203 script tests, spellcheck, knip, build, sync:docs:check)
- [x] New `scripts/__tests__/twoslash-enabled.test.mjs`, 12 cases, including the `WORKERS_CI` regression guard, the `CLOUDFLARE=0` mirror-Waku case, the empty-string fallthrough, and a manual-sync test pinning the `package.json` copies of the env var names (the only copies outside TypeScript)
- [x] Gate proof, production: `pnpm run build` then `grep -c 'twoslash-hover"'` gives 215 / 102 / 105
- [x] Gate proof, `WORKERS_CI=1`: 0 before, 215 / 102 / 105 after
- [x] Gate proof, kill switch: `BLIT386_TWOSLASH=0 CLOUDFLARE=1` gives 0 / 0 / 0
- [x] Gate proof, dev: `pnpm run dev:twoslash` serves 215 hovers on `api/audio` and survives an edit cycle; plain `pnpm run dev` serves 0 across all 25 doc routes
- [x] Root gates: `docs:links`, `agents:check`, `check-dash-typography`, `bump:check`

## Noted, not fixed here

Measurement surfaced **three pre-existing Twoslash blocks that fail compilation and render as plain code today** (TS2307 on `vitest` and on relative imports, in `reference-testing.md` and `performance-testing.md`) - the BT-427 class of silent failure. Left out of this PR deliberately, since they are content bugs in `packages/blit386/docs/` rather than gate bugs, and are being handled separately.

Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional `dev:twoslash` command for enabling type-on-hover popups during local development.
  * Twoslash now supports consistent activation across Cloudflare, Workers CI, production builds, and explicit overrides.
  * Added guidance for missing declaration files, full-site previews, and development resource requirements.

* **Documentation**
  * Updated website setup, configuration, validation, and performance guidance.

* **Tests**
  * Added coverage for activation rules and development/build script settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->