### PR TITLE
feat(website): add CI validation of well-known artifacts (BT-248)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -734,6 +734,12 @@ jobs:
         run: pnpm --filter blit386-website run knip
         background: true
 
+      # Structural validation only (no build needed) - see check-well-known-urls
+      # below in build-website for the URL-reachability half of BT-248.
+      - name: Check well-known artifact schemas
+        run: pnpm --filter blit386-website run check:well-known-schemas
+        background: true
+
       - wait-all:
 
       # Deliberately after the join rather than alongside the checks above: this one
@@ -774,6 +780,13 @@ jobs:
         run: pnpm --filter blit386-website run build
         env:
           NODE_ENV: production
+
+      # Boots the built worker (wrangler dev against dist/server/wrangler.json) and
+      # makes real requests against every URL/endpoint advertised to agents, including
+      # /mcp's JSON-RPC tools - a bare status check would not have caught BT-247's
+      # dead-endpoint bug, which returned 200 with the wrong content.
+      - name: Verify advertised URLs resolve in the built output
+        run: pnpm --filter blit386-website run check:well-known-urls
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/packages/website/CLAUDE.md
+++ b/packages/website/CLAUDE.md
@@ -46,6 +46,7 @@ rewritten by `rtk hook claude` – prefer `rtk read` / `rtk grep` over native Re
 | Worker plugin test coverage | `src/**/*.test.ts` (Vitest, via `pnpm run test:unit`) – see Test runners |
 | Why every git subprocess passes `gitEnv()` | `scripts/git-env.mjs` |
 | MCP server | `src/mcp-server.ts`, `public/.well-known/mcp/server-card.json`, `content/mcp-server.mdx` |
+| Well-known artifact CI validation (digest, schema, URL reachability) | `scripts/check-well-known-schemas.mjs` (`check:well-known-schemas`, structural checks, no build needed), `scripts/check-well-known-urls.mjs` (`check:well-known-urls`, boots the built worker and makes real requests, needs `pnpm run build` first); the digest check itself lives in `scripts/__tests__/agent-skills-manifest.test.mjs` |
 | Cloudflare security headers | `public/_headers` |
 | The CSP itself, and the nonce that replaces `'unsafe-inline'` | `src/csp.ts`, `src/csp-nonce.ts` – see Content-Security-Policy |
 

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -45,6 +45,8 @@
     "sync:docs": "node scripts/sync-docs-from-engine.mjs",
     "sync:docs:check": "node scripts/check-docs-sync.mjs",
     "sync:docs:watch": "node scripts/watch-engine-docs.mjs",
+    "check:well-known-schemas": "node scripts/check-well-known-schemas.mjs",
+    "check:well-known-urls": "node scripts/check-well-known-urls.mjs",
     "encode:video": "node scripts/encode-video.mjs",
     "knip": "cd ../.. && knip --workspace packages/website",
     "knip:fix": "cd ../.. && knip --workspace packages/website --fix",
@@ -54,7 +56,7 @@
     "test:unit": "vitest run",
     "test:unit:watch": "vitest watch",
     "test:unit:coverage": "vitest run --coverage",
-    "preflight": "pnpm run format:check && pnpm run typecheck && pnpm run test && pnpm run spellcheck && pnpm run knip && pnpm run build && pnpm run sync:docs:check",
+    "preflight": "pnpm run format:check && pnpm run typecheck && pnpm run test && pnpm run spellcheck && pnpm run knip && pnpm run check:well-known-schemas && pnpm run build && pnpm run check:well-known-urls && pnpm run sync:docs:check",
     "deploy": "wrangler deploy --config dist/server/wrangler.json --name blit386"
   },
   "dependencies": {

--- a/packages/website/public/.well-known/agent-skills/blit386-docs/SKILL.md
+++ b/packages/website/public/.well-known/agent-skills/blit386-docs/SKILL.md
@@ -28,7 +28,7 @@ Main documentation sections:
 
 - `/docs` – Documentation hub (start here)
 - `/docs/getting-started` – Installation and first steps
-- `/docs/api/` – Full API reference for the `BT` namespace
+- `/docs/api/core` – Full API reference for the `BT` namespace
 
 Use the MCP server's `search_docs` tool to locate specific content:
 

--- a/packages/website/public/.well-known/agent-skills/index.json
+++ b/packages/website/public/.well-known/agent-skills/index.json
@@ -6,7 +6,7 @@
       "type": "skill-md",
       "description": "Navigate and query the BLIT386 documentation site at blit386.dev. Use when helping a developer learn the BLIT386 JavaScript/TypeScript library, find API references, or locate guides.",
       "url": "/.well-known/agent-skills/blit386-docs/SKILL.md",
-      "digest": "sha256:246eb311f2869ae348d299c6ada1ba2dc7142e826a9c887801973c2aaf357ec0"
+      "digest": "sha256:f8dcb7a27d7a0792d23b35ec534c7d1f12128bc23a08dd0d4e6efdbe34f84ed1"
     }
   ]
 }

