### PR TITLE
refactor(kit): derive AddableAgent and AgentChoice from AgentKind

### DIFF
--- a/packages/create-blit386/src/scaffold.ts
+++ b/packages/create-blit386/src/scaffold.ts
@@ -20,6 +20,7 @@ import { dirname, join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
     agentsFile,
+    type AgentKind,
     classifyFile,
     collectDocs,
     type FileClass,
@@ -80,7 +81,7 @@ interface BlitManifest {
     files: ManifestEntry[];
 }
 
-export type AgentChoice = 'none' | 'claude' | 'cursor';
+export type AgentChoice = 'none' | AgentKind;
 
 /** Which language layer to scaffold. */
 export type LanguageChoice = 'js' | 'ts';

--- a/packages/create-blit386/src/wizard.ts
+++ b/packages/create-blit386/src/wizard.ts
@@ -6,6 +6,8 @@
 
 import { cancel, confirm, isCancel, select } from '@clack/prompts';
 
+import { AGENT_LABEL, AGENT_SETUP_HINT } from '@blit386/kit/adapters';
+
 import type { AgentChoice, LanguageChoice } from './scaffold';
 
 export interface WizardOptions {
@@ -37,8 +39,8 @@ export async function runWizard(): Promise<WizardOptions> {
         initialValue: 'none',
         options: [
             { value: 'none', label: 'No, just the game and docs', hint: 'recommended to start' },
-            { value: 'claude', label: 'Claude Code', hint: 'adds CLAUDE.md' },
-            { value: 'cursor', label: 'Cursor', hint: 'adds .cursor/rules' },
+            { value: 'claude', label: AGENT_LABEL.claude, hint: AGENT_SETUP_HINT.claude },
+            { value: 'cursor', label: AGENT_LABEL.cursor, hint: AGENT_SETUP_HINT.cursor },
         ],
     });
     if (isCancel(agent)) {

--- a/packages/kit/src/adapters.ts
+++ b/packages/kit/src/adapters.ts
@@ -29,7 +29,17 @@ import {
 // Ownership classification lives in its own leaf module (the generators below build every path they
 // emit from its constants), re-exported here because `./adapters` is the kit's only published
 // subpath – create-blit386 imports these from '@blit386/kit/adapters'.
-export { type AgentKind, type FileClass, classifyFile, hasAgentFiles, isAgentPath, isKitManaged } from './ownership';
+export {
+    AGENT_KINDS,
+    AGENT_LABEL,
+    AGENT_SETUP_HINT,
+    type AgentKind,
+    type FileClass,
+    classifyFile,
+    hasAgentFiles,
+    isAgentPath,
+    isKitManaged,
+} from './ownership';
 
 /** Managed-region markers shared by AGENTS.md and CLAUDE.md. */
 const MANAGED_START = '<!-- blit-kit:managed:start -->';

--- a/packages/kit/src/commands/agents.ts
+++ b/packages/kit/src/commands/agents.ts
@@ -38,7 +38,15 @@ import {
 } from '../adapters';
 import { detectPackageManager, findProjectRoot, type PackageManager } from '../env';
 import { ui } from '../messages';
-import { classifyFile, type FileClass, hasAgentFiles, isKitManaged } from '../ownership';
+import {
+    AGENT_KINDS,
+    AGENT_LABEL,
+    type AgentKind,
+    classifyFile,
+    type FileClass,
+    hasAgentFiles,
+    isKitManaged,
+} from '../ownership';
 
 /**
  * One entry as read back from `.blit/manifest.json`.
@@ -553,20 +561,9 @@ function printSummary(out: (line: string) => void, tally: SyncTally): void {
     out(ui.info(parts.join(', ')));
 }
 
-/** AI assistants `blit agents add` can set up. Matches the wizard's agent choices minus "none". */
-const ADDABLE_AGENTS = ['claude', 'cursor'] as const;
-
-type AddableAgent = (typeof ADDABLE_AGENTS)[number];
-
-/** Human-readable assistant names for Tier-1 messages. */
-const AGENT_LABEL: Record<AddableAgent, string> = {
-    claude: 'Claude Code',
-    cursor: 'Cursor',
-};
-
 /** Type guard: is `name` an assistant `add` knows how to set up? */
-function isAddableAgent(name: string): name is AddableAgent {
-    return (ADDABLE_AGENTS as readonly string[]).includes(name);
+function isAddableAgent(name: string): name is AgentKind {
+    return (AGENT_KINDS as readonly string[]).includes(name);
 }
 
 /** Result of reading the manifest: either the parsed manifest, or a friendly failure with an exit code. */
@@ -608,7 +605,7 @@ function readManifest(root: string, out: (line: string) => void): ManifestResult
  * untouched (so a later `sync` cannot clobber the user files). Returns the number of colliding files
  * that need the user's attention; 0 means the assistant was set up cleanly.
  */
-function runAddAgent(root: string, agent: AddableAgent, out: (line: string) => void): number {
+function runAddAgent(root: string, agent: AgentKind, out: (line: string) => void): number {
     const result = readManifest(root, out);
 
     if (!result.ok) {
@@ -761,7 +758,7 @@ export function runAgents(args: string[]): void {
 
         if (!isAddableAgent(name)) {
             out(ui.warn(`I do not know the assistant "${name}".`));
-            out(ui.info(`You can set up: ${ADDABLE_AGENTS.join(', ')}.`));
+            out(ui.info(`You can set up: ${AGENT_KINDS.join(', ')}.`));
             process.exitCode = 1;
             return;
         }

--- a/packages/kit/src/ownership.ts
+++ b/packages/kit/src/ownership.ts
@@ -118,10 +118,25 @@ export function isKitManaged(fileClass: FileClass): boolean {
 /**
  * One AI assistant the kit generates files for.
  *
- * Scoped to the path helpers below. The scaffolder's `AgentChoice` (which also has `none`) and the
- * CLI's `AddableAgent` remain separate unions whose values satisfy this one structurally.
+ * Scoped to the path helpers below. The scaffolder's `AgentChoice` narrows to `'none' | AgentKind`;
+ * `blit agents add` uses `AgentKind` directly.
  */
 export type AgentKind = 'claude' | 'cursor';
+
+/** Every `AgentKind` value, for iteration and membership checks (`blit agents add`, the wizard). */
+export const AGENT_KINDS: readonly AgentKind[] = ['claude', 'cursor'];
+
+/** Human-readable assistant names for Tier-1 messages and wizard hints. */
+export const AGENT_LABEL: Record<AgentKind, string> = {
+    claude: 'Claude Code',
+    cursor: 'Cursor',
+};
+
+/** Project-relative hint of what setting up each assistant adds, for wizard/CLI copy. */
+export const AGENT_SETUP_HINT: Record<AgentKind, string> = {
+    claude: `adds ${CLAUDE_MD}`,
+    cursor: `adds ${CURSOR_RULES_DIR}`,
+};
 
 /**
  * Exact paths and directory prefixes each assistant's generated files occupy.


### PR DESCRIPTION
## Summary
- `packages/kit/src/commands/agents.ts` re-declared `AddableAgent`/`ADDABLE_AGENTS`/`AGENT_LABEL` as a second copy of `AgentKind` ('claude' | 'cursor') from `packages/kit/src/ownership.ts`; `packages/create-blit386/src/scaffold.ts` did the same inside `AgentChoice`.
- `AGENT_KINDS`, `AGENT_LABEL`, and `AGENT_SETUP_HINT` now live once beside `AgentKind` in `ownership.ts` and are re-exported through the existing `@blit386/kit/adapters` subpath (no new export subpath added).
- `agents.ts`'s `isAddableAgent` type guard now narrows to `AgentKind`; `AgentChoice` narrows to `'none' | AgentKind`.
- `packages/create-blit386/src/wizard.ts`'s option hints ("adds CLAUDE.md", "adds .cursor/rules") are now derived from `AGENT_SETUP_HINT` instead of being hand-typed strings.
- `hook.claude`/`hook.cursor` keys in `packages/kit/src/adapters.ts` (a different, hooks.manifest.json-keyed domain) were left untouched, as were BT-295's assistant-addition concerns.

Fixes BT-479.

## Test plan
- [x] `pnpm --filter @blit386/kit run typecheck`
- [x] `pnpm --filter @blit386/kit run test` (46 passing)
- [x] `pnpm --filter @blit386/kit run build`
- [x] `pnpm --filter create-blit386 run build`
- [x] `pnpm --filter create-blit386 run test` (32 passing)
- [x] `pnpm exec knip --workspace packages/kit` (clean)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized support for Claude and Cursor agent options.
  * Added clearer agent labels and setup guidance during project creation and agent setup.
  * Improved validation and help text for supported agent selections.

* **Refactor**
  * Unified agent options and metadata across project scaffolding and command-line setup for more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->