### PR TITLE
refactor(kit): unify the writer-side and reader-side manifest types

### DIFF
--- a/packages/create-blit386/CLAUDE.md
+++ b/packages/create-blit386/CLAUDE.md
@@ -39,7 +39,9 @@ TypeScript strict, built with tsup, Biome for lint and format (no ESLint here), 
 6. `scaffold()` writes the ownership manifest `.blit/manifest.json` (path, class, kit version, sha256, plus the
    scaffold-time template `vars`) and pristine `.blit/base/` copies, so `blit agents sync` can update kit files later
    without clobbering user edits. The `class` values come from `classifyFile()` in `@blit386/kit/adapters` – the same
-   function `blit agents sync` / `add` use, not a local table.
+   function `blit agents sync` / `add` use, not a local table. The manifest's own shape is `BlitManifest` from
+   `@blit386/kit/adapters` as well – this package declares no local copy, so a field it stops emitting is a compile
+   error rather than a manifest the kit silently reads as legacy.
 7. Optional git init, dependency install, next-steps output.
 
 `blit agents sync` / `blit agents add` (the `blit` CLI, shipped by `packages/kit`) reuse the same generators in memory

--- a/packages/create-blit386/CREATE_BLIT386_DESIGN.md
+++ b/packages/create-blit386/CREATE_BLIT386_DESIGN.md
@@ -489,9 +489,10 @@ still accepts manifests written by any released scaffolder. Deriving rather than
 added to `BlitManifest` becomes required of every writer and visible to the reader in one edit. The widened shape is
 also what sync _writes_, not merely what it reads, and the two widened root fields differ on the way out. `createdAt` is
 copied across only when the manifest already had it, so an old manifest never gains a fabricated creation timestamp.
-`vars` is copied when present and _backfilled_ when absent – both write paths resolve it from `fallbackVars` and persist
-it – so an old manifest does gain `vars` on its first sync, by design: the package manager is then detected once instead
-of on every run.
+`vars` is copied when present and _backfilled_ when absent: sync resolves it from `fallbackVars` and persists it, so an
+old manifest gains `vars` on its first sync, by design – the package manager is then detected once instead of on every
+run. `add` backfills identically, but only where it completes; a generated file colliding with an untracked user file
+aborts it before the manifest is written at all.
 
 No schema version, deliberately (Round 28). A `schemaVersion` field was specified and rejected on inspection. It is
 absent from every manifest already in the wild, so the reader would carry the widened branch indefinitely and gain a

--- a/packages/create-blit386/CREATE_BLIT386_DESIGN.md
+++ b/packages/create-blit386/CREATE_BLIT386_DESIGN.md
@@ -480,6 +480,23 @@ path. After a clean three-way merge the on-disk file holds the user's edits, so 
 hash while the base copy stays the pristine kit version (shared files already worked this way; Round 19 made kit-owned
 files consistent).
 
+One declaration, two halves (Round 28). The manifest is written by two packages – `scaffold()` stamps it, and
+`blit agents sync` / `add` rewrite it after reconciling – but declared in exactly one place:
+`packages/kit/src/manifest.ts`, reached from both sides through `@blit386/kit/adapters`. `BlitManifest` is the written
+shape, every field required, so a writer that stops emitting one fails to compile. `ReadBlitManifest` is _derived_ from
+it, widening only the fields that postdate the format (`createdAt`, `vars`, and per-entry `kitVersion`) so the reader
+still accepts manifests written by any released scaffolder. Deriving rather than re-declaring is the point: a field
+added to `BlitManifest` becomes required of every writer and visible to the reader in one edit. The widened shape is
+also what sync _writes_, not merely what it reads: both write paths copy `createdAt`/`vars` across only when the
+manifest they read had them, so an old manifest stays old instead of gaining a fabricated creation timestamp.
+
+No schema version, deliberately (Round 28). A `schemaVersion` field was specified and rejected on inspection. It is
+absent from every manifest already in the wild, so the reader would carry the widened branch indefinitely and gain a
+second one beside it – additive, deleting nothing. The v0-to-v1 upgrade that would eventually retire the old branch
+cannot be written honestly, since it would have to invent a `createdAt` that no one knows. (`vars` is the easy half:
+`fallbackVars` covers the package-manager commands, which is the whole set `content/` substitutes.) Revisit only if a
+genuinely _incompatible_ manifest change arrives – a renamed or re-meaning field, not another additive one.
+
 Sync algorithm (deterministic, no AI involved):
 
 1. For each file the new kit wants to emit:

--- a/packages/create-blit386/CREATE_BLIT386_DESIGN.md
+++ b/packages/create-blit386/CREATE_BLIT386_DESIGN.md
@@ -487,8 +487,11 @@ shape, every field required, so a writer that stops emitting one fails to compil
 it, widening only the fields that postdate the format (`createdAt`, `vars`, and per-entry `kitVersion`) so the reader
 still accepts manifests written by any released scaffolder. Deriving rather than re-declaring is the point: a field
 added to `BlitManifest` becomes required of every writer and visible to the reader in one edit. The widened shape is
-also what sync _writes_, not merely what it reads: both write paths copy `createdAt`/`vars` across only when the
-manifest they read had them, so an old manifest stays old instead of gaining a fabricated creation timestamp.
+also what sync _writes_, not merely what it reads, and the two widened root fields differ on the way out. `createdAt` is
+copied across only when the manifest already had it, so an old manifest never gains a fabricated creation timestamp.
+`vars` is copied when present and _backfilled_ when absent – both write paths resolve it from `fallbackVars` and persist
+it – so an old manifest does gain `vars` on its first sync, by design: the package manager is then detected once instead
+of on every run.
 
 No schema version, deliberately (Round 28). A `schemaVersion` field was specified and rejected on inspection. It is
 absent from every manifest already in the wild, so the reader would carry the widened branch indefinitely and gain a

--- a/packages/create-blit386/src/scaffold.ts
+++ b/packages/create-blit386/src/scaffold.ts
@@ -21,13 +21,17 @@ import { fileURLToPath } from 'node:url';
 import {
     agentsFile,
     type AgentKind,
+    BASE_DIR,
+    BLIT_DIR,
+    type BlitManifest,
     classifyFile,
     collectDocs,
-    type FileClass,
     type GeneratedFile,
     generateClaudeAdapter,
     generateCursorAdapter,
     isKitManaged,
+    MANIFEST_FILE,
+    type ManifestEntry,
     render,
     type TemplateVars,
 } from '@blit386/kit/adapters';
@@ -40,46 +44,6 @@ const BLIT386_RANGE = '^1.5.0';
 /** Output directory names for optional wizard templates. */
 const GITHUB_DIR = '.github';
 const CURSOR_DIR = '.cursor';
-
-/** The `.blit` directory name inside every generated project. */
-const BLIT_DIR = '.blit';
-
-/**
- * One entry in `.blit/manifest.json`, as written at scaffold time.
- *
- * The writer half of a deliberate pair: `ManifestEntry` / `BlitManifest` in
- * `packages/kit/src/commands/agents.ts` are the reader half, and make these fields optional because
- * they read manifests written by any released scaffolder. This side must always emit them, so its
- * fields stay required. Only `class` is shared – it is `FileClass` from `@blit386/kit/adapters` on
- * both sides, so a typo is a compile error. Merging the two shapes needs a manifest schema version
- * first.
- */
-interface ManifestEntry {
-    /** File path relative to the project root. */
-    path: string;
-    /** Ownership class determining how `blit agents sync` handles this file. */
-    class: FileClass;
-    /** Kit version that last wrote this file. */
-    kitVersion: string;
-    /** SHA-256 hex digest of the file content as generated (before any user edits). */
-    sha256: string;
-}
-
-/** The full `.blit/manifest.json` structure. */
-interface BlitManifest {
-    /** Kit version that created this project. */
-    kitVersion: string;
-    /** ISO-8601 creation timestamp. */
-    createdAt: string;
-    /**
-     * Template variables used at scaffold time (package-manager commands, project name, ...).
-     * `blit agents sync` reads these back so it regenerates kit files with the exact same values,
-     * independent of the environment it runs in.
-     */
-    vars: Record<string, string>;
-    /** One entry per generated file, sorted by path for stable diffs. */
-    files: ManifestEntry[];
-}
 
 export type AgentChoice = 'none' | AgentKind;
 