--- a/packages/website/scripts/__tests__/check-well-known-schemas.test.mjs
+++ b/packages/website/scripts/__tests__/check-well-known-schemas.test.mjs
@@ -1,0 +1,185 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import { checkAllWellKnownFiles, WELL_KNOWN_FILES, validateWellKnownContent } from '../check-well-known-schemas.mjs';
+
+const VALID_AGENT_SKILLS_INDEX = {
+    $schema: 'https://schemas.agentskills.io/discovery/0.2.0/schema.json',
+    skills: [
+        {
+            name: 'blit386-docs',
+            type: 'skill-md',
+            description: 'Navigate and query the BLIT386 documentation site.',
+            url: '/.well-known/agent-skills/blit386-docs/SKILL.md',
+            digest: `sha256:${'a'.repeat(64)}`,
+        },
+    ],
+};
+
+const VALID_SERVER_CARD = {
+    serverInfo: { name: 'blit386-docs', version: '1.0.0' },
+    description: 'Documentation server.',
+    url: 'https://blit386.dev/mcp',
+    transport: { type: 'streamable-http' },
+    capabilities: { tools: true },
+};
+
+const VALID_API_CATALOG = {
+    linkset: [
+        {
+            anchor: 'https://blit386.dev/mcp',
+            'service-doc': [{ href: 'https://blit386.dev/mcp-server', type: 'text/html' }],
+        },
+    ],
+};
+
+const VALID_OAUTH_AUTHORIZATION_SERVER = {
+    issuer: 'https://blit386.dev/',
+    agent_auth: {
+        skill: 'https://blit386.dev/auth.md',
+        identity_types_supported: ['anonymous'],
+        identity_assertion: { assertion_types_supported: [] },
+    },
+};
+
+const VALID_OAUTH_PROTECTED_RESOURCE = {
+    resource: 'https://blit386.dev/',
+    resource_name: 'BLIT386 Documentation',
+    scopes_supported: [],
+};
+
+/** @param {string} label */
+function schemaFor(label) {
+    const file = WELL_KNOWN_FILES.find((entry) => entry.label === label);
+    assert.ok(file, `no WELL_KNOWN_FILES entry for ${label}`);
+    return file.schema;
+}
+
+/**
+ * Asserts `failures` holds exactly one message and it matches `pattern`.
+ *
+ * @param {string[]} failures
+ * @param {RegExp} pattern
+ */
+function assertSingleFailureMatches(failures, pattern) {
+    assert.equal(failures.length, 1);
+    const [message = ''] = failures;
+    assert.match(message, pattern);
+}
+
+describe('check-well-known-schemas', () => {
+    describe('agent-skills index', () => {
+        const schema = schemaFor('.well-known/agent-skills/index.json');
+
+        test('passes for a valid manifest', () => {
+            assert.deepEqual(validateWellKnownContent(schema, VALID_AGENT_SKILLS_INDEX), []);
+        });
+
+        test('fails on a malformed digest', () => {
+            const invalid = {
+                ...VALID_AGENT_SKILLS_INDEX,
+                skills: [{ ...VALID_AGENT_SKILLS_INDEX.skills[0], digest: 'sha256:not-hex' }],
+            };
+            assertSingleFailureMatches(validateWellKnownContent(schema, invalid), /64 hex characters/);
+        });
+
+        test('fails on an empty skills array', () => {
+            const invalid = { ...VALID_AGENT_SKILLS_INDEX, skills: [] };
+            assertSingleFailureMatches(validateWellKnownContent(schema, invalid), /skills must not be empty/);
+        });
+
+        test('fails on a wrong $schema version', () => {
+            const invalid = {
+                ...VALID_AGENT_SKILLS_INDEX,
+                $schema: 'https://schemas.agentskills.io/discovery/0.1.0/schema.json',
+            };
+            assert.equal(validateWellKnownContent(schema, invalid).length, 1);
+        });
+    });
+
+    describe('server-card', () => {
+        const schema = schemaFor('.well-known/mcp/server-card.json');
+
+        test('passes for a valid card', () => {
+            assert.deepEqual(validateWellKnownContent(schema, VALID_SERVER_CARD), []);
+        });
+
+        test('fails when serverInfo.version is missing', () => {
+            const invalid = { ...VALID_SERVER_CARD, serverInfo: { name: 'blit386-docs' } };
+            assertSingleFailureMatches(validateWellKnownContent(schema, invalid), /serverInfo\.version/);
+        });
+
+        test('fails when url is not absolute', () => {
+            const invalid = { ...VALID_SERVER_CARD, url: '/mcp' };
+            assertSingleFailureMatches(validateWellKnownContent(schema, invalid), /absolute URL/);
+        });
+    });
+
+    describe('api-catalog', () => {
+        const schema = schemaFor('.well-known/api-catalog');
+
+        test('passes for a valid linkset', () => {
+            assert.deepEqual(validateWellKnownContent(schema, VALID_API_CATALOG), []);
+        });
+
+        test('fails on an empty linkset', () => {
+            assertSingleFailureMatches(validateWellKnownContent(schema, { linkset: [] }), /linkset must not be empty/);
+        });
+
+        test('fails when a service-doc href is relative', () => {
+            const invalid = {
+                linkset: [
+                    { anchor: 'https://blit386.dev/mcp', 'service-doc': [{ href: '/mcp-server', type: 'text/html' }] },
+                ],
+            };
+            assert.equal(validateWellKnownContent(schema, invalid).length, 1);
+        });
+    });
+
+    describe('oauth-authorization-server', () => {
+        const schema = schemaFor('.well-known/oauth-authorization-server');
+
+        test('passes for a valid document', () => {
+            assert.deepEqual(validateWellKnownContent(schema, VALID_OAUTH_AUTHORIZATION_SERVER), []);
+        });
+
+        test('passes without the agent_auth extension', () => {
+            assert.deepEqual(validateWellKnownContent(schema, { issuer: 'https://blit386.dev/' }), []);
+        });
+
+        test('fails when issuer is missing', () => {
+            const invalid = { agent_auth: VALID_OAUTH_AUTHORIZATION_SERVER.agent_auth };
+            assertSingleFailureMatches(validateWellKnownContent(schema, invalid), /issuer/);
+        });
+    });
+
+    describe('oauth-protected-resource', () => {
+        const schema = schemaFor('.well-known/oauth-protected-resource');
+
+        test('passes for a valid document', () => {
+            assert.deepEqual(validateWellKnownContent(schema, VALID_OAUTH_PROTECTED_RESOURCE), []);
+        });
+
+        test('fails when resource is missing', () => {
+            const invalid = { resource_name: 'BLIT386 Documentation' };
+            assertSingleFailureMatches(validateWellKnownContent(schema, invalid), /resource/);
+        });
+    });
+
+    describe('checkAllWellKnownFiles', () => {
+        test('reports a missing file by label rather than throwing', () => {
+            const failures = checkAllWellKnownFiles([
+                {
+                    label: 'does-not-exist.json',
+                    path: '/nonexistent/does-not-exist.json',
+                    schema: schemaFor('.well-known/mcp/server-card.json'),
+                },
+            ]);
+            assertSingleFailureMatches(failures, /does-not-exist\.json: file does not exist/);
+        });
+
+        test('passes against the real repo files', () => {
+            assert.deepEqual(checkAllWellKnownFiles(WELL_KNOWN_FILES), []);
+        });
+    });
+});

