### PR TITLE
fix(demos): share CRT glitch types and UI color/anchor constants

### DIFF
--- a/packages/demos/src/animation.js
+++ b/packages/demos/src/animation.js
@@ -40,7 +40,7 @@
 import { applyEasing, bootstrap, BT, Color32, Rect2i, SpriteSheet, Timer, Vector2i } from 'blit386';
 
 import { canvasToImage, registerCanvasColors } from './shared/canvas-sprites.js';
-import { applyTheme, ui } from './shared/ui.js';
+import { applyTheme, ui, UI_ANCHORS } from './shared/ui.js';
 
 /** @typedef {import('blit386').IBTDemo} IBTDemo */
 
@@ -486,7 +486,7 @@ class Demo {
         }
 
         // A small bordered kit panel in the top-right corner names the current state.
-        ui.begin('topRight');
+        ui.begin(UI_ANCHORS.TOP_RIGHT);
         ui.panel('State');
         ui.label(this.animState, { color: stateRole });
         ui.end();
@@ -547,7 +547,7 @@ class Demo {
 
         // Timer readouts: a borderless kit group pinned near the top-left corner.
         // { x, y } pin the group's top-left corner; the kit stacks the rows below it.
-        ui.begin('topLeft', { x: 4, y: 22 });
+        ui.begin(UI_ANCHORS.TOP_LEFT, { x: 4, y: 22 });
 
         // Orange while counting down, green once the ability is ready again.
         // Math.ceil rounds up, so "1s" shows until the very last tick of the cooldown.
@@ -562,7 +562,7 @@ class Demo {
         ui.end();
 
         // Concept summary: another borderless kit group, pinned over the ground strip.
-        ui.begin('topLeft', { x: 4, y: 162 });
+        ui.begin(UI_ANCHORS.TOP_LEFT, { x: 4, y: 162 });
         ui.label('Tick-based timing:', { color: 'header' });
         ui.label('- Tick-based timing (update rate)', { color: 'dim' });
         ui.label('- Cooldown & event scheduling', { color: 'dim' });

--- a/packages/demos/src/audio-basics.js
+++ b/packages/demos/src/audio-basics.js
@@ -45,7 +45,7 @@
 
 import { AudioClip, bootstrap, BT, Rect2i } from 'blit386';
 
-import { applyTheme, ui } from './shared/ui.js';
+import { applyTheme, ui, UI_ANCHORS } from './shared/ui.js';
 
 /** @typedef {import('blit386').IBTDemo} IBTDemo */
 /** @typedef {import('blit386').Palette} Palette */
@@ -215,7 +215,7 @@ class Demo {
      * line of text, no panel around it.
      */
     renderStatusLine() {
-        ui.begin('topLeft');
+        ui.begin(UI_ANCHORS.TOP_LEFT);
 
         // The shared "click to enable sound" row – it draws itself only while sound is
         // still locked, and disappears on its own after the first click or key press.
@@ -253,7 +253,7 @@ class Demo {
      * same, which is what makes this demo playable on a touchscreen.
      */
     renderKeyboardPanel() {
-        ui.begin('bottomLeft');
+        ui.begin(UI_ANCHORS.BOTTOM_LEFT);
         ui.panel('Keyboard SFX (pitch)');
 
         for (const preset of KEY_PITCH_PRESETS) {
@@ -279,7 +279,7 @@ class Demo {
         const hasClicked = this.lastClickVolume !== null && this.lastClickPan !== null;
         const flashing = this.pointerFlashTimer > 0;
 
-        ui.begin('bottomRight');
+        ui.begin(UI_ANCHORS.BOTTOM_RIGHT);
         ui.panel('Pointer SFX (volume/pan)');
 
         // Two short reminders of how a click's position maps to sound.

--- a/packages/demos/src/audio-buses.js
+++ b/packages/demos/src/audio-buses.js
@@ -36,7 +36,7 @@
 
 import { AudioClip, bootstrap, BT, Vector2i } from 'blit386';
 
-import { applyTheme, ui } from './shared/ui.js';
+import { applyTheme, ui, UI_ANCHORS } from './shared/ui.js';
 
 /** @typedef {import('blit386').IBTDemo} IBTDemo */
 
@@ -167,13 +167,13 @@ class Demo {
         BT.clear(this.theme.bg);
 
         // The full-width title strip along the top edge.
-        ui.begin('topBar');
+        ui.begin(UI_ANCHORS.TOP_BAR);
         ui.panel('Audio Buses - drag a slider, toggle a Mute, try the Alert');
         ui.end();
 
         // The mixer panel, pinned just below the title strip. Width and height size
         // themselves to the widest row and the number of rows – no layout math here.
-        ui.begin('topLeft', { y: 30 });
+        ui.begin(UI_ANCHORS.TOP_LEFT, { y: 30 });
         ui.panel('Mixer');
 
         for (const row of BUSES) {

--- a/packages/demos/src/basics-enhanced.js
+++ b/packages/demos/src/basics-enhanced.js
@@ -53,8 +53,24 @@ import {
     Vignette,
 } from 'blit386';
 
+import {
+    ABERRATION_BASE,
+    applyGlitchUniforms,
+    FLICKER_BASE,
+    GLITCH_ACTIVE_MAX,
+    GLITCH_ACTIVE_MIN,
+    GLITCH_COOLDOWN_MAX,
+    GLITCH_COOLDOWN_MIN,
+    GLITCH_INTENSITY_MAX,
+    GLITCH_INTENSITY_MIN,
+    GLITCH_LABELS,
+    GLITCH_TYPES_CHROMA,
+    NOISE_BASE,
+    PIXEL_GLITCH_BAND_HEIGHT,
+    resetGlitchUniforms,
+} from './shared/crt-glitch.js';
 import { isAvailable, SOFTWARE_FALLBACK_NOTE } from './shared/post-process-backend.js';
-import { applyTheme, ui } from './shared/ui.js';
+import { applyTheme, ui, UI_ANCHORS } from './shared/ui.js';
 
 /** @typedef {import('blit386').IBTDemo} IBTDemo */
 
@@ -88,29 +104,6 @@ const TARGET_FPS = 30;
 // Run the display-tier post-process at a larger output buffer than the logical screen.
 const OUTPUT_W = 960;
 const OUTPUT_H = 720;
-
-const GLITCH_COOLDOWN_MIN = 120;
-const GLITCH_COOLDOWN_MAX = 360;
-const GLITCH_ACTIVE_MIN = 5;
-const GLITCH_ACTIVE_MAX = 30;
-
-const GLITCH_TYPES = ['hshift', 'chromasplit', 'noise', 'flicker', 'interference'];
-const GLITCH_INTENSITY_MIN = 0.35;
-const GLITCH_INTENSITY_MAX = 1.0;
-
-const FLICKER_BASE = 1.0;
-const FLICKER_DIP = 0.6;
-const ABERRATION_BASE = 0;
-const NOISE_BASE = 0.025;
-
-const GLITCH_LABELS = {
-    none: 'NONE',
-    hshift: 'H-SHIFT',
-    chromasplit: 'CHROMA',
-    noise: 'NOISE',
-    flicker: 'FLICKER',
-    interference: 'INTERFERENCE',
-};
 
 // The shared fallback note is one long sentence – too wide for this 320-pixel screen in
 // the 6-pixel-wide system font. split('. ') cuts the string at the sentence break, giving
@@ -294,7 +287,7 @@ class Demo {
 
         // --- Pixel tier: chunky band glitch on the index buffer ---
         this.pixelGlitch = new PixelGlitch();
-        this.pixelGlitch.bandHeight = 6;
+        this.pixelGlitch.bandHeight = PIXEL_GLITCH_BAND_HEIGHT;
         this.pixelGlitch.intensity = 0; // state machine raises this during hshift bursts
         BT.effectAdd(this.pixelGlitch);
 
@@ -403,12 +396,12 @@ class Demo {
             // t goes from 0 at burst start to 1 on the last tick; sin(t * PI) is a smooth hump.
             const t = 1 - (this.glitchTicksLeft - 1) / this.glitchDuration;
             const envelope = Math.sin(t * Math.PI);
-            this.applyGlitchUniforms(envelope);
+            applyGlitchUniforms(this, envelope);
 
             this.glitchTicksLeft--;
             if (this.glitchTicksLeft <= 0) {
                 // Burst finished – return effect uniforms to calm resting values.
-                this.resetGlitchUniforms();
+                resetGlitchUniforms(this);
 
                 this.glitchCooldown = BT.random.int(GLITCH_COOLDOWN_MIN, GLITCH_COOLDOWN_MAX);
             }
@@ -420,7 +413,7 @@ class Demo {
         if (this.glitchCooldown <= 0) {
             // Roll a new burst. pick() draws one item out of a list, like taking a card off the top of a shuffled deck.
             // float() is the decimal cousin of int(), for values that are not whole numbers.
-            this.glitchType = BT.random.pick(GLITCH_TYPES);
+            this.glitchType = BT.random.pick(GLITCH_TYPES_CHROMA);
             this.glitchDuration = BT.random.int(GLITCH_ACTIVE_MIN, GLITCH_ACTIVE_MAX);
             this.glitchTicksLeft = this.glitchDuration;
             this.glitchPeak = BT.random.float(GLITCH_INTENSITY_MIN, GLITCH_INTENSITY_MAX);
@@ -447,7 +440,7 @@ class Demo {
         // On-canvas text drawn with the shared UI kit: a borderless label group (no
         // ui.panel() call, so no box) pinned to the top-left corner. Small margin and
         // padding keep it tucked near the edge, like the old hand-drawn hint.
-        ui.begin('topLeft', { margin: 2, pad: 2 });
+        ui.begin(UI_ANCHORS.TOP_LEFT, { margin: 2, pad: 2 });
 
         // Hint: the engine overlay (FPS, position, CRT status) toggles with Backquote
         // or the small symbol in the bottom-left corner of the upscaled canvas.
@@ -489,34 +482,6 @@ class Demo {
         }
 
         return this.overlayRowData;
-    }
-
-    /**
-     * @param {number} envelope
-     */
-    applyGlitchUniforms(envelope) {
-        const peak = this.glitchPeak * envelope;
-        this.resetGlitchUniforms();
-
-        if (this.glitchType === 'hshift') {
-            this.pixelGlitch.intensity = peak;
-        } else if (this.glitchType === 'chromasplit') {
-            this.aberration.aberration = ABERRATION_BASE + peak * 4;
-        } else if (this.glitchType === 'noise') {
-            this.noise.amount = NOISE_BASE + peak * 0.08;
-        } else if (this.glitchType === 'flicker') {
-            this.flicker.amount = FLICKER_BASE - (FLICKER_BASE - FLICKER_DIP) * envelope;
-        } else if (this.glitchType === 'interference') {
-            this.interference.amount = peak * 0.06;
-        }
-    }
-
-    resetGlitchUniforms() {
-        this.pixelGlitch.intensity = 0;
-        this.aberration.aberration = ABERRATION_BASE;
-        this.noise.amount = NOISE_BASE;
-        this.flicker.amount = FLICKER_BASE;
-        this.interference.amount = 0;
     }
 }
 

--- a/packages/demos/src/basics.js
+++ b/packages/demos/src/basics.js
@@ -53,7 +53,7 @@ import { bootstrap, BT, Color32, SpriteSheet, Vector2i } from 'blit386';
 // The shared demo UI kit – every demo in this series uses it for on-screen text and panels
 // so they all look the same. applyTheme() installs the kit's colors into our palette, and
 // ui.* draws things like the hint label you see in the top-left corner.
-import { applyTheme, ui } from './shared/ui.js';
+import { applyTheme, ui, UI_ANCHORS } from './shared/ui.js';
 
 /**
  * These @typedef lines tell code editors what types we mean when we write
@@ -454,7 +454,7 @@ class Demo {
         // { color: 'dim' } picks the kit's muted gray so the hint stays out of the way.
         // (Under the hood the kit prints with the same built-in 6x14 system font.)
         // "~" is the Backquote key (usually under Esc, left of the 1 key).
-        ui.begin('topLeft');
+        ui.begin(UI_ANCHORS.TOP_LEFT);
         ui.label('Press ~ or click/tap the symbol below', { color: 'dim' });
         ui.label('to toggle the overlay', { color: 'dim' });
         ui.end();

--- a/packages/demos/src/bitmap-font.js
+++ b/packages/demos/src/bitmap-font.js
@@ -41,7 +41,7 @@ import { BitmapFont, bootstrap, BT, Color32, Vector2i } from 'blit386';
 // The shared demo UI kit. applyTheme() installs the kit's twelve UI colors high in the
 // palette (slots 240-251, far above this demo's slots 1-38), and ui.* draws the small
 // "Font Info" panel in the bottom-right corner of the screen.
-import { applyTheme, ui } from './shared/ui.js';
+import { applyTheme, ui, UI_ANCHORS } from './shared/ui.js';
 
 /** @typedef {import('blit386').IBTDemo} IBTDemo */
 
@@ -405,7 +405,7 @@ class Demo {
     renderFontInfo() {
         // Anchor the group to the bottom-right corner of the screen, away from the showcase
         // text on the left and the engine overlay's toggle hint in the bottom-left corner.
-        ui.begin('bottomRight');
+        ui.begin(UI_ANCHORS.BOTTOM_RIGHT);
 
         // Give the group a background, border, and an amber title.
         ui.panel('Font Info');

--- a/packages/demos/src/camera.js
+++ b/packages/demos/src/camera.js
@@ -29,7 +29,7 @@
 
 import { bootstrap, BT, Color32, Rect2i, Vector2i } from 'blit386';
 
-import { applyTheme, ui } from './shared/ui.js';
+import { applyTheme, ui, UI_ANCHORS } from './shared/ui.js';
 
 /** @typedef {import('blit386').IBTDemo} IBTDemo */
 
@@ -475,7 +475,7 @@ class Demo {
         // measures the rows, draws the panel background, and places it for us.
         // The kit draws in whatever camera space is active, so this must run AFTER
         // BT.cameraReset() – otherwise the panel would scroll away with the world.
-        ui.begin('topLeft');
+        ui.begin(UI_ANCHORS.TOP_LEFT);
         ui.panel();
         ui.label('Auto-scrolling camera', { color: 'dim' });
 

--- a/packages/demos/src/coordinate-patterns.js
+++ b/packages/demos/src/coordinate-patterns.js
@@ -44,7 +44,7 @@
 
 import { bootstrap, BT, Color32, hash1i, hash2i, hash3i, Rect2i, Vector2i } from 'blit386';
 
-import { applyTheme, ui } from './shared/ui.js';
+import { applyTheme, ui, UI_ANCHORS } from './shared/ui.js';
 
 /** @typedef {import('blit386').IBTDemo} IBTDemo */
 /** @typedef {import('blit386').HardwareSettings} HardwareSettings */
@@ -335,7 +335,7 @@ class Demo {
      * The travel buttons.
      */
     renderControlPanel() {
-        ui.begin('bottomLeft');
+        ui.begin(UI_ANCHORS.BOTTOM_LEFT);
         ui.panel('Travel');
 
         if (ui.button('Jump far', { key: 'KeyJ' })) {
@@ -360,7 +360,7 @@ class Demo {
      * Where we are, what layer we are on, and the number that matters most.
      */
     renderReadoutPanel() {
-        ui.begin('bottomRight');
+        ui.begin(UI_ANCHORS.BOTTOM_RIGHT);
         ui.panel('This world');
         ui.kv('tile x', Math.floor(this.camX / TILE));
         ui.kv('tile y', Math.floor(this.camY / TILE));

--- a/packages/demos/src/crt-pipboy.js
+++ b/packages/demos/src/crt-pipboy.js
@@ -90,8 +90,23 @@ import {
     Vignette,
 } from 'blit386';
 
+import {
+    ABERRATION_BASE,
+    applyGlitchUniforms,
+    FLICKER_BASE,
+    GLITCH_ACTIVE_MAX,
+    GLITCH_ACTIVE_MIN,
+    GLITCH_COOLDOWN_MAX,
+    GLITCH_COOLDOWN_MIN,
+    GLITCH_INTENSITY_MAX,
+    GLITCH_INTENSITY_MIN,
+    GLITCH_TYPES_CHROMA,
+    NOISE_BASE,
+    PIXEL_GLITCH_BAND_HEIGHT,
+    resetGlitchUniforms,
+} from './shared/crt-glitch.js';
 import { isAvailable, SOFTWARE_FALLBACK_NOTE } from './shared/post-process-backend.js';
-import { applyTheme, ui } from './shared/ui.js';
+import { applyTheme, ui, UI_ANCHORS } from './shared/ui.js';
 
 // The internal pixel resolution of the demo. Small numbers keep the pixel art look.
 const DISPLAY_W = 320;
@@ -162,36 +177,6 @@ const STATUS_LINES = [
 // The cursor blinks: ON for half a second, OFF for half a second.
 // 30 ticks at 60 FPS = 0.5 seconds. The cursor is just a bright square.
 const CURSOR_BLINK_TICKS = 30;
-
-// Glitch state machine tuning. All durations are in ticks (60 per second).
-// MIN/MAX cooldown = how long the screen stays calm BETWEEN glitches.
-// MIN/MAX active   = how long each glitch lasts once it starts.
-// Larger values = a calmer demo; smaller values = chaos.
-const GLITCH_COOLDOWN_MIN = 120; // 2 seconds
-const GLITCH_COOLDOWN_MAX = 360; // 6 seconds
-const GLITCH_ACTIVE_MIN = 5; // 0.083 seconds (a brief stutter)
-const GLITCH_ACTIVE_MAX = 30; // 0.5 seconds  (a noticeable hiccup)
-
-// The glitch personalities the state machine can pick from.
-// Each one drives a different combination of effect uniforms. Strings are easier to read
-// in `update()` than magic numbers when you decide to tune one of them.
-const GLITCH_TYPES = ['hshift', 'chromasplit', 'noise', 'flicker', 'interference'];
-
-// Multipliers per glitch type. We pick the strength for the current burst once and then
-// blend it in for the lifetime of the burst (envelope: ramp up, hold, ramp down).
-const GLITCH_INTENSITY_MIN = 0.35;
-const GLITCH_INTENSITY_MAX = 1.0;
-
-// Flicker dips the brightness of the WHOLE picture briefly. 1.0 = unmodulated; lower = darker.
-const FLICKER_BASE = 1.0;
-const FLICKER_DIP = 0.6;
-
-// Resting values the glitch state machine returns to between bursts.
-// ABERRATION_BASE is 0 so the screen is clean between bursts – chromasplit
-// glitches then clearly pop the channel split on from nothing rather than
-// boosting an already-visible split. NOISE_BASE is the constant faint grain.
-const ABERRATION_BASE = 0;
-const NOISE_BASE = 0.025;
 
 /** @typedef {import('blit386').IBTDemo} IBTDemo */
 
@@ -362,7 +347,7 @@ class Demo {
         // stay palette-native. If the same shift ran after resolve + upscale, each band
         // would span multiple output pixels and lose the chunky retro look.
         this.pixelGlitch = new PixelGlitch();
-        this.pixelGlitch.bandHeight = 6; // height of each glitch band in source pixels
+        this.pixelGlitch.bandHeight = PIXEL_GLITCH_BAND_HEIGHT; // height of each glitch band in source pixels
         this.pixelGlitch.intensity = 0; // 0 = no glitch right now (state machine will spike it)
         BT.effectAdd(this.pixelGlitch); // tier='pixel' on the effect routes this automatically
 
@@ -510,60 +495,10 @@ class Demo {
         // In software mode the CRT stack is skipped – say so with a kit label. Omitting
         // ui.panel() keeps the group borderless, so it reads as a single caption line.
         if (!this.effectsAvailable) {
-            ui.begin('bottomLeft');
+            ui.begin(UI_ANCHORS.BOTTOM_LEFT);
             ui.label(SOFTWARE_FALLBACK_NOTE, { color: 'warm' });
             ui.end();
         }
-    }
-
-    /**
-     * Layers the chosen glitch personality onto the resting effect uniforms.
-     * Different burst types drive different effect uniforms – that is what gives each
-     * burst its own visual feel.
-     *
-     * @param {number} envelope – 0 -> 1 -> 0 over the lifetime of the burst.
-     */
-    applyGlitchUniforms(envelope) {
-        const peak = this.glitchPeak * envelope;
-
-        // Reset to "calm" first, then layer the chosen personality.
-        // This way two bursts back-to-back never accidentally inherit each other's settings.
-        this.resetGlitchUniforms();
-
-        if (this.glitchType === 'hshift') {
-            // Pixel-tier band shift: chunky and palette-correct. Lives in 320x240 space
-            // so each band is one source-pixel row tall.
-            this.pixelGlitch.intensity = peak;
-        } else if (this.glitchType === 'chromasplit') {
-            // Boost chromatic aberration for a split-color look. The display-tier effect
-            // works in output-pixel space so we get smooth fringes, not jagged ones.
-            this.aberration.aberration = ABERRATION_BASE + peak * 4;
-        } else if (this.glitchType === 'noise') {
-            // Push noise up by a multiplier of its baseline. The noise reseeds every
-            // frame, so this looks like crackling static.
-            this.noise.amount = NOISE_BASE + peak * 0.08;
-        } else if (this.glitchType === 'flicker') {
-            // Whole-screen brightness dip via the Flicker effect. This is the "lights
-            // flicker" moment in a horror movie.
-            this.flicker.amount = FLICKER_BASE - (FLICKER_BASE - FLICKER_DIP) * envelope;
-        } else if (this.glitchType === 'interference') {
-            // Per-row jitter burst. At rest the interference amount is 0 (screen calm);
-            // during this burst we spike it so the rows suddenly start jittering.
-            this.interference.amount = peak * 0.06;
-        }
-    }
-
-    /**
-     * Returns every glitch-driven uniform to its resting value. Called between bursts
-     * AND at the start of each frame inside applyGlitchUniforms() so the state machine
-     * never accidentally inherits settings from the previous burst.
-     */
-    resetGlitchUniforms() {
-        this.pixelGlitch.intensity = 0;
-        this.aberration.aberration = ABERRATION_BASE;
-        this.noise.amount = NOISE_BASE;
-        this.flicker.amount = FLICKER_BASE;
-        this.interference.amount = 0;
     }
 
     /**
@@ -580,12 +515,12 @@ class Demo {
             const t = 1 - this.glitchTicksLeft / this.glitchDuration; // 0 at start, 1 at end
             const envelope = Math.sin(t * Math.PI); // 0 -> 1 -> 0
 
-            this.applyGlitchUniforms(envelope);
+            applyGlitchUniforms(this, envelope);
 
             this.glitchTicksLeft--;
             // When the burst ends, reset the uniforms so the screen calms down.
             if (this.glitchTicksLeft === 0) {
-                this.resetGlitchUniforms();
+                resetGlitchUniforms(this);
                 this.glitchCooldown = BT.random.int(GLITCH_COOLDOWN_MIN, GLITCH_COOLDOWN_MAX);
             }
         } else {
@@ -595,7 +530,7 @@ class Demo {
                 // Roll a new burst. pick() draws one item out of a list, like taking a
                 // card off the top of a shuffled deck. float() is the decimal cousin of
                 // int(), for values that are not whole numbers.
-                this.glitchType = BT.random.pick(GLITCH_TYPES);
+                this.glitchType = BT.random.pick(GLITCH_TYPES_CHROMA);
                 BT.assignTag(`Glitch: ${this.glitchType}`);
                 this.glitchDuration = BT.random.int(GLITCH_ACTIVE_MIN, GLITCH_ACTIVE_MAX);
                 this.glitchTicksLeft = this.glitchDuration;

--- a/packages/demos/src/crt-toggle.js
+++ b/packages/demos/src/crt-toggle.js
@@ -52,7 +52,7 @@
 import { bootstrap, BT, Color32, Rect2i, Vector2i } from 'blit386';
 
 import { isAvailable, SOFTWARE_FALLBACK_NOTE } from './shared/post-process-backend.js';
-import { applyTheme, ui } from './shared/ui.js';
+import { applyTheme, ui, UI_ANCHORS } from './shared/ui.js';
 
 // Internal pixel resolution.
 const DISPLAY_W = 320;
@@ -333,7 +333,7 @@ class Demo {
         // top of the moving squares. Like everything the demo draws, it lives on the
         // logical buffer, so the CRT effects warp and glow the panel too – a nice way to
         // read the toggle even when you cannot see the scanlines up close.
-        ui.begin('topLeft');
+        ui.begin(UI_ANCHORS.TOP_LEFT);
         ui.panel();
         if (this.effectsAvailable) {
             // 'accent' (phosphor green) while the stack is live, 'dim' gray while it rests.

--- a/packages/demos/src/fonts.js
+++ b/packages/demos/src/fonts.js
@@ -25,7 +25,7 @@
 
 import { bootstrap, BT, Color32, Vector2i } from 'blit386';
 
-import { applyTheme, ui } from './shared/ui.js';
+import { applyTheme, ui, UI_ANCHORS } from './shared/ui.js';
 
 /** @typedef {import('blit386').IBTDemo} IBTDemo */
 
@@ -194,7 +194,7 @@ class Demo {
 
         // A small dim caption in the bottom-left corner pointing to the next font lesson.
         // No ui.panel() call inside the group means it is just floating text – no box.
-        ui.begin('bottomLeft', { y: 160 });
+        ui.begin(UI_ANCHORS.BOTTOM_LEFT, { y: 160 });
         ui.label('To see how to load bitmap fonts from disk,', { color: 'dim' });
         ui.label('go to Bitmap Font demo', { color: 'dim' });
         ui.end();

--- a/packages/demos/src/game-scene.js
+++ b/packages/demos/src/game-scene.js
@@ -51,7 +51,7 @@
 
 import { applyEasing, AudioClip, bootstrap, BT, Color32, Rect2i, SpriteSheet, Timer, Vector2i } from 'blit386';
 
-import { applyTheme, ui } from './shared/ui.js';
+import { applyTheme, ui, UI_ANCHORS } from './shared/ui.js';
 
 /** @typedef {import('blit386').IBTDemo} IBTDemo */
 
@@ -963,7 +963,7 @@ class Demo {
      */
     renderLegend() {
         // Anchor the group to the top-left corner; the kit sizes the panel to fit its rows.
-        ui.begin('topLeft');
+        ui.begin(UI_ANCHORS.TOP_LEFT);
 
         // panel() gives the group a background, border, and an amber title line.
         ui.panel('Capstone: scroll, tiles, sprite, day/night');

--- a/packages/demos/src/gamepad-input.js
+++ b/packages/demos/src/gamepad-input.js
@@ -32,7 +32,7 @@
 
 import { bootstrap, BT, Color32, Rect2i, Vector2i } from 'blit386';
 
-import { applyTheme, ui } from './shared/ui.js';
+import { applyTheme, ui, UI_ANCHORS } from './shared/ui.js';
 
 /** @typedef {import('blit386').IBTDemo} IBTDemo */
 
@@ -258,7 +258,7 @@ class Demo {
         BT.clear(this.theme.bg);
 
         // The full-width title strip along the top edge.
-        ui.begin('topBar');
+        ui.begin(UI_ANCHORS.TOP_BAR);
         ui.panel('Gamepad Input - sticks, triggers, button masks');
         ui.end();
 
@@ -353,7 +353,7 @@ class Demo {
      * particular demo cannot work without a physical gamepad.
      */
     renderHints() {
-        ui.begin('topLeft', { y: 28 });
+        ui.begin(UI_ANCHORS.TOP_LEFT, { y: 28 });
         ui.label('Left stick move | Right stick aim', { color: 'dim' });
         ui.label('Triggers = pod size', { color: 'dim' });
         ui.label('A color | B trail | Start reset', { color: 'dim' });
@@ -429,7 +429,7 @@ class Demo {
         const aimY = BT.getAxis(BT.AXIS_RIGHT_Y, PLAYER);
         const throttle = Math.max(BT.getAxis(BT.AXIS_TRIGGER_L, PLAYER), BT.getAxis(BT.AXIS_TRIGGER_R, PLAYER));
 
-        ui.begin('topRight', { y: 28 });
+        ui.begin(UI_ANCHORS.TOP_RIGHT, { y: 28 });
         ui.panel('Gamepad');
 
         // How many gamepads the browser reports, and whether player one has one.
@@ -459,7 +459,7 @@ class Demo {
      * old hand-drawn warning, restyled as warm kit labels in a borderless group.
      */
     renderEmptyState() {
-        ui.begin('topLeft', { x: ARENA_X + 12, y: ARENA_Y + 42 });
+        ui.begin(UI_ANCHORS.TOP_LEFT, { x: ARENA_X + 12, y: ARENA_Y + 42 });
         ui.label('Connect a gamepad and press', { color: 'warm' });
         ui.label('any button to wake it.', { color: 'warm' });
         ui.end();

--- a/packages/demos/src/image-output.js
+++ b/packages/demos/src/image-output.js
@@ -12,7 +12,7 @@
 
 import { bootstrap, BT, Color32, Rect2i, Vector2i } from 'blit386';
 
-import { applyTheme, ui } from './shared/ui.js';
+import { applyTheme, ui, UI_ANCHORS } from './shared/ui.js';
 
 /** @typedef {import('blit386').IBTDemo} IBTDemo */
 
@@ -218,7 +218,7 @@ class Demo {
         // Note: this panel is drawn onto the frame, so it WILL be part of the saved
         // PNG. That is acceptable here – it even doubles as a caption telling you
         // which demo produced the screenshot.
-        ui.begin('topRight');
+        ui.begin(UI_ANCHORS.TOP_RIGHT);
         ui.panel('Image Output');
 
         // The Save button. ui.button() returns true only on the single frame it was

--- a/packages/demos/src/input-map-remapping.js
+++ b/packages/demos/src/input-map-remapping.js
@@ -31,7 +31,7 @@
 
 import { bootstrap, BT, Vector2i } from 'blit386';
 
-import { applyTheme, ui } from './shared/ui.js';
+import { applyTheme, ui, UI_ANCHORS } from './shared/ui.js';
 
 /** @typedef {import('blit386').IBTDemo} IBTDemo */
 
@@ -176,13 +176,13 @@ class Demo {
         BT.clear(this.theme.bg);
 
         // Full-width 22-pixel title strip across the top of the screen.
-        ui.begin('topBar');
+        ui.begin(UI_ANCHORS.TOP_BAR);
         ui.panel('Input Map Remapping - BT.inputMap / BT.inputMapReset');
         ui.end();
 
         // A borderless text group under the title: what the demo is about, plus the
         // classic "click the canvas" focus tip. No ui.panel() call means no box is drawn.
-        ui.begin('topLeft', { x: MARGIN_X, y: INTRO_Y });
+        ui.begin(UI_ANCHORS.TOP_LEFT, { x: MARGIN_X, y: INTRO_Y });
         ui.label('Face buttons use BT.isDown(BTN_*, player). Remap at runtime with BT.inputMap.', { color: 'dim' });
         ui.label('Tap a preset button or press its number key. Click the canvas if keys stop.', { color: 'dim' });
         ui.end();
@@ -194,7 +194,7 @@ class Demo {
         // The preset switcher lives in its own panel in the bottom-left corner. Each
         // ui.button() returns true on the one frame it is clicked, tapped, or its bound
         // key goes down – all three inputs behave exactly the same.
-        ui.begin('bottomLeft');
+        ui.begin(UI_ANCHORS.BOTTOM_LEFT);
         ui.panel('Presets');
 
         if (ui.button('1 - Defaults (inputMapReset)', { key: 'Digit1', width: PRESET_BUTTON_W })) {
@@ -272,7 +272,7 @@ class Demo {
     renderPlayerPanel(player, originX, originY) {
         // Pin the group at an exact position and force both panels to the same width so
         // the two columns line up regardless of how long each panel's text rows are.
-        ui.begin('topLeft', { x: originX, y: originY, width: PANEL_W });
+        ui.begin(UI_ANCHORS.TOP_LEFT, { x: originX, y: originY, width: PANEL_W });
         ui.panel(player === 0 ? 'Player 0' : 'Player 1');
 
         // Which physical keys feed this player's face buttons out of the box. The custom

--- a/packages/demos/src/keyboard-diagnostic.js
+++ b/packages/demos/src/keyboard-diagnostic.js
@@ -20,7 +20,7 @@
 
 import { bootstrap, BT, Color32, Rect2i, Vector2i } from 'blit386';
 
-import { applyTheme, ui } from './shared/ui.js';
+import { applyTheme, ui, UI_ANCHORS } from './shared/ui.js';
 
 /** @typedef {import('blit386').IBTDemo} IBTDemo */
 /** @typedef {import('blit386').HardwareSettings} HardwareSettings */
@@ -331,7 +331,7 @@ class Demo {
         // Full-width title strip. The second row is contextual: touch devices get a
         // warning that the demo is pointless without a keyboard, everyone else gets
         // the fast-tap testing hint.
-        ui.begin('topBar');
+        ui.begin(UI_ANCHORS.TOP_BAR);
         ui.panel('BLIT386 Keyboard Diagnostic');
 
         if (ui.hasTouch()) {
@@ -343,7 +343,7 @@ class Demo {
         ui.end();
 
         // Status readout: which edge fired last, and on which engine tick.
-        ui.begin('bottomLeft');
+        ui.begin(UI_ANCHORS.BOTTOM_LEFT);
         ui.panel();
         ui.kv('Last', this.lastEvent);
         ui.kv('Tick', this.lastTick === null ? '-' : this.lastTick);
@@ -351,7 +351,7 @@ class Demo {
 
         // Edge counters: after a burst of fast taps both numbers must match – a
         // mismatch means an edge was dropped somewhere.
-        ui.begin('bottomRight');
+        ui.begin(UI_ANCHORS.BOTTOM_RIGHT);
         ui.panel();
         ui.kv('Presses', this.pressCount);
         ui.kv('Releases', this.releaseCount);

--- a/packages/demos/src/keyboard-input.js
+++ b/packages/demos/src/keyboard-input.js
@@ -39,7 +39,7 @@
 
 import { bootstrap, BT } from 'blit386';
 
-import { applyTheme, ui } from './shared/ui.js';
+import { applyTheme, ui, UI_ANCHORS } from './shared/ui.js';
 
 /** @typedef {import('blit386').IBTDemo} IBTDemo */
 
@@ -264,7 +264,7 @@ class Demo {
         BT.clear(this.theme.bg);
 
         // Full-width title strip across the top, in the classic 22-pixel top-bar style.
-        ui.begin('topBar');
+        ui.begin(UI_ANCHORS.TOP_BAR);
         ui.panel('Keyboard Input (KeyboardEvent.code)');
         ui.end();
 
@@ -272,7 +272,7 @@ class Demo {
         // warning – this page has no on-screen substitute for a physical keyboard – and
         // otherwise it lists the default key maps as a quick reference. pad: 0 removes
         // the group's inner padding so the single line sits snug against its y position.
-        ui.begin('topLeft', { y: NOTICE_Y, pad: 0 });
+        ui.begin(UI_ANCHORS.TOP_LEFT, { y: NOTICE_Y, pad: 0 });
 
         if (ui.hasTouch()) {
             ui.label('This demo needs a keyboard', { color: 'warm' });
@@ -302,7 +302,7 @@ class Demo {
      */
     renderFacePanel(player, x) {
         // Pin the panel to its column; both player panels share the same top edge.
-        ui.begin('topLeft', { x, y: PANEL_TOP_Y });
+        ui.begin(UI_ANCHORS.TOP_LEFT, { x, y: PANEL_TOP_Y });
         ui.panel(player === 0 ? 'Player 0' : 'Player 1');
 
         const buttons = this.faceButtons[player];
@@ -323,7 +323,7 @@ class Demo {
      * Readout for edge-only press counting on one key at a time.
      */
     renderPressCounter() {
-        ui.begin('topLeft', { x: READOUT_COLUMN_X, y: PANEL_TOP_Y });
+        ui.begin(UI_ANCHORS.TOP_LEFT, { x: READOUT_COLUMN_X, y: PANEL_TOP_Y });
         ui.panel('isKeyPressed counter');
 
         // Before any counted key is tapped there is nothing to show, so both rows fall
@@ -341,7 +341,7 @@ class Demo {
      * Panel for Q held state and the last F release.
      */
     renderRawKeyPanel() {
-        ui.begin('topLeft', { x: READOUT_COLUMN_X, y: RAW_PANEL_Y });
+        ui.begin(UI_ANCHORS.TOP_LEFT, { x: READOUT_COLUMN_X, y: RAW_PANEL_Y });
         ui.panel('Raw keys');
 
         // Held state is safe to read in render() (see renderFacePanel above).
@@ -358,7 +358,7 @@ class Demo {
     renderTypedLine() {
         // A fixed width keeps the panel spanning the screen even while the buffer is
         // short; bottomLeft anchors it just above the bottom edge.
-        ui.begin('bottomLeft', { width: TYPED_PANEL_WIDTH });
+        ui.begin(UI_ANCHORS.BOTTOM_LEFT, { width: TYPED_PANEL_WIDTH });
         ui.panel('BT.inputString (typed this session)');
 
         const hasText = this.typedBuffer.length > 0;

--- a/packages/demos/src/logo-lowres.js
+++ b/packages/demos/src/logo-lowres.js
@@ -46,6 +46,7 @@ import {
     Vignette,
 } from 'blit386';
 
+import { GLITCH_TYPES_VROLL } from './shared/crt-glitch.js';
 import { isAvailable } from './shared/post-process-backend.js';
 
 /** @typedef {import('blit386').IBTDemo} IBTDemo */
@@ -110,10 +111,6 @@ const GLITCH_ACTIVE_MIN = 4; // Fault lasts at least 4 ticks (~0.07 s).
 const GLITCH_ACTIVE_MAX = 24; // Fault lasts up to 24 ticks (~0.4 s).
 const GLITCH_INTENSITY_MIN = 0.3; // Weakest fault (barely visible).
 const GLITCH_INTENSITY_MAX = 0.95; // Strongest fault (almost unwatchable).
-
-// The five kinds of B/W TV fault this demo can show.
-// (Chromatic aberration is omitted because a B/W set has no color to split.)
-const GLITCH_TYPES = ['hshift', 'noise', 'flicker', 'interference', 'vroll'];
 
 // --- Occasional subtle band-wobble (pixel-tier PixelGlitch) ---
 // This is separate from the bigger TV fault bursts. A real CRT sometimes has a
@@ -474,7 +471,7 @@ class Demo {
         if (this.glitchCooldown <= 0) {
             // Time for a fault! pick() draws one item out of a list, like taking a card
             // off the top of a shuffled deck. float() is the decimal cousin of int().
-            this.glitchType = BT.random.pick(GLITCH_TYPES);
+            this.glitchType = BT.random.pick(GLITCH_TYPES_VROLL);
             this.glitchDuration = BT.random.int(GLITCH_ACTIVE_MIN, GLITCH_ACTIVE_MAX);
             this.glitchTicksLeft = this.glitchDuration;
             this.glitchPeak = BT.random.float(GLITCH_INTENSITY_MIN, GLITCH_INTENSITY_MAX);

--- a/packages/demos/src/music.js
+++ b/packages/demos/src/music.js
@@ -37,7 +37,7 @@
 
 import { AudioClip, bootstrap, BT, Vector2i } from 'blit386';
 
-import { applyTheme, ui } from './shared/ui.js';
+import { applyTheme, ui, UI_ANCHORS } from './shared/ui.js';
 
 /** @typedef {import('blit386').IBTDemo} IBTDemo */
 
@@ -173,13 +173,13 @@ class Demo {
         BT.clear(this.theme.bg);
 
         // The full-width title strip along the top edge.
-        ui.begin('topBar');
+        ui.begin(UI_ANCHORS.TOP_BAR);
         ui.panel('Music Playback - Crossfade and Loop Points');
         ui.end();
 
         // The track panel, pinned just below the title strip. Width and height size
         // themselves to the widest row and the number of rows – no layout math here.
-        ui.begin('topLeft', { y: 30 });
+        ui.begin(UI_ANCHORS.TOP_LEFT, { y: 30 });
         ui.panel('Tracks');
 
         // One button per track. Each label ends with its keyboard hint, and the kit binds

--- a/packages/demos/src/named-colors.js
+++ b/packages/demos/src/named-colors.js
@@ -29,7 +29,7 @@ import { bootstrap, BT, Color32, Rect2i, Vector2i } from 'blit386';
 // The shared demo UI kit. applyTheme() installs the kit's twelve UI colors high in the
 // palette (slots 240-251, far above this demo's slots 1-9), and ui.* draws the title
 // strip, the caption text, and the Tips panel.
-import { applyTheme, ui } from './shared/ui.js';
+import { applyTheme, ui, UI_ANCHORS } from './shared/ui.js';
 
 /** @typedef {import('blit386').IBTDemo} IBTDemo */
 
@@ -188,7 +188,7 @@ class Demo {
 
         // Full-width title strip across the top of the screen, drawn by the shared UI kit.
         // 'topBar' is the classic 22-pixel strip; panel() gives it a background and title.
-        ui.begin('topBar');
+        ui.begin(UI_ANCHORS.TOP_BAR);
         ui.panel('Built-in lookups + register / update / unregister');
         ui.end();
 
@@ -207,7 +207,7 @@ class Demo {
         // Captions under the swatches: a borderless kit group pinned inside the panel.
         // Passing x and y pins the group's top-left corner; pad: 0 removes the group's
         // inner padding so the first row starts exactly at (16, 100).
-        ui.begin('topLeft', { x: 16, y: 100, pad: 0 });
+        ui.begin(UI_ANCHORS.TOP_LEFT, { x: 16, y: 100, pad: 0 });
         ui.label("Custom dynamic name: 'demo-dynamic'");
         ui.label("Custom optional name: 'demo-optional'");
 
@@ -223,7 +223,7 @@ class Demo {
 
         // Lower panel: API tips as a kit panel anchored to the bottom-left corner.
         // The kit sizes the panel to its widest row and keeps a small screen margin.
-        ui.begin('bottomLeft');
+        ui.begin(UI_ANCHORS.BOTTOM_LEFT);
         ui.panel('Tips');
         ui.label('Names are trim + lowercase normalized.', { color: 'dim' });
         ui.label('registerColor throws if the name exists.', { color: 'dim' });

--- a/packages/demos/src/noise.js
+++ b/packages/demos/src/noise.js
@@ -33,7 +33,7 @@
 
 import { bootstrap, BT, Color32, PerlinNoise, Rect2i, SimplexNoise, ValueNoise } from 'blit386';
 
-import { applyTheme, ui } from './shared/ui.js';
+import { applyTheme, ui, UI_ANCHORS } from './shared/ui.js';
 
 /** @typedef {import('blit386').IBTDemo} IBTDemo */
 /** @typedef {import('blit386').Palette} Palette */
@@ -334,7 +334,7 @@ class Demo {
      * The three flavor buttons and the block size.
      */
     renderKindPanel() {
-        ui.begin('bottomLeft');
+        ui.begin(UI_ANCHORS.BOTTOM_LEFT);
         ui.panel('Flavor');
 
         for (let i = 0; i < KIND_NAMES.length; i++) {
@@ -357,7 +357,7 @@ class Demo {
      * The sliders and switches that shape the landscape.
      */
     renderShapePanel() {
-        ui.begin('bottomRight');
+        ui.begin(UI_ANCHORS.BOTTOM_RIGHT);
         ui.panel(`${KIND_NAMES[this.kind]} noise`);
 
         // Every control compares its new value against the old one, and only asks for a

--- a/packages/demos/src/palette-animation.js
+++ b/packages/demos/src/palette-animation.js
@@ -42,7 +42,7 @@
 
 import { bootstrap, BT, Color32, Rect2i, Vector2i } from 'blit386';
 
-import { applyTheme, ui } from './shared/ui.js';
+import { applyTheme, ui, UI_ANCHORS } from './shared/ui.js';
 
 /** @typedef {import('blit386').IBTDemo} IBTDemo */
 
@@ -416,7 +416,7 @@ class Demo {
         // The heading and subtitle live in a kit panel pinned to the band position.
         // ui.end() draws the panel right away, so the swatches drawn after it land ON TOP
         // of the panel background. ui.spacer() reserves empty rows for that artwork.
-        ui.begin('topLeft', { x: 0, y: bandY, width: 320 });
+        ui.begin(UI_ANCHORS.TOP_LEFT, { x: 0, y: bandY, width: 320 });
         ui.panel('Scrolling Gradient');
         ui.label('Hues rotate in update() each tick', { color: 'dim' });
         ui.spacer(18);
@@ -439,7 +439,7 @@ class Demo {
         const bandY = 70;
 
         // Kit panel with the heading; the spacer reserves room for the 80-pixel column.
-        ui.begin('topLeft', { x: 0, y: bandY, width: 320 });
+        ui.begin(UI_ANCHORS.TOP_LEFT, { x: 0, y: bandY, width: 320 });
         ui.panel('Fire Column');
         ui.label('Color stack shifts upward in update()', { color: 'dim' });
         ui.spacer(86);
@@ -478,7 +478,7 @@ class Demo {
         // The status text turns warm orange when health is critical, dim gray otherwise.
         const isCritical = this.health <= HEALTH_LOW;
 
-        ui.begin('topLeft', { x: 0, y: bandY, width: 320 });
+        ui.begin(UI_ANCHORS.TOP_LEFT, { x: 0, y: bandY, width: 320 });
         ui.panel('Flashing Health Bar');
         ui.spacer(18);
         ui.label(isCritical ? 'CRITICAL! slot 80 flashes red/white' : 'Healthy: slot 80 = steady red', {
@@ -511,7 +511,7 @@ class Demo {
         const bandY = 266;
 
         // Kit panel with the heading; the spacer reserves room for the tile strip.
-        ui.begin('topLeft', { x: 0, y: bandY, width: 320 });
+        ui.begin(UI_ANCHORS.TOP_LEFT, { x: 0, y: bandY, width: 320 });
         ui.panel('Cycling Water Strip');
         ui.label('3 slots (90..92) ripple in sequence', { color: 'dim' });
         ui.spacer(18);

--- a/packages/demos/src/palette-cycling.js
+++ b/packages/demos/src/palette-cycling.js
@@ -51,7 +51,7 @@
 
 import { bootstrap, BT, Color32, Rect2i } from 'blit386';
 
-import { applyTheme, ui } from './shared/ui.js';
+import { applyTheme, ui, UI_ANCHORS } from './shared/ui.js';
 
 /** @typedef {import('blit386').IBTDemo} IBTDemo */
 
@@ -282,7 +282,7 @@ class Demo {
         // The heading lives in a kit panel pinned to the band position. ui.end() draws
         // the panel right away, so the stripes drawn after it land ON TOP of the panel
         // background. ui.spacer() reserves empty rows for that artwork.
-        ui.begin('topLeft', { x: 0, y: bandY, width: 320 });
+        ui.begin(UI_ANCHORS.TOP_LEFT, { x: 0, y: bandY, width: 320 });
         ui.panel('Sky (0.5 steps/sec, forward)');
         ui.spacer(40);
         ui.end();
@@ -309,7 +309,7 @@ class Demo {
         const colW = Math.floor(308 / FIRE_SLOTS);
 
         // Kit panel with the heading; the spacer reserves room for the fire columns.
-        ui.begin('topLeft', { x: 0, y: bandY, width: 320 });
+        ui.begin(UI_ANCHORS.TOP_LEFT, { x: 0, y: bandY, width: 320 });
         ui.panel('Fire (-6 steps/sec, backward)');
         ui.spacer(40);
         ui.end();
@@ -340,7 +340,7 @@ class Demo {
         const colW = Math.floor(308 / WATER_SLOTS);
 
         // Kit panel with the heading; the spacer reserves room for the water tiles.
-        ui.begin('topLeft', { x: 0, y: bandY, width: 320 });
+        ui.begin(UI_ANCHORS.TOP_LEFT, { x: 0, y: bandY, width: 320 });
         ui.panel('Water (4 steps/sec, forward)');
         ui.spacer(54);
         ui.end();

--- a/packages/demos/src/palette-exposure-fade.js
+++ b/packages/demos/src/palette-exposure-fade.js
@@ -127,7 +127,14 @@
 
 import { bootstrap, BT, Color32, Rect2i, SpriteSheet, Vector2i } from 'blit386';
 
-import { applyTheme, THEME_DEFAULT_START_SLOT, THEME_PANEL_OFFSET, THEME_TEXT_OFFSET, ui } from './shared/ui.js';
+import {
+    applyTheme,
+    THEME_DEFAULT_START_SLOT,
+    THEME_PANEL_OFFSET,
+    THEME_TEXT_OFFSET,
+    ui,
+    UI_ANCHORS,
+} from './shared/ui.js';
 
 /** @typedef {import('blit386').IBTDemo} IBTDemo */
 /** @typedef {import('blit386').HardwareSettings} HardwareSettings */
@@ -447,7 +454,7 @@ class Demo {
 
         // Pinned to PANEL_Y rather than anchored to the bottom of the screen: the
         // overlay's palette grid owns the bottom, and it draws after this.
-        ui.begin('topLeft', { y: PANEL_Y });
+        ui.begin(UI_ANCHORS.TOP_LEFT, { y: PANEL_Y });
         ui.panel('Exposure Fade');
 
         // Dragging this changes the next fade, not the one already running – a fade

--- a/packages/demos/src/palette-fade.js
+++ b/packages/demos/src/palette-fade.js
@@ -61,7 +61,7 @@
 
 import { bootstrap, BT, Color32, Rect2i, Vector2i } from 'blit386';
 
-import { applyTheme, ui } from './shared/ui.js';
+import { applyTheme, ui, UI_ANCHORS } from './shared/ui.js';
 
 /** @typedef {import('blit386').IBTDemo} IBTDemo */
 
@@ -279,7 +279,7 @@ class Demo {
         // A small UI kit panel names the current phase, so viewers can follow the
         // cycle without opening the engine overlay. Its colors come from the theme
         // slots, which the fade leaves alone (see init()).
-        ui.begin('topLeft');
+        ui.begin(UI_ANCHORS.TOP_LEFT);
         ui.panel('Palette Fade & Flash');
         ui.label(this.getPhaseLabel());
         ui.end();

--- a/packages/demos/src/palette-presets.js
+++ b/packages/demos/src/palette-presets.js
@@ -46,7 +46,7 @@
 
 import { bootstrap, BT, Color32, Palette, Rect2i, Vector2i } from 'blit386';
 
-import { applyTheme, ui } from './shared/ui.js';
+import { applyTheme, ui, UI_ANCHORS } from './shared/ui.js';
 
 /** @typedef {import('blit386').IBTDemo} IBTDemo */
 
@@ -249,7 +249,7 @@ class Demo {
         BT.clear(this.theme.bg);
 
         // Full-width title strip across the top, drawn by the shared UI kit.
-        ui.begin('topBar');
+        ui.begin(UI_ANCHORS.TOP_BAR);
         ui.panel('Palette Presets - six built-in retro color sets');
         ui.end();
 
@@ -324,7 +324,7 @@ class Demo {
             // pad 0 draws nothing but the text, pinned right after the last swatch.
             const label = `${this.presetNames[p]} (${this.presets[p].size})`;
 
-            ui.begin('topLeft', { x: 6 + count * (SWATCH_W + 1) + 4, y: y + 1, pad: 0 });
+            ui.begin(UI_ANCHORS.TOP_LEFT, { x: 6 + count * (SWATCH_W + 1) + 4, y: y + 1, pad: 0 });
             ui.label(label, { color: 'dim' });
             ui.end();
         }
@@ -340,7 +340,7 @@ class Demo {
         // ui.spacer(28) reserves an empty band inside the panel where the 24px-tall
         // swatches will be drawn AFTER ui.end() – the kit paints its panel fill on
         // end(), so anything drawn later lands on top of it.
-        ui.begin('topLeft', { x: LIVE_PANEL_X, y: LIVE_PANEL_Y, width: 298 });
+        ui.begin(UI_ANCHORS.TOP_LEFT, { x: LIVE_PANEL_X, y: LIVE_PANEL_Y, width: 298 });
         ui.panel('Live view (cycles every 2s)');
         ui.spacer(28);
 

--- a/packages/demos/src/palette-swap.js
+++ b/packages/demos/src/palette-swap.js
@@ -50,7 +50,7 @@
 
 import { bootstrap, BT, Color32, Rect2i, SpriteSheet, Timer, Vector2i } from 'blit386';
 
-import { applyTheme, ui } from './shared/ui.js';
+import { applyTheme, ui, UI_ANCHORS } from './shared/ui.js';
 
 /** @typedef {import('blit386').IBTDemo} IBTDemo */
 
@@ -287,7 +287,7 @@ class Demo {
         // Section caption below the legend, drawn as a borderless kit group.
         // Passing x and y to ui.begin() pins the group's top-left corner exactly
         // there, so the caption sits right under the last legend entry.
-        ui.begin('topLeft', { x: 0, y: 113 });
+        ui.begin(UI_ANCHORS.TOP_LEFT, { x: 0, y: 113 });
         ui.label('Themes:', { color: 'header' });
         ui.label('2 s each', { color: 'dim' });
         ui.end();
@@ -310,7 +310,7 @@ class Demo {
         // under the artwork. The group's inner padding (6 px) shifts its text right
         // and down a little, so the pin point compensates by starting 6 px to the
         // left of the sprite and just 1 px below it.
-        ui.begin('topLeft', { x: spriteX - 6, y: spriteY + this.charSprite.height + 1 });
+        ui.begin(UI_ANCHORS.TOP_LEFT, { x: spriteX - 6, y: spriteY + this.charSprite.height + 1 });
 
         // Which theme the sprite is currently drawn with.
         ui.label(`Theme: ${this.themeNames[this.currentTheme]}`, { color: 'header' });
@@ -329,7 +329,7 @@ class Demo {
      * dim lines are code comments, blue "info" lines are the code itself.
      */
     renderCodePanel() {
-        ui.begin('topRight');
+        ui.begin(UI_ANCHORS.TOP_RIGHT);
 
         ui.label('How it works:', { color: 'header' });
         ui.label('// Build palettes', { color: 'dim' });

--- a/packages/demos/src/pointer-basics.js
+++ b/packages/demos/src/pointer-basics.js
@@ -26,7 +26,7 @@
 
 import { bootstrap, BT, Color32, Vector2i } from 'blit386';
 
-import { applyTheme, ui } from './shared/ui.js';
+import { applyTheme, ui, UI_ANCHORS } from './shared/ui.js';
 
 /** @typedef {import('blit386').IBTDemo} IBTDemo */
 
@@ -178,7 +178,7 @@ class Demo {
         BT.clear(this.theme.bg);
 
         // Full-width title strip with the one-line instructions.
-        ui.begin('topBar');
+        ui.begin(UI_ANCHORS.TOP_BAR);
         ui.panel('Pointer Basics - move, click, spin the wheel');
         ui.end();
 
@@ -205,7 +205,7 @@ class Demo {
         const scroll = BT.pointerScrollDelta;
 
         // The panel starts below the title strip (y: 28 skips past it).
-        ui.begin('topLeft', { y: 28 });
+        ui.begin(UI_ANCHORS.TOP_LEFT, { y: 28 });
         ui.panel('Slot 0 (mouse)');
 
         ui.kv('Active', active ? 'yes' : 'no');
@@ -240,7 +240,7 @@ class Demo {
      * released. BT.isDown() checks held state, which is safe from render().
      */
     renderButtonPips() {
-        ui.begin('topRight', { y: 28 });
+        ui.begin(UI_ANCHORS.TOP_RIGHT, { y: 28 });
         ui.panel('Buttons');
 
         // Each pip pairs a label with the live held-state of one button code.
@@ -264,7 +264,7 @@ class Demo {
         }
 
         // A borderless group (no ui.panel call) is just floating text.
-        ui.begin('bottomRight');
+        ui.begin(UI_ANCHORS.BOTTOM_RIGHT);
         ui.label('Scroll wheel and right-click: desktop only', { color: 'dim' });
         ui.end();
     }

--- a/packages/demos/src/pointer-drag-flick.js
+++ b/packages/demos/src/pointer-drag-flick.js
@@ -46,7 +46,7 @@
 
 import { AudioClip, bootstrap, BT, Color32, Vector2i } from 'blit386';
 
-import { applyTheme, ui } from './shared/ui.js';
+import { applyTheme, ui, UI_ANCHORS } from './shared/ui.js';
 
 /** @typedef {import('blit386').IBTDemo} IBTDemo */
 
@@ -492,7 +492,7 @@ class Demo {
      */
     renderHUD() {
         // The classic full-width 22 px title strip along the top edge.
-        ui.begin('topBar');
+        ui.begin(UI_ANCHORS.TOP_BAR);
         ui.panel('Drag a ball, release to flick');
 
         // Browsers refuse to play any sound until the page is clicked or a key
@@ -508,7 +508,7 @@ class Demo {
         // a wall. ui.pip() draws a small square that fills in while its state is true.
         const labels = ['M', 'T1', 'T2', 'T3'];
 
-        ui.begin('topRight', { y: HUD_HEIGHT + 6 });
+        ui.begin(UI_ANCHORS.TOP_RIGHT, { y: HUD_HEIGHT + 6 });
         ui.panel('Grabs');
 
         for (let slot = 0; slot < 4; slot++) {

--- a/packages/demos/src/pointer-paint.js
+++ b/packages/demos/src/pointer-paint.js
@@ -39,7 +39,7 @@
 
 import { bootstrap, BT, Color32, Vector2i } from 'blit386';
 
-import { applyTheme, THEME_DEFAULT_START_SLOT, ui } from './shared/ui.js';
+import { applyTheme, THEME_DEFAULT_START_SLOT, ui, UI_ANCHORS } from './shared/ui.js';
 
 /** @typedef {import('blit386').IBTDemo} IBTDemo */
 
@@ -371,7 +371,7 @@ class Demo {
      * reserved for that).
      */
     renderPanel() {
-        ui.begin('bottomRight');
+        ui.begin(UI_ANCHORS.BOTTOM_RIGHT);
         ui.panel('Paint');
 
         // One pip per pointer slot: lit while that mouse / finger is active.

--- a/packages/demos/src/random-basics.js
+++ b/packages/demos/src/random-basics.js
@@ -35,7 +35,7 @@
 
 import { bootstrap, BT, Color32, Rect2i, Vector2i } from 'blit386';
 
-import { applyTheme, ui } from './shared/ui.js';
+import { applyTheme, ui, UI_ANCHORS } from './shared/ui.js';
 
 /** @typedef {import('blit386').IBTDemo} IBTDemo */
 /** @typedef {import('blit386').Palette} Palette */
@@ -324,7 +324,7 @@ class Demo {
         // The mode picker sits in the same corner in every scene, so it never moves around.
         // Two arrow buttons rather than five named ones: at 320x240 a five-row panel would
         // swallow half the screen, and the number keys still jump straight to a scene.
-        ui.begin('bottomLeft');
+        ui.begin(UI_ANCHORS.BOTTOM_LEFT);
         ui.panel(`Scene ${this.mode + 1}/5 (keys 1-5)`);
         ui.label(MODE_NAMES[this.mode], { color: 'accent' });
 
@@ -609,7 +609,7 @@ class Demo {
      * The two shuffle buttons, which are the whole lesson of this scene.
      */
     renderShufflePanel() {
-        ui.begin('bottomRight');
+        ui.begin(UI_ANCHORS.BOTTOM_RIGHT);
         ui.panel('Shuffle');
 
         if (ui.button('shuffle() a copy', { key: 'KeyC' })) {
@@ -641,7 +641,7 @@ class Demo {
             total += count;
         }
 
-        ui.begin('bottomRight');
+        ui.begin(UI_ANCHORS.BOTTOM_RIGHT);
         ui.panel('Drops so far');
 
         for (let i = 0; i < TIER_NAMES.length; i++) {
@@ -662,7 +662,7 @@ class Demo {
      * The spread slider and the flat-versus-clumped switch.
      */
     renderGaussianPanel() {
-        ui.begin('bottomRight');
+        ui.begin(UI_ANCHORS.BOTTOM_RIGHT);
         ui.panel('Scatter');
 
         this.useGaussian = ui.checkbox('Use gaussian()', this.useGaussian, { key: 'KeyG' });
@@ -686,7 +686,7 @@ class Demo {
     renderSignPanel() {
         const total = this.leftCount + this.rightCount;
 
-        ui.begin('bottomRight');
+        ui.begin(UI_ANCHORS.BOTTOM_RIGHT);
         ui.panel('Coin flips');
         ui.kv('Left (-1)', this.leftCount);
         ui.kv('Right (+1)', this.rightCount);
@@ -701,7 +701,7 @@ class Demo {
      * A reminder of what separates the two bugs.
      */
     renderDirectionsPanel() {
-        ui.begin('bottomRight');
+        ui.begin(UI_ANCHORS.BOTTOM_RIGHT);
         ui.panel('Two bugs');
         ui.label('Blue: direction4()', { color: 'info' });
         ui.label('up, down, left, right', { color: 'dim' });

--- a/packages/demos/src/seeded-worlds.js
+++ b/packages/demos/src/seeded-worlds.js
@@ -32,7 +32,7 @@
 
 import { bootstrap, BT, Color32, Random, Rect2i, Vector2i } from 'blit386';
 
-import { applyTheme, ui } from './shared/ui.js';
+import { applyTheme, ui, UI_ANCHORS } from './shared/ui.js';
 
 /** @typedef {import('blit386').IBTDemo} IBTDemo */
 /** @typedef {import('blit386').Palette} Palette */
@@ -327,7 +327,7 @@ class Demo {
      * The three buttons that reseed the worlds.
      */
     renderSeedPanel() {
-        ui.begin('bottomLeft');
+        ui.begin(UI_ANCHORS.BOTTOM_LEFT);
         ui.panel('Seeds');
 
         if (ui.button('New left', { key: 'KeyQ' })) {
@@ -354,7 +354,7 @@ class Demo {
      * The clone-versus-fork comparison.
      */
     renderStreamPanel() {
-        ui.begin('bottomRight');
+        ui.begin(UI_ANCHORS.BOTTOM_RIGHT);
         ui.panel(`One more generator (seed ${this.streams.seed})`);
         ui.kv('original', this.streams.base.join(' '));
         ui.kv('clone()', this.streams.cloned.join(' '));

--- a/packages/demos/src/shared/crt-glitch.js
+++ b/packages/demos/src/shared/crt-glitch.js
@@ -1,0 +1,122 @@
+/**
+ * Shared CRT "TV fault" glitch constants for the five glitch-driven demos.
+ *
+ * Two glitch-type sets exist here by design, not by accident: the full-color group
+ * (crt-pipboy, snake-game, basics-enhanced) includes 'chromasplit', a color-channel
+ * split that only reads as a glitch on a color CRT. The Tesla Orava B/W group
+ * (sprite-effects, logo-lowres) swaps that for 'vroll', a vertical roll – a fault a
+ * black-and-white tube shows instead, since it has no color channels to split. Before
+ * this module existed the two groups' overlapping type keys (hshift/noise/flicker/
+ * interference) had drifted to different on-screen labels between the two groups –
+ * see .claude/rules/named-constants.md for the worked example. GLITCH_LABELS below is
+ * the fix: one canonical label per key, covering both groups' full key set.
+ *
+ * applyGlitchUniforms()/resetGlitchUniforms() are shared ONLY by crt-pipboy.js,
+ * snake-game.js, and basics-enhanced.js – their glitch-apply code and tuning constants
+ * were verified byte-for-byte identical before this extraction. sprite-effects.js and
+ * logo-lowres.js have real behavioral differences from that group and from each other
+ * (different tuning constants, logo-lowres's hshift also drives chroma aberration, its
+ * flicker scales by peak instead of envelope) and keep their own bespoke apply methods –
+ * they only import the type list and labels from here, not the shared functions.
+ */
+
+// Glitch state-machine tuning shared by crt-pipboy.js, snake-game.js, and
+// basics-enhanced.js. sprite-effects.js and logo-lowres.js use their own, different
+// tuning constants and do not import these.
+const GLITCH_COOLDOWN_MIN = 120;
+const GLITCH_COOLDOWN_MAX = 360;
+const GLITCH_ACTIVE_MIN = 5;
+const GLITCH_ACTIVE_MAX = 30;
+const GLITCH_INTENSITY_MIN = 0.35;
+const GLITCH_INTENSITY_MAX = 1.0;
+
+const FLICKER_BASE = 1.0;
+const FLICKER_DIP = 0.6;
+const ABERRATION_BASE = 0;
+const NOISE_BASE = 0.025;
+
+// Pixel-tier glitch band height, identical across the three full-color demos.
+const PIXEL_GLITCH_BAND_HEIGHT = 6;
+
+// The five full-color TV faults: horizontal tear, chroma split, snow, brightness
+// waver, ghosting. Used by crt-pipboy.js, snake-game.js, basics-enhanced.js.
+const GLITCH_TYPES_CHROMA = ['hshift', 'chromasplit', 'noise', 'flicker', 'interference'];
+
+// The five Tesla Orava B/W faults: horizontal tear, snow, brightness waver, ghosting,
+// vertical roll (no chroma split – a B/W tube has no color channels). Used by
+// sprite-effects.js and logo-lowres.js.
+const GLITCH_TYPES_VROLL = ['hshift', 'noise', 'flicker', 'interference', 'vroll'];
+
+// Canonical on-screen label for every glitch key across both groups. Any demo with a
+// HUD looks a key up here instead of hand-typing its own label map.
+const GLITCH_LABELS = {
+    none: 'NONE',
+    hshift: 'H-HOLD',
+    chromasplit: 'CHROMA',
+    noise: 'SNOW',
+    flicker: 'DIM',
+    interference: 'GHOST',
+    vroll: 'V-ROLL',
+};
+
+/**
+ * Returns every glitch-driven effect uniform to its resting value. Shared by
+ * crt-pipboy.js, snake-game.js, and basics-enhanced.js only.
+ *
+ * @param {object} instance – The demo's `this`. Must already have `.pixelGlitch`,
+ *   `.aberration`, `.noise`, `.flicker`, `.interference` effect objects created.
+ */
+function resetGlitchUniforms(instance) {
+    instance.pixelGlitch.intensity = 0;
+    instance.aberration.aberration = ABERRATION_BASE;
+    instance.noise.amount = NOISE_BASE;
+    instance.flicker.amount = FLICKER_BASE;
+    instance.interference.amount = 0;
+}
+
+/**
+ * Layers the chosen glitch personality onto the resting effect uniforms. Shared by
+ * crt-pipboy.js, snake-game.js, and basics-enhanced.js only – verified byte-for-byte
+ * identical across those three before extraction (same GLITCH_TYPES_CHROMA keys, same
+ * tuning constants, same math per branch).
+ *
+ * @param {object} instance – The demo's `this`. Must have `.glitchType`, `.glitchPeak`,
+ *   and the same five effect objects as resetGlitchUniforms().
+ * @param {number} envelope – 0 -> 1 -> 0 over the lifetime of the burst.
+ */
+function applyGlitchUniforms(instance, envelope) {
+    const peak = instance.glitchPeak * envelope;
+
+    resetGlitchUniforms(instance);
+
+    if (instance.glitchType === 'hshift') {
+        instance.pixelGlitch.intensity = peak;
+    } else if (instance.glitchType === 'chromasplit') {
+        instance.aberration.aberration = ABERRATION_BASE + peak * 4;
+    } else if (instance.glitchType === 'noise') {
+        instance.noise.amount = NOISE_BASE + peak * 0.08;
+    } else if (instance.glitchType === 'flicker') {
+        instance.flicker.amount = FLICKER_BASE - (FLICKER_BASE - FLICKER_DIP) * envelope;
+    } else if (instance.glitchType === 'interference') {
+        instance.interference.amount = peak * 0.06;
+    }
+}
+
+export {
+    ABERRATION_BASE,
+    applyGlitchUniforms,
+    FLICKER_BASE,
+    FLICKER_DIP,
+    GLITCH_ACTIVE_MAX,
+    GLITCH_ACTIVE_MIN,
+    GLITCH_COOLDOWN_MAX,
+    GLITCH_COOLDOWN_MIN,
+    GLITCH_INTENSITY_MAX,
+    GLITCH_INTENSITY_MIN,
+    GLITCH_LABELS,
+    GLITCH_TYPES_CHROMA,
+    GLITCH_TYPES_VROLL,
+    NOISE_BASE,
+    PIXEL_GLITCH_BAND_HEIGHT,
+    resetGlitchUniforms,
+};

--- a/packages/demos/src/shared/ui-core.js
+++ b/packages/demos/src/shared/ui-core.js
@@ -59,6 +59,17 @@ const CMD_TEXT = 2;
 // flush time (used by ui.separator(), which cannot know the final width when declared).
 const FULL_WIDTH = -1;
 
+// The five group anchors a demo can pass to ui.begin(anchor). 'topBar' is the classic
+// full-width title strip; the other four pin a group to a screen corner, with bottom
+// anchors growing the group upward (see resolveOriginY()).
+const UI_ANCHORS = {
+    TOP_LEFT: 'topLeft',
+    TOP_RIGHT: 'topRight',
+    BOTTOM_LEFT: 'bottomLeft',
+    BOTTOM_RIGHT: 'bottomRight',
+    TOP_BAR: 'topBar',
+};
+
 // The engine tracks up to four pointers: slot 0 is the mouse, slots 1-3 are touches.
 const POINTER_SLOTS = 4;
 
@@ -195,7 +206,7 @@ class UiContext {
     // Per-group layout state (valid between begin() and end()).
     inGroup = false;
 
-    anchor = 'topLeft';
+    anchor = UI_ANCHORS.TOP_LEFT;
 
     groupOptX = null;
 
@@ -351,7 +362,7 @@ class UiContext {
      *   to the screen edge; pad is the inner padding; kvCols is the key column width of
      *   ui.kv() rows, in characters.
      */
-    begin(anchor = 'topLeft', opts = {}) {
+    begin(anchor = UI_ANCHORS.TOP_LEFT, opts = {}) {
         if (!T.ready) {
             throw new Error('ui.begin: call applyTheme(palette) in init() before drawing any UI.');
         }
@@ -373,7 +384,7 @@ class UiContext {
 
         this.inGroup = true;
         this.anchor = anchor;
-        this.isTopBar = anchor === 'topBar';
+        this.isTopBar = anchor === UI_ANCHORS.TOP_BAR;
         this.groupOptX = typeof opts.x === 'number' ? opts.x : null;
         this.groupOptY = typeof opts.y === 'number' ? opts.y : null;
         this.groupOptWidth = typeof opts.width === 'number' ? opts.width : null;
@@ -446,7 +457,7 @@ class UiContext {
             return 0;
         }
 
-        const isRight = this.anchor === 'topRight' || this.anchor === 'bottomRight';
+        const isRight = this.anchor === UI_ANCHORS.TOP_RIGHT || this.anchor === UI_ANCHORS.BOTTOM_RIGHT;
 
         return isRight ? display.x - this.margin - groupW : this.margin;
     }
@@ -469,7 +480,7 @@ class UiContext {
             return 0;
         }
 
-        const isBottom = this.anchor === 'bottomLeft' || this.anchor === 'bottomRight';
+        const isBottom = this.anchor === UI_ANCHORS.BOTTOM_LEFT || this.anchor === UI_ANCHORS.BOTTOM_RIGHT;
 
         return isBottom ? display.y - this.margin - groupH : this.margin;
     }
@@ -756,4 +767,15 @@ class UiContext {
     }
 }
 
-export { BUTTON_H, CMD_RECT_FILL, CMD_RECT_STROKE, CMD_TEXT, FONT_W, FULL_WIDTH, hitContains, ROW_H, UiContext };
+export {
+    BUTTON_H,
+    CMD_RECT_FILL,
+    CMD_RECT_STROKE,
+    CMD_TEXT,
+    FONT_W,
+    FULL_WIDTH,
+    hitContains,
+    ROW_H,
+    UI_ANCHORS,
+    UiContext,
+};

--- a/packages/demos/src/shared/ui-theme.js
+++ b/packages/demos/src/shared/ui-theme.js
@@ -66,6 +66,12 @@ const THEME_DEFAULT_START_SLOT = 240;
 const THEME_PANEL_OFFSET = THEME_COLORS.findIndex((entry) => entry.key === 'panel');
 const THEME_TEXT_OFFSET = THEME_COLORS.findIndex((entry) => entry.key === 'text');
 
+// The five color roles a demo can pass as `{ color: '<role>' }` at any UI kit call site.
+// ui-widgets.js's roleSlot() derives its role -> T-slot lookup from this list so the two
+// can never independently drift – see the worked example in the root
+// .claude/rules/named-constants.md for what happens when they do.
+const UI_ROLES = ['dim', 'header', 'accent', 'warm', 'info'];
+
 const T = {
     bg: 0,
     shadow: 0,
@@ -140,4 +146,4 @@ function applyTheme(palette, startSlot = THEME_DEFAULT_START_SLOT) {
     };
 }
 
-export { applyTheme, T, THEME_DEFAULT_START_SLOT, THEME_PANEL_OFFSET, THEME_TEXT_OFFSET };
+export { applyTheme, T, THEME_DEFAULT_START_SLOT, THEME_PANEL_OFFSET, THEME_TEXT_OFFSET, UI_ROLES };

--- a/packages/demos/src/shared/ui-widgets.js
+++ b/packages/demos/src/shared/ui-widgets.js
@@ -64,7 +64,7 @@ function roleSlot(role) {
 
     if (!warnedRoles.has(role)) {
         console.warn(
-            `ui: unrecognized color role "${role}" - falling back to text. Valid roles: ${UI_ROLES.join(', ')}.`,
+            `ui: unrecognized color role "${role}" – falling back to text. Valid roles: ${UI_ROLES.join(', ')}.`,
         );
         warnedRoles.add(role);
     }

--- a/packages/demos/src/shared/ui-widgets.js
+++ b/packages/demos/src/shared/ui-widgets.js
@@ -14,7 +14,7 @@
 import { BT } from 'blit386';
 
 import { BUTTON_H, CMD_RECT_FILL, CMD_RECT_STROKE, CMD_TEXT, FONT_W, FULL_WIDTH, ROW_H } from './ui-core.js';
-import { T } from './ui-theme.js';
+import { T, UI_ROLES } from './ui-theme.js';
 
 // Checkbox pip geometry: a 10x10 square with the label starting 14 pixels in.
 const PIP_SIZE = 10;
@@ -40,27 +40,36 @@ function clamp(value, min, max) {
     return Math.max(min, Math.min(max, value));
 }
 
+// Roles that already failed a roleSlot() lookup once – logged once each, not once per
+// frame, so a demo with a typo'd role does not spam the console at 60 FPS.
+const warnedRoles = new Set();
+
 /**
  * Translates a color role name ('dim', 'header', ...) into its theme palette slot.
+ * 'text' (and any other unrecognized value, including undefined) falls back to T.text –
+ * this fallback is intentional: a demo passing no {color} option, or the literal role
+ * 'text', should draw with the plain text color, not throw.
  *
- * @param {string | undefined} role – One of 'text', 'dim', 'header', 'accent', 'warm', 'info'.
+ * @param {string | undefined} role – One of UI_ROLES, or 'text', or omitted.
  * @returns {number} A palette index from the shared theme.
  */
 function roleSlot(role) {
-    switch (role) {
-        case 'dim':
-            return T.dim;
-        case 'header':
-            return T.header;
-        case 'accent':
-            return T.accent;
-        case 'warm':
-            return T.warm;
-        case 'info':
-            return T.info;
-        default:
-            return T.text;
+    if (role === undefined || role === 'text') {
+        return T.text;
     }
+
+    if (UI_ROLES.includes(role)) {
+        return T[role];
+    }
+
+    if (!warnedRoles.has(role)) {
+        console.warn(
+            `ui: unrecognized color role "${role}" - falling back to text. Valid roles: ${UI_ROLES.join(', ')}.`,
+        );
+        warnedRoles.add(role);
+    }
+
+    return T.text;
 }
 
 /**

--- a/packages/demos/src/shared/ui.js
+++ b/packages/demos/src/shared/ui.js
@@ -34,7 +34,7 @@
  * so steady-state frames allocate nothing – safe to call from render() at 60 FPS.
  */
 
-import { UiContext } from './ui-core.js';
+import { UI_ANCHORS, UiContext } from './ui-core.js';
 import { dpadIsDown, dpadIsPressed, dpadWidget, stepDpad } from './ui-dpad.js';
 import { stepGestures, swipeResult, tapIn } from './ui-gestures.js';
 import { applyTheme, THEME_DEFAULT_START_SLOT, THEME_PANEL_OFFSET, THEME_TEXT_OFFSET } from './ui-theme.js';
@@ -279,4 +279,4 @@ const ui = {
     },
 };
 
-export { applyTheme, THEME_DEFAULT_START_SLOT, THEME_PANEL_OFFSET, THEME_TEXT_OFFSET, ui };
+export { applyTheme, THEME_DEFAULT_START_SLOT, THEME_PANEL_OFFSET, THEME_TEXT_OFFSET, ui, UI_ANCHORS };

--- a/packages/demos/src/snake-game.js
+++ b/packages/demos/src/snake-game.js
@@ -50,8 +50,23 @@ import {
     Vignette,
 } from 'blit386';
 
+import {
+    ABERRATION_BASE,
+    applyGlitchUniforms,
+    FLICKER_BASE,
+    GLITCH_ACTIVE_MAX,
+    GLITCH_ACTIVE_MIN,
+    GLITCH_COOLDOWN_MAX,
+    GLITCH_COOLDOWN_MIN,
+    GLITCH_INTENSITY_MAX,
+    GLITCH_INTENSITY_MIN,
+    GLITCH_TYPES_CHROMA,
+    NOISE_BASE,
+    PIXEL_GLITCH_BAND_HEIGHT,
+    resetGlitchUniforms,
+} from './shared/crt-glitch.js';
 import { isAvailable, SOFTWARE_FALLBACK_NOTE } from './shared/post-process-backend.js';
-import { applyTheme, ui } from './shared/ui.js';
+import { applyTheme, ui, UI_ANCHORS } from './shared/ui.js';
 
 /** @typedef {import('blit386').IBTDemo} IBTDemo */
 /** @typedef {import('blit386').HardwareSettings} HardwareSettings */
@@ -118,23 +133,6 @@ const MUSIC_PITCH_FADE_MS = 120;
 
 // Two seconds at 60 ticks per second before a new round starts.
 const RESTART_DELAY_TICKS = 120;
-
-// CRT glitch state machine (same tuning as crt-pipboy demo)
-const GLITCH_COOLDOWN_MIN = 120;
-const GLITCH_COOLDOWN_MAX = 360;
-const GLITCH_ACTIVE_MIN = 5;
-const GLITCH_ACTIVE_MAX = 30;
-
-const GLITCH_TYPES = ['hshift', 'chromasplit', 'noise', 'flicker', 'interference'];
-
-const GLITCH_INTENSITY_MIN = 0.35;
-const GLITCH_INTENSITY_MAX = 1.0;
-
-const FLICKER_BASE = 1.0;
-const FLICKER_DIP = 0.6;
-
-const ABERRATION_BASE = 0;
-const NOISE_BASE = 0.025;
 
 /**
  * Minimal snake with PipBoy CRT post-processing from crt-pipboy demo.
@@ -435,7 +433,7 @@ class Demo {
         // the same gesture that starts the snake moving, so the hint is usually only
         // visible for a single frame. The default sentence is too long for this 160-wide
         // playfield, so we pass a short override.
-        ui.begin('topLeft', { margin: 3 });
+        ui.begin(UI_ANCHORS.TOP_LEFT, { margin: 3 });
         ui.audioUnlockHint({ text: 'Click for sound' });
         ui.end();
 
@@ -453,7 +451,7 @@ class Demo {
     setupCrtEffects() {
         // Pixel-tier glitch (same role as crt-pipboy demo).
         this.pixelGlitch = new PixelGlitch();
-        this.pixelGlitch.bandHeight = 6;
+        this.pixelGlitch.bandHeight = PIXEL_GLITCH_BAND_HEIGHT;
         this.pixelGlitch.intensity = 0;
         BT.effectAdd(this.pixelGlitch);
 
@@ -607,14 +605,14 @@ class Demo {
             const t = 1 - this.glitchTicksLeft / this.glitchDuration;
             const envelope = Math.sin(t * Math.PI);
 
-            this.applyGlitchUniforms(envelope);
+            applyGlitchUniforms(this, envelope);
 
             this.glitchTicksLeft--;
 
             // Countdown just hit zero: the burst is over, so calm the effects down
             // and roll a fresh cooldown until the next burst.
             if (this.glitchTicksLeft === 0) {
-                this.resetGlitchUniforms();
+                resetGlitchUniforms(this);
                 this.glitchCooldown = BT.random.int(GLITCH_COOLDOWN_MIN, GLITCH_COOLDOWN_MAX);
             }
 
@@ -626,41 +624,12 @@ class Demo {
         if (this.glitchCooldown <= 0) {
             // pick() draws one item out of a list, like taking a card off the top of a shuffled deck.
             // float() is the decimal cousin of int(), for values that are not whole numbers.
-            this.glitchType = BT.random.pick(GLITCH_TYPES);
+            this.glitchType = BT.random.pick(GLITCH_TYPES_CHROMA);
             this.glitchDuration = BT.random.int(GLITCH_ACTIVE_MIN, GLITCH_ACTIVE_MAX);
             this.glitchTicksLeft = this.glitchDuration;
             this.glitchPeak = BT.random.float(GLITCH_INTENSITY_MIN, GLITCH_INTENSITY_MAX);
             this.pixelGlitch.seed = BT.random.float(0, 1000);
         }
-    }
-
-    /**
-     * @param {number} envelope – 0 -> 1 -> 0 over the glitch burst.
-     */
-    applyGlitchUniforms(envelope) {
-        const peak = this.glitchPeak * envelope;
-
-        this.resetGlitchUniforms();
-
-        if (this.glitchType === 'hshift') {
-            this.pixelGlitch.intensity = peak;
-        } else if (this.glitchType === 'chromasplit') {
-            this.aberration.aberration = ABERRATION_BASE + peak * 4;
-        } else if (this.glitchType === 'noise') {
-            this.noise.amount = NOISE_BASE + peak * 0.08;
-        } else if (this.glitchType === 'flicker') {
-            this.flicker.amount = FLICKER_BASE - (FLICKER_BASE - FLICKER_DIP) * envelope;
-        } else if (this.glitchType === 'interference') {
-            this.interference.amount = peak * 0.06;
-        }
-    }
-
-    resetGlitchUniforms() {
-        this.pixelGlitch.intensity = 0;
-        this.aberration.aberration = ABERRATION_BASE;
-        this.noise.amount = NOISE_BASE;
-        this.flicker.amount = FLICKER_BASE;
-        this.interference.amount = 0;
     }
 
     /**

--- a/packages/demos/src/sprite-effects.js
+++ b/packages/demos/src/sprite-effects.js
@@ -60,8 +60,9 @@ import {
     Vignette,
 } from 'blit386';
 
+import { GLITCH_LABELS, GLITCH_TYPES_VROLL } from './shared/crt-glitch.js';
 import { isAvailable, SOFTWARE_FALLBACK_NOTE } from './shared/post-process-backend.js';
-import { applyTheme, ui } from './shared/ui.js';
+import { applyTheme, ui, UI_ANCHORS } from './shared/ui.js';
 
 /** @typedef {import('blit386').IBTDemo} IBTDemo */
 
@@ -151,17 +152,6 @@ const GLITCH_ACTIVE_MIN = 4;
 const GLITCH_ACTIVE_MAX = 24;
 const GLITCH_INTENSITY_MIN = 0.3;
 const GLITCH_INTENSITY_MAX = 0.95;
-
-// Tesla Orava B/W: horizontal tear, snow, brightness waver, ghosting, vertical roll (no chroma split).
-const GLITCH_TYPES = ['hshift', 'noise', 'flicker', 'interference', 'vroll'];
-const GLITCH_LABELS = {
-    none: 'NONE',
-    hshift: 'H-HOLD',
-    noise: 'SNOW',
-    flicker: 'DIM',
-    interference: 'GHOST',
-    vroll: 'V-ROLL',
-};
 
 // The shared fallback note is one long sentence. split('. ') cuts the string at the
 // sentence break, giving us an array of two shorter lines the UI kit can draw one under
@@ -473,7 +463,7 @@ class Demo {
         // borderless kit group in the top-left corner; the shared note was split into
         // two lines up top (FALLBACK_LINES) so it stays short and easy to read.
         if (!this.effectsAvailable) {
-            ui.begin('topLeft', { margin: 2, pad: 2 });
+            ui.begin(UI_ANCHORS.TOP_LEFT, { margin: 2, pad: 2 });
 
             for (const line of FALLBACK_LINES) {
                 ui.label(line, { color: 'warm' });
@@ -620,7 +610,7 @@ class Demo {
         if (this.glitchCooldown <= 0) {
             // pick() draws one item out of a list, like taking a card off the top of a shuffled deck.
             // float() is the decimal cousin of int().
-            this.glitchType = BT.random.pick(GLITCH_TYPES);
+            this.glitchType = BT.random.pick(GLITCH_TYPES_VROLL);
             this.glitchDuration = BT.random.int(GLITCH_ACTIVE_MIN, GLITCH_ACTIVE_MAX);
             this.glitchTicksLeft = this.glitchDuration;
             this.glitchPeak = BT.random.float(GLITCH_INTENSITY_MIN, GLITCH_INTENSITY_MAX);

--- a/packages/demos/src/sprites.js
+++ b/packages/demos/src/sprites.js
@@ -41,7 +41,7 @@
 import { bootstrap, BT, Color32, Rect2i, SpriteSheet, Vector2i } from 'blit386';
 
 import { canvasToImage, registerCanvasColors } from './shared/canvas-sprites.js';
-import { applyTheme, ui } from './shared/ui.js';
+import { applyTheme, ui, UI_ANCHORS } from './shared/ui.js';
 
 /** @typedef {import('blit386').IBTDemo} IBTDemo */
 
@@ -422,7 +422,7 @@ class Demo {
      * to the bottom-left corner of the screen.
      */
     renderCodeSnippet() {
-        ui.begin('bottomLeft', { y: 178 });
+        ui.begin(UI_ANCHORS.BOTTOM_LEFT, { y: 178 });
         ui.panel('Production PNG load:');
         ui.label('const indexed = await SpriteSheet', { color: 'info' });
         ui.label("  .loadIndexed('/sprites/test.png', palette, 10);", { color: 'info' });

--- a/packages/demos/src/starfield.js
+++ b/packages/demos/src/starfield.js
@@ -39,7 +39,7 @@
 
 import { bootstrap, BT, Color32, Rect2i, Vector2i } from 'blit386';
 
-import { applyTheme, ui } from './shared/ui.js';
+import { applyTheme, ui, UI_ANCHORS } from './shared/ui.js';
 
 /** @typedef {import('blit386').IBTDemo} IBTDemo */
 
@@ -423,7 +423,7 @@ class Demo {
      * keeps the sky visible behind the caption instead of covering it with a box.
      */
     drawLabels() {
-        ui.begin('topLeft');
+        ui.begin(UI_ANCHORS.TOP_LEFT);
         ui.label('FAR: slow, dim, 1 pixel', { color: 'dim' });
         ui.label('MED: faster, brighter pixel', { color: 'dim' });
         ui.label('NEAR: fastest, bright 2x2 block', { color: 'dim' });

--- a/packages/demos/src/synth-toy.js
+++ b/packages/demos/src/synth-toy.js
@@ -51,7 +51,7 @@
 
 import { AudioClip, bootstrap, BT } from 'blit386';
 
-import { applyTheme, THEME_DEFAULT_START_SLOT, ui } from './shared/ui.js';
+import { applyTheme, THEME_DEFAULT_START_SLOT, ui, UI_ANCHORS } from './shared/ui.js';
 
 /** @typedef {import('blit386').IBTDemo} IBTDemo */
 /** @typedef {import('blit386').Palette} Palette */
@@ -242,7 +242,7 @@ class Demo {
         BT.clear(this.theme.bg);
 
         // The full-width title strip along the top edge.
-        ui.begin('topBar');
+        ui.begin(UI_ANCHORS.TOP_BAR);
         ui.panel('Synth Toy - six presets and a randomizer');
         ui.end();
 
@@ -257,7 +257,7 @@ class Demo {
      * the title strip.
      */
     renderUnlockPrompt() {
-        ui.begin('topLeft', { y: 28 });
+        ui.begin(UI_ANCHORS.TOP_LEFT, { y: 28 });
 
         // The shared "click to enable sound" row – it draws itself only while sound is
         // still locked, and disappears on its own after the first click or key press.
@@ -276,7 +276,7 @@ class Demo {
      * on click, tap, or its keyboard shortcut – ui.button() treats all three the same.
      */
     renderPresetPanel() {
-        ui.begin('bottomLeft');
+        ui.begin(UI_ANCHORS.BOTTOM_LEFT);
         ui.panel('Presets');
 
         for (let i = 0; i < PRESET_DEFINITIONS.length; i++) {
@@ -302,7 +302,7 @@ class Demo {
     renderRandomPanel() {
         const params = this.lastRandomParams;
 
-        ui.begin('bottomRight');
+        ui.begin(UI_ANCHORS.BOTTOM_RIGHT);
         ui.panel('Randomizer');
 
         if (ui.button('R - Randomize', { key: 'KeyR' })) {

--- a/packages/demos/src/tilemap.js
+++ b/packages/demos/src/tilemap.js
@@ -27,7 +27,7 @@
 
 import { bootstrap, BT, Color32, Rect2i, Vector2i } from 'blit386';
 
-import { applyTheme, ui } from './shared/ui.js';
+import { applyTheme, ui, UI_ANCHORS } from './shared/ui.js';
 
 /** @typedef {import('blit386').IBTDemo} IBTDemo */
 
@@ -406,7 +406,7 @@ class Demo {
         // rows, draws the panel background, and places the group for us.
         // The kit draws in whatever camera space is active, so this must run AFTER
         // BT.cameraReset() – otherwise the panel would scroll away with the world.
-        ui.begin('topLeft');
+        ui.begin(UI_ANCHORS.TOP_LEFT);
         ui.panel('Tilemap');
         ui.label('30x20 tiles, 16px each', { color: 'dim' });
         ui.label('Camera scrolls automatically', { color: 'dim' });
@@ -429,7 +429,7 @@ class Demo {
 
         // Backing panel from the shared UI kit (same look as every other demo panel).
         // spacer() reserves the tile area; the custom tile overlay draws on top after end().
-        ui.begin('topLeft', { x: mapX - 2, y: mapY - 2, width: mapPixelW + 4, margin: 0, pad: 2 });
+        ui.begin(UI_ANCHORS.TOP_LEFT, { x: mapX - 2, y: mapY - 2, width: mapPixelW + 4, margin: 0, pad: 2 });
         ui.panel();
         ui.spacer(mapPixelH);
         ui.end();


### PR DESCRIPTION
## Summary

- Fixes a real shipped bug: `basics-enhanced.js` showed conflicting on-screen glitch labels (H-SHIFT/NOISE/FLICKER) versus `sprite-effects.js`/`logo-lowres.js` (H-HOLD/SNOW/DIM) for the same glitch-type keys, because all five demos hand-rolled their own `GLITCH_TYPES`/`GLITCH_LABELS` with no shared source of truth.
- Adds `src/shared/crt-glitch.js` exporting the canonical `GLITCH_TYPES_CHROMA`/`GLITCH_TYPES_VROLL` type sets and one `GLITCH_LABELS` map (H-HOLD/SNOW/DIM/GHOST/CHROMA/V-ROLL), plus the shared `applyGlitchUniforms()`/`resetGlitchUniforms()` for the three demos (`crt-pipboy`, `snake-game`, `basics-enhanced`) whose glitch-apply code was verified byte-for-byte identical. `sprite-effects` and `logo-lowres` keep their own bespoke apply logic (different tuning constants, an extra chroma-fringe effect on `hshift` in `logo-lowres`) and only import the shared type list/labels — zero behavior change beyond the label-text fix, both glitch-type sets kept as-is by design (a full-color CRT group with `chromasplit`, a B/W Tesla Orava group with `vroll`).
- Adds `UI_ROLES` to `ui-theme.js`; `roleSlot()` in `ui-widgets.js` now validates against it with a once-per-role `console.warn` on an unrecognized role instead of silently falling back to plain text.
- Adds `UI_ANCHORS` to `ui-core.js`, re-exported through `ui.js`; migrates all 88 `ui.begin()` call sites across 40 demo files from bare anchor literals to the shared constant.

Implements [BT-316](https://linear.app/vancura/issue/BT-316), sub-issue of the [BT-313](https://linear.app/vancura/issue/BT-313) named-constants epic.

## Test plan

- [x] `pnpm run preflight` (format, lint, spellcheck, knip, demo-registry, comment-links, build) passes clean
- [x] Deterministically verified `GLITCH_LABELS`/`GLITCH_TYPES_CHROMA`/`GLITCH_TYPES_VROLL` and `applyGlitchUniforms()` math via a standalone Node import of the new module
- [x] Live-browser-checked `crt-pipboy`, `snake-game`, `basics-enhanced`, `sprite-effects`, `logo-lowres` load with no console errors, WebGPU renders correctly, and `basics-enhanced`'s overlay correctly reads the new labels from the shared import at runtime
- [x] Live-browser-checked role colors (`random-basics`) and anchor positions (`sprite-effects`) render correctly post-migration
- [ ] Reviewer spot-check: trigger a few glitch bursts in `basics-enhanced` to visually confirm H-HOLD/SNOW/DIM labels (the automated browser preview's tick throttling made this impractical to catch live during development — see PR description above for the deterministic alternative used instead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Standardized panel and overlay positioning across demos for more consistent layouts.
  * Improved handling of UI color roles, including safer fallbacks for invalid values.
* **Visual Effects**
  * Unified CRT glitch behavior across applicable demos, including shared tuning, labels, and effect patterns.
  * Maintained consistent glitch presentation across color, monochrome, and vertical-roll effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->