### PR TITLE
chore(repo): finish BT-478 – stale .coderabbit.yaml refs and the rejection rationale

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -195,12 +195,12 @@ reviews:
     - path: 'packages/kit/content/**'
       instructions: >-
         Canonical kit IR shipped into every scaffolded game (`AGENTS.md`, `docs/`, `rules/`, `skills/`, hooks,
-        `agents.config.json`). American English; no emoji; beginner-friendly prose. Self-contained: reference only
+        `hooks.manifest.json`). American English; no emoji; beginner-friendly prose. Self-contained: reference only
         `blit386` and other local kit files – never `blit386-demos` slugs or URLs. `AGENTS.md` and `docs/` are copied
         byte-for-byte (no `{{placeholder}}` substitution), so spell out both `src/game.js` and `src/game.ts`. Skills and
-        rules are discovered by directory scan – adding a skill folder is enough (`agents.config.json` does not list
-        skills by name). Keep public `BT` / `configure()` names aligned with the sibling blit386 engine. Canonical
-        detail: `packages/kit/CLAUDE.md` "Kit content vs engine docs" and root `.claude/rules/docs-sync-required.md`.
+        rules are discovered by directory scan – adding a skill folder is enough; nothing registers a skill by name.
+        Keep public `BT` / `configure()` names aligned with the sibling blit386 engine. Canonical detail:
+        `packages/kit/CLAUDE.md` "Kit content vs engine docs" and root `.claude/rules/docs-sync-required.md`.
     - path: 'packages/{create-blit386,kit}/CLAUDE.md'
       instructions: >-
         Repo contributor guide - each package has its own file (not a mirror); `create-blit386/CLAUDE.md` covers

--- a/packages/create-blit386/CREATE_BLIT386_DESIGN.md
+++ b/packages/create-blit386/CREATE_BLIT386_DESIGN.md
@@ -288,9 +288,18 @@ kit/
   docs/*.md                 # progressive-disclosure deep dives (trimmed from engine docs/api-*.md)
 ```
 
-The matrix below was originally also mirrored into a `kit/agents.config.json`. That file was descriptive only, drifted
-twice, and was deleted in BT-478 – `src/ownership.ts` plus `src/adapters.ts` are the executable answer to "which adapter
-renders what".
+The matrix below was originally also mirrored into a machine-readable `kit/agents.config.json`, which BT-478 deleted. No
+code ever read it, yet `files: ["dist", "content"]` shipped it to npm as inert bytes in every generated game's
+dependency tree, and it was wrong twice over – once in the Cursor `emits` list (the generated `.cursor/hooks/{script}`),
+and again by omitting `AGENTS.md` and the whole of `docs/` from both adapters. Regenerating it at build time behind a
+`--check` gate was considered and rejected, because `src/ownership.ts` cannot produce it: that module holds directory
+prefixes and exact paths, while the `{name}` / `{script}` filename patterns live as inline literals in the emitters
+(`` `${CLAUDE_SKILLS_DIR}${entry.name}/SKILL.md` ``, `entry.name.replace(/\.md$/, '.mdc')`). A faithful generator would
+have to re-derive the emitters' naming conventions – a second, drift-capable model of `adapters.ts`, guarding a file
+with zero consumers. The durable rule: `src/ownership.ts` (paths + ownership classes, pinned by
+`test/ownership.test.mjs`) plus `src/adapters.ts` are the executable answer to "which adapter renders what", and a
+descriptive mirror of them is a liability, not documentation. `content/hooks.manifest.json` is the counter-case and
+stays – `adapters.ts` parses it, so it cannot drift unnoticed.
 
 Capability matrix (what each adapter emits from the same source):
 


### PR DESCRIPTION
Follow-up to #573 (BT-478), which merged while these two gaps were still open.

## 1. `.coderabbit.yaml` still points at the deleted file

#573 deleted `packages/kit/content/agents.config.json`, but two mentions survived in the `packages/kit/content/**` review instructions, so CodeRabbit is being told about a file that no longer exists.

They were missed because **ripgrep skips dotfiles unless `--hidden` is passed** — the reference scan that cleared the deletion never saw `.coderabbit.yaml`. Worth remembering for the next "is this file really dead?" sweep: `git grep` has no such blind spot.

Fixed by naming `hooks.manifest.json` in the kit-IR inventory instead (that is the manifest that actually ships) and restating the skill-discovery note without leaning on the deleted file.

## 2. The durable half of BT-478 went unrecorded

#573 landed as a merge whose conflict resolution kept a two-line note in §4.3 but dropped the reasoning, and the changelog migration in 1dde3e49 had already removed the dated entry that carried it. What is left says the file was deleted, but not **why regenerating it was rejected** — which is the part a future reader would otherwise re-litigate.

`src/ownership.ts` holds directory prefixes and exact paths, while the `{name}` / `{script}` filename patterns live as inline literals in the emitters (`` `${CLAUDE_SKILLS_DIR}${entry.name}/SKILL.md` ``, `entry.name.replace(/\.md$/, '.mdc')`). A faithful generator would have to re-derive the emitters' naming conventions — a second, drift-capable model of `adapters.ts`, guarding a file with zero consumers. `content/hooks.manifest.json` is noted as the counter-case: `adapters.ts` parses it, so it cannot drift unnoticed.

Folded into §4.3 as a durable decision, per the convention 1dde3e49 established, rather than appended as a dated entry.

## Test plan

- [x] `git grep -n "agents\.config\.json"` — hits only the two intended prose mentions in `CREATE_BLIT386_DESIGN.md`; nothing in any config, `.ts`, or `.mjs`. (Used `git grep`, not `rg`, precisely because of the dotfile blind spot above.)
- [x] `pnpm run format:check` — exit 0.
- [x] `pnpm run docs:links` — exit 0.
- [x] `pnpm run check-dash-typography` — exit 0.
- [x] `pnpm --filter @blit386/kit run test` — 46/46 pass.
- [x] Pre-push hook chain passed on both commits.

Docs and review-config only; no runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)