--- a/packages/website/scripts/__tests__/check-well-known-urls.test.mjs
+++ b/packages/website/scripts/__tests__/check-well-known-urls.test.mjs
@@ -1,0 +1,119 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import {
+    collectAdvertisedPaths,
+    extractFetchPaths,
+    extractJsonUrls,
+    extractMarkdownPaths,
+    normalizeToSitePath,
+} from '../check-well-known-urls.mjs';
+
+describe('check-well-known-urls', () => {
+    describe('normalizeToSitePath', () => {
+        test('strips the origin from an absolute site URL', () => {
+            assert.equal(normalizeToSitePath('https://blit386.dev/docs/getting-started'), '/docs/getting-started');
+        });
+
+        test('maps the bare origin to the root path', () => {
+            assert.equal(normalizeToSitePath('https://blit386.dev/'), '/');
+            assert.equal(normalizeToSitePath('https://blit386.dev'), '/');
+        });
+
+        test('passes an already-relative path through unchanged', () => {
+            assert.equal(normalizeToSitePath('/mcp'), '/mcp');
+        });
+    });
+
+    describe('extractFetchPaths', () => {
+        test('finds every literal fetch() argument', () => {
+            const source = `
+                async function go() {
+                    const a = await fetch('/mcp', { method: 'POST' });
+                    const b = await fetch("/llms.txt");
+                }
+            `;
+            assert.deepEqual(extractFetchPaths(source), ['/mcp', '/llms.txt']);
+        });
+
+        test('returns an empty array when there are no fetch calls', () => {
+            assert.deepEqual(extractFetchPaths('const x = 1;'), []);
+        });
+    });
+
+    describe('extractMarkdownPaths', () => {
+        test('finds absolute site URLs in a markdown table and backtick paths in prose', () => {
+            const source = `
+                | Resource | URL |
+                | --- | --- |
+                | Docs | https://blit386.dev/docs |
+                | Sitemap | https://blit386.dev/sitemap.xml |
+
+                - \`/docs\` - Documentation hub
+                - \`/docs/getting-started\` - Installation and first steps
+            `;
+            assert.deepEqual(extractMarkdownPaths(source), [
+                'https://blit386.dev/docs',
+                'https://blit386.dev/sitemap.xml',
+                '/docs',
+                '/docs/getting-started',
+            ]);
+        });
+
+        test('ignores backtick spans that are not root-relative paths', () => {
+            const source = 'Query the active backend at runtime: `BT.activeBackend`, or call `tools/list`.';
+            assert.deepEqual(extractMarkdownPaths(source), []);
+        });
+
+        test('would have caught the BT-248 /docs/api/ regression', () => {
+            // SKILL.md used to advertise `/docs/api/` (a trailing-slash section index)
+            // with no matching page in the build. This fixture proves the extractor
+            // surfaces that exact path so check-well-known-urls.mjs's live GET would
+            // have failed it, rather than the check silently missing the class of bug
+            // it exists to catch.
+            const source = '- `/docs/api/` - Full API reference for the `BT` namespace';
+            assert.deepEqual(extractMarkdownPaths(source), ['/docs/api/']);
+        });
+
+        test('does not match a non-blit386.dev origin', () => {
+            assert.deepEqual(extractMarkdownPaths('Source: https://github.com/blit386/blit386'), []);
+        });
+    });
+
+    describe('extractJsonUrls', () => {
+        test('recursively collects absolute site URLs from nested objects and arrays', () => {
+            const doc = {
+                url: 'https://blit386.dev/mcp',
+                linkset: [
+                    { anchor: 'https://blit386.dev/mcp', 'service-doc': [{ href: 'https://blit386.dev/mcp-server' }] },
+                ],
+                unrelated: 'not a url',
+            };
+            assert.deepEqual(extractJsonUrls(doc), [
+                'https://blit386.dev/mcp',
+                'https://blit386.dev/mcp',
+                'https://blit386.dev/mcp-server',
+            ]);
+        });
+
+        test('ignores non-blit386.dev strings', () => {
+            assert.deepEqual(extractJsonUrls({ href: 'https://example.com/other' }), []);
+        });
+
+        test('returns an empty array for primitives with no matching strings', () => {
+            assert.deepEqual(extractJsonUrls(42), []);
+            assert.deepEqual(extractJsonUrls(null), []);
+        });
+    });
+
+    describe('collectAdvertisedPaths', () => {
+        test('normalizes, dedupes, and sorts across all three source kinds', () => {
+            const paths = collectAdvertisedPaths({
+                webmcpSource: "fetch('/mcp'); fetch('/llms.txt');",
+                skillMdSource: '| MCP | https://blit386.dev/mcp | JSON-RPC |\n- `/docs` - hub',
+                jsonDocs: [{ url: 'https://blit386.dev/mcp' }, { resource: 'https://blit386.dev/' }],
+            });
+            assert.deepEqual(paths, ['/', '/docs', '/llms.txt', '/mcp']);
+        });
+    });
+});

