### PR TITLE
refactor(assets): centralize palette transparent-index and buffer-size constants

### DIFF
--- a/packages/blit386/src/BLIT386.ts
+++ b/packages/blit386/src/BLIT386.ts
@@ -15,7 +15,7 @@ import { AssetLoader } from './assets/AssetLoader';
 import { AudioClip } from './assets/AudioClip';
 import type { TextSize } from './assets/BitmapFont';
 import { BitmapFont } from './assets/BitmapFont';
-import { Palette } from './assets/Palette';
+import { MAX_PALETTE_SIZE, Palette } from './assets/Palette';
 import type { ExposureFadeOptions } from './assets/PaletteEffect';
 import type { IndexedSpriteLoadResult } from './assets/SpriteSheet';
 import { SpriteSheet } from './assets/SpriteSheet';
@@ -1062,7 +1062,7 @@ export const BT = {
      * @param size – Palette size. Defaults to 256 colors.
      * @returns New mutable palette.
      */
-    paletteCreate: (size: number = 256): Palette => {
+    paletteCreate: (size: number = MAX_PALETTE_SIZE): Palette => {
         return new Palette(size);
     },
 

--- a/packages/blit386/src/__test__/webgpu-mock.ts
+++ b/packages/blit386/src/__test__/webgpu-mock.ts
@@ -8,7 +8,8 @@ const DEFAULT_SIZE_PX = 256;
 
 /**
  * Palette uniform byte size: 256 palette indices x vec4(f32) x 4 bytes.
- * Matches {@link WebGPURenderer} palette buffer layout.
+ * Matches {@link WebGPURenderer} palette buffer layout (`Palette.ts`'s `MAX_PALETTE_SIZE`, not imported here – a
+ * test mock deliberately pins the expected wire value rather than importing the production constant).
  */
 const INDEX_COUNT = 256;
 const RGBA_COMPONENT_COUNT = 4;

--- a/packages/blit386/src/assets/Palette.ts
+++ b/packages/blit386/src/assets/Palette.ts
@@ -17,8 +17,19 @@ import {
 import { HUD_SLOTS } from './palettes/hudData';
 import { C64_HEX, CGA_HEX, GAMEBOY_HEX, NES_HEX, PICO8_HEX, VGA_HEX } from './palettes/presetData';
 
-/** Uniform-buffer slot count used by the renderer regardless of active palette size. */
-const GPU_SIZE = 256;
+/**
+ * Palette slot that is always transparent, regardless of palette size.
+ *
+ * `errorMessages.ts#hudStartSlotError` re-types this value in its message text instead of importing it, to avoid a
+ * circular import (this file already imports from `errorMessages.ts`) – keep the two in sync by hand.
+ */
+export const TRANSPARENT_PALETTE_INDEX = 0;
+
+/**
+ * Maximum number of colors a palette can hold – the fixed size of the GPU palette buffer, the WGSL palette array,
+ * and the usage-tracking mask.
+ */
+export const MAX_PALETTE_SIZE = 256;
 
 /** Number of normalized floats stored per palette color in GPU upload buffers. */
 const GPU_FLOATS_PER_COLOR = 4;
@@ -51,7 +62,7 @@ type Serialized = {
  */
 function isValidSize(size: number): boolean {
     // Supported palette sizes exposed by the public API.
-    const validSizes = [2, 4, 16, 32, 64, 128, 256] as const;
+    const validSizes = [2, 4, 16, 32, 64, 128, MAX_PALETTE_SIZE] as const;
 
     return validSizes.includes(size as (typeof validSizes)[number]);
 }
@@ -170,7 +181,7 @@ export class Palette {
      *
      * @param size – Palette size. Must be one of `2, 4, 16, 32, 64, 128, 256`.
      */
-    constructor(size: number = GPU_SIZE) {
+    constructor(size: number = MAX_PALETTE_SIZE) {
         validateSize(size);
 
         this.size = size;
@@ -356,7 +367,7 @@ export class Palette {
      * @throws Error if the six entries would exceed the palette size.
      */
     public applyHUD(startSlot: number = 1): void {
-        if (!Number.isInteger(startSlot) || startSlot < 1) {
+        if (!Number.isInteger(startSlot) || startSlot < TRANSPARENT_PALETTE_INDEX + 1) {
             throw new Error(hudStartSlotError(startSlot));
         }
 
@@ -382,9 +393,11 @@ export class Palette {
     public set(index: number, color: Color32): void {
         this.assertIndexInRange(index);
 
-        if (index === 0) {
+        if (index === TRANSPARENT_PALETTE_INDEX) {
             if (color.a !== 0) {
-                throw new Error('Slot 0 is always see-through (transparent). Put solid colors in slot 1 or higher.');
+                throw new Error(
+                    `Slot ${TRANSPARENT_PALETTE_INDEX} is always see-through (transparent). Put solid colors in slot 1 or higher.`,
+                );
             }
 
             this.colors[0] = Color32.transparent;
@@ -574,7 +587,7 @@ export class Palette {
      * @returns Float buffer containing normalized RGBA values.
      */
     public toFloat32Array(): Float32Array {
-        const floats = new Float32Array(GPU_SIZE * GPU_FLOATS_PER_COLOR);
+        const floats = new Float32Array(MAX_PALETTE_SIZE * GPU_FLOATS_PER_COLOR);
 
         this.toFloat32ArrayInto(floats);
 

--- a/packages/blit386/src/assets/SpriteSheet.ts
+++ b/packages/blit386/src/assets/SpriteSheet.ts
@@ -8,12 +8,10 @@ import { Rect2i } from '../utils/Rect2i';
 import { Vector2i } from '../utils/Vector2i';
 import { AssetLoader } from './AssetLoader';
 import type { Palette } from './Palette';
-
-/** Number of slots in a palette; matches the 8-bit palette index range. */
-const PALETTE_SLOT_COUNT = 256;
+import { MAX_PALETTE_SIZE, TRANSPARENT_PALETTE_INDEX } from './Palette';
 
 /** Reused per-call bitmask of sheet indices seen while scanning a source rect. */
-const MARK_INDICES_IN_RECT_SCRATCH = new Uint8Array(PALETTE_SLOT_COUNT);
+const MARK_INDICES_IN_RECT_SCRATCH = new Uint8Array(MAX_PALETTE_SIZE);
 
 /** RGBA byte stride per pixel when reading decoded image data. */
 const RGBA_BYTES_PER_PIXEL = 4;
@@ -154,9 +152,9 @@ function collectUniqueOpaqueColors(data: Uint8Array): Color32[] {
  */
 function assertOpaqueColorsFitInPalette(collected: Color32[], palette: Palette, startSlot: number): void {
     if (collected.length > 0) {
-        if (startSlot < 1) {
+        if (startSlot < TRANSPARENT_PALETTE_INDEX + 1) {
             throw new RangeError(
-                `loadColorsIntoPalette: startSlot ${startSlot} is invalid (slot 0 is reserved for transparency).`,
+                `loadColorsIntoPalette: startSlot ${startSlot} is invalid (slot ${TRANSPARENT_PALETTE_INDEX} is reserved for transparency).`,
             );
         }
 
@@ -215,7 +213,7 @@ function markUniqueIndicesInBounds(
         const x = startX + (flat % rectWidth);
         const sheetIndex = pixels[y * sheetWidth + x] ?? 0;
 
-        if (sheetIndex === 0) {
+        if (sheetIndex === TRANSPARENT_PALETTE_INDEX) {
             continue;
         }
 

--- a/packages/blit386/src/core/BTAPI.ts
+++ b/packages/blit386/src/core/BTAPI.ts
@@ -2,6 +2,7 @@ import { AssetLoader } from '../assets/AssetLoader';
 import { AudioClip } from '../assets/AudioClip';
 import type { BitmapFont } from '../assets/BitmapFont';
 import type { Palette } from '../assets/Palette';
+import { TRANSPARENT_PALETTE_INDEX } from '../assets/Palette';
 import {
     CycleEffect,
     ExposureFadeEffect,
@@ -1254,7 +1255,7 @@ export class BTAPI {
         this.assertPaletteIndex(paletteIndex);
 
         // Palette index 0 is transparent – nothing to draw.
-        if (paletteIndex === 0) {
+        if (paletteIndex === TRANSPARENT_PALETTE_INDEX) {
             return;
         }
 

--- a/packages/blit386/src/core/RenderPaletteUsage.ts
+++ b/packages/blit386/src/core/RenderPaletteUsage.ts
@@ -5,8 +5,10 @@
  * and passes the usage mask directly to the overlay palette grid.
  */
 
-/** Maximum palette slots tracked by the usage mask. */
-export const USAGE_CAPACITY = 256;
+import { MAX_PALETTE_SIZE } from '../assets/Palette';
+
+/** Maximum palette slots tracked by the usage mask. Equal to {@link MAX_PALETTE_SIZE}. */
+export const USAGE_CAPACITY = MAX_PALETTE_SIZE;
 
 /**
  * Clears a palette usage bitmask.

--- a/packages/blit386/src/overlay/Overlay.ts
+++ b/packages/blit386/src/overlay/Overlay.ts
@@ -7,6 +7,7 @@
 
 import type { BitmapFont } from '../assets/BitmapFont';
 import type { Palette } from '../assets/Palette';
+import { MAX_PALETTE_SIZE } from '../assets/Palette';
 import type {
     Backend,
     OverlayAudioMeterStyle,
@@ -303,7 +304,7 @@ export class Overlay {
             const customRows = getCustomRows?.();
             const { layoutConfig, plan } = this.#buildFramePlan(customRows?.length ?? 0, palette);
             const grid = layoutConfig.paletteGrid;
-            const colorCount = palette?.size ?? 256;
+            const colorCount = palette?.size ?? MAX_PALETTE_SIZE;
 
             if (grid !== undefined && plan.paletteBand.height > 0) {
                 this.#paletteInteraction.syncScrollBounds(grid);
@@ -469,7 +470,7 @@ export class Overlay {
      */
     #createLayoutConfig(customRowCount: number, palette: Palette | null | undefined): OverlayLayoutConfig {
         const isOverlayPaletteEnabled = this.#paletteView.isEnabled;
-        const colorCount = palette?.size ?? 256;
+        const colorCount = palette?.size ?? MAX_PALETTE_SIZE;
 
         const paletteGrid = isOverlayPaletteEnabled
             ? computeGrid(
@@ -621,7 +622,7 @@ export class Overlay {
                 this.#idxText,
             );
 
-            const colorCount = palette?.size ?? 256;
+            const colorCount = palette?.size ?? MAX_PALETTE_SIZE;
 
             this.#paletteInteraction.tickCopyStatus(currentTick);
 

--- a/packages/blit386/src/overlay/palette/PaletteView.ts
+++ b/packages/blit386/src/overlay/palette/PaletteView.ts
@@ -7,6 +7,7 @@
  */
 
 import type { Palette } from '../../assets/Palette';
+import { MAX_PALETTE_SIZE } from '../../assets/Palette';
 import { Rect2i } from '../../utils/Rect2i';
 import { OVERLAY_EDGE_MARGIN_PX } from '../layout/constants';
 import { overlayToggleHintIconX } from '../layout/layoutHelpers';
@@ -142,7 +143,7 @@ export function resolveGridVisibleRows(totalRows: number, maxVisibleRows?: numbe
 export function computeGrid(
     displayWidth: number,
     swatchSize = DEFAULT_PALETTE_SWATCH_SIZE,
-    colorCount = 256,
+    colorCount = MAX_PALETTE_SIZE,
     gap = PALETTE_SWATCH_GAP_PX,
     maxColumns?: number,
     maxVisibleRows?: number,

--- a/packages/blit386/src/render/PaletteResolveUpscalePass.ts
+++ b/packages/blit386/src/render/PaletteResolveUpscalePass.ts
@@ -1,3 +1,4 @@
+import { MAX_PALETTE_SIZE } from '../assets/Palette';
 import type { Vector2i } from '../utils/Vector2i';
 import { VS_WGSL } from './effects/fullscreenVS';
 import type { UpscaleFilter } from './UpscalePass';
@@ -174,7 +175,7 @@ struct Params {
 }
 
 struct Palette {
-    colors: array<vec4<f32>, 256>,
+    colors: array<vec4<f32>, ${MAX_PALETTE_SIZE}>,
 }
 
 @group(0) @binding(0) var<uniform> params: Params;

--- a/packages/blit386/src/render/PaletteResolveUpscalePass.ts
+++ b/packages/blit386/src/render/PaletteResolveUpscalePass.ts
@@ -32,7 +32,7 @@ export class PaletteResolveUpscalePass {
      * @param device – WebGPU device.
      * @param destFormat – RGBA output format (swap chain format).
      * @param filter - `'nearest'` or `'linear'` magnification (linear blends resolved RGBA neighbors).
-     * @param paletteBuffer – Shared 256-entry palette uniform buffer (same as scene pipelines).
+     * @param paletteBuffer – Shared {@link MAX_PALETTE_SIZE}-entry palette uniform buffer (same as scene pipelines).
      */
     init(device: GPUDevice, destFormat: GPUTextureFormat, filter: UpscaleFilter, paletteBuffer: GPUBuffer): void {
         this.uniformBuffer?.destroy();

--- a/packages/blit386/src/render/PrimitivePipeline.ts
+++ b/packages/blit386/src/render/PrimitivePipeline.ts
@@ -1,3 +1,4 @@
+import { MAX_PALETTE_SIZE } from '../assets/Palette';
 import { Rect2i } from '../utils/Rect2i';
 import { Vector2i } from '../utils/Vector2i';
 
@@ -355,7 +356,7 @@ export class PrimitivePipeline {
                 }
 
                 struct Palette {
-                    colors: array<vec4<f32>, 256>,
+                    colors: array<vec4<f32>, ${MAX_PALETTE_SIZE}>,
                 }
 
                 @group(0) @binding(0) var<uniform> uniforms: Uniforms;

--- a/packages/blit386/src/render/PrimitivePipeline.ts
+++ b/packages/blit386/src/render/PrimitivePipeline.ts
@@ -93,7 +93,7 @@ export class PrimitivePipeline {
      *
      * @param device – WebGPU device for GPU operations.
      * @param displaySize – Render target resolution in pixels.
-     * @param paletteBuffer – Shared palette uniform buffer (256 x vec4f = 4096 bytes).
+     * @param paletteBuffer – Shared palette uniform buffer ({@link MAX_PALETTE_SIZE} x vec4f).
      * @param targetFormat – Color attachment format for primitive output.
      */
     async init(

--- a/packages/blit386/src/render/SoftwareRenderer.ts
+++ b/packages/blit386/src/render/SoftwareRenderer.ts
@@ -1,5 +1,6 @@
 import type { BitmapFont } from '../assets/BitmapFont';
 import type { Palette } from '../assets/Palette';
+import { TRANSPARENT_PALETTE_INDEX } from '../assets/Palette';
 import type { SpriteSheet } from '../assets/SpriteSheet';
 import type { OverlayDrawTarget, OverlayRendererDiagnostics } from '../overlay';
 import { clipSpriteSourceRect } from '../utils/AssetLimits';
@@ -818,7 +819,7 @@ export class SoftwareRenderer implements IRenderer, OverlayDrawTarget {
                 const srcY = clipped.y + y;
                 const rawIndex = indexedPixels[srcY * sheetWidth + srcX] ?? 0;
 
-                if (rawIndex === 0) {
+                if (rawIndex === TRANSPARENT_PALETTE_INDEX) {
                     continue;
                 }
 

--- a/packages/blit386/src/render/SpritePipeline.ts
+++ b/packages/blit386/src/render/SpritePipeline.ts
@@ -41,7 +41,7 @@ export class SpritePipeline {
     /** Uniform buffer containing screen resolution. */
     private uniformBuffer: GPUBuffer | null = null;
 
-    /** Shared palette uniform buffer (256 x vec4f, 4 KB). */
+    /** Shared palette uniform buffer ({@link MAX_PALETTE_SIZE} x vec4f). */
     private paletteBuffer: GPUBuffer | null = null;
 
     /** Bind group 0: uniforms + palette (shared across all textures). */
@@ -104,7 +104,7 @@ export class SpritePipeline {
      *
      * @param device – WebGPU device for GPU operations.
      * @param displaySize – Render target resolution in pixels.
-     * @param paletteBuffer – Shared palette uniform buffer (256 x vec4f).
+     * @param paletteBuffer – Shared palette uniform buffer ({@link MAX_PALETTE_SIZE} x vec4f).
      * @param targetFormat – Color attachment format for sprite output.
      */
     async init(
@@ -304,7 +304,7 @@ export class SpritePipeline {
                     if (rawIndex == ${TRANSPARENT_PALETTE_INDEX}u) { discard; }
 
                     let combined = rawIndex + input.paletteOffset;
-                    let index = min(combined, 255u);
+                    let index = min(combined, ${MAX_PALETTE_SIZE - 1}u);
 
                     let color = palette.colors[index];
                     if (color.a == 0.0) { discard; }

--- a/packages/blit386/src/render/SpritePipeline.ts
+++ b/packages/blit386/src/render/SpritePipeline.ts
@@ -1,4 +1,5 @@
 import type { BitmapFont } from '../assets/BitmapFont';
+import { MAX_PALETTE_SIZE, TRANSPARENT_PALETTE_INDEX } from '../assets/Palette';
 import type { SpriteSheet } from '../assets/SpriteSheet';
 import type { Rect2i } from '../utils/Rect2i';
 import { Vector2i } from '../utils/Vector2i';
@@ -256,7 +257,7 @@ export class SpritePipeline {
                 }
 
                 struct Palette {
-                    colors: array<vec4<f32>, 256>,
+                    colors: array<vec4<f32>, ${MAX_PALETTE_SIZE}>,
                 }
 
                 @group(0) @binding(0) var<uniform> uniforms: Uniforms;
@@ -300,7 +301,7 @@ export class SpritePipeline {
                     // r8uint: single-channel unsigned integer index.
                     let rawIndex = textureLoad(spriteTexture, coords, 0).r;
 
-                    if (rawIndex == 0u) { discard; }
+                    if (rawIndex == ${TRANSPARENT_PALETTE_INDEX}u) { discard; }
 
                     let combined = rawIndex + input.paletteOffset;
                     let index = min(combined, 255u);

--- a/packages/blit386/src/render/WebGPURenderer.ts
+++ b/packages/blit386/src/render/WebGPURenderer.ts
@@ -1,5 +1,6 @@
 import type { BitmapFont } from '../assets/BitmapFont';
 import type { Palette } from '../assets/Palette';
+import { MAX_PALETTE_SIZE } from '../assets/Palette';
 import type { SpriteSheet } from '../assets/SpriteSheet';
 import type { OverlayDrawTarget, OverlayRendererDiagnostics } from '../overlay';
 import { noActivePaletteError } from '../utils/errorMessages';
@@ -15,9 +16,9 @@ import { SpritePipeline } from './SpritePipeline';
 import type { UpscaleFilter } from './UpscalePass';
 
 /**
- * GPU palette uniform buffer size: 256 entries x 4 floats x 4 bytes = 4096 bytes.
+ * GPU palette uniform buffer size: {@link MAX_PALETTE_SIZE} entries x 4 floats x 4 bytes = 4096 bytes.
  */
-const PALETTE_BUFFER_SIZE = 256 * 4 * 4;
+const PALETTE_BUFFER_SIZE = MAX_PALETTE_SIZE * 4 * 4;
 
 /** Logical scene + pixel chain format (palette index in the red channel). */
 const LOGICAL_TARGET_FORMAT: GPUTextureFormat = 'r8uint';
@@ -81,7 +82,7 @@ export class WebGPURenderer implements IRenderer, OverlayDrawTarget {
     private paletteBuffer: GPUBuffer | null = null;
 
     /** Reusable staging buffer for GPU palette uploads. Avoids per-frame allocation. */
-    private readonly paletteStaging = new Float32Array(256 * 4);
+    private readonly paletteStaging = new Float32Array(MAX_PALETTE_SIZE * 4);
 
     /**
      * True after {@link setPalette} is called, guaranteeing at least one upload

--- a/packages/blit386/src/render/WebGPURenderer.ts
+++ b/packages/blit386/src/render/WebGPURenderer.ts
@@ -16,7 +16,7 @@ import { SpritePipeline } from './SpritePipeline';
 import type { UpscaleFilter } from './UpscalePass';
 
 /**
- * GPU palette uniform buffer size: {@link MAX_PALETTE_SIZE} entries x 4 floats x 4 bytes = 4096 bytes.
+ * GPU palette uniform buffer size: {@link MAX_PALETTE_SIZE} entries x 4 floats x 4 bytes.
  */
 const PALETTE_BUFFER_SIZE = MAX_PALETTE_SIZE * 4 * 4;
 
@@ -78,7 +78,7 @@ export class WebGPURenderer implements IRenderer, OverlayDrawTarget {
     /** Active palette for color lookups and GPU upload. */
     private palette: Palette | null = null;
 
-    /** GPU uniform buffer for the 256-entry palette. */
+    /** GPU uniform buffer for the {@link MAX_PALETTE_SIZE}-entry palette. */
     private paletteBuffer: GPUBuffer | null = null;
 
     /** Reusable staging buffer for GPU palette uploads. Avoids per-frame allocation. */
@@ -197,7 +197,7 @@ export class WebGPURenderer implements IRenderer, OverlayDrawTarget {
             this.sceneTexView = null;
             this.lastFrameMs = 0;
 
-            // Create shared palette uniform buffer (256 entries x vec4f).
+            // Create shared palette uniform buffer (MAX_PALETTE_SIZE entries x vec4f).
             this.paletteBuffer = this.device.createBuffer({
                 label: 'Palette Uniform Buffer',
                 size: PALETTE_BUFFER_SIZE,

--- a/packages/blit386/src/utils/errorMessages.ts
+++ b/packages/blit386/src/utils/errorMessages.ts
@@ -448,6 +448,8 @@ export function paletteIndexOutOfRangeError(index: number, size: number): string
  * @returns User-facing error string.
  */
 export function hudStartSlotError(startSlot: number): string {
+    // The "0" below is Palette.ts's TRANSPARENT_PALETTE_INDEX, re-typed rather than imported:
+    // Palette.ts already imports from this file, so importing back would create a cycle.
     return `HUD preset slots start from 1 (slot 0 is always transparent). Got ${startSlot}.`;
 }
 


### PR DESCRIPTION
## Summary

Closes BT-315 (sub-issue of the BT-313 named-constants epic).

A read-only literal-comparison audit found two clusters of bare numeric sentinels crossing the TS/WGSL shader boundary with zero compiler protection:

- **Cluster A** — palette slot `0` is always transparent, re-typed as `=== 0`, `< 1`, `== 0u` (in a WGSL shader string), and message prose across 6+ files.
- **Cluster B** — the palette/GPU buffer size `256`, independently redeclared as four differently-named local constants (`GPU_SIZE`, `PALETTE_SLOT_COUNT`, `USAGE_CAPACITY`, `PALETTE_BUFFER_SIZE`) plus bare `256` literals in 6 more files, 3 of which are WGSL shader template literals.

- Added `TRANSPARENT_PALETTE_INDEX = 0` and `MAX_PALETTE_SIZE = 256` as single exported constants in `Palette.ts` — the natural domain owner (already had `GPU_SIZE` and the valid-sizes list).
- Replaced every re-typed comparison/literal at the sites the audit found: `SpriteSheet.ts`, `BTAPI.ts`, `SoftwareRenderer.ts`, `WebGPURenderer.ts`, `Overlay.ts` (×3), `PaletteView.ts`, `BLIT386.ts`.
- Interpolated the constants into the three WGSL shader template literals (`SpritePipeline.ts`, `PrimitivePipeline.ts`, `PaletteResolveUpscalePass.ts`) rather than leaving the shader source as a disconnected hardcoded copy.
- `RenderPaletteUsage.ts`'s `USAGE_CAPACITY` now derives from `MAX_PALETTE_SIZE` instead of an independent literal, keeping `BTAPI.ts`'s existing import untouched.
- `errorMessages.ts` keeps a re-typed literal with a manual-sync comment instead of importing the constant — `Palette.ts` already imports from `errorMessages.ts`, so importing back would create a circular dependency. This is the rule's documented fallback (document the duplication) rather than threading the constant through.

Pure refactor — no behavior change.

## Test plan

- [x] `pnpm run test:unit` — 2755 tests pass
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run lint` — clean
- [x] `pnpm run format:check` — clean
- [x] `pnpm run preflight` (packages/blit386) — passes in full
- [ ] `pnpm run test:visual` — could not run in the sandboxed dev environment (Playwright's Chromium isn't installed and installing it needs `sudo`, unavailable there). This is the highest-risk check given the shader template edits and should run in CI before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Standardized palette sizing across creation, rendering, overlays, and GPU processing.
  - Ensured palette tools and renderers consistently support the full 256-color palette.
  - Improved consistency when identifying transparent pixels across sprites, text, software rendering, and GPU rendering.
  - Shared palette settings now remain aligned throughout the application.
  - Existing palette limits, transparency behavior, and visual output remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->