### PR TITLE
fix(kit): merge a pre-existing MCP config on agents add instead of aborting

### DIFF
--- a/packages/create-blit386/test/scaffold.test.mjs
+++ b/packages/create-blit386/test/scaffold.test.mjs
@@ -22,6 +22,7 @@ import {
     generateCursorAdapter,
     isKitManaged,
     kitRoot,
+    MCP_SERVER_NAME,
     resolveKitRoot,
 } from '@blit386/kit/adapters';
 
@@ -1240,7 +1241,7 @@ test('blit agents sync keeps a user-added MCP server in .mcp.json', { skip: !has
     }
 });
 
-test('blit agents add claude aborts safely on a hand-written .mcp.json', () => {
+test('blit agents add claude aborts safely on a conflicting .mcp.json server entry', () => {
     const work = mkdtempSync(join(tmpdir(), 'cbt-mcp-collision-'));
 
     try {
@@ -1255,10 +1256,11 @@ test('blit agents add claude aborts safely on a hand-written .mcp.json', () => {
             pmRunLint: 'npm run lint',
         });
 
-        // The user already registered an unrelated MCP server before asking for Claude. That file is
-        // theirs, so the add is all-or-nothing: nothing is written except the .new copy.
+        // The user already registered a server under the same key the kit wants to add, but pointing
+        // somewhere else. That is a real conflict, not a mergeable addition, so the add is
+        // all-or-nothing: nothing is written except the .new copy.
         const mcpPath = join(project, '.mcp.json');
-        const userContent = `${JSON.stringify({ mcpServers: { mine: { type: 'http', url: 'https://example.test/mcp' } } }, null, 2)}\n`;
+        const userContent = `${JSON.stringify({ mcpServers: { [MCP_SERVER_NAME]: { type: 'http', url: 'https://example.test/mcp' } } }, null, 2)}\n`;
         writeFileSync(mcpPath, userContent);
 
         const { exitCode, output } = runBlit(project, ['agents', 'add', 'claude']);
@@ -1276,6 +1278,78 @@ test('blit agents add claude aborts safely on a hand-written .mcp.json', () => {
             userContent,
             'a later sync must not overwrite the user .mcp.json after an aborted add',
         );
+    } finally {
+        rmSync(work, { recursive: true, force: true });
+    }
+});
+
+test('blit agents add claude merges a pre-existing .mcp.json', () => {
+    const work = mkdtempSync(join(tmpdir(), 'cbt-mcp-merge-add-'));
+
+    try {
+        const project = join(work, 'mcp-merge-add-game');
+        scaffold({
+            targetDir: project,
+            projectName: 'mcp-merge-add-game',
+            pmInstall: 'npm install',
+            pmRunDev: 'npm run dev',
+            pmRunBuild: 'npm run build',
+            pmRunFormat: 'npm run format',
+            pmRunLint: 'npm run lint',
+        });
+
+        // The user already registered an unrelated MCP server before asking for Claude. .mcp.json is
+        // an allowlisted structural-merge target, so the kit's server is added next to it instead of
+        // aborting the whole add.
+        const mcpPath = join(project, '.mcp.json');
+        const userContent = `${JSON.stringify({ mcpServers: { mine: { type: 'http', url: 'https://example.test/mcp' } } }, null, 2)}\n`;
+        writeFileSync(mcpPath, userContent);
+
+        const { exitCode } = runBlit(project, ['agents', 'add', 'claude']);
+
+        assert.equal(exitCode, 0, 'a clean merge should exit 0');
+        assert.ok(!existsSync(`${mcpPath}.new`), 'a clean merge should not leave a .new conflict copy');
+        assert.ok(existsSync(join(project, 'CLAUDE.md')), 'a clean merge should still set up the rest of Claude');
+
+        const merged = JSON.parse(readFileSync(mcpPath, 'utf8'));
+        assert.ok(merged.mcpServers.mine, 'the user server must survive the add');
+        assert.ok(merged.mcpServers[MCP_SERVER_NAME], 'the kit server must be present');
+
+        const check = runBlit(project, ['agents', 'sync', '--check']);
+        assert.equal(check.exitCode, 0, 'a clean-merged .mcp.json must not be reported as drift');
+    } finally {
+        rmSync(work, { recursive: true, force: true });
+    }
+});
+
+test('blit agents add claude aborts safely on malformed .mcp.json', () => {
+    const work = mkdtempSync(join(tmpdir(), 'cbt-mcp-malformed-'));
+
+    try {
+        const project = join(work, 'mcp-malformed-game');
+        scaffold({
+            targetDir: project,
+            projectName: 'mcp-malformed-game',
+            pmInstall: 'npm install',
+            pmRunDev: 'npm run dev',
+            pmRunBuild: 'npm run build',
+            pmRunFormat: 'npm run format',
+            pmRunLint: 'npm run lint',
+        });
+
+        // A pre-existing .mcp.json that isn't even valid JSON cannot be merged. It must fall back to
+        // the same collision behavior as a file that fails to parse, not crash.
+        const mcpPath = join(project, '.mcp.json');
+        const userContent = '{ not valid json';
+        writeFileSync(mcpPath, userContent);
+
+        const { exitCode, output } = runBlit(project, ['agents', 'add', 'claude']);
+
+        assert.equal(readFileSync(mcpPath, 'utf8'), userContent, 'the malformed .mcp.json must not be overwritten');
+        assert.ok(existsSync(`${mcpPath}.new`), 'the kit version should be saved as .mcp.json.new');
+        assert.ok(output.includes('.mcp.json.new'), 'output should mention the .new copy');
+        assert.notEqual(exitCode, 0, 'a needs-review collision should exit non-zero');
+        assert.ok(!existsSync(join(project, 'CLAUDE.md')), 'an aborted add must not write the other Claude files');
     } finally {
         rmSync(work, { recursive: true, force: true });
     }

--- a/packages/create-blit386/test/scaffold.test.mjs
+++ b/packages/create-blit386/test/scaffold.test.mjs
@@ -1241,6 +1241,16 @@ test('blit agents sync keeps a user-added MCP server in .mcp.json', { skip: !has
     }
 });
 
+// Shared pmInstall/pmRunDev/pmRunBuild/pmRunFormat/pmRunLint fixture for the MCP-config tests below – they
+// only care about the .mcp.json merge behavior, not which package manager the scaffold fixture records.
+const PNPM_SCAFFOLD_COMMANDS = {
+    pmInstall: 'pnpm install',
+    pmRunDev: 'pnpm run dev',
+    pmRunBuild: 'pnpm run build',
+    pmRunFormat: 'pnpm run format',
+    pmRunLint: 'pnpm run lint',
+};
+
 test('blit agents add claude aborts safely on a conflicting .mcp.json server entry', () => {
     const work = mkdtempSync(join(tmpdir(), 'cbt-mcp-collision-'));
 
@@ -1249,11 +1259,7 @@ test('blit agents add claude aborts safely on a conflicting .mcp.json server ent
         scaffold({
             targetDir: project,
             projectName: 'mcp-collision-game',
-            pmInstall: 'pnpm install',
-            pmRunDev: 'pnpm run dev',
-            pmRunBuild: 'pnpm run build',
-            pmRunFormat: 'pnpm run format',
-            pmRunLint: 'pnpm run lint',
+            ...PNPM_SCAFFOLD_COMMANDS,
         });
 
         // The user already registered a server under the same key the kit wants to add, but pointing
@@ -1291,11 +1297,7 @@ test('blit agents add claude merges a pre-existing .mcp.json', () => {
         scaffold({
             targetDir: project,
             projectName: 'mcp-merge-add-game',
-            pmInstall: 'pnpm install',
-            pmRunDev: 'pnpm run dev',
-            pmRunBuild: 'pnpm run build',
-            pmRunFormat: 'pnpm run format',
-            pmRunLint: 'pnpm run lint',
+            ...PNPM_SCAFFOLD_COMMANDS,
         });
 
         // The user already registered an unrelated MCP server before asking for Claude. .mcp.json is
@@ -1330,11 +1332,7 @@ test('blit agents add claude aborts safely on malformed .mcp.json', () => {
         scaffold({
             targetDir: project,
             projectName: 'mcp-malformed-game',
-            pmInstall: 'pnpm install',
-            pmRunDev: 'pnpm run dev',
-            pmRunBuild: 'pnpm run build',
-            pmRunFormat: 'pnpm run format',
-            pmRunLint: 'pnpm run lint',
+            ...PNPM_SCAFFOLD_COMMANDS,
         });
 
         // A pre-existing .mcp.json that isn't even valid JSON cannot be merged. It must fall back to
@@ -1363,11 +1361,7 @@ test('blit agents add claude aborts safely on a non-object .mcp.json mcpServers 
         scaffold({
             targetDir: project,
             projectName: 'mcp-bad-shape-game',
-            pmInstall: 'pnpm install',
-            pmRunDev: 'pnpm run dev',
-            pmRunBuild: 'pnpm run build',
-            pmRunFormat: 'pnpm run format',
-            pmRunLint: 'pnpm run lint',
+            ...PNPM_SCAFFOLD_COMMANDS,
         });
 
         // Valid JSON, but `mcpServers` is an array instead of an object – not a shape the merge can
@@ -1396,11 +1390,7 @@ test('blit agents add claude merges when the same server entry is written in a d
         scaffold({
             targetDir: project,
             projectName: 'mcp-key-order-game',
-            pmInstall: 'pnpm install',
-            pmRunDev: 'pnpm run dev',
-            pmRunBuild: 'pnpm run build',
-            pmRunFormat: 'pnpm run format',
-            pmRunLint: 'pnpm run lint',
+            ...PNPM_SCAFFOLD_COMMANDS,
         });
 
         // Same server entry as the kit generates, but with its keys written in a different order.

--- a/packages/create-blit386/test/scaffold.test.mjs
+++ b/packages/create-blit386/test/scaffold.test.mjs
@@ -1249,11 +1249,11 @@ test('blit agents add claude aborts safely on a conflicting .mcp.json server ent
         scaffold({
             targetDir: project,
             projectName: 'mcp-collision-game',
-            pmInstall: 'npm install',
-            pmRunDev: 'npm run dev',
-            pmRunBuild: 'npm run build',
-            pmRunFormat: 'npm run format',
-            pmRunLint: 'npm run lint',
+            pmInstall: 'pnpm install',
+            pmRunDev: 'pnpm run dev',
+            pmRunBuild: 'pnpm run build',
+            pmRunFormat: 'pnpm run format',
+            pmRunLint: 'pnpm run lint',
         });
 
         // The user already registered a server under the same key the kit wants to add, but pointing
@@ -1291,11 +1291,11 @@ test('blit agents add claude merges a pre-existing .mcp.json', () => {
         scaffold({
             targetDir: project,
             projectName: 'mcp-merge-add-game',
-            pmInstall: 'npm install',
-            pmRunDev: 'npm run dev',
-            pmRunBuild: 'npm run build',
-            pmRunFormat: 'npm run format',
-            pmRunLint: 'npm run lint',
+            pmInstall: 'pnpm install',
+            pmRunDev: 'pnpm run dev',
+            pmRunBuild: 'pnpm run build',
+            pmRunFormat: 'pnpm run format',
+            pmRunLint: 'pnpm run lint',
         });
 
         // The user already registered an unrelated MCP server before asking for Claude. .mcp.json is
@@ -1330,11 +1330,11 @@ test('blit agents add claude aborts safely on malformed .mcp.json', () => {
         scaffold({
             targetDir: project,
             projectName: 'mcp-malformed-game',
-            pmInstall: 'npm install',
-            pmRunDev: 'npm run dev',
-            pmRunBuild: 'npm run build',
-            pmRunFormat: 'npm run format',
-            pmRunLint: 'npm run lint',
+            pmInstall: 'pnpm install',
+            pmRunDev: 'pnpm run dev',
+            pmRunBuild: 'pnpm run build',
+            pmRunFormat: 'pnpm run format',
+            pmRunLint: 'pnpm run lint',
         });
 
         // A pre-existing .mcp.json that isn't even valid JSON cannot be merged. It must fall back to
@@ -1350,6 +1350,69 @@ test('blit agents add claude aborts safely on malformed .mcp.json', () => {
         assert.ok(output.includes('.mcp.json.new'), 'output should mention the .new copy');
         assert.notEqual(exitCode, 0, 'a needs-review collision should exit non-zero');
         assert.ok(!existsSync(join(project, 'CLAUDE.md')), 'an aborted add must not write the other Claude files');
+    } finally {
+        rmSync(work, { recursive: true, force: true });
+    }
+});
+
+test('blit agents add claude aborts safely on a non-object .mcp.json mcpServers value', () => {
+    const work = mkdtempSync(join(tmpdir(), 'cbt-mcp-bad-shape-'));
+
+    try {
+        const project = join(work, 'mcp-bad-shape-game');
+        scaffold({
+            targetDir: project,
+            projectName: 'mcp-bad-shape-game',
+            pmInstall: 'pnpm install',
+            pmRunDev: 'pnpm run dev',
+            pmRunBuild: 'pnpm run build',
+            pmRunFormat: 'pnpm run format',
+            pmRunLint: 'pnpm run lint',
+        });
+
+        // Valid JSON, but `mcpServers` is an array instead of an object – not a shape the merge can
+        // reason about, so it must fall back to the collision path rather than silently coercing it.
+        const mcpPath = join(project, '.mcp.json');
+        const userContent = `${JSON.stringify({ mcpServers: [] }, null, 2)}\n`;
+        writeFileSync(mcpPath, userContent);
+
+        const { exitCode, output } = runBlit(project, ['agents', 'add', 'claude']);
+
+        assert.equal(readFileSync(mcpPath, 'utf8'), userContent, 'the user .mcp.json must not be overwritten');
+        assert.ok(existsSync(`${mcpPath}.new`), 'the kit version should be saved as .mcp.json.new');
+        assert.ok(output.includes('.mcp.json.new'), 'output should mention the .new copy');
+        assert.notEqual(exitCode, 0, 'a needs-review collision should exit non-zero');
+        assert.ok(!existsSync(join(project, 'CLAUDE.md')), 'an aborted add must not write the other Claude files');
+    } finally {
+        rmSync(work, { recursive: true, force: true });
+    }
+});
+
+test('blit agents add claude merges when the same server entry is written in a different key order', () => {
+    const work = mkdtempSync(join(tmpdir(), 'cbt-mcp-key-order-'));
+
+    try {
+        const project = join(work, 'mcp-key-order-game');
+        scaffold({
+            targetDir: project,
+            projectName: 'mcp-key-order-game',
+            pmInstall: 'pnpm install',
+            pmRunDev: 'pnpm run dev',
+            pmRunBuild: 'pnpm run build',
+            pmRunFormat: 'pnpm run format',
+            pmRunLint: 'pnpm run lint',
+        });
+
+        // Same server entry as the kit generates, but with its keys written in a different order.
+        // Structural equality must treat this as identical, not as a conflict.
+        const mcpPath = join(project, '.mcp.json');
+        const userContent = `${JSON.stringify({ mcpServers: { [MCP_SERVER_NAME]: { url: 'https://blit386.dev/mcp', type: 'http' } } }, null, 2)}\n`;
+        writeFileSync(mcpPath, userContent);
+
+        const { exitCode } = runBlit(project, ['agents', 'add', 'claude']);
+
+        assert.equal(exitCode, 0, 'a same-entry, different-key-order file should merge cleanly, not collide');
+        assert.ok(!existsSync(`${mcpPath}.new`), 'a clean merge should not leave a .new conflict copy');
     } finally {
         rmSync(work, { recursive: true, force: true });
     }

--- a/packages/kit/src/adapters.ts
+++ b/packages/kit/src/adapters.ts
@@ -75,7 +75,7 @@ const MANAGED_END = '<!-- blit-kit:managed:end -->';
  * edit on either side that is not mirrored on the other fails the kit test suite rather than shipping
  * a generated game that points at a dead endpoint.
  */
-const MCP_SERVER_NAME = 'blit386-docs';
+export const MCP_SERVER_NAME = 'blit386-docs';
 const MCP_SERVER_URL = 'https://blit386.dev/mcp';
 
 /** A regenerated file: a project-relative path (forward slashes) and its full content. */

--- a/packages/kit/src/commands/agents.ts
+++ b/packages/kit/src/commands/agents.ts
@@ -26,6 +26,7 @@ import { createHash } from 'node:crypto';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, isAbsolute, join, normalize, resolve, sep } from 'node:path';
+import { isDeepStrictEqual } from 'node:util';
 
 import {
     agentsFile,
@@ -67,11 +68,17 @@ interface McpConfigLike {
     [key: string]: unknown;
 }
 
+/** True for a plain JSON object – the only shape `mcpServers` is allowed to have. */
+function isMcpServerMap(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 /**
  * Merge the kit's generated MCP config into a pre-existing hand-written one. Adds the kit's server(s)
  * under `mcpServers` next to whatever the user already registered. Returns null – not a crash – when
- * the existing file isn't a mergeable JSON object, or when a server key the kit wants to add already
- * exists with different content: both cases fall back to the existing collision (`.new` + abort) path.
+ * the existing file isn't a mergeable JSON object, its `mcpServers` isn't a plain object, or a server
+ * key the kit wants to add already exists with different content: all three cases fall back to the
+ * existing collision (`.new` + abort) path.
  */
 function tryMergeMcpConfig(existingContent: string, generatedContent: string): string | null {
     let existing: McpConfigLike;
@@ -82,7 +89,11 @@ function tryMergeMcpConfig(existingContent: string, generatedContent: string): s
         return null;
     }
 
-    if (typeof existing !== 'object' || existing === null || Array.isArray(existing)) {
+    if (!isMcpServerMap(existing)) {
+        return null;
+    }
+
+    if (existing.mcpServers !== undefined && !isMcpServerMap(existing.mcpServers)) {
         return null;
     }
 
@@ -92,7 +103,7 @@ function tryMergeMcpConfig(existingContent: string, generatedContent: string): s
 
     for (const [name, entry] of Object.entries(generatedServers)) {
         const existingEntry = existingServers[name];
-        if (existingEntry !== undefined && JSON.stringify(existingEntry) !== JSON.stringify(entry)) {
+        if (existingEntry !== undefined && !isDeepStrictEqual(existingEntry, entry)) {
             return null;
         }
     }

--- a/packages/kit/src/commands/agents.ts
+++ b/packages/kit/src/commands/agents.ts
@@ -38,7 +38,19 @@ import { detectPackageManager, findProjectRoot, type PackageManager } from '../e
 import { kitRoot } from '../kit-root';
 import { BASE_DIR, BLIT_DIR, MANIFEST_FILE, type ReadBlitManifest, type TemplateVars } from '../manifest';
 import { ui } from '../messages';
-import { AGENT_KINDS, AGENT_LABEL, type AgentKind, classifyFile, hasAgentFiles, isKitManaged } from '../ownership';
+import {
+    AGENT_KINDS,
+    AGENT_LABEL,
+    type AgentKind,
+    CLAUDE_MCP_JSON,
+    classifyFile,
+    CURSOR_MCP_JSON,
+    hasAgentFiles,
+    isKitManaged,
+} from '../ownership';
+
+/** JSON config paths eligible for structural (not text) merge in `runAddAgent`. */
+const MERGEABLE_JSON_PATHS: readonly string[] = [CLAUDE_MCP_JSON, CURSOR_MCP_JSON];
 
 /** SHA-256 hex digest of a string. */
 function sha256Text(text: string): string {
@@ -48,6 +60,46 @@ function sha256Text(text: string): string {
 /** SHA-256 hex digest of a file's current on-disk content. */
 function sha256(filePath: string): string {
     return createHash('sha256').update(readFileSync(filePath)).digest('hex');
+}
+
+interface McpConfigLike {
+    mcpServers?: Record<string, unknown>;
+    [key: string]: unknown;
+}
+
+/**
+ * Merge the kit's generated MCP config into a pre-existing hand-written one. Adds the kit's server(s)
+ * under `mcpServers` next to whatever the user already registered. Returns null – not a crash – when
+ * the existing file isn't a mergeable JSON object, or when a server key the kit wants to add already
+ * exists with different content: both cases fall back to the existing collision (`.new` + abort) path.
+ */
+function tryMergeMcpConfig(existingContent: string, generatedContent: string): string | null {
+    let existing: McpConfigLike;
+
+    try {
+        existing = JSON.parse(existingContent) as McpConfigLike;
+    } catch {
+        return null;
+    }
+
+    if (typeof existing !== 'object' || existing === null || Array.isArray(existing)) {
+        return null;
+    }
+
+    const generated = JSON.parse(generatedContent) as McpConfigLike;
+    const generatedServers = generated.mcpServers ?? {};
+    const existingServers = existing.mcpServers ?? {};
+
+    for (const [name, entry] of Object.entries(generatedServers)) {
+        const existingEntry = existingServers[name];
+        if (existingEntry !== undefined && JSON.stringify(existingEntry) !== JSON.stringify(entry)) {
+            return null;
+        }
+    }
+
+    const merged = { ...existing, mcpServers: { ...existingServers, ...generatedServers } };
+
+    return `${JSON.stringify(merged, null, 2)}\n`;
 }
 
 /**
@@ -561,8 +613,11 @@ function readManifest(root: string, out: (line: string) => void): ManifestResult
 /**
  * Set up one AI assistant's files in `root`. All-or-nothing: if any generated file would collide with
  * an existing untracked user file, nothing is written except `.new` copies and the manifest is left
- * untouched (so a later `sync` cannot clobber the user files). Returns the number of colliding files
- * that need the user's attention; 0 means the assistant was set up cleanly.
+ * untouched (so a later `sync` cannot clobber the user files). A generated path on the mergeable-JSON
+ * allowlist (`.mcp.json`, `.cursor/mcp.json`) is the one exception: a clean structural merge with the
+ * user's existing file is written and tracked like any other generated file instead of counting as a
+ * collision. Returns the number of colliding files that need the user's attention; 0 means the
+ * assistant was set up cleanly.
  */
 function runAddAgent(root: string, agent: AgentKind, out: (line: string) => void): number {
     const result = readManifest(root, out);
@@ -587,13 +642,44 @@ function runAddAgent(root: string, agent: AgentKind, out: (line: string) => void
     const entryByPath = new Map(manifest.files.map((e) => [e.path, e] as const));
 
     // A generated path that already exists on disk but is not tracked in the manifest belongs to the
-    // user. Setting up the assistant must be all-or-nothing: if we wrote only the non-colliding files,
-    // the assistant would be half-present, and a later `sync` would regenerate the colliding path, find
-    // no manifest entry, and overwrite the very user file we are protecting here. So if anything
-    // collides, save the kit versions beside the originals and stop without touching the project or the
-    // manifest.
-    const collisions = generated.filter(
-        (file) => isSafeRelPath(file.path, root) && existsSync(resolve(root, file.path)) && !entryByPath.has(file.path),
+    // user. For an allowlisted JSON config (the MCP config files), try a structural merge first: the
+    // kit's server can usually be added next to whatever the user already registered without touching
+    // their entries. Only a real conflict (same server key, different content) or an existing file
+    // that fails to parse as JSON falls through to the collision path below.
+    const mergedPaths = new Set<string>();
+    const preparedGenerated = generated.map((file) => {
+        if (
+            !MERGEABLE_JSON_PATHS.includes(file.path) ||
+            !isSafeRelPath(file.path, root) ||
+            !existsSync(resolve(root, file.path)) ||
+            entryByPath.has(file.path)
+        ) {
+            return file;
+        }
+
+        const onDisk = readFileSync(resolve(root, file.path), 'utf8');
+        const mergedContent = tryMergeMcpConfig(onDisk, file.content);
+
+        if (mergedContent === null) {
+            return file;
+        }
+
+        mergedPaths.add(file.path);
+
+        return { ...file, content: mergedContent };
+    });
+
+    // Setting up the assistant must be all-or-nothing: if we wrote only the non-colliding files, the
+    // assistant would be half-present, and a later `sync` would regenerate the colliding path, find no
+    // manifest entry, and overwrite the very user file we are protecting here. So if anything still
+    // collides after the merge attempt above, save the kit versions beside the originals and stop
+    // without touching the project or the manifest.
+    const collisions = preparedGenerated.filter(
+        (file) =>
+            isSafeRelPath(file.path, root) &&
+            existsSync(resolve(root, file.path)) &&
+            !entryByPath.has(file.path) &&
+            !mergedPaths.has(file.path),
     );
 
     if (collisions.length > 0) {
@@ -619,7 +705,7 @@ function runAddAgent(root: string, agent: AgentKind, out: (line: string) => void
         manifest.vars = vars;
     }
 
-    for (const file of generated) {
+    for (const file of preparedGenerated) {
         const relPath = file.path;
 
         if (!isSafeRelPath(relPath, root)) {
@@ -651,7 +737,7 @@ function runAddAgent(root: string, agent: AgentKind, out: (line: string) => void
     writeFileSync(join(root, BLIT_DIR, MANIFEST_FILE), `${JSON.stringify(refreshed, null, 2)}\n`);
 
     for (const path of added) {
-        out(ui.success(`Added ${path}.`));
+        out(ui.success(mergedPaths.has(path) ? `Merged ${path}.` : `Added ${path}.`));
     }
 
     out('');


### PR DESCRIPTION
## Summary

- Since BT-253, every scaffolded game gets a generated MCP config (`.mcp.json` for Claude Code, `.cursor/mcp.json` for Cursor). That file is also the natural place a developer registers their own MCP servers, but `runAddAgent` treated any pre-existing untracked file as a hard collision and aborted the whole `agents add`, even when the addition would have been a clean merge.
- Give `.mcp.json` and `.cursor/mcp.json` a narrow structural-merge path: parse both sides, add the kit's server under `mcpServers` next to whatever's already there, and fall back to the existing `.new`-and-abort behavior only when the same server key exists with different content or the existing file isn't valid JSON.
- The all-or-nothing guarantee for every other generated file is unchanged, and a merged file still lands in `.blit/manifest.json` with a matching `.blit/base/` copy, so a later `sync`'s three-way merge treats it like any other kit-owned file.

## Test plan

- [x] `pnpm --filter @blit386/kit run build && pnpm --filter create-blit386 run build`
- [x] `pnpm --filter @blit386/kit run test` (52 passing)
- [x] `pnpm --filter create-blit386 run test` (35 passing, including the repurposed same-key-conflict test, a new clean-merge test, and a new malformed-JSON test)
- [x] Manual run: scaffolded a game with no assistant, hand-wrote `.mcp.json` with an unrelated server, ran `blit agents add claude`, confirmed both servers survive in `.mcp.json` and `blit agents sync --check` exits 0
- [x] Repo-wide `format:check`, `docs:links`, `agents:check`, `check-dash-typography`, `bump:check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Existing Claude and Cursor MCP configurations now merge safely, preserving unrelated server entries while adding generated servers.
  * Equivalent configurations merge cleanly without unnecessary collision files.
  * Setup output distinguishes merged configuration files from newly created files.

* **Bug Fixes**
  * Conflicting or malformed MCP configurations no longer overwrite user content.
  * Invalid configurations are preserved, with a `.new` file created when needed to prevent incomplete setup changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->