--- a/packages/website/scripts/check-well-known-schemas.mjs
+++ b/packages/website/scripts/check-well-known-schemas.mjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+/**
+ * Validate the shape of every agent-facing `.well-known` file this site publishes:
+ * the agent-skills discovery index (0.2.0), the MCP server-card, the RFC 9727
+ * api-catalog linkset, and the two OAuth discovery documents (RFC 8414 / RFC 9728).
+ *
+ * None of these files declare a live, fetchable JSON Schema except the agent-skills
+ * index (`$schema: https://schemas.agentskills.io/discovery/0.2.0/schema.json`), and
+ * fetching that over the network would make this check non-deterministic. Every
+ * schema here is instead hand-encoded from the relevant spec / the shape this repo
+ * already ships, using `zod` (already a direct dependency of this package).
+ *
+ * This only checks structure – it does not check that any advertised URL actually
+ * resolves. See `check-well-known-urls.mjs` for that.
+ *
+ * Usage:
+ *   node scripts/check-well-known-schemas.mjs
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { z } from 'zod';
+
+const PACKAGE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const WELL_KNOWN_DIR = join(PACKAGE_ROOT, 'public', '.well-known');
+
+const SHA256_DIGEST_PATTERN = /^sha256:[0-9a-f]{64}$/u;
+const ABSOLUTE_URL_PATTERN = /^https?:\/\//u;
+
+/** Agent-skills discovery manifest (`.well-known/agent-skills/index.json`), spec version 0.2.0. */
+const AgentSkillsIndexSchema = z.object({
+    $schema: z.literal('https://schemas.agentskills.io/discovery/0.2.0/schema.json'),
+    skills: z
+        .array(
+            z.object({
+                name: z.string().min(1),
+                type: z.literal('skill-md'),
+                description: z.string().min(1),
+                url: z.string().min(1),
+                digest: z.string().regex(SHA256_DIGEST_PATTERN, 'must be "sha256:" followed by 64 hex characters'),
+            }),
+        )
+        .min(1, 'skills must not be empty'),
+});
+
+/** MCP server-card (`.well-known/mcp/server-card.json`). */
+const ServerCardSchema = z.object({
+    serverInfo: z.object({
+        name: z.string().min(1),
+        version: z.string().min(1),
+    }),
+    description: z.string().min(1),
+    url: z.string().regex(ABSOLUTE_URL_PATTERN, 'must be an absolute URL'),
+    transport: z.object({
+        type: z.string().min(1),
+    }),
+    capabilities: z.record(z.string(), z.boolean()),
+});
+
+/** RFC 9727 api-catalog linkset (`.well-known/api-catalog`, no file extension). */
+const ApiCatalogSchema = z.object({
+    linkset: z
+        .array(
+            z.object({
+                anchor: z.string().regex(ABSOLUTE_URL_PATTERN, 'must be an absolute URL'),
+                'service-doc': z
+                    .array(
+                        z.object({
+                            href: z.string().regex(ABSOLUTE_URL_PATTERN, 'must be an absolute URL'),
+                            type: z.string().min(1),
+                        }),
+                    )
+                    .optional(),
+            }),
+        )
+        .min(1, 'linkset must not be empty'),
+});
+
+/** RFC 8414 authorization server metadata, plus this site's `agent_auth` extension. */
+const OauthAuthorizationServerSchema = z.object({
+    issuer: z.string().regex(ABSOLUTE_URL_PATTERN, 'must be an absolute URL'),
+    agent_auth: z
+        .object({
+            skill: z.string().regex(ABSOLUTE_URL_PATTERN, 'must be an absolute URL'),
+            identity_types_supported: z.array(z.string()),
+            identity_assertion: z.object({
+                assertion_types_supported: z.array(z.string()),
+            }),
+        })
+        .optional(),
+});
+
+/** RFC 9728 protected resource metadata. */
+const OauthProtectedResourceSchema = z.object({
+    resource: z.string().regex(ABSOLUTE_URL_PATTERN, 'must be an absolute URL'),
+    resource_name: z.string().min(1).optional(),
+    scopes_supported: z.array(z.string()).optional(),
+});
+
+/**
+ * One schema-validated well-known file: its repo-relative path (for error messages),
+ * its path on disk under `public/.well-known`, and the zod schema it must satisfy.
+ *
+ * @typedef {{ label: string, path: string, schema: z.ZodType }} WellKnownFile
+ */
+
+/** @type {WellKnownFile[]} */
+export const WELL_KNOWN_FILES = [
+    {
+        label: '.well-known/agent-skills/index.json',
+        path: join(WELL_KNOWN_DIR, 'agent-skills', 'index.json'),
+        schema: AgentSkillsIndexSchema,
+    },
+    {
+        label: '.well-known/mcp/server-card.json',
+        path: join(WELL_KNOWN_DIR, 'mcp', 'server-card.json'),
+        schema: ServerCardSchema,
+    },
+    {
+        label: '.well-known/api-catalog',
+        path: join(WELL_KNOWN_DIR, 'api-catalog'),
+        schema: ApiCatalogSchema,
+    },
+    {
+        label: '.well-known/oauth-authorization-server',
+        path: join(WELL_KNOWN_DIR, 'oauth-authorization-server'),
+        schema: OauthAuthorizationServerSchema,
+    },
+    {
+        label: '.well-known/oauth-protected-resource',
+        path: join(WELL_KNOWN_DIR, 'oauth-protected-resource'),
+        schema: OauthProtectedResourceSchema,
+    },
+];
+
+/**
+ * Validates one well-known file's already-parsed JSON content against its schema.
+ *
+ * @param {z.ZodType} schema
+ * @param {unknown} content
+ * @returns {string[]} Human-readable failure messages (empty when valid).
+ */
+export function validateWellKnownContent(schema, content) {
+    const result = schema.safeParse(content);
+
+    if (result.success) {
+        return [];
+    }
+
+    return result.error.issues.map((issue) => {
+        const path = issue.path.length > 0 ? issue.path.join('.') : '(root)';
+        return `${path}: ${issue.message}`;
+    });
+}
+
+/**
+ * Reads and validates every file in `WELL_KNOWN_FILES` against its schema.
+ *
+ * @param {WellKnownFile[]} files
+ * @returns {string[]} Human-readable failure messages, prefixed with the file label.
+ */
+export function checkAllWellKnownFiles(files) {
+    const failures = [];
+
+    for (const file of files) {
+        if (!existsSync(file.path)) {
+            failures.push(`${file.label}: file does not exist`);
+            continue;
+        }
+
+        let content;
+
+        try {
+            content = JSON.parse(readFileSync(file.path, 'utf8'));
+        } catch (error) {
+            failures.push(`${file.label}: invalid JSON (${error instanceof Error ? error.message : String(error)})`);
+            continue;
+        }
+
+        for (const message of validateWellKnownContent(file.schema, content)) {
+            failures.push(`${file.label}: ${message}`);
+        }
+    }
+
+    return failures;
+}
+
+function main() {
+    const failures = checkAllWellKnownFiles(WELL_KNOWN_FILES);
+
+    if (failures.length > 0) {
+        console.error('Well-known artifact schema check failed:');
+
+        for (const failure of failures) {
+            console.error(`  - ${failure}`);
+        }
+
+        process.exit(1);
+    }
+
+    console.log(`Well-known artifact schemas OK (${WELL_KNOWN_FILES.length} files checked).`);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+    main();
+}