@@ -185,7 +149,7 @@ function sha256(filePath: string): string {
  */
 function writeBlitManifest(targetDir: string, writtenPaths: Set<string>, kitVer: string, vars: TemplateVars): void {
     const blitDir = join(targetDir, BLIT_DIR);
-    const baseDir = join(blitDir, 'base');
+    const baseDir = join(blitDir, BASE_DIR);
     mkdirSync(baseDir, { recursive: true });
 
     const entries: ManifestEntry[] = [];
@@ -194,7 +158,7 @@ function writeBlitManifest(targetDir: string, writtenPaths: Set<string>, kitVer:
         const relPath = relative(targetDir, absPath).replace(/\\/g, '/');
 
         // Skip files that are inside .blit/ itself (manifest and base copies).
-        if (relPath.startsWith('.blit/')) {
+        if (relPath.startsWith(`${BLIT_DIR}/`)) {
             continue;
         }
 
@@ -221,7 +185,7 @@ function writeBlitManifest(targetDir: string, writtenPaths: Set<string>, kitVer:
         files: entries,
     };
 
-    writeFileSync(join(blitDir, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`);
+    writeFileSync(join(blitDir, MANIFEST_FILE), `${JSON.stringify(manifest, null, 2)}\n`);
 }
 
 /**

--- a/packages/kit/CLAUDE.md
+++ b/packages/kit/CLAUDE.md
@@ -95,8 +95,11 @@ list of what ships, and it has no automated guard.
    build when either drifts. `blit386.docsReviewedAt` is the opposite case – hand-set only, bumped by whoever actually
    reviewed `content/docs/*.md` against a new engine release; no script writes it, `scripts/check-kit-docs-drift.mjs`
    (repo root) only reads it. Any other literal this package uses to describe the engine or the scaffolder follows the
-   same derive-or-document discipline: file classes and generated-project paths live once in `src/ownership.ts`, which
-   `create-blit386` imports through `@blit386/kit/adapters`. Same discipline, one boundary further out:
+   same derive-or-document discipline: file classes and generated-project paths live once in `src/ownership.ts`, and the
+   `.blit/manifest.json` path and shape live once in `src/manifest.ts` – both of which `create-blit386` imports through
+   `@blit386/kit/adapters`. The manifest is written by two packages and read by one, so its declaration is authored once
+   (`BlitManifest`) and the reader's leniency toward manifests from older scaffolders is _derived_ from it
+   (`ReadBlitManifest`), never hand-maintained as a second interface. Same discipline, one boundary further out:
    `MCP_SERVER_NAME` and `MCP_SERVER_URL` in `src/adapters.ts` are a documented copy of
    `packages/website/public/.well-known/mcp/server-card.json`, which this package cannot import;
    `test/mcp-config.test.mjs` compares the two, so the copy fails loudly instead of drifting. See root
@@ -111,7 +114,7 @@ list of what ships, and it has no automated guard.
 | Docs-MCP config shipped into games | `buildMcpConfig` in `src/adapters.ts`; canonical server definition lives in `packages/website` |
 | What do `blit agents sync` / `add` do? | `src/commands/agents.ts` (drift `--check` + write path, `runAddAgent`) |
 | How do API migrations / codemods work? | `src/migrations/` (registry + codemod engine), `src/commands/migrate.ts` |
-| Sync ownership model / manifest | `.blit/manifest.json` (classes + `vars`), `src/commands/agents.ts` |
+| Sync ownership model / manifest | `src/manifest.ts` (where the manifest lives and what shape it has), `src/commands/agents.ts` (the read/reconcile/write algorithm) |
 | Which files the kit owns, and the paths it writes into a game | `src/ownership.ts` – shared with `create-blit386` via `@blit386/kit/adapters` |
 | Engine API names for generated games | `packages/blit386/CLAUDE.md`, `packages/blit386/docs/api-core.md` |
 | What does the scaffolder generate? | `packages/create-blit386/CLAUDE.md` |

--- a/packages/kit/src/adapters.ts
+++ b/packages/kit/src/adapters.ts
@@ -25,6 +25,7 @@ import {
     CURSOR_RULES_DIR,
     DOCS_DIR,
 } from './ownership';
+import type { TemplateVars } from './manifest';
 
 // Ownership classification lives in its own leaf module (the generators below build every path they
 // emit from its constants), re-exported here because `./adapters` is the kit's only published
@@ -40,6 +41,20 @@ export {
     isAgentPath,
     isKitManaged,
 } from './ownership';
+
+// The `.blit/manifest.json` location and shape live in their own leaf module, re-exported for the
+// same reason: create-blit386 stamps the manifest that `blit agents sync` later reads back, so both
+// sides must see one declaration.
+export {
+    BASE_DIR,
+    BLIT_DIR,
+    type BlitManifest,
+    MANIFEST_FILE,
+    type ManifestEntry,
+    type ReadBlitManifest,
+    type ReadManifestEntry,
+    type TemplateVars,
+} from './manifest';
 
 /** Managed-region markers shared by AGENTS.md and CLAUDE.md. */
 const MANAGED_START = '<!-- blit-kit:managed:start -->';
@@ -65,9 +80,6 @@ export interface GeneratedFile {
     /** Full file content as the kit would write it. */
     content: string;
 }
-
-/** Template variables substituted into kit content (package-manager commands, project name, ...). */
-export type TemplateVars = Record<string, string>;
 
 /** The kit package root (the folder containing this kit's package.json and content/). */
 export function kitRoot(): string {

--- a/packages/kit/src/commands/agents.ts
+++ b/packages/kit/src/commands/agents.ts
@@ -34,57 +34,11 @@ import {
     generateCursorAdapter,
     kitRoot,
     replaceManagedRegion,
-    type TemplateVars,
 } from '../adapters';
 import { detectPackageManager, findProjectRoot, type PackageManager } from '../env';
+import { BASE_DIR, BLIT_DIR, MANIFEST_FILE, type ReadBlitManifest, type TemplateVars } from '../manifest';
 import { ui } from '../messages';
-import {
-    AGENT_KINDS,
-    AGENT_LABEL,
-    type AgentKind,
-    classifyFile,
-    type FileClass,
-    hasAgentFiles,
-    isKitManaged,
-} from '../ownership';
-
-/**
- * One entry as read back from `.blit/manifest.json`.
- *
- * The reader half of a deliberate pair: `ManifestEntry` / `BlitManifest` in
- * `packages/create-blit386/src/scaffold.ts` are the writer half, and require the fields optional
- * here. This side reads manifests written by any released scaffolder, so it must tolerate older
- * ones that predate `kitVersion`, `createdAt`, and `vars`; the writer must never stop emitting
- * them. Only `class` is shared – it is `FileClass` from `../ownership` on both sides, so a typo is
- * a compile error. Merging the two shapes needs a manifest schema version first.
- */
-interface ManifestEntry {
-    /** File path relative to the project root. */
-    path: string;
-    /** Ownership class: kit-owned or shared files are checked; user-owned are skipped. */
-    class: FileClass;
-    /** Kit version that last wrote this file. */
-    kitVersion?: string;
-    /**
-     * SHA-256 hex digest of the reconciled on-disk content from the last sync (at scaffold time this is
-     * simply the generated content). `--check`/doctor compare the current file against this to detect
-     * drift, so a clean-merged file is in-sync, not flagged forever. The pristine kit version used as the
-     * merge ancestor lives separately in `.blit/base/<path>`.
-     */
-    sha256: string;
-}
-
-/** The `.blit/manifest.json` root structure. */
-interface BlitManifest {
-    /** Kit version that created the project. */
-    kitVersion: string;
-    /** ISO-8601 creation timestamp. */
-    createdAt?: string;
-    /** Template variables captured at scaffold time, used to regenerate kit files deterministically. */
-    vars?: TemplateVars;
-    /** One entry per generated file. */
-    files: ManifestEntry[];
-}
+import { AGENT_KINDS, AGENT_LABEL, type AgentKind, classifyFile, hasAgentFiles, isKitManaged } from '../ownership';
 
 /** SHA-256 hex digest of a string. */
 function sha256Text(text: string): string {
@@ -106,7 +60,7 @@ function sha256(filePath: string): string {
  * caller controls where it goes.
  */
 export function checkSyncDrift(root: string, out: (line: string) => void): number {
-    const manifestPath = join(root, '.blit', 'manifest.json');
+    const manifestPath = join(root, BLIT_DIR, MANIFEST_FILE);
 
     if (!existsSync(manifestPath)) {
         out(ui.info('This project has no .blit/manifest.json.'));
@@ -114,10 +68,10 @@ export function checkSyncDrift(root: string, out: (line: string) => void): numbe
         return 0;
     }
 
-    let manifest: BlitManifest;
+    let manifest: ReadBlitManifest;
 
     try {
-        manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as BlitManifest;
+        manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as ReadBlitManifest;
     } catch {
         out(ui.error('Could not read .blit/manifest.json. The file may be damaged.'));
         return 1;
@@ -193,7 +147,12 @@ function isSafeRelPath(relPath: string, root: string): boolean {
     return abs === root || abs.startsWith(root + sep);
 }
 
-/** Default template vars when an older manifest did not record them (npm commands, project name). */
+/**
+ * Default template vars when an older manifest did not record them.
+ *
+ * Only the package-manager commands, which is exactly the set `content/` substitutes – so a manifest
+ * predating `vars` still regenerates byte-identical kit files once the package manager is detected.
+ */
 function fallbackVars(root: string): TemplateVars {
     const pm: PackageManager = detectPackageManager(root);
     const runPrefix = pm === 'yarn' ? `${pm} ` : `${pm} run `;
@@ -223,7 +182,7 @@ function currentKitVersion(): string {
  * Always includes AGENTS.md and docs/. Includes the Claude or Cursor adapter outputs only when the
  * manifest shows the project already uses that assistant.
  */
-function regenerate(manifest: BlitManifest, root: string): Map<string, string> {
+function regenerate(manifest: ReadBlitManifest, root: string): Map<string, string> {
     const kr = kitRoot();
     const vars = manifest.vars ?? fallbackVars(root);
 
@@ -269,7 +228,7 @@ function writeRel(root: string, relPath: string, content: string): void {
 
 /** Update (or create) the pristine base copy used as the merge ancestor. */
 function writeBase(root: string, relPath: string, content: string): void {
-    writeRel(root, join('.blit', 'base', relPath), content);
+    writeRel(root, join(BLIT_DIR, BASE_DIR, relPath), content);
 }
 
 /**
@@ -327,7 +286,7 @@ export function runFullSync(
     out: (line: string) => void,
     options: { force: boolean; forcePaths: string[] } = { force: false, forcePaths: [] },
 ): number {
-    const manifestPath = join(root, '.blit', 'manifest.json');
+    const manifestPath = join(root, BLIT_DIR, MANIFEST_FILE);
 
     if (!existsSync(manifestPath)) {
         out(ui.info('This project has no .blit/manifest.json.'));
@@ -335,10 +294,10 @@ export function runFullSync(
         return 0;
     }
 
-    let manifest: BlitManifest;
+    let manifest: ReadBlitManifest;
 
     try {
-        manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as BlitManifest;
+        manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as ReadBlitManifest;
     } catch {
         out(ui.error('Could not read .blit/manifest.json. The file may be damaged.'));
         return 1;
@@ -376,7 +335,7 @@ export function runFullSync(
 
         const entry = entryByPath.get(relPath);
         const abs = resolve(root, relPath);
-        const basePath = resolve(root, '.blit', 'base', relPath);
+        const basePath = resolve(root, BLIT_DIR, BASE_DIR, relPath);
 
         // New file the kit added since this project was scaffolded.
         if (!entry) {
@@ -507,7 +466,7 @@ export function runFullSync(
     }
 
     // Write the refreshed manifest, preserving createdAt and vars when present.
-    const refreshed: BlitManifest = {
+    const refreshed: ReadBlitManifest = {
         kitVersion: newKitVersion,
         files: [...entryByPath.values()].sort((a, b) => a.path.localeCompare(b.path)),
     };
@@ -567,14 +526,14 @@ function isAddableAgent(name: string): name is AgentKind {
 }
 
 /** Result of reading the manifest: either the parsed manifest, or a friendly failure with an exit code. */
-type ManifestResult = { ok: true; manifest: BlitManifest } | { ok: false; exitCode: number };
+type ManifestResult = { ok: true; manifest: ReadBlitManifest } | { ok: false; exitCode: number };
 
 /**
  * Read and validate `.blit/manifest.json`. Prints a Tier-1 line on failure.
  * A missing manifest is informational (exit 0); a damaged one is an error (exit 1).
  */
 function readManifest(root: string, out: (line: string) => void): ManifestResult {
-    const manifestPath = join(root, '.blit', 'manifest.json');
+    const manifestPath = join(root, BLIT_DIR, MANIFEST_FILE);
 
     if (!existsSync(manifestPath)) {
         out(ui.info('This project has no .blit/manifest.json.'));
@@ -582,10 +541,10 @@ function readManifest(root: string, out: (line: string) => void): ManifestResult
         return { ok: false, exitCode: 0 };
     }
 
-    let manifest: BlitManifest;
+    let manifest: ReadBlitManifest;
 
     try {
-        manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as BlitManifest;
+        manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as ReadBlitManifest;
     } catch {
         out(ui.error('Could not read .blit/manifest.json. The file may be damaged.'));
         return { ok: false, exitCode: 1 };
@@ -679,7 +638,7 @@ function runAddAgent(root: string, agent: AgentKind, out: (line: string) => void
         added.push(relPath);
     }
 
-    const refreshed: BlitManifest = {
+    const refreshed: ReadBlitManifest = {
         kitVersion: manifest.kitVersion,
         files: [...entryByPath.values()].sort((a, b) => a.path.localeCompare(b.path)),
     };
@@ -689,7 +648,7 @@ function runAddAgent(root: string, agent: AgentKind, out: (line: string) => void
     if (manifest.vars !== undefined) {
         refreshed.vars = manifest.vars;
     }
-    writeFileSync(join(root, '.blit', 'manifest.json'), `${JSON.stringify(refreshed, null, 2)}\n`);
+    writeFileSync(join(root, BLIT_DIR, MANIFEST_FILE), `${JSON.stringify(refreshed, null, 2)}\n`);
 
     for (const path of added) {
         out(ui.success(`Added ${path}.`));

--- a/packages/kit/src/manifest.ts
+++ b/packages/kit/src/manifest.ts
@@ -81,9 +81,12 @@ export type ReadManifestEntry = LegacyOptional<ManifestEntry, 'kitVersion'>;
  * second, hand-maintained interface – is what keeps the two halves honest: a field added to
  * `BlitManifest` is required of every writer and simultaneously visible to the reader.
  *
- * This is also the shape `sync` and `add` write, not just read: both preserve `createdAt`/`vars`
- * only when the manifest they read had them, so a legacy manifest stays legacy rather than gaining
- * a fabricated creation timestamp.
+ * This is also the shape `sync` and `add` write, not just read, and the two widened root fields are
+ * treated differently on the way out. `createdAt` is copied across only when the manifest they read
+ * had it, so a legacy manifest never gains a fabricated creation timestamp. `vars` is copied across
+ * when present but *backfilled* when absent: both commands resolve it from `fallbackVars` and write
+ * it back, so a legacy manifest does gain `vars` on its first sync – deliberately, so the package
+ * manager is detected once rather than re-detected on every run.
  *
  * Deliberately not a schema version. A version field is absent from every manifest already in the
  * wild, so the reader would keep this widened branch indefinitely and gain a second one beside it;

--- a/packages/kit/src/manifest.ts
+++ b/packages/kit/src/manifest.ts
@@ -84,9 +84,11 @@ export type ReadManifestEntry = LegacyOptional<ManifestEntry, 'kitVersion'>;
  * This is also the shape `sync` and `add` write, not just read, and the two widened root fields are
  * treated differently on the way out. `createdAt` is copied across only when the manifest they read
  * had it, so a legacy manifest never gains a fabricated creation timestamp. `vars` is copied across
- * when present but *backfilled* when absent: both commands resolve it from `fallbackVars` and write
- * it back, so a legacy manifest does gain `vars` on its first sync – deliberately, so the package
- * manager is detected once rather than re-detected on every run.
+ * when present but *backfilled* when absent: `sync` resolves it from `fallbackVars` and writes it
+ * back, so a legacy manifest gains `vars` on its first sync – deliberately, so the package manager
+ * is detected once rather than re-detected on every run. `add` backfills the same way, but only on
+ * the path where it completes: a generated file colliding with an untracked user file aborts it
+ * before the manifest is touched at all.
  *
  * Deliberately not a schema version. A version field is absent from every manifest already in the
  * wild, so the reader would keep this widened branch indefinitely and gain a second one beside it;

--- a/packages/kit/src/manifest.ts
+++ b/packages/kit/src/manifest.ts
@@ -1,0 +1,96 @@
+/**
+ * The `.blit/manifest.json` ownership manifest: where it lives and what shape it has.
+ *
+ * Single source of truth for both halves of the round trip. `create-blit386` stamps the manifest at
+ * scaffold time; `blit agents sync` and `blit agents add` read it back, reconcile, and write it
+ * again. Both import these declarations through `@blit386/kit/adapters`, so the two sides cannot
+ * drift apart.
+ *
+ * A leaf module on purpose, like `ownership.ts`: one type-only import, no filesystem access, so
+ * `adapters.ts` can depend on it without a cycle.
+ */
+
+import type { FileClass } from './ownership';
+
+/** The per-project kit directory, relative to the project root. */
+export const BLIT_DIR = '.blit';
+
+/** The manifest filename inside `BLIT_DIR`. */
+export const MANIFEST_FILE = 'manifest.json';
+
+/**
+ * The pristine-copies directory inside `BLIT_DIR`.
+ *
+ * Holds the kit content exactly as generated, which `sync` uses as the merge ancestor for a
+ * three-way merge against the user's edits.
+ */
+export const BASE_DIR = 'base';
+
+/** Template variables substituted into kit content (package-manager commands, project name, ...). */
+export type TemplateVars = Record<string, string>;
+
+/** One entry in `.blit/manifest.json`, as written. */
+export interface ManifestEntry {
+    /** File path relative to the project root, using forward slashes. */
+    path: string;
+    /** Ownership class determining how `blit agents sync` handles this file. */
+    class: FileClass;
+    /** Kit version that last wrote this file. */
+    kitVersion: string;
+    /**
+     * SHA-256 hex digest of the reconciled on-disk content from the last sync (at scaffold time this
+     * is simply the generated content). `--check`/doctor compare the current file against this to
+     * detect drift, so a clean-merged file is in-sync, not flagged forever. The pristine kit version
+     * used as the merge ancestor lives separately in `.blit/base/<path>`.
+     */
+    sha256: string;
+}
+
+/** The full `.blit/manifest.json` structure, as written. */
+export interface BlitManifest {
+    /** Kit version that last wrote this manifest. */
+    kitVersion: string;
+    /** ISO-8601 creation timestamp. */
+    createdAt: string;
+    /**
+     * Template variables used at scaffold time (package-manager commands, project name, ...).
+     * `blit agents sync` reads these back so it regenerates kit files with the exact same values,
+     * independent of the environment it runs in.
+     */
+    vars: TemplateVars;
+    /** One entry per generated file, sorted by path for stable diffs. */
+    files: ManifestEntry[];
+}
+
+/** Widen `K` to optional, leaving every other field of `T` alone. */
+type LegacyOptional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+
+/**
+ * `ManifestEntry` as read back from disk.
+ *
+ * `kitVersion` is widened because manifests written by older scaffolders lack it. See
+ * `ReadBlitManifest` for why this is a derived type rather than a schema version.
+ */
+export type ReadManifestEntry = LegacyOptional<ManifestEntry, 'kitVersion'>;
+
+/**
+ * `BlitManifest` as read back from disk.
+ *
+ * The reader must accept manifests written by any released scaffolder, so fields that arrived after
+ * the format did are optional here. Deriving that from the written shape – rather than declaring a
+ * second, hand-maintained interface – is what keeps the two halves honest: a field added to
+ * `BlitManifest` is required of every writer and simultaneously visible to the reader.
+ *
+ * This is also the shape `sync` and `add` write, not just read: both preserve `createdAt`/`vars`
+ * only when the manifest they read had them, so a legacy manifest stays legacy rather than gaining
+ * a fabricated creation timestamp.
+ *
+ * Deliberately not a schema version. A version field is absent from every manifest already in the
+ * wild, so the reader would keep this widened branch indefinitely and gain a second one beside it;
+ * and the v0-to-v1 upgrade that would justify the fork cannot be written honestly, since it would
+ * have to invent a `createdAt` that no one knows.
+ */
+export type ReadBlitManifest = LegacyOptional<Omit<BlitManifest, 'files'>, 'createdAt' | 'vars'> & {
+    /** One entry per tracked file. */
+    files: ReadManifestEntry[];
+};


### PR DESCRIPTION
Closes BT-476.

## Summary

`ManifestEntry` and `BlitManifest` were declared twice – all-required in the scaffolder ([`packages/create-blit386/src/scaffold.ts`](../blob/main/packages/create-blit386/src/scaffold.ts)) and with `kitVersion`/`createdAt`/`vars` optional in the reader ([`packages/kit/src/commands/agents.ts`](../blob/main/packages/kit/src/commands/agents.ts)). Both copies carried a comment naming the other and concluding that merging them needed a manifest schema version first.

It does not. The optionality split is a **derivation, not a fork**. A new leaf module `packages/kit/src/manifest.ts` declares the written shape once and derives the read shape from it:

```ts
type LegacyOptional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;

export type ReadManifestEntry = LegacyOptional<ManifestEntry, 'kitVersion'>;
export type ReadBlitManifest = LegacyOptional<Omit<BlitManifest, 'files'>, 'createdAt' | 'vars'> & {
    files: ReadManifestEntry[];
};
```

A field added to `BlitManifest` is now required of every writer and visible to the reader in one edit. Under `exactOptionalPropertyTypes` the derived type reproduces the reader's previous declaration exactly, so `manifest.vars ?? fallbackVars(root)` and every `!== undefined` guard compile untouched.

The module also owns the `.blit` / `manifest.json` / `base` path literals both packages had hardcoded, and `TemplateVars` moves here from `adapters.ts` since it is a persisted manifest field. Everything is re-exported through `@blit386/kit/adapters`, the kit's only published subpath – no second subpath, no new tsup entry.

## Two premises in the issue that turned out to be wrong

Both are now recorded in section 4.10 of `CREATE_BLIT386_DESIGN.md` so they are not re-derived later.

**The kit is a writer too, not a read-only consumer.** `sync` and `add` copy `createdAt`/`vars` across only when the manifest they read had them, so a legacy manifest stays legacy instead of gaining a fabricated creation timestamp. The widened shape is what they *write*, not merely what they read.

**A schema version would have deleted no code.** Absent from every manifest already in the wild, it would leave the widened branch in place forever and add a second one beside it – purely additive. The v0-to-v1 upgrade that would eventually retire the old branch cannot be written honestly, since it would have to invent a `createdAt` no one knows.

## Also in this PR

`fallbackVars`' doc comment promised a project name it does not produce – and does not need to. It supplies the five package-manager commands, which is the whole set `packages/kit/content/` substitutes. Comment corrected; no behavior change.

## Test plan

- [x] `pnpm --filter @blit386/kit run typecheck` and `pnpm --filter create-blit386 run typecheck` – the derived types are the whole risk here
- [x] `pnpm --filter @blit386/kit run test` – 46/46
- [x] `pnpm --filter create-blit386 run test` – 32/32, including the two tests that decide this change: "blit agents sync (full) changes nothing on a freshly scaffolded Claude project" and its Cursor twin, plus the three adjacent manifest guards
- [x] `pnpm run format:check`, `check-dash-typography`, `agents:check`, `bump:check`, knip (no findings in either touched package), cspell over the changed files
- [x] **Built-output diff against a `main` build**: every difference in `dist/cli.js`, `dist/adapters.js`, and `dist/scaffold.js` is a string literal replaced by an identically-valued named constant, plus three new exports. No logic change anywhere – this is the strongest evidence sync behavior did not move.
- [x] **Legacy manifest, by hand**: scaffolded a project, stripped `createdAt`, `vars`, and every entry `kitVersion` to simulate an older scaffolder, then ran `blit agents sync`. Reports "Everything is already up to date", the refreshed manifest gains no fabricated `createdAt`, and `sync --check` exits 0 on 45 files.

No README touched – no quick start, prerequisite, or compatibility claim changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Compatibility**
  * Improved support for existing and legacy manifests while preserving optional fields.
  * Standardized manifest handling across project creation, synchronization, and agent workflows.

* **Reliability**
  * Preserved existing creation timestamps during synchronization.
  * Retained existing variables and populated missing variables when needed for package-manager detection.
  * Centralized manifest paths and structure for more consistent project setup and synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->