### PR TITLE
docs(docs): make the three failing testing twoslash blocks compile

### DIFF
--- a/packages/blit386/.claude/rules/twoslash-docs.md
+++ b/packages/blit386/.claude/rules/twoslash-docs.md
@@ -30,6 +30,35 @@ BT.paletteFade(nightPalette, 2000, 'ease-in-out');
 
 Everything above `// ---cut---` is compiled by TypeScript but hidden from the reader. Everything below is shown.
 
+**Multi-file block** (the visible code imports a relative module that does not exist – a test file importing its
+subject, a benchmark importing the type it measures – use hidden `// @filename:` stubs before the cut):
+
+```ts twoslash
+// @filename: MyType.ts
+export declare class MyType {
+  newMethod(): void;
+}
+// @filename: MyType.bench.ts
+// ---cut---
+import { bench, describe } from 'vitest';
+
+import { MyType } from './MyType';
+
+describe('MyType hot paths', () => {
+  const instance = new MyType();
+
+  bench('newMethod()', () => {
+    instance.newMethod();
+  });
+});
+```
+
+Each `// @filename:` opens a virtual file; the last one holds the visible code, and its path has to sit at the depth the
+relative import expects (`../__test__/webgpu-mock` needs the visible file one directory down, e.g.
+`render/SpritePipeline.test.ts`). Stub the imported module with `export declare class` / `export declare function` –
+signatures only, no bodies. Real packages (`vitest`) resolve from `packages/website/node_modules` and need no stub;
+`declare module 'vitest'` in a block that has imports is a module _augmentation_ and fails instead.
+
 Preamble rules:
 
 - Import all blit386 names used in the block from `'blit386'` in one line.

--- a/packages/blit386/docs/performance-testing.md
+++ b/packages/blit386/docs/performance-testing.md
@@ -104,6 +104,13 @@ src/render/SpritePipeline.bench.ts
 ### Basic structure
 
 ```ts twoslash
+// @filename: MyType.ts
+export declare class MyType {
+  newMethod(): void;
+  oldMethod(): void;
+}
+// @filename: MyType.bench.ts
+// ---cut---
 import { bench, describe } from 'vitest';
 
 import { MyType } from './MyType';

--- a/packages/blit386/docs/reference-testing.md
+++ b/packages/blit386/docs/reference-testing.md
@@ -137,6 +137,13 @@ tests/visual/
 ## Writing a new test
 
 ```ts twoslash
+// @filename: MyClass.ts
+export declare class MyClass {
+  myMethod(): number;
+}
+// @filename: MyClass.test.ts
+declare const expected: number;
+// ---cut---
 import { describe, expect, it } from 'vitest';
 
 import { MyClass } from './MyClass';
@@ -179,6 +186,11 @@ Use these patterns when adding or reviewing palette-related features:
 For tests that need GPU objects, import from the mock factory:
 
 ```ts twoslash
+// @filename: __test__/webgpu-mock.ts
+export declare function createMockGPUDevice(): GPUDevice;
+export declare function createMockGPUTexture(width: number, height: number): GPUTexture;
+// @filename: render/SpritePipeline.test.ts
+// ---cut---
 import { createMockGPUDevice, createMockGPUTexture } from '../__test__/webgpu-mock';
 
 const device = createMockGPUDevice();

--- a/packages/website/content/docs/performance/testing.mdx
+++ b/packages/website/content/docs/performance/testing.mdx
@@ -3,7 +3,7 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Performance Testing"
 description: "CPU micro-benchmarks: when to use them, how to add one, and the CI benchmark gate."
-lastModified: "2026-07-28T16:49:29+02:00"
+lastModified: "2026-08-21T08:18:38+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/performance-testing.md"
 ---
 
@@ -101,6 +101,13 @@ src/render/SpritePipeline.bench.ts
 ### Basic structure
 
 ```ts twoslash
+// @filename: MyType.ts
+export declare class MyType {
+  newMethod(): void;
+  oldMethod(): void;
+}
+// @filename: MyType.bench.ts
+// ---cut---
 import { bench, describe } from 'vitest';
 
 import { MyType } from './MyType';