--- a/packages/website/scripts/check-well-known-urls.mjs
+++ b/packages/website/scripts/check-well-known-urls.mjs
@@ -1,0 +1,330 @@
+#!/usr/bin/env node
+/**
+ * Cross-check that every URL/endpoint this site advertises to agents – in
+ * `public/webmcp.js`, the agent-skills `SKILL.md`, and the well-known JSON files –
+ * actually resolves in the *built* output.
+ *
+ * This is deliberately more than a 404 check. The bug BT-247 fixed
+ * (`925033c8`) was a dead `/api/search` endpoint that returned HTTP 200 with
+ * someone else's content – a plain status check would not have caught it. So this
+ * boots the real built worker (`wrangler dev` against `dist/server/wrangler.json`,
+ * the same config `pnpm run start` uses) and, for `/mcp`, sends the exact JSON-RPC
+ * calls `webmcp.js` itself makes and asserts the response actually contains results,
+ * not just a 200.
+ *
+ * `/mcp` cannot be checked any other way: it is Hono middleware registered by a
+ * Fumapress plugin (`src/mcp-server.ts`), not a static file, and it reads its docs
+ * corpus from the Cloudflare `ASSETS` binding at request time – there is no static
+ * route manifest to inspect and no dist/ file to check for existence.
+ *
+ * Requires a build to have already run (`pnpm run build`) – see `preflight` in
+ * package.json for the ordering.
+ *
+ * Usage:
+ *   node scripts/check-well-known-urls.mjs
+ */
+import { spawn } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { createServer } from 'node:net';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const PACKAGE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const PUBLIC_DIR = join(PACKAGE_ROOT, 'public');
+const DIST_SERVER_WRANGLER_CONFIG = join(PACKAGE_ROOT, 'dist', 'server', 'wrangler.json');
+
+const SITE_ORIGIN_PATTERN = /https:\/\/blit386\.dev(\/[^\s"'`)|]*)?/gu;
+const BACKTICK_ROOT_PATH_PATTERN = /`(\/[a-zA-Z0-9/_-]+)`/gu;
+const FETCH_CALL_PATTERN = /fetch\(\s*['"]([^'"]+)['"]/gu;
+
+const SERVER_READY_TIMEOUT_MS = 30_000;
+const SERVER_POLL_INTERVAL_MS = 300;
+const SERVER_SHUTDOWN_GRACE_MS = 3_000;
+
+/**
+ * Normalizes an absolute `https://blit386.dev/...` URL, or an already-relative path,
+ * to a site-relative path starting with `/`.
+ *
+ * @param {string} pathOrUrl
+ * @returns {string}
+ */
+export function normalizeToSitePath(pathOrUrl) {
+    const match = /^https:\/\/blit386\.dev(\/.*)?$/u.exec(pathOrUrl);
+    if (match) {
+        return match[1] && match[1].length > 0 ? match[1] : '/';
+    }
+    return pathOrUrl;
+}
+
+/**
+ * Extracts every literal string argument passed to `fetch(...)` in a JS source string.
+ *
+ * @param {string} source
+ * @returns {string[]}
+ */
+export function extractFetchPaths(source) {
+    return [...source.matchAll(FETCH_CALL_PATTERN)].map((match) => match[1]).filter((path) => path !== undefined);
+}
+
+/**
+ * Extracts advertised URLs/paths from Markdown source: absolute `https://blit386.dev/...`
+ * links (table cells, code blocks) and backtick-wrapped root-relative paths
+ * (e.g. `` `/docs/getting-started` ``) in prose bullet lists.
+ *
+ * @param {string} source
+ * @returns {string[]}
+ */
+export function extractMarkdownPaths(source) {
+    const absolute = [...source.matchAll(SITE_ORIGIN_PATTERN)].map((match) => match[0]);
+    const backticked = [...source.matchAll(BACKTICK_ROOT_PATH_PATTERN)]
+        .map((match) => match[1])
+        .filter((path) => path !== undefined);
+    return [...absolute, ...backticked];
+}
+
+/**
+ * Recursively walks a parsed JSON value, collecting every string that is an
+ * absolute `https://blit386.dev/...` URL.
+ *
+ * @param {unknown} value
+ * @param {string[]} [out]
+ * @returns {string[]}
+ */
+export function extractJsonUrls(value, out = []) {
+    if (typeof value === 'string') {
+        if (/^https:\/\/blit386\.dev(\/.*)?$/u.test(value)) {
+            out.push(value);
+        }
+        return out;
+    }
+    if (Array.isArray(value)) {
+        for (const entry of value) extractJsonUrls(entry, out);
+        return out;
+    }
+    if (value && typeof value === 'object') {
+        for (const entry of Object.values(value)) extractJsonUrls(entry, out);
+    }
+    return out;
+}
+
+/**
+ * Builds the deduped, normalized, sorted list of every path advertised across
+ * `webmcp.js`, `SKILL.md`, and the well-known JSON files.
+ *
+ * @param {{ webmcpSource: string, skillMdSource: string, jsonDocs: unknown[] }} sources
+ * @returns {string[]}
+ */
+export function collectAdvertisedPaths({ webmcpSource, skillMdSource, jsonDocs }) {
+    const raw = [
+        ...extractFetchPaths(webmcpSource),
+        ...extractMarkdownPaths(skillMdSource),
+        ...jsonDocs.flatMap((doc) => extractJsonUrls(doc)),
+    ];
+    return [...new Set(raw.map(normalizeToSitePath))].sort();
+}
+
+/**
+ * Reads the real repo sources and returns the advertised-path list. Split out from
+ * `collectAdvertisedPaths` (pure) so tests exercise the pure function against
+ * fixtures without touching disk.
+ *
+ * @returns {string[]}
+ */
+function collectAdvertisedPathsFromRepo() {
+    const webmcpSource = readFileSync(join(PUBLIC_DIR, 'webmcp.js'), 'utf8');
+    const skillMdSource = readFileSync(
+        join(PUBLIC_DIR, '.well-known', 'agent-skills', 'blit386-docs', 'SKILL.md'),
+        'utf8',
+    );
+    const jsonDocPaths = [
+        join(PUBLIC_DIR, '.well-known', 'mcp', 'server-card.json'),
+        join(PUBLIC_DIR, '.well-known', 'api-catalog'),
+        join(PUBLIC_DIR, '.well-known', 'oauth-authorization-server'),
+        join(PUBLIC_DIR, '.well-known', 'oauth-protected-resource'),
+    ];
+    const jsonDocs = jsonDocPaths.map((path) => JSON.parse(readFileSync(path, 'utf8')));
+
+    return collectAdvertisedPaths({ webmcpSource, skillMdSource, jsonDocs });
+}
+
+/** @returns {Promise<number>} A free TCP port on 127.0.0.1. */
+function getFreePort() {
+    return new Promise((resolvePort, reject) => {
+        const server = createServer();
+        server.unref();
+        server.on('error', reject);
+        server.listen(0, '127.0.0.1', () => {
+            const address = server.address();
+            const port = typeof address === 'object' && address ? address.port : null;
+            server.close(() => (port ? resolvePort(port) : reject(new Error('could not allocate a free port'))));
+        });
+    });
+}
+
+/**
+ * Spawns `wrangler dev` against the built worker on `port` and resolves once it is
+ * ready. Rejects (and lets the caller kill the child) if it never becomes ready.
+ *
+ * @param {number} port
+ * @returns {{ child: import('node:child_process').ChildProcess, ready: Promise<void> }}
+ */
+function startWranglerDev(port) {
+    const child = spawn(
+        'pnpm',
+        [
+            'exec',
+            'wrangler',
+            'dev',
+            '--config',
+            DIST_SERVER_WRANGLER_CONFIG,
+            '--port',
+            String(port),
+            '--ip',
+            '127.0.0.1',
+        ],
+        {
+            cwd: PACKAGE_ROOT,
+            env: { ...process.env, WRANGLER_SEND_METRICS: 'false', CI: 'true' },
+            stdio: ['ignore', 'pipe', 'pipe'],
+        },
+    );
+
+    let output = '';
+    child.stdout?.on('data', (chunk) => (output += String(chunk)));
+    child.stderr?.on('data', (chunk) => (output += String(chunk)));
+
+    const ready = (async () => {
+        const baseUrl = `http://127.0.0.1:${port}`;
+        const deadline = Date.now() + SERVER_READY_TIMEOUT_MS;
+
+        while (Date.now() < deadline) {
+            if (child.exitCode !== null) {
+                throw new Error(`wrangler dev exited early (code ${child.exitCode}):\n${output}`);
+            }
+            try {
+                const res = await fetch(baseUrl, { signal: AbortSignal.timeout(2_000) });
+                if (res.ok || res.status === 404) return;
+            } catch {
+                // Not up yet – keep polling.
+            }
+            await new Promise((r) => setTimeout(r, SERVER_POLL_INTERVAL_MS));
+        }
+
+        throw new Error(`wrangler dev did not become ready within ${SERVER_READY_TIMEOUT_MS}ms:\n${output}`);
+    })();
+
+    return { child, ready };
+}
+
+/** @param {import('node:child_process').ChildProcess} child */
+async function stopWranglerDev(child) {
+    if (child.exitCode !== null) return;
+
+    child.kill('SIGTERM');
+    const exited = await Promise.race([
+        new Promise((r) => child.once('exit', () => r(true))),
+        new Promise((r) => setTimeout(() => r(false), SERVER_SHUTDOWN_GRACE_MS)),
+    ]);
+    if (!exited) child.kill('SIGKILL');
+}
+
+/**
+ * Sends the two JSON-RPC calls `webmcp.js` itself makes to `/mcp` and asserts each
+ * response carries real content, not just a 200.
+ *
+ * @param {string} baseUrl
+ * @returns {Promise<string[]>} Failure messages (empty when both calls succeed).
+ */
+async function checkMcpEndpoint(baseUrl) {
+    /** @type {string[]} */
+    const failures = [];
+
+    /** @param {string} name @param {Record<string, unknown>} args */
+    const call = async (name, args) => {
+        const res = await fetch(`${baseUrl}/mcp`, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name, arguments: args } }),
+        });
+        if (!res.ok) {
+            failures.push(`/mcp tools/call ${name}: HTTP ${res.status}`);
+            return;
+        }
+        const body = await res.json();
+        if (body.error) {
+            failures.push(`/mcp tools/call ${name}: JSON-RPC error ${body.error.code} ${body.error.message}`);
+            return;
+        }
+        const text = body.result?.content?.[0]?.text;
+        if (typeof text !== 'string' || text.length === 0) {
+            failures.push(`/mcp tools/call ${name}: response has no result.content[0].text`);
+        }
+    };
+
+    await call('search_docs', { query: 'palette' });
+    await call('get_docs_summary', {});
+
+    return failures;
+}
+
+/**
+ * GETs a site-relative path and asserts it resolves with a non-empty body.
+ *
+ * @param {string} baseUrl
+ * @param {string} path
+ * @returns {Promise<string[]>}
+ */
+async function checkStaticPath(baseUrl, path) {
+    const res = await fetch(`${baseUrl}${path}`);
+    if (!res.ok) {
+        return [`${path}: HTTP ${res.status}`];
+    }
+    const body = await res.text();
+    if (body.length === 0) {
+        return [`${path}: resolved with an empty body`];
+    }
+    return [];
+}
+
+async function main() {
+    if (!existsSync(DIST_SERVER_WRANGLER_CONFIG)) {
+        console.error(
+            `check:well-known-urls requires a build first – ${DIST_SERVER_WRANGLER_CONFIG} does not exist. Run "pnpm run build".`,
+        );
+        process.exit(1);
+    }
+
+    const paths = collectAdvertisedPathsFromRepo();
+    const port = await getFreePort();
+    const { child, ready } = startWranglerDev(port);
+    const baseUrl = `http://127.0.0.1:${port}`;
+    const failures = [];
+
+    try {
+        await ready;
+
+        for (const path of paths) {
+            if (path === '/mcp') {
+                failures.push(...(await checkMcpEndpoint(baseUrl)));
+            } else {
+                failures.push(...(await checkStaticPath(baseUrl, path)));
+            }
+        }
+    } finally {
+        await stopWranglerDev(child);
+    }
+
+    if (failures.length > 0) {
+        console.error('Advertised-URL reachability check failed:');
+        for (const failure of failures) {
+            console.error(`  - ${failure}`);
+        }
+        process.exit(1);
+    }
+
+    console.log(`Advertised URLs OK (${paths.length} paths checked: ${paths.join(', ')}).`);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+    main();
+}

