### PR TITLE
fix(website): build the engine automatically when dist is missing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,10 @@ jobs:
         run: pnpm run test:spellcheck-coverage
         background: true
 
+      - name: Run ensure-engine-built tests
+        run: pnpm run test:ensure-engine-built
+        background: true
+
       - wait-all:
 
   security-audit:

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:compact-tables": "node --test scripts/prettier-plugin-compact-tables.test.mjs",
     "test:shell-safety": "node --test scripts/shell-safety.test.mjs",
     "test:spellcheck-coverage": "node --test scripts/spellcheck-coverage.test.mjs",
+    "test:ensure-engine-built": "node --test scripts/ensure-engine-built.test.mjs",
     "bump": "node scripts/bump-lockstep.mjs",
     "bump:check": "node scripts/bump-lockstep.mjs --check",
     "test:bump-lockstep": "node --test scripts/bump-lockstep.test.mjs",

--- a/packages/demos/package.json
+++ b/packages/demos/package.json
@@ -33,10 +33,10 @@
     "node": ">=22.18.0"
   },
   "scripts": {
-    "dev": "node scripts/ensure-engine-built.mjs && vite",
+    "dev": "node ../../scripts/ensure-engine-built.mjs && vite",
     "dev:watch": "pnpm --filter blit386 run build && concurrently -n \"lib,demos\" -c \"blue,green\" \"pnpm --filter blit386 run build:browser --watch\" \"pnpm run dev\"",
-    "build": "node scripts/ensure-engine-built.mjs && vite build",
-    "preview": "node scripts/ensure-engine-built.mjs && vite preview",
+    "build": "node ../../scripts/ensure-engine-built.mjs && vite build",
+    "preview": "node ../../scripts/ensure-engine-built.mjs && vite preview",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "biome format --write . && prettier --ignore-path ../../.prettierignore --write \"**/*.{md,mdx,yml,yaml}\"",
@@ -52,7 +52,7 @@
     "generate:audio-loops": "node scripts/generate-audio-loops.mjs",
     "test": "node --test \"scripts/__tests__/*.test.mjs\" \"plugins/__tests__/*.test.mjs\"",
     "preflight": "pnpm run format:check && pnpm run lint && pnpm run test && pnpm run spellcheck && pnpm run knip && pnpm run check:demo-registry && pnpm run check:demo-comment-links && pnpm run build",
-    "knip": "node scripts/ensure-engine-built.mjs && cd ../.. && knip --workspace packages/demos",
+    "knip": "node ../../scripts/ensure-engine-built.mjs && cd ../.. && knip --workspace packages/demos",
     "knip:fix": "knip --fix",
     "clean": "rm -rf dist node_modules/.vite",
     "prepare": "husky",

--- a/packages/website/CLAUDE.md
+++ b/packages/website/CLAUDE.md
@@ -235,11 +235,14 @@ block that fails compilation degrades to plain highlighting instead of crashing 
 `blit386` is a `workspace:*` devDependency (BT-414), not a pinned npm version – Twoslash resolves its type declarations
 from `packages/blit386/dist`, so a doc can reference and validate unreleased engine API before it ships, and the engine
 must be built (`pnpm --filter blit386 run build`) before this package's `build` in every CI/deploy job that runs one –
-and now before `pnpm run dev:twoslash` too, since dev can run the transformer as well. Because `throws: false` swallows
-a failing block into plain highlighting rather than an error, a regression here is silent.
-`grep -c twoslash-hover "dist/public/docs/<page>/index.html"` after a build (`<page>` is a placeholder, e.g.
-`api/random`; keep it quoted or the shell reads `<`/`>` as redirection) is only a page-wide smoke check, not proof a
-specific block typechecked – a page with several blocks can show a nonzero count while one block still silently failed
+and now before `pnpm run dev:twoslash` too, since dev can run the transformer as well. `pnpm run test` and
+`pnpm run build` self-heal a missing `packages/blit386/dist` automatically – both are prefixed with the shared
+`scripts/ensure-engine-built.mjs` at the repo root (BT-480), the same guard `packages/demos` already runs (BT-399), so a
+freshly created checkout or git worktree builds the engine once instead of failing `test` with a TS2307 inside Twoslash
+compilation. Because `throws: false` swallows a failing block into plain highlighting rather than an error, a regression
+here is silent. `grep -c twoslash-hover "dist/public/docs/<page>/index.html"` after a build (`<page>` is a placeholder,
+e.g. `api/random`; keep it quoted or the shell reads `<`/`>` as redirection) is only a page-wide smoke check, not proof
+a specific block typechecked – a page with several blocks can show a nonzero count while one block still silently failed
 (see BT-427). To confirm one block specifically, grep the built HTML for a distinctive identifier from that block's
 source and check whether it renders as a hoverable `twoslash-hover` token instead of plain syntax-highlighted text.
 

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -33,7 +33,7 @@
   "scripts": {
     "dev": "waku dev",
     "dev:twoslash": "cross-env BLIT386_TWOSLASH=1 NODE_OPTIONS=--max-old-space-size=8192 waku dev",
-    "build": "fumadocs-mdx && cross-env CLOUDFLARE=1 waku build",
+    "build": "node ../../scripts/ensure-engine-built.mjs && fumadocs-mdx && cross-env CLOUDFLARE=1 waku build",
     "postbuild": "node scripts/patch-wrangler.mjs && node scripts/patch-html-title.mjs",
     "start": "wrangler dev --config dist/server/wrangler.json",
     "typecheck": "fumadocs-mdx && tsc --noEmit",
@@ -48,7 +48,7 @@
     "encode:video": "node scripts/encode-video.mjs",
     "knip": "cd ../.. && knip --workspace packages/website",
     "knip:fix": "cd ../.. && knip --workspace packages/website --fix",
-    "test": "pnpm run test:scripts && pnpm run test:unit:coverage",
+    "test": "node ../../scripts/ensure-engine-built.mjs && pnpm run test:scripts && pnpm run test:unit:coverage",
     "test:scripts": "node --test scripts/__tests__/*.test.mjs",
     "test:scripts:watch": "node --test --watch scripts/__tests__/*.test.mjs",
     "test:unit": "vitest run",

--- a/scripts/ensure-engine-built.mjs
+++ b/scripts/ensure-engine-built.mjs
@@ -2,16 +2,19 @@
 /**
  * Build the BLIT386 engine automatically when `packages/blit386/dist` is missing – the case for
  * every freshly created checkout or git worktree, since `dist/` is gitignored and only a build
- * produces it. `vite.config.js` imports `blit386/vite` at the top of the file, unconditionally,
- * so `dev`, `build`, `preview`, and `knip` (which loads `vite.config.js` via its own Vite plugin)
- * all crash before that import is even reached if the engine has never been built. Run before
- * each of those so the failure self-heals instead of surfacing as a confusing "Cannot find
- * module" error partway through `git push`.
+ * produces it. Shared by `packages/demos` and `packages/website`, which hit this in different
+ * ways: `packages/demos/vite.config.js` imports `blit386/vite` at the top of the file,
+ * unconditionally, so `dev`, `build`, `preview`, and `knip` (which loads `vite.config.js` via its
+ * own Vite plugin) all crash before that import is even reached; `packages/website`'s Twoslash
+ * pipeline compiles docs samples against the workspace engine (BT-414), so its `test` and `build`
+ * fail inside that compilation with TS2307 instead. Run before any of those so the failure
+ * self-heals instead of surfacing as a confusing "Cannot find module" error partway through
+ * `git push`.
  *
  * A no-op once the engine is built – existsSync is the only cost on every normal run.
  *
- * Usage:
- *   node scripts/ensure-engine-built.mjs
+ * Usage (from a package directory):
+ *   node ../../scripts/ensure-engine-built.mjs
  */
 import { spawnSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
@@ -20,7 +23,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const scriptDir = fileURLToPath(new URL('.', import.meta.url));
 
-const resolveEngineViteEntry = () => resolve(scriptDir, '..', '..', 'blit386', 'dist', 'vite.js');
+const resolveEngineViteEntry = () => resolve(scriptDir, '..', 'packages', 'blit386', 'dist', 'vite.js');
 
 const isEngineBuilt = (engineViteEntry = resolveEngineViteEntry(), exists = existsSync) => exists(engineViteEntry);
 

--- a/scripts/ensure-engine-built.test.mjs
+++ b/scripts/ensure-engine-built.test.mjs
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
 
-import { buildEngineBuildCommand, isEngineBuilt, resolveEngineViteEntry } from '../ensure-engine-built.mjs';
+import { buildEngineBuildCommand, isEngineBuilt, resolveEngineViteEntry } from './ensure-engine-built.mjs';
 
 describe('ensure-engine-built', () => {
     describe('resolveEngineViteEntry', () => {
@@ -36,7 +36,7 @@ describe('ensure-engine-built', () => {
 
             assert.equal(command, 'pnpm');
             assert.deepEqual(args, ['--filter', 'blit386', 'run', 'build']);
-            assert.ok(cwd.endsWith(join('packages', 'demos')));
+            assert.ok(!cwd.includes('packages'));
         });
     });
 });

--- a/scripts/ensure-engine-built.test.mjs
+++ b/scripts/ensure-engine-built.test.mjs
@@ -1,8 +1,11 @@
 import assert from 'node:assert/strict';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
 
 import { buildEngineBuildCommand, isEngineBuilt, resolveEngineViteEntry } from './ensure-engine-built.mjs';
+
+const repositoryRoot = resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
 
 describe('ensure-engine-built', () => {
     describe('resolveEngineViteEntry', () => {
@@ -36,7 +39,7 @@ describe('ensure-engine-built', () => {
 
             assert.equal(command, 'pnpm');
             assert.deepEqual(args, ['--filter', 'blit386', 'run', 'build']);
-            assert.ok(!cwd.includes('packages'));
+            assert.equal(cwd, repositoryRoot);
         });
     });
 });


### PR DESCRIPTION
## Summary

- `packages/website`'s `test` step fails in any freshly created git worktree with `TS2307` ("Cannot find module 'blit386'"), because `packages/blit386`'s `dist/` is gitignored and Twoslash (BT-414) compiles docs samples against the workspace engine, not the published one. This takes `preflight` and the pre-push hook down with it.
- BT-399 (PR #561) fixed the identical failure class for `packages/demos` via `packages/demos/scripts/ensure-engine-built.mjs`. This PR promotes that script to a single shared implementation at `scripts/ensure-engine-built.mjs` (matching the existing root-`scripts/` convention for cross-package scripts, e.g. `check-markdown-links.mjs`) instead of duplicating it, and wires both `demos` and `website` through it.
- Verified empirically in a dist-less checkout which website scripts actually need the guard: `typecheck` and `knip` both pass without a built engine, so only `test` and `build` are prefixed with the guard.

## Test plan

- [x] Confirmed the exact reported `TS2307` failure reproduces by moving `packages/blit386/dist` aside and running the website twoslash test directly
- [x] `pnpm --filter blit386-website run typecheck` and `pnpm --filter blit386-website run knip` both pass with no engine dist — confirmed no guard needed there
- [x] `pnpm --filter blit386-website run preflight` passes end-to-end with `packages/blit386/dist` fully removed (fresh-worktree simulation), with the guard's "building the engine first" message printing exactly once
- [x] `pnpm --filter blit386-website run preflight` still passes with `dist/` already built, and does **not** re-invoke the engine build (no log message, fast run) — the guard is a no-op
- [x] `pnpm --filter blit386-demos run build` and `pnpm --filter blit386-demos run preflight` pass with the rewired `../../scripts/ensure-engine-built.mjs` path
- [x] `pnpm run test:ensure-engine-built` passes at the root for the moved/adapted test suite
- [x] Pre-push hook (this PR's own push) ran `preflight` for `website`/`demos`/root-shared scope and passed cleanly

Relates to Linear BT-480.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Development, testing, and build workflows now automatically ensure the required engine is built first.
  - Demo and website commands use a consistent engine-build process, reducing setup issues and workflow failures.
  - Continuous integration now verifies engine-build readiness as part of quality checks.

- **Documentation**
  - Clarified when the engine must be built for Twoslash development.
  - Documented automatic engine builds during testing and production builds.
  - Added guidance on interpreting Twoslash hover-token checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->