### PR TITLE
fix(kit): reject symlinked paths in agents.ts file operations

### DIFF
--- a/packages/create-blit386/test/scaffold.test.mjs
+++ b/packages/create-blit386/test/scaffold.test.mjs
@@ -1469,6 +1469,52 @@ test('blit agents add claude does not read or write through a symlinked .mcp.jso
     }
 });
 
+test('blit agents add claude does not write through a pre-planted symlinked .new sidecar', () => {
+    const work = mkdtempSync(join(tmpdir(), 'cbt-symlink-new-'));
+
+    try {
+        const project = join(work, 'symlink-new-game');
+        scaffold({
+            targetDir: project,
+            projectName: 'symlink-new-game',
+            pmInstall: 'npm install',
+            pmRunDev: 'npm run dev',
+            pmRunBuild: 'npm run build',
+            pmRunFormat: 'npm run format',
+            pmRunLint: 'npm run lint',
+        });
+
+        // The user hand-wrote their own CLAUDE.md (an ordinary collision), but also has CLAUDE.md.new
+        // pre-planted as a symlink pointing outside the project – the sidecar `writeRel` writes when a
+        // collision (or an unmerged conflict) needs saving alongside the original. Nothing before that
+        // write ever validated the `.new` path itself.
+        const claudePath = join(project, 'CLAUDE.md');
+        const userContent = '# my own CLAUDE notes\n';
+        writeFileSync(claudePath, userContent);
+
+        const externalPath = join(work, 'outside-the-project.new');
+        const externalContent = 'nothing kit-generated should ever land here\n';
+        writeFileSync(externalPath, externalContent);
+        symlinkSync(externalPath, `${claudePath}.new`);
+
+        const { output } = runBlit(project, ['agents', 'add', 'claude']);
+
+        assert.equal(
+            readFileSync(externalPath, 'utf8'),
+            externalContent,
+            'the file outside the project must not be written through the symlinked .new sidecar',
+        );
+        assert.ok(
+            lstatSync(`${claudePath}.new`).isSymbolicLink(),
+            'the symlink itself must be left in place, not replaced with a regular file',
+        );
+        assert.ok(output.includes('CLAUDE.md.new'), 'output should mention the skipped unsafe .new path');
+        assert.equal(readFileSync(claudePath, 'utf8'), userContent, 'the user CLAUDE.md must not be overwritten');
+    } finally {
+        rmSync(work, { recursive: true, force: true });
+    }
+});
+
 test('blit agents sync does not write through a symlinked kit-owned directory', () => {
     const work = mkdtempSync(join(tmpdir(), 'cbt-symlink-sync-'));
 

--- a/packages/create-blit386/test/scaffold.test.mjs
+++ b/packages/create-blit386/test/scaffold.test.mjs
@@ -9,7 +9,17 @@
 import { strict as assert } from 'node:assert';
 import { execFileSync, spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+    existsSync,
+    lstatSync,
+    mkdirSync,
+    mkdtempSync,
+    readdirSync,
+    readFileSync,
+    rmSync,
+    symlinkSync,
+    writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { test } from 'node:test';
@@ -1403,6 +1413,97 @@ test('blit agents add claude merges when the same server entry is written in a d
 
         assert.equal(exitCode, 0, 'a same-entry, different-key-order file should merge cleanly, not collide');
         assert.ok(!existsSync(`${mcpPath}.new`), 'a clean merge should not leave a .new conflict copy');
+    } finally {
+        rmSync(work, { recursive: true, force: true });
+    }
+});
+
+test('blit agents add claude does not read or write through a symlinked .mcp.json', () => {
+    const work = mkdtempSync(join(tmpdir(), 'cbt-symlink-add-'));
+
+    try {
+        const project = join(work, 'symlink-add-game');
+        scaffold({
+            targetDir: project,
+            projectName: 'symlink-add-game',
+            pmInstall: 'npm install',
+            pmRunDev: 'npm run dev',
+            pmRunBuild: 'npm run build',
+            pmRunFormat: 'npm run format',
+            pmRunLint: 'npm run lint',
+        });
+
+        // A file outside the project root, made to look like a plausible pre-existing MCP config so a
+        // vulnerable merge path would happily read and rewrite it. `.mcp.json` is on the mergeable-JSON
+        // allowlist, so this exercises the MCP-merge read as well as the plain collision/write paths.
+        const externalPath = join(work, 'outside-the-project.mcp.json');
+        const externalContent = `${JSON.stringify({ mcpServers: { 'attacker-server': { url: 'https://evil.example/mcp' } } }, null, 2)}\n`;
+        writeFileSync(externalPath, externalContent);
+        symlinkSync(externalPath, join(project, '.mcp.json'));
+
+        const { output } = runBlit(project, ['agents', 'add', 'claude']);
+
+        assert.equal(
+            readFileSync(externalPath, 'utf8'),
+            externalContent,
+            'the file outside the project must not be read, merged, or overwritten through the symlink',
+        );
+        assert.ok(
+            lstatSync(join(project, '.mcp.json')).isSymbolicLink(),
+            'the symlink itself must be left in place, not replaced with a regular file',
+        );
+        assert.ok(output.includes('.mcp.json'), 'output should mention the skipped unsafe path');
+
+        // Every other Claude file the kit generates does not depend on the symlinked path and should
+        // still have been written normally.
+        assert.ok(existsSync(join(project, 'CLAUDE.md')), 'unrelated Claude files should still be added');
+
+        const manifest = JSON.parse(readFileSync(join(project, '.blit', 'manifest.json'), 'utf8'));
+        assert.ok(
+            !manifest.files.some((f) => f.path === '.mcp.json'),
+            'the skipped symlinked path must not be recorded in the manifest',
+        );
+    } finally {
+        rmSync(work, { recursive: true, force: true });
+    }
+});
+
+test('blit agents sync does not write through a symlinked kit-owned directory', () => {
+    const work = mkdtempSync(join(tmpdir(), 'cbt-symlink-sync-'));
+
+    try {
+        const project = join(work, 'symlink-sync-game');
+        scaffold({
+            targetDir: project,
+            projectName: 'symlink-sync-game',
+            pmInstall: 'npm install',
+            pmRunDev: 'npm run dev',
+            pmRunBuild: 'npm run build',
+            pmRunFormat: 'npm run format',
+            pmRunLint: 'npm run lint',
+            agent: 'claude',
+        });
+
+        // Replace the kit-owned rules directory (already tracked in the manifest from scaffolding) with
+        // a symlink pointing outside the project. The external target starts empty; if sync ever wrote
+        // through the symlink, regenerated kit rule files would land there.
+        const rulesDir = join(project, '.claude', 'rules');
+        rmSync(rulesDir, { recursive: true, force: true });
+        const externalDir = join(work, 'outside-the-project-rules');
+        mkdirSync(externalDir, { recursive: true });
+        symlinkSync(externalDir, rulesDir);
+
+        runBlit(project, ['agents', 'sync']);
+
+        assert.deepEqual(
+            readdirSync(externalDir),
+            [],
+            'sync must not write kit rule files through the symlinked directory',
+        );
+        assert.ok(
+            lstatSync(rulesDir).isSymbolicLink(),
+            'the symlink itself must be left in place, not replaced with a regular directory',
+        );
     } finally {
         rmSync(work, { recursive: true, force: true });
     }

--- a/packages/create-blit386/test/scaffold.test.mjs
+++ b/packages/create-blit386/test/scaffold.test.mjs
@@ -1441,8 +1441,9 @@ test('blit agents add claude does not read or write through a symlinked .mcp.jso
         writeFileSync(externalPath, externalContent);
         symlinkSync(externalPath, join(project, '.mcp.json'));
 
-        const { output } = runBlit(project, ['agents', 'add', 'claude']);
+        const { exitCode, output } = runBlit(project, ['agents', 'add', 'claude']);
 
+        assert.equal(exitCode, 0, `blit agents add claude should still succeed overall: ${output}`);
         assert.equal(
             readFileSync(externalPath, 'utf8'),
             externalContent,
@@ -1493,8 +1494,9 @@ test('blit agents sync does not write through a symlinked kit-owned directory', 
         mkdirSync(externalDir, { recursive: true });
         symlinkSync(externalDir, rulesDir);
 
-        runBlit(project, ['agents', 'sync']);
+        const { exitCode, output } = runBlit(project, ['agents', 'sync']);
 
+        assert.equal(exitCode, 0, `blit agents sync should still succeed overall: ${output}`);
         assert.deepEqual(
             readdirSync(externalDir),
             [],

--- a/packages/kit/src/commands/agents.ts
+++ b/packages/kit/src/commands/agents.ts
@@ -23,9 +23,9 @@
 
 import { spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, isAbsolute, join, normalize, resolve, sep } from 'node:path';
+import { dirname, isAbsolute, join, normalize, relative, resolve, sep } from 'node:path';
 import { isDeepStrictEqual } from 'node:util';
 
 import {
@@ -199,7 +199,46 @@ export function checkSyncDrift(root: string, out: (line: string) => void): numbe
     return driftCount;
 }
 
-/** Reject manifest paths that are absolute or escape the project root via `..` segments. */
+/**
+ * True if `absPath` (assumed to resolve under `root`) is reached through a symlink at any existing
+ * path segment – the file itself or any of its parent directories. Checked with `lstatSync`, which
+ * does not follow symlinks, so a symlink pointing outside `root` (or to a file outside it) is caught
+ * even when it resolves to something that exists. A segment that does not exist yet is not a symlink
+ * and is treated as safe – the caller is about to create it, not read or write through it.
+ */
+function hasSymlinkedSegment(absPath: string, root: string): boolean {
+    const rel = relative(root, absPath);
+
+    if (rel === '' || rel.startsWith(`..${sep}`)) {
+        return false;
+    }
+
+    let current = root;
+
+    for (const segment of rel.split(sep)) {
+        current = join(current, segment);
+
+        let stat;
+
+        try {
+            stat = lstatSync(current);
+        } catch {
+            return false;
+        }
+
+        if (stat.isSymbolicLink()) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * Reject manifest paths that are absolute, escape the project root via `..` segments, or are reached
+ * through a symlink (the file itself or a parent directory) – lexical safety alone would still let a
+ * symlink swapped in after scaffolding redirect a read or write outside the project.
+ */
 function isSafeRelPath(relPath: string, root: string): boolean {
     if (isAbsolute(relPath) || normalize(relPath).startsWith(`..${sep}`)) {
         return false;
@@ -207,7 +246,11 @@ function isSafeRelPath(relPath: string, root: string): boolean {
 
     const abs = resolve(root, relPath);
 
-    return abs === root || abs.startsWith(root + sep);
+    if (abs !== root && !abs.startsWith(root + sep)) {
+        return false;
+    }
+
+    return !hasSymlinkedSegment(abs, root);
 }
 
 /**
@@ -289,9 +332,20 @@ function writeRel(root: string, relPath: string, content: string): void {
     writeFileSync(abs, content);
 }
 
-/** Update (or create) the pristine base copy used as the merge ancestor. */
-function writeBase(root: string, relPath: string, content: string): void {
-    writeRel(root, join(BLIT_DIR, BASE_DIR, relPath), content);
+/**
+ * Update (or create) the pristine base copy used as the merge ancestor. Skips the write (and warns)
+ * if `.blit/base/<relPath>` is reached through a symlink – `relPath` itself was already validated by
+ * the caller, but the base copy lives at a different path and needs its own check.
+ */
+function writeBase(root: string, relPath: string, content: string, out: (line: string) => void): void {
+    const baseRelPath = join(BLIT_DIR, BASE_DIR, relPath);
+
+    if (hasSymlinkedSegment(resolve(root, baseRelPath), root)) {
+        out(ui.warn(`Skipping unsafe base path: ${baseRelPath}`));
+        return;
+    }
+
+    writeRel(root, baseRelPath, content);
 }
 
 /**
@@ -399,11 +453,15 @@ export function runFullSync(
         const entry = entryByPath.get(relPath);
         const abs = resolve(root, relPath);
         const basePath = resolve(root, BLIT_DIR, BASE_DIR, relPath);
+        // Checked once per file: the base copy lives at a different path than `relPath` itself (an
+        // extra `.blit/base/` prefix), so it needs its own symlink check rather than inheriting the
+        // `isSafeRelPath` check above.
+        const baseSafe = !hasSymlinkedSegment(basePath, root);
 
         // New file the kit added since this project was scaffolded.
         if (!entry) {
             writeRel(root, relPath, incoming);
-            writeBase(root, relPath, incoming);
+            writeBase(root, relPath, incoming, out);
             entryByPath.set(relPath, {
                 path: relPath,
                 class: classifyFile(relPath),
@@ -419,7 +477,7 @@ export function runFullSync(
         // Missing on disk: restore the kit version.
         if (!existsSync(abs)) {
             writeRel(root, relPath, incoming);
-            writeBase(root, relPath, incoming);
+            writeBase(root, relPath, incoming, out);
             entry.sha256 = incomingHash;
             entry.kitVersion = newKitVersion;
             tally.restored.push(relPath);
@@ -437,7 +495,7 @@ export function runFullSync(
             } else {
                 tally.unchanged++;
             }
-            writeBase(root, relPath, incoming);
+            writeBase(root, relPath, incoming, out);
             entry.sha256 = incomingHash;
             entry.kitVersion = newKitVersion;
             continue;
@@ -459,7 +517,7 @@ export function runFullSync(
                 }
                 // entry.sha256 tracks the reconciled on-disk content so `--check` treats a preserved
                 // note as in-sync; the base copy keeps the kit version as the merge ancestor.
-                writeBase(root, relPath, incoming);
+                writeBase(root, relPath, incoming, out);
                 entry.sha256 = sha256Text(merged);
                 entry.kitVersion = newKitVersion;
                 continue;
@@ -475,13 +533,13 @@ export function runFullSync(
         // sync (the merge ancestor in .blit/base/), NOT entry.sha256. entry.sha256 records the reconciled
         // on-disk content so `--check`/doctor do not flag a clean-merged file as drift. Older projects may
         // lack a base copy; fall back to entry.sha256 there.
-        const baseHash = existsSync(basePath) ? sha256(basePath) : entry.sha256;
+        const baseHash = baseSafe && existsSync(basePath) ? sha256(basePath) : entry.sha256;
 
         // Kit-owned, unchanged from the pristine kit version: adopt the new kit version freely.
         if (diskHash === baseHash) {
             if (diskHash !== incomingHash) {
                 writeRel(root, relPath, incoming);
-                writeBase(root, relPath, incoming);
+                writeBase(root, relPath, incoming, out);
                 entry.sha256 = incomingHash;
                 entry.kitVersion = newKitVersion;
                 tally.updated.push(relPath);
@@ -493,7 +551,7 @@ export function runFullSync(
 
         // Kit-owned, user-modified: try a real three-way merge; clean merges apply.
         {
-            const merged = gitThreeWayMerge(onDisk, basePath, incoming);
+            const merged = baseSafe ? gitThreeWayMerge(onDisk, basePath, incoming) : null;
 
             if (merged !== null) {
                 if (merged !== onDisk) {
@@ -506,7 +564,7 @@ export function runFullSync(
                 // still detects the user's edits and re-merges them). entry.sha256 records the reconciled
                 // on-disk content instead, so `--check` treats this clean-merged file as in-sync rather
                 // than flagging it as drift forever.
-                writeBase(root, relPath, incoming);
+                writeBase(root, relPath, incoming, out);
                 entry.sha256 = sha256Text(merged);
                 entry.kitVersion = newKitVersion;
                 continue;
@@ -725,7 +783,7 @@ function runAddAgent(root: string, agent: AgentKind, out: (line: string) => void
         }
 
         writeRel(root, relPath, file.content);
-        writeBase(root, relPath, file.content);
+        writeBase(root, relPath, file.content, out);
         entryByPath.set(relPath, {
             path: relPath,
             class: classifyFile(relPath),

--- a/packages/kit/src/commands/agents.ts
+++ b/packages/kit/src/commands/agents.ts
@@ -330,11 +330,23 @@ function regenerate(manifest: ReadBlitManifest, root: string): Map<string, strin
     return map;
 }
 
-/** Write `content` to a project-relative path, creating parent directories as needed. */
-function writeRel(root: string, relPath: string, content: string): void {
+/**
+ * Write `content` to a project-relative path, creating parent directories as needed. Returns false
+ * without writing anything if `relPath` is reached through a symlinked segment – the final path (not
+ * just the `relPath` a caller may have validated earlier) is what matters, since a `.new` sidecar path
+ * is never checked anywhere else before reaching here.
+ */
+function writeRel(root: string, relPath: string, content: string): boolean {
     const abs = resolve(root, relPath);
+
+    if (hasSymlinkedSegment(abs, root)) {
+        return false;
+    }
+
     mkdirSync(dirname(abs), { recursive: true });
     writeFileSync(abs, content);
+
+    return true;
 }
 
 /**
@@ -345,12 +357,9 @@ function writeRel(root: string, relPath: string, content: string): void {
 function writeBase(root: string, relPath: string, content: string, out: (line: string) => void): void {
     const baseRelPath = join(BLIT_DIR, BASE_DIR, relPath);
 
-    if (hasSymlinkedSegment(resolve(root, baseRelPath), root)) {
+    if (!writeRel(root, baseRelPath, content)) {
         out(ui.warn(`Skipping unsafe base path: ${baseRelPath}`));
-        return;
     }
-
-    writeRel(root, baseRelPath, content);
 }
 
 /**
@@ -534,8 +543,11 @@ export function runFullSync(
             }
 
             // Managed markers were removed: save the kit version alongside for the user to reconcile.
-            writeRel(root, `${relPath}.new`, incoming);
-            tally.review.push(relPath);
+            if (writeRel(root, `${relPath}.new`, incoming)) {
+                tally.review.push(relPath);
+            } else {
+                out(ui.warn(`Skipping unsafe path: ${relPath}.new`));
+            }
             continue;
         }
 
@@ -582,8 +594,11 @@ export function runFullSync(
         }
 
         // No clean merge: save the kit version alongside and keep the user's file.
-        writeRel(root, `${relPath}.new`, incoming);
-        tally.review.push(relPath);
+        if (writeRel(root, `${relPath}.new`, incoming)) {
+            tally.review.push(relPath);
+        } else {
+            out(ui.warn(`Skipping unsafe path: ${relPath}.new`));
+        }
     }
 
     // Pass 2: files the manifest tracks that the new kit no longer ships.
@@ -768,8 +783,11 @@ function runAddAgent(root: string, agent: AgentKind, out: (line: string) => void
 
     if (collisions.length > 0) {
         for (const file of collisions) {
-            writeRel(root, `${file.path}.new`, file.content);
-            out(ui.warn(`${file.path} already exists, so I saved the kit version as ${file.path}.new.`));
+            if (writeRel(root, `${file.path}.new`, file.content)) {
+                out(ui.warn(`${file.path} already exists, so I saved the kit version as ${file.path}.new.`));
+            } else {
+                out(ui.warn(`Skipping unsafe path: ${file.path}.new`));
+            }
         }
 
         out('');

--- a/packages/kit/src/commands/agents.ts
+++ b/packages/kit/src/commands/agents.ts
@@ -125,6 +125,11 @@ function tryMergeMcpConfig(existingContent: string, generatedContent: string): s
 export function checkSyncDrift(root: string, out: (line: string) => void): number {
     const manifestPath = join(root, BLIT_DIR, MANIFEST_FILE);
 
+    if (hasSymlinkedSegment(manifestPath, root)) {
+        out(ui.error('.blit/manifest.json is reached through a symlink and will not be read.'));
+        return 1;
+    }
+
     if (!existsSync(manifestPath)) {
         out(ui.info('This project has no .blit/manifest.json.'));
         out(ui.info('Scaffold with `npm create blit386` to enable sync support.'));
@@ -405,6 +410,11 @@ export function runFullSync(
 ): number {
     const manifestPath = join(root, BLIT_DIR, MANIFEST_FILE);
 
+    if (hasSymlinkedSegment(manifestPath, root)) {
+        out(ui.error('.blit/manifest.json is reached through a symlink and will not be read or written.'));
+        return 1;
+    }
+
     if (!existsSync(manifestPath)) {
         out(ui.info('This project has no .blit/manifest.json.'));
         out(ui.info('Scaffold with `npm create blit386` to enable sync support.'));
@@ -655,6 +665,11 @@ type ManifestResult = { ok: true; manifest: ReadBlitManifest } | { ok: false; ex
  */
 function readManifest(root: string, out: (line: string) => void): ManifestResult {
     const manifestPath = join(root, BLIT_DIR, MANIFEST_FILE);
+
+    if (hasSymlinkedSegment(manifestPath, root)) {
+        out(ui.error('.blit/manifest.json is reached through a symlink and will not be read or written.'));
+        return { ok: false, exitCode: 1 };
+    }
 
     if (!existsSync(manifestPath)) {
         out(ui.info('This project has no .blit/manifest.json.'));


### PR DESCRIPTION
## Summary

- `isSafeRelPath` in `packages/kit/src/commands/agents.ts` only validated a manifest/generated path lexically (absolute-path and leading-`..` checks) – it never checked whether the path, or a parent directory, was a symlink. Every read or write that resolved through it inherited that gap: `writeRel` (every generated file and `.new` collision copy), the untracked-file collision check in `runAddAgent`, the MCP-merge read added in #580, `checkSyncDrift`'s per-file hash read, and `runFullSync`'s on-disk read, `.blit/base/` read, and three-way-merge write.
- `isSafeRelPath` now also rejects a path reached through a symlinked segment, walked with `lstatSync` (which does not follow symlinks itself, so it also catches a symlink pointing at a nonexistent target). This protects every call site listed above with one change.
- The `.blit/base/` mirror lives at a different path than the tracked file (an extra `.blit/base/` prefix), so it needed its own guard: `writeBase` now checks and skips the write (with a warning) instead of writing through a symlinked base path, and the two direct `basePath` reads in `runFullSync` (the three-way-merge ancestor hash, and the merge call itself) are gated on the same check.

Deferred from BT-475 / #580 per [this CodeRabbit comment](https://github.com/blit386/blit386/pull/580#discussion_r3831513513). Scope is `packages/kit/src/commands/agents.ts` only – `tryMergeMcpConfig` and the MCP-merge behavior itself are untouched.

## Test plan

- [x] `pnpm --filter @blit386/kit run build && pnpm --filter create-blit386 run build`
- [x] `pnpm --filter @blit386/kit run test` (52/52)
- [x] `pnpm --filter create-blit386 run test` (39/39), including two new symlink regressions in `scaffold.test.mjs`:
  - `blit agents add claude does not read or write through a symlinked .mcp.json` – exercises the MCP-merge read path specifically
  - `blit agents sync does not write through a symlinked kit-owned directory`
- [x] Manual repro: scaffolded a game, symlinked `.mcp.json` to a file outside the project, ran `npx blit agents add claude` – output showed `Skipping unsafe path: .mcp.json`, the external file was untouched, and the symlink was left in place
- [x] `pnpm run format:check`, `check-dash-typography`, `agents:check`, `bump:check`, `docs:links` – all clean (also verified by pre-push hooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection for symlinked configuration and kit files during agent setup and synchronization.
  * Prevented operations from reading, overwriting, recording, or writing through unsafe symlinked paths.
  * Added safer handling for synchronization comparisons and merges when protected paths are detected.
  * Unsafe writes, including collision sidecars, are now skipped rather than modifying unintended files.
  * Setup and synchronization continue successfully while safely processing unrelated files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->