--- a/packages/website/scripts/check-well-known-urls.mjs
+++ b/packages/website/scripts/check-well-known-urls.mjs
@@ -40,6 +40,7 @@ const FETCH_CALL_PATTERN = /fetch\(\s*['"]([^'"]+)['"]/gu;
 const SERVER_READY_TIMEOUT_MS = 30_000;
 const SERVER_POLL_INTERVAL_MS = 300;
 const SERVER_SHUTDOWN_GRACE_MS = 3_000;
+const REQUEST_TIMEOUT_MS = 15_000;
 
 /**
  * Normalizes an absolute `https://blit386.dev/...` URL, or an already-relative path,
@@ -228,6 +229,11 @@ async function stopWranglerDev(child) {
     if (!exited) child.kill('SIGKILL');
 }
 
+/** @param {unknown} error @returns {string} */
+function describeError(error) {
+    return error instanceof Error ? error.message : String(error);
+}
+
 /**
  * Sends the two JSON-RPC calls `webmcp.js` itself makes to `/mcp` and asserts each
  * response carries real content, not just a 200.
@@ -241,11 +247,25 @@ async function checkMcpEndpoint(baseUrl) {
 
     /** @param {string} name @param {Record<string, unknown>} args */
     const call = async (name, args) => {
-        const res = await fetch(`${baseUrl}/mcp`, {
-            method: 'POST',
-            headers: { 'content-type': 'application/json' },
-            body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name, arguments: args } }),
-        });
+        let res;
+
+        try {
+            res = await fetch(`${baseUrl}/mcp`, {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify({
+                    jsonrpc: '2.0',
+                    id: 1,
+                    method: 'tools/call',
+                    params: { name, arguments: args },
+                }),
+                signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+            });
+        } catch (error) {
+            failures.push(`/mcp tools/call ${name}: request failed (${describeError(error)})`);
+            return;
+        }
+
         if (!res.ok) {
             failures.push(`/mcp tools/call ${name}: HTTP ${res.status}`);
             return;
@@ -275,7 +295,14 @@ async function checkMcpEndpoint(baseUrl) {
  * @returns {Promise<string[]>}
  */
 async function checkStaticPath(baseUrl, path) {
-    const res = await fetch(`${baseUrl}${path}`);
+    let res;
+
+    try {
+        res = await fetch(`${baseUrl}${path}`, { signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) });
+    } catch (error) {
+        return [`${path}: request failed (${describeError(error)})`];
+    }
+
     if (!res.ok) {
         return [`${path}: HTTP ${res.status}`];
     }
@@ -326,5 +353,8 @@ async function main() {
 }
 
 if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
-    main();
+    main().catch((error) => {
+        console.error(`check:well-known-urls failed: ${describeError(error)}`);
+        process.exit(1);
+    });
 }


### PR DESCRIPTION
## Summary

* Adds CI validation of the agent-discovery surface (`public/.well-known/**`, `webmcp.js`, `SKILL.md`), which is how the digest and dead-endpoint bugs BT-247 fixed drifted in silently.
* `check-well-known-schemas.mjs` validates the five `.well-known` JSON files (agent-skills index, server-card, api-catalog/RFC 9727, oauth-authorization-server/RFC 8414, oauth-protected-resource/RFC 9728) against `zod` schemas hand-encoded from each spec, run in `quality-website` (source-only, no build needed).
* `check-well-known-urls.mjs` extracts every URL/endpoint advertised to agents in `webmcp.js`, `SKILL.md`, and the well-known JSON files, boots the actual built worker (`wrangler dev`), and makes real requests — GET for static paths, and for `/mcp`, the same JSON-RPC `search_docs`/`get_docs_summary` calls `webmcp.js` itself makes, asserting real result content rather than just a 200. Run in `build-website` after the build step, since `/mcp` is Hono middleware with no static route manifest to inspect.
* Fixes a real bug the new URL check found while under construction: `SKILL.md` advertised `/docs/api/` (no matching index page exists), now points at `/docs/api/core`; digest in `index.json` recomputed accordingly.
* The sha256 digest recompute BT-248 also asked for already existed (`f8e34121`) and already runs in CI — not duplicated here.
* Both new checks wired into `pnpm run preflight` in build order, and noted in `packages/website/CLAUDE.md`'s reference table.

Depends on BT-247 (already merged: `925033c8`, `f8e34121`).

## Test plan

- [x] `pnpm --filter blit386-website run check:well-known-schemas` — passes against the real files; 17 unit tests cover valid + invalid fixtures per schema
- [x] `pnpm --filter blit386-website run test:scripts` — 267 tests green, including 13 new extraction-logic unit tests for `check-well-known-urls.mjs`
- [x] `pnpm --filter blit386-website run build && pnpm --filter blit386-website run check:well-known-urls` — boots `wrangler dev`, exercises `/mcp` (`search_docs`, `get_docs_summary`), `/llms.txt`, `/docs/api/core`, etc. — verified green
- [x] Verified the check actually fails: temporarily reintroduced the `/docs/api/` bug and confirmed `check:well-known-urls` reported `/docs/api/: HTTP 404`, then restored the fix and re-verified green
- [x] `pnpm --filter blit386-website run preflight` — full package gate green (format, typecheck, tests, spellcheck, knip, both new checks, build, docs-sync)
- [x] Pre-push hook (full-repo preflight) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the documentation API reference link to `/docs/api/core`.
  - Updated the agent-skills discovery index to match the latest documentation artifact.

- **Quality Improvements**
  - Added automated validation for published metadata, schemas, required fields, and advertised URLs.
  - Build checks now verify documented endpoints, including MCP responses, are reachable and return valid content.
  - Added coverage for malformed metadata, invalid URLs, missing files, and endpoint regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->