--- a/packages/website/content/docs/reference/testing.mdx
+++ b/packages/website/content/docs/reference/testing.mdx
@@ -3,7 +3,7 @@
 # Do not edit by hand: edit the engine source, then run `pnpm run sync:docs`.
 title: "Testing"
 description: "Testing tiers (unit, integration, visual) plus CPU benchmarks and WebGPU mocks."
-lastModified: "2026-08-08T14:20:19+02:00"
+lastModified: "2026-08-21T08:18:38+02:00"
 editUrl: "https://github.com/blit386/blit386/blob/main/docs/reference-testing.md"
 ---
 
@@ -134,6 +134,13 @@ tests/visual/
 ## Writing a new test
 
 ```ts twoslash
+// @filename: MyClass.ts
+export declare class MyClass {
+  myMethod(): number;
+}
+// @filename: MyClass.test.ts
+declare const expected: number;
+// ---cut---
 import { describe, expect, it } from 'vitest';
 
 import { MyClass } from './MyClass';
@@ -176,6 +183,11 @@ Use these patterns when adding or reviewing palette-related features:
 For tests that need GPU objects, import from the mock factory:
 
 ```ts twoslash
+// @filename: __test__/webgpu-mock.ts
+export declare function createMockGPUDevice(): GPUDevice;
+export declare function createMockGPUTexture(width: number, height: number): GPUTexture;
+// @filename: render/SpritePipeline.test.ts
+// ---cut---
 import { createMockGPUDevice, createMockGPUTexture } from '../__test__/webgpu-mock';
 
 const device = createMockGPUDevice();


### PR DESCRIPTION
## Summary

Three Twoslash blocks in the published docs failed compilation and silently degraded to plain highlighting on
blit386.dev – no type-on-hover popups at all (the BT-427 failure mode that `packages/website/CLAUDE.md` warns about).
Found while measuring Twoslash cost for BT-188.

| Block | Diagnostics | Cause |
| --- | --- | --- |
| `docs/reference-testing.md` "Writing a new test" | TS2307, TS2552 | imports `./MyClass`, references undeclared `expected` |
| `docs/reference-testing.md` "WebGPU mock usage" | TS2307 | imports `../__test__/webgpu-mock` |
| `docs/performance-testing.md` "Basic structure" | TS2307 | imports `./MyType` |

Each block now carries a hidden `// @filename:` preamble that stubs the imported module with signature-only
declarations, followed by `// ---cut---`. The visible code is byte-identical to what was there before, and no
`// @noErrors` was added – per `packages/blit386/.claude/rules/twoslash-docs.md`.

`declare module 'vitest'` is not usable in these blocks: in a sample that has imports it is a module *augmentation*, not
an ambient declaration, so it fails with TS2664. `vitest` itself resolves from the website's `node_modules` and never
needed a stub – only the relative imports did.

The rule file gains a third documented pattern (multi-file), which it previously did not cover: it only described
self-contained blocks and single-file fragments.

Canonical files in `packages/blit386/docs/` were edited; `packages/website/content/docs/` was regenerated with
`pnpm --filter blit386-website run sync:docs` in a separate commit, after the source commit landed, so the
`lastModified` stamps match `git log` on the source files.

## Test plan

- [x] Twoslash harness over every published doc (`api-*`, `guide-*`, `performance-*`, `reference-*`) with the production
      `TWOSLASH_COMPILER_OPTIONS`: every block compiles, no throws
- [x] `pnpm --filter blit386-website run build` succeeds
- [x] Built HTML hover counts match twoslasher's reported hovers exactly, so no block on either page falls back to plain
      highlighting: `docs/reference/testing/index.html` 40 `twoslash-hover` occurrences (20 hovers – 14 from block 1,
      6 from block 2), `docs/performance/testing/index.html` 24 (12 hovers, the page's one block)
- [x] Neither built page leaks `@filename` or `---cut---` into the rendered output
- [x] `pnpm --filter blit386 run preflight` clean
- [x] `pnpm --filter blit386-website run preflight` clean, including `sync:docs:check` ("Docs mirror matches the engine
      source")
- [x] Pre-push root pass clean: `format:check`, `docs:links`, `agents:check`, `check-dash-typography`, `bump:check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for documenting multi-file Twoslash examples, imports, and module stubs.
  * Updated performance-testing examples with typed benchmark declarations.
  * Enhanced reference-testing examples with filename directives, class declarations, expected values, and WebGPU mock helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->